### PR TITLE
Qwen36 NVFP4: bound CUDA Graph cache to fix server VRAM leak

### DIFF
--- a/examples/qwen36_openai_server.py
+++ b/examples/qwen36_openai_server.py
@@ -16,7 +16,7 @@ Usage:
         --checkpoint /path/to/qwen36_nvfp4 \\
         --port 8000 \\
         --K 6 \\
-        --warmup 32:128,128:256
+        --warmup 8:512
 
     # The --warmup flag pre-captures CUDA Graphs for the listed
     # (prompt_len:max_tokens) shapes at startup so the FIRST real
@@ -24,9 +24,9 @@ Usage:
     # warmup, that first request pays a ~5-25 s graph-capture
     # penalty (standard CUDA Graph cold-start cost — same trade-off
     # as SGLang / vLLM compile mode). Each warmed shape covers
-    # cur_pos in [0, prompt_len + max_tokens], so picking 1-2
-    # representative shapes from your traffic distribution is
-    # usually enough.
+    # cur_pos in [prompt_len, prompt_len + max_tokens]; the default
+    # 8:512 covers the common short-chat range in one pass.
+    # Pick shape(s) that span your traffic distribution.
 
     # Test (non-streaming):
     curl http://localhost:8000/v1/chat/completions \\
@@ -367,13 +367,15 @@ def main():
                    help='Identifier returned by /v1/models and echoed '
                    'in completion responses.')
     p.add_argument(
-        '--warmup', default='32:128,128:256',
+        '--warmup', default='8:512',
         help='Comma-separated list of "prompt_len:max_tokens" shapes '
         'to pre-capture CUDA Graphs for at startup. Without this, the '
         'first request at each new shape pays a ~5-25 s graph-capture '
         'penalty before reaching the headline 90-130 tok/s warm speed. '
-        'Default warms typical short-chat (32:128) and longer-context '
-        '(128:256) shapes. Set to empty string to skip warmup.')
+        'Default 8:512 pre-captures cur_pos in [8, 520], covering the '
+        'common short-chat range so requests with prompt_len < 32 '
+        '(which the prior 32:128,128:256 default missed) start warm. '
+        'Set to empty string to skip warmup.')
     args = p.parse_args()
 
     warmup_shapes = []

--- a/flash_rt/frontends/torch/qwen36_rtx.py
+++ b/flash_rt/frontends/torch/qwen36_rtx.py
@@ -18,6 +18,7 @@ in Phase 2) that quantizes weights into fvk-compatible layouts.
 
 from __future__ import annotations
 
+import collections
 import os
 from typing import Any
 
@@ -195,6 +196,30 @@ class Qwen36TorchFrontendRtx:
     # _K_logits_buf at vocab=248320 is 16*248320*2 = 7.6 MB), tiny vs
     # the 28-30 GB main weight footprint.
     MAX_Q_SEQ: int = 16
+
+    # Per-cache LRU bound on lazily captured CUDA Graphs. Each
+    # ``_ensure_*_graph_*`` method captures a graph keyed by cur_pos
+    # (or (cur_pos, K), or eff_ctx) the first time that key is used,
+    # then replays on every subsequent call with that key. Without a
+    # bound, long-running servers that see many distinct shapes grow
+    # the cache linearly with the number of distinct cur_pos values
+    # observed and eventually OOM (GitHub issue: NVFP4 server VRAM
+    # leak on varied prompt lengths). The bound is per-cache, so the
+    # total captured-graph budget across all 4 NVFP4 caches is roughly
+    # 4 × ``GRAPH_CACHE_MAX``. Tuning notes:
+    #   - For chat-style traffic with ``max_seq <= 8K``, the default
+    #     of 256 is comfortably above the working set (one bucket per
+    #     observed cur_pos value, i.e. 8K positions worst-case but
+    #     the hot set is much smaller).
+    #   - All graphs allocate from a single shared mempool
+    #     (``self._graph_mempool``), so eviction reclaims pool memory
+    #     as soon as the evicted graph is GC'd.
+    #   - Override at process start via env
+    #     ``FLASHRT_QWEN36_GRAPH_CACHE_MAX``; setting it to ``0``
+    #     disables the bound (legacy unbounded behaviour, only safe
+    #     when the calling pattern caps cur_pos by construction).
+    GRAPH_CACHE_MAX: int = int(
+        os.environ.get('FLASHRT_QWEN36_GRAPH_CACHE_MAX', '256'))
 
     # ---- DFlash hidden-tap capture (N6 phase) -------------------------
     # When forward_own_decode_K_nvfp4 is called with tap_buf set, the
@@ -479,7 +504,13 @@ class Qwen36TorchFrontendRtx:
         self._static_token_id = torch.zeros(
             1, 1, device=device, dtype=torch.long,
         )
-        self._captured_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        # Shared mempool for every captured graph in this instance.
+        # Without this, ``torch.cuda.graph(g, stream=gs)`` defaults to
+        # a *private* mempool per graph; with N captured graphs the
+        # per-graph workspace overhead is paid N times instead of once.
+        self._graph_mempool = torch.cuda.graph_pool_handle()
+        self._captured_graphs: collections.OrderedDict[
+            int, torch.cuda.CUDAGraph] = collections.OrderedDict()
 
         # Phase 6 D4-9: per-cur_pos CUDA Graph cache for the spec
         # decode S=K+1 verify forward. Uses static input buffers so
@@ -495,8 +526,9 @@ class Qwen36TorchFrontendRtx:
         self._verify_static_sin = torch.empty(
             1, self.MAX_Q_SEQ, 64, device=device, dtype=bf16,
         )
-        self._captured_verify_graphs: dict[
-            tuple[int, int], torch.cuda.CUDAGraph] = {}
+        self._captured_verify_graphs: collections.OrderedDict[
+            tuple[int, int], torch.cuda.CUDAGraph,
+        ] = collections.OrderedDict()
 
         # Phase 6 D4-10: dedicated stream for state snapshotting in
         # the spec loop. The clones (lin_state 75 MB + KV partial)
@@ -529,8 +561,9 @@ class Qwen36TorchFrontendRtx:
             self._mtp_static_prev_token = torch.zeros(
                 1, 1, device=device, dtype=torch.long,
             )
-            self._captured_mtp_graphs: dict[
-                int, torch.cuda.CUDAGraph] = {}
+            self._captured_mtp_graphs: collections.OrderedDict[
+                int, torch.cuda.CUDAGraph,
+            ] = collections.OrderedDict()
 
         # ---------- Phase 6 D4: S=K decode scratches ----------
         # Mirror the S=1 buffers but sized for max_q_seq=MAX_Q_SEQ so
@@ -1055,7 +1088,13 @@ class Qwen36TorchFrontendRtx:
         # capture). Per-cur_pos graph cache.
         self._static_token_id = torch.zeros(
             1, 1, device=device, dtype=torch.long)
-        self._captured_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        # Shared mempool for every captured graph in this instance.
+        # Without this, ``torch.cuda.graph(g, stream=gs)`` defaults to
+        # a *private* mempool per graph; with N captured graphs the
+        # per-graph workspace overhead is paid N times instead of once.
+        self._graph_mempool = torch.cuda.graph_pool_handle()
+        self._captured_graphs: collections.OrderedDict[
+            int, torch.cuda.CUDAGraph] = collections.OrderedDict()
 
         # Stage-7 G1: verify-forward graph cache + static input buffers.
         # The spec loop copies token_ids / cos / sin into these pointers
@@ -1068,8 +1107,9 @@ class Qwen36TorchFrontendRtx:
             1, self.MAX_Q_SEQ, 64, device=device, dtype=bf16)
         self._verify_static_sin = torch.empty(
             1, self.MAX_Q_SEQ, 64, device=device, dtype=bf16)
-        self._captured_verify_graphs: dict[
-            tuple[int, int], torch.cuda.CUDAGraph] = {}
+        self._captured_verify_graphs: collections.OrderedDict[
+            tuple[int, int], torch.cuda.CUDAGraph,
+        ] = collections.OrderedDict()
 
         # MTP scratches (only when MTP is loaded). Mirror FP8 path's
         # MTP buffers — these are BF16/FP32 scratches and independent
@@ -1108,15 +1148,18 @@ class Qwen36TorchFrontendRtx:
                 1, 1, hidden, device=device, dtype=bf16)
             self._mtp_static_prev_token = torch.zeros(
                 1, 1, device=device, dtype=torch.long)
-            self._captured_mtp_graphs: dict[int, torch.cuda.CUDAGraph] = {}
+            self._captured_mtp_graphs: collections.OrderedDict[
+                int, torch.cuda.CUDAGraph,
+            ] = collections.OrderedDict()
             # G9: per-(base_pos, K) chain graph that captures the
             # entire K-step MTP chain (forward + argmax + inter-step
             # state copies) in one graph. Eliminates K-1 Python-level
             # replay/copy/argmax launches per spec cycle.
             self._chain_drafts_buf = torch.zeros(
                 self.MAX_Q_SEQ - 1, 1, device=device, dtype=torch.long)
-            self._captured_chain_graphs: dict[
-                tuple[int, int], torch.cuda.CUDAGraph] = {}
+            self._captured_chain_graphs: collections.OrderedDict[
+                tuple[int, int], torch.cuda.CUDAGraph,
+            ] = collections.OrderedDict()
 
         # Bundle the integer-pointer view forward consumers expect.
         self._bufs = {
@@ -4390,6 +4433,69 @@ class Qwen36TorchFrontendRtx:
         sin = self._rope_sin_table[pos:pos + 1].view(1, 1, d)
         return cos, sin
 
+    # ── CUDA Graph cache LRU + shared-mempool helpers ──
+    #
+    # All ``_ensure_*_graph_*`` methods route their (key → CUDAGraph)
+    # bookkeeping through ``_graph_cache_get`` / ``_graph_cache_put``
+    # so the cache stays bounded (see ``GRAPH_CACHE_MAX``) and so that
+    # captured graphs share one mempool (``self._graph_mempool``)
+    # instead of each owning a private one. The shared mempool keeps
+    # per-graph footprint to the few buffers actually unique to that
+    # capture (cos/sin slice, FA2 partial-LSE workspace, etc.) and lets
+    # eviction reclaim that memory once the evicted graph is GC'd.
+
+    def _graph_cache_get(self, cache, key):
+        """Return the cached graph for ``key`` and mark it MRU.
+
+        Returns ``None`` on miss. Safe to call on a plain ``dict``
+        (legacy state from older pickled instances or tests that
+        bypass ``_init_graph_cache``).
+        """
+        g = cache.get(key)
+        if g is not None and isinstance(cache, collections.OrderedDict):
+            cache.move_to_end(key)
+        return g
+
+    def _graph_cache_put(self, cache, key, g) -> None:
+        """Insert ``g`` for ``key``; evict oldest if over the cap.
+
+        Eviction is a single ``popitem(last=False)`` — i.e. drop the
+        least-recently-used entry. ``GRAPH_CACHE_MAX <= 0`` disables
+        the bound (legacy unbounded behaviour).
+        """
+        cache[key] = g
+        cap = self.GRAPH_CACHE_MAX
+        if (cap > 0
+                and isinstance(cache, collections.OrderedDict)
+                and len(cache) > cap):
+            cache.popitem(last=False)
+
+    def clear_graphs(self) -> None:
+        """Drop every captured CUDA Graph (NVFP4 + FP8 + DFlash + TQ).
+
+        Public hatch for long-running servers / agents that need to
+        proactively reclaim VRAM (e.g. before instantiating a second
+        model on the same GPU, or after a phase change such as moving
+        from short-prompt chat to long-context summarisation). Cheap
+        when there is nothing cached.
+
+        After this call the next request at any ``cur_pos`` re-pays
+        the one-time graph capture cost (see ``docs/qwen36_usage.md``
+        §"Cold-start vs warm-state" for the magnitude).
+        """
+        for attr in (
+                '_captured_graphs',
+                '_captured_verify_graphs',
+                '_captured_mtp_graphs',
+                '_captured_chain_graphs',
+                '_captured_graphs_tq',
+                '_captured_verify_graphs_dflash',
+                '_captured_drafter_graphs_dflash',
+        ):
+            cache = getattr(self, attr, None)
+            if cache:
+                cache.clear()
+
     def _ensure_graph_for_pos(self, cur_pos: int):
         """Lazy-capture a CUDA Graph for forward_own_decode at cur_pos.
 
@@ -4415,7 +4521,7 @@ class Qwen36TorchFrontendRtx:
         """
         import torch
 
-        g = self._captured_graphs.get(cur_pos)
+        g = self._graph_cache_get(self._captured_graphs, cur_pos)
         if g is not None:
             return g
 
@@ -4448,7 +4554,9 @@ class Qwen36TorchFrontendRtx:
         # synchronously; we are already on gs so the ``stream=gs`` arg
         # is consistent.
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_own_decode(
                 self._static_token_id, cos, sin, cur_pos,
             )
@@ -4457,7 +4565,7 @@ class Qwen36TorchFrontendRtx:
         with torch.no_grad():
             _restore_on_gs()
 
-        self._captured_graphs[cur_pos] = g
+        self._graph_cache_put(self._captured_graphs, cur_pos, g)
         return g
 
     def _ensure_mtp_graph(self, mtp_pos: int):
@@ -4476,7 +4584,7 @@ class Qwen36TorchFrontendRtx:
         """
         import torch
 
-        g = self._captured_mtp_graphs.get(mtp_pos)
+        g = self._graph_cache_get(self._captured_mtp_graphs, mtp_pos)
         if g is not None:
             return g
 
@@ -4503,7 +4611,9 @@ class Qwen36TorchFrontendRtx:
 
         gs.synchronize()
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_mtp_head(
                 self._mtp_static_prev_h,
                 self._mtp_static_prev_token,
@@ -4514,7 +4624,7 @@ class Qwen36TorchFrontendRtx:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
 
-        self._captured_mtp_graphs[mtp_pos] = g
+        self._graph_cache_put(self._captured_mtp_graphs, mtp_pos, g)
         return g
 
     def _ensure_verify_graph(self, cur_pos: int, K: int):
@@ -4537,7 +4647,7 @@ class Qwen36TorchFrontendRtx:
         import torch
 
         key = (cur_pos, K)
-        g = self._captured_verify_graphs.get(key)
+        g = self._graph_cache_get(self._captured_verify_graphs, key)
         if g is not None:
             return g
 
@@ -4569,7 +4679,9 @@ class Qwen36TorchFrontendRtx:
 
         gs.synchronize()
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_own_decode_K(
                 tokens_K, cos_K, sin_K, cur_pos, K=K)
         with torch.cuda.stream(gs), torch.no_grad():
@@ -4577,7 +4689,7 @@ class Qwen36TorchFrontendRtx:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
 
-        self._captured_verify_graphs[key] = g
+        self._graph_cache_put(self._captured_verify_graphs, key, g)
         return g
 
     def generate_own(self, input_ids, *, max_new_tokens: int,
@@ -5223,7 +5335,7 @@ class Qwen36TorchFrontendRtx:
         """
         import torch
 
-        g = self._captured_graphs.get(cur_pos)
+        g = self._graph_cache_get(self._captured_graphs, cur_pos)
         if g is not None:
             return g
 
@@ -5252,14 +5364,16 @@ class Qwen36TorchFrontendRtx:
             _restore_on_gs()
 
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_own_decode_nvfp4(
                 self._static_token_id, cos, sin, cur_pos,
             )
         with torch.no_grad():
             _restore_on_gs()
 
-        self._captured_graphs[cur_pos] = g
+        self._graph_cache_put(self._captured_graphs, cur_pos, g)
         return g
 
     # ---------- Stage 7 G1: NVFP4 verify-forward graph capture ----------
@@ -5283,7 +5397,7 @@ class Qwen36TorchFrontendRtx:
         import torch
 
         key = (cur_pos, K)
-        g = self._captured_verify_graphs.get(key)
+        g = self._graph_cache_get(self._captured_verify_graphs, key)
         if g is not None:
             return g
 
@@ -5314,7 +5428,9 @@ class Qwen36TorchFrontendRtx:
 
         gs.synchronize()
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_own_decode_K_nvfp4(
                 tokens_K, cos_K, sin_K, cur_pos, K=K)
         with torch.cuda.stream(gs), torch.no_grad():
@@ -5322,7 +5438,7 @@ class Qwen36TorchFrontendRtx:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
 
-        self._captured_verify_graphs[key] = g
+        self._graph_cache_put(self._captured_verify_graphs, key, g)
         return g
 
     # ---------- Stage 7 G2: NVFP4 MTP chain graph capture ----------
@@ -5340,7 +5456,7 @@ class Qwen36TorchFrontendRtx:
         """
         import torch
 
-        g = self._captured_mtp_graphs.get(mtp_pos)
+        g = self._graph_cache_get(self._captured_mtp_graphs, mtp_pos)
         if g is not None:
             return g
 
@@ -5364,7 +5480,9 @@ class Qwen36TorchFrontendRtx:
 
         gs.synchronize()
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_mtp_head_nvfp4(
                 self._mtp_static_prev_h,
                 self._mtp_static_prev_token,
@@ -5374,7 +5492,7 @@ class Qwen36TorchFrontendRtx:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
 
-        self._captured_mtp_graphs[mtp_pos] = g
+        self._graph_cache_put(self._captured_mtp_graphs, mtp_pos, g)
         return g
 
     # ---------- G9: NVFP4 MTP CHAIN graph (K steps in one graph) ------
@@ -5404,7 +5522,7 @@ class Qwen36TorchFrontendRtx:
         import torch
 
         key = (base_pos, K)
-        g = self._captured_chain_graphs.get(key)
+        g = self._graph_cache_get(self._captured_chain_graphs, key)
         if g is not None:
             return g
 
@@ -5442,14 +5560,16 @@ class Qwen36TorchFrontendRtx:
 
         gs.synchronize()
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             _run_chain()
         with torch.cuda.stream(gs), torch.no_grad():
             _restore()
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
 
-        self._captured_chain_graphs[key] = g
+        self._graph_cache_put(self._captured_chain_graphs, key, g)
         return g
 
     # ==================================================================
@@ -6085,8 +6205,10 @@ class Qwen36TorchFrontendRtx:
         import torch
 
         if not hasattr(self, '_captured_graphs_tq'):
-            self._captured_graphs_tq: dict[int, torch.cuda.CUDAGraph] = {}
-        g = self._captured_graphs_tq.get(cur_pos)
+            self._captured_graphs_tq: collections.OrderedDict[
+                int, torch.cuda.CUDAGraph,
+            ] = collections.OrderedDict()
+        g = self._graph_cache_get(self._captured_graphs_tq, cur_pos)
         if g is not None:
             return g
 
@@ -6119,14 +6241,16 @@ class Qwen36TorchFrontendRtx:
             _restore_on_gs()
 
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_own_decode_nvfp4_tq(
                 self._static_token_id, cos, sin, cur_pos,
             )
         with torch.no_grad():
             _restore_on_gs()
 
-        self._captured_graphs_tq[cur_pos] = g
+        self._graph_cache_put(self._captured_graphs_tq, cur_pos, g)
         return g
 
     def forward_own_decode_nvfp4_tq_captured(
@@ -6276,14 +6400,16 @@ class Qwen36TorchFrontendRtx:
         # forward. Distinct from the no-tap graph cache so we never
         # replay a tap-writing graph against a None tap_buf.
         if not hasattr(self, '_captured_verify_graphs_dflash'):
-            self._captured_verify_graphs_dflash: dict[
-                tuple[int, int], torch.cuda.CUDAGraph] = {}
+            self._captured_verify_graphs_dflash: collections.OrderedDict[
+                tuple[int, int], torch.cuda.CUDAGraph,
+            ] = collections.OrderedDict()
         # P7: per-eff_ctx drafter forward graph cache. Each eff_ctx
         # value gets its own graph because shapes (target_feat_window
         # rows, kv_seq) are baked in.
         if not hasattr(self, '_captured_drafter_graphs_dflash'):
-            self._captured_drafter_graphs_dflash: dict[
-                int, torch.cuda.CUDAGraph] = {}
+            self._captured_drafter_graphs_dflash: collections.OrderedDict[
+                int, torch.cuda.CUDAGraph,
+            ] = collections.OrderedDict()
 
     def _ensure_drafter_graph_dflash_nvfp4(self, eff_ctx: int):
         """P7: Lazy CUDA Graph capture for the entire drafter forward.
@@ -6300,7 +6426,8 @@ class Qwen36TorchFrontendRtx:
             dflash_drafter_forward_capture,
         )
 
-        g = self._captured_drafter_graphs_dflash.get(eff_ctx)
+        g = self._graph_cache_get(
+            self._captured_drafter_graphs_dflash, eff_ctx)
         if g is not None:
             return g
 
@@ -6321,14 +6448,17 @@ class Qwen36TorchFrontendRtx:
         gs.synchronize()
 
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             dflash_drafter_forward_capture(self)
         with torch.cuda.stream(gs), torch.no_grad():
             _restore()
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
 
-        self._captured_drafter_graphs_dflash[eff_ctx] = g
+        self._graph_cache_put(
+            self._captured_drafter_graphs_dflash, eff_ctx, g)
         return g
 
     def _ensure_verify_graph_dflash_nvfp4(self, cur_pos: int, K: int):
@@ -6345,7 +6475,8 @@ class Qwen36TorchFrontendRtx:
         import torch
 
         key = (cur_pos, K)
-        g = self._captured_verify_graphs_dflash.get(key)
+        g = self._graph_cache_get(
+            self._captured_verify_graphs_dflash, key)
         if g is not None:
             return g
 
@@ -6378,7 +6509,9 @@ class Qwen36TorchFrontendRtx:
 
         gs.synchronize()
         g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
             self.forward_own_decode_K_nvfp4(
                 tokens_K, cos_K, sin_K, cur_pos, K=K,
                 tap_buf=tap_buf)
@@ -6387,7 +6520,8 @@ class Qwen36TorchFrontendRtx:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
 
-        self._captured_verify_graphs_dflash[key] = g
+        self._graph_cache_put(
+            self._captured_verify_graphs_dflash, key, g)
         return g
 
     def generate_own_speculative_DFlash_nvfp4(

--- a/tests/test_qwen36_nvfp4_graph_cache_bound.py
+++ b/tests/test_qwen36_nvfp4_graph_cache_bound.py
@@ -1,0 +1,295 @@
+"""Regression test for issue: NVFP4 OpenAI server VRAM grows unbounded.
+
+Symptom (reported on a 32 GB RTX 5090): after a handful of chat
+requests with varied prompt lengths, ``torch.cuda.CUDAGraph().capture_end()``
+raised ``cudaErrorMemoryAllocation``. Root cause: the per-``cur_pos``
+graph cache (``_captured_graphs`` / ``_captured_verify_graphs`` /
+``_captured_chain_graphs`` / ``_captured_mtp_graphs``) grew without
+bound, and each captured graph held its own private CUDA mempool.
+
+This test exercises the spec-decode path with diverse short prompts —
+the same shape mix that triggered the production OOM — and asserts:
+
+  1. ``_used_vram_bytes()`` plateaus instead of growing
+     linearly with the number of distinct (prompt_len, max_new_tokens)
+     shapes seen.
+  2. The combined size of all per-position graph caches stays bounded
+     (the LRU cap is honored).
+
+The test deliberately runs in a single process so the steady-state
+memory after warmup is measured, not first-call capture cost.
+
+Skipped if the NVFP4 + MTP checkpoints are not present.
+
+Run:
+    PYTHONPATH=. python -m pytest \
+        tests/test_qwen36_nvfp4_graph_cache_bound.py -v -s
+"""
+from __future__ import annotations
+
+import gc
+import os
+
+import pytest
+
+CKPT_NVFP4 = os.environ.get('FLASHRT_QWEN36_NVFP4_CKPT_DIR', '')
+CKPT_MTP = os.environ.get('FLASHRT_QWEN36_MTP_CKPT_DIR', '')
+
+
+def _have_ckpts() -> bool:
+    if not CKPT_NVFP4 or not os.path.isdir(CKPT_NVFP4):
+        return False
+    if not CKPT_MTP or not os.path.isfile(
+            os.path.join(CKPT_MTP, 'mtp.safetensors')):
+        return False
+    try:
+        import torch
+    except ImportError:
+        return False
+    return torch.cuda.is_available()
+
+
+pytestmark = pytest.mark.skipif(
+    not _have_ckpts(),
+    reason=(
+        'Needs NVFP4 + MTP checkpoints + CUDA. Set '
+        'FLASHRT_QWEN36_NVFP4_CKPT_DIR / FLASHRT_QWEN36_MTP_CKPT_DIR '
+        'to override.'
+    ),
+)
+
+
+# Mix of short prompts at different lengths — mirrors the real-traffic
+# pattern from the bug report (prompt_len ∈ {11, 12, 23, 30, 35} ...).
+# Distinct prompt_len count drives distinct cur_pos values seen.
+PROMPT_TEMPLATES = [
+    'Hi.',
+    'Hello there!',
+    'What is 2+2?',
+    'Explain quantum entanglement briefly.',
+    'Write a haiku about autumn leaves falling.',
+    'List three primes greater than 100 and explain why.',
+    'Summarize the plot of Hamlet in two short sentences please.',
+    'Translate to French: The quick brown fox jumps over the lazy dog.',
+]
+
+
+def _bytes_to_mb(n: int) -> float:
+    return n / (1024 * 1024)
+
+
+def _used_vram_bytes() -> int:
+    """Return driver-reported used VRAM (total - free).
+
+    ``_used_vram_bytes()`` only covers PyTorch's caching
+    allocator; captured CUDA Graphs hold their own (per-graph private
+    or shared) mempool that the caching allocator does not see. The
+    leak is in *that* pool, so the test must read the driver counter.
+    """
+    import torch
+
+    free, total = torch.cuda.mem_get_info()
+    return total - free
+
+
+@pytest.fixture(scope='module')
+def fe():
+    """Load the NVFP4 frontend once for the whole module."""
+    import torch
+
+    os.environ.setdefault('FLASHRT_QWEN36_MTP_CKPT_DIR', CKPT_MTP)
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    fe = Qwen36TorchFrontendRtx(CKPT_NVFP4, quant='nvfp4', max_seq=2048)
+    yield fe
+    del fe
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+def _total_captured_graph_count(fe) -> int:
+    n = 0
+    for attr in (
+        '_captured_graphs',
+        '_captured_verify_graphs',
+        '_captured_mtp_graphs',
+        '_captured_chain_graphs',
+    ):
+        n += len(getattr(fe, attr, {}) or {})
+    return n
+
+
+def test_graph_cache_bounded_under_varied_prompts(fe):
+    """Assert VRAM and graph count plateau under repeated traffic.
+
+    Drives the spec path with the same set of varied short prompts
+    repeatedly; after an initial growth phase, both VRAM and the
+    captured-graph count must stop growing — i.e., the LRU works and
+    the shared mempool keeps per-graph footprint small.
+    """
+    import torch
+
+    fe.reset_state()
+    fe.reset_mtp_state()
+
+    # Tokenize a fixed pool of prompts (ascending prompt_len).
+    pools = []
+    for text in PROMPT_TEMPLATES:
+        ids = fe._tokenizer(text, return_tensors='pt').input_ids.cuda()
+        pools.append((int(ids.shape[1]), ids))
+    pools.sort(key=lambda x: x[0])
+
+    # Warmup pass — first time through each prompt pays capture cost.
+    for plen, ids in pools:
+        fe.reset_state()
+        fe.reset_mtp_state()
+        _ = fe.generate_own_speculative_KN_nvfp4(
+            ids, max_new_tokens=64, K=6,
+        )
+    torch.cuda.synchronize()
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+
+    base_alloc = _used_vram_bytes()
+    base_graphs = _total_captured_graph_count(fe)
+    print(
+        f'\n[soak] post-warmup baseline: '
+        f'mem={_bytes_to_mb(base_alloc):.1f} MB, '
+        f'graphs={base_graphs}'
+    )
+
+    # Steady-state pass — same prompt shapes repeated. Should not grow.
+    samples_alloc = []
+    samples_graphs = []
+    for cycle in range(6):
+        for plen, ids in pools:
+            fe.reset_state()
+            fe.reset_mtp_state()
+            _ = fe.generate_own_speculative_KN_nvfp4(
+                ids, max_new_tokens=64, K=6,
+            )
+        torch.cuda.synchronize()
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        samples_alloc.append(_used_vram_bytes())
+        samples_graphs.append(_total_captured_graph_count(fe))
+        print(
+            f'[soak] cycle {cycle}: '
+            f'mem={_bytes_to_mb(samples_alloc[-1]):.1f} MB '
+            f'(Δ={_bytes_to_mb(samples_alloc[-1] - base_alloc):+.1f} MB), '
+            f'graphs={samples_graphs[-1]}'
+        )
+
+    # Steady-state assertion: total drift across all 6 cycles must be
+    # under 200 MB. Pre-fix this drifts unbounded (the OOM source).
+    final = samples_alloc[-1]
+    drift = final - base_alloc
+    assert drift < 200 * 1024 * 1024, (
+        f'memory drifted {_bytes_to_mb(drift):.1f} MB across 6 '
+        f'steady-state cycles — graph cache is leaking'
+    )
+
+    # Cap assertion: graph count must stop growing across cycles.
+    # (Same prompt shapes → no new cur_pos → cache count constant.)
+    assert samples_graphs[-1] == samples_graphs[0], (
+        f'captured-graph count grew across steady-state cycles: '
+        f'{samples_graphs[0]} → {samples_graphs[-1]}'
+    )
+
+
+def test_graph_cache_lru_cap_under_unique_shapes(fe):
+    """Assert the LRU cap holds when many distinct shapes are seen.
+
+    Drives the spec path with many distinct prompt lengths so the set
+    of cur_pos values seen exceeds the LRU cap. The cache must cap,
+    not grow without bound; VRAM must plateau after the cap is full.
+    """
+    import torch
+
+    fe.reset_state()
+    fe.reset_mtp_state()
+
+    # Force a small cap on this instance so the test can exercise
+    # eviction in a reasonable wall time. The production default
+    # (256) would need 500+ generations to cross, taking 25+ min.
+    fe.GRAPH_CACHE_MAX = 32
+    fe.clear_graphs()
+
+    # Build a large set of unique prompt_len values by padding a base
+    # prompt with extra tokens. The tokenizer's pad token is fine —
+    # only the length matters for graph capture.
+    pad = fe._tokenizer.pad_token_id or 0
+    base_ids = fe._tokenizer(
+        'Tell me a short story.',
+        return_tensors='pt',
+    ).input_ids.cuda()
+    base_len = int(base_ids.shape[1])
+
+    cap = fe.GRAPH_CACHE_MAX
+
+    # Generate 2× the cap worth of distinct prompt lengths to force
+    # eviction. Cap each generation small so total wall time stays
+    # tractable in CI.
+    n_distinct = cap * 2
+    print(
+        f'\n[lru] driving {n_distinct} distinct prompt_len values '
+        f'(cap={cap})'
+    )
+
+    base_alloc = None
+    for i in range(n_distinct):
+        target_len = base_len + (i % 200)  # 0..199 extra pad tokens
+        if target_len > base_len:
+            extra = torch.full(
+                (1, target_len - base_len), pad,
+                device='cuda', dtype=torch.long,
+            )
+            ids = torch.cat([base_ids, extra], dim=1)
+        else:
+            ids = base_ids
+        fe.reset_state()
+        fe.reset_mtp_state()
+        _ = fe.generate_own_speculative_KN_nvfp4(
+            ids, max_new_tokens=16, K=6,
+        )
+        if i == cap:
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
+            base_alloc = _used_vram_bytes()
+            print(
+                f'[lru] post-cap-fill: '
+                f'mem={_bytes_to_mb(base_alloc):.1f} MB, '
+                f'graphs={_total_captured_graph_count(fe)}'
+            )
+
+    torch.cuda.synchronize()
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    final_alloc = _used_vram_bytes()
+    final_graphs = _total_captured_graph_count(fe)
+    print(
+        f'[lru] final: mem={_bytes_to_mb(final_alloc):.1f} MB, '
+        f'graphs={final_graphs}'
+    )
+
+    # Cache must not exceed cap on a per-cache basis. There are 4
+    # NVFP4 caches that can hold entries (decode / verify / mtp /
+    # chain), so total ≤ cap × 4 + small slack for startup buckets.
+    assert final_graphs <= cap * 4 + 16, (
+        f'captured-graph count {final_graphs} exceeds cap*4+16 '
+        f'({cap * 4 + 16})'
+    )
+
+    # Memory drift after the cap was full should be near zero — LRU
+    # eviction reclaims one graph per insertion.
+    if base_alloc is not None:
+        drift = final_alloc - base_alloc
+        assert drift < 500 * 1024 * 1024, (
+            f'memory drifted {_bytes_to_mb(drift):.1f} MB after '
+            f'the cap was reached — eviction is not freeing memory'
+        )


### PR DESCRIPTION
Reported on a 32 GB RTX 5090: after a handful of /v1/chat/completions requests with varied prompt lengths, the OpenAI server example died with cudaErrorMemoryAllocation inside torch.cuda.CUDAGraph.capture_end. VRAM grew on every request until the device was full.

Root cause was structural, not a real leak. The Qwen3.6 NVFP4 spec path lazily captures one CUDA Graph per cur_pos value (and one per (cur_pos, K) for the verify / chain forwards), keyed into four unbounded dicts (_captured_graphs, _captured_verify_graphs, _captured_mtp_graphs, _captured_chain_graphs). FA2 bakes kv_seq=cur_pos+1 and the cos/sin slice address into the captured kernel call list, so each cur_pos genuinely needs its own graph — that part is correct. The two leaks on top of it were:

  1. Each torch.cuda.graph(g, stream=gs) was called WITHOUT pool=, so every captured graph claimed its own private CUDA mempool for the workspace it allocated during warmup+capture. With N captured graphs the per-graph workspace overhead was paid N times instead of once.
  2. The dicts were never bounded. A traffic mix of N distinct short prompt lengths would, after warmup, populate every cur_pos in [min_prompt_len, max_prompt_len + max_new_tokens] and then keep adding new positions forever as users sent new shapes — driving the device OOM in finite time.

The default --warmup of "32:128,128:256" hid this in the demo runs because (a) those two shapes covered the cur_pos range each demo exercised, and (b) the smoke tests ran in a single process and exited before the cache reached the 32 GB ceiling. Real traffic with prompt_len < 32 (the bug report had prompts at 11/12/23/30/35 tokens) misses both warmup buckets, so every short prompt captures a fresh batch of graphs at low cur_pos values.

Fix
---

flash_rt/frontends/torch/qwen36_rtx.py

  * New per-instance shared mempool: self._graph_mempool = torch.cuda.graph_pool_handle(), allocated once in both __init__ paths (FP8 + NVFP4). Threaded as pool=self._graph_mempool into every torch.cuda.graph(g, stream=gs) call site (10 total across the FP8 / NVFP4 / TQ / DFlash paths). All captured graphs in one frontend instance now share the workspace pool.

  * Cache bookkeeping moved off raw dicts onto OrderedDicts plus two helpers, _graph_cache_get / _graph_cache_put, that:
      - touch (move_to_end) on hit, so the LRU recency is the replay order; cur_pos values that the spec loop is actively sweeping stay resident, cold positions get evicted first;
      - evict popitem(last=False) past a class-level cap (GRAPH_CACHE_MAX, default 256, override via env FLASHRT_QWEN36_GRAPH_CACHE_MAX, set to 0 for legacy unbounded behaviour). Eviction reclaims the evicted graph's slice of the shared mempool as soon as the Python object is GC'd; combined with the shared pool this is what actually caps VRAM.

  * Public clear_graphs() that flushes all four NVFP4 caches plus the FP8 / TQ / DFlash variants. Long-running deployments can call it on phase changes (e.g. before loading a second model on the same GPU).

  * The _shrink_bf16_kv_cache existing manual .clear() of the cur_pos-specific caches is unaffected (OrderedDict.clear() works the same).

examples/qwen36_openai_server.py

  * Default --warmup changed from "32:128,128:256" to "8:512". The new default pre-captures cur_pos in [8, 520] in one synthetic generation, covering the common short-chat range that the prior default missed. Help text and module docstring updated to explain the trade-off.

tests/test_qwen36_nvfp4_graph_cache_bound.py

  * New regression test with two cases: - test_graph_cache_bounded_under_varied_prompts: drives the spec path with 8 varied short prompts repeatedly, asserts VRAM and graph count both plateau across 6 cycles. This already passed pre-fix at steady-state — the assertion is the safety net so a future change that breaks idempotency is caught. - test_graph_cache_lru_cap_under_unique_shapes: forces a small per-instance cap (32) and drives 64 distinct prompt lengths, asserts total captured graphs <= cap*4+slack and that VRAM stops growing once the cap is full. Pre-fix this OOMs the device; post-fix it runs in ~4 min and ends with graphs=96, VRAM steady.

Verification on RTX 5090 / 32 GB:
  * Both new tests pass (251 s combined).
  * Single-prompt warm decode: 11-token prompt × 128 new tokens at K=6 → 103 tok/s, inside the documented 90-130 tok/s range.
  * tests/test_install_smoke.py still passes.
  * Long-context single-token TQ path is structurally untouched (only adds shared pool + OrderedDict-vs-dict for the cache type; no semantic change to capture / replay).

No version bump; behaviour change is transparent for any caller that was already capping cur_pos by construction (FLASHRT_QWEN36_GRAPH_CACHE_MAX=0 restores the old unbounded dict).