### PR TITLE
Add Pi0.5 Thor FP16 baseline path (use_fp8=False)

### DIFF
--- a/flash_rt/frontends/torch/_pi05_thor_spec.py
+++ b/flash_rt/frontends/torch/_pi05_thor_spec.py
@@ -26,14 +26,24 @@ from flash_rt.frontends.torch._thor_spec_common import (
 )
 
 
-def _decoder_block() -> LayerBlock:
+def _decoder_block(*, use_fp8: bool = True) -> LayerBlock:
     """Gemma-expert decoder / action expert (18 layers, cuBLASLt path).
 
     Unlike Pi0, Pi0.5 does **not** fuse the per-layer norm weight into
     QKV/GateUp — modulation happens via AdaRMSNorm Dense layers instead.
     Weights go through ``.t().contiguous()`` + FP8 quant, then FlatCat
     into ``_dec_{qkv,o,gu,d}_flat``.
+
+    With ``use_fp8=False`` the ``Quant()`` step is dropped; weights stay
+    FP16 in the same ``[K, N]`` row-major layout (``tT()`` is kept).
+    The FlatCat'd tensors are then FP16 instead of FP8, and
+    ``_ae_w_scales`` is not populated.
     """
+    qkv_tx = [tT(), Quant()]            if use_fp8 else [tT()]
+    o_tx   = [ToFp16(), tT(), Quant()]  if use_fp8 else [ToFp16(), tT()]
+    gu_tx  = [tT(), Quant()]            if use_fp8 else [tT()]
+    d_tx   = [ToFp16(), tT(), Quant()]  if use_fp8 else [ToFp16(), tT()]
+    scale_into = "_ae_w_scales" if use_fp8 else None
     dp = "paligemma_with_expert.gemma_expert.model.layers.{i}"
     items = [
         Item("qkv_w",
@@ -42,19 +52,19 @@ def _decoder_block() -> LayerBlock:
                       v=f"{dp}.self_attn.v_proj.weight",
                       interleave_q_heads=8,
                       interleave_k_heads=1),
-             [tT(), Quant()],
-             FlatCat("_dec_qkv_flat"), scale_into="_ae_w_scales"),
+             qkv_tx,
+             FlatCat("_dec_qkv_flat"), scale_into=scale_into),
         Item("o_w", f"{dp}.self_attn.o_proj.weight",
-             [ToFp16(), tT(), Quant()],
-             FlatCat("_dec_o_flat"), scale_into="_ae_w_scales"),
+             o_tx,
+             FlatCat("_dec_o_flat"), scale_into=scale_into),
         Item("gu_w",
              FusedGateUp(gate=f"{dp}.mlp.gate_proj.weight",
                          up=f"{dp}.mlp.up_proj.weight"),
-             [tT(), Quant()],
-             FlatCat("_dec_gu_flat"), scale_into="_ae_w_scales"),
+             gu_tx,
+             FlatCat("_dec_gu_flat"), scale_into=scale_into),
         Item("d_w", f"{dp}.mlp.down_proj.weight",
-             [ToFp16(), tT(), Quant()],
-             FlatCat("_dec_d_flat"), scale_into="_ae_w_scales"),
+             d_tx,
+             FlatCat("_dec_d_flat"), scale_into=scale_into),
     ]
     return LayerBlock(prefix_fmt="", num_layers=18, items=items, name="decoder")
 
@@ -75,13 +85,13 @@ def _decoder_mods_block() -> LayerBlock:
     return LayerBlock(prefix_fmt="", num_layers=18, items=items, name="decoder_mods")
 
 
-def build_spec() -> ModelWeightSpec:
+def build_spec(*, use_fp8: bool = True) -> ModelWeightSpec:
     return ModelWeightSpec(
         framework="torch",
         blocks=[
-            paligemma_siglip_block(),
-            paligemma_encoder_block(),
-            _decoder_block(),
+            paligemma_siglip_block(use_fp8=use_fp8),
+            paligemma_encoder_block(use_fp8=use_fp8),
+            _decoder_block(use_fp8=use_fp8),
             _decoder_mods_block(),
         ],
     )

--- a/flash_rt/frontends/torch/_thor_spec_common.py
+++ b/flash_rt/frontends/torch/_thor_spec_common.py
@@ -27,13 +27,24 @@ def paligemma_siglip_block(
     *,
     model_root: str = "paligemma_with_expert.paligemma.model",
     num_layers: int = 27,
+    use_fp8: bool = True,
 ) -> LayerBlock:
     """SigLIP encoder block used by Pi0.5 / Pi0 / Pi0-FAST torch frontends.
 
     27 layers × (LN1, LN2, fused QKV, O, FC1, FC2). All quantized GEMMs
     go through ``.T.contiguous()`` + per-tensor FP8 quant; scales land
     in ``target._sig_alpha`` in (q, o, up, down) order per layer.
+
+    When ``use_fp8=False``, weights stay FP16 in the same ``[K, N]``
+    row-major layout (the ``T()`` transpose is kept so ``gemm.fp16_nn``
+    can read them directly). ``Quant()`` is dropped and ``_sig_alpha``
+    is not populated.
     """
+    qkv_tx  = [T(), Quant()]              if use_fp8 else [T()]
+    o_tx    = [ToFp16(), T(), Quant()]    if use_fp8 else [ToFp16(), T()]
+    up_tx   = [ToFp16(), T(), Quant()]    if use_fp8 else [ToFp16(), T()]
+    down_tx = [ToFp16(), T(), Quant()]    if use_fp8 else [ToFp16(), T()]
+    scale_into = "_sig_alpha" if use_fp8 else None
     vp = f"{model_root}.vision_tower.vision_model.encoder.layers.{{i}}"
     items = [
         Item("ln_attn_w", f"{vp}.layer_norm1.weight", [ToFp16()], TensorList("_sig_ln_attn_w")),
@@ -45,8 +56,8 @@ def paligemma_siglip_block(
              Cat([f"{vp}.self_attn.q_proj.weight",
                   f"{vp}.self_attn.k_proj.weight",
                   f"{vp}.self_attn.v_proj.weight"], dim=0),
-             [T(), Quant()],
-             TensorList("_sig_qkv_w"), scale_into="_sig_alpha"),
+             qkv_tx,
+             TensorList("_sig_qkv_w"), scale_into=scale_into),
         Item("qkv_b",
              Cat([f"{vp}.self_attn.q_proj.bias",
                   f"{vp}.self_attn.k_proj.bias",
@@ -55,20 +66,20 @@ def paligemma_siglip_block(
              TensorList("_sig_qkv_b")),
 
         Item("o_w", f"{vp}.self_attn.out_proj.weight",
-             [ToFp16(), T(), Quant()],
-             TensorList("_sig_o_w"), scale_into="_sig_alpha"),
+             o_tx,
+             TensorList("_sig_o_w"), scale_into=scale_into),
         Item("o_b", f"{vp}.self_attn.out_proj.bias",
              [ToFp16()], TensorList("_sig_o_b")),
 
         Item("up_w", f"{vp}.mlp.fc1.weight",
-             [ToFp16(), T(), Quant()],
-             TensorList("_sig_up_w"), scale_into="_sig_alpha"),
+             up_tx,
+             TensorList("_sig_up_w"), scale_into=scale_into),
         Item("up_b", f"{vp}.mlp.fc1.bias",
              [ToFp16()], TensorList("_sig_up_b")),
 
         Item("down_w", f"{vp}.mlp.fc2.weight",
-             [ToFp16(), T(), Quant()],
-             TensorList("_sig_down_w"), scale_into="_sig_alpha"),
+             down_tx,
+             TensorList("_sig_down_w"), scale_into=scale_into),
         Item("down_b", f"{vp}.mlp.fc2.bias",
              [ToFp16()], TensorList("_sig_down_b")),
     ]
@@ -79,6 +90,7 @@ def paligemma_encoder_block(
     *,
     model_root: str = "paligemma_with_expert.paligemma.model",
     num_layers: int = 18,
+    use_fp8: bool = True,
 ) -> LayerBlock:
     """Paligemma encoder (18 layers, GQA, AdaRMSNorm fused into QKV/gate-up).
 
@@ -88,7 +100,17 @@ def paligemma_encoder_block(
       gu   : FusedGateUp(norm_fuse=post_attention_layernorm)      → [Quant()]
       d    : ToFp16 → Quant
     Scales append to ``target._enc_w_scales`` in (q, o, gu, d) order.
+
+    When ``use_fp8=False``, ``Quant()`` is dropped and a ``T()``
+    transpose is added so weights land in ``[K, N]`` row-major (the
+    layout ``gemm.fp16_nn`` reads). FusedQKV / FusedGateUp natively
+    produce ``[N, K]``; ``T()`` flips them to the row-major NN layout.
     """
+    qkv_tx = [Quant()]            if use_fp8 else [T()]
+    o_tx   = [ToFp16(), Quant()]  if use_fp8 else [ToFp16(), T()]
+    gu_tx  = [Quant()]            if use_fp8 else [T()]
+    d_tx   = [ToFp16(), Quant()]  if use_fp8 else [ToFp16(), T()]
+    scale_into = "_enc_w_scales" if use_fp8 else None
     ep = f"{model_root}.language_model.layers.{{i}}"
     items = [
         Item("qkv_w",
@@ -98,20 +120,20 @@ def paligemma_encoder_block(
                       norm_fuse=f"{ep}.input_layernorm.weight",
                       interleave_q_heads=8,
                       interleave_k_heads=1),
-             [Quant()],
-             TensorList("_enc_qkv_w"), scale_into="_enc_w_scales"),
+             qkv_tx,
+             TensorList("_enc_qkv_w"), scale_into=scale_into),
         Item("o_w", f"{ep}.self_attn.o_proj.weight",
-             [ToFp16(), Quant()],
-             TensorList("_enc_o_w"), scale_into="_enc_w_scales"),
+             o_tx,
+             TensorList("_enc_o_w"), scale_into=scale_into),
         Item("gu_w",
              FusedGateUp(gate=f"{ep}.mlp.gate_proj.weight",
                          up=f"{ep}.mlp.up_proj.weight",
                          norm_fuse=f"{ep}.post_attention_layernorm.weight"),
-             [Quant()],
-             TensorList("_enc_gu_w"), scale_into="_enc_w_scales"),
+             gu_tx,
+             TensorList("_enc_gu_w"), scale_into=scale_into),
         Item("d_w", f"{ep}.mlp.down_proj.weight",
-             [ToFp16(), Quant()],
-             TensorList("_enc_d_w"), scale_into="_enc_w_scales"),
+             d_tx,
+             TensorList("_enc_d_w"), scale_into=scale_into),
     ]
     return LayerBlock(prefix_fmt="", num_layers=num_layers, items=items, name="encoder")
 

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -205,7 +205,20 @@ class Pi05TorchFrontendThor:
         #   self._ae_w_scales                                 (72 fp32 scales)
         #   self._{attn,ffn}_mod_{w,b}                        (18-layer lists)
         _src = SafetensorsSource(str(safetensors_path), device='cuda')
-        WeightLoader(source=_src, target=self, spec=build_spec()).run()
+        WeightLoader(source=_src, target=self,
+                     spec=build_spec(use_fp8=self.use_fp8)).run()
+        # FP16 path: spec drops Quant() / scale_into, so _sig_alpha,
+        # _enc_w_scales, _ae_w_scales never get populated. Provide
+        # empty placeholders so downstream pointer-dict construction
+        # (which still reads these attrs) stays happy — the FP16
+        # forward branches ignore them.
+        if not self.use_fp8:
+            if not hasattr(self, '_sig_alpha'):
+                self._sig_alpha = []
+            if not hasattr(self, '_enc_w_scales'):
+                self._enc_w_scales = []
+            if not hasattr(self, '_ae_w_scales'):
+                self._ae_w_scales = []
 
         self.embedding_weight = g('paligemma_with_expert.paligemma.lm_head.weight')
 
@@ -253,6 +266,12 @@ class Pi05TorchFrontendThor:
         self._sig_attn   = torch.empty(S_sig, D_sig, dtype=fp16, device='cuda')
         self._sig_hidden = torch.empty(S_sig, H_sig, dtype=fp16, device='cuda')
         self._sig_hid_fp8 = torch.zeros(S_sig * H_sig, dtype=torch.uint8, device='cuda')
+        # FP16 path needs a dedicated O/Down GEMM output buffer (one
+        # epilogue away from the residual add). The x_norm scratch
+        # aliases ``_sig_attn`` since the LN output is consumed by the
+        # QKV GEMM before attention overwrites the buffer.
+        self._sig_fg = (torch.empty(S_sig, D_sig, dtype=fp16, device='cuda')
+                        if not self.use_fp8 else None)
 
         self._sig_bufs = {
             'x':       self._sig_x.data_ptr(),
@@ -261,6 +280,8 @@ class Pi05TorchFrontendThor:
             'attn_out': self._sig_attn.data_ptr(),
             'hidden':  self._sig_hidden.data_ptr(),
             'hid_fp8': self._sig_hid_fp8.data_ptr(),
+            'x_norm':  self._sig_attn.data_ptr(),
+            'fg':      self._sig_fg.data_ptr() if self._sig_fg is not None else 0,
         }
         self._sig_dims = {
             'S': S_sig, 'D': D_sig, 'H': H_sig,
@@ -305,7 +326,11 @@ class Pi05TorchFrontendThor:
         #   self._enc_gu_w    list of [2*H, D]    fp8 (fused post-attn norm)
         #   self._enc_d_w     list of [H, D]      fp8
         #   self._enc_w_scales  host list of Le*4 floats (order: q, o, gu, d per layer)
-        self._enc_w_dev = torch.tensor(self._enc_w_scales, dtype=torch.float32, device='cuda')
+        # When use_fp8=False the spec skips Quant() so _enc_w_scales is
+        # not populated; keep an empty tensor so downstream pointer
+        # arithmetic still works (the FP16 path never reads it).
+        _enc_w_scales = getattr(self, '_enc_w_scales', []) or [0.0] * (Le * 4)
+        self._enc_w_dev = torch.tensor(_enc_w_scales, dtype=torch.float32, device='cuda')
 
         # RoPE table
         inv_freq = 1.0 / (10000 ** (torch.arange(0, 256, 2, dtype=torch.float32, device='cuda') / 256))
@@ -332,6 +357,11 @@ class Pi05TorchFrontendThor:
         self._enc_hidden = torch.empty(Se_max, He, dtype=fp16, device='cuda')
         self._enc_hid_fp8 = torch.zeros(Se_max * He, dtype=torch.uint8, device='cuda')
         self._enc_fg     = torch.empty(Se_max, De, dtype=fp16, device='cuda')
+        # All-ones gamma for the FP16 noweight RMSNorm (encoder uses
+        # ``rms_norm_fp8_noweight_fp16`` in the FP8 path; ``rms_norm_fp16``
+        # takes a weight pointer, so we feed it ones for parity).
+        self._enc_ones_fp16 = (torch.ones(De, dtype=fp16, device='cuda')
+                               if not self.use_fp8 else None)
 
         # ===============================================================
         # Decoder / AE  (18 layers, 10 steps)
@@ -354,7 +384,8 @@ class Pi05TorchFrontendThor:
         self._aow = g('action_out_proj.weight').t().contiguous() * (-1.0 / steps)
         self._aob = g('action_out_proj.bias') * (-1.0 / steps)
 
-        self._ae_w_dev = torch.tensor(self._ae_w_scales, dtype=torch.float32, device='cuda')
+        _ae_w_scales = getattr(self, '_ae_w_scales', []) or [0.0] * (La * 4)
+        self._ae_w_dev = torch.tensor(_ae_w_scales, dtype=torch.float32, device='cuda')
 
         # Time conditioning weights
         self._time_mlp_in_w  = g('time_mlp_in.weight')
@@ -1014,7 +1045,16 @@ class Pi05TorchFrontendThor:
         self._capture_siglip_graph()
 
         # ---- Calibrate FP8 scales (using SigLIP warmup output in enc_x) ----
-        self._calibrate(Se)
+        if self.use_fp8:
+            self._calibrate(Se)
+        else:
+            # FP16 path: no calibration needed; populate dummy scales /
+            # alpha so the enc/ae forward dicts stay shape-compatible
+            # (the FP16 branches never read them).
+            self._enc_calib_scales = torch.zeros(self.Le * 4, dtype=torch.float32, device='cuda')
+            self._enc_alpha_host = [1.0] * (self.Le * 4)
+            self._ae_calib_scales = torch.zeros(self.La * 4, dtype=torch.float32, device='cuda')
+            logger.info("use_fp8=False — skipping FP8 calibration (FP16 baseline)")
 
         # ---- Capture encoder+decoder graph ----
         if self.autotune > 0:
@@ -1237,7 +1277,8 @@ class Pi05TorchFrontendThor:
             self._patch_embed_ops(0)
             self._sig_x.zero_()  # match production: SigLIP sees zeros
             siglip_forward(self._gemm, fvk, self._sig_bufs, self._sig_weights,
-                           self._sig_dims, stream=0, attn=self._attn)
+                           self._sig_dims, stream=0, attn=self._attn,
+                           use_fp8=self.use_fp8)
             self._postln_project_ops(0)
         torch.cuda.synchronize()
 
@@ -1249,7 +1290,8 @@ class Pi05TorchFrontendThor:
             self._siglip_graph.capture_begin()
             self._patch_embed_ops(s_int)
             siglip_forward(self._gemm, fvk, self._sig_bufs, self._sig_weights,
-                           self._sig_dims, stream=s_int, attn=self._attn)
+                           self._sig_dims, stream=s_int, attn=self._attn,
+                           use_fp8=self.use_fp8)
             self._postln_project_ops(s_int)
             self._siglip_graph.capture_end()
         torch.cuda.synchronize()
@@ -1276,6 +1318,11 @@ class Pi05TorchFrontendThor:
             'hid_fp8': self._enc_hid_fp8.data_ptr(),
             'fg':      self._enc_fg.data_ptr(),
             'ctx':     self._ctx,
+            # FP16 path: x_norm aliases _enc_attn (same size, disjoint
+            # lifetime); ones is the all-ones vector for noweight RMS.
+            'x_norm':  self._enc_attn.data_ptr(),
+            'ones':    (self._enc_ones_fp16.data_ptr()
+                        if self._enc_ones_fp16 is not None else 0),
         }
         enc_weights = {
             'qkv_w':     [w.data_ptr() for w in self._enc_qkv_w],
@@ -1336,9 +1383,11 @@ class Pi05TorchFrontendThor:
         for _ in range(3):
             self._Kc.zero_(); self._Vc.zero_()
             encoder_forward(self._gemm, fvk, enc_bufs, enc_weights,
-                            enc_dims, stream=0, attn=self._attn)
+                            enc_dims, stream=0, attn=self._attn,
+                            use_fp8=self.use_fp8)
             decoder_forward(self._ctx, fvk, ae_bufs, ae_weights,
-                            ae_dims, stream=0, attn=self._attn)
+                            ae_dims, stream=0, attn=self._attn,
+                            use_fp8=self.use_fp8)
         torch.cuda.synchronize()
 
         # Capture
@@ -1349,9 +1398,11 @@ class Pi05TorchFrontendThor:
             self._enc_ae_graph.capture_begin()
             self._Kc.zero_(); self._Vc.zero_()
             encoder_forward(self._gemm, fvk, enc_bufs, enc_weights,
-                            enc_dims, stream=s_int, attn=self._attn)
+                            enc_dims, stream=s_int, attn=self._attn,
+                            use_fp8=self.use_fp8)
             decoder_forward(self._ctx, fvk, ae_bufs, ae_weights,
-                            ae_dims, stream=s_int, attn=self._attn)
+                            ae_dims, stream=s_int, attn=self._attn,
+                            use_fp8=self.use_fp8)
             self._enc_ae_graph.capture_end()
         torch.cuda.synchronize()
         logger.info("Enc+AE CUDA graph captured (Se=%d)", Se)
@@ -1961,7 +2012,10 @@ class Pi05TorchFrontendThor:
         self._siglip_graph.replay()
 
         # ---- Lazy real-data recalibration on first call ----
-        if not self._real_data_calibrated:
+        # Skip when use_fp8=False: the FP16 baseline path has no FP8
+        # scales to refresh, and ``_recalibrate_with_real_data`` reads
+        # FP8-specific attrs.
+        if self.use_fp8 and not self._real_data_calibrated:
             torch.cuda.synchronize()
             self._recalibrate_with_real_data()
             self._real_data_calibrated = True

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -49,7 +49,8 @@ import numpy as np
 # SigLIP Vision Encoder (27 layers)
 # ══════════════════════════════════════════════════════════════════
 
-def siglip_forward(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None):
+def siglip_forward(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None,
+                   use_fp8=True):
     """Full SigLIP vision encoder ≡ siglip_forward_fp8_v7.
 
     Per-view independent attention (v7 strided FMHA).
@@ -61,13 +62,21 @@ def siglip_forward(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None):
         bufs: dict of GPU buffer pointers
             x (S,D), x_fp8 (S,D), qkv (S,3D), attn_out (S,D),
             hidden (S,H), hid_fp8 (S,H), scratch (S, max(D,H))
+            When use_fp8=False: also expects ``x_norm`` (S,D fp16) and
+            ``fg`` (S,D fp16) scratch buffers; ``x_fp8`` / ``hid_fp8``
+            may be ignored.
         weights: dict — per-layer lists of GPU pointers
             ln_attn_w[L], ln_attn_b[L], qkv_w[L], qkv_b[L],
             o_w[L], o_b[L], ln_ffn_w[L], ln_ffn_b[L],
             up_w[L], up_b[L], down_w[L], down_b[L],
-            alpha[L*4] (host floats)
+            alpha[L*4] (host floats; unused when use_fp8=False)
         dims: dict — S, D, H, NH, HD, L, num_views, seq_per_view
+        use_fp8: When False, run a pure FP16 forward (no FP8 cast, no
+            descale alpha; weights are FP16 [K,N] in the same layout).
     """
+    if not use_fp8:
+        return _siglip_forward_fp16(gemm, fvk, bufs, weights, dims, stream,
+                                     attn=attn)
     S = dims['S']
     D = dims['D']
     H = dims['H']
@@ -198,7 +207,133 @@ def _make_ones(D):
     import torch
     return torch.ones(D, dtype=torch.float16, device='cuda')
 
-def encoder_forward(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None):
+def _siglip_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None):
+    """FP16-only SigLIP forward. Mirrors siglip_forward structure with
+    every FP8 op split into its FP16 equivalent.
+    """
+    S = dims['S']; D = dims['D']; H = dims['H']
+    NH = dims['NH']; HD = dims['HD']; L = dims['L']
+    nv = dims['num_views']
+    spv = dims['seq_per_view']
+
+    x = bufs['x']
+    x_norm = bufs['x_norm']       # S*D fp16 scratch (FP16 path only)
+    qkv = bufs['qkv']
+    attn_out = bufs['attn_out']
+    hidden = bufs['hidden']
+    fg = bufs['fg']               # S*D fp16 scratch for O/Down GEMM output
+
+    for l in range(L):
+        # ── Attention LayerNorm → x_norm ──
+        fvk.layer_norm_fp16(x, weights['ln_attn_w'][l], weights['ln_attn_b'][l],
+                            x_norm, S, D, 1e-6, stream)
+
+        # ── QKV GEMM (FP16 NN) + bias ──
+        gemm.fp16_nn(x_norm, weights['qkv_w'][l], qkv, S, 3 * D, D, stream)
+        fvk.add_bias_fp16(qkv, weights['qkv_b'][l], S, 3 * D, stream)
+
+        # ── Strided FMHA ──
+        scale = 1.0 / math.sqrt(float(HD))
+        if attn is not None:
+            attn.run("siglip", 0, q_seq=spv, stream=stream)
+        else:
+            stride = 3 * D
+            Q_ptr = qkv
+            K_ptr = qkv + D * 2
+            V_ptr = qkv + 2 * D * 2
+            fvk.fmha_strided_full(Q_ptr, K_ptr, V_ptr, attn_out,
+                                  nv, spv, spv, NH, NH, HD,
+                                  stride, stride, stream)
+
+        # ── O projection + residual + bias ──
+        gemm.fp16_nn(attn_out, weights['o_w'][l], fg, S, D, D, stream)
+        fvk.bias_residual_fp16(x, fg, weights['o_b'][l], S, D, stream)
+
+        # ── FFN LayerNorm → x_norm ──
+        fvk.layer_norm_fp16(x, weights['ln_ffn_w'][l], weights['ln_ffn_b'][l],
+                            x_norm, S, D, 1e-6, stream)
+
+        # ── Up GEMM + bias + GELU ──
+        gemm.fp16_nn(x_norm, weights['up_w'][l], hidden, S, H, D, stream)
+        fvk.add_bias_fp16(hidden, weights['up_b'][l], S, H, stream)
+        fvk.gelu_inplace_fp16(hidden, S * H, stream)
+
+        # ── Down GEMM + residual + bias ──
+        gemm.fp16_nn(hidden, weights['down_w'][l], fg, S, D, H, stream)
+        fvk.bias_residual_fp16(x, fg, weights['down_b'][l], S, D, stream)
+
+
+def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None):
+    """FP16-only Paligemma encoder forward. Mirrors encoder_forward
+    structure with FP8 cast/descale dropped.
+    """
+    Se = dims['Se']; D = dims['D']; H = dims['H']
+    NH = dims['NH']; HD = dims['HD']; L = dims['L']
+    total_keys = dims['total_keys']
+    Q_dim = NH * HD
+    K_dim = HD
+    attn_scale = 1.0 / math.sqrt(float(HD))
+
+    x = bufs['x']
+    x_norm = bufs['x_norm']
+    qkv = bufs['qkv']
+    logits = bufs['logits']
+    attn_out = bufs['attn_out']
+    gate = bufs['gate']
+    hidden = bufs['hidden']
+    fg = bufs['fg']
+    ones = bufs['ones']
+
+    for l in range(L):
+        last = (l == L - 1)
+
+        # 1. RMSNorm (noweight via ones buf)
+        fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
+
+        # 2. QKV GEMM
+        gemm.fp16_nn(x_norm, weights['qkv_w'][l], qkv, Se, 2560, D, stream)
+
+        # 3+4. Split+RoPE+KV
+        kv_elem_off = l * total_keys * HD
+        fvk.qkv_split_rope_kvcache_fp16(
+            qkv, weights['rope'], attn_out,
+            weights['Kc'], weights['Vc'],
+            Se, Q_dim, K_dim, HD, 2560,
+            kv_elem_off, HD, stream)
+
+        if not last:
+            # 5. Attention
+            if attn is not None:
+                attn.run("encoder", l, q_seq=Se, stream=stream)
+            else:
+                K_ptr = weights['Kc'] + kv_elem_off * 2
+                V_ptr = weights['Vc'] + kv_elem_off * 2
+                fvk.attention_qkv_fp16(bufs['ctx'], attn_out, K_ptr, V_ptr,
+                                        logits, attn_out,
+                                        Se, Se, NH, HD, attn_scale, stream)
+
+            # 6. O proj
+            gemm.fp16_nn(attn_out, weights['o_w'][l], fg, Se, D, D, stream)
+
+            # 7. Residual + RMSNorm
+            fvk.residual_add_fp16(x, fg, Se * D, stream)
+            fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
+
+            # 8. Gate+Up GEMM
+            gemm.fp16_nn(x_norm, weights['gate_w'][l], gate, Se, H * 2, D, stream)
+
+            # 9. GELU(gate) × up
+            fvk.gate_geglu_merged_fp16(gate, hidden, Se, H, stream)
+
+            # 10. Down GEMM
+            gemm.fp16_nn(hidden, weights['down_w'][l], fg, Se, D, H, stream)
+
+            # 11. Residual (next layer's RMSNorm done at top of next iter)
+            fvk.residual_add_fp16(x, fg, Se * D, stream)
+
+
+def encoder_forward(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None,
+                    use_fp8=True):
     """Full encoder forward ≡ encoder_full_static_cutlass.
 
     Static FP8 descale scheme:
@@ -215,7 +350,15 @@ def encoder_forward(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None):
         weights: dict — qkv_w[L], o_w[L], gate_w[L], down_w[L], rope, Kc, Vc,
                         act_scales (device float ptr), alpha_host (host list[L*4])
         dims: dict — Se, D, H, NH, HD, L, total_keys
+        use_fp8: When False, run a pure FP16 forward. Bufs must
+            additionally provide ``x_norm`` (Se*D fp16) and ``ones``
+            (D fp16, all 1.0) for noweight RMSNorm; weights must point
+            at FP16 [K,N] tensors and ``act_scales``/``alpha_host`` are
+            ignored.
     """
+    if not use_fp8:
+        return _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream,
+                                      attn=attn)
     Se = dims['Se']
     D = dims['D']
     H = dims['H']

--- a/flash_rt/models/pi05/pipeline_thor.py
+++ b/flash_rt/models/pi05/pipeline_thor.py
@@ -37,7 +37,8 @@ from flash_rt.hardware.thor.shared_primitives import (
 # Decoder (18 layers, 10 diffusion steps, static FP8)
 # ══════════════════════════════════════════════════════════════════
 
-def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None):
+def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None,
+                    use_fp8=True):
     """Full AE decoder forward pass ≡ pi05 ae_forward_static.
 
     Args:
@@ -45,14 +46,23 @@ def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None):
         fvk: flash_rt_kernels module
         bufs: dict of GPU buffer pointers (uintptr_t)
             noise, x, xn, gate, qkv, logits, attn_out, hid, fg,
-            xn_fp8, hid_fp8, ctx_fp8
+            xn_fp8, hid_fp8, ctx_fp8     [xn_fp8/hid_fp8/ctx_fp8 only when use_fp8=True]
         weights: dict of GPU buffer pointers
             ain_w, ain_b, sa, qw, Kc, Vc, ow, sf, gw, dw,
             aow, aob, fs, rope, w_scales, act_scales
+            (w_scales/act_scales unused when use_fp8=False — weights are FP16)
         dims: dict
             S, D, H, NH, HD, steps, layers, enc_seq, total_keys
         stream: CUDA stream (int)
+        use_fp8: When True (default) run the production static-FP8 path.
+            When False, every GEMM uses ``fvk.gmm_fp16`` and the fused
+            FP8 norm/quantize kernels are split into their FP16
+            equivalents (``adarms_fp16``, ``gate_res_fp16``,
+            ``gate_geglu_merged_fp16``). Used for FP16 baseline runs.
     """
+    if not use_fp8:
+        return _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream,
+                                      attn=attn)
     S = dims['S']
     D = dims['D']
     H = dims['H']
@@ -179,6 +189,101 @@ def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None):
         fs_ptr = fs + fi * 2
         fvk.adarms_fp16(x, fs_ptr, xn, gate, S, D, stream)
 
+        fvk.gmm_fp16(ctx, xn, aow, noise, S, 32, D, 1.0, stream)
+        fvk.add_bias_fp16(noise, aob, S, 32, stream)
+
+
+# ══════════════════════════════════════════════════════════════════
+# FP16 decoder path (no quantization, FP16 weights, baseline only)
+# ══════════════════════════════════════════════════════════════════
+
+def _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None):
+    """FP16-only decoder forward. Structure mirrors the FP8 path; every
+    GEMM is ``fvk.gmm_fp16`` and the fused FP8 norm kernels are split.
+
+    Weight pointers (``qw/ow/gw/dw``) must reference FP16 [K,N] tensors
+    (NN layout — same as the FP8 layout, just unquantized; see the
+    ``use_fp8=False`` weight spec).
+    """
+    S = dims['S']; D = dims['D']; H = dims['H']
+    NH = dims['NH']; HD = dims['HD']
+    steps = dims['steps']; layers = dims['layers']
+    enc_seq = dims['enc_seq']; total_keys = dims['total_keys']
+    D3 = 3 * D
+    Q_dim = NH * HD
+    K_dim = HD
+    attn_scale = 1.0 / math.sqrt(float(HD))
+
+    noise = bufs['noise']; x = bufs['x']; xn = bufs['xn']
+    gate = bufs['gate']; qkv = bufs['qkv']; logits = bufs['logits']
+    attn_out = bufs['attn_out']; fg = bufs['fg']; hid = bufs['hid']
+
+    ain_w = weights['ain_w']; ain_b = weights['ain_b']
+    sa = weights['sa']; qw = weights['qw']
+    Kc = weights['Kc']; Vc = weights['Vc']
+    ow = weights['ow']; sf = weights['sf']
+    gw = weights['gw']; dw = weights['dw']
+    aow = weights['aow']; aob = weights['aob']
+    fs = weights['fs']; rope = weights['rope']
+
+    for s in range(steps):
+        fvk.gmm_fp16(ctx, noise, ain_w, x, S, D, 32, 0.0, stream)
+        fvk.add_bias_fp16(x, ain_b, S, D, stream)
+
+        for l in range(layers):
+            si = (s * layers + l) * S * D3
+            sa_ptr = sa + si * 2
+            sf_ptr = sf + si * 2
+
+            # C1: AdaRMSNorm (FP16, no FP8 quantize)
+            fvk.adarms_fp16(x, sa_ptr, xn, gate, S, D, stream)
+
+            # C2: QKV GEMM (FP16 NN; weight is [K, 2560])
+            qw_ptr = qw + l * D * 2560 * 2  # FP16 = 2 bytes/elem
+            fvk.gmm_fp16(ctx, xn, qw_ptr, qkv, S, 2560, D, 0.0, stream)
+
+            # C2b: Split + RoPE + KV cache write
+            kv_offset = l * total_keys * HD + enc_seq * HD
+            fvk.qkv_split_rope_kvcache_fp16(qkv, rope, attn_out, Kc, Vc,
+                                             S, Q_dim, K_dim, HD, 2560,
+                                             kv_offset, HD, stream)
+
+            # C3: Attention
+            if attn is not None:
+                attn.run("decoder", l, q_seq=S, kv_seq=total_keys, stream=stream)
+            else:
+                K_ptr = Kc + l * total_keys * HD * 2
+                V_ptr = Vc + l * total_keys * HD * 2
+                fvk.attention_qkv_fp16(ctx, attn_out, K_ptr, V_ptr,
+                                        logits, attn_out,
+                                        S, total_keys, NH, HD, attn_scale, stream)
+
+            # C4: O proj
+            ow_ptr = ow + l * NH * HD * D * 2  # FP16
+            fvk.gmm_fp16(ctx, attn_out, ow_ptr, fg, S, D, NH * HD, 0.0, stream)
+
+            # C4→C5: gated residual + post-attn AdaRMSNorm
+            fvk.gate_res_fp16(fg, gate, x, S * D, stream)
+            fvk.adarms_fp16(x, sf_ptr, xn, gate, S, D, stream)
+
+            # C5: Gate+Up merged GEMM (weight is [K, 2H])
+            gw_ptr = gw + l * D * H * 2 * 2  # FP16 = 2 bytes/elem; weight has 2H cols
+            fvk.gmm_fp16(ctx, xn, gw_ptr, fg, S, H * 2, D, 0.0, stream)
+
+            # C6: GELU(gate) × up (FP16)
+            fvk.gate_geglu_merged_fp16(fg, hid, S, H, stream)
+
+            # C6: Down GEMM (weight is [H, D])
+            dw_ptr = dw + l * H * D * 2  # FP16
+            fvk.gmm_fp16(ctx, hid, dw_ptr, fg, S, D, H, 0.0, stream)
+
+            # C7: residual into x (next layer's C1 will do AdaRMS)
+            fvk.gate_res_fp16(fg, gate, x, S * D, stream)
+
+        # Final: AdaRMSNorm + action output
+        fi = s * S * D3
+        fs_ptr = fs + fi * 2
+        fvk.adarms_fp16(x, fs_ptr, xn, gate, S, D, stream)
         fvk.gmm_fp16(ctx, xn, aow, noise, S, 32, D, 1.0, stream)
         fvk.add_bias_fp16(noise, aob, S, 32, stream)
 


### PR DESCRIPTION
Threads a functional use_fp8=False flag through the pi05 torch+thor stack so the same pipeline runs with FP16 weights and cuBLAS GEMMs instead of the static-FP8 fused path. Existing FP8 / FP4 paths are untouched (default use_fp8=True).

- Weight spec: build_spec(use_fp8) drops Quant() and keeps the tT() / T() transpose so weights land in [K, N] row-major fp16. The encoder spec adds an explicit T() because FusedQKV/FusedGateUp natively emit [N, K] (CUTLASS ColumnMajor B), which is not what cuBLAS NN expects.
- shared_primitives.siglip_forward / encoder_forward: add a use_fp8=False branch that splits each FP8-fused norm / cast / GEMM into the existing fp16 kernels (layer_norm_fp16, rms_norm_fp16, gemm.fp16_nn, gate_geglu_merged_fp16, bias_residual_fp16, residual_add_fp16).
- models/pi05/pipeline_thor.decoder_forward: mirror of the calibrate pass's split-kernel structure (adarms_fp16 + gate_res_fp16 + gmm_fp16 + gate_geglu_merged_fp16) with FP16 weight pointer arithmetic.
- pi05_thor frontend: plumb use_fp8 into build_spec, capture, and infer; skip _calibrate / _recalibrate_with_real_data on the FP16 path; allocate _sig_fg + _enc_ones_fp16 only when needed; alias x_norm to _sig_attn / _enc_attn (disjoint lifetimes).

Validated on Jetson AGX Thor (SM110) against the pi05_libero checkpoint:

  precision   p50 (2v)   p50 (3v)   cos vs FP16 (2v / 3v)
  FP8          44.5 ms    54.7 ms   0.99992 / 0.99952
  FP16         69.2 ms    92.5 ms   reference
  FP4          43.4 ms    48.0 ms   0.99671 / 0.98473

FP8 / FP4 numbers match the published Thor baselines; the FP16 row is the new unquantized reference path.