### PR TITLE
fix(pi0fast): also catch RuntimeError in tokenizer fallback

### DIFF
--- a/flash_rt/frontends/jax/pi0fast.py
+++ b/flash_rt/frontends/jax/pi0fast.py
@@ -158,7 +158,7 @@ class Pi0FastJaxFrontend:
             logger.info(
                 "PaliGemma SentencePiece loaded (vocab=%d)",
                 self._vocab_size)
-        except (ImportError, FileNotFoundError, OSError) as e:
+        except (ImportError, FileNotFoundError, OSError, RuntimeError) as e:
             logger.warning(
                 "PaliGemma SentencePiece not available (%s); "
                 "falling back to vocab=257152 default", e)

--- a/flash_rt/frontends/torch/pi0fast.py
+++ b/flash_rt/frontends/torch/pi0fast.py
@@ -167,7 +167,7 @@ class Pi0FastTorchFrontend:
             logger.info(
                 "PaliGemma SentencePiece loaded (vocab=%d)",
                 self._vocab_size)
-        except (ImportError, FileNotFoundError, OSError) as e:
+        except (ImportError, FileNotFoundError, OSError, RuntimeError) as e:
             logger.warning(
                 "PaliGemma SentencePiece not available (%s); "
                 "falling back to vocab=257152 default", e)


### PR DESCRIPTION
## Summary

`Pi0FastTorchFrontend._load_tokenizer` and the JAX twin caught `(ImportError, FileNotFoundError, OSError)` around `load_paligemma_sentencepiece()`, but the helper also raises `RuntimeError` when `sp.Load()` returns False on a corrupted / truncated SentencePiece model. Without this catch a corrupted tokenizer propagates through `__init__` and tears down model construction instead of falling through to the `vocab_size = 257152` placeholder + warning the wrapping `try` was designed to provide.

Aligns the catch set with the analogous Thor-side path (`flash_rt.core.thor_frontend_utils.embed_prompt_torch`) which already catches `(ImportError, FileNotFoundError, OSError, RuntimeError)`.

No behavior change when the tokenizer file is healthy and resolvable (the common case); only changes corrupted-file recovery from "init crashes" to "warn + use placeholder vocab_size", matching the documented intent of the existing fallback.

## Diff

```diff
-        except (ImportError, FileNotFoundError, OSError) as e:
+        except (ImportError, FileNotFoundError, OSError, RuntimeError) as e:
```

Applied to:
- `flash_rt/frontends/torch/pi0fast.py`
- `flash_rt/frontends/jax/pi0fast.py`

## Test plan

Fresh build + quickstart on Jetson AGX Thor (SM110, CUDA 13.1):

- [x] `cmake .. -DGPU_ARCH=110 && make -j8` clean
- [x] `flash_rt_kernels.so` / `flash_rt_fp4.so` / `flash_rt_jax_ffi.so` / `libfmha_fp16_strided.so` produced and importable
- [x] `flash_rt.utils.paligemma_tokenizer.load_paligemma_sentencepiece` resolves on legacy `~/.cache/openpi/...` cache and returns vocab=257152

Quickstart (`examples/quickstart.py`, 5 iter, warmup=20, autotune=0):

| Config | Framework | P50 | Sanity |
|---|---|---|---|
| pi05 (libero) | torch | 44.1 ms (23 Hz) | PASS |
| pi0  (base)   | torch | 42.9 ms (23 Hz) | PASS |
| pi05 (libero_jax) | jax | 41.9 ms (24 Hz) | PASS |
| pi05 + `--use_fp4` | torch | 39.8 ms (25 Hz) | PASS |
| pi0fast (base) | torch | 457.8 ms (2 Hz) | PASS |
| groot (N1.6-3B) | torch | 42.6 ms (23 Hz) | PASS |
