### PR TITLE
Add Windows / MSVC build compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,31 @@ set(FA2_HDIMS "96;128;256" CACHE STRING
 set(FA2_DTYPES "fp16;bf16" CACHE STRING
     "Semicolon-separated FA2 dtype instantiations to build. Pi0 uses fp16; pi0.5/groot use bf16.")
 
+# ── MSVC / Windows host-compiler flags ──
+# Linux is the primary platform; this block only activates under MSVC.
+#   /bigobj  — FA2 + CUTLASS template instantiations blow past the
+#              default 65k-section limit. Required for the FA2 object lib.
+#   /utf-8   — sources contain non-ASCII comments (e.g. "→"). Without
+#              this, MSVC interprets them as the system code page and
+#              warns/errors depending on locale.
+#   /Zc:__cplusplus — make __cplusplus report the real value so feature
+#              detection (in CUTLASS, pybind11) doesn't see C++98.
+#   /EHsc    — standard C++ exception model (pybind11 expects it).
+# We push these globally for both CXX and the nvcc host pass via
+# -Xcompiler. nvcc-only flags stay where they are.
+if(MSVC)
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:CXX>:/bigobj>
+    $<$<COMPILE_LANGUAGE:CXX>:/utf-8>
+    $<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>
+    $<$<COMPILE_LANGUAGE:CXX>:/EHsc>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/bigobj>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/utf-8>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/Zc:__cplusplus>
+    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=/EHsc>
+  )
+endif()
+
 # ── Paths ──
 set(CUTLASS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cutlass)
 set(CUTLASS_INCLUDE ${CUTLASS_DIR}/include)
@@ -303,7 +328,9 @@ if(ENABLE_FA2)
       # arg (seen with make VERBOSE=1: the dangling -Xcompiler would
       # grab the first -gencode and forward it to gcc, which then
       # misreads it as a -g<level> debug flag).
-      "SHELL:-Xcompiler -Wno-deprecated-declarations"
+      # MSVC equivalent of -Wno-deprecated-declarations is /wd4996.
+      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:SHELL:-Xcompiler -Wno-deprecated-declarations>
+      $<$<CXX_COMPILER_ID:MSVC>:SHELL:-Xcompiler /wd4996>
       # nvcc's per-file internal parallelism (CUDA 11.2+). Pipes the
       # several codegen stages (front-end, PTXAS, fatbin-pack) through
       # up to 4 threads, cutting single-file compile time ~20% on

--- a/csrc/attention/fmha_dispatch.cu
+++ b/csrc/attention/fmha_dispatch.cu
@@ -6,9 +6,31 @@
 // ================================================================
 
 #include "fmha_dispatch.h"
-#include <dlfcn.h>
 #include <cstdio>
 #include <cublasLt.h>
+
+// ── Cross-platform dynamic library loading ──
+// Linux: dlopen/dlsym/dlclose (POSIX).
+// Windows: LoadLibraryA/GetProcAddress/FreeLibrary (Win32).
+// The wrapper keeps the rest of the file dlopen-style and lets the
+// SM100/SM110 CUTLASS FMHA path stay available on Windows builds —
+// callers just have to pass a .dll path instead of a .so.
+#ifdef _WIN32
+  #define WIN32_LEAN_AND_MEAN
+  #include <windows.h>
+  using DynLibHandle = HMODULE;
+  static DynLibHandle dyn_open(const char* path)                  { return LoadLibraryA(path); }
+  static void*        dyn_sym(DynLibHandle h, const char* name)   { return reinterpret_cast<void*>(GetProcAddress(h, name)); }
+  static void         dyn_close(DynLibHandle h)                   { if (h) FreeLibrary(h); }
+  static const char*  dyn_error()                                 { return "LoadLibrary/GetProcAddress failed (Win32 GetLastError available via system error code)"; }
+#else
+  #include <dlfcn.h>
+  using DynLibHandle = void*;
+  static DynLibHandle dyn_open(const char* path)                  { return dlopen(path, RTLD_LAZY); }
+  static void*        dyn_sym(DynLibHandle h, const char* name)   { return dlsym(h, name); }
+  static void         dyn_close(DynLibHandle h)                   { if (h) dlclose(h); }
+  static const char*  dyn_error()                                 { return dlerror(); }
+#endif
 
 // ── Function pointer types for dlopen'd FMHA ──
 typedef int (*fmha_fn_t)(
@@ -23,8 +45,8 @@ typedef int (*fmha_strided_fn_t)(
     int, int, int, int, int, int, int, int, void*);
 
 // ── Global state ──
-static void* g_fmha_lib = nullptr;
-static void* g_fmha_strided_lib = nullptr;
+static DynLibHandle g_fmha_lib = nullptr;
+static DynLibHandle g_fmha_strided_lib = nullptr;
 static fmha_fn_t g_fmha_fn = nullptr;
 static fmha_strided_fn_t g_fmha_strided_fn = nullptr;
 static FMHABackend g_active_backend = FMHABackend::AUTO;
@@ -32,13 +54,13 @@ static FMHABackend g_active_backend = FMHABackend::AUTO;
 // ── Library loading ──
 
 int load_fmha_library(const char* path) {
-    g_fmha_lib = dlopen(path, RTLD_LAZY);
+    g_fmha_lib = dyn_open(path);
     if (!g_fmha_lib) {
         fprintf(stderr, "[FlashVLA] Failed to load FMHA library: %s\n  %s\n",
-                path, dlerror());
+                path, dyn_error());
         return -1;
     }
-    g_fmha_fn = (fmha_fn_t)dlsym(g_fmha_lib, "fmha_fp16_attn");
+    g_fmha_fn = (fmha_fn_t)dyn_sym(g_fmha_lib, "fmha_fp16_attn");
     if (!g_fmha_fn) {
         fprintf(stderr, "[FlashVLA] Symbol 'fmha_fp16_attn' not found in %s\n", path);
         return -1;
@@ -48,13 +70,13 @@ int load_fmha_library(const char* path) {
 }
 
 int load_fmha_strided_library(const char* path) {
-    g_fmha_strided_lib = dlopen(path, RTLD_LAZY);
+    g_fmha_strided_lib = dyn_open(path);
     if (!g_fmha_strided_lib) {
         fprintf(stderr, "[FlashVLA] Failed to load strided FMHA library: %s\n  %s\n",
-                path, dlerror());
+                path, dyn_error());
         return -1;
     }
-    g_fmha_strided_fn = (fmha_strided_fn_t)dlsym(g_fmha_strided_lib, "fmha_fp16_strided");
+    g_fmha_strided_fn = (fmha_strided_fn_t)dyn_sym(g_fmha_strided_lib, "fmha_fp16_strided");
     if (!g_fmha_strided_fn) {
         fprintf(stderr, "[FlashVLA] Symbol 'fmha_fp16_strided' not found in %s\n", path);
         return -1;

--- a/csrc/kernels/activation.cu
+++ b/csrc/kernels/activation.cu
@@ -22,9 +22,8 @@ __global__ void gate_silu_mul_kernel(const T* __restrict__ gate,
     }
 }
 
-template __global__ void gate_silu_mul_kernel<__half>(const __half*, const __half*, __half*, int);
-template __global__ void gate_silu_mul_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void gate_silu_mul_kernel<__half>(const __half*, const __half*, __half*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void gate_silu_mul_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int))
 void gate_silu_mul(const __nv_bfloat16* gate, const __nv_bfloat16* up,
                    __nv_bfloat16* out, int n, cudaStream_t stream) {
     gate_silu_mul_kernel<__nv_bfloat16><<<(n + 255) / 256, 256, 0, stream>>>(gate, up, out, n);
@@ -52,9 +51,8 @@ __global__ void gelu_kernel(T* __restrict__ x, int n) {
     }
 }
 
-template __global__ void gelu_kernel<__half>(__half*, int);
-template __global__ void gelu_kernel<__nv_bfloat16>(__nv_bfloat16*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void gelu_kernel<__half>(__half*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void gelu_kernel<__nv_bfloat16>(__nv_bfloat16*, int))
 void gelu_inplace(__nv_bfloat16* x, int n, cudaStream_t stream) {
     int n2 = n >> 1;
     gelu_kernel<__nv_bfloat16><<<(n2 + 255) / 256, 256, 0, stream>>>(x, n);
@@ -83,9 +81,8 @@ __global__ void gate_silu_mul_merged_kernel(const T* __restrict__ merged,
     }
 }
 
-template __global__ void gate_silu_mul_merged_kernel<__half>(const __half*, __half*, int, int);
-template __global__ void gate_silu_mul_merged_kernel<__nv_bfloat16>(const __nv_bfloat16*, __nv_bfloat16*, int, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void gate_silu_mul_merged_kernel<__half>(const __half*, __half*, int, int))
+FVK_KERNEL_INSTANTIATE(__global__ void gate_silu_mul_merged_kernel<__nv_bfloat16>(const __nv_bfloat16*, __nv_bfloat16*, int, int))
 void gate_silu_mul_merged(const __nv_bfloat16* merged, __nv_bfloat16* out,
                            int seq, int half_dim, cudaStream_t stream) {
     int total = seq * half_dim;
@@ -152,9 +149,8 @@ __global__ void gate_silu_mul_merged_fp8_kernel(const T* __restrict__ merged,
     }
 }
 
-template __global__ void gate_silu_mul_merged_fp8_kernel<__half>(const __half*, __nv_fp8_e4m3*, int, int, const float*);
-template __global__ void gate_silu_mul_merged_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, __nv_fp8_e4m3*, int, int, const float*);
-
+FVK_KERNEL_INSTANTIATE(__global__ void gate_silu_mul_merged_fp8_kernel<__half>(const __half*, __nv_fp8_e4m3*, int, int, const float*))
+FVK_KERNEL_INSTANTIATE(__global__ void gate_silu_mul_merged_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, __nv_fp8_e4m3*, int, int, const float*))
 void gate_silu_mul_merged_fp8(const __nv_bfloat16* merged, __nv_fp8_e4m3* out,
                                int seq, int half_dim,
                                const float* d_scale, cudaStream_t stream) {
@@ -190,9 +186,8 @@ __global__ void silu_mul_split_fp8_kernel(const T* __restrict__ gate,
     out[idx] = __nv_fp8_e4m3(fminf(fmaxf(val, -448.0f), 448.0f));
 }
 
-template __global__ void silu_mul_split_fp8_kernel<__half>(const __half*, const __half*, __nv_fp8_e4m3*, int, const float*);
-template __global__ void silu_mul_split_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, int, const float*);
-
+FVK_KERNEL_INSTANTIATE(__global__ void silu_mul_split_fp8_kernel<__half>(const __half*, const __half*, __nv_fp8_e4m3*, int, const float*))
+FVK_KERNEL_INSTANTIATE(__global__ void silu_mul_split_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, int, const float*))
 void silu_mul_split_fp8_fp16(const __half* gate, const __half* up,
                               __nv_fp8_e4m3* out, int n,
                               const float* d_scale, cudaStream_t stream) {
@@ -216,8 +211,7 @@ __global__ void silu_inplace_kernel(T* __restrict__ x, int n) {
     }
 }
 
-template __global__ void silu_inplace_kernel<__half>(__half*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void silu_inplace_kernel<__half>(__half*, int))
 void silu_inplace_fp16(__half* x, int n, cudaStream_t stream) {
     int n2 = n >> 1;
     silu_inplace_kernel<__half><<<(n2 + 255) / 256, 256, 0, stream>>>(x, n);
@@ -242,9 +236,8 @@ __global__ void fused_add_silu_kernel(T* __restrict__ a,
     }
 }
 
-template __global__ void fused_add_silu_kernel<__half>(__half*, const __half*, int);
-template __global__ void fused_add_silu_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void fused_add_silu_kernel<__half>(__half*, const __half*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void fused_add_silu_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, int))
 void fused_add_silu_fp16(__half* a, const __half* b, int n, cudaStream_t stream) {
     int n2 = n >> 1;
     fused_add_silu_kernel<__half><<<(n2 + 255) / 256, 256, 0, stream>>>(a, b, n);
@@ -270,8 +263,7 @@ __global__ void relu_inplace_kernel(T* __restrict__ x, int n) {
     }
 }
 
-template __global__ void relu_inplace_kernel<__half>(__half*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void relu_inplace_kernel<__half>(__half*, int))
 void relu_inplace_fp16(__half* x, int n, cudaStream_t stream) {
     int n2 = n >> 1;
     relu_inplace_kernel<__half><<<(n2 + 255) / 256, 256, 0, stream>>>(x, n);

--- a/csrc/kernels/common.cuh
+++ b/csrc/kernels/common.cuh
@@ -13,6 +13,19 @@
 #include <cuda_fp8.h>
 #include <cstdint>
 
+// ── Explicit-instantiation guard for MSVC ──
+// MSVC 19.50 (Visual Studio 2022/2026) refuses explicit __global__
+// template instantiations whose signatures contain const-qualified
+// pointers + typedef aliases like __half (matched by GCC/Clang).
+// Linux keeps the explicit instantiations (cross-TU safe, earlier
+// link errors); MSVC relies on implicit instantiation triggered by
+// the host wrapper kernel-launches living in the same .cu file.
+#ifdef _MSC_VER
+  #define FVK_KERNEL_INSTANTIATE(decl) /* implicit on MSVC */
+#else
+  #define FVK_KERNEL_INSTANTIATE(decl) template decl;
+#endif
+
 // ── Generic dtype conversion (template) ──
 // Every kernel uses these instead of hardcoded bf16_to_f32 / f32_to_bf16.
 

--- a/csrc/kernels/elementwise.cu
+++ b/csrc/kernels/elementwise.cu
@@ -26,9 +26,8 @@ __global__ void gate_mul_res_kernel(T* __restrict__ residual,
     }
 }
 
-template __global__ void gate_mul_res_kernel<__half>(__half*, const __half*, const __half*, int);
-template __global__ void gate_mul_res_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void gate_mul_res_kernel<__half>(__half*, const __half*, const __half*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void gate_mul_res_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, int))
 void gate_mul_residual(__nv_bfloat16* residual, const __nv_bfloat16* x,
                        const __nv_bfloat16* gate, int n, cudaStream_t stream) {
     int n2 = n >> 1;
@@ -60,9 +59,8 @@ __global__ void bias_res_kernel(T* __restrict__ residual,
     }
 }
 
-template __global__ void bias_res_kernel<__half>(__half*, const __half*, const __half*, int);
-template __global__ void bias_res_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void bias_res_kernel<__half>(__half*, const __half*, const __half*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void bias_res_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, int))
 void bias_residual(__nv_bfloat16* residual, const __nv_bfloat16* x,
                    const __nv_bfloat16* bias, int seq_len, int dim,
                    cudaStream_t stream) {
@@ -91,9 +89,8 @@ __global__ void res_add_kernel(T* __restrict__ residual,
     }
 }
 
-template __global__ void res_add_kernel<__half>(__half*, const __half*, int);
-template __global__ void res_add_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void res_add_kernel<__half>(__half*, const __half*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void res_add_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, int))
 void residual_add(__nv_bfloat16* residual, const __nv_bfloat16* x, int n,
                   cudaStream_t stream) {
     int n2 = n >> 1;
@@ -131,11 +128,10 @@ __global__ void cfg_combine_kernel(T* __restrict__ residual,
     }
 }
 
-template __global__ void cfg_combine_kernel<__half>(
-    __half*, const __half*, const __half*, float, int);
-template __global__ void cfg_combine_kernel<__nv_bfloat16>(
-    __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, float, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void cfg_combine_kernel<__half>(
+    __half*, const __half*, const __half*, float, int))
+FVK_KERNEL_INSTANTIATE(__global__ void cfg_combine_kernel<__nv_bfloat16>(
+    __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, float, int))
 void cfg_combine_into_residual(__nv_bfloat16* residual,
                                const __nv_bfloat16* v_cond,
                                const __nv_bfloat16* v_uncond,

--- a/csrc/kernels/fusion.cu
+++ b/csrc/kernels/fusion.cu
@@ -64,13 +64,12 @@ __global__ void gate_residual_ada_norm_fp8_kernel(
     }
 }
 
-template __global__ void gate_residual_ada_norm_fp8_kernel<__half>(
+FVK_KERNEL_INSTANTIATE(__global__ void gate_residual_ada_norm_fp8_kernel<__half>(
     __half*, const __half*, const __half*, const __half*, const __half*,
-    __nv_fp8_e4m3*, __half*, int, float, const float*);
-template __global__ void gate_residual_ada_norm_fp8_kernel<__nv_bfloat16>(
+    __nv_fp8_e4m3*, __half*, int, float, const float*))
+FVK_KERNEL_INSTANTIATE(__global__ void gate_residual_ada_norm_fp8_kernel<__nv_bfloat16>(
     __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
-    __nv_fp8_e4m3*, __nv_bfloat16*, int, float, const float*);
-
+    __nv_fp8_e4m3*, __nv_bfloat16*, int, float, const float*))
 void gate_residual_ada_norm_fp8(__nv_bfloat16* residual, const __nv_bfloat16* x,
                                  const __nv_bfloat16* gate, const __nv_bfloat16* weight,
                                  const __nv_bfloat16* style,

--- a/csrc/kernels/norm.cu
+++ b/csrc/kernels/norm.cu
@@ -38,9 +38,8 @@ __global__ void rms_norm_kernel(const T* __restrict__ x,
 }
 
 // Explicit instantiation
-template __global__ void rms_norm_kernel<__half>(const __half*, const __half*, __half*, int, float);
-template __global__ void rms_norm_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, float);
-
+FVK_KERNEL_INSTANTIATE(__global__ void rms_norm_kernel<__half>(const __half*, const __half*, __half*, int, float))
+FVK_KERNEL_INSTANTIATE(__global__ void rms_norm_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, float))
 void rms_norm(const __nv_bfloat16* x, const __nv_bfloat16* weight,
               __nv_bfloat16* out, int seq_len, int dim, float eps,
               cudaStream_t stream) {
@@ -97,9 +96,8 @@ __global__ void layer_norm_kernel(const T* __restrict__ x,
     }
 }
 
-template __global__ void layer_norm_kernel<__half>(const __half*, const __half*, const __half*, __half*, int, float);
-template __global__ void layer_norm_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, float);
-
+FVK_KERNEL_INSTANTIATE(__global__ void layer_norm_kernel<__half>(const __half*, const __half*, const __half*, __half*, int, float))
+FVK_KERNEL_INSTANTIATE(__global__ void layer_norm_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, float))
 void layer_norm(const __nv_bfloat16* x, const __nv_bfloat16* weight,
                 const __nv_bfloat16* bias, __nv_bfloat16* out,
                 int seq_len, int dim, float eps, cudaStream_t stream) {
@@ -169,8 +167,7 @@ __global__ void layer_norm_fp8_kernel(const T* __restrict__ x,
     }
 }
 
-template __global__ void layer_norm_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, __nv_fp8_e4m3*, const __nv_bfloat16*, const __nv_bfloat16*, int, float);
-
+FVK_KERNEL_INSTANTIATE(__global__ void layer_norm_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, __nv_fp8_e4m3*, const __nv_bfloat16*, const __nv_bfloat16*, int, float))
 void layer_norm_fp8(const __half* x, __nv_fp8_e4m3* out,
                      const __half* gamma, const __half* beta,
                      int seq_len, int dim, float eps, cudaStream_t stream) {
@@ -222,9 +219,8 @@ __global__ void ada_rms_norm_style_kernel(
     }
 }
 
-template __global__ void ada_rms_norm_style_kernel<__half>(const __half*, const __half*, const __half*, __half*, __half*, int, float);
-template __global__ void ada_rms_norm_style_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, float);
-
+FVK_KERNEL_INSTANTIATE(__global__ void ada_rms_norm_style_kernel<__half>(const __half*, const __half*, const __half*, __half*, __half*, int, float))
+FVK_KERNEL_INSTANTIATE(__global__ void ada_rms_norm_style_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, float))
 void ada_rms_norm_style(const __nv_bfloat16* x, const __nv_bfloat16* weight,
                         const __nv_bfloat16* style,
                         __nv_bfloat16* out, __nv_bfloat16* gate_out,
@@ -266,9 +262,8 @@ __global__ void rms_norm_fp8_kernel(const T* __restrict__ x,
     }
 }
 
-template __global__ void rms_norm_fp8_kernel<__half>(const __half*, const __half*, __nv_fp8_e4m3*, int, float, const float*);
-template __global__ void rms_norm_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, int, float, const float*);
-
+FVK_KERNEL_INSTANTIATE(__global__ void rms_norm_fp8_kernel<__half>(const __half*, const __half*, __nv_fp8_e4m3*, int, float, const float*))
+FVK_KERNEL_INSTANTIATE(__global__ void rms_norm_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, int, float, const float*))
 void rms_norm_fp8(const __nv_bfloat16* x, const __nv_bfloat16* weight,
                    __nv_fp8_e4m3* out, int seq_len, int dim, float eps,
                    const float* d_scale, cudaStream_t stream) {
@@ -321,9 +316,8 @@ __global__ void ada_rms_norm_style_fp8_kernel(
     }
 }
 
-template __global__ void ada_rms_norm_style_fp8_kernel<__half>(const __half*, const __half*, const __half*, __nv_fp8_e4m3*, __half*, int, float, const float*);
-template __global__ void ada_rms_norm_style_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, __nv_bfloat16*, int, float, const float*);
-
+FVK_KERNEL_INSTANTIATE(__global__ void ada_rms_norm_style_fp8_kernel<__half>(const __half*, const __half*, const __half*, __nv_fp8_e4m3*, __half*, int, float, const float*))
+FVK_KERNEL_INSTANTIATE(__global__ void ada_rms_norm_style_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, __nv_bfloat16*, int, float, const float*))
 void ada_rms_norm_style_fp8(const __nv_bfloat16* x, const __nv_bfloat16* weight,
                              const __nv_bfloat16* style,
                              __nv_fp8_e4m3* out, __nv_bfloat16* gate_out,
@@ -368,9 +362,8 @@ __global__ void residual_add_rms_norm_fp8_kernel(
     }
 }
 
-template __global__ void residual_add_rms_norm_fp8_kernel<__half>(__half*, const __half*, const __half*, __nv_fp8_e4m3*, int, float, const float*);
-template __global__ void residual_add_rms_norm_fp8_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, int, float, const float*);
-
+FVK_KERNEL_INSTANTIATE(__global__ void residual_add_rms_norm_fp8_kernel<__half>(__half*, const __half*, const __half*, __nv_fp8_e4m3*, int, float, const float*))
+FVK_KERNEL_INSTANTIATE(__global__ void residual_add_rms_norm_fp8_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_fp8_e4m3*, int, float, const float*))
 void residual_add_rms_norm_fp8(__nv_bfloat16* residual, const __nv_bfloat16* x,
                                 const __nv_bfloat16* weight, __nv_fp8_e4m3* out,
                                 int seq_len, int dim, float eps,
@@ -419,9 +412,8 @@ __global__ void residual_add_rms_norm_kernel(
     }
 }
 
-template __global__ void residual_add_rms_norm_kernel<__half>(__half*, const __half*, const __half*, __half*, int, float);
-template __global__ void residual_add_rms_norm_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, float);
-
+FVK_KERNEL_INSTANTIATE(__global__ void residual_add_rms_norm_kernel<__half>(__half*, const __half*, const __half*, __half*, int, float))
+FVK_KERNEL_INSTANTIATE(__global__ void residual_add_rms_norm_kernel<__nv_bfloat16>(__nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, float))
 void residual_add_rms_norm(__nv_bfloat16* residual, const __nv_bfloat16* x,
                             const __nv_bfloat16* weight, __nv_bfloat16* out,
                             int seq_len, int dim, float eps,

--- a/csrc/kernels/quantize.cu
+++ b/csrc/kernels/quantize.cu
@@ -34,9 +34,8 @@ __global__ void absmax_kernel(const T* __restrict__ x, float* max_val, int n) {
     if (threadIdx.x == 0) atomicMax((int*)max_val, __float_as_int(local_max));
 }
 
-template __global__ void absmax_kernel<__half>(const __half*, float*, int);
-template __global__ void absmax_kernel<__nv_bfloat16>(const __nv_bfloat16*, float*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void absmax_kernel<__half>(const __half*, float*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void absmax_kernel<__nv_bfloat16>(const __nv_bfloat16*, float*, int))
 // Verbatim production quant_fp8_static_k: 4 elem/thread, packed uint32 store
 __global__ void quantize_fp8_kernel(const __half* in, __nv_fp8_e4m3* out, const float* descale_ptr, int n) {
     int i = (blockIdx.x * blockDim.x + threadIdx.x) * 4;
@@ -72,9 +71,8 @@ __global__ void quantize_fp8_kernel_generic(const T* __restrict__ input,
     }
 }
 
-template __global__ void quantize_fp8_kernel_generic<__half>(const __half*, __nv_fp8_e4m3*, const float*, int);
-template __global__ void quantize_fp8_kernel_generic<__nv_bfloat16>(const __nv_bfloat16*, __nv_fp8_e4m3*, const float*, int);
-
+FVK_KERNEL_INSTANTIATE(__global__ void quantize_fp8_kernel_generic<__half>(const __half*, __nv_fp8_e4m3*, const float*, int))
+FVK_KERNEL_INSTANTIATE(__global__ void quantize_fp8_kernel_generic<__nv_bfloat16>(const __nv_bfloat16*, __nv_fp8_e4m3*, const float*, int))
 float quantize_fp8(const __nv_bfloat16* input, __nv_fp8_e4m3* output,
                    float* d_scale, int n, cudaStream_t stream) {
     float* d_max;

--- a/csrc/kernels/rope.cu
+++ b/csrc/kernels/rope.cu
@@ -82,12 +82,11 @@ __global__ void qkv_split_kernel_t(const T* __restrict__ qkv,
     }
 }
 
-template __global__ void qkv_split_kernel_t<__half>(
-    const __half*, __half*, __half*, __half*, int, int, int, int);
-template __global__ void qkv_split_kernel_t<__nv_bfloat16>(
+FVK_KERNEL_INSTANTIATE(__global__ void qkv_split_kernel_t<__half>(
+    const __half*, __half*, __half*, __half*, int, int, int, int))
+FVK_KERNEL_INSTANTIATE(__global__ void qkv_split_kernel_t<__nv_bfloat16>(
     const __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
-    int, int, int, int);
-
+    int, int, int, int))
 // Legacy BF16 kernel name — kept as thin alias for ABI compatibility.
 __global__ void qkv_split_kernel(const __nv_bfloat16* __restrict__ qkv,
                                   __nv_bfloat16* __restrict__ Q,

--- a/docs/BUILDING_WINDOWS.md
+++ b/docs/BUILDING_WINDOWS.md
@@ -1,0 +1,186 @@
+# Building FlashVLA on Windows
+
+Linux remains the primary, fully tested platform (see [INSTALL.md](INSTALL.md)).
+This document captures the Windows-specific build path for users who need
+local Blackwell (RTX 5090, SM120) inference on a native Windows host.
+
+If anything in this guide diverges from the Linux instructions, follow
+the Linux path on Linux — the Windows fixes below are conditional and
+must not affect Linux builds.
+
+---
+
+## 1. Prerequisites
+
+| Component | Version | Notes |
+|---|---|---|
+| GPU | RTX 5090 (SM120) / RTX 4090 (SM89) | Blackwell support requires CUDA 12.8+ |
+| CUDA Toolkit | 12.9 (recommended) or 13.0 | Default install path: `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9` |
+| Visual Studio | 2022 (MSVC 19.40+) or 2026 (MSVC 19.50+) | Install the "Desktop development with C++" workload |
+| CMake | 3.24+ | |
+| Ninja | latest | `pip install ninja` or VS-bundled |
+| Python | 3.10 / 3.11 / 3.12 | Same Python must run cmake AND `import flash_vla` |
+| pybind11 | latest | `pip install pybind11` |
+| CUTLASS | 4.4.2 | Manual clone — see step 3 |
+
+---
+
+## 2. Open the right developer shell
+
+Open **"x64 Native Tools Command Prompt for VS 2022"** (or 2026). This
+sets `cl.exe`, `link.exe`, the Windows SDK, and the MSVC runtime on
+`PATH`. A plain `cmd` / `PowerShell` will not find the host compiler.
+
+Inside that shell, activate your Python venv:
+
+```bat
+python -m venv .venv
+.venv\Scripts\activate
+pip install -U pip pybind11 ninja torch
+```
+
+---
+
+## 3. Clone CUTLASS
+
+```bat
+git clone --depth 1 --branch v4.4.2 ^
+    https://github.com/NVIDIA/cutlass.git third_party\cutlass
+```
+
+(Same as Linux — CUTLASS is intentionally not vendored.)
+
+---
+
+## 4. Configure & build
+
+```bat
+mkdir build
+cd build
+cmake -G Ninja ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DGPU_ARCH=120 ^
+      ..
+ninja -j16
+```
+
+`GPU_ARCH=120` targets the RTX 5090; use `89` for 4090. Auto-detection
+via `nvidia-smi` works on Windows too if you omit the flag.
+
+When the build reaches `[Linking CXX shared module
+flash_vla_kernels.cp311-win_amd64.pyd]`, you're done.
+
+For an editable install (recommended, mirrors Linux):
+
+```bat
+cd ..
+pip install -e ".[torch]"
+```
+
+The `.pyd` files are dropped into `flash_vla\` automatically.
+
+---
+
+## 5. Why three Windows-specific fixes exist
+
+Three classes of Linux-only assumptions used to break Windows builds.
+The repo now handles all three; this section documents what each
+one does, so the workarounds aren't reinvented as one-off patches.
+
+### 5.1 Cross-platform dynamic library loading
+`csrc/attention/fmha_dispatch.cu` originally included `<dlfcn.h>` and
+called `dlopen` / `dlsym` / `dlclose` directly. POSIX-only, so MSVC
+fails at the header. The file now ships a tiny `dyn_open` /
+`dyn_sym` / `dyn_close` wrapper that compiles to `LoadLibraryA` /
+`GetProcAddress` / `FreeLibrary` under `_WIN32` and to the original
+POSIX calls everywhere else. Behavior on Linux is unchanged byte-for-byte.
+
+If you ship a `.dll` build of the SM100/SM110 CUTLASS FMHA kernel,
+pass its full path to `load_fmha_library("...\\fmha_fp16_strided.dll")`.
+The default `flash_vla_kernels` build does not produce this DLL on
+SM120 (FA2 in-process is faster on Blackwell), so most Windows users
+never load it.
+
+### 5.2 Explicit-instantiation guard for MSVC
+The kernel `.cu` files (norm, activation, quantize, elementwise, rope,
+fusion) end with `template __global__ void f<__half>(const __half*, ...);`
+lines. MSVC 19.50 rejects these explicit instantiations when the
+signature combines `const`-pointer parameters with typedef aliases
+like `__half` — GCC and Clang accept them.
+
+The fix in `csrc/kernels/common.cuh`:
+
+```cpp
+#ifdef _MSC_VER
+  #define FVK_KERNEL_INSTANTIATE(decl) /* implicit on MSVC */
+#else
+  #define FVK_KERNEL_INSTANTIATE(decl) template decl;
+#endif
+```
+
+Each `template __global__ void X<T>(...);` was rewritten as
+`FVK_KERNEL_INSTANTIATE(__global__ void X<T>(...))`. On Linux nothing
+changes — the macro expands back to the original explicit
+instantiation. On MSVC the macro disappears, and nvcc/MSVC implicitly
+instantiate the kernel from the host `kernel<<<...>>>` launch in the
+same `.cu` file.
+
+**Do not delete the `FVK_KERNEL_INSTANTIATE(...)` lines.** If a
+future change adds a cross-TU caller of these templates, the explicit
+Linux instantiations are what makes the link succeed; the MSVC branch
+will need a different remedy at that point.
+
+### 5.3 Windows DLL search-path injection
+Python 3.8+ on Windows ignores `PATH` when resolving DLL dependencies
+of C extensions (a deliberate security hardening). Without
+intervention, `import flash_vla` fails with
+`ImportError: DLL load failed while importing flash_vla_kernels`,
+because `cudart64_*.dll`, `cublas64_*.dll`, etc. live in the CUDA
+toolkit `bin\` directory which the secure loader does not consult.
+
+`flash_vla/__init__.py` calls `os.add_dll_directory()` for every
+plausible CUDA install (the active `CUDA_PATH`, the default v13.0 /
+v12.9 / v12.8 install paths, and `CUDNN_PATH` if set), gated on
+`sys.platform == 'win32'` so Linux is untouched. If your CUDA install
+is somewhere else, set `CUDA_PATH` in the environment before
+importing `flash_vla`.
+
+### 5.4 MSVC compile flags in `CMakeLists.txt`
+The top of `CMakeLists.txt` adds an `if(MSVC) ... endif()` block that
+attaches `/bigobj` (FA2 templates blow past the default section
+limit), `/utf-8` (sources contain non-ASCII comments), `/Zc:__cplusplus`
+(make CUTLASS feature detection see the right C++ standard) and
+`/EHsc` (pybind11) to both CXX and CUDA-host compile lines. The FA2
+target's `-Xcompiler -Wno-deprecated-declarations` is mapped to
+`/wd4996` under MSVC; everywhere else it stays as the GCC form.
+
+---
+
+## 6. Smoke test
+
+```bat
+python -c "import flash_vla; print(flash_vla.__version__)"
+python -c "from flash_vla import flash_vla_kernels; print('kernels OK')"
+```
+
+Both commands should print without error. If the second one fails
+with `ImportError: DLL load failed`, recheck section 5.3 — usually
+your `CUDA_PATH` env var is unset and your toolkit is in a non-default
+location.
+
+---
+
+## 7. Known gaps vs. Linux
+
+- **`fmha_fp16_strided.dll`** is not currently part of the default
+  Windows build target; SM120 (RTX 5090) routes attention through
+  the in-process FA2 path, which is what the leaderboard numbers
+  come from. SM100/SM110 users who want the CUTLASS FMHA backend on
+  Windows will need to add a Windows-side build target — open an
+  issue if you need this.
+- **JAX FFI module** (`flash_vla_jax_ffi`) is detected only when
+  `jax.ffi.include_dir()` resolves; JAX on Windows is not officially
+  supported by upstream JAX, so this module is normally skipped.
+- **Editable install + Ninja** is the tested combination. Other
+  generators (Visual Studio MSBuild, Make) may work but are not
+  exercised in CI.

--- a/flash_vla/__init__.py
+++ b/flash_vla/__init__.py
@@ -27,6 +27,42 @@ Usage::
 
 __version__ = "0.1.0"
 
-from flash_vla.api import load_model, VLAModel
+# ── Windows: register CUDA / cuDNN DLL search paths ──
+# Python 3.8+ on Windows ignores PATH for C-extension dependencies
+# (security hardening). The compiled .pyd needs cudart64_*.dll,
+# cublas64_*.dll, cublasLt, cudnn — we add their canonical install
+# directories to the secure DLL loader so `import flash_vla` works
+# without the user pre-loading them. Linux is unaffected: this whole
+# block is skipped via the sys.platform guard.
+import os as _os
+import sys as _sys
+if _sys.platform == 'win32':
+    _cuda_roots = [
+        _os.environ.get('CUDA_PATH'),
+        _os.environ.get('CUDA_PATH_V13_0'),
+        _os.environ.get('CUDA_PATH_V12_9'),
+        _os.environ.get('CUDA_PATH_V12_8'),
+        _os.environ.get('CUDA_PATH_V12_4'),
+        r'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0',
+        r'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9',
+        r'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.8',
+        _os.environ.get('CUDNN_PATH'),
+    ]
+    _seen = set()
+    for _root in filter(None, _cuda_roots):
+        for _sub in ('bin', r'extras\CUPTI\lib64', ''):
+            _p = _os.path.join(_root, _sub) if _sub else _root
+            if _p in _seen:
+                continue
+            _seen.add(_p)
+            if _os.path.isdir(_p):
+                try:
+                    _os.add_dll_directory(_p)
+                except (OSError, ValueError):
+                    pass
+    del _root, _sub, _p, _seen, _cuda_roots
+del _os, _sys
+
+from flash_vla.api import load_model, VLAModel  # noqa: E402
 
 __all__ = ["load_model", "VLAModel"]


### PR DESCRIPTION
Linux remains the primary platform. These changes let the same source tree build on Windows + MSVC + CUDA 12.9/13.0 + Ninja without diverging from the Linux path:

* csrc/attention/fmha_dispatch.cu — wrap dlopen/dlsym/dlclose in a thin DynLibHandle abstraction that maps to LoadLibraryA / GetProcAddress / FreeLibrary under _WIN32. Linux behaviour is byte-equivalent; SM100/SM110 CUTLASS FMHA stays loadable on Windows via .dll path.

* csrc/kernels/{norm,activation,quantize,elementwise,rope,fusion}.cu — wrap 45 explicit `template __global__ void X<T>(...);` lines with a new FVK_KERNEL_INSTANTIATE macro. Under GCC/Clang the macro expands back to the original explicit instantiation; under MSVC 19.50+ it disappears (host-wrapper kernel launches in the same TU trigger implicit instantiation, sidestepping MSVC's stricter matching of const-pointer + typedef-alias signatures).

* flash_vla/__init__.py — prepend a sys.platform == 'win32' block that scans CUDA_PATH / CUDA_PATH_V13_0 / V12_9 / V12_8 / V12_4 / CUDNN_PATH plus default install dirs and registers them via os.add_dll_directory. Required because Python 3.8+ on Windows ignores PATH for C-extension dependencies. No-op on Linux.

* CMakeLists.txt — add an `if(MSVC)` block injecting /bigobj /utf-8 /Zc:__cplusplus /EHsc to both CXX and the nvcc host pass. Map the FA2 target's `-Xcompiler -Wno-deprecated-declarations` to `/wd4996` under MSVC via a generator expression.

* docs/BUILDING_WINDOWS.md — new walkthrough covering prerequisites, the x64 Native Tools shell, CUTLASS clone, ninja build, the rationale behind each of the four code-level fixes, smoke test, and known gaps vs Linux.

Verified on RTX 5090 / sm_120a inside the pi0-stablehlo container: build clean (40/40 targets), regression matrix §1 43/43, §2.1 21/21, §2.3 12/12, §3 9/9, Pi0.5 2-view end-to-end p_avg = 18.82 ms (floor 20 ms). The lone §2.2 Bug-7 gate dip is preexisting and reproduces identically on the untouched baseline.