### PR TITLE
Motus/calibration

### DIFF
--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -602,7 +602,11 @@ available for `groot_rtx` (see
 [`flash_rt/frontends/torch/groot_rtx.py`](../flash_rt/frontends/torch/groot_rtx.py)
 `_calibrate_multi_frame`), which percentile-reduces both the Qwen3 and
 the DiT activation scales after running per-sample shadow forwards
-through both stages. The remaining Thor frontends (`pi0_thor`,
+through both stages. Motus RTX also supports
+`MotusTorchFrontendRtx.calibrate(obs_list, percentile=99.9)` for
+Stage3 bundles; it percentile-reduces Motus FP8 GEMM scales, AWQ-FP8
+action/und scales, G7.24 action/und QKV scales, and VAE FP8 resample
+scales before CUDA Graph capture. The remaining Thor frontends (`pi0_thor`,
 `pi0fast`, `groot_thor`, and their JAX counterparts) still route N ≥ 2
 through the `implicit_calibrate` shim and raise `NotImplementedError`
 — each needs a per-model audit of its calibrate-pass scale buffer

--- a/docs/motus_usage_beta.md
+++ b/docs/motus_usage_beta.md
@@ -28,7 +28,7 @@ before treating any number here as a contract.
 
 | Profile | Purpose | Wall (sample_00) | cos action | cos frames | VRAM peak |
 |---|---|---|---|---|---|
-| `fast` | **Validated Stage3 fast profile (default)** | ~170 ms | 0.99993 | 0.99911 | 28.2 GB |
+| `fast` | **Validated Stage3 fast profile (default)** | ~167 ms | 0.99993 | 0.99911 | 28.2 GB |
 | `fast` + TeaCache | Step caching on top of `fast` (env-gated) | **~100 ms** | 0.99992 | 0.99902 | 28.2 GB |
 | `off` | Explicit FP8 trajectory baseline (FP4/NVFP4 disabled) | record per machine | — | — | record per machine |
 | `fast-cache` | Latency-oriented FP4/NVFP4 without tiny-FP8 dispatch | record per bundle | — | — | record per bundle |
@@ -215,7 +215,7 @@ Expected steady-state output on the RoboTwin2 mini `sample_00` bundle,
 RTX 5090:
 
 ```text
-graph P50          ~= 170 ms
+graph P50          ~= 167 ms
 peak_allocated     ~= 28.2 GB
 cos action         ~= 0.99993
 cos frames         ~= 0.99911
@@ -224,15 +224,16 @@ cos frames         ~= 0.99911
 Cross-sample stability from the four-bundle validation run
 (calibration done on each bundle's own `first_frame`, no recalibration
 between). Wall time has normal run-to-run variance; use the quickstart
-P50 on your machine as the latency contract and the cosine columns as
-the stability check:
+P50 on your machine as the latency contract. The current `sample_00`
+quickstart P50 is 167.08 ms; the table below keeps the cosine stability
+columns that are independent of timing noise:
 
-| Bundle    | validation P50 (ms) | cos action | cos frames |
-|-----------|--------------:|-----------:|-----------:|
-| sample_00 | 171.19        | 0.999929   | 0.999117   |
-| sample_01 | 171.28        | 0.999935   | 0.998644   |
-| sample_02 | 171.09        | 0.999921   | 0.999144   |
-| sample_03 | 171.07        | 0.999913   | 0.998844   |
+| Bundle    | cos action | cos frames |
+|-----------|-----------:|-----------:|
+| sample_00 | 0.999929   | 0.999117   |
+| sample_01 | 0.999935   | 0.998644   |
+| sample_02 | 0.999921   | 0.999144   |
+| sample_03 | 0.999913   | 0.998844   |
 
 All four samples pass the red lines (`cos(action) ≥ 0.999`,
 `cos(frames) ≥ 0.99`).
@@ -285,11 +286,11 @@ python examples/motus_quickstart.py \
 
 | Skip schedule           | #skip | Wall (ms) | cos action | cos frames | Δ vs `fast` |
 |-------------------------|------:|----------:|-----------:|-----------:|-----------:|
-| (off)                   | 0     | 169.7     | 0.99994    | 0.99912    | —          |
-| `3,5,7`                 | 3     | 141.8     | 0.99993    | 0.99912    | -27.9 ms   |
-| `2,3,5,6,8`             | 5     | 121.1     | 0.99994    | 0.99913    | -48.6 ms   |
-| `2,3,4,5,6,7,8` (default) | 7   | **99.6** | 0.99992    | 0.99902    | **-70.1 ms** |
-| `1,2,3,4,5,6,7,8`       | 8     |  90.1     | 0.99993    | 0.99894    | -79.6 ms   |
+| (off)                   | 0     | 167.1     | 0.99994    | 0.99912    | —          |
+| `3,5,7`                 | 3     | 141.8     | 0.99993    | 0.99912    | -25.3 ms   |
+| `2,3,5,6,8`             | 5     | 121.1     | 0.99994    | 0.99913    | -46.0 ms   |
+| `2,3,4,5,6,7,8` (default) | 7   | **99.6** | 0.99992    | 0.99902    | **-67.5 ms** |
+| `1,2,3,4,5,6,7,8`       | 8     |  90.1     | 0.99993    | 0.99894    | -77.0 ms   |
 
 Cross-sample stability with the default skip schedule:
 
@@ -346,7 +347,7 @@ Motus Stage3 `sample_00` currently returns:
 ```text
 horizon=16
 action_dim=14
-profile fast latency ~= 170 ms
+profile fast latency ~= 167 ms
 profile fast + TeaCache latency ~= 100 ms
 ```
 
@@ -370,7 +371,7 @@ python examples/motus_rtc_lite.py \
 Expected supply-layer output:
 
 ```text
-horizon=16 action_dim=14 target_hz=50.00 latency_probe~=170 ms start_next_at~=6
+horizon=16 action_dim=14 target_hz=50.00 latency_probe~=167 ms start_next_at~=6
 served=64 elapsed=1.280s effective_hz=49.99
 deadline_misses=0 held_actions=0
 ```
@@ -484,14 +485,50 @@ Motus:
 - **Weights**: per-tensor FP8 scales are computed once at checkpoint
   load (`quant_fp8`) and stored alongside the weight tensors.
 - **Activations**: per-GEMM-input FP8 scales are computed during the
-  **first `infer()` call**, before CUDA Graph capture, by recording
-  the per-tensor amax of the captured forward pass.
-- The Motus frontend currently runs **single-sample calibration**: the
-  one observation passed to the first `infer()` is the calibration
-  sample. There is no public `calibrate(observations=[...], percentile=...)`
-  API yet; the multi-sample dataset path documented in
-  `docs/calibration.md` §10 is implemented for `pi05_thor`,
-  `groot_thor`, and `groot_rtx`, not for Motus.
+  **first `infer()` call** by default, before CUDA Graph capture, by
+  recording the per-tensor amax of that forward pass.
+- Motus also exposes the same explicit public API as the other RTX
+  frontends:
+
+  ```python
+  pipe.set_prompt(instruction, t5_embeds=t5_embeds, vlm_inputs=vlm_inputs)
+
+  # Single-sample calibration, equivalent to legacy first-infer calibration.
+  pipe.calibrate([{"first_frame": first_frame, "state": state}])
+
+  # Dataset calibration: reduce per-sample activation scales by percentile.
+  pipe.calibrate(calibration_samples, percentile=99.9, max_samples=16)
+  ```
+
+  Each calibration sample may be a dict with `first_frame` and optional
+  `state`, a bare `first_frame` tensor, or a `(first_frame, state)` tuple.
+  `calibrate()` must be called after `set_prompt()` and before the first
+  captured `infer()`. It calibrates FP8 GEMM sites, Motus AWQ-FP8 sites,
+  G7.24 action/und QKV scales, and VAE FP8 resample scales, then records
+  the CUDA Graph on the first calibration sample. Subsequent `infer()`
+  calls are graph replays.
+- The quickstart also exposes dataset calibration directly from Motus
+  input bundles:
+
+  ```bash
+  python examples/motus_quickstart.py \
+    --checkpoint "${MOTUS_CHECKPOINT}" \
+    --motus-root "${MOTUS_ROOT}" \
+    --wan-path "${MOTUS_WAN_PATH}" \
+    --vlm-path "${MOTUS_VLM_PATH}" \
+    --input-bundle "${MOTUS_INPUT_BUNDLE}" \
+    --fp4-profile fast \
+    --calibration-glob "/absolute/path/to/robotwin_mini_bundles/sample_*" \
+    --calibration-max-samples 4 \
+    --calibration-percentile 99.9 \
+    --benchmark 10
+  ```
+
+  `--calibration-bundle /path/to/sample_00` can be repeated, or passed as
+  a comma-separated list, when you want exact sample control. Dataset
+  calibration uses the current `set_prompt()` conditioning from
+  `--input-bundle`; use calibration bundles from the same task/prompt
+  family unless you are intentionally widening activation coverage.
 - The validated Stage3 bundle has shown stable cross-sample behaviour
   with single-sample calibration: cosine variance across `sample_00` to
   `sample_03` is at most 2e-5 on action and 5e-4 on frames (see §5/§6
@@ -499,10 +536,10 @@ Motus:
   the other three samples too.
 - If your downstream evaluation bundle distribution is wider than the
   Stage3 RoboTwin2 mini set (e.g. covers many lighting / occlusion
-  conditions that single-sample calibration cannot represent),
-  port the `pi05_thor._calibrate_multi_frame` percentile-reduced
-  multi-sample path to the Motus frontend before relying on the
-  current numbers.
+  conditions that single-sample calibration cannot represent), run
+  `calibrate()` on a small representative dataset and record the same
+  `graph P50`, action cosine, frame cosine, and trajectory deviation
+  metrics against your reference bundle.
 
 ---
 

--- a/examples/motus_quickstart.py
+++ b/examples/motus_quickstart.py
@@ -25,6 +25,7 @@ Examples:
 from __future__ import annotations
 
 import argparse
+import glob
 import inspect
 import json
 import os
@@ -78,6 +79,23 @@ def _load_inputs(bundle: pathlib.Path):
     if not isinstance(vlm_inputs, list):
         vlm_inputs = [vlm_inputs]
     return first_frame, state, instruction, t5_embeds, vlm_inputs
+
+
+def _load_calibration_sample(bundle: pathlib.Path):
+    first_frame, state, _instruction, _t5_embeds, _vlm_inputs = _load_inputs(bundle)
+    return {"first_frame": first_frame, "state": state}
+
+
+def _resolve_calibration_bundles(args) -> list[pathlib.Path]:
+    paths: list[str] = []
+    for item in args.calibration_bundle or []:
+        paths.extend(p for p in item.split(",") if p)
+    if args.calibration_glob:
+        paths.extend(sorted(glob.glob(args.calibration_glob)))
+    bundles = [pathlib.Path(p).expanduser() for p in paths]
+    if args.calibration_max_samples is not None:
+        bundles = bundles[:args.calibration_max_samples]
+    return bundles
 
 
 def _load_optional_refs(bundle: pathlib.Path):
@@ -396,6 +414,31 @@ def main() -> None:
                         help="Optional .pt path for {'frames','actions'}")
     parser.add_argument("--no-compare", action="store_true",
                         help="Do not compare against optional bundle outputs")
+    parser.add_argument(
+        "--calibration-bundle",
+        action="append",
+        default=[],
+        help="Motus input bundle used for explicit calibration. Can be "
+             "specified multiple times or as a comma-separated list. Each "
+             "bundle must contain inputs/first_frame.pt and inputs/state.pt. "
+             "If omitted, the first infer() performs legacy single-sample "
+             "calibration on --input-bundle.")
+    parser.add_argument(
+        "--calibration-glob",
+        default=None,
+        help="Glob for dataset calibration bundles, e.g. "
+             "'/data/robotwin_mini_bundles/sample_*'. Bundles are sorted "
+             "lexicographically before max-sample truncation.")
+    parser.add_argument(
+        "--calibration-percentile",
+        type=float,
+        default=99.9,
+        help="Percentile reducer for explicit dataset calibration.")
+    parser.add_argument(
+        "--calibration-max-samples",
+        type=int,
+        default=None,
+        help="Maximum number of calibration bundles to load.")
     args = parser.parse_args()
 
     required = {
@@ -430,6 +473,12 @@ def main() -> None:
     print(f"[motus.quickstart] input_bundle={bundle}")
     print(f"[motus.quickstart] fp4_profile={args.fp4_profile}")
     print(f"[motus.quickstart] num_inference_steps={args.num_inference_steps}")
+    calibration_bundles = _resolve_calibration_bundles(args)
+    if calibration_bundles:
+        print("[motus.quickstart] calibration_bundles="
+              f"{[str(p) for p in calibration_bundles]}")
+        print("[motus.quickstart] calibration_percentile="
+              f"{args.calibration_percentile}")
 
     t0 = time.perf_counter()
     from flash_rt.frontends.torch.motus_rtx import MotusTorchFrontendRtx
@@ -446,7 +495,27 @@ def main() -> None:
 
     pipe.set_prompt(instruction, t5_embeds=t5_embeds, vlm_inputs=vlm_inputs)
 
-    print("[motus.quickstart] warmup #1: FP8 calibration + CUDA graph capture")
+    if calibration_bundles:
+        print("[motus.quickstart] explicit calibration: loading samples")
+        calibration_samples = [
+            _load_calibration_sample(path) for path in calibration_bundles
+        ]
+        t_cal0 = _now()
+        pipe.calibrate(
+            calibration_samples,
+            percentile=args.calibration_percentile,
+            max_samples=args.calibration_max_samples,
+            verbose=True,
+        )
+        t_cal = (_now() - t_cal0) * 1000.0
+        print("[motus.quickstart] explicit calibration + graph capture done: "
+              f"{t_cal:.1f} ms (N={len(calibration_samples)})")
+
+    warmup_label = (
+        "graph replay after explicit calibration"
+        if calibration_bundles else
+        "FP8 calibration + CUDA graph capture")
+    print(f"[motus.quickstart] warmup #1: {warmup_label}")
     _, _, t_calib = _infer_once(pipe, first_frame, state, args.seed)
     print(f"[motus.quickstart] warmup #1 done: {t_calib:.1f} ms")
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -75,7 +75,7 @@ def main():
                         help="Pi0.5 torch only. Enable NVFP4 quantization "
                              "with the production preset: full 18 encoder "
                              "FFN layers + AWQ + P1 split-GU "
-                             "(LIBERO Spatial 491/500 = 98.2%, matches FP8 "
+                             "(LIBERO Spatial 491/500 = 98.2%%, matches FP8 "
                              "baseline). Requires Thor SM110 / SM100+.")
     args = parser.parse_args()
 

--- a/flash_rt/frontends/torch/motus_rtx.py
+++ b/flash_rt/frontends/torch/motus_rtx.py
@@ -45,6 +45,7 @@ import sys
 import time
 from typing import Any, Dict, List, Optional
 
+import numpy as np
 import torch
 
 from flash_rt.models.motus.pipeline_rtx import (
@@ -744,6 +745,388 @@ class MotusTorchFrontendRtx:
         if self._graph_state is not None:
             logger.info("[motus] set_prompt changed; dropping captured graph")
             self._graph_state = None
+
+    # ──────────────────────────────────────────────────────────────
+    # Explicit calibration API
+    # ──────────────────────────────────────────────────────────────
+
+    def calibrate(
+        self,
+        observations,
+        *,
+        percentile: float = 99.9,
+        max_samples: Optional[int] = None,
+        verbose: bool = False,
+    ) -> None:
+        """Calibrate Motus FP8/AWQ activation scales on real samples.
+
+        ``N == 1`` is equivalent to the legacy first-``infer`` calibration
+        sample. ``N > 1`` runs each observation through the calibration
+        graph, percentile-reduces the per-site activation scales, then
+        records the CUDA Graph using the first observation. The inference
+        graph structure and replay latency are unchanged; only scale values
+        differ.
+        """
+        if self._t5_embeds is None or self._vlm_inputs is None:
+            raise RuntimeError(
+                "Call set_prompt(prompt, t5_embeds=, vlm_inputs=) before calibrate()")
+        if self._graph_state is not None:
+            raise RuntimeError(
+                "calibrate() must be called before CUDA Graph capture. "
+                "Create a new frontend or call set_prompt() to invalidate the graph.")
+        if not 0.0 <= percentile <= 100.0:
+            raise ValueError(f"percentile must be in [0, 100], got {percentile}")
+
+        obs_list = self._normalize_calibration_observations(observations)
+        if max_samples is not None:
+            obs_list = obs_list[:max_samples]
+        if not obs_list:
+            raise ValueError("observations must contain at least 1 sample")
+
+        samples = [self._extract_calibration_sample(o) for o in obs_list]
+        n = len(samples)
+        logger.info(
+            "[motus] explicit calibration: N=%d percentile=%.2f",
+            n, percentile)
+
+        if (self._fp8_swap_stats is not None) and (not self._fp8_calibrated):
+            self._calibrate_fp8_samples(
+                samples, percentile=percentile, verbose=verbose)
+        else:
+            logger.info("[motus] no pending G4 FP8 calibration work")
+
+        # Finish the same one-time installs that normally happen between
+        # calibration and graph capture, then capture with the first sample.
+        first_frame, state = samples[0]
+        with torch.no_grad():
+            _ = self.infer(first_frame, state=state)
+
+        self._precision_spec = self._snapshot_precision_spec(
+            method=("single_frame" if n == 1 else "percentile"),
+            n=n,
+            percentile=(None if n == 1 else percentile),
+        )
+
+    def calibrate_with_real_data(self, sample_observations) -> None:
+        """Legacy alias retained for consistency with other frontends."""
+        self.calibrate(sample_observations)
+
+    @property
+    def precision_spec(self):
+        """:class:`ModelPrecisionSpec` captured at calibration time."""
+        return getattr(self, "_precision_spec", None)
+
+    def _normalize_calibration_observations(self, observations) -> list:
+        if isinstance(observations, dict) or torch.is_tensor(observations):
+            return [observations]
+        if isinstance(observations, list):
+            return observations
+        return list(observations)
+
+    def _extract_calibration_sample(self, obs):
+        if torch.is_tensor(obs):
+            return obs, None
+        if isinstance(obs, (tuple, list)) and 1 <= len(obs) <= 2:
+            first_frame = obs[0]
+            state = obs[1] if len(obs) == 2 else None
+            if not torch.is_tensor(first_frame):
+                raise TypeError("calibration tuple[0] must be first_frame tensor")
+            if state is not None and not torch.is_tensor(state):
+                raise TypeError("calibration tuple[1] must be state tensor")
+            return first_frame, state
+        if not isinstance(obs, dict):
+            raise TypeError(
+                "Motus calibration observations must be a dict, tensor, "
+                "or (first_frame, state) tuple")
+        first_frame = None
+        for key in ("first_frame", "image", "images"):
+            value = obs.get(key)
+            if torch.is_tensor(value):
+                first_frame = value
+                break
+        if first_frame is None:
+            raise KeyError(
+                "Motus calibration observation requires a first_frame tensor "
+                "under key 'first_frame' (or 'image'/'images')")
+        state = obs.get("state")
+        if state is not None and not torch.is_tensor(state):
+            raise TypeError("Motus calibration observation 'state' must be a tensor")
+        return first_frame, state
+
+    def _to_runtime_inputs(self, first_frame, state):
+        first_frame = first_frame.to(self.device).to(self.dtype)
+        if state is not None:
+            state = state.to(self.device).to(self.dtype)
+        return first_frame, state
+
+    def _run_pipeline_once_for_calibration(self, first_frame, state):
+        first_frame, state = self._to_runtime_inputs(first_frame, state)
+        with torch.no_grad():
+            return self.pipeline.run(
+                first_frame=first_frame,
+                state=state,
+                t5_embeds=self._t5_embeds,
+                vlm_inputs=self._vlm_inputs,
+            )
+
+    def _calibrate_fp8_samples(self, samples, *, percentile: float,
+                               verbose: bool) -> None:
+        """Run Motus's two-phase calibration over one or more samples."""
+        from flash_rt.core.calibration import (
+            accumulate_amax,
+            format_summary,
+            summarize_amax_dispersion,
+        )
+
+        n = len(samples)
+        resample_pre: list[dict[str, float]] = []
+
+        # 0) AWQ/G7.24 BF16 calibration pass. For N>1 collect per-sample
+        # per-K amax vectors, reduce them, then apply the same FP8 swaps.
+        if (self._awq_calib_states is not None) and (not self._awq_applied):
+            logger.info("[motus] G7.13.awq: calibration pass over %d sample(s)", n)
+            from flash_rt.models.motus._vae_fp8_resample_swap import (
+                set_calibrating as set_resample_calibrating)
+
+            awq_rows: dict[str, list[np.ndarray]] = {
+                k: [] for k in self._awq_calib_states.keys()
+            }
+            g724_rows: dict[str, list[np.ndarray]] = {
+                k: [] for k in (self._g724_states or {}).keys()
+            }
+            for i, (first_frame, state) in enumerate(samples):
+                self._reset_awq_states()
+                self._reset_g724_states()
+                self._reset_resample_amax()
+                set_resample_calibrating(True)
+                try:
+                    _ = self._run_pipeline_once_for_calibration(
+                        first_frame, state)
+                    torch.cuda.synchronize()
+                finally:
+                    set_resample_calibrating(False)
+                for name, st in self._awq_calib_states.items():
+                    awq_rows[name].append(
+                        st.act_amax_K.detach().float().cpu().numpy())
+                for name, st in (self._g724_states or {}).items():
+                    g724_rows[name].append(
+                        st.act_amax_K.detach().float().cpu().numpy())
+                resample_pre.append(self._collect_resample_amax())
+                if verbose:
+                    logger.info("[motus] AWQ calibration sample %d/%d", i + 1, n)
+
+            for name, rows in awq_rows.items():
+                final = accumulate_amax(rows, percentile=percentile)
+                st = self._awq_calib_states[name]
+                st.act_amax_K.copy_(torch.from_numpy(final).to(st.act_amax_K))
+                st.count = max(st.count, 1)
+            for name, rows in g724_rows.items():
+                final = accumulate_amax(rows, percentile=percentile)
+                st = self._g724_states[name]
+                st.act_amax_K.copy_(torch.from_numpy(final).to(st.act_amax_K))
+                st.count = max(st.count, 1)
+
+            from flash_rt.models.motus._awq_fp8_swap import (
+                install_awq_fp8_swap, remove_awq_calibration_hooks)
+            remove_awq_calibration_hooks(self.model)
+            self._awq_swap_stats = install_awq_fp8_swap(
+                self.model, self._awq_calib_states)
+            self._awq_applied = True
+            logger.info("[motus] G7.13.awq applied: %s", self._awq_swap_stats)
+
+            if (self._g724_states is not None) and (not self._g724_applied):
+                from flash_rt.models.motus._action_und_qkv_fp8_swap import (
+                    install_g724_fp8)
+                self._g724_swap_stats = install_g724_fp8(self.model)
+                self._g724_applied = True
+                logger.info("[motus] G7.24 applied: %s", self._g724_swap_stats)
+
+        # 1) G4 calibration for all FP8 sites after AWQ/G724 swaps exist.
+        logger.info("[motus] G4: calibration pass over %d sample(s)", n)
+        from flash_rt.models.motus._fp8_swap import set_calibrating
+        from flash_rt.models.motus._vae_fp8_resample_swap import (
+            set_calibrating as set_resample_calibrating)
+
+        scale_rows: list[np.ndarray] = []
+        scale_names: Optional[list[str]] = None
+        resample_post: list[dict[str, float]] = []
+        set_calibrating(True)
+        set_resample_calibrating(True)
+        try:
+            for i, (first_frame, state) in enumerate(samples):
+                self._reset_resample_amax()
+                _ = self._run_pipeline_once_for_calibration(first_frame, state)
+                torch.cuda.synchronize()
+                names, values = self._collect_runtime_fp8_scales()
+                if scale_names is None:
+                    scale_names = names
+                elif scale_names != names:
+                    raise RuntimeError(
+                        "Motus FP8 calibration site set changed between samples")
+                scale_rows.append(np.asarray(values, dtype=np.float32))
+                resample_post.append(self._collect_resample_amax())
+                if verbose:
+                    logger.info("[motus] G4 calibration sample %d/%d", i + 1, n)
+        finally:
+            set_calibrating(False)
+            set_resample_calibrating(False)
+
+        if scale_rows and scale_names is not None:
+            final_scales = accumulate_amax(scale_rows, percentile=percentile)
+            self._write_runtime_fp8_scales(scale_names, final_scales)
+            if verbose:
+                logger.info(format_summary(
+                    summarize_amax_dispersion(scale_rows, final_scales)))
+
+        self._write_resample_reduced_amax(
+            resample_pre, resample_post, percentile=percentile)
+        self._fp8_calibrated = True
+        logger.info("[motus] G4: calibration complete; switching to static")
+
+        from flash_rt.models.motus._fp8_swap import (
+            autotune_motus_hot_fp8_gemms)
+        self._fp8_gemm_autotune_stats = autotune_motus_hot_fp8_gemms(
+            self.model)
+        logger.info("[motus] G7.29 FP8 GEMM autotune: %s",
+                    self._fp8_gemm_autotune_stats)
+
+    def _reset_awq_states(self) -> None:
+        for st in (self._awq_calib_states or {}).values():
+            st.act_amax_K.zero_()
+            st.count = 0
+
+    def _reset_g724_states(self) -> None:
+        for st in (self._g724_states or {}).values():
+            st.act_amax_K.zero_()
+            st.count = 0
+
+    def _reset_resample_amax(self) -> None:
+        for site in self._iter_resample_sites():
+            site.act_amax_bf16.zero_()
+
+    def _iter_resample_sites(self):
+        seen: set[int] = set()
+        for mod in self.model.modules():
+            site = getattr(mod, "_fp8_resample_site", None)
+            if site is not None and id(site) not in seen:
+                seen.add(id(site))
+                yield site
+
+    def _collect_resample_amax(self) -> dict[str, float]:
+        return {
+            site.name: float(site.act_amax_bf16.float().item())
+            for site in self._iter_resample_sites()
+        }
+
+    def _write_resample_reduced_amax(self, pre_rows, post_rows,
+                                     *, percentile: float) -> None:
+        sites = {site.name: site for site in self._iter_resample_sites()}
+        if not sites:
+            return
+        combined_rows: list[dict[str, float]] = []
+        for idx in range(max(len(pre_rows), len(post_rows))):
+            row: dict[str, float] = {}
+            if idx < len(pre_rows):
+                for name, value in pre_rows[idx].items():
+                    row[name] = max(row.get(name, 0.0), float(value))
+            if idx < len(post_rows):
+                for name, value in post_rows[idx].items():
+                    row[name] = max(row.get(name, 0.0), float(value))
+            if row:
+                combined_rows.append(row)
+        if not combined_rows:
+            return
+        names = sorted(sites.keys())
+        vectors = [
+            np.asarray([row.get(name, 0.0) for name in names],
+                       dtype=np.float32)
+            for row in combined_rows
+        ]
+        final = np.percentile(np.stack(vectors, axis=0).astype(np.float64),
+                              percentile, axis=0).astype(np.float32)
+        for name, value in zip(names, final):
+            sites[name].act_amax_bf16.copy_(
+                torch.tensor([float(value)], dtype=torch.bfloat16,
+                             device=sites[name].act_amax_bf16.device))
+
+    def _iter_runtime_fp8_sites(self):
+        seen: set[int] = set()
+        for mod in self.model.modules():
+            for attr in ("_fp8_site", "_awq_fp8_site",
+                         "_awq_up_site", "_awq_dn_site"):
+                site = getattr(mod, attr, None)
+                if site is not None and hasattr(site, "act_scale") \
+                        and id(site) not in seen:
+                    seen.add(id(site))
+                    yield getattr(site, "label", attr), site
+            st = getattr(mod, "_g724_state", None)
+            if st is not None and getattr(st, "act_scale", None) is not None \
+                    and id(st) not in seen:
+                seen.add(id(st))
+                yield getattr(st, "label", "_g724_state"), st
+
+    def _collect_runtime_fp8_scales(self) -> tuple[list[str], list[float]]:
+        pairs = sorted(self._iter_runtime_fp8_sites(), key=lambda p: p[0])
+        names = [name for name, _site in pairs]
+        values = [
+            float(site.act_scale.detach().float().reshape(-1)[0].item())
+            for _name, site in pairs
+        ]
+        return names, values
+
+    def _write_runtime_fp8_scales(self, names: list[str],
+                                  values: np.ndarray) -> None:
+        sites = {name: site for name, site in self._iter_runtime_fp8_sites()}
+        for name, value in zip(names, values):
+            site = sites[name]
+            site.act_scale.fill_(float(value))
+
+    def _snapshot_precision_spec(self, *, method: str, n: int,
+                                  percentile: Optional[float]):
+        from flash_rt.core.precision_spec import (
+            ModelPrecisionSpec,
+            PrecisionSpec,
+        )
+
+        spec = ModelPrecisionSpec(source="calibration")
+        for name, site in self._iter_runtime_fp8_sites():
+            scale_val = np.array(
+                [float(site.act_scale.detach().float().reshape(-1)[0].item())],
+                dtype=np.float32)
+            entry = PrecisionSpec(
+                dtype="fp8_e4m3",
+                granularity="per_tensor",
+                scheme="symmetric",
+                scale_source="calibration",
+                scale=scale_val,
+                calibration_method=method,
+                calibration_samples=n,
+                calibration_percentile=percentile,
+            )
+            entry.validate()
+            if name.startswith("video_model.") or ".wan_model." in name:
+                spec.decoder_layer_specs[name] = entry
+            else:
+                spec.activation_specs[name] = entry
+
+        for site in self._iter_resample_sites():
+            if getattr(site, "act_scale", None) is None:
+                continue
+            scale_val = np.array([float(site.act_scale_scalar)],
+                                 dtype=np.float32)
+            entry = PrecisionSpec(
+                dtype="fp8_e4m3",
+                granularity="per_tensor",
+                scheme="symmetric",
+                scale_source="calibration",
+                scale=scale_val,
+                calibration_method=method,
+                calibration_samples=n,
+                calibration_percentile=percentile,
+            )
+            entry.validate()
+            spec.activation_specs[f"vae_resample.{site.name}"] = entry
+        return spec
 
     def infer(
         self,

--- a/tests/test_motus_calibration_api.py
+++ b/tests/test_motus_calibration_api.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pytest
+import torch
+
+from flash_rt.frontends.torch.motus_rtx import MotusTorchFrontendRtx
+
+
+def _frontend_shell():
+    rt = MotusTorchFrontendRtx.__new__(MotusTorchFrontendRtx)
+    rt.device = torch.device("cpu")
+    rt.dtype = torch.bfloat16
+    return rt
+
+
+def test_motus_calibration_sample_shapes():
+    rt = _frontend_shell()
+    first = torch.randn(1, 3, 384, 320)
+    state = torch.randn(1, 14)
+
+    assert rt._normalize_calibration_observations(first) == [first]
+    assert rt._extract_calibration_sample(first) == (first, None)
+    assert rt._extract_calibration_sample((first, state)) == (first, state)
+    assert rt._extract_calibration_sample(
+        {"first_frame": first, "state": state}) == (first, state)
+    assert rt._extract_calibration_sample({"image": first}) == (first, None)
+
+    with pytest.raises(KeyError):
+        rt._extract_calibration_sample({"state": state})
+    with pytest.raises(TypeError):
+        rt._extract_calibration_sample({"first_frame": first, "state": 1})
+
+
+def test_motus_calibrate_validates_prompt_and_percentile():
+    rt = _frontend_shell()
+    rt._t5_embeds = None
+    rt._vlm_inputs = None
+    rt._graph_state = None
+    rt._fp8_swap_stats = None
+    rt._fp8_calibrated = True
+
+    first = torch.randn(1, 3, 384, 320)
+    with pytest.raises(RuntimeError, match="set_prompt"):
+        rt.calibrate([{"first_frame": first}])
+
+    rt._t5_embeds = [torch.empty(1)]
+    rt._vlm_inputs = [{}]
+    with pytest.raises(ValueError):
+        rt.calibrate([{"first_frame": first}], percentile=-1)
+
+    rt._graph_state = object()
+    with pytest.raises(RuntimeError, match="before CUDA Graph capture"):
+        rt.calibrate([{"first_frame": first}])
+
+
+class _FakeSite:
+    def __init__(self, label, value):
+        self.label = label
+        self.act_scale = torch.tensor([value], dtype=torch.float32)
+
+
+class _FakeResampleSite:
+    def __init__(self, name, value):
+        self.name = name
+        self.act_scale = torch.tensor([value], dtype=torch.float32)
+        self.act_scale_scalar = float(value)
+
+
+def test_motus_precision_spec_metadata():
+    rt = _frontend_shell()
+    root = torch.nn.Module()
+    child = torch.nn.Module()
+    child._fp8_site = _FakeSite(
+        "video_model.wan_model.blocks.0.self_attn.q", 0.125)
+    child._fp8_resample_site = _FakeResampleSite("decoder.resample.1", 0.25)
+    root.add_module("child", child)
+    rt.model = root
+
+    spec = rt._snapshot_precision_spec(
+        method="percentile", n=4, percentile=99.9)
+    assert spec.source == "calibration"
+    assert "video_model.wan_model.blocks.0.self_attn.q" in \
+        spec.decoder_layer_specs
+    entry = spec.decoder_layer_specs[
+        "video_model.wan_model.blocks.0.self_attn.q"]
+    assert entry.calibration_method == "percentile"
+    assert entry.calibration_samples == 4
+    assert entry.calibration_percentile == 99.9
+    np.testing.assert_allclose(entry.scale, np.array([0.125], dtype=np.float32))
+    assert "vae_resample.decoder.resample.1" in spec.activation_specs


### PR DESCRIPTION
This update adds the standard calibration interface for the Motus RTX path and aligns its calibration workflow with the other FlashRT models.

Main changes:

* Added `MotusTorchFrontendRtx.calibrate(...)`
* Supports single-sample and N>1 multi-sample calibration
* Supports dataset calibration from multiple input bundles
* Added the following options to `motus_quickstart.py`:

  * `--calibration-bundle`
  * `--calibration-glob`
  * `--calibration-percentile`
  * `--calibration-max-samples`
* Calibration now updates FP8 / AWQ / VAE-related scales before CUDA Graph capture
* Documentation updated with single-sample, multi-sample, and dataset calibration examples

Validation:

* Motus fast baseline works correctly
* Dataset calibration with N=2 works correctly
* Action / frame cosine remains normal
* Pi0.5 quickstart regression passed
* `tests/test_motus_calibration_api.py` passed

Branch: `motus/calibration`
