### PR TITLE
docker docs: align README with actual repo state

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -15,51 +15,24 @@ Thor uses a hand-tuned cuBLAS-decomposed attention path
 (`csrc/attention/fmha_dispatch.cu`) instead of the vendored
 Flash-Attention 2, so its image deliberately does NOT produce
 `flash_rt_fa2.so`. Everything else builds the same way. Skip to
-[§5](#5-thor-jetson-agx-thor-sm110-aarch64) for the Thor flow.
+[§4](#4-thor-jetson-agx-thor-sm110-aarch64) for the Thor flow.
 
 ---
 
-## 1. Pull the prebuilt image (recommended)
+## 1. Build the image locally (current default path)
 
-Once a release is tagged, the image is published to GitHub Container
-Registry by CI:
+> **Note on the prebuilt registry image.** Following the
+> `flash_vla → flash_rt` package-rename refactor that landed in
+> [#6](https://github.com/LiangSu8899/FlashRT/pull/6), the
+> `ghcr.io/liangsu8899/flashrt` image has not been re-pushed yet —
+> we plan to push the new image once the post-rename surface is
+> fully stable. Until then, build the image yourself with the
+> commands below — it's a one-time `cmake/make` pass on top of the
+> NGC base image, and the produced `.so` files match what the
+> registry image will eventually ship.
 
-```bash
-docker pull ghcr.io/liangsu8899/flashrt:<tag>
-docker run --rm --gpus all -it ghcr.io/liangsu8899/flashrt:<tag>
-```
-
-`<tag>` matches a release version (e.g. `0.2.0`) or `latest`.
-Available tags: <https://github.com/LiangSu8899/FlashRT/pkgs/container/flashrt>.
-
-### Modal / RunPod / Vast / cloud
-
-```python
-import modal
-
-image = modal.Image.from_registry(
-    "ghcr.io/liangsu8899/flashrt:0.2.0"
-).pip_install("your-app-deps")
-
-app = modal.App("flashrt-app", image=image)
-
-@app.function(gpu="L40S")  # or H100, A100, etc.
-def infer():
-    import flash_rt
-    model = flash_rt.load_model(checkpoint="/path/to/ckpt", framework="torch")
-    ...
-```
-
-The image already has CUDA 13.0, PyTorch 2.9 with SM120 support, cuBLAS,
-and the FlashRT kernels prebuilt — Modal cold-start is **dominated by
-the pull (~30s on a warm CDN)** instead of a 10-minute kernel compile.
-
----
-
-## 2. Build locally
-
-If you want to pin a specific commit, target a different GPU, or
-modify the kernels, build the image yourself:
+Build the image yourself when you want to pin a specific commit,
+target a different GPU than the build host, or modify the kernels:
 
 ```bash
 # Default — auto-detects GPU arch via nvidia-smi (requires --gpus on build).
@@ -88,14 +61,48 @@ docker build -t flashrt:slim \
 
 ### Build time
 
-Cold build (no NGC image cached): ~25 min, dominated by the FA2
-template instantiation pass (~10 min) and the NGC pull (~10 min).
-Warm build (NGC cached): ~12 min. With `FA2_ARCH_NATIVE_ONLY` and a
-single-arch slim, the kernel compile drops to ~4 min.
+Cold build dominated by two phases: pulling the NGC base image
+(network-bound, depends on bandwidth and CDN warmth) and the FA2
+template instantiation pass during `make -j`. Subsequent rebuilds
+reuse the NGC layer and CUTLASS clone, leaving only the kernel
+compile. `FA2_ARCH_NATIVE_ONLY=ON` plus a single-arch slim
+materially shortens the kernel compile by skipping non-native AOT
+passes — useful when iterating on the source.
+
+### Pushing your build to a private registry (Modal / RunPod / cloud)
+
+Until the public registry image is re-pushed, the standard cloud
+flow is to push your local build to a registry you own and point
+the cloud runtime at it:
+
+```bash
+docker tag flashrt:5090 <your-registry>/flashrt:0.2.0
+docker push <your-registry>/flashrt:0.2.0
+```
+
+```python
+# Modal example (mirrors the eventual public-image flow)
+import modal
+
+image = modal.Image.from_registry(
+    "<your-registry>/flashrt:0.2.0"
+).pip_install("your-app-deps")
+
+app = modal.App("flashrt-app", image=image)
+
+@app.function(gpu="L40S")  # or H100, A100, etc.
+def infer():
+    import flash_rt
+    model = flash_rt.load_model(checkpoint="/path/to/ckpt", framework="torch")
+    ...
+```
+
+Once `ghcr.io/liangsu8899/flashrt:<tag>` is re-pushed, swap in the
+public URL — the rest of the pipeline stays identical.
 
 ---
 
-## 3. Run
+## 2. Run
 
 ```bash
 # Default: drops you in a Python REPL with `flash_rt` already imported.
@@ -110,17 +117,30 @@ docker run --rm --gpus all \
 
 ---
 
-## 4. What's inside
+## 3. What's inside
 
 - Base: `nvcr.io/nvidia/pytorch:25.10-py3`
   (CUDA 13.0, PyTorch 2.9, cuBLASLt, nvcc, Python 3.12)
 - CUTLASS 4.4.2 vendored at `/opt/cutlass`
 - FlashRT source at `/workspace/FlashRT`, editable-installed
-- All five kernel `.so` files prebuilt under `flash_rt/`:
-  `flash_rt_kernels`, `flash_rt_fa2`, `flash_rt_fp4` (NVFP4-capable archs),
-  `flash_rt_jax_ffi`, and `libfmha_fp16_strided` (Thor/Hopper only)
+- Kernel `.so` files prebuilt directly into `flash_rt/`. The exact
+  set depends on the target GPU arch (gating defined in
+  [`CMakeLists.txt`](../CMakeLists.txt)):
+
+  | Target | Always | FA2 (sm_80/86/89/120) | NVFP4 GEMM (sm_120) | SM100 FMHA (sm_100/110) |
+  |---|---|---|---|---|
+  | `flash_rt_kernels.so`        | ✓ | — | — | — |
+  | `flash_rt_jax_ffi.so`        | ✓ | — | — | — |
+  | `flash_rt_fp4.so`            | ✓ | — | NVFP4 paths active here | — |
+  | `flash_rt_fa2.so`            | — | ✓ | — | skipped |
+  | `libfmha_fp16_strided.so`    | — | skipped | — | ✓ |
+
+  In the default x86 build (auto-detected sm_120 on RTX 5090) you
+  get 4 `.so` files: `flash_rt_kernels`, `flash_rt_fa2`,
+  `flash_rt_fp4`, `flash_rt_jax_ffi`. The Thor build (sm_110) also
+  produces 4 but swaps `flash_rt_fa2` for `libfmha_fp16_strided`.
 - An import smoke check runs at image-build time, so a broken image
-  fails the `docker build` instead of the user's first pull
+  fails the `docker build` instead of the user's first pull.
 
 The image deliberately does **not** include the upstream `flash-attn`
 pip wheel — the default RTX path uses the vendored `flash_rt_fa2.so`
@@ -129,12 +149,12 @@ GROOT, install it yourself:
 
 ```bash
 docker run --rm --gpus all flashrt:dev \
-    pip install flash-attn  # or grab a prebuilt wheel from the releases page
+    pip install flash-attn  # or build from source per upstream docs
 ```
 
 ---
 
-## 5. Thor (Jetson AGX Thor, SM110, aarch64)
+## 4. Thor (Jetson AGX Thor, SM110, aarch64)
 
 The Thor image uses a separate Dockerfile, [`Dockerfile.thor`](Dockerfile.thor),
 because Thor pulls a different NGC manifest (`linux/arm64`) and skips
@@ -180,16 +200,20 @@ Jetson, but the load-bearing flag here is `--runtime=nvidia`.
 - **Base**: `nvcr.io/nvidia/pytorch:25.09-py3` (one minor older than the
   x86 image — 25.09 has the validated arm64 / Thor manifest, 25.10
   arm64 has not been smoke-tested on SM110 yet).
-- **Build targets**: 4 `.so` files instead of 5
-  (`flash_rt_kernels`, `flash_rt_fp4`, `libfmha_fp16_strided`,
-  `flash_rt_jax_ffi`).
+- **Build targets**: 4 `.so` files (`flash_rt_kernels`,
+  `flash_rt_fp4`, `libfmha_fp16_strided`, `flash_rt_jax_ffi`).
+  Same artifact count as the default x86 build but with
+  `libfmha_fp16_strided` swapped in for `flash_rt_fa2`.
 - **No `flash_rt_fa2.so`**: Thor's `csrc/attention/fmha_dispatch.cu`
-  loads `libfmha_fp16_strided.so` at runtime via dlopen — no FA2
-  template instantiation, ~10 min faster cold build than x86.
-- **`flash_rt_fp4.so` on Thor**: built for sm_110a (NVFP4 instructions
-  are SM120-only at the SASS level, but the kernel object compiles
-  fine on Thor and the runtime dispatcher gates calls accordingly —
-  see `docs/kernel_catalog.md` § FP4 path).
+  loads `libfmha_fp16_strided.so` at runtime via dlopen instead of
+  going through the FA2 template instantiation pass — that's the
+  largest cold-build saving on Thor vs x86.
+- **`flash_rt_fp4.so` on Thor**: built for sm_110a, but NVFP4 GEMM
+  paths gate to sm_120 only at runtime
+  (see [`docs/kernel_catalog.md`](../docs/kernel_catalog.md), the
+  `quantize_bf16_to_nvfp4` and `has_nvfp4()` entries). The kernel
+  object compiles fine on Thor; calls into NVFP4-only entry points
+  short-circuit when `has_nvfp4()` returns False.
 
 ### Build args
 


### PR DESCRIPTION
Re-audited `docker/README.md` end-to-end after an external user hit `Error response from daemon: error from registry: denied` on the very first command in the docs. The pull failure traced back to `ghcr.io/liangsu8899/flashrt` not yet being pushed (HTTP 404 from the GitHub Packages API; `.github/workflows/` does not exist). The audit surfaced five other inaccuracies of the same family — claims that the docs made about the repo state but the repo did not back up — and this PR fixes all six.

## What this PR changes

1. **§1 (was "Pull the prebuilt image")** — replaced with "Build the image locally" plus a short note that, following the `flash_vla → flash_rt` rename refactor in #6, the registry image has not been re-pushed yet and will be re-pushed once the post-rename surface is fully stable. The URL stays discoverable in the note for the eventual republish.

2. **Modal / RunPod example** — was pointing at the same unavailable `ghcr.io/liangsu8899/flashrt:0.2.0`. Rewritten to show the standard cloud flow (`docker build → docker push <your-registry>/flashrt → modal.Image.from_registry(...)`), with one line about swapping in the public URL once it republishes.

3. **§3 (was §4) "All five kernel .so files"** — wrong on every arch. CMakeLists gates `libfmha_fp16_strided` to sm_100/110 and FA2 to sm_80/86/89/120, so the default x86 build (sm_120) ships 4 `.so` files, not 5; Thor (sm_110) also ships 4 but swaps FA2 for `libfmha_fp16_strided`. Replaced with a per-target table.

4. **"grab a prebuilt wheel from the releases page"** — the releases API returns 0 entries. Replaced with "build from source per upstream docs."

5. **§4 (was §5) Thor cross-ref `docs/kernel_catalog.md § FP4 path`** — that anchor does not exist. `kernel_catalog.md` has FP4-related entries scattered through §4 (Quantize) and §10 (Context flags). Updated to point at the file with named entries (`quantize_bf16_to_nvfp4`, `has_nvfp4()`).

6. **Thor "~10 min faster cold build"** and §1 "~25 / ~12 / ~4 min" build-time numbers — never measured on a clean machine. Replaced with qualitative statements about which phases dominate (NGC pull + FA2 template instantiation) rather than fictional minute counts.

Sections renumbered: §1 absorbs the old §1 + §2 build content; §2 = Run, §3 = What's inside, §4 = Thor. Top-of-file `[§4]` anchor updated.