### PR TITLE
Fix: ctypes 64-bit truncation on L40 (sm_89) + FP8 parameter support

### DIFF
--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -179,7 +179,8 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                fp4_layers=None,
                use_awq=None,
                awq_alpha=0.5,
-               use_p1_split_gu=None):
+               use_p1_split_gu=None,
+               use_fp8=True):
     """Load a FlashRT model.
 
     Args:
@@ -234,6 +235,9 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         fp4_layers: Tuple of encoder layer indices to FP4-quantize (only
             applies when use_fp4=True). Default (7, 8, 9) = middle FFN
             subset, LIBERO-validated. Other subsets untested at task level.
+        use_fp8: Enable FP8 execution where the selected frontend supports
+            an FP8/BF16 switch. Defaults to True to preserve existing
+            performance-oriented behavior.
 
     Returns:
         VLAModel instance with .predict() method.
@@ -325,9 +329,13 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                     framework, sorted(fp4_layers))
 
     # Build the kwarg set per-model so we only pass args the target class
-    # actually accepts. Keeps the dispatch table simple and avoids fragile
-    # introspection while still letting users specify groot/pi0fast knobs.
+    # actually accepts. Keeps the dispatch table simple while still letting
+    # users specify groot/pi0fast knobs.
+    import inspect
+    sig = inspect.signature(pipe_cls)
     kwargs: dict = {"num_views": num_views}
+    if "use_fp8" in sig.parameters:
+        kwargs["use_fp8"] = use_fp8
     if config == "pi0fast":
         kwargs.update(
             autotune=autotune,
@@ -339,8 +347,6 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         # rtx-side GROOT accepts embodiment_tag + action_horizon; Thor-side
         # GROOT accepts embodiment_tag + autotune. Feature-detect via the
         # concrete class signature so one call site works for both.
-        import inspect
-        sig = inspect.signature(pipe_cls)
         if "autotune" in sig.parameters:
             kwargs["autotune"] = autotune
         if "embodiment_tag" in sig.parameters and embodiment_tag is not None:
@@ -350,8 +356,6 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
     else:
         # pi05, pi0 — both Thor and rtx variants take (checkpoint, num_views, autotune)
         # or (checkpoint, num_views). Feature-detect.
-        import inspect
-        sig = inspect.signature(pipe_cls)
         if "autotune" in sig.parameters:
             kwargs["autotune"] = autotune
         if "weight_cache" in sig.parameters:

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -179,7 +179,8 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                fp4_layers=None,
                use_awq=None,
                awq_alpha=0.5,
-               use_p1_split_gu=None):
+               use_p1_split_gu=None,
+               use_fp8=True):
     """Load a FlashRT model.
 
     Args:
@@ -327,7 +328,7 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
     # Build the kwarg set per-model so we only pass args the target class
     # actually accepts. Keeps the dispatch table simple and avoids fragile
     # introspection while still letting users specify groot/pi0fast knobs.
-    kwargs: dict = {"num_views": num_views}
+    kwargs: dict = {"num_views": num_views, "use_fp8": use_fp8}
     if config == "pi0fast":
         kwargs.update(
             autotune=autotune,

--- a/flash_rt/core/cuda_buffer.py
+++ b/flash_rt/core/cuda_buffer.py
@@ -9,6 +9,43 @@ logger = logging.getLogger(__name__)
 _cudart = ctypes.CDLL("libcudart.so")
 
 
+def _configure_cudart_signatures() -> None:
+    """Declare ctypes signatures for CUDA runtime calls used here."""
+    ptr_p = ctypes.POINTER(ctypes.c_void_p)
+    signatures = {
+        "cudaMallocManaged": (
+            [ptr_p, ctypes.c_size_t, ctypes.c_uint], ctypes.c_int),
+        "cudaMalloc": ([ptr_p, ctypes.c_size_t], ctypes.c_int),
+        "cudaFree": ([ctypes.c_void_p], ctypes.c_int),
+        "cudaMemcpy": (
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+             ctypes.c_int],
+            ctypes.c_int,
+        ),
+        "cudaMemcpyAsync": (
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+             ctypes.c_int, ctypes.c_void_p],
+            ctypes.c_int,
+        ),
+        "cudaMemset": (
+            [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t], ctypes.c_int),
+        "cudaMemsetAsync": (
+            [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t,
+             ctypes.c_void_p],
+            ctypes.c_int,
+        ),
+        "cudaDeviceSynchronize": ([], ctypes.c_int),
+        "cudaStreamSynchronize": ([ctypes.c_void_p], ctypes.c_int),
+    }
+    for name, (argtypes, restype) in signatures.items():
+        fn = getattr(_cudart, name)
+        fn.argtypes = argtypes
+        fn.restype = restype
+
+
+_configure_cudart_signatures()
+
+
 def _check(ret, msg=""):
     if ret != 0:
         raise RuntimeError(f"CUDA error {ret}: {msg}")

--- a/flash_rt/core/cuda_buffer.py
+++ b/flash_rt/core/cuda_buffer.py
@@ -8,6 +8,9 @@ logger = logging.getLogger(__name__)
 
 _cudart = ctypes.CDLL("libcudart.so")
 
+_cudart.cudaMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p]
+_cudart.cudaMemcpyAsync.restype = ctypes.c_int
+
 
 def _check(ret, msg=""):
     if ret != 0:

--- a/flash_rt/frontends/jax/pi05_rtx.py
+++ b/flash_rt/frontends/jax/pi05_rtx.py
@@ -440,6 +440,7 @@ class Pi05JaxFrontendRtx(Pi05TorchFrontendRtx):
         num_views: int = 2,
         chunk_size: int = CHUNK_SIZE,
         max_prompt_len: int = MAX_PROMPT_LEN_DEFAULT,
+        use_fp8: bool = True,
     ):
         # Don't chain to Pi05TorchFrontendRtx.__init__ — it expects a safetensors
         # file. We replicate the body and swap the loader.
@@ -447,6 +448,7 @@ class Pi05JaxFrontendRtx(Pi05TorchFrontendRtx):
         self.num_views = int(num_views)
         self.chunk_size = int(chunk_size)
         self.max_prompt_len = int(max_prompt_len)
+        self.use_fp8 = bool(use_fp8)
 
         self.latency_records: list[float] = []
         self.calibrated = False
@@ -492,7 +494,8 @@ class Pi05JaxFrontendRtx(Pi05TorchFrontendRtx):
         # ── FP8 quantize large GEMM weights (shared method) ──
         self._fp8_weights: dict = {}
         self._fp8_store: list = []
-        self._quantize_all_fp8()
+        if self.use_fp8:
+            self._quantize_all_fp8()
 
         # ── Pre-compute decoder styles (shared helper) ──
         from flash_rt.frontends.torch.pi05_rtx import _precompute_decoder_styles
@@ -503,7 +506,6 @@ class Pi05JaxFrontendRtx(Pi05TorchFrontendRtx):
         # ── Attention backend, fvk, GemmRunner, reusable buffers ──
         from flash_rt.hardware.rtx.attn_backend import RtxFlashAttnBackend
         from flash_rt import flash_rt_kernels as fvk
-        import ctypes
 
         enc_seq_max = self.num_views * 256 + self.max_prompt_len
         self.attn_backend = RtxFlashAttnBackend(
@@ -525,7 +527,8 @@ class Pi05JaxFrontendRtx(Pi05TorchFrontendRtx):
         self._noise_out = torch.empty(
             self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda"
         )
-        self._cudart = ctypes.CDLL("libcudart.so")
+        from flash_rt.core.cuda_buffer import _cudart
+        self._cudart = _cudart
 
         logger.info(
             "Pi05JaxFrontendRtx initialised (num_views=%d, chunk=%d)",

--- a/flash_rt/frontends/jax/pi05_thor.py
+++ b/flash_rt/frontends/jax/pi05_thor.py
@@ -62,7 +62,7 @@ class Pi05JaxFrontendThor:
 
     def __init__(self, checkpoint_dir, engine_path=None, fmha_path=None,
                  use_cuda_graph=True, num_views=2, autotune=3,
-                 weight_cache=True, **kwargs):
+                 weight_cache=True, use_fp8=True, **kwargs):
         """
         Args:
             autotune: CUDA Graph autotune trials per set_prompt().
@@ -78,6 +78,7 @@ class Pi05JaxFrontendThor:
         self._sync = sync
 
         checkpoint_dir = pathlib.Path(checkpoint_dir)
+        self.use_fp8 = bool(use_fp8)
 
         # ── Load norm stats (openpi or lerobot HF release) ──
         from flash_rt.core.utils.norm_stats import (

--- a/flash_rt/frontends/jax/pi05_thor_fp4.py
+++ b/flash_rt/frontends/jax/pi05_thor_fp4.py
@@ -79,6 +79,7 @@ class Pi05JaxFrontendThorFP4(Pi05JaxFrontendThor):
         awq_alpha: float = 0.5,
         awq_calib_iters: int = 8,
         use_p1_split_gu: bool = False,
+        use_fp8: bool = True,
         **kwargs,
     ):
         # Set FP4 state BEFORE super().__init__ because the base class
@@ -118,6 +119,7 @@ class Pi05JaxFrontendThorFP4(Pi05JaxFrontendThor):
             num_views=num_views,
             autotune=autotune,
             weight_cache=weight_cache,
+            use_fp8=use_fp8,
             **kwargs,
         )
 

--- a/flash_rt/frontends/jax/pi0_thor.py
+++ b/flash_rt/frontends/jax/pi0_thor.py
@@ -66,11 +66,12 @@ class Pi0JaxFrontendThor:
 
     def __init__(self, checkpoint_dir, engine_path=None, fmha_path=None,
                  use_cuda_graph=True, num_views=2, autotune=3,
-                 weight_cache=True, **kwargs):
+                 weight_cache=True, use_fp8=True, **kwargs):
         from flash_rt.core.cuda_buffer import CudaBuffer, sync
         from flash_rt.core.weights.transformer import quantize_fp8_e4m3, compute_time_embeddings
         self._CudaBuffer = CudaBuffer
         self._sync = sync
+        self.use_fp8 = bool(use_fp8)
 
         checkpoint_dir = pathlib.Path(checkpoint_dir)
 

--- a/flash_rt/frontends/jax/pi0fast.py
+++ b/flash_rt/frontends/jax/pi0fast.py
@@ -79,10 +79,12 @@ class Pi0FastJaxFrontend:
                  use_cuda_graph: bool = True, autotune: int = 3,
                  max_decode_steps: int = 256,
                  decode_cuda_graph: bool = False,
-                 decode_graph_steps: int = 80):
+                 decode_graph_steps: int = 80,
+                 use_fp8: bool = True):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.num_views = num_views
         self.use_cuda_graph = use_cuda_graph
+        self.use_fp8 = bool(use_fp8)
         self.autotune = int(autotune) if autotune is not True else 3
         if autotune is False:
             self.autotune = 0

--- a/flash_rt/frontends/torch/groot_rtx.py
+++ b/flash_rt/frontends/torch/groot_rtx.py
@@ -511,6 +511,7 @@ class GrootTorchFrontendRtx:
         num_views: int = 2,
         embodiment_tag: str = "new_embodiment",
         action_horizon: int = ACTION_HORIZON_MAX,
+        use_fp8: bool = True,
     ):
         if not (1 <= int(action_horizon) <= ACTION_HORIZON_MAX):
             raise ValueError(
@@ -523,6 +524,7 @@ class GrootTorchFrontendRtx:
                 f"Trained in GR00T-N1.6-3B: {PUBLIC_TRAINED_TAGS}.")
         self._checkpoint_dir = pathlib.Path(checkpoint_dir)
         self._num_views = int(num_views)
+        self.use_fp8 = bool(use_fp8)
         self._embodiment_tag = embodiment_tag
         self._embodiment_id = EMBODIMENT_TAG_TO_INDEX[embodiment_tag]
         self._calibrated = False

--- a/flash_rt/frontends/torch/groot_thor.py
+++ b/flash_rt/frontends/torch/groot_thor.py
@@ -80,7 +80,7 @@ class GrootTorchFrontendThor:
     """GROOT N1.6 inference pipeline on Thor SM110."""
 
     def __init__(self, checkpoint, num_views=2, autotune=3,
-                 embodiment_tag="new_embodiment"):
+                 embodiment_tag="new_embodiment", use_fp8=True):
         """Initialize GROOT pipeline.
 
         Args:
@@ -97,6 +97,7 @@ class GrootTorchFrontendThor:
         self._checkpoint_path = pathlib.Path(checkpoint)
         self._num_views = num_views
         self._autotune = autotune
+        self.use_fp8 = bool(use_fp8)
         self._embodiment_tag = embodiment_tag
         self._embodiment_id = EMBODIMENT_TAG_TO_INDEX[embodiment_tag]
         self._real_data_calibrated = False

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -422,11 +422,13 @@ class Pi05TorchFrontendRtx:
                  checkpoint_dir: Union[str, pathlib.Path],
                  num_views: int = 2,
                  chunk_size: int = CHUNK_SIZE,
-                 max_prompt_len: int = MAX_PROMPT_LEN_DEFAULT):
+                 max_prompt_len: int = MAX_PROMPT_LEN_DEFAULT,
+                 use_fp8: bool = True):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.num_views = int(num_views)
         self.chunk_size = int(chunk_size)
         self.max_prompt_len = int(max_prompt_len)
+        self.use_fp8 = bool(use_fp8)
 
         self.latency_records: list[float] = []
         self.calibrated = False
@@ -472,7 +474,8 @@ class Pi05TorchFrontendRtx:
         # ── FP8 quantize large GEMM weights ──
         self._fp8_weights: dict = {}
         self._fp8_store: list = []  # holds tensors alive
-        self._quantize_all_fp8()
+        if self.use_fp8:
+            self._quantize_all_fp8()
 
         # ── Pre-compute decoder styles (time MLP + style modulation) ──
         self._precomputed_styles = _precompute_decoder_styles(
@@ -498,7 +501,8 @@ class Pi05TorchFrontendRtx:
             self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
         self._noise_out = torch.empty(
             self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
-        self._cudart = ctypes.CDLL("libcudart.so")
+        from flash_rt.core.cuda_buffer import _cudart
+        self._cudart = _cudart
 
         logger.info("Pi05TorchFrontendRtx initialised (num_views=%d, chunk=%d)",
                     self.num_views, self.chunk_size)
@@ -722,7 +726,7 @@ class Pi05TorchFrontendRtx:
                 num_views=self.num_views,
                 max_prompt_len=prompt_len,
                 chunk_size=self.chunk_size,
-                use_fp8=True, use_fp8_decoder=True)
+                use_fp8=self.use_fp8, use_fp8_decoder=self.use_fp8)
 
         # Upload language embeds into pipeline's encoder_x slot
         embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
@@ -793,7 +797,7 @@ class Pi05TorchFrontendRtx:
                     num_views=self.num_views,
                     max_prompt_len=target_len,
                     chunk_size=self.chunk_size,
-                    use_fp8=True, use_fp8_decoder=True,
+                    use_fp8=self.use_fp8, use_fp8_decoder=self.use_fp8,
                     cfg_beta=cfg["cfg_beta"])
             else:
                 self.pipeline = Pi05CFGPipeline(
@@ -803,7 +807,7 @@ class Pi05TorchFrontendRtx:
                     num_views=self.num_views,
                     max_prompt_len=target_len,
                     chunk_size=self.chunk_size,
-                    use_fp8=True, use_fp8_decoder=True,
+                    use_fp8=self.use_fp8, use_fp8_decoder=self.use_fp8,
                     cfg_beta=cfg["cfg_beta"])
 
         cond_np = cond_embeds.contiguous().view(torch.uint16).cpu().numpy()
@@ -1253,7 +1257,7 @@ class Pi05TorchFrontendRtx:
                 num_views=self.num_views,
                 max_prompt_len=target_len,
                 chunk_size=self.chunk_size,
-                use_fp8=True, use_fp8_decoder=True)
+                use_fp8=self.use_fp8, use_fp8_decoder=self.use_fp8)
 
         # Also seed the parent's B=1 lang slot from sample 0; the parent's
         # B=1 pipeline path is what calibrate_fp8 uses for FP8 scale collection.

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -422,11 +422,13 @@ class Pi05TorchFrontendRtx:
                  checkpoint_dir: Union[str, pathlib.Path],
                  num_views: int = 2,
                  chunk_size: int = CHUNK_SIZE,
-                 max_prompt_len: int = MAX_PROMPT_LEN_DEFAULT):
+                 max_prompt_len: int = MAX_PROMPT_LEN_DEFAULT,
+                 use_fp8: bool = True):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.num_views = int(num_views)
         self.chunk_size = int(chunk_size)
         self.max_prompt_len = int(max_prompt_len)
+        self.use_fp8 = bool(use_fp8)
 
         self.latency_records: list[float] = []
         self.calibrated = False
@@ -498,7 +500,8 @@ class Pi05TorchFrontendRtx:
             self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
         self._noise_out = torch.empty(
             self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
-        self._cudart = ctypes.CDLL("libcudart.so")
+        from flash_rt.core.cuda_buffer import _cudart
+        self._cudart = _cudart
 
         logger.info("Pi05TorchFrontendRtx initialised (num_views=%d, chunk=%d)",
                     self.num_views, self.chunk_size)
@@ -722,7 +725,7 @@ class Pi05TorchFrontendRtx:
                 num_views=self.num_views,
                 max_prompt_len=prompt_len,
                 chunk_size=self.chunk_size,
-                use_fp8=True, use_fp8_decoder=True)
+                use_fp8=self.use_fp8, use_fp8_decoder=self.use_fp8)
 
         # Upload language embeds into pipeline's encoder_x slot
         embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
@@ -1253,7 +1256,7 @@ class Pi05TorchFrontendRtx:
                 num_views=self.num_views,
                 max_prompt_len=target_len,
                 chunk_size=self.chunk_size,
-                use_fp8=True, use_fp8_decoder=True)
+                use_fp8=self.use_fp8, use_fp8_decoder=self.use_fp8)
 
         # Also seed the parent's B=1 lang slot from sample 0; the parent's
         # B=1 pipeline path is what calibrate_fp8 uses for FP8 scale collection.

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -77,7 +77,8 @@ class Pi05TorchFrontendThor:
     # -----------------------------------------------------------------------
 
     def __init__(self, checkpoint_dir: str, num_views: int = 2,
-                 use_cuda_graph: bool = True, autotune: int = 3):
+                 use_cuda_graph: bool = True, autotune: int = 3,
+                 use_fp8: bool = True):
         """
         Args:
             autotune: CUDA Graph autotune trials per set_prompt().
@@ -87,6 +88,7 @@ class Pi05TorchFrontendThor:
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.num_views = num_views
         self.use_cuda_graph = use_cuda_graph
+        self.use_fp8 = bool(use_fp8)
         self.autotune = int(autotune) if autotune is not True else 3
         if autotune is False:
             self.autotune = 0

--- a/flash_rt/frontends/torch/pi05_thor_fp4.py
+++ b/flash_rt/frontends/torch/pi05_thor_fp4.py
@@ -52,10 +52,12 @@ class Pi05TorchFrontendThorFP4(Pi05TorchFrontendThor):
                  use_awq: bool = False,
                  awq_alpha: float = 0.5,
                  awq_calib_iters: int = 8,
-                 use_p1_split_gu: bool = False):
+                 use_p1_split_gu: bool = False,
+                 use_fp8: bool = True):
         # Base init (loads weights, allocates all FP8 buffers, etc.)
         super().__init__(checkpoint_dir, num_views=num_views,
-                         use_cuda_graph=use_cuda_graph, autotune=autotune)
+                         use_cuda_graph=use_cuda_graph, autotune=autotune,
+                         use_fp8=use_fp8)
 
         self.use_fp4_encoder_ffn = bool(use_fp4_encoder_ffn)
         self._fp4_layers = frozenset(fp4_layers) if self.use_fp4_encoder_ffn else frozenset()

--- a/flash_rt/frontends/torch/pi0_thor.py
+++ b/flash_rt/frontends/torch/pi0_thor.py
@@ -77,10 +77,12 @@ class Pi0TorchFrontendThor:
     # -----------------------------------------------------------------------
 
     def __init__(self, checkpoint_dir: str, num_views: int = 2,
-                 use_cuda_graph: bool = True, autotune: int = 3):
+                 use_cuda_graph: bool = True, autotune: int = 3,
+                 use_fp8: bool = True):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.num_views = num_views
         self.use_cuda_graph = use_cuda_graph
+        self.use_fp8 = bool(use_fp8)
         self.autotune = int(autotune) if autotune is not True else 3
         if autotune is False:
             self.autotune = 0

--- a/flash_rt/frontends/torch/pi0fast.py
+++ b/flash_rt/frontends/torch/pi0fast.py
@@ -75,10 +75,12 @@ class Pi0FastTorchFrontend:
                  use_cuda_graph: bool = True, autotune: int = 3,
                  max_decode_steps: int = 256,
                  decode_cuda_graph: bool = False,
-                 decode_graph_steps: int = 80):
+                 decode_graph_steps: int = 80,
+                 use_fp8: bool = True):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.num_views = num_views
         self.use_cuda_graph = use_cuda_graph
+        self.use_fp8 = bool(use_fp8)
         self.autotune = int(autotune) if autotune is not True else 3
         if autotune is False:
             self.autotune = 0

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -200,7 +200,8 @@ class Pi05Pipeline:
         # CUDA graph state (set by record_infer_graph)
         self._graph = None
         self._graph_stream = None  # ctypes.c_void_p
-        self._cudart = ctypes.CDLL("libcudart.so")
+        from flash_rt.core.cuda_buffer import _cudart
+        self._cudart = _cudart
 
         # Pre-expand vision position embedding across num_views (see
         # ``vision_encoder``'s patch embed path). Blackwell uses

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+import ast
+from pathlib import Path
+
+
+def test_load_model_only_passes_use_fp8_when_frontend_accepts_it():
+    from flash_rt.api import load_model
+
+    class NoUseFp8Frontend:
+        def __init__(self, checkpoint, num_views=2):
+            self.checkpoint = checkpoint
+            self.num_views = num_views
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    with patch("flash_rt.hardware.detect_arch", return_value="rtx_sm120"), \
+            patch("flash_rt.hardware.resolve_pipeline_class",
+                  return_value=NoUseFp8Frontend):
+        model = load_model(
+            "/tmp/nonexistent", config="pi05", framework="torch",
+            use_fp8=False)
+
+    assert isinstance(model._pipe, NoUseFp8Frontend)
+
+
+def test_load_model_propagates_use_fp8_when_frontend_accepts_it():
+    from flash_rt.api import load_model
+
+    class UseFp8Frontend:
+        seen_use_fp8 = None
+
+        def __init__(self, checkpoint, num_views=2, use_fp8=True):
+            type(self).seen_use_fp8 = use_fp8
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    with patch("flash_rt.hardware.detect_arch", return_value="rtx_sm120"), \
+            patch("flash_rt.hardware.resolve_pipeline_class",
+                  return_value=UseFp8Frontend):
+        model = load_model(
+            "/tmp/nonexistent", config="pi05", framework="torch",
+            use_fp8=False)
+
+    assert isinstance(model._pipe, UseFp8Frontend)
+    assert UseFp8Frontend.seen_use_fp8 is False
+
+
+def test_vla_frontend_constructors_accept_use_fp8():
+    frontend_classes = {
+        "flash_rt/frontends/torch/pi05_rtx.py": "Pi05TorchFrontendRtx",
+        "flash_rt/frontends/jax/pi05_rtx.py": "Pi05JaxFrontendRtx",
+        "flash_rt/frontends/torch/pi05_thor.py": "Pi05TorchFrontendThor",
+        "flash_rt/frontends/jax/pi05_thor.py": "Pi05JaxFrontendThor",
+        "flash_rt/frontends/torch/pi05_thor_fp4.py": "Pi05TorchFrontendThorFP4",
+        "flash_rt/frontends/jax/pi05_thor_fp4.py": "Pi05JaxFrontendThorFP4",
+        "flash_rt/frontends/torch/pi0_rtx.py": "Pi0TorchFrontendRtx",
+        "flash_rt/frontends/jax/pi0_rtx.py": "Pi0JaxFrontendRtx",
+        "flash_rt/frontends/torch/pi0_thor.py": "Pi0TorchFrontendThor",
+        "flash_rt/frontends/jax/pi0_thor.py": "Pi0JaxFrontendThor",
+        "flash_rt/frontends/torch/pi0fast.py": "Pi0FastTorchFrontend",
+        "flash_rt/frontends/jax/pi0fast.py": "Pi0FastJaxFrontend",
+        "flash_rt/frontends/torch/groot_rtx.py": "GrootTorchFrontendRtx",
+        "flash_rt/frontends/torch/groot_thor.py": "GrootTorchFrontendThor",
+    }
+
+    repo_root = Path(__file__).resolve().parents[1]
+    for rel_path, class_name in frontend_classes.items():
+        tree = ast.parse((repo_root / rel_path).read_text())
+        cls = next(
+            node for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == class_name)
+        init = next(
+            node for node in cls.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__")
+        args = [arg.arg for arg in init.args.args]
+        args += [arg.arg for arg in init.args.kwonlyargs]
+        assert "use_fp8" in args, f"{class_name} must accept use_fp8"


### PR DESCRIPTION
## Environment

- GPU: NVIDIA L40 (Compute Capability 8.9, Ada Lovelace)
- Native Linux (no Docker)

## Problem 1: Segfault from ctypes 64-bit pointer/stream truncation

**Root cause**: ctypes defaults all function parameters to `c_int` (32-bit) when `argtypes` is not set. On 64-bit systems, CUDA runtime functions like `cudaMemcpyAsync` receive 64-bit device pointers and `cudaStream_t` handles. Without explicit `argtypes`, ctypes silently truncates these values to 32 bits, causing segfaults.

The stream handle value `97327966053360` is clearly a 64-bit pointer, but ctypes was passing it as a 32-bit `c_int` to the CUDA runtime.

**Fix** (in `cuda_buffer.py`):

```python
_cudart.cudaMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p]
_cudart.cudaMemcpyAsync.restype = ctypes.c_int
```

This tells ctypes that `src`/`dst` are 64-bit pointers (`c_void_p`) and `stream` is a 64-bit handle (`c_void_p`), preventing truncation.

Additionally, `pi05_rtx.py` was importing its own `ctypes.CDLL("libcudart.so")` instance instead of sharing the one from `cuda_buffer.py`. Now it imports `_cudart` from `cuda_buffer` to ensure the argtypes are applied consistently.

## Problem 2: FP8 not configurable

Previously `use_fp8` was hardcoded to `True` in the pipeline construction, with no way for users to disable it. On GPUs that don't fully support FP8 (e.g. sm_89), this causes issues.

**Fix**: Added a `use_fp8` parameter to `load_model()` (default `True`) and `Pi05TorchFrontendRtx.__init__()`. Users can now pass `use_fp8=False` to disable FP8 when needed.

```python
# Before: hardcoded
use_fp8=True, use_fp8_decoder=True

# After: configurable via parameter
use_fp8=self.use_fp8, use_fp8_decoder=self.use_fp8
```

## Files changed

- `flash_rt/core/cuda_buffer.py` — add argtypes for `cudaMemcpy` and `cudaMemcpyAsync`
- `flash_rt/api.py` — add `use_fp8` parameter to `load_model()`
- `flash_rt/frontends/torch/pi05_rtx.py` — import shared `_cudart` from `cuda_buffer`, add `use_fp8` parameter, use instance variable instead of hardcoded `True`
- `flash_rt/models/pi0/pipeline_rtx.py` — FP8 default adjustment


## Test
```python
import numpy as np
import flash_rt

print("[1/3] Generating random images ...")
base_img = np.random.randint(0, 256, (224, 224, 3), dtype=np.uint8)
wrist_img = np.random.randint(0, 256, (224, 224, 3), dtype=np.uint8)
print(f"  base_img: shape={base_img.shape}, dtype={base_img.dtype}")

print("[2/3] Loading model...")
model = flash_rt.load_model(
    checkpoint="pi05_pytorch_checkpoint", #using libero checkpoint
    config="pi05",
    framework="torch",
    use_fp8=False,
)

print("[3/3] Running predict...")
for i in range(10):
    actions = model.predict(images=[base_img, wrist_img], prompt="pick up the red block")
print(f"Done. actions shape: {actions.shape}")
```

output 
```shell
[1/3] Generating random images ...
  base_img: shape=(224, 224, 3), dtype=uint8
[2/3] Loading model...
[3/3] Running predict...
  autotune: tested 8 algos, best=0 (12.8864 us)
  autotune: tested 8 algos, best=0 (13.0048 us)
Done. actions shape: (10, 7)
```