### PR TITLE
fix(cmake): include quantize sources in flash_rt_kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,16 +329,7 @@ if(FLASHRT_ENABLE_MOTUS AND GPU_ARCH STREQUAL "120")
     csrc/conv/motus/motus_bf16_rms_silu_quant_nvfp4_sm120.cu
     csrc/conv/motus/motus_fp4_conv3d_v19sf_sm120.cu
     csrc/conv/motus/motus_fp4_conv3d_v19sfb_sm120.cu
-    csrc/conv/motus/motus_fp4_conv3d_v19sfb_k128_sm120.cu
-    csrc/quantize/ada_layer_norm_fp8.cu
-    csrc/quantize/awq_quant_fp8_static_bf16.cu
-    csrc/quantize/bf16_ndhwc_to_ncdhw_transpose.cu
-    csrc/quantize/bf16_quant_fp8_ncdhw_to_ndhwc.cu
-    csrc/quantize/bf16_rms_silu_ncdhw.cu
-    csrc/quantize/bf16_rms_silu_quant_fp8_ncdhw_to_ndhwc_v4.cu
-    csrc/quantize/bias_gelu_quantize_fp8.cu
-    csrc/quantize/qkv_split_norm_rope_bf16.cu
-    csrc/quantize/rope_apply_bf16.cu)
+    csrc/conv/motus/motus_fp4_conv3d_v19sfb_k128_sm120.cu)
   set_target_properties(motus_aux_sm120_obj PROPERTIES
     CUDA_STANDARD 17
     POSITION_INDEPENDENT_CODE ON
@@ -672,6 +663,15 @@ pybind11_add_module(flash_rt_kernels
   csrc/quantize/tq_dequant_kv.cu
   csrc/quantize/wmma_probe.cu
   csrc/quantize/tq_dequant_cutlass.cu
+  csrc/quantize/ada_layer_norm_fp8.cu
+  csrc/quantize/awq_quant_fp8_static_bf16.cu
+  csrc/quantize/bf16_ndhwc_to_ncdhw_transpose.cu
+  csrc/quantize/bf16_quant_fp8_ncdhw_to_ndhwc.cu
+  csrc/quantize/bf16_rms_silu_ncdhw.cu
+  csrc/quantize/bf16_rms_silu_quant_fp8_ncdhw_to_ndhwc_v4.cu
+  csrc/quantize/bias_gelu_quantize_fp8.cu
+  csrc/quantize/qkv_split_norm_rope_bf16.cu
+  csrc/quantize/rope_apply_bf16.cu
   csrc/gemm/fp8_block128_gemm.cu
   csrc/kernels/causal_conv1d_qwen36.cu
   csrc/kernels/gated_deltanet_qwen36.cu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,42 @@ Unsupported shapes/layouts should raise a clear exception with the operation
 name and shape. Undefined outputs, all-zero fallthroughs, and warning-only
 failures are not acceptable for runtime kernels.
 
+### Kernel Bindings And CMake Ownership
+
+Every pybind entry must have matching CMake target ownership.
+
+- If `csrc/bindings.cpp` exposes a function unconditionally, the `.cu` file
+  that implements it must be compiled into `flash_rt_kernels` for every
+  supported `GPU_ARCH`, or the binding must call an unconditional stub that
+  raises a clear "not built / not supported" error.
+- If a kernel implementation is compiled only behind a hardware or feature
+  gate, the binding must use the same compile-time guard. Do not leave an
+  unconditional `m.def(...)` that references symbols from a gated object
+  library.
+- Model-specific object libraries, such as Motus SM120-only targets, should
+  contain only model- and hardware-specific kernels. Shared quantize, layout,
+  RoPE, activation, and utility kernels belong in the main target unless
+  every binding and caller is gated with the same condition.
+- When moving sources between object libraries and `flash_rt_kernels`, verify
+  both sides: the target that was missing the symbols imports successfully,
+  and the target that already had them does not fail with duplicate
+  definitions.
+
+Minimum validation for binding / CMake changes:
+
+```bash
+cmake -B build -S . -DGPU_ARCH=<arch>
+cmake --build build -j$(nproc) --target flash_rt_kernels
+python - <<'PY'
+from flash_rt import flash_rt_kernels
+print(flash_rt_kernels.__file__)
+PY
+```
+
+Run this for each affected hardware family, not only for the GPU in your
+workstation. Undefined symbols often show up at Python import time even when
+the CMake build itself completed.
+
 ### Calibration And Precision
 
 FP8/NVFP4 changes must preserve the calibration cache contract described in
@@ -199,6 +235,9 @@ Before requesting review:
 - Update docs when the user-facing API, build flow, supported hardware, or
   performance claims change.
 - Add or update tests for new behavior.
+- For CMake / kernel binding changes, confirm each affected `GPU_ARCH` builds
+  `flash_rt_kernels` and imports it from Python; check for missing or duplicate
+  symbols when a source moves between targets.
 - Include validation commands and results in the PR description.
 - Mention unsupported hardware or missing local fixtures explicitly.
 - Avoid committing generated build outputs, local checkpoints, logs, or

--- a/docs/adding_new_model.md
+++ b/docs/adding_new_model.md
@@ -434,7 +434,44 @@ Recompiling the same MLIR → Myelin picks a different tactic → ±2ms P50 drif
 
 Thor has 122Gi of unified memory. Loading two models concurrently will OOM. Tests must run serially.
 
-### 4.3 Don't rebuild the kernel .so
+### 4.3 Kernel binding and CMake ownership
+
+Adding a new model should usually reuse existing `fvk.*` entries. If you do
+need a new kernel or a new pybind entry, keep the CMake target ownership in
+lockstep with the binding:
+
+- An unconditional `m.def(...)` in `csrc/bindings.cpp` must link against an
+  implementation that exists in every supported `GPU_ARCH` build, or it must
+  call an unconditional stub that raises a clear "not built / not supported"
+  error.
+- If the `.cu` implementation is hardware- or feature-gated, the binding must
+  be gated the same way. Do not let a public `flash_rt_kernels` symbol depend
+  on a model-specific object target that only builds for one architecture.
+- Shared quantize, layout, RoPE, activation, and utility kernels belong in
+  the main `flash_rt_kernels` target unless every binding and every caller is
+  gated with the same condition.
+- Model-specific object libraries should contain only model- and
+  hardware-specific kernels.
+
+For any CMake / binding ownership change, validate every affected hardware
+family:
+
+```bash
+cmake -B build_<arch> -S . -DGPU_ARCH=<arch>
+cmake --build build_<arch> -j$(nproc) --target flash_rt_kernels
+PYTHONPATH=. python - <<'PY'
+from flash_rt import flash_rt_kernels
+print(flash_rt_kernels.__file__)
+PY
+nm -D -u flash_rt/flash_rt_kernels*.so | c++filt | grep 'flash_rt::' || true
+```
+
+When moving a source out of a model-specific object target into
+`flash_rt_kernels`, test both sides of the change: the architecture that was
+missing the symbol must import cleanly, and the architecture that already had
+the source must not fail with duplicate definitions.
+
+### 4.4 Don't rebuild the kernel .so
 
 `flash_rt/flash_rt_kernels.cpython-312-aarch64-linux-gnu.so` (3.6MB) is a production binary. Adding a new model should not trigger a kernel rebuild — every fvk function you need is already in this .so. If you genuinely need a new kernel, that's a separate CUDA development flow, with explicit version backups.
 
@@ -467,6 +504,8 @@ If the backbone is a new architecture (Qwen3-like), add **1-2 more weeks** for s
 - [ ] (4) Frontend is fully implemented, **each `(framework, hardware)` has its own `<m>_<hw>.py` file**, and all buffers are pre-allocated in `_load_weights`.
 - [ ] **No file uses `if self._has_sm100` or `hasattr(fvk, '...')` to branch on hardware.**
 - [ ] **`shared_primitives.py` has not gained any model-specific functions.**
+- [ ] Any new `csrc/bindings.cpp` entry and its `.cu` implementation have matching CMake guards / target ownership.
+- [ ] If a kernel source moved between object targets and `flash_rt_kernels`, every affected `GPU_ARCH` builds `flash_rt_kernels`, imports it from Python, and has no missing or duplicate symbols.
 - [ ] (6) The four `_PIPELINE_MAP` entries are one-to-one, with no two rows pointing at the same class.
 - [ ] (7) YAML dims match the constants in the code.
 - [ ] (8) `test_all_models_precision.py` passes three consecutive A/B runs.


### PR DESCRIPTION
# fix(cmake): include quantize sources in flash_rt_kernels

## Summary

Fixes import-time undefined symbols on non-SM120 builds by moving shared
quantize CUDA sources into the main `flash_rt_kernels` target.

`csrc/bindings.cpp` unconditionally exports several quantize helper bindings,
but their implementations were only compiled through the SM120 Motus object
target. On Jetson AGX Orin (SM87), importing `flash_rt_kernels` failed with
undefined symbols such as:

- `bf16_pack_t1_cache3_nchw_channels_last`
- `bf16_ndhwc_to_ncdhw_add_bf16`

This PR moves those shared quantize sources into `flash_rt_kernels` and removes
them from the Motus-only object list to avoid duplicate definitions on SM120.

## Before this change

On Jetson AGX Orin (SM87), the build could complete but importing the extension
failed at runtime because the shared quantize implementations were not linked
into `flash_rt_kernels`.

Example failure:

```text
ImportError: /root/FlashRT/flash_rt/flash_rt_kernels.cpython-310-aarch64-linux-gnu.so:
undefined symbol: _ZN8flash_rt8quantize38bf16_pack_t1_cache3_nchw_channels_lastEPKvS2_PviiiP11CUstream_st
```

After this change, the same SM87 build imports `flash_rt_kernels` successfully.

## Validation

Validated on Jetson AGX Orin 32G:

| Field | Value |
|---|---|
| Device | Jetson AGX Orin 32G |
| Machine | KST Jetson AGX Orin AVSAI |
| SoC | tegra234 |
| Arch | aarch64 |
| L4T | R36.4.7 |
| Ubuntu | 22.04.5 LTS |
| Kernel | 5.15.148-tegra |
| CUDA Toolkit | 12.6.68 |
| Python | 3.10.12 |
| GCC/G++ | 11.4.0 |
| RAM | 30698 MB |
| PyTorch | 2.8.0 |
| Torch CUDA | 12.6 |
| GPU capability | SM87 / compute capability 8.7 |
| Visible GPU memory | 29.98 GB |
| SM count | 14 |

Build:

```bash
cmake -B build -S . \
  -DGPU_ARCH=87 \
  -DFA2_ARCH_NATIVE_ONLY=ON \
  -DFA2_HDIMS='96;128;256' \
  -DFA2_DTYPES='bf16' \
  -DPython3_EXECUTABLE=$(which python)

cmake --build build -j4 --target flash_rt_kernels
cmake --build build -j4 --target flash_rt_fa2
```

CMake confirmed:

```text
Using gencode flag: -gencode=arch=compute_87,code=sm_87
FA2 in-SO attention: ENABLED (sm_87)
SM80-family CUTLASS INT8: ENABLED (sm_87)
FA2 vendor arch: sm_87 AOT only (FA2_ARCH_NATIVE_ONLY=ON)
FA2 vendor instantiations: hdim={96,128,256} x dtype={bf16}
```

Import check:

```bash
python - <<'PY'
import flash_rt
from flash_rt.hardware import detect_arch
from flash_rt import flash_rt_kernels, flash_rt_fa2

print("flash_rt:", flash_rt.__version__)
print("arch:", detect_arch())
print("flash_rt_kernels loaded")
print("flash_rt_fa2 loaded")
PY
```

Output:

```text
flash_rt: 0.1.0
arch: rtx_sm87
flash_rt_kernels loaded
flash_rt_fa2 loaded
```

BF16 Pi0.5 Orin smoke:

```bash
unset FVK_PI05_RTX_FORCE_INT8
python examples/orin/bench_pi05.py \
  --checkpoint /root/models/pi05_libero_finetuned_v044 \
  --preset lossless \
  --no-int8
```

Output:

```text
Config : num_views=2  pool=1  layers=27  steps=10  cache_frames=1
Actions: (10, 7)
p50    : 246.8 ms   -> 4.05 Hz
p95    : 247.0 ms
min    : 246.8 ms   -> 4.05 Hz
```

Note: this PR is scoped to fixing `flash_rt_kernels` linkage/import for shared
quantize bindings on non-SM120 builds. INT8 Pi0.5 runtime behavior is not part
of this change.
