### PR TITLE
docker 文档补充解释 — clarify why --runtime=nvidia is required on Jetson

### DIFF
--- a/docker/Dockerfile.thor
+++ b/docker/Dockerfile.thor
@@ -10,7 +10,7 @@
 #   docker build -t flashrt:thor -f docker/Dockerfile.thor .
 #
 # Run:
-#   docker run --rm --gpus all -it --runtime nvidia flashrt:thor
+#   docker run --rm --gpus all -it --runtime=nvidia flashrt:thor
 #
 # Note on FA2: Thor (SM110) uses the in-tree cuBLAS-decomposed attention
 # path (csrc/attention/fmha_dispatch.cu + libfmha_fp16_strided.so), not
@@ -103,5 +103,5 @@ assert os.path.exists(os.path.join(os.path.dirname(flash_rt.__file__), 'libfmha_
 print('Thor build OK — kernels + fmha_fp16_strided + fp4 + jax_ffi present')"
 
 # Default to a Python REPL with flash_rt pre-imported. Override with
-#   docker run --rm --gpus all -it --runtime nvidia flashrt:thor <cmd>
+#   docker run --rm --gpus all -it --runtime=nvidia flashrt:thor <cmd>
 CMD ["python3", "-c", "import flash_rt; print('flash_rt', flash_rt.__version__, '— Thor (SM110) build ready'); import code; code.interact(local={'flash_rt': flash_rt})"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -145,9 +145,35 @@ host so `nvidia-smi` auto-detects `sm_110a`:
 # On the Thor host
 docker build -t flashrt:thor -f docker/Dockerfile.thor .
 
-# Run (note --runtime nvidia for Jetson)
-docker run --rm --gpus all -it --runtime nvidia flashrt:thor
+# Run (note --runtime=nvidia for Jetson — see below for why)
+docker run --rm --gpus all -it --runtime=nvidia flashrt:thor
 ```
+
+### Why `--runtime=nvidia` on Jetson
+
+Unlike a discrete-GPU host (where `--gpus all` alone is enough — the
+libnvidia-container shim auto-discovers `/dev/nvidia*` and the
+matching driver libs), Jetson's iGPU stack is bound to host kernel
+drivers and is exposed to containers through a **CSV-driven
+mount mechanism** owned by `nvidia-container-runtime`:
+
+```
+/etc/nvidia-container-runtime/host-files-for-container.d/
+├── devices.csv     # /dev/nvgpu, /dev/nvhost-*, /dev/nvmap, …
+└── drivers.csv     # /usr/lib/aarch64-linux-gnu/tegra/libcuda.so.*, …
+```
+
+Passing `--runtime=nvidia` is what activates that runtime, which in
+turn parses the two CSV files at container start and bind-mounts
+every listed device node and driver library from the Tegra host
+into the container. Without the flag the standard runc starts the
+container without those mounts; the result is no `/dev/nvgpu`, no
+`libcuda.so`, and `torch.cuda.is_available()` returns `False` even
+though `nvidia-smi` works on the host.
+
+`--gpus all` is left in the example for parity with the x86 docs and
+because the libnvidia-container CLI hook ignores it gracefully on
+Jetson, but the load-bearing flag here is `--runtime=nvidia`.
 
 ### What's different vs the x86 image
 


### PR DESCRIPTION
Adds a short subsection to the Thor part of `docker/README.md` explaining why `docker run` on Jetson needs `--runtime=nvidia` while the x86 docs get away with just `--gpus all`.

The Thor run command has carried `--runtime=nvidia` since the original Thor Dockerfile commit, but the docs never justified it. External feedback pointed out that without the flag the standard runc starts the container without bind-mounting the Tegra iGPU device nodes or driver libs, and `torch.cuda.is_available()` returns `False` even though `nvidia-smi` works on the host — easy to misdiagnose, so worth calling out explicitly.

The new subsection walks through the CSV-driven mount mechanism owned by `nvidia-container-runtime`:

```
/etc/nvidia-container-runtime/host-files-for-container.d/
├── devices.csv     # /dev/nvgpu, /dev/nvhost-*, /dev/nvmap, …
└── drivers.csv     # /usr/lib/aarch64-linux-gnu/tegra/libcuda.so.*, …
```

Also normalises the flag form to `--runtime=nvidia` (with `=`) across both `docker/README.md` and `docker/Dockerfile.thor` for consistency. The existing `--gpus all` is kept in the example for parity with the x86 docs since the libnvidia-container CLI hook ignores it gracefully on Jetson.