### PR TITLE
Add Pi0.5 Thor FP16 CUTLASS+megakernel encoder path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,13 @@ else()
   set(ENABLE_SM100_CUTLASS OFF)
 endif()
 
+# Developer-only SM100 kernels. OFF by default so production flash_rt_kernels
+# neither compiles nor exports them; turn on locally for kernel bring-up.
+option(FLASHRT_BUILD_SM100_SWEEP
+       "Build the transient FP16 CUTLASS tile-sweep bench kernel" OFF)
+option(FLASHRT_BUILD_SM100_ENCODER_MLP
+       "Build the WIP Path C encoder MLP megakernel scaffold" OFF)
+
 # SM120+ (Blackwell): NVFP4/W4A8 block-scaled GEMM
 if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "120a")
   set(ENABLE_NVFP4 ON)
@@ -304,41 +311,45 @@ if(ENABLE_SM100_CUTLASS)
     >
   )
 
-  # Path C encoder MLP megakernel (scaffold, fallback to 3-step GEMMs).
-  add_library(encoder_mlp_sm100_obj OBJECT csrc/gemm/mega/encoder_mlp_sm100.cu)
-  set_target_properties(encoder_mlp_sm100_obj PROPERTIES
-    CUDA_STANDARD 17
-    POSITION_INDEPENDENT_CODE ON
-  )
-  target_include_directories(encoder_mlp_sm100_obj PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
-    ${CUTLASS_INCLUDE}
-    ${CUTLASS_DIR}/tools/util/include
-  )
-  target_compile_options(encoder_mlp_sm100_obj PRIVATE
-    $<$<COMPILE_LANGUAGE:CUDA>:
-      --expt-relaxed-constexpr -O3 --use_fast_math
-      ${GPU_GENCODE}
-    >
-  )
+  # Path C encoder MLP megakernel scaffold (WIP, unused by the runtime).
+  if(FLASHRT_BUILD_SM100_ENCODER_MLP)
+    add_library(encoder_mlp_sm100_obj OBJECT csrc/gemm/mega/encoder_mlp_sm100.cu)
+    set_target_properties(encoder_mlp_sm100_obj PROPERTIES
+      CUDA_STANDARD 17
+      POSITION_INDEPENDENT_CODE ON
+    )
+    target_include_directories(encoder_mlp_sm100_obj PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+      ${CUTLASS_INCLUDE}
+      ${CUTLASS_DIR}/tools/util/include
+    )
+    target_compile_options(encoder_mlp_sm100_obj PRIVATE
+      $<$<COMPILE_LANGUAGE:CUDA>:
+        --expt-relaxed-constexpr -O3 --use_fast_math
+        ${GPU_GENCODE}
+      >
+    )
+  endif()
 
-  # FP16 CUTLASS GEMM tile-sweep (transient, used by R1.1 sweep bench).
-  add_library(cutlass_sm100_fp16_sweep_obj OBJECT csrc/gemm/cutlass_sm100_fp16_sweep.cu)
-  set_target_properties(cutlass_sm100_fp16_sweep_obj PROPERTIES
-    CUDA_STANDARD 17
-    POSITION_INDEPENDENT_CODE ON
-  )
-  target_include_directories(cutlass_sm100_fp16_sweep_obj PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
-    ${CUTLASS_INCLUDE}
-    ${CUTLASS_DIR}/tools/util/include
-  )
-  target_compile_options(cutlass_sm100_fp16_sweep_obj PRIVATE
-    $<$<COMPILE_LANGUAGE:CUDA>:
-      --expt-relaxed-constexpr -O3 --use_fast_math
-      ${GPU_GENCODE}
-    >
-  )
+  # FP16 CUTLASS GEMM tile-sweep bench kernel (transient bring-up tool).
+  if(FLASHRT_BUILD_SM100_SWEEP)
+    add_library(cutlass_sm100_fp16_sweep_obj OBJECT csrc/gemm/cutlass_sm100_fp16_sweep.cu)
+    set_target_properties(cutlass_sm100_fp16_sweep_obj PROPERTIES
+      CUDA_STANDARD 17
+      POSITION_INDEPENDENT_CODE ON
+    )
+    target_include_directories(cutlass_sm100_fp16_sweep_obj PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+      ${CUTLASS_INCLUDE}
+      ${CUTLASS_DIR}/tools/util/include
+    )
+    target_compile_options(cutlass_sm100_fp16_sweep_obj PRIVATE
+      $<$<COMPILE_LANGUAGE:CUDA>:
+        --expt-relaxed-constexpr -O3 --use_fast_math
+        ${GPU_GENCODE}
+      >
+    )
+  endif()
 endif()
 
 # ── libfmha_fp16_strided.so — CUTLASS SM100 FP16 FMHA for SigLIP ──
@@ -823,12 +834,18 @@ if(ENABLE_SM100_CUTLASS)
   target_sources(flash_rt_kernels PRIVATE
     $<TARGET_OBJECTS:cutlass_sm100_obj>
     $<TARGET_OBJECTS:cutlass_sm100_fp16_obj>
-    $<TARGET_OBJECTS:cutlass_sm100_fp16_sweep_obj>
-    $<TARGET_OBJECTS:encoder_mlp_sm100_obj>
     $<TARGET_OBJECTS:flashrt_megakernel_obj>
     $<TARGET_OBJECTS:flashrt_megakernel_geglu_obj>
     $<TARGET_OBJECTS:flashrt_megakernel_geglu_g8_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE ENABLE_SM100_CUTLASS=1)
+  if(FLASHRT_BUILD_SM100_SWEEP)
+    target_sources(flash_rt_kernels PRIVATE $<TARGET_OBJECTS:cutlass_sm100_fp16_sweep_obj>)
+    target_compile_definitions(flash_rt_kernels PRIVATE FLASHRT_HAVE_SM100_SWEEP=1)
+  endif()
+  if(FLASHRT_BUILD_SM100_ENCODER_MLP)
+    target_sources(flash_rt_kernels PRIVATE $<TARGET_OBJECTS:encoder_mlp_sm100_obj>)
+    target_compile_definitions(flash_rt_kernels PRIVATE FLASHRT_HAVE_SM100_ENCODER_MLP=1)
+  endif()
 endif()
 
 if(ENABLE_NVFP4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,28 @@ if(ENABLE_SM100_CUTLASS)
   )
   message(STATUS "SM100 CUTLASS FP16 GEMMs: building for sm_${GPU_ARCH}")
 
+  # Path C: vendored production sm100_gemm_tma_warpspecialized.hpp +
+  # single-GEMM instantiation for "match production" gate test.  The
+  # header is a literal copy of CUTLASS production; the .cu file
+  # instantiates it for the split-G7 shape via CollectiveBuilder.
+  add_library(flashrt_megakernel_obj OBJECT csrc/gemm/mega/flashrt_megakernel_single.cu)
+  set_target_properties(flashrt_megakernel_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(flashrt_megakernel_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm/mega
+    ${CUTLASS_INCLUDE}
+    ${CUTLASS_DIR}/tools/util/include
+  )
+  target_compile_options(flashrt_megakernel_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3 --use_fast_math
+      ${GPU_GENCODE}
+    >
+  )
+
   # Path C encoder MLP megakernel (scaffold, fallback to 3-step GEMMs).
   add_library(encoder_mlp_sm100_obj OBJECT csrc/gemm/mega/encoder_mlp_sm100.cu)
   set_target_properties(encoder_mlp_sm100_obj PROPERTIES
@@ -750,7 +772,8 @@ if(ENABLE_SM100_CUTLASS)
     $<TARGET_OBJECTS:cutlass_sm100_obj>
     $<TARGET_OBJECTS:cutlass_sm100_fp16_obj>
     $<TARGET_OBJECTS:cutlass_sm100_fp16_sweep_obj>
-    $<TARGET_OBJECTS:encoder_mlp_sm100_obj>)
+    $<TARGET_OBJECTS:encoder_mlp_sm100_obj>
+    $<TARGET_OBJECTS:flashrt_megakernel_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE ENABLE_SM100_CUTLASS=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,24 @@ if(ENABLE_SM100_CUTLASS)
   )
   message(STATUS "SM100 CUTLASS FP16 GEMMs: building for sm_${GPU_ARCH}")
 
+  # Path C encoder MLP megakernel (scaffold, fallback to 3-step GEMMs).
+  add_library(encoder_mlp_sm100_obj OBJECT csrc/gemm/mega/encoder_mlp_sm100.cu)
+  set_target_properties(encoder_mlp_sm100_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(encoder_mlp_sm100_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+    ${CUTLASS_INCLUDE}
+    ${CUTLASS_DIR}/tools/util/include
+  )
+  target_compile_options(encoder_mlp_sm100_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3 --use_fast_math
+      ${GPU_GENCODE}
+    >
+  )
+
   # FP16 CUTLASS GEMM tile-sweep (transient, used by R1.1 sweep bench).
   add_library(cutlass_sm100_fp16_sweep_obj OBJECT csrc/gemm/cutlass_sm100_fp16_sweep.cu)
   set_target_properties(cutlass_sm100_fp16_sweep_obj PROPERTIES
@@ -731,7 +749,8 @@ if(ENABLE_SM100_CUTLASS)
   target_sources(flash_rt_kernels PRIVATE
     $<TARGET_OBJECTS:cutlass_sm100_obj>
     $<TARGET_OBJECTS:cutlass_sm100_fp16_obj>
-    $<TARGET_OBJECTS:cutlass_sm100_fp16_sweep_obj>)
+    $<TARGET_OBJECTS:cutlass_sm100_fp16_sweep_obj>
+    $<TARGET_OBJECTS:encoder_mlp_sm100_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE ENABLE_SM100_CUTLASS=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,24 @@ if(ENABLE_SM100_CUTLASS)
     >
   )
   message(STATUS "SM100 CUTLASS FP16 GEMMs: building for sm_${GPU_ARCH}")
+
+  # FP16 CUTLASS GEMM tile-sweep (transient, used by R1.1 sweep bench).
+  add_library(cutlass_sm100_fp16_sweep_obj OBJECT csrc/gemm/cutlass_sm100_fp16_sweep.cu)
+  set_target_properties(cutlass_sm100_fp16_sweep_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(cutlass_sm100_fp16_sweep_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+    ${CUTLASS_INCLUDE}
+    ${CUTLASS_DIR}/tools/util/include
+  )
+  target_compile_options(cutlass_sm100_fp16_sweep_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3 --use_fast_math
+      ${GPU_GENCODE}
+    >
+  )
 endif()
 
 # ── libfmha_fp16_strided.so — CUTLASS SM100 FP16 FMHA for SigLIP ──
@@ -712,7 +730,8 @@ set_target_properties(flash_rt_kernels PROPERTIES
 if(ENABLE_SM100_CUTLASS)
   target_sources(flash_rt_kernels PRIVATE
     $<TARGET_OBJECTS:cutlass_sm100_obj>
-    $<TARGET_OBJECTS:cutlass_sm100_fp16_obj>)
+    $<TARGET_OBJECTS:cutlass_sm100_fp16_obj>
+    $<TARGET_OBJECTS:cutlass_sm100_fp16_sweep_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE ENABLE_SM100_CUTLASS=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,25 @@ if(ENABLE_SM100_CUTLASS)
     >
   )
   message(STATUS "SM100 CUTLASS FP8 GEMMs: building for sm_${GPU_ARCH}")
+
+  # FP16 CUTLASS GEMMs (encoder/SigLIP FP16 path).
+  add_library(cutlass_sm100_fp16_obj OBJECT csrc/gemm/cutlass_sm100_fp16.cu)
+  set_target_properties(cutlass_sm100_fp16_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(cutlass_sm100_fp16_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+    ${CUTLASS_INCLUDE}
+    ${CUTLASS_DIR}/tools/util/include
+  )
+  target_compile_options(cutlass_sm100_fp16_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3 --use_fast_math
+      ${GPU_GENCODE}
+    >
+  )
+  message(STATUS "SM100 CUTLASS FP16 GEMMs: building for sm_${GPU_ARCH}")
 endif()
 
 # ── libfmha_fp16_strided.so — CUTLASS SM100 FP16 FMHA for SigLIP ──
@@ -691,7 +710,9 @@ set_target_properties(flash_rt_kernels PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
 
 if(ENABLE_SM100_CUTLASS)
-  target_sources(flash_rt_kernels PRIVATE $<TARGET_OBJECTS:cutlass_sm100_obj>)
+  target_sources(flash_rt_kernels PRIVATE
+    $<TARGET_OBJECTS:cutlass_sm100_obj>
+    $<TARGET_OBJECTS:cutlass_sm100_fp16_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE ENABLE_SM100_CUTLASS=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,58 @@ if(ENABLE_SM100_CUTLASS)
     >
   )
 
+  # MK-1 encoder split-G7 megakernel (gate+up GeGLU fused).  Stage A.0
+  # scaffold: byte-copy of the vendored single-GEMM kernel under a new
+  # name; Stage A.1 will extend to the two-Mainloop/Epilogue chain.
+  # Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
+  add_library(flashrt_megakernel_geglu_obj OBJECT csrc/gemm/mega/flashrt_megakernel_geglu.cu)
+  set_target_properties(flashrt_megakernel_geglu_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON
+  )
+  # Include-path priority (mirrors libfmha_fp16_strided rules):
+  #   1. csrc/gemm/mega/  — vendored CUTLASS hooks under cutlass/pipeline,
+  #      cutlass/epilogue/collective, cutlass/gemm/collective. MUST be
+  #      before ${CUTLASS_INCLUDE} so the patched headers shadow the
+  #      stock CUTLASS versions only for this translation unit.
+  #   2. ${CUTLASS_INCLUDE} — upstream CUTLASS for everything else.
+  target_include_directories(flashrt_megakernel_geglu_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm/mega
+    ${CUTLASS_INCLUDE}
+    ${CUTLASS_DIR}/tools/util/include
+  )
+  target_compile_options(flashrt_megakernel_geglu_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3 --use_fast_math
+      ${GPU_GENCODE}
+    >
+  )
+
+  # MK-2 scaffold (F-1): fused GeGLU + G8 down-proj + residual megakernel.
+  # F-1 is currently a byte-equivalent copy of MK-1 (same per-tile
+  # behaviour) with the class renamed.  F-2..F-6 will extend the kernel
+  # to fold the down GEMM via persistent CTA + h_chunk loop.  Same
+  # include-precedence rules as MK-1 (mega dir before upstream CUTLASS).
+  # Plan: megakernel_dev/notes/MK2_DESIGN.md.
+  add_library(flashrt_megakernel_geglu_g8_obj OBJECT csrc/gemm/mega/flashrt_megakernel_geglu_g8.cu)
+  set_target_properties(flashrt_megakernel_geglu_g8_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(flashrt_megakernel_geglu_g8_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm/mega
+    ${CUTLASS_INCLUDE}
+    ${CUTLASS_DIR}/tools/util/include
+  )
+  target_compile_options(flashrt_megakernel_geglu_g8_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3 --use_fast_math
+      ${GPU_GENCODE}
+    >
+  )
+
   # Path C encoder MLP megakernel (scaffold, fallback to 3-step GEMMs).
   add_library(encoder_mlp_sm100_obj OBJECT csrc/gemm/mega/encoder_mlp_sm100.cu)
   set_target_properties(encoder_mlp_sm100_obj PROPERTIES
@@ -773,7 +825,9 @@ if(ENABLE_SM100_CUTLASS)
     $<TARGET_OBJECTS:cutlass_sm100_fp16_obj>
     $<TARGET_OBJECTS:cutlass_sm100_fp16_sweep_obj>
     $<TARGET_OBJECTS:encoder_mlp_sm100_obj>
-    $<TARGET_OBJECTS:flashrt_megakernel_obj>)
+    $<TARGET_OBJECTS:flashrt_megakernel_obj>
+    $<TARGET_OBJECTS:flashrt_megakernel_geglu_obj>
+    $<TARGET_OBJECTS:flashrt_megakernel_geglu_g8_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE ENABLE_SM100_CUTLASS=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,10 +259,8 @@ if(ENABLE_SM100_CUTLASS)
     >
   )
 
-  # MK-1 encoder split-G7 megakernel (gate+up GeGLU fused).  Stage A.0
-  # scaffold: byte-copy of the vendored single-GEMM kernel under a new
-  # name; Stage A.1 will extend to the two-Mainloop/Epilogue chain.
-  # Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
+  # Encoder GeGLU megakernel: fuses the gate and up GEMMs (one launch
+  # computes hidden = GELU(X @ W_gate) * (X @ W_up)).
   add_library(flashrt_megakernel_geglu_obj OBJECT csrc/gemm/mega/flashrt_megakernel_geglu.cu)
   set_target_properties(flashrt_megakernel_geglu_obj PROPERTIES
     CUDA_STANDARD 17
@@ -287,12 +285,9 @@ if(ENABLE_SM100_CUTLASS)
     >
   )
 
-  # MK-2 scaffold (F-1): fused GeGLU + G8 down-proj + residual megakernel.
-  # F-1 is currently a byte-equivalent copy of MK-1 (same per-tile
-  # behaviour) with the class renamed.  F-2..F-6 will extend the kernel
-  # to fold the down GEMM via persistent CTA + h_chunk loop.  Same
-  # include-precedence rules as MK-1 (mega dir before upstream CUTLASS).
-  # Plan: megakernel_dev/notes/MK2_DESIGN.md.
+  # Encoder GeGLU + down-proj megakernel: bundles the GeGLU megakernel and
+  # the down GEMM (beta=1 residual) into one C entry.  Uses the same
+  # include precedence as the GeGLU object (mega dir before upstream CUTLASS).
   add_library(flashrt_megakernel_geglu_g8_obj OBJECT csrc/gemm/mega/flashrt_megakernel_geglu_g8.cu)
   set_target_properties(flashrt_megakernel_geglu_g8_obj PROPERTIES
     CUDA_STANDARD 17

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -276,6 +276,11 @@ extern "C" float launch_w4a8_gemm(void*, void*, void*, void*, void*, void*, int,
 extern "C" int cutlass_fp8_sq(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_t1(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_wide(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+// CUTLASS FP16 variants (encoder/SigLIP FP16 path)
+extern "C" int cutlass_fp16_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_sq(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_t1(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_wide(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_sq_f32out(void*, void*, void*, int, int, int, float, float, cudaStream_t);
@@ -1375,6 +1380,35 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     m.def("cutlass_fp8_gelu", [](uintptr_t A, uintptr_t B, uintptr_t D,
                                    int M, int N, int K, float alpha, float beta, uintptr_t stream) {
         return cutlass_fp8_gelu(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    // ── CUTLASS FP16 GEMMs (FP16 path, NT layout — B is [N,K] row-major) ──
+    m.def("cutlass_fp16_plain", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                     int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_plain(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_sq", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                  int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_sq(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_t1", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                  int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_t1(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_wide", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                    int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_wide(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
     }, py::arg("A"), py::arg("B"), py::arg("D"),
        py::arg("M"), py::arg("N"), py::arg("K"),
        py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -284,6 +284,7 @@ extern "C" int cutlass_fp16_wide(void*, void*, void*, int, int, int, float, floa
 extern "C" int cutlass_fp16_k64(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_2sm21(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_k64_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_sq_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_k64_mul_aux(void*, void*, void*, void*, int, int, int, cudaStream_t);
 extern "C" int cutlass_fp16_sweep(int variant, void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep_count();
@@ -1443,6 +1444,13 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     m.def("cutlass_fp16_k64_gelu", [](uintptr_t A, uintptr_t B, uintptr_t D,
                                        int M, int N, int K, float alpha, float beta, uintptr_t stream) {
         return cutlass_fp16_k64_gelu(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_sq_gelu", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                      int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_sq_gelu(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
     }, py::arg("A"), py::arg("B"), py::arg("D"),
        py::arg("M"), py::arg("N"), py::arg("K"),
        py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -283,6 +283,8 @@ extern "C" int cutlass_fp16_t1(void*, void*, void*, int, int, int, float, float,
 extern "C" int cutlass_fp16_wide(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_k64(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_2sm21(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_k64_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_k64_mul_aux(void*, void*, void*, void*, int, int, int, cudaStream_t);
 extern "C" int cutlass_fp16_sweep(int variant, void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep_count();
 extern "C" int cutlass_fp8_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
@@ -1108,6 +1110,13 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                                    reinterpret_cast<__half*>(out), seq, half_dim, to_stream(stream));
     }, py::arg("merged"), py::arg("out"), py::arg("seq"), py::arg("half_dim"), py::arg("stream") = 0);
 
+    m.def("mul_fp16", [](uintptr_t a, uintptr_t b, uintptr_t out,
+                         int n, uintptr_t stream) {
+        mul_fp16(reinterpret_cast<const __half*>(a),
+                 reinterpret_cast<const __half*>(b),
+                 reinterpret_cast<__half*>(out), n, to_stream(stream));
+    }, py::arg("a"), py::arg("b"), py::arg("out"), py::arg("n"), py::arg("stream") = 0);
+
     // Merged GEGLU (tanh-approx GELU) → FP8 (FP16 input, matches pi05 FFN quant path)
     m.def("gate_geglu_merged_fp8_fp16", [](uintptr_t merged, uintptr_t out,
                                             int seq, int half_dim,
@@ -1430,6 +1439,20 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     }, py::arg("A"), py::arg("B"), py::arg("D"),
        py::arg("M"), py::arg("N"), py::arg("K"),
        py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_k64_gelu", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                       int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_k64_gelu(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_k64_mul_aux", [](uintptr_t A, uintptr_t B, uintptr_t Aux, uintptr_t D,
+                                          int M, int N, int K, uintptr_t stream) {
+        return cutlass_fp16_k64_mul_aux(to_ptr(A), to_ptr(B), to_ptr(Aux), to_ptr(D),
+                                         M, N, K, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("Aux"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
 
     // R1.1 tile-sweep dispatch (transient; remove once winner is promoted).
     m.def("cutlass_fp16_sweep", [](int variant, uintptr_t A, uintptr_t B, uintptr_t D,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -286,6 +286,9 @@ extern "C" int cutlass_fp16_2sm21(void*, void*, void*, int, int, int, float, flo
 extern "C" int cutlass_fp16_k64_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sq_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_k64_mul_aux(void*, void*, void*, void*, int, int, int, cudaStream_t);
+extern "C" int encoder_mlp_fused_fp16(void*, void*, void*, void*,
+                                       void*, void*, void*, void*,
+                                       int, int, int, int, cudaStream_t);
 extern "C" int cutlass_fp16_sweep(int variant, void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep_count();
 extern "C" int cutlass_fp8_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
@@ -1461,6 +1464,22 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                                          M, N, K, to_stream(stream));
     }, py::arg("A"), py::arg("B"), py::arg("Aux"), py::arg("D"),
        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+
+    // Path C encoder MLP megakernel (currently a 3-step fallback;
+    // real SMEM-staged kernel TBD in future sessions).
+    m.def("encoder_mlp_fused_fp16",
+          [](uintptr_t X, uintptr_t W_gate, uintptr_t W_up, uintptr_t W_down,
+             uintptr_t gate_buf, uintptr_t up_buf, uintptr_t hid_buf, uintptr_t out,
+             int M, int N_out, int K, int H, uintptr_t stream) {
+              return encoder_mlp_fused_fp16(
+                  to_ptr(X), to_ptr(W_gate), to_ptr(W_up), to_ptr(W_down),
+                  to_ptr(gate_buf), to_ptr(up_buf), to_ptr(hid_buf), to_ptr(out),
+                  M, N_out, K, H, to_stream(stream));
+          },
+          py::arg("X"), py::arg("W_gate"), py::arg("W_up"), py::arg("W_down"),
+          py::arg("gate_buf"), py::arg("up_buf"), py::arg("hid_buf"), py::arg("out"),
+          py::arg("M"), py::arg("N_out"), py::arg("K"), py::arg("H"),
+          py::arg("stream") = 0);
 
     // R1.1 tile-sweep dispatch (transient; remove once winner is promoted).
     m.def("cutlass_fp16_sweep", [](int variant, uintptr_t A, uintptr_t B, uintptr_t D,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -286,9 +286,11 @@ extern "C" int cutlass_fp16_2sm21(void*, void*, void*, int, int, int, float, flo
 extern "C" int cutlass_fp16_k64_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sq_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_k64_mul_aux(void*, void*, void*, void*, int, int, int, cudaStream_t);
+#ifdef FLASHRT_HAVE_SM100_ENCODER_MLP
 extern "C" int encoder_mlp_fused_fp16(void*, void*, void*, void*,
                                        void*, void*, void*, void*,
                                        int, int, int, int, cudaStream_t);
+#endif
 extern "C" int flashrt_megakernel_single_fp16(void*, void*, void*,
                                                int, int, int,
                                                float, float, cudaStream_t);
@@ -296,18 +298,17 @@ extern "C" int flashrt_megakernel_geglu_fp16(void*, void*, void*,
                                               void*, void*,
                                               int, int, int,
                                               cudaStream_t);
-// (Stage B-v2 signature: X, W_gate, W_up, D_gate_scratch, hidden, M, N, K, stream)
-// MK-2 fused entry: (X, W_gate, W_up, W_down, hidden_scratch, x_inout, M, H, D, stream)
-// Computes x_inout += GeGLU(X @ W_gate, X @ W_up) @ W_down.
-// F-2: bundles MK-1 mega + 2sm21(beta=1) internally (two launches).
-// F-3+: replaces with a single persistent-CTA fused kernel.
+// Fused encoder GeGLU + down-proj with residual.
+// Args: (X, W_gate, W_up, W_down, hidden_scratch, x_inout, M, H, D, stream).
+// Computes x_inout += GeGLU(X @ W_gate, X @ W_up) @ W_down, bundling the
+// GeGLU megakernel and the down GEMM (beta=1) into one C entry.
 extern "C" int flashrt_megakernel_geglu_g8_fp16(void*, void*, void*,
                                                  void*,
                                                  void*, void*,
                                                  int, int, int,
                                                  cudaStream_t);
 
-// MK-2 F-3 bundle: rms_norm + mega + G8 + resid into one C entry.
+// Bundle: rms_norm + GeGLU + down-proj + residual into one C entry.
 extern "C" int flashrt_encoder_ffn_block_fp16(void*, void*, void*,
                                                void*, void*, void*,
                                                void*, void*,
@@ -317,8 +318,10 @@ extern "C" int flashrt_encoder_ffn_block_fp16(void*, void*, void*,
 // Bundle: rms_norm + QKV (k64) into one C entry.
 extern "C" int flashrt_rms_qkv_fp16(void*, void*, void*, void*, void*,
                                      int, int, int, float, cudaStream_t);
+#ifdef FLASHRT_HAVE_SM100_SWEEP
 extern "C" int cutlass_fp16_sweep(int variant, void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep_count();
+#endif
 extern "C" int cutlass_fp8_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_sq_f32out(void*, void*, void*, int, int, int, float, float, cudaStream_t);
@@ -1508,12 +1511,9 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
           py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f,
           py::arg("stream") = 0);
 
-    // MK-1 megakernel (Stage A.1).  Two-phase chain: one kernel launch
-    // computes D_gate = GELU(X @ W_gate) AND D_up = X @ W_up.  Both
-    // sub-GEMMs share one tcgen05.alloc; per-CTA work tile runs phase1
-    // then phase2 in series via a single AccumulatorPipeline.  Stage B
-    // (SMEM_gate routing) will fold the GeGLU multiply into the kernel.
-    // Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
+    // GeGLU megakernel: one launch computes hidden = GELU(X @ W_gate) * (X @ W_up).
+    // The two sub-GEMMs share one tcgen05.alloc; each CTA work tile runs the
+    // gate GEMM then the up GEMM in series via a single AccumulatorPipeline.
     m.def("flashrt_megakernel_geglu_fp16",
           [](uintptr_t X, uintptr_t W_gate, uintptr_t W_up,
              uintptr_t D_gate_scratch, uintptr_t hidden,
@@ -1528,9 +1528,8 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
           py::arg("M"), py::arg("N"), py::arg("K"),
           py::arg("stream") = 0);
 
-    // MK-2 fused GeGLU + G8 + resid.  F-2 bundles two launches inside
-    // the .cu entry; F-3+ folds them into one persistent-CTA kernel.
-    // Plan: megakernel_dev/notes/MK2_DESIGN.md.
+    // Fused GeGLU + down-proj with residual: the GeGLU megakernel and the
+    // down GEMM (beta=1) are bundled inside one .cu entry (two launches).
     m.def("flashrt_megakernel_geglu_g8_fp16",
           [](uintptr_t X, uintptr_t W_gate, uintptr_t W_up,
              uintptr_t W_down,
@@ -1563,7 +1562,8 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
           py::arg("M"), py::arg("D"), py::arg("N_qkv"),
           py::arg("rms_eps") = 1e-6f, py::arg("stream") = 0);
 
-    // MK-2 F-3: bundled FFN block — rms_norm + mega + G8 + resid in one C.
+    // Bundled FFN block: rms_norm + GeGLU megakernel + down-proj + residual
+    // in one C entry.
     m.def("flashrt_encoder_ffn_block_fp16",
           [](uintptr_t x_resid, uintptr_t rms_weight, uintptr_t x_norm,
              uintptr_t W_gate, uintptr_t W_up, uintptr_t W_down,
@@ -1581,8 +1581,9 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
           py::arg("M"), py::arg("H"), py::arg("D"),
           py::arg("rms_eps") = 1e-6f, py::arg("stream") = 0);
 
-    // Path C encoder MLP megakernel (currently a 3-step fallback;
-    // real SMEM-staged kernel TBD in future sessions).
+#ifdef FLASHRT_HAVE_SM100_ENCODER_MLP
+    // Path C encoder MLP megakernel scaffold (WIP, off by default; built only
+    // with -DFLASHRT_BUILD_SM100_ENCODER_MLP=ON).
     m.def("encoder_mlp_fused_fp16",
           [](uintptr_t X, uintptr_t W_gate, uintptr_t W_up, uintptr_t W_down,
              uintptr_t gate_buf, uintptr_t up_buf, uintptr_t hid_buf, uintptr_t out,
@@ -1596,8 +1597,11 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
           py::arg("gate_buf"), py::arg("up_buf"), py::arg("hid_buf"), py::arg("out"),
           py::arg("M"), py::arg("N_out"), py::arg("K"), py::arg("H"),
           py::arg("stream") = 0);
+#endif
 
-    // R1.1 tile-sweep dispatch (transient; remove once winner is promoted).
+#ifdef FLASHRT_HAVE_SM100_SWEEP
+    // FP16 tile-sweep bench dispatch (off by default; built only with
+    // -DFLASHRT_BUILD_SM100_SWEEP=ON).
     m.def("cutlass_fp16_sweep", [](int variant, uintptr_t A, uintptr_t B, uintptr_t D,
                                     int M, int N, int K, float alpha, float beta, uintptr_t stream) {
         return cutlass_fp16_sweep(variant, to_ptr(A), to_ptr(B), to_ptr(D),
@@ -1606,6 +1610,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("M"), py::arg("N"), py::arg("K"),
        py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
     m.def("cutlass_fp16_sweep_count", []() { return cutlass_fp16_sweep_count(); });
+#endif
 
     // FP32 output variants — for models with activations exceeding FP16 range
     m.def("cutlass_fp8_sq_f32out", [](uintptr_t A, uintptr_t B, uintptr_t D,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -281,6 +281,10 @@ extern "C" int cutlass_fp16_plain(void*, void*, void*, int, int, int, float, flo
 extern "C" int cutlass_fp16_sq(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_t1(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_wide(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_k64(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_2sm21(void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_sweep(int variant, void*, void*, void*, int, int, int, float, float, cudaStream_t);
+extern "C" int cutlass_fp16_sweep_count();
 extern "C" int cutlass_fp8_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_gelu(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp8_sq_f32out(void*, void*, void*, int, int, int, float, float, cudaStream_t);
@@ -1412,6 +1416,30 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     }, py::arg("A"), py::arg("B"), py::arg("D"),
        py::arg("M"), py::arg("N"), py::arg("K"),
        py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_k64", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                  int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_k64(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    m.def("cutlass_fp16_2sm21", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                    int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_2sm21(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+
+    // R1.1 tile-sweep dispatch (transient; remove once winner is promoted).
+    m.def("cutlass_fp16_sweep", [](int variant, uintptr_t A, uintptr_t B, uintptr_t D,
+                                    int M, int N, int K, float alpha, float beta, uintptr_t stream) {
+        return cutlass_fp16_sweep(variant, to_ptr(A), to_ptr(B), to_ptr(D),
+                                  M, N, K, alpha, beta, to_stream(stream));
+    }, py::arg("variant"), py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f, py::arg("stream") = 0);
+    m.def("cutlass_fp16_sweep_count", []() { return cutlass_fp16_sweep_count(); });
 
     // FP32 output variants — for models with activations exceeding FP16 range
     m.def("cutlass_fp8_sq_f32out", [](uintptr_t A, uintptr_t B, uintptr_t D,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -292,6 +292,31 @@ extern "C" int encoder_mlp_fused_fp16(void*, void*, void*, void*,
 extern "C" int flashrt_megakernel_single_fp16(void*, void*, void*,
                                                int, int, int,
                                                float, float, cudaStream_t);
+extern "C" int flashrt_megakernel_geglu_fp16(void*, void*, void*,
+                                              void*, void*,
+                                              int, int, int,
+                                              cudaStream_t);
+// (Stage B-v2 signature: X, W_gate, W_up, D_gate_scratch, hidden, M, N, K, stream)
+// MK-2 fused entry: (X, W_gate, W_up, W_down, hidden_scratch, x_inout, M, H, D, stream)
+// Computes x_inout += GeGLU(X @ W_gate, X @ W_up) @ W_down.
+// F-2: bundles MK-1 mega + 2sm21(beta=1) internally (two launches).
+// F-3+: replaces with a single persistent-CTA fused kernel.
+extern "C" int flashrt_megakernel_geglu_g8_fp16(void*, void*, void*,
+                                                 void*,
+                                                 void*, void*,
+                                                 int, int, int,
+                                                 cudaStream_t);
+
+// MK-2 F-3 bundle: rms_norm + mega + G8 + resid into one C entry.
+extern "C" int flashrt_encoder_ffn_block_fp16(void*, void*, void*,
+                                               void*, void*, void*,
+                                               void*, void*,
+                                               int, int, int, float,
+                                               cudaStream_t);
+
+// Bundle: rms_norm + QKV (k64) into one C entry.
+extern "C" int flashrt_rms_qkv_fp16(void*, void*, void*, void*, void*,
+                                     int, int, int, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep(int variant, void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep_count();
 extern "C" int cutlass_fp8_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
@@ -1482,6 +1507,79 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
           py::arg("M"), py::arg("N"), py::arg("K"),
           py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f,
           py::arg("stream") = 0);
+
+    // MK-1 megakernel (Stage A.1).  Two-phase chain: one kernel launch
+    // computes D_gate = GELU(X @ W_gate) AND D_up = X @ W_up.  Both
+    // sub-GEMMs share one tcgen05.alloc; per-CTA work tile runs phase1
+    // then phase2 in series via a single AccumulatorPipeline.  Stage B
+    // (SMEM_gate routing) will fold the GeGLU multiply into the kernel.
+    // Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
+    m.def("flashrt_megakernel_geglu_fp16",
+          [](uintptr_t X, uintptr_t W_gate, uintptr_t W_up,
+             uintptr_t D_gate_scratch, uintptr_t hidden,
+             int M, int N, int K, uintptr_t stream) {
+              return flashrt_megakernel_geglu_fp16(
+                  to_ptr(X), to_ptr(W_gate), to_ptr(W_up),
+                  to_ptr(D_gate_scratch), to_ptr(hidden),
+                  M, N, K, to_stream(stream));
+          },
+          py::arg("X"), py::arg("W_gate"), py::arg("W_up"),
+          py::arg("D_gate_scratch"), py::arg("hidden"),
+          py::arg("M"), py::arg("N"), py::arg("K"),
+          py::arg("stream") = 0);
+
+    // MK-2 fused GeGLU + G8 + resid.  F-2 bundles two launches inside
+    // the .cu entry; F-3+ folds them into one persistent-CTA kernel.
+    // Plan: megakernel_dev/notes/MK2_DESIGN.md.
+    m.def("flashrt_megakernel_geglu_g8_fp16",
+          [](uintptr_t X, uintptr_t W_gate, uintptr_t W_up,
+             uintptr_t W_down,
+             uintptr_t hidden_scratch, uintptr_t x_inout,
+             int M, int H, int D, uintptr_t stream) {
+              return flashrt_megakernel_geglu_g8_fp16(
+                  to_ptr(X), to_ptr(W_gate), to_ptr(W_up),
+                  to_ptr(W_down),
+                  to_ptr(hidden_scratch), to_ptr(x_inout),
+                  M, H, D, to_stream(stream));
+          },
+          py::arg("X"), py::arg("W_gate"), py::arg("W_up"),
+          py::arg("W_down"),
+          py::arg("hidden_scratch"), py::arg("x_inout"),
+          py::arg("M"), py::arg("H"), py::arg("D"),
+          py::arg("stream") = 0);
+
+    // Bundle: rms_norm + QKV (k64) in one C entry.
+    m.def("flashrt_rms_qkv_fp16",
+          [](uintptr_t x, uintptr_t rms_weight, uintptr_t x_norm,
+             uintptr_t qkv_weight, uintptr_t qkv_out,
+             int M, int D, int N_qkv, float rms_eps, uintptr_t stream) {
+              return flashrt_rms_qkv_fp16(
+                  to_ptr(x), to_ptr(rms_weight), to_ptr(x_norm),
+                  to_ptr(qkv_weight), to_ptr(qkv_out),
+                  M, D, N_qkv, rms_eps, to_stream(stream));
+          },
+          py::arg("x"), py::arg("rms_weight"), py::arg("x_norm"),
+          py::arg("qkv_weight"), py::arg("qkv_out"),
+          py::arg("M"), py::arg("D"), py::arg("N_qkv"),
+          py::arg("rms_eps") = 1e-6f, py::arg("stream") = 0);
+
+    // MK-2 F-3: bundled FFN block — rms_norm + mega + G8 + resid in one C.
+    m.def("flashrt_encoder_ffn_block_fp16",
+          [](uintptr_t x_resid, uintptr_t rms_weight, uintptr_t x_norm,
+             uintptr_t W_gate, uintptr_t W_up, uintptr_t W_down,
+             uintptr_t gate_scratch, uintptr_t hidden_scratch,
+             int M, int H, int D, float rms_eps, uintptr_t stream) {
+              return flashrt_encoder_ffn_block_fp16(
+                  to_ptr(x_resid), to_ptr(rms_weight), to_ptr(x_norm),
+                  to_ptr(W_gate), to_ptr(W_up), to_ptr(W_down),
+                  to_ptr(gate_scratch), to_ptr(hidden_scratch),
+                  M, H, D, rms_eps, to_stream(stream));
+          },
+          py::arg("x_resid"), py::arg("rms_weight"), py::arg("x_norm"),
+          py::arg("W_gate"), py::arg("W_up"), py::arg("W_down"),
+          py::arg("gate_scratch"), py::arg("hidden_scratch"),
+          py::arg("M"), py::arg("H"), py::arg("D"),
+          py::arg("rms_eps") = 1e-6f, py::arg("stream") = 0);
 
     // Path C encoder MLP megakernel (currently a 3-step fallback;
     // real SMEM-staged kernel TBD in future sessions).

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -289,6 +289,9 @@ extern "C" int cutlass_fp16_k64_mul_aux(void*, void*, void*, void*, int, int, in
 extern "C" int encoder_mlp_fused_fp16(void*, void*, void*, void*,
                                        void*, void*, void*, void*,
                                        int, int, int, int, cudaStream_t);
+extern "C" int flashrt_megakernel_single_fp16(void*, void*, void*,
+                                               int, int, int,
+                                               float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep(int variant, void*, void*, void*, int, int, int, float, float, cudaStream_t);
 extern "C" int cutlass_fp16_sweep_count();
 extern "C" int cutlass_fp8_plain(void*, void*, void*, int, int, int, float, float, cudaStream_t);
@@ -1464,6 +1467,21 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                                          M, N, K, to_stream(stream));
     }, py::arg("A"), py::arg("B"), py::arg("Aux"), py::arg("D"),
        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+
+    // Path C foundation: vendored production sm100_gemm_tma_warpspecialized
+    // kernel struct, single GEMM.  Must match cutlass_fp16_sq isolation
+    // perf before extending to multi-mainloop megakernel.
+    m.def("flashrt_megakernel_single_fp16",
+          [](uintptr_t A, uintptr_t B, uintptr_t D, int M, int N, int K,
+             float alpha, float beta, uintptr_t stream) {
+              return flashrt_megakernel_single_fp16(
+                  to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                  alpha, beta, to_stream(stream));
+          },
+          py::arg("A"), py::arg("B"), py::arg("D"),
+          py::arg("M"), py::arg("N"), py::arg("K"),
+          py::arg("alpha") = 1.0f, py::arg("beta") = 0.0f,
+          py::arg("stream") = 0);
 
     // Path C encoder MLP megakernel (currently a 3-step fallback;
     // real SMEM-staged kernel TBD in future sessions).

--- a/csrc/gemm/cutlass_sm100_fp16.cu
+++ b/csrc/gemm/cutlass_sm100_fp16.cu
@@ -100,6 +100,11 @@ int cutlass_fp16_k64_gelu(void* A, void* B, void* D, int M, int N, int K,
     return cutlass_run_impl_fp16<sm100_fp16_k64_gelu::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
 }
 
+int cutlass_fp16_sq_gelu(void* A, void* B, void* D, int M, int N, int K,
+                          float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_sq_gelu::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
 // R3.1 Phase 2 runner: GEMM with LinCombDeEltAct epilogue that multiplies
 // the accumulator by an auxiliary tensor (gate_buf [M, N] row-major).
 // D[m,n] = (acc[m,n]) * Aux[m,n].

--- a/csrc/gemm/cutlass_sm100_fp16.cu
+++ b/csrc/gemm/cutlass_sm100_fp16.cu
@@ -85,4 +85,14 @@ int cutlass_fp16_wide(void* A, void* B, void* D, int M, int N, int K,
     return cutlass_run_impl_fp16<sm100_fp16_wide::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
 }
 
+int cutlass_fp16_k64(void* A, void* B, void* D, int M, int N, int K,
+                      float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_k64::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
+int cutlass_fp16_2sm21(void* A, void* B, void* D, int M, int N, int K,
+                        float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_2sm21::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
 }  // extern "C"

--- a/csrc/gemm/cutlass_sm100_fp16.cu
+++ b/csrc/gemm/cutlass_sm100_fp16.cu
@@ -95,4 +95,70 @@ int cutlass_fp16_2sm21(void* A, void* B, void* D, int M, int N, int K,
     return cutlass_run_impl_fp16<sm100_fp16_2sm21::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
 }
 
+int cutlass_fp16_k64_gelu(void* A, void* B, void* D, int M, int N, int K,
+                           float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_k64_gelu::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
+// R3.1 Phase 2 runner: GEMM with LinCombDeEltAct epilogue that multiplies
+// the accumulator by an auxiliary tensor (gate_buf [M, N] row-major).
+// D[m,n] = (acc[m,n]) * Aux[m,n].
+int cutlass_fp16_k64_mul_aux(void* A, void* B, void* Aux, void* D,
+                              int M, int N, int K, cudaStream_t stream) {
+    using GemmOp = sm100_fp16_k64_mul_aux::Gemm;
+    using ElementA = typename GemmOp::ElementA;
+    using ElementB = typename GemmOp::ElementB;
+    using ElementD = typename GemmOp::ElementD;
+
+    auto sA = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideA{}, {M, K, 1});
+    auto sB = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideB{}, {N, K, 1});
+    auto sD = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideD{}, {M, N, 1});
+
+    // Aux is row-major [M, N] with the same shape as D.
+    using AuxStride = cutlass::gemm::TagToStrideC_t<cutlass::layout::RowMajor>;
+    auto dAux = cutlass::make_cute_packed_stride(AuxStride{}, {M, N, 1});
+
+    typename GemmOp::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, N, K, 1},
+        {(ElementA*)A, sA, (ElementB*)B, sB},
+        {
+            {  // FusionCallbacks::Arguments (LinCombDeEltAct)
+                1.0f,                                  // alpha
+                0.0f,                                  // beta
+                nullptr, nullptr,                      // alpha_ptr, beta_ptr
+                {}, {},                                // dAlpha, dBeta (broadcast stride)
+                {},                                    // activation args (multiplies has none)
+                (cutlass_fp16_t const*)Aux,            // aux_ptr
+                dAux                                   // dAux stride
+            },
+            nullptr, {},                               // ptr_C (unused since beta=0), dC
+            (ElementD*)D, sD
+        }
+    };
+
+    GemmOp gemm;
+    size_t ws_size = GemmOp::get_workspace_size(args);
+    static cutlass::device_memory::allocation<uint8_t> workspace(0);
+    if (ws_size > workspace.size()) {
+        workspace = cutlass::device_memory::allocation<uint8_t>(ws_size);
+    }
+    if (gemm.can_implement(args) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[k64_mul_aux] cannot implement: M=%d N=%d K=%d\n", M, N, K);
+        return -1;
+    }
+    if (gemm.initialize(args, workspace.get(), stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[k64_mul_aux] init failed: M=%d N=%d K=%d\n", M, N, K);
+        return -2;
+    }
+    if (gemm.run(stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[k64_mul_aux] run failed: M=%d N=%d K=%d\n", M, N, K);
+        return -3;
+    }
+    return 0;
+}
+
 }  // extern "C"

--- a/csrc/gemm/cutlass_sm100_fp16.cu
+++ b/csrc/gemm/cutlass_sm100_fp16.cu
@@ -1,0 +1,88 @@
+// ================================================================
+// FlashRT — CUTLASS FP16 GEMM implementations for SM100/SM110
+//
+// FP16 mirror of cutlass_sm100.cu. Tile configurations match the FP8
+// variants so we can compare cuBLASLt vs CUTLASS on the same shapes.
+//
+// Layout: A row-major (M, K), B column-major (K, N) [stored as
+// [N, K] row-major in memory — same as PyTorch nn.Linear weights],
+// D row-major (M, N).
+// ================================================================
+
+#include "gemm_types_sm100_fp16.h"
+#include "cutlass/util/device_memory.h"
+#include <cuda_runtime.h>
+#include <cstdio>
+
+// ── Generic runner ──
+template <typename GemmOp>
+static int cutlass_run_impl_fp16(void* A, void* B, void* D,
+                                  int M, int N, int K,
+                                  float alpha, float beta,
+                                  cudaStream_t stream) {
+    using ElementA = typename GemmOp::ElementA;
+    using ElementB = typename GemmOp::ElementB;
+    using ElementD = typename GemmOp::ElementD;
+
+    auto stride_A = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideA{}, {M, K, 1});
+    auto stride_B = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideB{}, {N, K, 1});
+    auto stride_D = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideD{}, {M, N, 1});
+
+    typename GemmOp::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, N, K, 1},
+        {(ElementA*)A, stride_A, (ElementB*)B, stride_B},
+        {{alpha, beta}, (ElementD*)D, stride_D, (ElementD*)D, stride_D}
+    };
+
+    GemmOp gemm;
+    size_t ws_size = GemmOp::get_workspace_size(args);
+    static cutlass::device_memory::allocation<uint8_t> workspace(0);
+    if (ws_size > workspace.size()) {
+        workspace = cutlass::device_memory::allocation<uint8_t>(ws_size);
+    }
+
+    auto status = gemm.can_implement(args);
+    if (status != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[CUTLASS-FP16] cannot implement: M=%d N=%d K=%d\n", M, N, K);
+        return -1;
+    }
+    status = gemm.initialize(args, workspace.get(), stream);
+    if (status != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[CUTLASS-FP16] init failed: M=%d N=%d K=%d\n", M, N, K);
+        return -2;
+    }
+    status = gemm.run(stream);
+    if (status != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[CUTLASS-FP16] run failed: M=%d N=%d K=%d\n", M, N, K);
+        return -3;
+    }
+    return 0;
+}
+
+extern "C" {
+
+int cutlass_fp16_plain(void* A, void* B, void* D, int M, int N, int K,
+                        float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_plain::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
+int cutlass_fp16_sq(void* A, void* B, void* D, int M, int N, int K,
+                     float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_sq::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
+int cutlass_fp16_t1(void* A, void* B, void* D, int M, int N, int K,
+                     float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_t1::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
+int cutlass_fp16_wide(void* A, void* B, void* D, int M, int N, int K,
+                       float alpha, float beta, cudaStream_t stream) {
+    return cutlass_run_impl_fp16<sm100_fp16_wide::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+}
+
+}  // extern "C"

--- a/csrc/gemm/cutlass_sm100_fp16_sweep.cu
+++ b/csrc/gemm/cutlass_sm100_fp16_sweep.cu
@@ -2,15 +2,15 @@
 // FlashRT — CUTLASS FP16 GEMM TILE SWEEP (transient infrastructure)
 //
 // Provides ~8 tile/cluster/schedule variants in a single dispatch
-// entry point.  Used by megakernel_dev/bench/r1_tile_sweep.py to
-// find the best CUTLASS configuration per encoder GEMM shape.
+// entry point, used to find the best CUTLASS configuration per encoder
+// GEMM shape.  Developer-only: built behind -DFLASHRT_BUILD_SM100_SWEEP=ON.
 //
 // Layout matches cutlass_sm100_fp16.cu:
 //   A row-major (M, K), B column-major (K, N) stored as [N, K]
 //   row-major, D row-major (M, N).  FP16 in/out, FP32 accumulate.
 //
-// After R1.1 sweep concludes, the winning variant should be
-// promoted into gemm_types_sm100_fp16.h and this file deleted.
+// Once the sweep concludes, the winning variant should be promoted
+// into gemm_types_sm100_fp16.h and this file deleted.
 // ================================================================
 
 #include "cutlass/cutlass.h"

--- a/csrc/gemm/cutlass_sm100_fp16_sweep.cu
+++ b/csrc/gemm/cutlass_sm100_fp16_sweep.cu
@@ -1,0 +1,129 @@
+// ================================================================
+// FlashRT — CUTLASS FP16 GEMM TILE SWEEP (transient infrastructure)
+//
+// Provides ~8 tile/cluster/schedule variants in a single dispatch
+// entry point.  Used by megakernel_dev/bench/r1_tile_sweep.py to
+// find the best CUTLASS configuration per encoder GEMM shape.
+//
+// Layout matches cutlass_sm100_fp16.cu:
+//   A row-major (M, K), B column-major (K, N) stored as [N, K]
+//   row-major, D row-major (M, N).  FP16 in/out, FP32 accumulate.
+//
+// After R1.1 sweep concludes, the winning variant should be
+// promoted into gemm_types_sm100_fp16.h and this file deleted.
+// ================================================================
+
+#include "cutlass/cutlass.h"
+#include "cute/tensor.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/epilogue/thread/activation.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/device_memory.h"
+#include <cuda_runtime.h>
+#include <cstdio>
+
+using namespace cute;
+using fp16_t = cutlass::half_t;
+
+namespace sweep_fp16 {
+
+template <class TileShape_, class ClusterShape_,
+          class KernelSched_ = cutlass::gemm::collective::KernelScheduleAuto,
+          class EpiSched_    = cutlass::epilogue::collective::EpilogueScheduleAuto>
+struct Variant {
+    using Tile    = TileShape_;
+    using Cluster = ClusterShape_;
+    using Fusion  = cutlass::epilogue::fusion::LinCombEltAct<
+        cutlass::epilogue::thread::Identity, fp16_t, float>;
+    using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+        Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+        float, float, fp16_t, cutlass::layout::RowMajor, 8,
+        fp16_t, cutlass::layout::RowMajor, 8,
+        EpiSched_, Fusion>::CollectiveOp;
+    using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+        fp16_t, cutlass::layout::RowMajor, 8,
+        fp16_t, cutlass::layout::ColumnMajor, 8,
+        float, Tile, Cluster,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+        KernelSched_>::CollectiveOp;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+        cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+};
+
+// V0: Baseline = current `sq`. (256, 256, 128) cluster (2, 2, 1) auto.
+using V0 = Variant<Shape<_256,_256,_128>, Shape<_2,_2,_1>>;
+// V1: Smaller K-tile, expect more pipelined stages.
+using V1 = Variant<Shape<_256,_256,_64>,  Shape<_2,_2,_1>>;
+// V2: Narrower M (good when M=1024 << N).
+using V2 = Variant<Shape<_128,_256,_128>, Shape<_2,_2,_1>>;
+// V3: Narrower N (good for K-heavy shapes like G8).
+using V3 = Variant<Shape<_256,_128,_128>, Shape<_2,_2,_1>>;
+// V4: 1SM mode, no cluster (Tile_M <= 128 and reduced N/K so >=2 stages fit).
+using V4 = Variant<Shape<_128,_128,_128>, Shape<_1,_1,_1>>;
+// V5: Tile match, 2x1 cluster (TMA 2SM friendly).
+using V5 = Variant<Shape<_256,_256,_128>, Shape<_2,_1,_1>,
+                   cutlass::gemm::KernelTmaWarpSpecialized2SmSm100,
+                   cutlass::epilogue::TmaWarpSpecialized2Sm>;
+// V6: Larger M-tile (test 256x128 narrow N pattern with 2x2).
+using V6 = Variant<Shape<_128,_128,_256>, Shape<_2,_2,_1>>;
+// V7: 4x2 cluster (more SMs per group; 8 SMs needed).
+using V7 = Variant<Shape<_256,_256,_128>, Shape<_4,_2,_1>>;
+// V8: Explicit 1SM small-M tile (probe whether tall-skinny tile helps M=1024).
+using V8 = Variant<Shape<_64,_128,_128>, Shape<_1,_1,_1>,
+                   cutlass::gemm::KernelTmaWarpSpecialized1SmSm100,
+                   cutlass::epilogue::TmaWarpSpecialized1Sm>;
+
+}  // namespace sweep_fp16
+
+template <typename GemmOp>
+static int run_impl(void* A, void* B, void* D, int M, int N, int K,
+                    float alpha, float beta, cudaStream_t stream) {
+    using ElementA = typename GemmOp::ElementA;
+    using ElementB = typename GemmOp::ElementB;
+    using ElementD = typename GemmOp::ElementD;
+    auto sA = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideA{}, {M, K, 1});
+    auto sB = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideB{}, {N, K, 1});
+    auto sD = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideD{}, {M, N, 1});
+    typename GemmOp::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm, {M, N, K, 1},
+        {(ElementA*)A, sA, (ElementB*)B, sB},
+        {{alpha, beta}, (ElementD*)D, sD, (ElementD*)D, sD}
+    };
+    GemmOp gemm;
+    size_t ws_size = GemmOp::get_workspace_size(args);
+    static cutlass::device_memory::allocation<uint8_t> workspace(0);
+    if (ws_size > workspace.size()) {
+        workspace = cutlass::device_memory::allocation<uint8_t>(ws_size);
+    }
+    if (gemm.can_implement(args) != cutlass::Status::kSuccess) return -10;
+    if (gemm.initialize(args, workspace.get(), stream) != cutlass::Status::kSuccess) return -11;
+    if (gemm.run(stream) != cutlass::Status::kSuccess) return -12;
+    return 0;
+}
+
+extern "C" int cutlass_fp16_sweep(int variant, void* A, void* B, void* D,
+                                  int M, int N, int K,
+                                  float alpha, float beta, cudaStream_t stream) {
+    switch (variant) {
+        case 0: return run_impl<sweep_fp16::V0::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 1: return run_impl<sweep_fp16::V1::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 2: return run_impl<sweep_fp16::V2::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 3: return run_impl<sweep_fp16::V3::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 4: return run_impl<sweep_fp16::V4::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 5: return run_impl<sweep_fp16::V5::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 6: return run_impl<sweep_fp16::V6::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 7: return run_impl<sweep_fp16::V7::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        case 8: return run_impl<sweep_fp16::V8::Gemm>(A, B, D, M, N, K, alpha, beta, stream);
+        default: return -1;
+    }
+}
+
+extern "C" int cutlass_fp16_sweep_count() { return 9; }

--- a/csrc/gemm/gemm_types_sm100_fp16.h
+++ b/csrc/gemm/gemm_types_sm100_fp16.h
@@ -33,6 +33,37 @@ using namespace cute;
 using cutlass_fp16_t = cutlass::half_t;
 #endif
 
+// GELU tanh-approximation activation matching gate_silu_mul_merged_kernel
+// (csrc/kernels/activation.cu): x * sigmoid(1.59576... * x * (1 + 0.04471 x^2))
+// Equivalent to x * 0.5 * (1 + tanh(sqrt(2/pi) * (x + 0.044715 x^3))).
+// Compute type is FP32 (matches the FP32 accumulator path).
+template <typename T>
+struct GeluTanhApprox {
+  static const bool kIsHeavy = true;
+  CUTLASS_HOST_DEVICE
+  T operator()(T const& x) const {
+    float xf = static_cast<float>(x);
+    float k = 1.5957691216057308f;   // 2 * sqrt(2/pi)
+    float c = 0.044715f;
+    float z = k * xf * (1.0f + c * xf * xf);
+    float sig = 1.0f / (1.0f + expf(-z));
+    return static_cast<T>(xf * sig);
+  }
+};
+
+template <typename T, int N>
+struct GeluTanhApprox<cutlass::Array<T, N>> {
+  static const bool kIsHeavy = true;
+  CUTLASS_HOST_DEVICE
+  cutlass::Array<T, N> operator()(cutlass::Array<T, N> const& v) const {
+    cutlass::Array<T, N> r;
+    GeluTanhApprox<T> op;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < N; ++i) r[i] = op(v[i]);
+    return r;
+  }
+};
+
 // ============================================================
 //  PlainFp16: 256×128×64, Cluster 2×2×1
 //  General FP16→FP16 GEMM (Identity epilogue)
@@ -143,6 +174,75 @@ using Main = typename cutlass::gemm::collective::CollectiveBuilder<
 using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
     cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
 }  // namespace sm100_fp16_k64
+
+// ============================================================
+//  K64GeluFp16: same tile as k64 but with GELU-tanh epilogue.
+//  Used by R3.1 split-G7: gate_buf = GELU(X @ W_gate).
+// ============================================================
+namespace sm100_fp16_k64_gelu {
+using Tile = Shape<_256, _256, _64>;
+using Cluster = Shape<_2, _2, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    GeluTanhApprox, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_k64_gelu
+
+// ============================================================
+//  K64MulAuxFp16: same tile as k64 with binary `multiplies` epilogue
+//  pulling an auxiliary tensor (gate_buf) via TMA.  R3.1 Phase 2:
+//  D = acc * Aux, where Aux is GELU(X @ W_gate) loaded element-wise
+//  alongside the up-GEMM accumulator.  Replaces the post-GEMM
+//  mul_fp16 kernel by folding the multiply into the epilogue.
+//
+//  Uses Sm90 EVT visitor tree via LinCombDeEltAct (Sm100 callbacks
+//  inherit Sm90 implementations for non-block-scale ops).
+// ============================================================
+namespace sm100_fp16_k64_mul_aux {
+using Tile = Shape<_256, _256, _64>;
+using Cluster = Shape<_2, _2, _1>;
+// LinCombDeEltAct semantics: D = ActivationFn(beta*C + alpha*acc, Aux).
+// With beta=0, alpha=1 and ActivationFn=multiplies: D = acc * Aux.
+using Fusion = cutlass::epilogue::fusion::LinCombDeEltAct<
+    cutlass::layout::RowMajor,
+    cutlass::multiplies,
+    cutlass_fp16_t,   // ElementOutput
+    float,            // ElementCompute
+    cutlass_fp16_t,   // ElementAux
+    cutlass_fp16_t,   // ElementSource (unused; beta=0)
+    float             // ElementScalar
+>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_k64_mul_aux
 
 // ============================================================
 //  Sm2x1Fp16: 256×256×128, Cluster 2×1×1, explicit 2SM-Sm100

--- a/csrc/gemm/gemm_types_sm100_fp16.h
+++ b/csrc/gemm/gemm_types_sm100_fp16.h
@@ -1,0 +1,143 @@
+// ================================================================
+// FlashRT — CUTLASS FP16 GEMM Templates for SM100/SM110
+// (Jetson AGX Thor, etc.)
+//
+// FP16 mirror of gemm_types_sm100.h.  Inputs are FP16, output is FP16,
+// accumulate in FP32. Layout follows the same NT convention as the FP8
+// templates: A row-major (M, K), B column-major (K, N), D row-major.
+// Weight storage is therefore [N, K] row-major in memory — identical to
+// PyTorch's nn.Linear weight layout, so no extra transpose is needed
+// on the spec side (drop the T() the cuBLAS NN fallback used).
+//
+// Element alignment 8 (= 128 bits / FP16) — matches TMA load width.
+// ================================================================
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cute/tensor.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/epilogue/thread/activation.h"
+#include "cutlass/util/packed_stride.hpp"
+
+using namespace cute;
+
+// Reuse cutlass_fp16 alias from the FP8 header (it's defined there too).
+// We include neither header into the other; both must compile standalone.
+#ifndef FLASHRT_CUTLASS_FP16_TYPES_DEFINED
+#define FLASHRT_CUTLASS_FP16_TYPES_DEFINED
+using cutlass_fp16_t = cutlass::half_t;
+#endif
+
+// ============================================================
+//  PlainFp16: 256×128×64, Cluster 2×2×1
+//  General FP16→FP16 GEMM (Identity epilogue)
+// ============================================================
+namespace sm100_fp16_plain {
+using Tile = Shape<_256, _128, _64>;
+using Cluster = Shape<_2, _2, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_plain
+
+// ============================================================
+//  SqFp16: 256×256×128 — deeper K pipeline for square large GEMMs
+//  Targets encoder G5 (QKV M=1024 N=2560 K=2048) and G6 (O M=1024 N=2048 K=2048)
+// ============================================================
+namespace sm100_fp16_sq {
+using Tile = Shape<_256, _256, _128>;
+using Cluster = Shape<_2, _2, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_sq
+
+// ============================================================
+//  T1Fp16: 128×256×128, Cluster 2×1×1, TmaWarpSpecialized2Sm
+//  Targets encoder G7 (Gate+Up M=1024 N=32768 K=2048) — wide-N shape
+//  Mirrors the FP8 t1 tactic that beat Myelin s128x256.
+// ============================================================
+namespace sm100_fp16_t1 {
+using Tile = Shape<_128, _256, _128>;
+using Cluster = Shape<_2, _1, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::TmaWarpSpecialized2Sm, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_t1
+
+// ============================================================
+//  WideFp16: 256×128×128 — deeper K for wide-K shapes
+//  Targets encoder G8 (Down M=1024 N=2048 K=16384)
+// ============================================================
+namespace sm100_fp16_wide {
+using Tile = Shape<_256, _128, _128>;
+using Cluster = Shape<_2, _2, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_wide

--- a/csrc/gemm/gemm_types_sm100_fp16.h
+++ b/csrc/gemm/gemm_types_sm100_fp16.h
@@ -176,6 +176,35 @@ using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
 }  // namespace sm100_fp16_k64
 
 // ============================================================
+//  SqGeluFp16: sq tile (256×256×128 C(2,2,1)) with GELU-tanh epilogue.
+//  R3.1-tile-sweep winner for split-G7 shape M=1024 N=H=16384 K=2048
+//  (sq 606.7us beats k64 710.1us and cuBLAS 676.7us per isolation
+//  bench, n_trials=500).
+// ============================================================
+namespace sm100_fp16_sq_gelu {
+using Tile = Shape<_256, _256, _128>;
+using Cluster = Shape<_2, _2, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    GeluTanhApprox, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_sq_gelu
+
+// ============================================================
 //  K64GeluFp16: same tile as k64 but with GELU-tanh epilogue.
 //  Used by R3.1 split-G7: gate_buf = GELU(X @ W_gate).
 // ============================================================

--- a/csrc/gemm/gemm_types_sm100_fp16.h
+++ b/csrc/gemm/gemm_types_sm100_fp16.h
@@ -116,6 +116,65 @@ using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
 }  // namespace sm100_fp16_t1
 
 // ============================================================
+//  K64Fp16: 256×256×64, Cluster 2×2×1 — small K-tile, deep pipeline
+//  R1.2 sweep winner for encoder G6 (O) and G7 (Gate+Up).
+//  K-tile=64 admits more pipeline stages, hiding BW latency on
+//  square/wide-N shapes (M=1024).
+// ============================================================
+namespace sm100_fp16_k64 {
+using Tile = Shape<_256, _256, _64>;
+using Cluster = Shape<_2, _2, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_k64
+
+// ============================================================
+//  Sm2x1Fp16: 256×256×128, Cluster 2×1×1, explicit 2SM-Sm100
+//  R1.2 sweep winner for encoder G8 (Down M=1024 N=2048 K=16384).
+//  K-heavy shapes prefer the 2x1x1 cluster (less cross-SM
+//  contention, more SMEM per stage) with the explicit 2SM
+//  kernel/epilogue schedule.
+// ============================================================
+namespace sm100_fp16_2sm21 {
+using Tile = Shape<_256, _256, _128>;
+using Cluster = Shape<_2, _1, _1>;
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity, cutlass_fp16_t, float>;
+using Epi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::TmaWarpSpecialized2Sm, Fusion>::CollectiveOp;
+using Main = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    cutlass_fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass_fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename Epi::SharedStorage))>,
+    cutlass::gemm::KernelTmaWarpSpecialized2SmSm100>::CollectiveOp;
+using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Main, Epi>>;
+}  // namespace sm100_fp16_2sm21
+
+// ============================================================
 //  WideFp16: 256×128×128 — deeper K for wide-K shapes
 //  Targets encoder G8 (Down M=1024 N=2048 K=16384)
 // ============================================================

--- a/csrc/gemm/mega/cutlass/epilogue/collective/collective_epilogue.hpp
+++ b/csrc/gemm/mega/cutlass/epilogue/collective/collective_epilogue.hpp
@@ -1,0 +1,75 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include <cutlass/detail/dependent_false.hpp>
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::epilogue::collective {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <
+  class DispatchPolicy,
+  class... Args
+>
+class CollectiveEpilogue {
+  static_assert(cutlass::detail::dependent_false<DispatchPolicy>, "Could not find an epilogue specialization.");
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass::epilogue::collective
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "cutlass/epilogue/collective/detail.hpp"
+
+//
+// Gemm
+//
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/collective/default_epilogue_array.hpp"
+#include "cutlass/epilogue/collective/epilogue_tensor_broadcast.hpp"
+#include "cutlass/epilogue/collective/sm70_epilogue_vectorized.hpp"
+#include "cutlass/epilogue/collective/sm70_epilogue_vectorized_array.hpp"
+#include "cutlass/epilogue/collective/sm90_epilogue_tma_warpspecialized.hpp"
+#include "cutlass/epilogue/collective/sm90_epilogue_tma_warpspecialized_bias_elementwise.hpp"
+#include "cutlass/epilogue/collective/sm90_epilogue_array_tma_warpspecialized.hpp"
+#include "cutlass/epilogue/collective/sm100_epilogue_nosmem.hpp"  
+#include "cutlass/epilogue/collective/sm100_epilogue_array_nosmem.hpp"  
+#include "cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp" 
+#include "cutlass/epilogue/collective/sm100_epilogue_array_tma_warpspecialized.hpp" 
+//
+// Conv
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/gemm/mega/cutlass/epilogue/collective/collective_epilogue.hpp
+++ b/csrc/gemm/mega/cutlass/epilogue/collective/collective_epilogue.hpp
@@ -65,10 +65,10 @@ class CollectiveEpilogue {
 #include "cutlass/epilogue/collective/sm90_epilogue_tma_warpspecialized.hpp"
 #include "cutlass/epilogue/collective/sm90_epilogue_tma_warpspecialized_bias_elementwise.hpp"
 #include "cutlass/epilogue/collective/sm90_epilogue_array_tma_warpspecialized.hpp"
-#include "cutlass/epilogue/collective/sm100_epilogue_nosmem.hpp"  
-#include "cutlass/epilogue/collective/sm100_epilogue_array_nosmem.hpp"  
-#include "cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp" 
-#include "cutlass/epilogue/collective/sm100_epilogue_array_tma_warpspecialized.hpp" 
+#include "cutlass/epilogue/collective/sm100_epilogue_nosmem.hpp"
+#include "cutlass/epilogue/collective/sm100_epilogue_array_nosmem.hpp"
+#include "cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp"
+#include "cutlass/epilogue/collective/sm100_epilogue_array_tma_warpspecialized.hpp"
 //
 // Conv
 //

--- a/csrc/gemm/mega/cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp
+++ b/csrc/gemm/mega/cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp
@@ -138,7 +138,7 @@ private:
   constexpr static int StagesD = StagesD_;
   static_assert(StagesC >= 1, "StagesC must be >= 1");
   static_assert(StagesD >= 1, "StagesD must be >= 1");
-  
+
   constexpr static bool ReuseSmemC = ReuseSmemC_;
   constexpr static bool is_source_supported = not cute::is_void_v<ElementC>;
 
@@ -280,7 +280,7 @@ private:
                                   make_layout(problem_shape_mnl, append<3>(args.dD, _0{})));
     return make_tma_copy(CopyOpS2G{}, tensor_d, SmemLayoutStageD{}, TmaEpilogueTile{}, _1{});
   }
-  
+
 public:
   // Device side epilogue params
   struct Params {
@@ -326,7 +326,7 @@ public:
 
   template <class ProblemShape>
   static cutlass::Status
-  initialize_workspace(ProblemShape const& problem_shape, Arguments const& args, void* workspace, cudaStream_t stream, 
+  initialize_workspace(ProblemShape const& problem_shape, Arguments const& args, void* workspace, cudaStream_t stream,
       CudaHostAdapter* cuda_adapter = nullptr) {
     return FusionCallbacks::initialize_workspace(problem_shape, args.thread, workspace, stream, cuda_adapter);
   }
@@ -772,22 +772,22 @@ public:
         if (issue_tma_store) {
           copy(params.tma_store_d, bSG_sD(_,_,_,store_pipe_producer_state.index()), bSG_gD(_,_,_,epi_m,epi_n));
         }
-  
+
         // Post async fence, pre TMA commit callback entry point
         cst_callbacks.tma_store(epi_m, epi_n, store_pipe_producer_state.count(), issue_tma_store);
-  
+
         // Commit the TMA stores for this stage
         if (issue_tma_store) {
           store_pipeline.producer_commit(store_pipe_producer_state);
         }
         ++store_pipe_producer_state;
-  
+
         // Wait for the next smem buffer to be available
         if (issue_tma_store) {
           store_pipeline.producer_acquire(store_pipe_producer_state);
         }
         synchronize();
-  
+
         if constexpr (ReuseSmemC) {
           // producer_acquire returns when at most StagesD-1 committed stores are pending
           bool store_finished = store_pipe_producer_state.count() > StorePipeline::UnacquiredStages;
@@ -1211,7 +1211,7 @@ public:
         }
 
         Tensor tTR_rAcc_epi_tile = tTR_rAcc(_,_,_,epi_m,epi_n);
-        Tensor tTR_rAcc_frg = recast<Array<ElementAccumulator, FragmentSize>>(coalesce(tTR_rAcc_epi_tile));     // (EPI_V)        
+        Tensor tTR_rAcc_frg = recast<Array<ElementAccumulator, FragmentSize>>(coalesce(tTR_rAcc_epi_tile));     // (EPI_V)
 
         // Vectorized fragment loop with visitor callback entry point
         CUTLASS_PRAGMA_UNROLL

--- a/csrc/gemm/mega/cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp
+++ b/csrc/gemm/mega/cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp
@@ -436,7 +436,7 @@ public:
   CollectiveEpilogue(Params const& params_, TensorStorage& shared_tensors)
       : params(params_), fusion_callbacks(params_.thread, shared_tensors.thread) {}
 
-public:  // FlashRT MK-1 patch: expose fusion_callbacks for cross-phase SMEM bridge.
+public:  // FlashRT patch: expose fusion_callbacks for cross-phase SMEM bridge.
   FusionCallbacks fusion_callbacks;
 
 private:

--- a/csrc/gemm/mega/cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp
+++ b/csrc/gemm/mega/cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp
@@ -1,0 +1,1301 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+/*! \file
+  \brief Functor performing elementwise operations used by epilogues.
+*/
+
+
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/arch/barrier.h"
+#include "cutlass/conv/convnd_problem_shape.hpp"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/detail.hpp"
+#include "cutlass/epilogue/thread/scale_type.h"
+#include "cutlass/epilogue/fusion/callbacks.hpp"
+#include "cutlass/epilogue/fusion/sm100_callbacks_tma_warpspecialized.hpp"
+#include "cutlass/detail/layout.hpp"
+#include "cutlass/detail/helper_macros.hpp"
+#include "cutlass/trace.h"
+
+#include "cutlass/conv/detail.hpp"
+#include "cute/tensor.hpp"
+#include "cutlass/cuda_host_adapter.hpp"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::epilogue::collective {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <
+  int StagesC_,
+  int StagesD_,
+  int FragmentSize_,
+  bool ReuseSmemC_,
+  bool DelayTmaStore_,
+  class CtaTileShape_, // (CTA_M,CTA_N,CTA_K, optional: Tile_L)
+  class EpilogueTile_, // (EPI_TILE_M, EPI_TILE_N)
+  class ElementC_,
+  class StrideC_,
+  class ElementD_,
+  class StrideD_,
+  class FusionCallbacks_,
+  class CopyOpT2R_,
+  class CopyOpG2S_,
+  class SmemLayoutAtomC_,
+  class CopyOpS2R_,
+  class CopyOpS2G_,
+  class SmemLayoutAtomD_,
+  class CopyOpR2S_,
+  class CopyOpR2R_
+>
+class CollectiveEpilogue<
+    Sm100TmaWarpSpecialized<StagesC_, StagesD_, FragmentSize_, ReuseSmemC_, DelayTmaStore_>,
+    CtaTileShape_,
+    EpilogueTile_,
+    ElementC_,
+    StrideC_,
+    ElementD_,
+    StrideD_,
+    FusionCallbacks_,
+    CopyOpT2R_,
+    CopyOpG2S_,
+    SmemLayoutAtomC_,
+    CopyOpS2R_,
+    CopyOpS2G_,
+    SmemLayoutAtomD_,
+    CopyOpR2S_,
+    CopyOpR2R_
+> {
+public:
+  //
+  // Type Aliases
+  //
+  using DispatchPolicy = Sm100TmaWarpSpecialized<StagesC_, StagesD_, FragmentSize_, ReuseSmemC_, DelayTmaStore_>;
+  using CtaTileShape = CtaTileShape_;
+  using EpilogueTile = EpilogueTile_;
+  using FusionCallbacks = FusionCallbacks_;
+  using ElementC = ElementC_;
+  using StrideC = StrideC_;
+  using ElementD = ElementD_;
+  using StrideD = StrideD_;
+  using CopyOpT2R = CopyOpT2R_;
+  using CopyOpG2S = CopyOpG2S_;
+  using SmemLayoutAtomC = SmemLayoutAtomC_;
+  using CopyOpS2R = CopyOpS2R_;
+  using CopyOpS2G = CopyOpS2G_;
+  using SmemLayoutAtomD = SmemLayoutAtomD_;
+  using CopyOpR2S = CopyOpR2S_;
+  using CopyOpR2R = CopyOpR2R_;
+
+  using ThreadEpilogueOp = typename epilogue::fusion::FusionCallbacksTraits<FusionCallbacks>::Operation;
+  using GmemTiledCopyC = CopyOpG2S;
+  using GmemTiledCopyD = CopyOpS2G;
+
+  constexpr static int ThreadCount = 128;
+
+  static_assert(!is_layout<EpilogueTile>::value && is_tuple<EpilogueTile>::value, "EpilogueTile must be a cute::Tile or cute::Shape");
+  static_assert(rank(EpilogueTile{}) == 2, "EpilogueTile must be rank-2: [EPI_TILE_M, EPI_TILE_N]");
+
+private:
+  using GmemElementD = ElementD;
+  using GmemElementC = cute::conditional_t<cute::is_void_v<ElementC>,ElementD,ElementC>; // prevents void ref breakages
+  using SmemElementD = typename cutlass::detail::get_unpacked_element_type<GmemElementD>::type;
+  using SmemElementC = typename cutlass::detail::get_unpacked_element_type<GmemElementC>::type;
+  constexpr static int StagesC = StagesC_;
+  constexpr static int StagesD = StagesD_;
+  static_assert(StagesC >= 1, "StagesC must be >= 1");
+  static_assert(StagesD >= 1, "StagesD must be >= 1");
+  
+  constexpr static bool ReuseSmemC = ReuseSmemC_;
+  constexpr static bool is_source_supported = not cute::is_void_v<ElementC>;
+
+  constexpr static bool is_m_major_C = detail::is_m_major<StrideC>();
+  constexpr static bool is_m_major_D = detail::is_m_major<StrideD>();
+
+  constexpr static bool is_im2col_C = cute::is_same_v<CopyOpG2S, SM90_TMA_LOAD_IM2COL>;
+  constexpr static bool is_im2col_D = cute::is_same_v<CopyOpS2G, SM90_TMA_STORE_IM2COL>;
+
+  using SmemLayoutStageC = decltype(tile_to_shape(SmemLayoutAtomC{}, product_each(shape(EpilogueTile{})),
+      cute::conditional_t<is_m_major_C, Step<_2,_1>, Step<_1,_2>>{} ));
+  using SmemLayoutStageD = decltype(tile_to_shape(SmemLayoutAtomD{}, product_each(shape(EpilogueTile{})),
+      cute::conditional_t<is_m_major_D, Step<_2,_1>, Step<_1,_2>>{} ));
+
+  constexpr static int StageCBits = cosize_v<SmemLayoutStageC> * sizeof_bits_v<SmemElementC>;
+  constexpr static int StageDBits = cosize_v<SmemLayoutStageD> * sizeof_bits_v<SmemElementD>;
+  constexpr static int MaxStageBits = cute::max(StageCBits, StageDBits);
+  constexpr static int StrideStageC = (ReuseSmemC ? MaxStageBits : StageCBits) / sizeof_bits_v<SmemElementC>;
+  constexpr static int StrideStageD = (ReuseSmemC ? MaxStageBits : StageDBits) / sizeof_bits_v<SmemElementD>;
+
+  using SmemLayoutC = decltype(cute::append<3>(SmemLayoutStageC{}, Layout<Int<StagesC>,                        Int<StrideStageC>>{}));
+  using SmemLayoutD = decltype(cute::append<3>(SmemLayoutStageD{}, Layout<Int<ReuseSmemC ? StagesC : StagesD>, Int<StrideStageD>>{}));
+
+  constexpr static bool support_smem_reuse = is_source_supported && StagesD <= StagesC
+                                              && MaxStageBits % sizeof_bits_v<SmemElementC> == 0
+                                              && MaxStageBits % sizeof_bits_v<SmemElementD> == 0;
+  static_assert(not (ReuseSmemC && not support_smem_reuse), "Smem reuse requirements not met");
+
+  constexpr static size_t SmemAlignmentC = cutlass::detail::alignment_for_swizzle(SmemLayoutC{});
+  constexpr static size_t SmemAlignmentD = cutlass::detail::alignment_for_swizzle(SmemLayoutD{});
+  constexpr static size_t MaxSmemAlignment = cute::max(SmemAlignmentC, SmemAlignmentD);
+
+  // Not unroll epi subtile loop when the activation op is heavy to reduce instruction size and register pressure.
+  constexpr static bool UnrollEpiLoop =
+    not cutlass::epilogue::thread::kIsHeavy_member_or_false<typename ThreadEpilogueOp::ActivationFn>::value;
+  // TMA store delay only benefits with loop unrolling
+  constexpr static bool DelayTmaStore = DelayTmaStore_ and UnrollEpiLoop;
+
+  struct CollectiveStorageWithC {
+    alignas(SmemAlignmentC) ArrayEngine<SmemElementC, cosize_v<SmemLayoutC>> smem_C;
+    alignas(SmemAlignmentD) ArrayEngine<SmemElementD, cosize_v<SmemLayoutD>> smem_D;
+  };
+
+  union CollectiveStorageWithoutC {
+    cute::array<SmemElementC, 0> smem_C;
+    alignas(SmemAlignmentD) ArrayEngine<SmemElementD, cosize_v<SmemLayoutD>> smem_D;
+  };
+
+  union CollectiveStorageReuseC {
+    alignas(MaxSmemAlignment) ArrayEngine<SmemElementC, cosize_v<SmemLayoutC>> smem_C;
+    alignas(MaxSmemAlignment) ArrayEngine<SmemElementD, cosize_v<SmemLayoutD>> smem_D;
+  };
+
+public:
+  // TMA pipeline for loading C
+  using LoadPipeline = cutlass::PipelineTransactionAsync<StagesC>;
+  using LoadPipelineState = cutlass::PipelineState<StagesC>;
+  constexpr static uint32_t TmaTransactionBytes = StageCBits / 8;
+
+  // TMA pipeline for storing D
+  using StorePipeline = cute::conditional_t<ReuseSmemC,
+                          cutlass::PipelineTmaStore<StagesC, StagesD-1>,
+                          cutlass::PipelineTmaStore<StagesD>>;
+  using StorePipelineState = cutlass::PipelineState<ReuseSmemC ? StagesC : StagesD>;
+
+  struct SharedStorage {
+    struct TensorStorage {
+      using CollectiveStorage = cute::conditional_t<not is_source_supported, CollectiveStorageWithoutC,
+                                  cute::conditional_t<ReuseSmemC, CollectiveStorageReuseC, CollectiveStorageWithC>>;
+      CollectiveStorage collective;
+
+      using FusionStorage = typename FusionCallbacks::SharedStorage;
+      FusionStorage thread;
+    } tensors;
+
+    using PipelineStorage = typename LoadPipeline::SharedStorage;
+    PipelineStorage pipeline;
+  };
+  using TensorStorage = typename SharedStorage::TensorStorage;
+  using PipelineStorage = typename SharedStorage::PipelineStorage;
+
+  // Planar complex kernels have two accumulator copies for the real and imaginary tensors.
+  constexpr static int NumAccumulatorMtxs = 1;
+
+  // Host side epilogue arguments
+  struct Arguments {
+    typename FusionCallbacks::Arguments thread{};
+    ElementC const* ptr_C = nullptr;
+    StrideC dC{};
+    ElementD* ptr_D = nullptr;
+    StrideD dD{};
+  };
+
+private:
+  static constexpr auto
+  get_tma_epi_tile() {
+    return cute::transform_apply(EpilogueTile{}, seq<0,1>{},
+      [] (auto epi_tiler, auto mode) {
+        auto cta_tiler_shape = get<mode>(CtaTileShape{});
+        // Use a dynamic stride to prevent mode coalescing
+        auto cta_tiler_stride = repeat_like(cta_tiler_shape, 0);
+        auto cta_tiler = make_layout(cta_tiler_shape, cta_tiler_stride);
+        // This is a multimodal CTA tiler, transform before returning
+        if constexpr (depth(cta_tiler) > 0) {
+          // This is an implicit multimodal tiler, match profile and return
+          if constexpr (tuple_size_v<decltype(shape(cta_tiler))> == 1) {
+            return make_tile(epi_tiler);
+          }
+          // This is an explicit multimodal tiler, compose out epi tiler
+          else {
+            return shape(composition(cta_tiler, epi_tiler));
+          }
+        }
+        // This is a flat CTA tiler, no need for transformation
+        else {
+          return epi_tiler;
+        }
+      },
+      [] (auto... epi_tilers) {
+        return make_tile(epi_tilers...);
+      }
+    );
+  }
+
+  using TmaEpilogueTile = decltype(get_tma_epi_tile());
+
+  template <class ProblemShapeMNL>
+  static constexpr auto
+  get_tma_load_c(ProblemShapeMNL const& problem_shape_mnl, Arguments const& args) {
+    Tensor tensor_c = make_tensor(make_gmem_ptr<GmemElementC>(args.ptr_C),
+                                  make_layout(problem_shape_mnl, append<3>(args.dC, _0{})));
+    return make_tma_copy(CopyOpG2S{}, tensor_c, SmemLayoutStageC{}, TmaEpilogueTile{}, _1{});
+  }
+
+  template <class ProblemShapeMNL>
+  static constexpr auto
+  get_tma_store_d(ProblemShapeMNL const& problem_shape_mnl, Arguments const& args) {
+    Tensor tensor_d = make_tensor(make_gmem_ptr<GmemElementD>(args.ptr_D),
+                                  make_layout(problem_shape_mnl, append<3>(args.dD, _0{})));
+    return make_tma_copy(CopyOpS2G{}, tensor_d, SmemLayoutStageD{}, TmaEpilogueTile{}, _1{});
+  }
+  
+public:
+  // Device side epilogue params
+  struct Params {
+    using TMA_C = decltype(get_tma_load_c (repeat_like(append<3>(StrideC{},_1{}), int32_t(0)), Arguments{}));
+    using TMA_D = decltype(get_tma_store_d(repeat_like(append<3>(StrideD{},_1{}), int32_t(0)), Arguments{}));
+
+    typename FusionCallbacks::Params thread{};
+    TMA_C tma_load_c;
+    TMA_D tma_store_d;
+  };
+
+  //
+  // Gemm Host Functions
+  //
+
+  template <class ProblemShape>
+  static constexpr Params
+  to_underlying_arguments(
+      ProblemShape const& problem_shape,
+      Arguments const& args,
+      [[maybe_unused]] void* workspace) {
+    // Optionally append 1s until problem shape is rank-4 in case its is only rank-3 (MNK)
+    auto problem_shape_mnl = select<0,1,3>(append<4>(problem_shape, 1));
+    typename Params::TMA_C tma_load_c{};
+    if constexpr (is_source_supported) {
+      tma_load_c = get_tma_load_c(problem_shape_mnl, args);
+    }
+
+    typename Params::TMA_D tma_store_d = get_tma_store_d(problem_shape_mnl, args);
+
+    return {
+      FusionCallbacks::to_underlying_arguments(problem_shape, args.thread, workspace),
+      tma_load_c,
+      tma_store_d
+    };
+  }
+
+  template <class ProblemShape>
+  static size_t
+  get_workspace_size(ProblemShape const& problem_shape, Arguments const& args) {
+    return FusionCallbacks::get_workspace_size(problem_shape, args.thread);
+  }
+
+  template <class ProblemShape>
+  static cutlass::Status
+  initialize_workspace(ProblemShape const& problem_shape, Arguments const& args, void* workspace, cudaStream_t stream, 
+      CudaHostAdapter* cuda_adapter = nullptr) {
+    return FusionCallbacks::initialize_workspace(problem_shape, args.thread, workspace, stream, cuda_adapter);
+  }
+
+  template <class ProblemShape>
+  static bool
+  can_implement(
+      ProblemShape const& problem_shape,
+      [[maybe_unused]] Arguments const& args) {
+    constexpr int tma_alignment_bits_d = cutlass::detail::get_output_alignment_bits<ElementD>();
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+    auto [M,N,K,L] = problem_shape_MNKL;
+    auto shape = cute::make_shape(M,N,L);
+
+    bool implementable = true;
+    constexpr int min_tma_aligned_elements_D = tma_alignment_bits_d / cutlass::sizeof_bits<ElementD>::value;
+    if constexpr (cute::is_same_v<CopyOpS2G, SM90_TMA_STORE_IM2COL>) { // ignore L stride for implicit gemm
+      implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_D>(take<0,2>(shape), take<0,2>(StrideD{}));
+    }
+    else {
+      implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_D>(shape, StrideD{});
+    }
+
+    if constexpr (is_source_supported) {
+      constexpr int tma_alignment_bits_c = cutlass::detail::get_output_alignment_bits<ElementC>();
+      constexpr int min_tma_aligned_elements_C = tma_alignment_bits_c / cutlass::sizeof_bits<ElementC>::value;
+      if constexpr (cute::is_same_v<CopyOpG2S, SM90_TMA_LOAD_IM2COL>) { // ignore L stride for implicit gemm
+        implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_C>(take<0,2>(shape), take<0,2>(StrideC{}));
+      }
+      else {
+        implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_C>(shape, StrideC{});
+      }
+    }
+
+    if (!implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: Problem Size doesn't meet the minimum alignment requirements for TMA.\n");
+    }
+
+    bool fusion_implementable = FusionCallbacks::can_implement(problem_shape, args.thread);
+
+    if (!fusion_implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: Problem Size doesn't meet the minimum requirements for FusionCallbacks.\n");
+    }
+
+    return implementable && fusion_implementable;
+  }
+
+  //
+  // Conv Host Functions
+  //
+
+  template <conv::Operator ConvOp, int NumDims>
+  static constexpr Params
+  to_underlying_arguments(cutlass::conv::ConvProblemShape<ConvOp,NumDims> const& problem_shape, Arguments const& args, void* workspace) {
+    return to_underlying_arguments(cutlass::conv::detail::get_transformed_problem_shape_MNKL(problem_shape), args, workspace);
+  }
+
+  template <conv::Operator ConvOp, int NumDims>
+  static size_t
+  get_workspace_size(cutlass::conv::ConvProblemShape<ConvOp,NumDims> const& problem_shape, Arguments const& args) {
+    return get_workspace_size(cutlass::conv::detail::get_transformed_problem_shape_MNKL(problem_shape), args);
+  }
+
+  template <conv::Operator ConvOp, int NumDims>
+  static cutlass::Status
+  initialize_workspace(cutlass::conv::ConvProblemShape<ConvOp,NumDims> const& problem_shape, Arguments const& args,
+      void* workspace, cudaStream_t stream, CudaHostAdapter* cuda_adapter = nullptr) {
+    return initialize_workspace(cutlass::conv::detail::get_transformed_problem_shape_MNKL(problem_shape), args, workspace, stream, cuda_adapter);
+  }
+
+  template <conv::Operator ConvOp, int NumDims>
+  static bool
+  can_implement(cutlass::conv::ConvProblemShape<ConvOp,NumDims> const& problem_shape, Arguments const& args) {
+    return can_implement(cutlass::conv::detail::get_transformed_problem_shape_MNKL(problem_shape), args);
+  }
+
+  //
+  // Static Device Functions
+  //
+
+  template<class CtaTileMNK>
+  CUTLASS_DEVICE
+  static constexpr int
+  get_load_pipe_increment(CtaTileMNK const& cta_tile_mnk) {
+    // Compute number of epilogue subtiles
+    return size<1>(zipped_divide(make_layout(take<0,2>(cta_tile_mnk)), EpilogueTile{}));
+  }
+
+  template<class CtaTileMNK>
+  CUTLASS_DEVICE
+  static constexpr int
+  get_store_pipe_increment(CtaTileMNK const& cta_tile_mnk) {
+    return get_load_pipe_increment(cta_tile_mnk);
+  }
+
+  /// Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
+  CUTLASS_DEVICE static void
+  prefetch_tma_descriptors(Params const& epilogue_params) {
+    cute::prefetch_tma_descriptor(epilogue_params.tma_load_c.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(epilogue_params.tma_store_d.get_tma_descriptor());
+  }
+
+  //
+  // Constructor and Data Members
+  //
+  CUTLASS_DEVICE
+  CollectiveEpilogue(Params const& params_, TensorStorage& shared_tensors)
+      : params(params_), fusion_callbacks(params_.thread, shared_tensors.thread) {}
+
+public:  // FlashRT MK-1 patch: expose fusion_callbacks for cross-phase SMEM bridge.
+  FusionCallbacks fusion_callbacks;
+
+private:
+  Params const& params;
+
+  //
+  // Non-static Device Functions
+  //
+public:
+  CUTLASS_DEVICE bool
+  is_producer_load_needed() const {
+    return fusion_callbacks.is_producer_load_needed();
+  }
+
+  template<
+    bool ReuseTmem = false,
+    class ProblemShapeMNKL,
+    class CtaTileMNK,
+    class CtaCoordMNKL,
+    class MmaTileMNK,
+    class TiledMma
+  >
+  CUTLASS_DEVICE auto
+  load(
+      LoadPipeline load_pipeline,
+      LoadPipelineState load_pipe_producer_state,
+      ProblemShapeMNKL problem_shape_mnkl,
+      CtaTileMNK cta_tile_mnk,
+      CtaCoordMNKL cta_coord_mnkl,
+      MmaTileMNK mma_tile_mnk,
+      TiledMma tiled_mma,
+      TensorStorage& shared_tensors,
+      bool reverse_epi_n = false) {
+    using namespace cute;
+
+    int lane_idx = canonical_lane_idx();
+    auto [M, N, K, L] = problem_shape_mnkl;
+    auto [m_coord, n_coord, k_coord, l_coord] = cta_coord_mnkl;
+
+    // The tma tensor C under im2col mode only has two modes (M, N) which
+    // should be local tiled with only (m_coord, n_coord).
+    auto coord_shape =
+      conditional_return<is_im2col_C>(make_coord(m_coord, n_coord), make_coord(m_coord, n_coord, l_coord));
+
+    // Represent the full source tensor, slice to get the tile this CTA is currently responsible for
+    Tensor mC_mn = params.tma_load_c.get_tma_tensor(make_shape(M,N,L));                                //       (M,N,L)
+    Tensor mC = coalesce(mC_mn, take<0,2>(cta_tile_mnk));
+    Tensor gC = local_tile(mC, take<0,2>(cta_tile_mnk), coord_shape);                                  // (CTA_M,CTA_N)
+
+    // Apply epilogue subtile, get matching smem tensor
+    auto ptr_sC = shared_tensors.collective.smem_C.begin();
+    Tensor gC_epi = flat_divide(gC, EpilogueTile{});                             // (EPI_TILE_M,EPI_TILE_N,EPI_M,EPI_N)
+    Tensor sC_epi = make_tensor(make_smem_ptr(ptr_sC), SmemLayoutC{});           //      (EPI_TILE_M,EPI_TILE_N,PIPE_C)
+
+    // Prepare the thread(b)lock's (G)mem to (S)mem TMA tiled copy (bGS_)
+    ThrCopy thrblk_g2s = params.tma_load_c.get_slice(Int<0>{});
+    Tensor bGS_gC = thrblk_g2s.partition_S(gC_epi);                                    // (TMA,TMA_M,TMA_N,EPI_M,EPI_N)
+    Tensor bGS_sC = thrblk_g2s.partition_D(sC_epi);                                    // (TMA,TMA_M,TMA_N,PIPE_C)
+
+    // Get the fusion callbacks for the producer load warp
+    auto pld_args = cutlass::epilogue::fusion::detail::ProducerLoadArgs{
+                      problem_shape_mnkl,
+                      cta_tile_mnk,
+                      cta_coord_mnkl,
+                      tiled_mma,
+                      EpilogueTile{},
+                      lane_idx
+                    };
+    auto pld_callbacks = fusion_callbacks.get_producer_load_callbacks(pld_args);
+    bool is_C_load_needed = is_source_supported && fusion_callbacks.is_C_load_needed();
+
+    // Predication for TMA load (one thread issues TMA load)
+    bool issue_tma_load = cute::elect_one_sync();
+
+    // Pre-loop fusion callback entry point
+    pld_callbacks.begin();
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int iter_n = 0; iter_n < size<3>(gC_epi); ++iter_n) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int iter_m = 0; iter_m < size<2>(gC_epi); ++iter_m) {
+        int epi_m = iter_m, epi_n = iter_n;
+        if constexpr (ReuseTmem) {
+          if (reverse_epi_n) {
+            epi_n = size<3>(gC_epi) - 1 - iter_n;
+          }
+        }
+        // Acquire the lock for this stage
+        constexpr uint16_t mcast_mask = 0;
+        uint64_t* tma_barrier = load_pipeline.producer_get_barrier(load_pipe_producer_state);
+        load_pipeline.producer_acquire(load_pipe_producer_state);
+
+        // Execute the TMA load for C if needed
+        if (issue_tma_load && is_C_load_needed) {
+          copy(params.tma_load_c.with(*tma_barrier, mcast_mask),
+              bGS_gC(_,_,_,epi_m,epi_n), bGS_sC(_,_,_,load_pipe_producer_state.index()));
+          load_pipeline.producer_expect_transaction(load_pipe_producer_state);
+        }
+
+        // Loop fusion callback entry point
+        pld_callbacks.step(tma_barrier, epi_m, epi_n, load_pipe_producer_state.count(), issue_tma_load);
+
+        // Commit TMA loads for this stage and release the lock
+        load_pipeline.producer_commit(load_pipe_producer_state);
+        ++load_pipe_producer_state;
+      }
+    }
+
+    // Post-loop fusion callback entry point
+    pld_callbacks.end();
+
+    return load_pipe_producer_state;
+  }
+
+  CUTLASS_DEVICE void
+  load_tail(
+      LoadPipeline load_pipeline,
+      LoadPipelineState load_pipe_producer_state,
+      [[maybe_unused]] StorePipeline store_pipeline,
+      [[maybe_unused]] StorePipelineState store_pipe_producer_state) {
+    load_pipeline.producer_tail(load_pipe_producer_state);
+  }
+
+  template<
+    bool ReuseTmem = false,
+    class AccumulatorPipeline,
+    class AccumulatorPipelineState,
+    class ProblemShapeMNKL,
+    class CtaTileMNK,
+    class CtaCoordMNKL,
+    class MmaTileMNK,
+    class TiledMma,
+    class AccEngine,
+    class AccLayout
+  >
+  CUTLASS_DEVICE auto
+  store(
+      LoadPipeline load_pipeline,
+      LoadPipelineState load_pipe_consumer_state,
+      StorePipeline store_pipeline,
+      StorePipelineState store_pipe_producer_state,
+      AccumulatorPipeline acc_pipeline,
+      AccumulatorPipelineState acc_pipe_consumer_state,
+      ProblemShapeMNKL problem_shape_mnkl,
+      CtaTileMNK cta_tile_mnk,
+      CtaCoordMNKL cta_coord_mnkl,
+      MmaTileMNK mma_tile_mnk,
+      TiledMma tiled_mma,
+      cute::Tensor<AccEngine,AccLayout> accumulators,
+      TensorStorage& shared_tensors
+      ) {
+    using namespace cute;
+    using ElementAccumulator = typename AccEngine::value_type;
+    using ElementCompute_ = typename epilogue::fusion::FusionCallbacksTraits<FusionCallbacks>::ElementCompute;
+    using ElementCompute = cute::conditional_t<cute::is_void_v<ElementCompute_>,ElementAccumulator,ElementCompute_>;
+
+    static_assert(is_tmem<AccEngine>::value, "Accumulator must be TMEM resident.");
+    static_assert(rank(accumulators) == 3, "Accumulators must be MMA-partitioned: [MMA, MMA_M, MMA_N]");
+    static_assert(size<1>(accumulators) == 1 && size<2>(accumulators) == 1, "TiledMMA must match partitioned ShapeMN");
+    static_assert(rank(ProblemShapeMNKL{}) == 4, "ProblemShapeMNKL must be rank 4");
+    static_assert(rank(CtaCoordMNKL{}) == 4, "CoordMNKL must be rank 4");
+
+    // Indexing variables
+    auto [M, N, K, L] = problem_shape_mnkl;
+    auto [m_coord, n_coord, k_coord, l_coord] = cta_coord_mnkl;
+    int thread_idx = threadIdx.x % ThreadCount;
+    int warp_idx = thread_idx / NumThreadsPerWarp;
+    [[maybe_unused]] int lane_idx = thread_idx % NumThreadsPerWarp;
+
+    // The tma tensor D under im2col mode only has two modes (M, N) which
+    // should be local tiled with only (m_coord, n_coord).
+    auto coord_shape =
+      conditional_return<is_im2col_D>(make_coord(m_coord, n_coord), make_coord(m_coord, n_coord, l_coord));
+
+    // Represent the full output tensor, slice to get the tile this CTA is responsible for
+    Tensor mD_mn = params.tma_store_d.get_tma_tensor(make_shape(M,N,L));                               //       (M,N,L)
+    Tensor mD = coalesce(mD_mn, take<0,2>(cta_tile_mnk));
+    Tensor gD = local_tile(mD, take<0,2>(cta_tile_mnk), coord_shape);                                  // (CTA_M,CTA_N)
+
+    Tensor tAcc = accumulators(make_coord(_,_),_0{},_0{});                                             // (CTA_M,CTA_N)
+
+    // Apply epilogue subtiling
+    Tensor tAcc_epi = flat_divide(tAcc, EpilogueTile{});                         // (EPI_TILE_M,EPI_TILE_N,EPI_M,EPI_N)
+    Tensor gD_epi   = flat_divide(  gD, EpilogueTile{});                         // (EPI_TILE_M,EPI_TILE_N,EPI_M,EPI_N)
+
+    // Construct the corresponding pipelined smem tensors
+    auto ptr_sC = shared_tensors.collective.smem_C.begin();
+    auto ptr_sD = shared_tensors.collective.smem_D.begin();
+    Tensor sC_epi = cute::as_position_independent_swizzle_tensor(
+                      make_tensor(make_smem_ptr(ptr_sC), SmemLayoutC{}));             // (EPI_TILE_M,EPI_TILE_N,PIPE_C)
+    Tensor sD_epi = cute::as_position_independent_swizzle_tensor(
+                      make_tensor(make_smem_ptr(ptr_sD), SmemLayoutD{}));             // (EPI_TILE_M,EPI_TILE_N,PIPE_D)
+
+    // (t)hread-partition for (t)mem to (r)egister copy (tTR_)
+    TiledCopy tiled_t2r = make_tmem_copy(CopyOpT2R{}, tAcc_epi(_,_,_0{},_0{}));
+    ThrCopy thread_t2r = tiled_t2r.get_slice(thread_idx);
+    Tensor tTR_tAcc = thread_t2r.partition_S(tAcc_epi);                                // (T2R,T2R_M,T2R_N,EPI_M,EPI_N)
+    Tensor tTR_sD   = thread_t2r.partition_D(sD_epi(_,_,_0{}));                        // (T2R,T2R_M,T2R_N)
+
+    // Allocate D and accumulator registers
+    // Does directly store the visitor into smem.
+    constexpr bool IsDirectR2S = cute::is_same_v<CopyOpR2R, AutoVectorizingCopyWithAssumedAlignment<128>>;
+    using RegisterElementD = cute::conditional_t<!IsDirectR2S, ElementCompute, SmemElementD>;
+    Tensor tTR_rAcc = make_tensor<ElementAccumulator>(shape(tTR_sD));                              // (T2R,T2R_M,T2R_N)
+    Tensor tTR_rD   = make_tensor<RegisterElementD>(shape(tTR_sD));                                // (T2R,T2R_M,T2R_N)
+
+    // Vectorized fragment view
+    constexpr int FragmentSize = DispatchPolicy::FragmentSize;
+    Tensor tTR_rAcc_frg = recast<Array<ElementAccumulator, FragmentSize>>(coalesce(tTR_rAcc));               // (EPI_V)
+    Tensor tTR_rD_frg   = recast<Array<RegisterElementD, FragmentSize>>(coalesce(tTR_rD));                   // (EPI_V)
+    CUTE_STATIC_ASSERT(size(tTR_rAcc) % DispatchPolicy::FragmentSize == 0, "Fragment size does not vectorize properly");
+
+    // (t)hread-partition for (s)mem to (r)egister copy (tSR_)
+    TiledCopy tiled_s2r = make_tiled_copy_D(Copy_Atom<CopyOpS2R, SmemElementC>{}, tiled_t2r);
+    ThrCopy thread_s2r = tiled_s2r.get_slice(thread_idx);
+    Tensor tSR_sC        = thread_s2r.partition_S(sC_epi);                                  // (S2R,S2R_M,S2R_N,PIPE_C)
+    Layout tSR_rC_layout = thread_s2r.retile_D(tTR_rD).layout();                            // (S2R,S2R_M,S2R_N)
+
+    // Allocate C registers
+    // If C smem load is a non-vectorized dst(i) = src(i) then we can allocate C registers directly in the compute type
+    // to eliminate some redundant pack+unpack instruction sequences for sub-word types
+    constexpr bool IsDirectS2R = cute::is_same_v<CopyOpS2R, AutoVectorizingCopyWithAssumedAlignment<128>>
+                                && decltype(max_common_vector(tSR_rC_layout, tSR_sC.layout()))::value <= 1;
+    using RegisterElementC = cute::conditional_t<IsDirectS2R, ElementCompute, SmemElementC>;
+    Tensor tTR_rC = make_tensor<RegisterElementC>(shape(tTR_sD));                                  // (T2R,T2R_M,T2R_N)
+    Tensor tSR_rC = thread_s2r.retile_D(tTR_rC);                                                   // (S2R,S2R_M,S2R_N)
+
+    // (t)hread-partition for (r)egister to (r)egister copy (tRR_)
+    TiledCopy tiled_r2r = make_tiled_copy_D(Copy_Atom<CopyOpR2R, RegisterElementD>{}, tiled_t2r);
+    ThrCopy thread_r2r = tiled_r2r.get_slice(thread_idx);
+    Tensor tRR_rD_src = thread_r2r.retile_S(tTR_rD);                                   // (R2R,R2R_M,R2R_N,EPI_M,EPI_N)
+    Tensor tRR_rD_dst = thread_r2r.retile_D(tTR_rD);                                   // (R2R,R2R_M,R2R_N,EPI_M,EPI_N)
+
+    // (t)hread-partition for (r)egister to (s)mem copy (tRS_)
+    TiledCopy tiled_r2s = make_tiled_copy_D(Copy_Atom<CopyOpR2S, SmemElementD>{}, tiled_r2r);
+    ThrCopy thread_r2s = tiled_r2s.get_slice(thread_idx);
+    Tensor tRS_sD = thread_r2s.partition_D(sD_epi);                                         // (R2S,R2S_M,R2S_N,PIPE_D)
+    Tensor tRS_rD = [&]() CUTLASS_LAMBDA_FUNC_INLINE {
+      if constexpr (!IsDirectR2S) {
+        return make_tensor<SmemElementD>(shape(tRS_sD(_,_,_,_0{})));
+      }
+      else{
+        return thread_r2s.retile_S(tTR_rD);                                                 // (R2S,R2S_M,R2S_N)
+      }
+    }();
+
+    Tensor tRR_rD_dst_frg = recast<Array<RegisterElementD, FragmentSize>>(coalesce(tRR_rD_dst));
+    Tensor tRS_rD_frg     = recast<Array<SmemElementD, FragmentSize>>(coalesce(tRS_rD));
+
+    // thread(b)lock-partition for (s)mem to (g)mem copy (bSG_)
+    ThrCopy thrblk_s2g = params.tma_store_d.get_slice(Int<0>{});
+    Tensor bSG_sD = thrblk_s2g.partition_S(sD_epi);                                    // (S2G,S2G_M,S2G_N,PIPE_D)
+    Tensor bSG_gD = thrblk_s2g.partition_D(gD_epi);                                    // (S2G,S2G_M,S2G_N,EPI_M,EPI_N)
+
+    // OOB predication for tile quantization "residue"
+    // Absolute coordinate tensors (dynamic)
+    Tensor mD_crd = make_identity_tensor(make_shape(M,N));                                                     // (M,N)
+    Tensor cD_mn = local_tile(mD_crd, take<0,2>(cta_tile_mnk), make_coord(m_coord, n_coord));          // (CTA_M,CTA_N)
+    Tensor tTR_cD_mn = thread_t2r.partition_D(flat_divide(cD_mn, EpilogueTile{}));     // (T2R,T2R_M,T2R_N,EPI_M,EPI_N)
+    // Relative coordinate tensors (static)
+    Tensor cD = make_coord_tensor(cD_mn.layout());                                                  // (CTA_M,CTA_N)
+    Tensor tTR_cD = make_coord_tensor(tTR_cD_mn.layout());                          // (T2R,T2R_M,T2R_N,EPI_M,EPI_N)
+    // Subtract the global "bottom right" corner from the local "top left" corner to get the max relative coordinate
+    auto residue_cD = make_coord(M,N) - cD_mn(_0{});                                                           // (m,n)
+    auto residue_tTR_cD = make_coord(M,N) - tTR_cD_mn(_0{});                                                   // (m,n)
+
+    // Arguments for the fusion callbacks for the consumer store warps
+    constexpr bool RefSrc = false; // Register tensors reference T2R copy dst layout
+    auto cst_args = cutlass::epilogue::fusion::detail::ConsumerStoreArgs{
+                      problem_shape_mnkl,
+                      cta_tile_mnk,
+                      cta_coord_mnkl,
+                      tiled_mma,
+                      EpilogueTile{},
+                      tiled_t2r,
+                      cD,
+                      residue_cD,
+                      tTR_cD,
+                      residue_tTR_cD,
+                      tTR_rC,
+                      thread_idx
+                    };
+
+    // Thread synchronizer for previously issued waits or fences
+    // to ensure visibility of smem reads/writes to threads or TMA unit
+    auto synchronize = [] () { cutlass::arch::NamedBarrier::sync(ThreadCount, cutlass::arch::ReservedNamedBarriers::EpilogueBarrier); };
+
+    // Predication for sub-128 thread T2R tiled copy
+    Layout tmem_warp_layout = typename decltype(make_tmem_warp_partitioner(tAcc_epi(_,_,0,0)))::TiledLayout_TV{};
+    constexpr bool predicate_tmem_load = size(tmem_warp_layout) != cosize(tmem_warp_layout);
+    bool issue_tmem_load = true;
+
+    // If tmem doesn't have enough capacity to support double buffering, a portion of tmem (a column of epilogue tiles)
+    // is overlapped between 2 pseudo-buffers. The shared tmem portion corresponds to the last epilogue tile column of
+    // tmem accumulator buffer 0, and the first epilogue tile column of tmem accumulator 1.
+    // Thus, whenever we are processing tmem accumulator buffer 0, we process the epilogue tiles with reversed column order.
+    // Once the last epilogue tile column is loaded from tmem, the acc_pipeline is released.
+    // Then, the next accumulation stage for buffer 1 can start.
+    [[maybe_unused]] bool reverse_epi_n = ReuseTmem && acc_pipe_consumer_state.phase() == 0;
+    static_assert(not (ReuseTmem && AccumulatorPipeline::Stages != 1), "Tmem reuse requires 1 accumulator stage");
+
+    // Predication for TMA store (one warp issues TMA store)
+    bool issue_tma_store = warp_idx == 0;
+
+    // In the reuse smem configuration we have StagesC smem buffers and at most StagesD committed TMA stores in flight.
+    // The TMA store pipeline producer acquire returns when at most StagesD-1 committed stores are in-flight, so we can
+    // only guarantee store completion after StagesD iterations, then we can begin issuing releases on the smem buffer locks.
+    // store_pipe_producer_state tracks the acquire and load_pipe_consumer_state tracks the release, in circular buffer fashion.
+    // If TMA store supported async transaction mbarriers we would not need this synchronous release behavior.
+    LoadPipelineState load_wait_state = load_pipe_consumer_state;
+    if constexpr (ReuseSmemC) {
+      load_wait_state = store_pipe_producer_state;
+      load_wait_state.phase_ ^= 1;
+    }
+
+    // We can delay issue of TMA store by one iteration to achieve better interleaving of non-TMA instructions
+    // Sync requirements of smem reuse may preclude this optimization
+    // Delayed stores cause delayed stage releases which causes deadlock when StagesC == StagesD
+    [[maybe_unused]] int epi_m_prev = 0;
+    [[maybe_unused]] int epi_n_prev = 0;
+    static_assert(not (DelayTmaStore and ReuseSmemC and StagesC <= StagesD), "This TMA epilogue configuration will deadlock");
+
+    // The Epilogue Loop
+    auto epi_loop_fn = [&] (auto& cst_callbacks) CUTLASS_LAMBDA_FUNC_INLINE {
+      bool is_producer_load_needed = fusion_callbacks.is_producer_load_needed();
+      bool is_C_load_needed = is_source_supported && fusion_callbacks.is_C_load_needed();
+
+      // The TMA store sequence for one epilogue loop iteration
+      auto tma_store_fn = [&] (int epi_m, int epi_n) CUTLASS_LAMBDA_FUNC_INLINE {
+        // Write the tile from smem to gmem with TMA
+        cutlass::arch::fence_view_async_shared(); // ensure smem writes are visible to TMA
+        synchronize(); // ensure all threads have issued their async fence
+        if (issue_tma_store) {
+          copy(params.tma_store_d, bSG_sD(_,_,_,store_pipe_producer_state.index()), bSG_gD(_,_,_,epi_m,epi_n));
+        }
+  
+        // Post async fence, pre TMA commit callback entry point
+        cst_callbacks.tma_store(epi_m, epi_n, store_pipe_producer_state.count(), issue_tma_store);
+  
+        // Commit the TMA stores for this stage
+        if (issue_tma_store) {
+          store_pipeline.producer_commit(store_pipe_producer_state);
+        }
+        ++store_pipe_producer_state;
+  
+        // Wait for the next smem buffer to be available
+        if (issue_tma_store) {
+          store_pipeline.producer_acquire(store_pipe_producer_state);
+        }
+        synchronize();
+  
+        if constexpr (ReuseSmemC) {
+          // producer_acquire returns when at most StagesD-1 committed stores are pending
+          bool store_finished = store_pipe_producer_state.count() > StorePipeline::UnacquiredStages;
+          // Let dma warp know earliest smem buffer is consumed and empty after StagesD producer commits
+          if (store_finished) {
+            if (is_producer_load_needed) {
+              load_pipeline.consumer_release(load_pipe_consumer_state);
+            }
+            ++load_pipe_consumer_state;
+          }
+        }
+      }; // tma_store_fn
+
+      cst_callbacks.begin();
+      if (cst_callbacks.begin_sync_needed()) {
+        synchronize();
+      }
+
+      // Begin the wait for the producer load results
+      ConsumerToken load_wait_token{BarrierStatus::WaitDone};
+      if (is_producer_load_needed) {
+        load_wait_token = load_pipeline.consumer_try_wait(load_wait_state);
+      }
+      // Begin the wait for the accumulator results
+      ConsumerToken acc_wait_token = acc_pipeline.consumer_try_wait(acc_pipe_consumer_state);
+
+      // For each epilogue subtile within the CTA tile
+      constexpr int NumEpiSubtilesN = CUTE_STATIC_V(size<3>(gD_epi));
+      constexpr int NumEpiSubtilesM = CUTE_STATIC_V(size<2>(gD_epi));
+      #pragma unroll(UnrollEpiLoop ? NumEpiSubtilesN : 1)
+      for (int iter_n = 0; iter_n < NumEpiSubtilesN; ++iter_n) {
+        #pragma unroll(UnrollEpiLoop ? NumEpiSubtilesM : 1)
+        for (int iter_m = 0; iter_m < NumEpiSubtilesM; ++iter_m) {
+          int epi_m = iter_m, epi_n = iter_n;
+          bool is_first_iteration = iter_m == 0 && iter_n == 0;
+          bool is_last_iteration = iter_m == size<2>(gD_epi)-1 && iter_n == size<3>(gD_epi)-1;
+          bool do_acc_release = is_last_iteration;
+
+          // Reverse subtile order for tmem reuse if necessary
+          if constexpr (ReuseTmem) {
+            if (reverse_epi_n) {
+              epi_n = size<3>(gD_epi) - 1 - iter_n;
+            }
+            do_acc_release = iter_m == size<2>(gD_epi)-1 && iter_n == 0;
+          }
+
+          cst_callbacks.begin_loop(epi_m, epi_n);
+
+          if (is_producer_load_needed) {
+            // Wait for the producer load to fill smem
+            load_pipeline.consumer_wait(load_wait_state, load_wait_token);
+
+            if (is_C_load_needed) {
+              // Copy source tile from smem to register
+              copy(tiled_s2r, tSR_sC(_,_,_,load_wait_state.index()), tSR_rC);
+              // Ensure smem loads are complete before reusing smem for mixed types/layouts
+              if constexpr (ReuseSmemC && not (SmemLayoutC{} == SmemLayoutD{})) {
+                synchronize();
+              }
+            }
+          }
+
+          // First loop fusion callback entry point
+          cst_callbacks.previsit(epi_m, epi_n, load_wait_state.count(), is_producer_load_needed);
+
+          if (is_producer_load_needed) {
+            // Let producer load warp know smem buffers are consumed and empty
+            if constexpr (not ReuseSmemC) {
+              cutlass::arch::fence_view_async_shared();
+              load_pipeline.consumer_release(load_pipe_consumer_state);
+              ++load_pipe_consumer_state;
+            }
+            ++load_wait_state;
+          }
+
+          if (is_first_iteration) {
+            // Wait for mma warp to fill tmem buffer with accumulator results
+            acc_pipeline.consumer_wait(acc_pipe_consumer_state, acc_wait_token);
+          }
+
+          // The current tile in tmem
+          Tensor tTR_tAcc_mn = tTR_tAcc(_,_,_,epi_m,epi_n);
+
+          // Compute tmem load predication if necessary
+          if constexpr (predicate_tmem_load) {
+            // Issue tmem load if this tile's tmem subpartition is accessible by this warp
+            int subpart_idx = (tTR_tAcc_mn.data().dp_ / 32) % 4;
+            issue_tmem_load = warp_idx == subpart_idx;
+          }
+          bool issue_smem_store = issue_tmem_load;
+
+          // Copy accumulator tile from tmem to register
+          if (issue_tmem_load) {
+            copy(tiled_t2r, tTR_tAcc_mn, tTR_rAcc);
+          }
+
+          // After the last tmem load, signal that tmem buffer is consumed and empty
+          if (do_acc_release) {
+            cutlass::arch::fence_view_async_tmem_load();
+            acc_pipeline.consumer_release(acc_pipe_consumer_state);
+            ++acc_pipe_consumer_state;
+          }
+
+          // Vectorized fragment loop with visitor callback entry point
+          CUTLASS_PRAGMA_UNROLL
+          for (int epi_v = 0; epi_v < size(tTR_rD_frg); ++epi_v) {
+            tTR_rD_frg(epi_v) = cst_callbacks.visit(tTR_rAcc_frg(epi_v), epi_v, epi_m, epi_n);
+          }
+
+          // The latest we can delay the TMA store is right before the smem store of the next iteration
+          // since the current TMA store needs to be committed before we can acquire the next smem buffer
+          if constexpr (DelayTmaStore) {
+            // Issue TMA stores for the previous subtile
+            if (not is_first_iteration) {
+              tma_store_fn(epi_m_prev, epi_n_prev);
+            }
+            epi_m_prev = epi_m;
+            epi_n_prev = epi_n;
+          }
+
+          if constexpr (!IsDirectR2S) {
+            // At present, only FP4 col output with scalefactor generation fusion would go into these branch
+            copy(tiled_r2r, tRR_rD_src, tRR_rD_dst);
+          }
+          tRS_rD_frg(_0{}) = cutlass::NumericArrayConverter<SmemElementD, RegisterElementD, FragmentSize>{}(tRR_rD_dst_frg(_0{}));
+
+          // Smem reduction callback entry point using current store buffer for workspace
+          Tensor reduction_buffer = make_tensor(raw_pointer_cast(sD_epi(_,_,store_pipe_producer_state.index()).data()),
+                                                make_layout(stride<2>(get_nonswizzle_portion(SmemLayoutD{})), _1{}));
+          cst_callbacks.reduce(reduction_buffer, synchronize, epi_m, epi_n, is_last_iteration, tRS_rD_frg);
+
+          // Copy output tile from register to smem
+          if (issue_smem_store) {
+            copy(tiled_r2s, tRS_rD, tRS_sD(_,_,_,store_pipe_producer_state.index()));
+          }
+
+          // Post reduction, pre TMA store callback entry point
+          cst_callbacks.postreduce(epi_m, epi_n, store_pipe_producer_state.count(), issue_smem_store);
+
+          if constexpr (not DelayTmaStore) {
+            // Issue TMA stores for this subtile
+            tma_store_fn(epi_m, epi_n);
+          }
+
+          cst_callbacks.end_loop(epi_m, epi_n);
+
+          if (is_producer_load_needed) {
+            // Begin the wait for the next subtile producer load
+            load_wait_token = load_pipeline.consumer_try_wait(load_wait_state, is_last_iteration);
+          }
+        } // for epi_m
+      } // for epi_n
+
+      if constexpr (DelayTmaStore) {
+        // Issue TMA stores for the last subtile
+        tma_store_fn(epi_m_prev, epi_n_prev);
+      }
+
+      cst_callbacks.end();
+    }; // epi_loop_fn
+
+    //
+    // BEGIN EPILOGUE
+    //
+    auto cst_callbacks = fusion_callbacks.template get_consumer_store_callbacks<RefSrc>(cst_args);
+    epi_loop_fn(cst_callbacks);
+    return cute::make_tuple(load_pipe_consumer_state, store_pipe_producer_state, acc_pipe_consumer_state);
+  }
+
+  // API with Global Accumulator in registers for FastFP32 (emulated MMA) kernels.
+  // The accumulator in TMEM periodically loaded into the registers so that the MMA can clear out the TMEM accumulator
+  // values for better accuracy. This epilogue accepts the accumulator in registers and take TiledCopy for the
+  // TMEM->Reg as a parameter to be used in partitioning GMEM tensors C and D.
+  template<
+    class ProblemShapeMNKL,
+    class CtaTileMNK,
+    class CtaCoordMNKL,
+    class MmaTileMNK,
+    class TiledMma,
+    class AccEngine,
+    class AccLayout,
+    class TiledCopyT2R
+  >
+  CUTLASS_DEVICE auto
+  store(
+      LoadPipeline load_pipeline,
+      LoadPipelineState load_pipe_consumer_state,
+      StorePipeline store_pipeline,
+      StorePipelineState store_pipe_producer_state,
+      ProblemShapeMNKL problem_shape_mnkl,
+      CtaTileMNK cta_tile_mnk,
+      CtaCoordMNKL cta_coord_mnkl,
+      MmaTileMNK mma_tile_mnk,
+      TiledMma tiled_mma,
+      cute::Tensor<AccEngine, AccLayout>& tTR_rAcc,                                     // (T2R,T2R_M,T2R_N,EPI_M,EPI_N)
+      TensorStorage& shared_tensors,
+      TiledCopyT2R tiled_t2r
+      ) {
+    using namespace cute;
+    using ElementAccumulator = typename AccEngine::value_type;
+    using ElementCompute_ = typename epilogue::fusion::FusionCallbacksTraits<FusionCallbacks>::ElementCompute;
+    using ElementCompute = cute::conditional_t<cute::is_void_v<ElementCompute_>,ElementAccumulator,ElementCompute_>;
+
+    static_assert(is_rmem<AccEngine>::value, "Accumulator must be Register resident.");
+    static_assert(rank(AccLayout{}) == 5, "Accumulators must be copy-partitioned:  (T2R,T2R_M,T2R_N,EPI_M,EPI_N)");
+    static_assert(rank(ProblemShapeMNKL{}) == 4, "ProblemShapeMNKL must be rank 4");
+    static_assert(rank(CtaCoordMNKL{}) == 4, "CoordMNKL must be rank 4");
+
+    // Indexing variables
+    auto [M, N, K, L] = problem_shape_mnkl;
+    auto [m_coord, n_coord, k_coord, l_coord] = cta_coord_mnkl;
+    int thread_idx = threadIdx.x % ThreadCount;
+    int warp_idx = thread_idx / NumThreadsPerWarp;
+    [[maybe_unused]] int lane_idx = thread_idx % NumThreadsPerWarp;
+
+    // The tma tensor D under im2col mode only has two modes (M, N) which
+    // should be local tiled with only (m_coord, n_coord).
+    auto coord_shape =
+      conditional_return<is_im2col_D>(make_coord(m_coord, n_coord), make_coord(m_coord, n_coord, l_coord));
+
+    // Represent the full output tensor, slice to get the tile this CTA is responsible for
+    Tensor mD_mn = params.tma_store_d.get_tma_tensor(make_shape(M,N,L));                               //       (M,N,L)
+    Tensor mD = coalesce(mD_mn, take<0,2>(cta_tile_mnk));
+    Tensor gD = local_tile(mD, take<0,2>(cta_tile_mnk), coord_shape);                                  // (CTA_M,CTA_N)
+
+    // Apply epilogue subtiling
+    Tensor gD_epi = flat_divide(  gD, EpilogueTile{});                           // (EPI_TILE_M,EPI_TILE_N,EPI_M,EPI_N)
+
+    // Construct the corresponding pipelined smem tensors
+    auto ptr_sC = shared_tensors.collective.smem_C.begin();
+    auto ptr_sD = shared_tensors.collective.smem_D.begin();
+    Tensor sC_epi = cute::as_position_independent_swizzle_tensor(
+                      make_tensor(make_smem_ptr(ptr_sC), SmemLayoutC{}));             // (EPI_TILE_M,EPI_TILE_N,PIPE_C)
+    Tensor sD_epi = cute::as_position_independent_swizzle_tensor(
+                      make_tensor(make_smem_ptr(ptr_sD), SmemLayoutD{}));             // (EPI_TILE_M,EPI_TILE_N,PIPE_D)
+
+    // (t)hread-partition for (t)mem to (r)egister copy (tTR_)
+    ThrCopy thread_t2r = tiled_t2r.get_slice(thread_idx);
+    Tensor tTR_sD = thread_t2r.partition_D(sD_epi(_,_,_0{}));                                      // (T2R,T2R_M,T2R_N)
+
+    // Allocate D and accumulator registers
+    Tensor tTR_rD = make_tensor<SmemElementD>(shape(tTR_sD));                                      // (T2R,T2R_M,T2R_N)
+
+    // Vectorized fragment view
+    constexpr int FragmentSize = DispatchPolicy::FragmentSize;
+    Tensor tTR_rD_frg = recast<Array<SmemElementD, FragmentSize>>(coalesce(tTR_rD));                         // (EPI_V)
+
+    // (t)hread-partition for (s)mem to (r)egister copy (tSR_)
+    TiledCopy tiled_s2r  = make_tiled_copy_D(Copy_Atom<CopyOpS2R, SmemElementC>{}, tiled_t2r);
+    ThrCopy thread_s2r   = tiled_s2r.get_slice(thread_idx);
+    Tensor tSR_sC        = thread_s2r.partition_S(sC_epi);                                  // (S2R,S2R_M,S2R_N,PIPE_C)
+    Layout tSR_rC_layout = thread_s2r.retile_D(tTR_rD).layout();                                   // (S2R,S2R_M,S2R_N)
+
+    // Allocate C registers
+    // If C smem load is a non-vectorized dst(i) = src(i) then we can allocate C registers directly in the compute type
+    // to eliminate some redundant pack+unpack instruction sequences for sub-word types
+    constexpr bool IsDirectS2R = cute::is_same_v<CopyOpS2R, AutoVectorizingCopyWithAssumedAlignment<128>>
+                                && decltype(max_common_vector(tSR_rC_layout, tSR_sC.layout()))::value <= 1;
+    using RegisterElementC = cute::conditional_t<IsDirectS2R, ElementCompute, SmemElementC>;
+    Tensor tTR_rC = make_tensor<RegisterElementC>(shape(tTR_sD));                                  // (T2R,T2R_M,T2R_N)
+    Tensor tSR_rC = thread_s2r.retile_D(tTR_rC);                                                   // (S2R,S2R_M,S2R_N)
+
+    // (t)hread-partition for (r)egister to (s)mem copy (tRS_)
+    TiledCopy tiled_r2s = make_tiled_copy_D(Copy_Atom<CopyOpR2S,SmemElementD>{}, tiled_t2r);
+    ThrCopy thread_r2s = tiled_r2s.get_slice(thread_idx);
+    Tensor tRS_rD = thread_r2s.retile_S(tTR_rD);                                                   // (R2S,R2S_M,R2S_N)
+    Tensor tRS_sD = thread_r2s.partition_D(sD_epi);                                         // (R2S,R2S_M,R2S_N,PIPE_D)
+
+    // thread(b)lock-partition for (s)mem to (g)mem copy (bSG_)
+    ThrCopy thrblk_s2g = params.tma_store_d.get_slice(Int<0>{});
+    Tensor bSG_sD = thrblk_s2g.partition_S(sD_epi);                                         // (S2G,S2G_M,S2G_N,PIPE_D)
+    Tensor bSG_gD = thrblk_s2g.partition_D(gD_epi);                                    // (S2G,S2G_M,S2G_N,EPI_M,EPI_N)
+
+    // OOB predication for tile quantization "residue"
+    // Absolute coordinate tensors (dynamic)
+    Tensor mD_crd = make_identity_tensor(make_shape(M,N));                                                     // (M,N)
+    Tensor cD_mn = local_tile(mD_crd, take<0,2>(cta_tile_mnk), make_coord(m_coord, n_coord));          // (CTA_M,CTA_N)
+    Tensor tTR_cD_mn = thread_t2r.partition_D(flat_divide(cD_mn, EpilogueTile{}));     // (T2R,T2R_M,T2R_N,EPI_M,EPI_N)
+    // Relative coordinate tensors (static)
+    Tensor cD = make_coord_tensor(cD_mn.layout());                                                  // (CTA_M,CTA_N)
+    Tensor tTR_cD = make_coord_tensor(tTR_cD_mn.layout());                          // (T2R,T2R_M,T2R_N,EPI_M,EPI_N)
+    // Subtract the global "bottom right" corner from the local "top left" corner to get the max relative coordinate
+    auto residue_cD = make_coord(M,N) - cD_mn(_0{});                                                           // (m,n)
+    auto residue_tTR_cD = make_coord(M,N) - tTR_cD_mn(_0{});                                                   // (m,n)
+
+    // Get the fusion callbacks for the consumer store warps
+    constexpr bool RefSrc = false; // Register tensors reference T2R copy dst layout
+    auto cst_args = cutlass::epilogue::fusion::detail::ConsumerStoreArgs{
+                      problem_shape_mnkl,
+                      cta_tile_mnk,
+                      cta_coord_mnkl,
+                      tiled_mma,
+                      EpilogueTile{},
+                      tiled_t2r,
+                      cD,
+                      residue_cD,
+                      tTR_cD,
+                      residue_tTR_cD,
+                      tTR_rC,
+                      thread_idx
+                    };
+
+    auto cst_callbacks = fusion_callbacks.template get_consumer_store_callbacks<RefSrc>(cst_args);
+    bool is_producer_load_needed = fusion_callbacks.is_producer_load_needed();
+    bool is_C_load_needed = is_source_supported && fusion_callbacks.is_C_load_needed();
+
+    // Thread synchronizer for previously issued waits or fences
+    // to ensure visibility of smem reads/writes to threads or TMA unit
+    auto synchronize = [] () { cutlass::arch::NamedBarrier::sync(ThreadCount, cutlass::arch::ReservedNamedBarriers::EpilogueBarrier); };
+
+    // Predication for TMA store (one warp issues TMA store)
+    bool issue_tma_store = warp_idx == 0;
+
+    // In the reuse smem configuration we have StagesC smem buffers and at most StagesD committed TMA stores in flight.
+    // The TMA store pipeline producer acquire returns when at most StagesD-1 committed stores are in-flight, so we can
+    // only guarantee store completion after StagesD iterations, then we can begin issuing releases on the smem buffer locks.
+    // store_pipe_producer_state tracks the acquire and load_pipe_consumer_state tracks the release, in circular buffer fashion.
+    // If TMA store supported async transaction mbarriers we would not need this synchronous release behavior.
+    LoadPipelineState load_wait_state = load_pipe_consumer_state;
+    if constexpr (ReuseSmemC) {
+      load_wait_state = store_pipe_producer_state;
+      load_wait_state.phase_ ^= 1;
+    }
+
+    // We can delay issue of TMA store by one iteration to achieve better interleaving of non-TMA instructions
+    // Sync requirements of smem reuse may preclude this optimization
+    // Delayed stores cause delayed stage releases which causes deadlock when StagesC == StagesD
+    int epi_m_prev = 0, epi_n_prev = 0;
+    static_assert(not (DelayTmaStore and ReuseSmemC and StagesC <= StagesD), "This TMA epilogue configuration will deadlock");
+
+    // The TMA store sequence for one subtile iteration
+    auto tma_store_fn = [&] (int epi_m, int epi_n) CUTLASS_LAMBDA_FUNC_INLINE {
+      // Write the tile from smem to gmem with TMA
+      cutlass::arch::fence_view_async_shared(); // ensure smem writes are visible to TMA
+      synchronize(); // ensure all threads have issued their async fence
+      if (issue_tma_store) {
+        copy(params.tma_store_d, bSG_sD(_,_,_,store_pipe_producer_state.index()), bSG_gD(_,_,_,epi_m,epi_n));
+      }
+
+      // Post async fence, pre TMA commit callback entry point
+      cst_callbacks.tma_store(epi_m, epi_n, store_pipe_producer_state.count(), issue_tma_store);
+
+      // Commit the TMA stores for this stage
+      if (issue_tma_store) {
+        store_pipeline.producer_commit(store_pipe_producer_state);
+      }
+      ++store_pipe_producer_state;
+
+      // Wait for the next smem buffer to be available
+      if (issue_tma_store) {
+        store_pipeline.producer_acquire(store_pipe_producer_state);
+      }
+      synchronize();
+
+      if constexpr (ReuseSmemC) {
+        // producer_acquire returns when at most StagesD-1 committed stores are pending
+        bool store_finished = store_pipe_producer_state.count() > StorePipeline::UnacquiredStages;
+        // Let dma warp know earliest smem buffer is consumed and empty after StagesD producer commits
+        if (store_finished) {
+          if (is_producer_load_needed) {
+            load_pipeline.consumer_release(load_pipe_consumer_state);
+          }
+          ++load_pipe_consumer_state;
+        }
+      }
+    };
+
+    //
+    // BEGIN EPILOGUE
+    //
+
+    cst_callbacks.begin();
+    if (cst_callbacks.begin_sync_needed()) {
+      synchronize();
+    }
+
+    // Begin the wait for the producer load results
+    ConsumerToken load_wait_token{BarrierStatus::WaitDone};
+    if (is_producer_load_needed) {
+      load_wait_token = load_pipeline.consumer_try_wait(load_wait_state);
+    }
+
+    // For each epilogue subtile within the CTA tile
+    constexpr int NumEpiSubtilesN = CUTE_STATIC_V(size<3>(gD_epi));
+    constexpr int NumEpiSubtilesM = CUTE_STATIC_V(size<2>(gD_epi));
+    #pragma unroll(UnrollEpiLoop ? NumEpiSubtilesN : 1)
+    for (int iter_n = 0; iter_n < NumEpiSubtilesN; ++iter_n) {
+      #pragma unroll(UnrollEpiLoop ? NumEpiSubtilesM : 1)
+      for (int iter_m = 0; iter_m < NumEpiSubtilesM; ++iter_m) {
+        int epi_m = iter_m, epi_n = iter_n;
+        bool is_first_iteration = iter_m == 0 && iter_n == 0;
+        bool is_last_iteration = iter_m == size<2>(gD_epi)-1 && iter_n == size<3>(gD_epi)-1;
+
+        cst_callbacks.begin_loop(epi_m, epi_n);
+
+        if (is_producer_load_needed) {
+          // Wait for the producer load to fill smem
+          load_pipeline.consumer_wait(load_wait_state, load_wait_token);
+
+          if (is_C_load_needed) {
+            // Copy source tile from smem to register
+            copy(tiled_s2r, tSR_sC(_,_,_,load_wait_state.index()), tSR_rC);
+            // Ensure smem loads are complete before reusing smem for mixed types/layouts
+            if constexpr (ReuseSmemC && not (SmemLayoutC{} == SmemLayoutD{})) {
+              synchronize();
+            }
+          }
+        }
+
+        // First loop fusion callback entry point
+        cst_callbacks.previsit(epi_m, epi_n, load_wait_state.count(), is_producer_load_needed);
+
+        if (is_producer_load_needed) {
+          // Let producer load warp know smem buffers are consumed and empty
+          if constexpr (not ReuseSmemC) {
+            cutlass::arch::fence_view_async_shared();
+            load_pipeline.consumer_release(load_pipe_consumer_state);
+            ++load_pipe_consumer_state;
+          }
+          ++load_wait_state;
+        }
+
+        Tensor tTR_rAcc_epi_tile = tTR_rAcc(_,_,_,epi_m,epi_n);
+        Tensor tTR_rAcc_frg = recast<Array<ElementAccumulator, FragmentSize>>(coalesce(tTR_rAcc_epi_tile));     // (EPI_V)        
+
+        // Vectorized fragment loop with visitor callback entry point
+        CUTLASS_PRAGMA_UNROLL
+        for (int epi_v = 0; epi_v < size(tTR_rD_frg); ++epi_v) {
+          tTR_rD_frg(epi_v) = cst_callbacks.visit(tTR_rAcc_frg(epi_v), epi_v, epi_m, epi_n);
+        }
+
+        // The latest we can delay the TMA store is right before the smem store of the next iteration
+        // since the current TMA store needs to be committed before we can acquire the next smem buffer
+        if constexpr (DelayTmaStore) {
+          // Issue TMA stores for the previous subtile
+          if (not is_first_iteration) {
+            tma_store_fn(epi_m_prev, epi_n_prev);
+          }
+          epi_m_prev = epi_m;
+          epi_n_prev = epi_n;
+        }
+
+        // Smem reduction callback entry point using current store buffer for workspace
+        Tensor reduction_buffer = make_tensor(raw_pointer_cast(sD_epi(_,_,store_pipe_producer_state.index()).data()),
+                                              make_layout(stride<2>(get_nonswizzle_portion(SmemLayoutD{})), _1{}));
+        cst_callbacks.reduce(reduction_buffer, synchronize, epi_m, epi_n, is_last_iteration, tTR_rD_frg);
+
+        // Copy output tile from register to smem
+        bool issue_smem_store = true;
+        if (issue_smem_store) {
+          copy(tiled_r2s, tRS_rD, tRS_sD(_,_,_,store_pipe_producer_state.index()));
+        }
+
+        // Post reduction, pre TMA store callback entry point
+        cst_callbacks.postreduce(epi_m, epi_n, store_pipe_producer_state.count(), issue_smem_store);
+
+        if constexpr (not DelayTmaStore) {
+          // Issue TMA stores for this subtile
+          tma_store_fn(epi_m, epi_n);
+        }
+
+        cst_callbacks.end_loop(epi_m, epi_n);
+
+        if (is_producer_load_needed) {
+          // Begin the wait for the next subtile producer load
+          load_wait_token = load_pipeline.consumer_try_wait(load_wait_state, is_last_iteration);
+        }
+      } // for epi_m
+    } // for epi_n
+
+    if constexpr (DelayTmaStore) {
+      // Issue TMA stores for the last subtile
+      tma_store_fn(epi_m_prev, epi_n_prev);
+    }
+
+    cst_callbacks.end();
+
+    return cute::make_tuple(load_pipe_consumer_state, store_pipe_producer_state);
+  }
+
+  template <class CtaTileMNK>
+  CUTLASS_DEVICE void
+  store_tail(
+      LoadPipeline load_pipeline,
+      LoadPipelineState load_pipe_consumer_state,
+      StorePipeline store_pipeline,
+      StorePipelineState store_pipe_producer_state,
+      CtaTileMNK cta_tile_mnk) {
+    if constexpr (ReuseSmemC) {
+      if (fusion_callbacks.is_producer_load_needed()) {
+        // wait for all TMA stores to complete
+        store_pipeline.producer_tail(store_pipe_producer_state);
+
+        // Issue releases on up to StagesD-1 previously issued TMA stores
+        constexpr int release_stages = cute::min(StorePipeline::UnacquiredStages, get_load_pipe_increment(cta_tile_mnk));
+        CUTLASS_PRAGMA_UNROLL
+        for (int stage = 0; stage < release_stages; ++stage) {
+          load_pipeline.consumer_release(load_pipe_consumer_state);
+          ++load_pipe_consumer_state;
+        }
+      }
+    }
+  }
+};
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass::epilogue::collective
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/gemm/mega/cutlass/gemm/collective/sm100_mma_warpspecialized.hpp
+++ b/csrc/gemm/mega/cutlass/gemm/collective/sm100_mma_warpspecialized.hpp
@@ -237,7 +237,7 @@ struct CollectiveMma<
   static constexpr uint32_t TmaTransactionBytesB =
     cutlass::bits_to_bytes(size(AtomThrShapeMNK{}) * cosize(take<0,3>(SmemLayoutB{})) * cute::sizeof_bits_v<ElementB>);
   static constexpr uint32_t TmaTransactionBytes = TmaTransactionBytesA + TmaTransactionBytesB;
-  // FlashRT MK-1 Stage E: phase-2 mainloop skips A TMA (uses shared smem_A
+  // FlashRT patch: phase-2 mainloop skips A TMA (uses shared smem_A
   // pre-filled by phase 1); only B bytes counted in transaction barrier.
   static constexpr uint32_t TmaTransactionBytesBOnly = TmaTransactionBytesB;
 
@@ -496,7 +496,7 @@ struct CollectiveMma<
   /// tBsB - partitioned smem tensor for B
   /// mcast_mask_a - tma multicast mask for A
   /// mcast_mask_b - tma multicast mask for B
-  // FlashRT MK-1 patch: template-ize TensorStorage so kernels can pass a
+  // FlashRT patch: template-ize TensorStorage so kernels can pass a
   // duck-typed view that shares SMEM_A across multiple CollectiveMma
   // instances.  Default (no explicit template arg) preserves CUTLASS
   // behavior.
@@ -586,7 +586,7 @@ struct CollectiveMma<
 
   /// Perform a collective-scoped matrix multiply-accumulate
   /// Producer Perspective
-  // FlashRT MK-1 Stage E: SkipA template flag — when true, the load issues
+  // FlashRT patch: SkipA template flag — when true, the load issues
   // only the B TMA copy (A is assumed pre-loaded in shared SMEM by a peer
   // mainloop).  Caller MUST configure MainloopPipeline transaction_bytes
   // to TmaTransactionBytesBOnly so the barrier completes correctly.

--- a/csrc/gemm/mega/cutlass/gemm/collective/sm100_mma_warpspecialized.hpp
+++ b/csrc/gemm/mega/cutlass/gemm/collective/sm100_mma_warpspecialized.hpp
@@ -1,0 +1,742 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/detail/collective.hpp"
+#include "cutlass/detail/cluster.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/numeric_types.h"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/trace.h"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "cutlass/detail/sm100_tmem_helper.hpp"
+
+#include "cute/algorithm/functional.hpp"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/algorithm/gemm.hpp"
+#include "cute/numeric/arithmetic_tuple.hpp"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::collective {
+using namespace cute;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// WarpSpecialized Mainloop
+// Both DMA Load and MMA methods of this class must be run by a single thread that's picked by elect_one
+template <
+  int Stages,
+  int SchedulerPipelineStageCount,
+  int AccumulatorPipelineStageCount,
+  class ClusterShape,   // Static cluster shape or dynamic (int, int, _1)
+  class TileShape_,     // (MmaAtomShapeM, MmaAtomShapeN, TileK)
+  class ElementA_,
+  class StrideA_,
+  class ElementB_,
+  class StrideB_,
+  class TiledMma_,
+  class GmemTiledCopyA_,
+  class SmemLayoutAtomA_,
+  class SmemCopyAtomA_,
+  class TransformA_,
+  class GmemTiledCopyB_,
+  class SmemLayoutAtomB_,
+  class SmemCopyAtomB_,
+  class TransformB_>
+struct CollectiveMma<
+    MainloopSm100TmaUmmaWarpSpecialized<
+      Stages,
+      SchedulerPipelineStageCount,
+      AccumulatorPipelineStageCount,
+      ClusterShape>,
+    TileShape_,
+    ElementA_,
+    StrideA_,
+    ElementB_,
+    StrideB_,
+    TiledMma_,
+    GmemTiledCopyA_,
+    SmemLayoutAtomA_,
+    SmemCopyAtomA_,
+    TransformA_,
+    GmemTiledCopyB_,
+    SmemLayoutAtomB_,
+    SmemCopyAtomB_,
+    TransformB_>
+{
+  //
+  // Type Aliases
+  //
+  using TiledMma = TiledMma_;
+  using AtomThrShapeMNK = Shape<decltype(shape<0>(typename TiledMma::ThrLayoutVMNK{})), _1, _1>;
+
+  using DispatchPolicy = MainloopSm100TmaUmmaWarpSpecialized<
+                          Stages,
+                          SchedulerPipelineStageCount,
+                          AccumulatorPipelineStageCount,
+                          ClusterShape>;
+  using TileShape = TileShape_;
+
+  static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+
+  CUTE_STATIC_ASSERT_V(evenly_divides(TileShape{}, tile_shape(TiledMma{})),
+                       "Static cluster shape used: TileShape should be evenly divided by TiledMma");
+
+  using CtaShape_MNK = decltype(shape_div(TileShape{}, AtomThrShapeMNK{}));
+
+  // Define A and B block shapes for reduced size TMA_LOADs
+  using MmaShapeA_MK = decltype(partition_shape_A(TiledMma{}, make_shape(size<0>(TileShape{}), size<2>(TileShape{}))));
+  using MmaShapeB_NK = decltype(partition_shape_B(TiledMma{}, make_shape(size<1>(TileShape{}), size<2>(TileShape{}))));
+
+  using ElementA = ElementA_;
+  using ElementAMma = typename TiledMma::ValTypeA;
+  using StrideA = StrideA_;
+  using ElementB = ElementB_;
+  using ElementBMma = typename TiledMma::ValTypeB;
+  using StrideB = StrideB_;
+
+  static constexpr bool IsRuntimeDataTypeA = cutlass::gemm::collective::detail::is_sm10x_runtime_f8f6f4<ElementA>();
+
+  static constexpr bool IsRuntimeDataTypeB = cutlass::gemm::collective::detail::is_sm10x_runtime_f8f6f4<ElementB>();
+
+  static_assert((IsRuntimeDataTypeA && IsRuntimeDataTypeB) ||
+                (!IsRuntimeDataTypeA && !IsRuntimeDataTypeB),
+                "ElementA and ElementB should be both runtime or both static.");
+
+  static constexpr bool IsRuntimeDataType = IsRuntimeDataTypeA && IsRuntimeDataTypeB;
+
+  using ElementAccumulator = typename TiledMma::ValTypeC;
+  using GmemTiledCopyA = GmemTiledCopyA_;
+  using GmemTiledCopyB = GmemTiledCopyB_;
+  using SmemLayoutAtomA = SmemLayoutAtomA_;
+  using SmemLayoutAtomB = SmemLayoutAtomB_;
+  using SmemCopyAtomA = SmemCopyAtomA_;
+  using SmemCopyAtomB = SmemCopyAtomB_;
+  using TransformA = TransformA_;
+  using TransformB = TransformB_;
+  using ArchTag = typename DispatchPolicy::ArchTag;
+
+  using MainloopPipeline = cutlass::PipelineTmaUmmaAsync<
+                             DispatchPolicy::Stages,
+                             ClusterShape,
+                             AtomThrShapeMNK>;
+  using MainloopPipelineState = typename MainloopPipeline::PipelineState;
+
+  static_assert(rank(SmemLayoutAtomA{}) == 2, "SmemLayoutAtomA must be rank 2 (M,K)");
+  static_assert(((size<0,0>(MmaShapeA_MK{}) * size<1>(MmaShapeA_MK{})) % size<0>(SmemLayoutAtomA{})) == 0,
+      "SmemLayoutAtom must evenly divide tile shape.");
+  static_assert(((size<0,1>(MmaShapeA_MK{}) * size<2>(MmaShapeA_MK{})) % size<1>(SmemLayoutAtomA{})) == 0,
+      "SmemLayoutAtom must evenly divide tile shape.");
+  static_assert(cute::is_void_v<SmemCopyAtomA>,
+      "SM100 UMMA cannot have a non-void copy atom for smem sourced instructions.");
+
+  static_assert(rank(SmemLayoutAtomB{}) == 2, "SmemLayoutAtomB must be rank 2 (N,K)");
+  static_assert(((size<0,0>(MmaShapeB_NK{}) * size<1>(MmaShapeB_NK{})) % size<0>(SmemLayoutAtomB{})) == 0,
+      "SmemLayoutAtom must evenly divide tile shape.");
+  static_assert(((size<0,1>(MmaShapeB_NK{}) * size<2>(MmaShapeB_NK{})) % size<1>(SmemLayoutAtomB{})) == 0,
+      "SmemLayoutAtom must evenly divide tile shape.");
+  static_assert(cute::is_void_v<SmemCopyAtomB>,
+      "SM100 UMMA cannot have a non-void copy atom for smem sourced instructions.");
+
+  // Tile along K mode first before tiling over MN. PIPE mode last as usual.
+  // This maximizes TMA boxes due to better smem-K vectorization, reducing total issued TMAs.
+  // (MMA_TILE_M,MMA_TILE_K),MMA_M,MMA_K,PIPE)
+  using SmemLayoutA = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomA{},
+      append(MmaShapeA_MK{}, Int<DispatchPolicy::Stages>{}),
+      cute::conditional_t<cutlass::gemm::detail::is_mn_major<StrideA>(), Step<_2,_1,_3>, Step<_1,_2,_3>>{}));
+  // (MMA_TILE_N,MMA_TILE_K),MMA_N,MMA_K,PIPE)
+  using SmemLayoutB = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomB{},
+      append(MmaShapeB_NK{}, Int<DispatchPolicy::Stages>{}),
+      cute::conditional_t<cutlass::gemm::detail::is_mn_major<StrideB>(), Step<_2,_1,_3>, Step<_1,_2,_3>>{}));
+
+  static_assert(DispatchPolicy::Stages >= 2, "Specialization requires Stages set to value 1 or more.");
+  static_assert(cute::is_base_of<cute::UMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value &&
+                cute::is_base_of<cute::UMMA::DescriptorIterator, typename TiledMma::FrgTypeB>::value,
+                "MMA atom must source both A and B operand from smem_desc for this mainloop.");
+  static_assert(
+      (size(AtomThrShapeMNK{}) == 1 &&
+        (cute::is_same_v<GmemTiledCopyA, SM90_TMA_LOAD> || cute::is_same_v<GmemTiledCopyA, SM90_TMA_LOAD_MULTICAST>)) ||
+      (size(AtomThrShapeMNK{}) == 2 &&
+        (cute::is_same_v<GmemTiledCopyA, SM100_TMA_2SM_LOAD> || cute::is_same_v<GmemTiledCopyA, SM100_TMA_2SM_LOAD_MULTICAST>)),
+      "GmemTiledCopy - invalid TMA copy atom specified.");
+  static_assert(
+      (size(AtomThrShapeMNK{}) == 1 &&
+        (cute::is_same_v<GmemTiledCopyB, SM90_TMA_LOAD> || cute::is_same_v<GmemTiledCopyB, SM90_TMA_LOAD_MULTICAST>)) ||
+      (size(AtomThrShapeMNK{}) == 2 &&
+        (cute::is_same_v<GmemTiledCopyB, SM100_TMA_2SM_LOAD> || cute::is_same_v<GmemTiledCopyB, SM100_TMA_2SM_LOAD_MULTICAST>)),
+      "GmemTiledCopy -  invalid TMA copy atom specified.");
+
+  using TmaInternalElementA = cute::conditional_t<cute::is_same_v<ElementA, float>, cutlass::tfloat32_t, ElementAMma>;
+  using TmaInternalElementB = cute::conditional_t<cute::is_same_v<ElementB, float>, cutlass::tfloat32_t, ElementBMma>;
+
+  using SmemAllocTypeA = cute::conditional_t<cute::sizeof_bits_v<ElementAMma> < 8, uint8_t, ElementAMma>;
+  using SmemAllocTypeB = cute::conditional_t<cute::sizeof_bits_v<ElementBMma> < 8, uint8_t, ElementBMma>;
+
+  using BitTypeElementA = cute::uint_bit_t<cute::sizeof_bits_v<ElementA>>;
+  using BitTypeElementB = cute::uint_bit_t<cute::sizeof_bits_v<ElementB>>;
+
+  using ArrayElementA = cute::conditional_t<IsRuntimeDataTypeA, BitTypeElementA, ElementA>;
+  using ArrayElementB = cute::conditional_t<IsRuntimeDataTypeB, BitTypeElementB, ElementB>;
+
+  using RuntimeDataTypeA = cute::conditional_t<IsRuntimeDataTypeA, cute::UMMA::MXF8F6F4Format, void*>;
+  using RuntimeDataTypeB = cute::conditional_t<IsRuntimeDataTypeB, cute::UMMA::MXF8F6F4Format, void*>;
+
+  struct SharedStorage {
+    struct TensorStorage : cute::aligned_struct<128, _0> {
+      cute::ArrayEngine<SmemAllocTypeA, cute::cosize_v<SmemLayoutA>> smem_A;
+      cute::ArrayEngine<SmemAllocTypeB, cute::cosize_v<SmemLayoutB>> smem_B;
+    } tensors;
+
+    using PipelineStorage = typename MainloopPipeline::SharedStorage;
+    PipelineStorage pipeline;
+  };
+
+  // Expose shared storage for tensors/pipelines separately to allow kernel layer to reorder them.
+  using TensorStorage = typename SharedStorage::TensorStorage;
+  using PipelineStorage = typename SharedStorage::PipelineStorage;
+
+  // Only one thread issues the TMA and updates the barriers in a 2SM MMA, adjust bytes accordingly
+  static constexpr uint32_t TmaTransactionBytesA =
+    cutlass::bits_to_bytes(size(AtomThrShapeMNK{}) * cosize(take<0,3>(SmemLayoutA{})) * cute::sizeof_bits_v<ElementA>);
+  static constexpr uint32_t TmaTransactionBytesB =
+    cutlass::bits_to_bytes(size(AtomThrShapeMNK{}) * cosize(take<0,3>(SmemLayoutB{})) * cute::sizeof_bits_v<ElementB>);
+  static constexpr uint32_t TmaTransactionBytes = TmaTransactionBytesA + TmaTransactionBytesB;
+  // FlashRT MK-1 Stage E: phase-2 mainloop skips A TMA (uses shared smem_A
+  // pre-filled by phase 1); only B bytes counted in transaction barrier.
+  static constexpr uint32_t TmaTransactionBytesBOnly = TmaTransactionBytesB;
+
+  template <class AccTensor>
+  struct TmemStorage {
+    AccTensor accumulators;
+  };
+
+  template <
+    class KTileCount,
+    class GTensorPartitionedA, class GTensorPartitionedB,
+    class STensorA, class STensorB
+  >
+  struct LoadParams {
+    // for scheduler
+    KTileCount k_tiles;
+    // for input tensor values
+    GTensorPartitionedA tAgA_mkl;
+    GTensorPartitionedB tBgB_nkl;
+    STensorA tAsA;
+    STensorB tBsB;
+    // the TMA multicast masks
+    uint16_t mcast_mask_a;
+    uint16_t mcast_mask_b;
+
+    CUTLASS_DEVICE
+    LoadParams (
+        KTileCount k_tiles_,
+        GTensorPartitionedA tAgA_mkl_, GTensorPartitionedB tBgB_nkl_,
+        STensorA tAsA_, STensorB tBsB_,
+        uint16_t mcast_mask_a_, uint16_t mcast_mask_b_)
+    : k_tiles(k_tiles_)
+    , tAgA_mkl(tAgA_mkl_), tBgB_nkl(tBgB_nkl_)
+    , tAsA(tAsA_), tBsB(tBsB_)
+    , mcast_mask_a(mcast_mask_a_), mcast_mask_b(mcast_mask_b_) {}
+  };
+
+  template <
+    class TiledMma,
+    class FragmentA, class FragmentB
+  >
+  struct MmaParams {
+    TiledMma tiled_mma;
+    FragmentA tCrA;
+    FragmentB tCrB;
+
+    CUTLASS_DEVICE
+    MmaParams (
+        TiledMma tiled_mma_,
+        FragmentA tCrA_, FragmentB tCrB_)
+    : tiled_mma(tiled_mma_)
+    , tCrA(tCrA_), tCrB(tCrB_) {}
+  };
+
+  // Host side kernel arguments
+  struct Arguments {
+    ArrayElementA const* ptr_A{nullptr};
+    StrideA dA{};
+    ArrayElementB const* ptr_B{nullptr};
+    StrideB dB{};
+    RuntimeDataTypeA runtime_data_type_a{};
+    RuntimeDataTypeB runtime_data_type_b{};
+  };
+
+  // Device side kernel params
+  struct Params {
+    using ClusterLayout_VMNK = decltype(tiled_divide(make_layout(conditional_return<IsDynamicCluster>(make_shape(uint32_t(0), uint32_t(0), Int<1>{}), ClusterShape{})),
+                                                     make_tile(typename TiledMma::AtomThrID{})));
+
+    using TMA_A = decltype(make_tma_atom_A_sm100<TmaInternalElementA>(
+        GmemTiledCopyA{},
+        make_tensor(recast_ptr<TmaInternalElementA>(nullptr), repeat_like(StrideA{}, int32_t(0)), StrideA{}),
+        SmemLayoutA{}(_,_,_,cute::Int<0>{}),
+        TileShape{},
+        TiledMma{},
+        ClusterLayout_VMNK{})
+      );
+
+    using TMA_B = decltype(make_tma_atom_B_sm100<TmaInternalElementB>(
+        GmemTiledCopyB{},
+        make_tensor(recast_ptr<TmaInternalElementB>(nullptr), repeat_like(StrideB{}, int32_t(0)), StrideB{}),
+        SmemLayoutB{}(_,_,_,cute::Int<0>{}),
+        TileShape{},
+        TiledMma{},
+        ClusterLayout_VMNK{})
+      );
+
+    TMA_A tma_load_a;
+    TMA_B tma_load_b;
+    TMA_A tma_load_a_fallback;
+    TMA_B tma_load_b_fallback;
+    dim3 cluster_shape_fallback;
+    RuntimeDataTypeA runtime_data_type_a;
+    RuntimeDataTypeB runtime_data_type_b;
+  };
+
+  CUTLASS_DEVICE
+  CollectiveMma(Params const& params, ClusterShape cluster_shape, uint32_t block_rank_in_cluster)
+    : cluster_shape_(cluster_shape)
+    , block_rank_in_cluster_(block_rank_in_cluster)
+    , runtime_data_type_a_(params.runtime_data_type_a)
+    , runtime_data_type_b_(params.runtime_data_type_b) {
+    if constexpr (IsDynamicCluster) {
+      const bool is_fallback_cluster = (cute::size<0>(cluster_shape_) == params.cluster_shape_fallback.x &&
+                                        cute::size<1>(cluster_shape_) == params.cluster_shape_fallback.y);
+      observed_tma_load_a_ = is_fallback_cluster ? &params.tma_load_a_fallback : &params.tma_load_a;
+      observed_tma_load_b_ = is_fallback_cluster ? &params.tma_load_b_fallback : &params.tma_load_b;
+    }
+    else {
+      observed_tma_load_a_ = &params.tma_load_a;
+      observed_tma_load_b_ = &params.tma_load_b;
+    }
+  }
+
+  template <class ProblemShape>
+  static constexpr Params
+  to_underlying_arguments(
+    ProblemShape const& problem_shape,
+    Arguments const& args,
+    [[maybe_unused]] void* workspace,
+    cutlass::KernelHardwareInfo const& hw_info = cutlass::KernelHardwareInfo{}) {
+
+    // Optionally append 1s until problem shape is rank-4 (MNKL), in case it is only rank-3 (MNK)
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+    auto [M,N,K,L] = problem_shape_MNKL;
+
+    auto ptr_A = recast_ptr<TmaInternalElementA>(args.ptr_A);
+    auto ptr_B = recast_ptr<TmaInternalElementB>(args.ptr_B);
+
+    Tensor tensor_a = make_tensor(ptr_A, make_layout(make_shape(M,K,L), args.dA));
+    Tensor tensor_b = make_tensor(ptr_B, make_layout(make_shape(N,K,L), args.dB));
+
+    auto cluster_shape = cutlass::detail::select_cluster_shape(ClusterShape{}, hw_info.cluster_shape);
+
+    // Cluster layout for TMA construction
+    auto cluster_layout_vmnk = tiled_divide(make_layout(cluster_shape), make_tile(typename TiledMma::AtomThrID{}));
+    auto cluster_shape_fallback = cutlass::detail::select_cluster_shape(ClusterShape{}, hw_info.cluster_shape_fallback);
+    auto cluster_layout_vmnk_fallback = tiled_divide(make_layout(cluster_shape_fallback), make_tile(typename TiledMma::AtomThrID{}));
+    typename Params::TMA_A tma_load_a = make_tma_atom_A_sm100<TmaInternalElementA>(
+        GmemTiledCopyA{},
+        tensor_a,
+        SmemLayoutA{}(_,_,_,cute::Int<0>{}),
+        TileShape{},
+        TiledMma{},
+        cluster_layout_vmnk);
+
+    typename Params::TMA_B tma_load_b = make_tma_atom_B_sm100<TmaInternalElementB>(
+        GmemTiledCopyB{},
+        tensor_b,
+        SmemLayoutB{}(_,_,_,cute::Int<0>{}),
+        TileShape{},
+        TiledMma{},
+        cluster_layout_vmnk);
+
+    typename Params::TMA_A tma_load_a_fallback = make_tma_atom_A_sm100<TmaInternalElementA>(
+        GmemTiledCopyA{},
+        tensor_a,
+        SmemLayoutA{}(_,_,_,cute::Int<0>{}),
+        TileShape{},
+        TiledMma{},
+        cluster_layout_vmnk_fallback);
+
+    typename Params::TMA_B tma_load_b_fallback = make_tma_atom_B_sm100<TmaInternalElementB>(
+        GmemTiledCopyB{},
+        tensor_b,
+        SmemLayoutB{}(_,_,_,cute::Int<0>{}),
+        TileShape{},
+        TiledMma{},
+        cluster_layout_vmnk_fallback);
+
+    return {
+      tma_load_a,
+      tma_load_b,
+      tma_load_a_fallback,
+      tma_load_b_fallback,
+      hw_info.cluster_shape_fallback,
+      args.runtime_data_type_a,
+      args.runtime_data_type_b
+    };
+  }
+
+  template <class ProblemShape>
+  static bool
+  can_implement(
+      ProblemShape const& problem_shape,
+      [[maybe_unused]] Arguments const& args) {
+
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+    auto [M,N,K,L] = problem_shape_MNKL;
+
+    static constexpr bool IsF8F6F4 = detail::is_sm100_mma_f8f6f4<TiledMma, ElementA, ElementB>();
+    constexpr int tma_alignment_bits_A = cutlass::detail::get_input_alignment_bits<ElementA, IsF8F6F4>();
+    constexpr int tma_alignment_bits_B = cutlass::detail::get_input_alignment_bits<ElementB, IsF8F6F4>();
+    constexpr int min_tma_aligned_elements_A = tma_alignment_bits_A / cute::sizeof_bits<ElementA>::value;
+
+    bool implementable = true;
+    implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_A>(cute::make_shape(M,K,L), StrideA{});
+    constexpr int min_tma_aligned_elements_B = tma_alignment_bits_B / cute::sizeof_bits<ElementB>::value;
+    implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_B>(cute::make_shape(N,K,L), StrideB{});
+
+    if (!implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: Problem Size doesn't meet the minimum alignment requirements for TMA.\n");
+    }
+    return implementable;
+  }
+
+  /// Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
+  CUTLASS_DEVICE void
+  prefetch_tma_descriptors() {
+    cute::prefetch_tma_descriptor(observed_tma_load_a_->get_tma_descriptor());
+    cute::prefetch_tma_descriptor(observed_tma_load_b_->get_tma_descriptor());
+  }
+
+  /// Construct A Single Stage's Accumulator Shape
+  CUTLASS_DEVICE static
+  auto
+  partition_accumulator_shape() {
+    auto acc_shape = partition_shape_C(TiledMma{}, take<0,2>(TileShape{}));  // ((MMA_TILE_M,MMA_TILE_N),MMA_M,MMA_N)
+
+    return acc_shape;
+  }
+
+  template <class TmemStorage>
+  CUTLASS_DEVICE static
+  auto
+  slice_accumulator(TmemStorage tmem_storage, int stage) {
+    return cute::make_tuple(tmem_storage.accumulators(_,_,_,stage));
+  }
+
+  template <class EpilogueTile, bool IsOverlappingAccum = false>
+  CUTLASS_DEVICE static
+  auto
+  init_tmem_tensors(EpilogueTile epi_tile) {
+    TiledMma tiled_mma;
+    auto acc_shape = partition_accumulator_shape();
+    // ((MMA_TILE_M,MMA_TILE_N),MMA_M,MMA_N,ACC_PIPE) where ACC_PIPE=2 so we can double buffer our accumulators for mainloop and epilogue.
+    Tensor accumulators = cutlass::detail::make_sm100_accumulator<AccumulatorPipelineStageCount, IsOverlappingAccum>(
+        tiled_mma, acc_shape, EpilogueTile{});
+    TmemStorage<decltype(accumulators)> tmem_storage;
+    tmem_storage.accumulators = accumulators;
+    return tmem_storage;
+  }
+
+  template <class TmemStorage>
+  CUTLASS_DEVICE static
+  void
+  set_tmem_offsets(TmemStorage& tmem_storage, uint32_t tmem_base_addr) {
+    tmem_storage.accumulators.data() = tmem_base_addr;
+  }
+
+  /// Set up the data needed by this collective for load.
+  /// Return tuple element contain
+  /// gA_mkl - The tiled tma tensor for input A
+  /// gB_nkl - The tiled tma tensor for input B
+  /// tAsA - partitioned smem tensor for A
+  /// tBsB - partitioned smem tensor for B
+  /// mcast_mask_a - tma multicast mask for A
+  /// mcast_mask_b - tma multicast mask for B
+  // FlashRT MK-1 patch: template-ize TensorStorage so kernels can pass a
+  // duck-typed view that shares SMEM_A across multiple CollectiveMma
+  // instances.  Default (no explicit template arg) preserves CUTLASS
+  // behavior.
+  template <class ProblemShape_MNKL, class TensorStorageT = TensorStorage>
+  CUTLASS_DEVICE auto
+  load_init(
+      ProblemShape_MNKL const& problem_shape_MNKL,
+      TensorStorageT& shared_tensors) const {
+    using X = Underscore;
+
+    // Separate out problem shape for convenience
+    auto [M,N,K,L] = problem_shape_MNKL;
+
+    // Represent the full tensors -- get these from TMA
+    Tensor mA_mkl = observed_tma_load_a_->get_tma_tensor(make_shape(M,K,L));
+    Tensor mB_nkl = observed_tma_load_b_->get_tma_tensor(make_shape(N,K,L));
+
+    // Tile the tensors and defer the slice
+    Tensor gA_mkl = local_tile(mA_mkl, TileShape{}, make_coord(_,_,_), Step<_1, X,_1>{});    // (BLK_M, BLK_K, m, k, l)
+    Tensor gB_nkl = local_tile(mB_nkl, TileShape{}, make_coord(_,_,_), Step< X,_1,_1>{});    // (BLK_N, BLK_K, n, k, l)
+
+    // Partition for this CTA
+    ThrMMA cta_mma = TiledMma{}.get_slice(blockIdx.x % size(typename TiledMma::AtomThrID{}));
+
+    Tensor tCgA_mkl = cta_mma.partition_A(gA_mkl);          // (MMA, MMA_M, MMA_K, m, k, l)
+    Tensor tCgB_nkl = cta_mma.partition_B(gB_nkl);          // (MMA, MMA_N, MMA_K, n, k, l)
+
+    Tensor sA = make_tensor(make_smem_ptr(shared_tensors.smem_A.begin()), SmemLayoutA{});  // (MMA,MMA_M,MMA_K,PIPE)
+    Tensor sB = make_tensor(make_smem_ptr(shared_tensors.smem_B.begin()), SmemLayoutB{});  // (MMA,MMA_N,MMA_K,PIPE)
+
+    // Define the CTA-in-cluster Layout and Coord
+    Layout cta_layout_mnk  = make_layout(cluster_shape_);
+    Layout cta_layout_vmnk = tiled_divide(cta_layout_mnk, make_tile(typename TiledMma::AtomThrID{}));
+    auto cta_coord_vmnk  = cta_layout_vmnk.get_flat_coord(block_rank_in_cluster_);
+
+    // Project the cta_layout for tma_a along the n-modes
+    auto [tAgA_mkl, tAsA] = tma_partition(*observed_tma_load_a_,
+                                      get<2>(cta_coord_vmnk), make_layout(size<2>(cta_layout_vmnk)),
+                                      group_modes<0,3>(sA), group_modes<0,3>(tCgA_mkl));
+
+    // Project the cta_layout for tma_b along the m-modes
+    auto [tBgB_nkl, tBsB] = tma_partition(*observed_tma_load_b_,
+                                      get<1>(cta_coord_vmnk), make_layout(size<1>(cta_layout_vmnk)),
+                                      group_modes<0,3>(sB), group_modes<0,3>(tCgB_nkl));
+
+    // TMA Multicast Masks
+    uint16_t mcast_mask_a = create_tma_multicast_mask<2>(cta_layout_vmnk, cta_coord_vmnk);
+    uint16_t mcast_mask_b = create_tma_multicast_mask<1>(cta_layout_vmnk, cta_coord_vmnk);
+
+    return LoadParams{
+      shape<3>(gA_mkl),                       // for scheduler
+      tAgA_mkl, tBgB_nkl, tAsA, tBsB,        // for input tensor values
+      mcast_mask_a, mcast_mask_b};           // multicast masks
+  }
+
+  /// Set up the data needed by this collective for mma compute.
+  template <class TmemStorage, class TensorStorageT = TensorStorage>
+  CUTLASS_DEVICE auto
+  mma_init(
+    [[maybe_unused]] TmemStorage tmem_storage,
+    TensorStorageT& shared_tensors) const {
+
+    // Allocate "fragments/descriptors" for A and B matrices
+    Tensor sA = make_tensor(make_smem_ptr(shared_tensors.smem_A.begin()), SmemLayoutA{});          // (BLK_M,BLK_K,PIPE)
+    Tensor sB = make_tensor(make_smem_ptr(shared_tensors.smem_B.begin()), SmemLayoutB{});          // (BLK_N,BLK_K,PIPE)
+
+    // Allocate "fragments/descriptors" for A and B matrices
+    Tensor tCrA = TiledMma::make_fragment_A(sA);                                           // (MMA,MMA_M,MMA_K,PIPE)
+    Tensor tCrB = TiledMma::make_fragment_B(sB);                                           // (MMA,MMA_N,MMA_K,PIPE)
+
+    CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<3>(sA));                                     // PIPE
+    CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<3>(sB));                                     // PIPE
+
+    TiledMma tiled_mma;
+
+    if constexpr (IsRuntimeDataType) {
+      // Update instruction descriptor according to runtime argument.
+      // Applying bitmask (0b111) to help compiler deduce that the conversion and assignment are safe.
+      tiled_mma.idesc_.a_format_ = uint8_t(runtime_data_type_a_) & 0b111;
+      tiled_mma.idesc_.b_format_ = uint8_t(runtime_data_type_b_) & 0b111;
+    }
+
+    return MmaParams{
+      tiled_mma,
+      tCrA, tCrB};
+  }
+
+  /// Perform a collective-scoped matrix multiply-accumulate
+  /// Producer Perspective
+  // FlashRT MK-1 Stage E: SkipA template flag — when true, the load issues
+  // only the B TMA copy (A is assumed pre-loaded in shared SMEM by a peer
+  // mainloop).  Caller MUST configure MainloopPipeline transaction_bytes
+  // to TmaTransactionBytesBOnly so the barrier completes correctly.
+  template <
+    bool SkipA = false,
+    class LoadParams,
+    class TileCoordMNKL,
+    class KTileIterator
+  >
+  CUTLASS_DEVICE auto
+  load(
+    MainloopPipeline mainloop_pipeline,
+    MainloopPipelineState mainloop_pipe_producer_state,
+    LoadParams const& load_inputs,
+    TileCoordMNKL const& cta_coord_mnkl,
+    KTileIterator k_tile_iter, int k_tile_count) {
+
+    auto [unused_k_tiles,
+          tAgA_mkl, tBgB_nkl, tAsA, tBsB,
+          mcast_mask_a, mcast_mask_b] = load_inputs;
+
+    // slice out the work coord from partitioned tensors
+    Tensor tAgA = tAgA_mkl(_, get<0>(cta_coord_mnkl) / size(typename TiledMma::AtomThrID{}), _, get<3>(cta_coord_mnkl));
+    Tensor tBgB = tBgB_nkl(_, get<1>(cta_coord_mnkl), _, get<3>(cta_coord_mnkl));
+
+    auto barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+
+    // Issue the Mainloop loads
+    CUTLASS_PRAGMA_NO_UNROLL
+    while (k_tile_count > 0) {
+      // LOCK mainloop_pipe_producer_state for _writing_
+      mainloop_pipeline.producer_acquire(mainloop_pipe_producer_state, barrier_token);
+
+      using BarrierType = typename MainloopPipeline::ProducerBarrierType;
+      BarrierType* tma_barrier = mainloop_pipeline.producer_get_barrier(mainloop_pipe_producer_state);
+
+      int write_stage = mainloop_pipe_producer_state.index();
+      ++mainloop_pipe_producer_state;
+      barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+
+      if (cute::elect_one_sync()) {
+        if constexpr (!SkipA) {
+          copy(observed_tma_load_a_->with(*tma_barrier, mcast_mask_a), tAgA(_,*k_tile_iter), tAsA(_,write_stage));
+        }
+        copy(observed_tma_load_b_->with(*tma_barrier, mcast_mask_b), tBgB(_,*k_tile_iter), tBsB(_,write_stage));
+      }
+
+      --k_tile_count;
+      ++k_tile_iter;
+    }
+
+    return cute::make_tuple(mainloop_pipe_producer_state, k_tile_iter);
+  }
+
+  /// Perform a Producer Epilogue to prevent early exit of ctas in a Cluster
+  CUTLASS_DEVICE void
+  load_tail(MainloopPipeline mainloop_pipeline, MainloopPipelineState mainloop_pipe_producer_state) {
+    // Issue the epilogue waits
+    // This helps avoid early exit of ctas in Cluster
+    // Waits for all stages to either be released (all
+    // Consumer UNLOCKs), or if the stage was never used
+    // then would just be acquired since the phase was
+    // still inverted from make_producer_start_state
+    mainloop_pipeline.producer_tail(mainloop_pipe_producer_state);
+  }
+
+  /// Perform a collective-scoped matrix multiply-accumulate
+  /// Consumer Perspective
+  template <
+    class AccumulatorPipeline,
+    class FrgEngine, class FrgLayout,
+    class MmaParams,
+    class CtaTileCoord
+  >
+  CUTLASS_DEVICE auto
+  mma(cute::tuple<MainloopPipeline,
+                  AccumulatorPipeline> pipelines,
+      cute::tuple<MainloopPipelineState,
+                  typename AccumulatorPipeline::PipelineState> pipeline_states,
+      cute::tuple<cute::Tensor<FrgEngine, FrgLayout>> const& accumulators_pair,
+      MmaParams const& mma_inputs,
+      CtaTileCoord cta_tile_coord,
+      int k_tile_count
+  ) {
+    static_assert(is_tmem<FrgEngine>::value, "Accumulator must be tmem resident.");
+    static_assert(rank(FrgLayout{}) == 3, "Accumulator must be MMA-partitioned: (MMA, MMA_M, MMA_N)");
+
+    auto accumulators = get<0>(accumulators_pair);
+    auto [tiled_mma, tCrA, tCrB] = mma_inputs;
+
+    auto [mainloop_pipeline, accumulator_pipeline] = pipelines;
+    auto [mainloop_pipe_consumer_state, accumulator_pipe_producer_state] = pipeline_states;
+
+    uint32_t skip_wait = k_tile_count <= 0;
+    auto barrier_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+
+    //
+    // PIPELINED MAIN LOOP
+    //
+    tiled_mma.accumulate_ = UMMA::ScaleOut::Zero;
+    // Wait for tmem accumulator buffer to become empty with a flipped phase
+    accumulator_pipeline.producer_acquire(accumulator_pipe_producer_state);
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    while (k_tile_count > 0) {
+      // WAIT on mainloop_pipe_consumer_state until its data are available
+      // (phase bit flips from mainloop_pipe_consumer_state.phase() value)
+      mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, barrier_token);
+
+      // Compute on k_tile
+      int read_stage = mainloop_pipe_consumer_state.index();
+      // Save current mainlop pipeline read state
+      auto curr_mainloop_pipe_consumer_state = mainloop_pipe_consumer_state;
+
+      // Advance mainloop_pipe
+      ++mainloop_pipe_consumer_state;
+      --k_tile_count;
+      skip_wait = k_tile_count <= 0;
+      // Peek at next iteration
+      barrier_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+
+      // Unroll the K mode manually so we can set scale C to 1
+      CUTLASS_PRAGMA_UNROLL
+      for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+        // (V,M) x (V,N) => (V,M,N)
+        cute::gemm(tiled_mma,
+                   tCrA(_,_,k_block,read_stage),
+                   tCrB(_,_,k_block,read_stage),
+                   accumulators);
+        tiled_mma.accumulate_ = UMMA::ScaleOut::One;
+      }
+      mainloop_pipeline.consumer_release(curr_mainloop_pipe_consumer_state);
+    }
+
+    return mainloop_pipe_consumer_state;
+  }
+
+protected:
+
+  typename Params::TMA_A const* observed_tma_load_a_{nullptr};
+  typename Params::TMA_B const* observed_tma_load_b_{nullptr};
+  RuntimeDataTypeA runtime_data_type_a_{};
+  RuntimeDataTypeB runtime_data_type_b_{};
+
+  ClusterShape cluster_shape_;
+  uint32_t block_rank_in_cluster_;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass::gemm::collective
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/gemm/mega/cutlass/pipeline/sm100_pipeline.hpp
+++ b/csrc/gemm/mega/cutlass/pipeline/sm100_pipeline.hpp
@@ -1,0 +1,1334 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+//
+
+//
+
+#include "cute/numeric/integral_constant.hpp"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cutlass/arch/barrier.h"
+#include "cutlass/pipeline/sm90_pipeline.hpp"
+#include "cutlass/pipeline/sm90_pipeline.hpp"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass {
+
+using namespace cute;
+
+enum class McastDirection {
+  kRow,
+  kCol,
+  kRowCol
+};
+namespace detail {
+
+template<McastDirection McastDir, class ClusterShape, class AtomThrShape_MNK>
+CUTLASS_DEVICE
+uint16_t calculate_multicast_mask(ClusterShape cluster_shape, AtomThrShape_MNK atom_thr_shape, dim3 block_id_in_cluster) {
+  auto is_participant = [&](auto x, auto y) {
+    if constexpr (McastDir == McastDirection::kRowCol) {
+      return (x/size<0>(atom_thr_shape) == block_id_in_cluster.x/size<0>(atom_thr_shape) || // is same MMA cluster col
+              y/size<1>(atom_thr_shape) == block_id_in_cluster.y/size<1>(atom_thr_shape));  // is same MMA cluster row
+    }
+    else if constexpr (McastDir == McastDirection::kRow) {
+      return (x/size<0>(atom_thr_shape) == block_id_in_cluster.x/size<0>(atom_thr_shape));  // is same MMA cluster row
+    }
+    else { // (McastDir == McastDirection::kCol)
+      return (y/size<1>(atom_thr_shape) == block_id_in_cluster.y/size<1>(atom_thr_shape));  // is same MMA cluster col
+    }
+  };
+  
+  uint16_t block_id_mask = 0;
+  auto cluster_layout = make_layout(cluster_shape);
+  // When MMA_2x1SM instructions are used, the definition of "same row" changes.
+  // With MMA_2x1SM, we need to send the notification for MMA completion to all
+  // 2x1 threadblocks of the cluster. Below is a 4x4 example where R are the threadblocks
+  // that receives the release for A/B buffers that threadblock (0,0) uses.
+  // Row&Col   Row     Col
+  // RRRR      RRRR    Cxxx
+  // RRRR      RRRR    Cxxx
+  // Rxxx      xxxx    Cxxx
+  // Rxxx      xxxx    Cxxx
+  CUTLASS_PRAGMA_UNROLL
+  for (int x = 0; x<size<0>(cluster_shape); x++) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int y = 0; y<size<1>(cluster_shape); y++) {
+      if (is_participant(x,y)) {
+        block_id_mask |= (1 << cluster_layout(x,y, Int<0>{}));
+      }
+    }
+  }
+  return block_id_mask;
+}
+
+template<class ClusterShape, class AtomThrShape_MNK>
+CUTLASS_DEVICE
+uint16_t calculate_umma_peer_mask(ClusterShape cluster_shape, AtomThrShape_MNK atom_thr_shape, dim3 block_id_in_cluster) {
+  uint16_t tmem_sync_mask = 0;
+  auto cluster_layout =  make_layout(cluster_shape);
+  int block_id_in_cluster_x = (block_id_in_cluster.x / size<0>(AtomThrShape_MNK{})) * size<0>(AtomThrShape_MNK{}) ;
+  int block_id_in_cluster_y = (block_id_in_cluster.y / size<1>(AtomThrShape_MNK{})) * size<1>(AtomThrShape_MNK{}) ;
+  CUTLASS_PRAGMA_UNROLL
+  for (int x = 0; x < size<0>(AtomThrShape_MNK{}); x++) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int y = 0; y < size<1>(AtomThrShape_MNK{}); y++) {
+      tmem_sync_mask |= (1 << cluster_layout(block_id_in_cluster_x + x, block_id_in_cluster_y + y, Int<0>{}));
+    }
+  }
+
+  return tmem_sync_mask;
+}
+} // namespace detail
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// TMA (producer) Async Pipeline class for Blackwell UMMA
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////
+template <int Stages_, class AtomThrShape_MNK_ = Shape<_1,_1,_1>>
+class PipelineUmmaAsync {
+public:
+  static constexpr uint32_t Stages = Stages_;
+  using AtomThrShape_MNK = AtomThrShape_MNK_;
+private:
+  using Impl = PipelineAsync<Stages>;
+public:
+  using FullBarrier  = typename Impl::FullBarrier;
+  using EmptyBarrier = typename Impl::EmptyBarrier;
+  using ProducerBarrierType = typename Impl::ProducerBarrierType;
+  using ConsumerBarrierType = typename Impl::ConsumerBarrierType;
+  using PipelineState = typename Impl::PipelineState;
+  using SharedStorage = typename Impl::SharedStorage;
+  using ThreadCategory = typename Impl::ThreadCategory;
+  using Params = typename Impl::Params;
+
+  // Helper function to initialize barriers
+  static
+  CUTLASS_DEVICE
+  void
+  init_barriers(SharedStorage& storage, Params params) {
+    int warp_idx = canonical_warp_idx_sync();
+    if (warp_idx == params.initializing_warp) {
+      // Barrier FULL and EMPTY init
+      CUTLASS_ASSERT(params.producer_arv_count > 0 && "Producer arrival count must be non-zero");
+      CUTLASS_ASSERT(params.consumer_arv_count > 0 && "Consumer arrival count must be non-zero");
+      cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(storage.full_barrier_), decltype(storage.empty_barrier_), Stages>(
+          storage.full_barrier_, storage.empty_barrier_, params.producer_arv_count, params.consumer_arv_count);
+    }
+    cutlass::arch::fence_barrier_init();
+  }
+
+  template <class ClusterShape>
+  CUTLASS_DEVICE
+  void init_masks(ClusterShape cluster_shape, dim3 block_id_in_cluster = cute::block_id_in_cluster()) {
+    // Calculate producer mask
+    if (params_.role == ThreadCategory::Producer) {
+      // The leader threadblock executing the MMA_2x1SM instruction will signal its peer
+      // threadblock when it is done with MMA operations. tmem_sync_mask encodes the
+      // position of peer SMs in the cluster
+      tmem_sync_mask_ = detail::calculate_umma_peer_mask(cluster_shape, AtomThrShape_MNK{}, block_id_in_cluster);
+    }
+  }
+
+  // Constructor by default initializes barriers and calculates masks. 
+  // These operations can be explicity deferred by specifying InitBarriers and InitMasks. 
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  template<class ClusterShape, class InitBarriers = cute::true_type, class InitMasks = cute::true_type>
+  CUTLASS_DEVICE
+  PipelineUmmaAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
+      : impl_(storage, params, InitBarriers{})
+      , params_(params)
+      , full_barrier_ptr_(&storage.full_barrier_[0])
+      , empty_barrier_ptr_(&storage.empty_barrier_[0]) {
+
+    static_assert(cute::is_same_v<InitMasks, cute::true_type> || cute::is_same_v<InitMasks, cute::false_type>);
+    if constexpr (cute::is_same_v<InitMasks, cute::true_type>) {
+      init_masks(cluster_shape);
+    }
+  }
+
+
+  ////////////////////
+  // Producer APIs
+  ////////////////////
+  // Four member functions are always used in pairs:
+  //
+  // * producer_try_acquire and producer_acquire, and
+  // * consumer_try_wait and consumer_wait.
+  //
+  // The two functions with "try" in their names are called "try" functions,
+  // and the other two are conceptually "finalize" functions.
+  // The "try" function in each pair starts the process of waiting on the barrier to flip.
+  // It opportunistically waits for an implementation-dependent timeout.
+  // Whether or not the barrier has flipped yet, the try function will return a token.
+  // If the token indicates that the barrier has not flipped,
+  // then the token must be passed into the corresponding "finalize" function.
+  // The finalize function will then block until the barrier has flipped.
+  // If the token indicates that the barrier _has_ flipped,
+  // then it is still correct to pass it into the finalize function.
+  // The finalize function will return immediately in that case.
+
+  CUTLASS_DEVICE
+  ProducerToken producer_try_acquire(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.producer_try_acquire(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    impl_.producer_acquire(state, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void producer_commit(PipelineState state) {
+    producer_commit(state.index());
+  }
+
+  // Prevents early exit of producer blocks in Cluster.
+  // This should be called once before kernel exits.
+  CUTLASS_DEVICE
+  void producer_tail(PipelineState state) {
+    impl_.producer_tail(state);
+  }
+
+  CUTLASS_DEVICE
+  ProducerBarrierType* producer_get_barrier(PipelineState state) {
+    return impl_.producer_get_barrier(state.index());
+  }
+
+  ////////////////////
+  // Consumer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ConsumerToken consumer_try_wait(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.consumer_try_wait(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state, ConsumerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    impl_.consumer_wait(state, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(PipelineState state) {
+    detail::pipeline_check_is_consumer(params_.role);
+    if constexpr (is_2sm_mma) {
+      consumer_release_2x1SM(state.index());
+    } else {
+      impl_.consumer_release(state);
+    }
+  }
+
+private:
+  Impl impl_;
+  Params params_;
+  FullBarrier* full_barrier_ptr_ = nullptr;
+  EmptyBarrier* empty_barrier_ptr_ = nullptr;
+  uint16_t tmem_sync_mask_ = 0;
+  static constexpr bool is_2sm_mma = size(AtomThrShape_MNK{}) > 1;
+
+  CUTLASS_DEVICE
+  void producer_commit(uint32_t stage) {
+    detail::pipeline_check_is_producer(params_.role);
+    uint64_t* smem_ptr = reinterpret_cast<uint64_t*>(&full_barrier_ptr_[stage]);
+    if constexpr (is_2sm_mma) {
+      cutlass::arch::umma_arrive_multicast_2x1SM(smem_ptr, tmem_sync_mask_);
+    }
+    else {
+      cutlass::arch::umma_arrive(smem_ptr);
+    }
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release_2x1SM(uint32_t stage) {
+    detail::pipeline_check_is_consumer(params_.role);
+    uint64_t* smem_ptr = reinterpret_cast<uint64_t*>(&empty_barrier_ptr_[stage]);
+    cutlass::arch::umma_arrive_2x1SM_sm0(smem_ptr);
+    static_assert(is_2sm_mma, "ERROR : AtomThrShape_MNK does not correspond to a 2SM MMMA");
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// TMA (producer) Transform (consumer) Async Pipeline
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////
+template <
+  int Stages_,
+  class AtomThrShape_MNK_ = Shape<_1,_1,_1>
+>
+class PipelineTmaTransformAsync {
+public:
+  static constexpr uint32_t Stages = Stages_;
+  using AtomThrShape_MNK = AtomThrShape_MNK_;
+private:
+  using Impl = PipelineTmaAsync<Stages>;
+public:
+  using FullBarrier  = typename Impl::FullBarrier;
+  using EmptyBarrier = typename Impl::EmptyBarrier;
+  using ProducerBarrierType = typename Impl::ProducerBarrierType;
+  using ConsumerBarrierType = typename Impl::ConsumerBarrierType;
+  using PipelineState = typename Impl::PipelineState;
+  using SharedStorage = typename Impl::SharedStorage;
+  using ThreadCategory = typename Impl::ThreadCategory;
+  using Params = typename Impl::Params;
+
+  // Constructor
+  template <class ClusterShape, class InitBarriers = cute::true_type, class InitMasks = cute::true_type>
+  CUTLASS_DEVICE
+  PipelineTmaTransformAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
+      : impl_(storage, params, cluster_shape, cute::false_type{}, cute::false_type{})
+      , params_(params)
+      , full_barrier_ptr_(&storage.full_barrier_[0])
+      , empty_barrier_ptr_(&storage.empty_barrier_[0]) {
+
+    static_assert(cute::is_same_v<InitBarriers, cute::true_type> || cute::is_same_v<InitBarriers, cute::false_type>);
+    if constexpr (cute::is_same_v<InitBarriers, cute::true_type>) {
+      init_barriers(storage, params_, cluster_shape);
+    }
+
+    static_assert(cute::is_same_v<InitMasks, cute::true_type> || cute::is_same_v<InitMasks, cute::false_type>);
+    if constexpr (cute::is_same_v<InitMasks, cute::true_type>) {
+      init_masks(cluster_shape);
+    }
+  }
+
+  template<class ClusterShape, class InitBarriers = cute::true_type, class InitMasks = cute::true_type>
+  CUTLASS_DEVICE
+  PipelineTmaTransformAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, McastDirection mcast_direction, InitBarriers = {}, InitMasks = {})
+      : impl_(storage, params, cluster_shape, cute::false_type{}, cute::false_type{})
+      , params_(params)
+      , empty_barrier_ptr_(&storage.empty_barrier_[0])
+      , full_barrier_ptr_(&storage.full_barrier_[0]) {
+    static_assert(cute::is_same_v<InitBarriers, cute::true_type> || cute::is_same_v<InitBarriers, cute::false_type>);
+    if constexpr (cute::is_same_v<InitBarriers, cute::true_type>) {
+      init_barriers(storage, params_, cluster_shape, mcast_direction);
+    }
+
+    static_assert(cute::is_same_v<InitMasks, cute::true_type> || cute::is_same_v<InitMasks, cute::false_type>);
+    if constexpr (cute::is_same_v<InitMasks, cute::true_type>) {
+      init_masks(cluster_shape, mcast_direction);
+    }
+  }
+
+  // Helper function to initialize barriers
+  template <class ClusterShape>
+  static
+  CUTLASS_DEVICE
+  void
+  init_barriers(SharedStorage& storage, Params params, ClusterShape cluster_shape) {
+    int warp_idx = canonical_warp_idx_sync();
+    if (warp_idx == params.initializing_warp) {
+      // Barrier FULL and EMPTY init
+      constexpr int producer_arv_cnt = 1;
+      auto atom_thr_shape = AtomThrShape_MNK{};
+      static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+      static_assert(IsDynamicCluster or ((cute::size<0>(cluster_shape) % cute::size<0>(atom_thr_shape) == 0) &&
+                    (cute::size<1>(cluster_shape) % cute::size<1>(atom_thr_shape) == 0)));
+      uint32_t const num_consumer_per_cluster = cute::ceil_div(params.num_consumers, static_cast<uint32_t>(NumThreadsPerWarpGroup));
+      uint32_t const multicast_consumer_arrival_count = ((cute::size<0>(cluster_shape) / cute::size<0>(atom_thr_shape)) +
+                                     (cute::size<1>(cluster_shape) / cute::size<1>(atom_thr_shape)) - 1) * num_consumer_per_cluster;
+      CUTLASS_ASSERT(multicast_consumer_arrival_count > 0 && "Multicast consumer arrival count must be non-zero");
+      CUTLASS_ASSERT(producer_arv_cnt > 0 && "Producer arrival count must be non-zero");
+      cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(storage.full_barrier_), decltype(storage.empty_barrier_), Stages>(
+          storage.full_barrier_, storage.empty_barrier_, producer_arv_cnt, multicast_consumer_arrival_count);
+    }
+    cutlass::arch::fence_barrier_init();
+  }
+
+  template <class ClusterShape>
+  static
+  CUTLASS_DEVICE
+  void
+  init_barriers(SharedStorage& storage, Params params, ClusterShape cluster_shape, McastDirection mcast_direction) {
+    auto atom_thr_shape = AtomThrShape_MNK{};
+
+    int warp_idx = canonical_warp_idx_sync();
+    if (warp_idx == params.initializing_warp) {
+      // Barrier FULL and EMPTY init
+      constexpr int producer_arv_cnt = 1;
+      uint32_t const num_consumer_per_cluster = params.num_consumers / NumThreadsPerWarpGroup;
+      uint32_t const multicast_consumer_arrival_count = (mcast_direction == McastDirection::kRow) ?
+        (cute::size<1>(cluster_shape) / cute::size<1>(atom_thr_shape)) * num_consumer_per_cluster : // Mcast with row ctas
+        (cute::size<0>(cluster_shape) / cute::size<0>(atom_thr_shape)) * num_consumer_per_cluster;  // Mcast with col ctas
+
+      cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(storage.full_barrier_), decltype(storage.empty_barrier_), Stages>(
+          storage.full_barrier_, storage.empty_barrier_, producer_arv_cnt, multicast_consumer_arrival_count);
+
+    }
+    cutlass::arch::fence_barrier_init();
+  }
+
+  template <class ClusterShape>
+  CUTLASS_DEVICE
+  void init_masks(ClusterShape cluster_shape, dim3 block_id_in_cluster = cute::block_id_in_cluster(), McastDirection mcast_dir = McastDirection::kRowCol) {
+    // Calculate consumer mask
+    if (params_.role == ThreadCategory::Consumer) {
+      // Logic to optimally schedule Empty Arrives
+      // Goal : To divide SYNCS Empty Arrival duty equally amongst the Warp-Group (128 threads)
+      int warp_idx = canonical_warp_idx_sync();
+      int thread_idx = threadIdx.x;
+      auto cluster_size = cute::size(cluster_shape);
+
+      // STEP 1 : Use Cute Layout function to generate an optimal dst block-id (0-15)
+      if (params_.num_consumers % NumThreadsPerWarpGroup == 0) {
+        auto [is_signaling_thread, dst_blockid] = detail::spread_arrivals_to_warpgroup(thread_idx % NumThreadsPerWarpGroup, warp_idx);
+        is_signaling_thread_ = is_signaling_thread;
+        dst_blockid_ = dst_blockid;
+      }
+      else if (params_.num_consumers == 32) {
+        auto [is_signaling_thread, dst_blockid] = detail::spread_arrivals_to_warp(thread_idx % 32);
+        is_signaling_thread_ = is_signaling_thread;
+        dst_blockid_ = dst_blockid;
+      }
+      else {
+        is_signaling_thread_ = 0;
+        #ifndef NDEBUG
+          asm volatile ("brkpt;\n" ::);
+        #endif
+      }
+
+      // STEP 2: Find if this dst block-id needs an arrival for this problem
+      is_signaling_thread_ &= dst_blockid_ < cluster_size;
+      if(mcast_dir == McastDirection::kRowCol){
+        is_signaling_thread_ &= is_same_row_or_col(dst_blockid_, block_id_in_cluster, cluster_shape);
+      }
+      if(mcast_dir == McastDirection::kRow){
+        is_signaling_thread_ &= is_same_row(dst_blockid_, block_id_in_cluster, cluster_shape);
+      }
+    }
+  }
+
+  template <class ClusterShape>
+  CUTLASS_DEVICE
+  bool is_same_row(int dst_block_id, dim3 block_id, ClusterShape cluster_shape) {
+    return (((dst_block_id % cute::size<0>(cluster_shape)) == block_id.x) 
+              // If we are in the same cluster column and using 2CTA MMA, only odd or only even CTAs sync with each other
+                 && ((dst_block_id % cute::size<0>(cluster_shape)) % cute::size<0>(AtomThrShape_MNK{}) ==
+                      block_id.x % cute::size<0>(AtomThrShape_MNK{}))
+            );
+  }
+
+  template <class ClusterShape>
+  CUTLASS_DEVICE
+  bool is_same_row_or_col(int dst_block_id, dim3 block_id, ClusterShape cluster_shape) {
+    return (((dst_block_id % cute::size<0>(cluster_shape)) == block_id.x) ||
+            (
+              ((dst_block_id / cute::size<0>(cluster_shape)) == block_id.y)
+              // If we are in the same cluster column and using 2CTA MMA, only odd or only even CTAs sync with each other
+                 && ((dst_block_id % cute::size<0>(cluster_shape)) % cute::size<0>(AtomThrShape_MNK{}) ==
+                      block_id.x % cute::size<0>(AtomThrShape_MNK{}))
+            ));
+  }
+
+  ////////////////////
+  // Producer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ProducerToken producer_try_acquire(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.producer_try_acquire(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    impl_.producer_acquire(state, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void producer_commit(PipelineState state, uint32_t bytes) {
+    impl_.producer_commit(state, bytes);
+  }
+
+  // Prevents early exit of producer blocks in Cluster.
+  // This should be called once before kernel exits.
+  CUTLASS_DEVICE
+  void producer_tail(PipelineState state) {
+    impl_.producer_tail(state);
+  }
+
+  CUTLASS_DEVICE
+  ProducerBarrierType* producer_get_barrier(PipelineState state) {
+    return impl_.producer_get_barrier(state);
+  }
+
+  ////////////////////
+  // Consumer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ConsumerToken consumer_try_wait(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.consumer_try_wait(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  ConsumerToken consumer_test_wait(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.consumer_test_wait(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state) {
+    impl_.consumer_wait(state);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state, ConsumerToken barrier_token) {
+    impl_.consumer_wait(state, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(PipelineState state, uint32_t skip = false) {
+    detail::pipeline_check_is_consumer(params_.role);
+    empty_barrier_ptr_[state.index()].arrive(dst_blockid_, is_signaling_thread_ & (!skip));
+  }
+
+private:
+  Impl impl_;
+  uint32_t dst_blockid_ = 0;
+  uint32_t is_signaling_thread_ = 0;
+  FullBarrier *full_barrier_ptr_ = nullptr;
+  EmptyBarrier *empty_barrier_ptr_ = nullptr;
+  Params params_;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// TMA (consumer) Async Pipeline classes for Blackwell UMMA
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Producer-consumer pipeline implementation
+// for UMMA producer. In this case, UMMA barrier arrives are used
+// by producer_commit. Use case, accumulator generation as
+// the result of MMA instructions.
+template <
+  int Stages_,
+  class ClusterShape = Shape<int,int,_1>,
+  class AtomThrShape_MNK_ = Shape<_1,_1,_1>
+>
+class PipelineTmaUmmaAsync {
+public:
+  static constexpr uint32_t Stages = Stages_;
+  using AtomThrShape_MNK = AtomThrShape_MNK_;
+private:
+  using Impl = PipelineTmaAsync<Stages>;
+public:
+  using FullBarrier  = typename Impl::FullBarrier;
+  using EmptyBarrier = typename Impl::EmptyBarrier;
+  using ProducerBarrierType = typename Impl::ProducerBarrierType;
+  using ConsumerBarrierType = typename Impl::ConsumerBarrierType;
+  using PipelineState = typename Impl::PipelineState;
+  using SharedStorage = typename Impl::SharedStorage;
+  using ThreadCategory = typename Impl::ThreadCategory;
+  using Params = typename Impl::Params;
+
+  using McastDirection = McastDirection;
+
+  // Helper function to initialize barriers
+  static
+  CUTLASS_DEVICE
+  void
+  init_barriers(SharedStorage& storage, Params params, ClusterShape cluster_shape) {
+    int warp_idx = canonical_warp_idx_sync();
+    if (warp_idx == params.initializing_warp) {
+      // Barrier FULL and EMPTY init
+      constexpr int producer_arv_cnt = 1;
+      auto atom_thr_shape = AtomThrShape_MNK{};
+      uint32_t const multicast_consumer_arrival_count = (cute::size<0>(cluster_shape) / cute::size<0>(atom_thr_shape)) +
+                                     (cute::size<1>(cluster_shape) / cute::size<1>(atom_thr_shape)) - 1;
+      // FlashRT MK-1 Stage E2 patch: if params.num_consumers > 1, multiply
+      // arrival count so the slot only releases after ALL N consumer groups
+      // arrive (used for shared-pipeline across two CollectiveMma instances).
+      uint32_t const effective_consumer_arrival_count =
+          (params.num_consumers > 1) ? (multicast_consumer_arrival_count * params.num_consumers)
+                                     : multicast_consumer_arrival_count;
+      CUTLASS_ASSERT(effective_consumer_arrival_count > 0 && "Consumer arrival count must be non-zero");
+      CUTLASS_ASSERT(producer_arv_cnt > 0 && "Producer arrival count must be non-zero");
+      cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(storage.full_barrier_), decltype(storage.empty_barrier_), Stages>(
+          storage.full_barrier_, storage.empty_barrier_, producer_arv_cnt, effective_consumer_arrival_count);
+    }
+    cutlass::arch::fence_barrier_init();
+  }
+
+  static
+  CUTLASS_DEVICE
+  void
+  init_barriers(SharedStorage& storage, Params params, ClusterShape cluster_shape, McastDirection mcast_direction) {
+    auto atom_thr_shape = AtomThrShape_MNK{};
+
+    int warp_idx = canonical_warp_idx_sync();
+    if (warp_idx == params.initializing_warp) {
+      // Barrier FULL and EMPTY init
+      constexpr int producer_arv_cnt = 1;
+      uint32_t const multicast_consumer_arrival_count = (mcast_direction == McastDirection::kRow) ?
+        cute::size<1>(cluster_shape) / cute::size<1>(atom_thr_shape) : // Mcast with row ctas
+        cute::size<0>(cluster_shape) / cute::size<0>(atom_thr_shape);  // Mcast with col ctas
+
+      CUTLASS_ASSERT(multicast_consumer_arrival_count > 0 && "Multicast consumer arrival count must be non-zero");
+      CUTLASS_ASSERT(producer_arv_cnt > 0 && "Producer arrival count must be non-zero");
+      cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(storage.full_barrier_), decltype(storage.empty_barrier_), Stages>(
+          storage.full_barrier_, storage.empty_barrier_, producer_arv_cnt, multicast_consumer_arrival_count);
+    }
+    cutlass::arch::fence_barrier_init();
+  }
+
+  CUTLASS_DEVICE
+  void init_masks(ClusterShape cluster_shape, dim3 block_id_in_cluster = cute::block_id_in_cluster()) {
+    // Calculate consumer mask
+    if (params_.role == ThreadCategory::Consumer) {
+      auto cluster_layout = make_layout(cluster_shape);
+      block_id_mask_ = detail::calculate_multicast_mask<McastDirection::kRowCol>(cluster_shape, AtomThrShape_MNK{}, block_id_in_cluster);
+    }
+  }
+
+  CUTLASS_DEVICE
+  void init_masks(ClusterShape cluster_shape, McastDirection mcast_direction) {
+    // Calculate consumer mask
+    dim3 block_id_in_cluster = cute::block_id_in_cluster();
+    auto cluster_layout = make_layout(cluster_shape);
+    if (mcast_direction == McastDirection::kRow) {
+      block_id_mask_ = detail::calculate_multicast_mask<McastDirection::kRow>(cluster_shape, AtomThrShape_MNK{}, block_id_in_cluster);
+    }
+    else {
+      block_id_mask_ = detail::calculate_multicast_mask<McastDirection::kCol>(cluster_shape, AtomThrShape_MNK{}, block_id_in_cluster);
+    }
+  }
+
+  // Constructor by default initializes barriers and calculates masks. 
+  // These operations can be explicity deferred by specifying InitBarriers and InitMasks. 
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  template<typename InitBarriers = cute::true_type, typename InitMasks = cute::true_type>
+  CUTLASS_DEVICE
+  PipelineTmaUmmaAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
+      : impl_(storage, params, cluster_shape, cute::false_type{}, cute::false_type{})
+      , params_(params)
+      , empty_barrier_ptr_(&storage.empty_barrier_[0])
+      , full_barrier_ptr_(&storage.full_barrier_[0]) {
+    static_assert(cute::is_same_v<InitBarriers, cute::true_type> || cute::is_same_v<InitBarriers, cute::false_type>);
+    if constexpr (cute::is_same_v<InitBarriers, cute::true_type>) {
+      init_barriers(storage, params_, cluster_shape);
+    }
+
+    static_assert(cute::is_same_v<InitMasks, cute::true_type> || cute::is_same_v<InitMasks, cute::false_type>);
+    if constexpr (cute::is_same_v<InitMasks, cute::true_type>) {
+      init_masks(cluster_shape);
+    }
+  }
+
+  template<typename InitBarriers = cute::true_type, typename InitMasks = cute::true_type>
+  CUTLASS_DEVICE
+  PipelineTmaUmmaAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, McastDirection mcast_direction, InitBarriers = {}, InitMasks = {})
+      : impl_(storage, params, cluster_shape, cute::false_type{}, cute::false_type{})
+      , params_(params)
+      , empty_barrier_ptr_(&storage.empty_barrier_[0])
+      , full_barrier_ptr_(&storage.full_barrier_[0]) {
+    static_assert(cute::is_same_v<InitBarriers, cute::true_type> || cute::is_same_v<InitBarriers, cute::false_type>);
+    if constexpr (cute::is_same_v<InitBarriers, cute::true_type>) {
+      init_barriers(storage, params_, cluster_shape, mcast_direction);
+    }
+
+    static_assert(cute::is_same_v<InitMasks, cute::true_type> || cute::is_same_v<InitMasks, cute::false_type>);
+    if constexpr (cute::is_same_v<InitMasks, cute::true_type>) {
+      init_masks(cluster_shape, mcast_direction);
+    }
+  }
+
+
+  ////////////////////
+  // Producer APIs
+  ////////////////////
+  // Four member functions are always used in pairs:
+  //
+  // * producer_try_acquire and producer_acquire, and
+  // * consumer_try_wait and consumer_wait.
+  //
+  // The two functions with "try" in their names are called "try" functions,
+  // and the other two are conceptually "finalize" functions.
+  // The "try" function in each pair starts the process of waiting on the barrier to flip.
+  // It opportunistically waits for an implementation-dependent timeout.
+  // Whether or not the barrier has flipped yet, the try function will return a token.
+  // If the token indicates that the barrier has not flipped,
+  // then the token must be passed into the corresponding "finalize" function.
+  // The finalize function will then block until the barrier has flipped.
+  // If the token indicates that the barrier _has_ flipped,
+  // then it is still correct to pass it into the finalize function.
+  // The finalize function will return immediately in that case.
+  CUTLASS_DEVICE
+  ProducerToken producer_try_acquire(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.producer_try_acquire(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    impl_.producer_acquire(state, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void producer_expect_transaction(PipelineState state, uint32_t transaction_bytes) {
+    impl_.producer_expect_transaction(state, transaction_bytes);
+  }
+
+  // NOP for TMA based mainloop
+  CUTLASS_DEVICE
+  void producer_commit(PipelineState state, uint32_t bytes) {
+    impl_.producer_commit(state, bytes);
+  }
+
+  // Prevents early exit of producer blocks in Cluster.
+  // This should be called once before kernel exits.
+  CUTLASS_DEVICE
+  void producer_tail(PipelineState state) {
+    impl_.producer_tail(state);
+  }
+
+  CUTLASS_DEVICE
+  ProducerBarrierType* producer_get_barrier(PipelineState state) {
+    return impl_.producer_get_barrier(state);
+  }
+
+  ////////////////////
+  // Consumer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ConsumerToken consumer_try_wait(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.consumer_try_wait(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state, ConsumerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    impl_.consumer_wait(state, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(PipelineState state) {
+    consumer_release(state.index(), false);
+  }
+
+private:
+  Impl impl_;
+  Params params_;
+  EmptyBarrier *empty_barrier_ptr_;
+  FullBarrier *full_barrier_ptr_;
+  uint16_t block_id_mask_ = 0;
+  static constexpr bool is_2sm_mma = size(AtomThrShape_MNK{}) > 1;
+
+  // Consumer signalling Producer of completion
+  // Ensures all blocks in the Same Row and Column get notifed.
+  CUTLASS_DEVICE
+  void consumer_release(uint32_t stage, uint32_t skip) {
+    detail::pipeline_check_is_consumer(params_.role);
+    uint64_t* smem_ptr = reinterpret_cast<uint64_t*>(&empty_barrier_ptr_[stage]);
+    if constexpr (is_2sm_mma) { // Mma cluster shape is 2x1
+      if (!skip) {
+        cutlass::arch::umma_arrive_multicast_2x1SM(smem_ptr, block_id_mask_);
+      }
+    }
+    else {
+      if (!skip) {
+        if constexpr (cute::is_static_v<ClusterShape> and size(ClusterShape{}) == 1) {
+          cutlass::arch::umma_arrive(smem_ptr);
+        }
+        else {
+          cutlass::arch::umma_arrive_multicast(smem_ptr, block_id_mask_);
+        }
+      }
+    }
+  }
+};
+
+// Producer-consumer pipeline implementation
+// for UMMA consumer. In this case, UMMA barrier arrives are
+// used by consumer_release.
+template <int Stages_, class AtomThrShape_MNK_ = Shape<_1,_1,_1>>
+class PipelineUmmaConsumerAsync {
+public:
+  static constexpr uint32_t Stages = Stages_;
+  using AtomThrShape_MNK = AtomThrShape_MNK_;
+private:
+  using Impl = PipelineAsync<Stages>;
+public:
+  using FullBarrier  = typename Impl::FullBarrier;
+  using EmptyBarrier = typename Impl::EmptyBarrier;
+  using ProducerBarrierType = typename Impl::ProducerBarrierType;
+  using ConsumerBarrierType = typename Impl::ConsumerBarrierType;
+  using PipelineState = typename Impl::PipelineState;
+  using SharedStorage = typename Impl::SharedStorage;
+  using ThreadCategory = typename Impl::ThreadCategory;
+  using Params = typename Impl::Params;
+
+  template <class ClusterShape>
+  CUTLASS_DEVICE
+  void init_masks(ClusterShape cluster_shape, dim3 block_id_in_cluster = cute::block_id_in_cluster()) {
+    // Calculate consumer mask
+    if (params_.role == ThreadCategory::Consumer) {
+      // The leader threadblock executing the MMA_2x1SM instruction will signal its peer
+      // threadblock when it is done with MMA operations. tmem_sync_mask encodes the
+      // position of peer SMs in the cluster
+      tmem_sync_mask_ = detail::calculate_umma_peer_mask(cluster_shape, AtomThrShape_MNK{}, block_id_in_cluster);
+    }
+  }
+
+  // Constructor by default initializes barriers and calculates masks. 
+  // These operations can be explicity deferred by specifying InitBarriers and InitMasks. 
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  template<class ClusterShape, class InitBarriers = cute::true_type, class InitMasks = cute::true_type>
+  CUTLASS_DEVICE
+  PipelineUmmaConsumerAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
+      : impl_(storage, params, InitBarriers{})
+      , params_(params)
+      , full_barrier_ptr_(&storage.full_barrier_[0])
+      , empty_barrier_ptr_(&storage.empty_barrier_[0]) {
+
+    static_assert(cute::is_same_v<InitMasks, cute::true_type> || cute::is_same_v<InitMasks, cute::false_type>);
+    if constexpr (cute::is_same_v<InitMasks, cute::true_type>) {
+      init_masks(cluster_shape);
+    }
+  }
+
+  ////////////////////
+  // Producer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ProducerToken producer_try_acquire(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.producer_try_acquire(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    impl_.producer_acquire(state, barrier_token);
+  }
+
+  template<class UserDefinedArriveOp>
+  CUTLASS_DEVICE
+  void producer_commit(PipelineState state, UserDefinedArriveOp&& user_defined_arrive_op) {
+    cute::forward<UserDefinedArriveOp>(user_defined_arrive_op)(producer_get_barrier(state));
+    producer_commit(state);
+  }
+
+  CUTLASS_DEVICE
+  void producer_commit(PipelineState state) {
+    if constexpr (is_2sm_mma) {
+      producer_commit_2x1SM(state.index());
+    } else {
+      impl_.producer_commit(state);
+    }
+  }
+
+  // Prevents early exit of producer blocks in Cluster.
+  // This should be called once before kernel exits.
+  CUTLASS_DEVICE
+  void producer_tail(PipelineState state) {
+    impl_.producer_tail(state);
+  }
+
+  CUTLASS_DEVICE
+  ProducerBarrierType* producer_get_barrier(PipelineState state) {
+    return impl_.producer_get_barrier(state.index());
+  }
+
+  ////////////////////
+  // Consumer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ConsumerToken consumer_try_wait(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.consumer_try_wait(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state, ConsumerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    if (barrier_token == BarrierStatus::WaitAgain) {
+      impl_.consumer_wait(state);
+    }
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(PipelineState state) {
+    consumer_release(state.index());
+  }
+
+private:
+  Impl impl_;
+  Params params_;
+  FullBarrier* full_barrier_ptr_ = nullptr;
+  EmptyBarrier* empty_barrier_ptr_ = nullptr;
+  uint16_t tmem_sync_mask_ = 0;
+  static constexpr bool is_2sm_mma = size(AtomThrShape_MNK{}) > 1;
+
+  CUTLASS_DEVICE
+  void producer_commit_2x1SM(uint32_t stage) {
+    detail::pipeline_check_is_producer(params_.role);
+    uint64_t* smem_ptr = reinterpret_cast<uint64_t*>(&full_barrier_ptr_[stage]);
+    cutlass::arch::umma_arrive_2x1SM_sm0(smem_ptr);
+    static_assert(is_2sm_mma, "ERROR : AtomThrShape_MNK does not correspond to a 2SM MMMA");
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(uint32_t stage, uint32_t skip = false) {
+    detail::pipeline_check_is_consumer(params_.role);
+    uint64_t* smem_ptr = reinterpret_cast<uint64_t*>(&empty_barrier_ptr_[stage]);
+    if constexpr (is_2sm_mma) {
+      cutlass::arch::umma_arrive_multicast_2x1SM(smem_ptr, tmem_sync_mask_);
+    }
+    else {
+      cutlass::arch::umma_arrive(smem_ptr);
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// CLC Async Pipeline class for Blackwell UMMA
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace PipelineDetail {
+
+template<int Stages_>
+using PipelineCLCFetchAsyncPipelineState = cutlass::PipelineState<Stages_>;
+
+template<int Stages_>
+struct PipelineCLCFetchAsyncSharedStorage {
+  using FullBarrier = cutlass::arch::ClusterTransactionBarrier;
+  using EmptyBarrier = cutlass::arch::ClusterBarrier;
+
+  FullBarrier full_barrier_[static_cast<size_t>(Stages_)];
+  EmptyBarrier empty_barrier_[static_cast<size_t>(Stages_)];
+};
+
+} // namespace PipelineDetail
+
+template <int Stages_, class ClusterShape = Shape<int,int,_1>>
+class PipelineCLCFetchAsync {
+
+public:
+  static constexpr uint32_t Stages = Stages_;
+  using PipelineState = PipelineDetail::PipelineCLCFetchAsyncPipelineState<Stages>;
+  using SharedStorage = PipelineDetail::PipelineCLCFetchAsyncSharedStorage<Stages>;
+  using FullBarrier = typename SharedStorage::FullBarrier;
+  using EmptyBarrier = typename SharedStorage::EmptyBarrier;
+
+  enum class ThreadCategory {
+    NonParticipant,
+    Producer,
+    Consumer,
+    ProducerConsumer
+  };
+
+  struct Params {
+    uint32_t transaction_bytes = 0;
+    ThreadCategory role = ThreadCategory::NonParticipant;
+    uint32_t is_leader = 0;
+    uint32_t num_consumers = 0;
+    uint32_t producer_blockid = 0;
+    uint32_t producer_arv_count = 0;
+    uint32_t consumer_arv_count = 0;
+    int initializing_warp = 0;
+  };
+
+  // Constructor
+  CUTLASS_DEVICE
+  PipelineCLCFetchAsync(SharedStorage& storage, Params const& params) :
+  params_(params),
+  full_barrier_ptr_(&storage.full_barrier_[0]),
+  empty_barrier_ptr_(&storage.empty_barrier_[0]) {
+    int warp_idx = canonical_warp_idx_sync();
+    if (warp_idx == params.initializing_warp) {
+      // Barrier FULL and EMPTY init
+      CUTLASS_ASSERT(params.producer_arv_count > 0 && "Producer arrival count must be non-zero");
+      CUTLASS_ASSERT(params.consumer_arv_count > 0 && "Consumer arrival count must be non-zero");
+      cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(full_barrier_ptr_), decltype(empty_barrier_ptr_), Stages>(
+          full_barrier_ptr_, empty_barrier_ptr_, params_.producer_arv_count, params_.consumer_arv_count);
+    }
+    cutlass::arch::fence_barrier_init();
+
+    cluster_size_ = []() { auto cs = cute::cluster_shape(); return cs.x * cs.y; }();
+  }
+
+  // Constructor
+  CUTLASS_DEVICE
+  PipelineCLCFetchAsync(SharedStorage& storage, Params const& params, ClusterShape cluster_shape)
+  : params_(params)
+  , full_barrier_ptr_(&storage.full_barrier_[0])
+  , empty_barrier_ptr_(&storage.empty_barrier_[0]) {
+    int warp_idx = canonical_warp_idx_sync();
+    if (warp_idx == params.initializing_warp) {
+      // Barrier FULL and EMPTY init
+      CUTLASS_ASSERT(params.producer_arv_count > 0 && "Producer arrival count must be non-zero");
+      CUTLASS_ASSERT(params.consumer_arv_count > 0 && "Consumer arrival count must be non-zero");
+      cutlass::arch::detail::initialize_barrier_array_pair_aligned<decltype(full_barrier_ptr_), decltype(empty_barrier_ptr_), Stages>(
+          full_barrier_ptr_, empty_barrier_ptr_, params_.producer_arv_count, params_.consumer_arv_count);
+    }
+    cutlass::arch::fence_barrier_init();
+
+    cluster_size_ = cute::size<0>(cluster_shape)
+                  * cute::size<1>(cluster_shape)
+                  * cute::size<2>(cluster_shape);
+  }
+
+  ////////////////////
+  // Producer APIs
+  ////////////////////
+  // Four member functions are always used in pairs:
+  //
+  // * producer_try_acquire and producer_acquire, and
+  // * consumer_try_wait and consumer_wait.
+  //
+  // The two functions with "try" in their names are called "try" functions,
+  // and the other two are conceptually "finalize" functions.
+  // The "try" function in each pair starts the process of waiting on the barrier to flip.
+  // It opportunistically waits for an implementation-dependent timeout.
+  // Whether or not the barrier has flipped yet, the try function will return a token.
+  // If the token indicates that the barrier has not flipped,
+  // then the token must be passed into the corresponding "finalize" function.
+  // The finalize function will then block until the barrier has flipped.
+  // If the token indicates that the barrier _has_ flipped,
+  // then it is still correct to pass it into the finalize function.
+  // The finalize function will return immediately in that case.
+  CUTLASS_DEVICE
+  ProducerToken producer_try_acquire(PipelineState state, uint32_t skip_wait = false) {
+    return producer_try_acquire(state.index(), state.phase(), skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    producer_acquire(state.index(), state.phase(), barrier_token);
+  }
+
+  // Manual completion of transaction count
+  CUTLASS_DEVICE
+  void producer_commit(PipelineState state) {
+    producer_commit(state.index(), state.phase());
+  }
+
+  // Prevents early exit of producer blocks in Cluster.
+  // Does NOT reset transaction bytes.
+  // This should be called once before kernel exits.
+  CUTLASS_DEVICE
+  void producer_tail(PipelineState state) {
+    detail::pipeline_check_is_producer(params_.role);
+    for (int count = 0; count < Stages; ++count) {
+      bool done = empty_barrier_ptr_[state.index()].test_wait(state.phase());
+      if (!done) {
+        empty_barrier_ptr_[state.index()].wait(state.phase());
+      }
+      ++state;
+    }
+  }
+
+  ////////////////////
+  // Consumer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ConsumerToken consumer_try_wait(PipelineState state, uint32_t skip_wait = false) {
+    return consumer_try_wait(state.index(), state.phase(), skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state, ConsumerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    consumer_wait(state.index(), state.phase(), barrier_token);
+  }
+
+  // Consumer signalling Producer of completion
+  // Notifies the producer block in the Cluster
+  CUTLASS_DEVICE
+  void consumer_release(PipelineState state) {
+    consumer_release(state.index());
+  }
+
+  CUTLASS_HOST_DEVICE
+  uint32_t producer_get_barrier(PipelineState state) {
+    return cute::cast_smem_ptr_to_uint(reinterpret_cast<void*>(&full_barrier_ptr_[state.index()]));
+  }
+
+private:
+  FullBarrier *full_barrier_ptr_ = nullptr;
+  EmptyBarrier *empty_barrier_ptr_ = nullptr;
+  Params params_;
+  int lane_idx_ = canonical_lane_idx();
+  int cluster_size_;
+
+  CUTLASS_DEVICE
+  ProducerToken producer_try_acquire(uint32_t stage, uint32_t phase, uint32_t skip_wait) {
+    detail::pipeline_check_is_producer(params_.role);
+    if (skip_wait) {
+      return {BarrierStatus::WaitDone};
+    }
+    bool barrier_stat = empty_barrier_ptr_[stage].try_wait(phase);
+    return {static_cast<BarrierStatus>(barrier_stat)};
+  }
+
+  CUTLASS_DEVICE
+  void producer_acquire(uint32_t stage, uint32_t phase, ProducerToken barrier_token) {
+    detail::pipeline_check_is_producer(params_.role);
+    // 1. Wait for empty barrier to be ready
+    // 2. Set the transaction bytes set to occur on the Full barrier for all blocks
+    if (barrier_token == BarrierStatus::WaitAgain) {
+      empty_barrier_ptr_[stage].wait(phase);
+    }
+
+    full_barrier_ptr_[stage].arrive_and_expect_tx(params_.transaction_bytes, lane_idx_, uint32_t(lane_idx_ < cluster_size_));
+  }
+
+  CUTLASS_DEVICE
+  void producer_commit(uint32_t stage, uint32_t phase) {
+    int cluster_size_ = []() { auto cs = cute::cluster_shape(); return cs.x * cs.y; }();
+    full_barrier_ptr_[stage].complete_transaction(lane_idx_, params_.transaction_bytes,  uint32_t(lane_idx_ < cluster_size_));
+  }
+
+  CUTLASS_DEVICE
+  ConsumerToken consumer_try_wait(uint32_t stage, uint32_t phase, uint32_t skip_wait) {
+    detail::pipeline_check_is_consumer(params_.role);
+    if (skip_wait) {
+      return {BarrierStatus::WaitDone};
+    }
+    bool barrier_stat = full_barrier_ptr_[stage].try_wait(phase);
+    return {static_cast<BarrierStatus>(barrier_stat)};
+  }
+
+  // Wait for producer to commit transactions
+  CUTLASS_DEVICE
+  void consumer_wait(uint32_t stage, uint32_t phase, ConsumerToken barrier_token) {
+    detail::pipeline_check_is_consumer(params_.role);
+    if (barrier_token == BarrierStatus::WaitAgain) {
+      full_barrier_ptr_[stage].wait(phase);
+    }
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(uint32_t stage) {
+    detail::pipeline_check_is_consumer(params_.role);
+    empty_barrier_ptr_[stage].arrive(params_.producer_blockid);
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// Empty Pipeline class
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+class PipelineEmpty {
+public:
+  static constexpr uint32_t Stages = 0;
+  using PipelineState = cutlass::PipelineState<0>;
+  struct Params {};
+  struct SharedStorage {};
+
+  // Constructor
+  CUTLASS_DEVICE
+  PipelineEmpty(SharedStorage& storage, Params const& params) {}
+
+  // Constructor
+  CUTLASS_DEVICE
+  PipelineEmpty(SharedStorage&& storage, Params const& params) {}
+
+  // Constructor with throwaway ClusterShape
+  template <class ClusterShape = Shape<int,int,_1>>
+  CUTLASS_DEVICE
+  PipelineEmpty(SharedStorage&& storage, Params const& params, ClusterShape) {}
+
+ CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+  }
+
+  CUTLASS_DEVICE
+  void producer_commit(PipelineState state) {
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state, ConsumerToken barrier_token = {BarrierStatus::WaitAgain}) {
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(PipelineState state) {
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// TMA (producer - consumer) Async Pipeline classes for Blackwell Sparse UMMA
+// This is designed for the pattern that kernel has two different staged tensors. (AB and metadata)
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Producer-consumer pipeline implementation
+// for UMMA producer. In this case, UMMA barrier arrives are used
+// by producer_commit. Use case, accumulator generation as
+// the result of MMA instructions.
+template <
+  int Stages_,
+  class ClusterShape = Shape<int,int,_1>,
+  class AtomThrShape_MNK_ = Shape<_1,_1,_1>
+>
+class PipelineTmaSparseUmmaAsync {
+public:
+  static constexpr uint32_t Stages = Stages_;
+  using AtomThrShape_MNK = AtomThrShape_MNK_;
+private:
+  using Impl = PipelineTmaUmmaAsync<Stages, ClusterShape, AtomThrShape_MNK>;
+public:
+  using FullBarrier  = typename Impl::FullBarrier;
+  using EmptyBarrier = typename Impl::EmptyBarrier;
+  using ProducerBarrierType = typename Impl::ProducerBarrierType;
+  using ConsumerBarrierType = typename Impl::ConsumerBarrierType;
+  using PipelineState = typename Impl::PipelineState;
+  using SharedStorage = typename Impl::SharedStorage;
+  using ThreadCategory = typename Impl::ThreadCategory;
+  using Params = typename Impl::Params;
+
+  struct ParamsMetadata {
+    uint32_t transaction_bytes = 0;
+    uint32_t metadata_transaction_bytes = 0;
+  };
+
+  static
+  CUTLASS_DEVICE
+  void
+  init_barriers(SharedStorage& storage, Params params, ClusterShape cluster_shape) {
+    Impl::init_barriers(storage, params, cluster_shape);
+  }
+
+  CUTLASS_DEVICE
+  void init_masks(ClusterShape cluster_shape, dim3 block_id_in_cluster = cute::block_id_in_cluster()) {
+    impl_.init_masks(cluster_shape, block_id_in_cluster);
+  }
+
+  // Constructor by default initializes barriers and calculates masks. 
+  // These operations can be deferred by specifying InitBarriers and InitMasks. 
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  template<typename InitBarriers = cute::true_type, typename InitMasks = cute::true_type>
+  CUTLASS_DEVICE
+  PipelineTmaSparseUmmaAsync(SharedStorage& storage, Params params, ParamsMetadata params_metadata, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
+      : impl_(storage, params, cluster_shape, cute::false_type{}, cute::false_type{})
+      , params_(params)
+      , params_metadata_(params_metadata)
+      , empty_barrier_ptr_(&storage.empty_barrier_[0])
+      , full_barrier_ptr_(&storage.full_barrier_[0]) {
+    static_assert(cute::is_same_v<InitBarriers, cute::true_type> || cute::is_same_v<InitBarriers, cute::false_type>);
+    if constexpr (cute::is_same_v<InitBarriers, cute::true_type>) {
+      init_barriers(storage, params_, cluster_shape);
+    }
+
+    static_assert(cute::is_same_v<InitMasks, cute::true_type> || cute::is_same_v<InitMasks, cute::false_type>);
+    if constexpr (cute::is_same_v<InitMasks, cute::true_type>) {
+      init_masks(cluster_shape);
+    }
+  }
+
+  ////////////////////
+  // Producer APIs
+  ////////////////////
+  // Four member functions are always used in pairs:
+  //
+  // * producer_try_acquire and producer_acquire, and
+  // * consumer_try_wait and consumer_wait.
+  //
+  // The two functions with "try" in their names are called "try" functions,
+  // and the other two are conceptually "finalize" functions.
+  // The "try" function in each pair starts the process of waiting on the barrier to flip.
+  // It opportunistically waits for an implementation-dependent timeout.
+  // Whether or not the barrier has flipped yet, the try function will return a token.
+  // If the token indicates that the barrier has not flipped,
+  // then the token must be passed into the corresponding "finalize" function.
+  // The finalize function will then block until the barrier has flipped.
+  // If the token indicates that the barrier _has_ flipped,
+  // then it is still correct to pass it into the finalize function.
+  // The finalize function will return immediately in that case.
+  CUTLASS_DEVICE
+  ProducerToken producer_try_acquire(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.producer_try_acquire(state, skip_wait);
+  }
+
+  // Customized for metadata load
+  CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, bool load_e, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    producer_acquire(state.index(), state.phase(), load_e, barrier_token);
+  }
+
+  // Customized for metadata load
+  CUTLASS_DEVICE
+  void producer_acquire(PipelineState state, ProducerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    producer_acquire(state, true, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void producer_tail(PipelineState state) {
+    return impl_.producer_tail(state);
+  }
+
+  CUTLASS_DEVICE
+  ProducerBarrierType* producer_get_barrier(PipelineState state) {
+    return impl_.producer_get_barrier(state);
+  }
+
+  ////////////////////
+  // Consumer APIs
+  ////////////////////
+  CUTLASS_DEVICE
+  ConsumerToken consumer_try_wait(PipelineState state, uint32_t skip_wait = false) {
+    return impl_.consumer_try_wait(state, skip_wait);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_wait(PipelineState state, ConsumerToken barrier_token = {BarrierStatus::WaitAgain}) {
+    return impl_.consumer_wait(state, barrier_token);
+  }
+
+  CUTLASS_DEVICE
+  void consumer_release(PipelineState state) {
+    return impl_.consumer_release(state);
+  }
+
+private:
+  Impl impl_;
+  Params params_;
+  ParamsMetadata params_metadata_;
+  EmptyBarrier *empty_barrier_ptr_{nullptr};
+  FullBarrier *full_barrier_ptr_{nullptr};
+
+  CUTLASS_DEVICE
+  void producer_acquire(uint32_t stage, uint32_t phase, bool load_e, ProducerToken barrier_token) {
+    detail::pipeline_check_is_producer(params_.role);
+    if (barrier_token == BarrierStatus::WaitAgain) {
+      empty_barrier_ptr_[stage].wait(phase);
+    }
+    uint32_t bytes_now = load_e ? params_metadata_.transaction_bytes + params_metadata_.metadata_transaction_bytes : params_metadata_.transaction_bytes;
+
+    if (params_.is_leader) {
+      full_barrier_ptr_[stage].arrive_and_expect_tx(bytes_now);
+    }
+  }
+
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass

--- a/csrc/gemm/mega/cutlass/pipeline/sm100_pipeline.hpp
+++ b/csrc/gemm/mega/cutlass/pipeline/sm100_pipeline.hpp
@@ -67,7 +67,7 @@ uint16_t calculate_multicast_mask(ClusterShape cluster_shape, AtomThrShape_MNK a
       return (y/size<1>(atom_thr_shape) == block_id_in_cluster.y/size<1>(atom_thr_shape));  // is same MMA cluster col
     }
   };
-  
+
   uint16_t block_id_mask = 0;
   auto cluster_layout = make_layout(cluster_shape);
   // When MMA_2x1SM instructions are used, the definition of "same row" changes.
@@ -160,9 +160,9 @@ public:
     }
   }
 
-  // Constructor by default initializes barriers and calculates masks. 
-  // These operations can be explicity deferred by specifying InitBarriers and InitMasks. 
-  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  // Constructor by default initializes barriers and calculates masks.
+  // These operations can be explicity deferred by specifying InitBarriers and InitMasks.
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called.
   template<class ClusterShape, class InitBarriers = cute::true_type, class InitMasks = cute::true_type>
   CUTLASS_DEVICE
   PipelineUmmaAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
@@ -431,7 +431,7 @@ public:
   template <class ClusterShape>
   CUTLASS_DEVICE
   bool is_same_row(int dst_block_id, dim3 block_id, ClusterShape cluster_shape) {
-    return (((dst_block_id % cute::size<0>(cluster_shape)) == block_id.x) 
+    return (((dst_block_id % cute::size<0>(cluster_shape)) == block_id.x)
               // If we are in the same cluster column and using 2CTA MMA, only odd or only even CTAs sync with each other
                  && ((dst_block_id % cute::size<0>(cluster_shape)) % cute::size<0>(AtomThrShape_MNK{}) ==
                       block_id.x % cute::size<0>(AtomThrShape_MNK{}))
@@ -622,9 +622,9 @@ public:
     }
   }
 
-  // Constructor by default initializes barriers and calculates masks. 
-  // These operations can be explicity deferred by specifying InitBarriers and InitMasks. 
-  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  // Constructor by default initializes barriers and calculates masks.
+  // These operations can be explicity deferred by specifying InitBarriers and InitMasks.
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called.
   template<typename InitBarriers = cute::true_type, typename InitMasks = cute::true_type>
   CUTLASS_DEVICE
   PipelineTmaUmmaAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
@@ -796,9 +796,9 @@ public:
     }
   }
 
-  // Constructor by default initializes barriers and calculates masks. 
-  // These operations can be explicity deferred by specifying InitBarriers and InitMasks. 
-  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  // Constructor by default initializes barriers and calculates masks.
+  // These operations can be explicity deferred by specifying InitBarriers and InitMasks.
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called.
   template<class ClusterShape, class InitBarriers = cute::true_type, class InitMasks = cute::true_type>
   CUTLASS_DEVICE
   PipelineUmmaConsumerAsync(SharedStorage& storage, Params params, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})
@@ -1221,9 +1221,9 @@ public:
     impl_.init_masks(cluster_shape, block_id_in_cluster);
   }
 
-  // Constructor by default initializes barriers and calculates masks. 
-  // These operations can be deferred by specifying InitBarriers and InitMasks. 
-  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called. 
+  // Constructor by default initializes barriers and calculates masks.
+  // These operations can be deferred by specifying InitBarriers and InitMasks.
+  // If deferred, user code needs to guarantee init_masks and/or init_barriers is/are called.
   template<typename InitBarriers = cute::true_type, typename InitMasks = cute::true_type>
   CUTLASS_DEVICE
   PipelineTmaSparseUmmaAsync(SharedStorage& storage, Params params, ParamsMetadata params_metadata, ClusterShape cluster_shape, InitBarriers = {}, InitMasks = {})

--- a/csrc/gemm/mega/cutlass/pipeline/sm100_pipeline.hpp
+++ b/csrc/gemm/mega/cutlass/pipeline/sm100_pipeline.hpp
@@ -564,7 +564,7 @@ public:
       auto atom_thr_shape = AtomThrShape_MNK{};
       uint32_t const multicast_consumer_arrival_count = (cute::size<0>(cluster_shape) / cute::size<0>(atom_thr_shape)) +
                                      (cute::size<1>(cluster_shape) / cute::size<1>(atom_thr_shape)) - 1;
-      // FlashRT MK-1 Stage E2 patch: if params.num_consumers > 1, multiply
+      // FlashRT patch: if params.num_consumers > 1, multiply
       // arrival count so the slot only releases after ALL N consumer groups
       // arrive (used for shared-pipeline across two CollectiveMma instances).
       uint32_t const effective_consumer_arrival_count =

--- a/csrc/gemm/mega/encoder_mlp_sm100.cu
+++ b/csrc/gemm/mega/encoder_mlp_sm100.cu
@@ -2,14 +2,11 @@
 // FlashRT — Path C megakernel: encoder MLP fused (G7+GeGLU+G8)
 // on a single SM100 kernel without materializing the hidden tensor.
 //
-// Status: SCAFFOLD ONLY.  This first commit lands the extern C
-// signature, the build wiring, and a *fallback* implementation that
-// calls the existing 3-step path (sq_gelu + sq + mul_fp16 + 2sm21).
-// The fallback exists so that integration tests and bindings can be
-// exercised end-to-end while the real kernel is still being written.
-//
-// Replacing the fallback is the main goal of subsequent sessions.
-// See megakernel_dev/notes/PATH_C_DESIGN.md for the architectural plan.
+// Status: WIP scaffold, not wired into the runtime. The current body is
+// a fallback that calls the existing 3-step path (sq_gelu + sq +
+// mul_fp16 + 2sm21); the single-kernel SMEM/tmem-staged version is not
+// implemented yet. Built only behind -DFLASHRT_BUILD_SM100_ENCODER_MLP=ON
+// so production flash_rt_kernels neither compiles nor exports it.
 //
 // Why Path C is the next step:
 // - Tile-sweep + epilogue-activation fusion already pushed FP16 3v
@@ -104,8 +101,7 @@ extern "C" int encoder_mlp_fused_fp16(
 }
 
 // ================================================================
-// Implementation roadmap (must follow this approach — see
-// megakernel_dev/notes/PATH_C_DESIGN.md for full rationale)
+// Implementation roadmap
 // ================================================================
 //
 // CORRECT approach: reuse production CUTLASS CollectiveMma by calling

--- a/csrc/gemm/mega/encoder_mlp_sm100.cu
+++ b/csrc/gemm/mega/encoder_mlp_sm100.cu
@@ -1,0 +1,164 @@
+// ================================================================
+// FlashRT — Path C megakernel: encoder MLP fused (G7+GeGLU+G8)
+// on a single SM100 kernel without materializing the hidden tensor.
+//
+// Status: SCAFFOLD ONLY.  This first commit lands the extern C
+// signature, the build wiring, and a *fallback* implementation that
+// calls the existing 3-step path (sq_gelu + sq + mul_fp16 + 2sm21).
+// The fallback exists so that integration tests and bindings can be
+// exercised end-to-end while the real kernel is still being written.
+//
+// Replacing the fallback is the main goal of subsequent sessions.
+// See megakernel_dev/notes/PATH_C_DESIGN.md for the architectural plan.
+//
+// Why Path C is the next step:
+// - Tile-sweep + epilogue-activation fusion already pushed FP16 3v
+//   from 98.93 ms (Phase 1.A) to 91 ms in the Thor SM110 hot regime
+//   (stable; FP8 2v = 44 ms anchors the regime).
+// - Empirically tested and REJECTED in hot regime (all regress):
+//     LinCombDeEltAct mul-aux (k64 +0.3ms, sq +9ms)
+//     LinearCombination beta!=0 residual-fused epilogue (+11ms)
+//   Root cause: any external GMEM tensor read inside the SM100
+//   epilogue (Aux or C) adds enough TMA descriptor pressure to keep
+//   Thor in the slower power state.
+// - The only remaining fusion path is keeping intermediates entirely
+//   in SMEM/tmem, which requires a hand-composed multi-stage kernel
+//   (Path C).
+//
+// ================================================================
+// Reference math (what the megakernel must compute):
+//     gate_buf[m, h] = GELU_tanh(sum_k X[m, k] * W_gate[h, k])
+//     up_buf[m, h]   =          sum_k X[m, k] * W_up  [h, k]
+//     hid[m, h]      = gate_buf[m, h] * up_buf[m, h]
+//     out[m, n]      = sum_h hid[m, h] * W_down[n, h]
+//   where M=Se, K=D, H=ffn_hidden, N=D.
+// ================================================================
+// Resource budget for the eventual real kernel (Thor SM100):
+//     SMEM per CTA <= 228 KB.  Planned slices:
+//       X stage:       2 * TILE_M * K_CHUNK * 2 B
+//       W_gate stage:  2 * H_CHUNK * K_CHUNK * 2 B
+//       W_up stage:    2 * H_CHUNK * K_CHUNK * 2 B
+//       W_down stage:  2 * TILE_N_OUT * H_CHUNK * 2 B
+//       hid_smem:      TILE_M * H_CHUNK * 2 B   (geglu intermediate)
+//       out_smem:      TILE_M * TILE_N_OUT * 2 B (epilogue staging)
+//     Target: TILE_M=64, TILE_N_OUT=64, K_CHUNK=64, H_CHUNK=128
+// ================================================================
+
+#include "../gemm_types_sm100_fp16.h"
+#include "cutlass/util/device_memory.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdio>
+
+// Declared in csrc/kernels/activation.cuh; forward-declared here so the
+// header chain doesn't pull in unrelated dependencies.
+void mul_fp16(const __half* a, const __half* b, __half* out, int n,
+              cudaStream_t stream);
+
+// Fallback runner.  Calls the three existing CUTLASS GEMMs + the
+// mul_fp16 element-wise kernel that the production spec uses today.
+// The signature matches what the real megakernel will eventually
+// expose, so callers wired to encoder_mlp_sm100 can transparently
+// upgrade.
+extern "C" int cutlass_fp16_k64_gelu(void* A, void* B, void* D, int M, int N, int K,
+                                      float alpha, float beta, cudaStream_t stream);
+extern "C" int cutlass_fp16_sq_gelu(void* A, void* B, void* D, int M, int N, int K,
+                                     float alpha, float beta, cudaStream_t stream);
+extern "C" int cutlass_fp16_sq(void* A, void* B, void* D, int M, int N, int K,
+                                float alpha, float beta, cudaStream_t stream);
+extern "C" int cutlass_fp16_2sm21(void* A, void* B, void* D, int M, int N, int K,
+                                   float alpha, float beta, cudaStream_t stream);
+
+// Encoder MLP fused: out[M, N_out] = G8(GeGLU(G7_gate(X, W_gate), G7_up(X, W_up)), W_down).
+//
+//   X        : [M,    K]       row-major, FP16
+//   W_gate   : [H,    K]       row-major (N-major view = ColumnMajor on K), FP16
+//   W_up     : [H,    K]       row-major,                                    FP16
+//   W_down   : [N_out, H]      row-major,                                    FP16
+//   gate_buf : [M, H]   scratch, FP16  (used by fallback only)
+//   up_buf   : [M, H]   scratch, FP16  (used by fallback only)
+//   hid_buf  : [M, H]   scratch, FP16  (used by fallback only)
+//   out      : [M, N_out]      row-major, FP16
+//
+// Sizes are taken as runtime ints to keep the signature stable across
+// FFN dimensions.  Eventually the real kernel will template on shape.
+extern "C" int encoder_mlp_fused_fp16(
+    void* X, void* W_gate, void* W_up, void* W_down,
+    void* gate_buf, void* up_buf, void* hid_buf, void* out,
+    int M, int N_out, int K, int H,
+    cudaStream_t stream)
+{
+    // TODO(path-c): replace with the single SMEM-staged kernel.
+    // Reference fallback below preserves correctness.
+    int rc;
+    rc = cutlass_fp16_sq_gelu(X, W_gate, gate_buf, M, H, K, 1.0f, 0.0f, stream);
+    if (rc != 0) return rc;
+    rc = cutlass_fp16_sq(X, W_up, up_buf, M, H, K, 1.0f, 0.0f, stream);
+    if (rc != 0) return rc;
+    mul_fp16(reinterpret_cast<const __half*>(gate_buf),
+             reinterpret_cast<const __half*>(up_buf),
+             reinterpret_cast<__half*>(hid_buf),
+             M * H, stream);
+    rc = cutlass_fp16_2sm21(hid_buf, W_down, out, M, N_out, H, 1.0f, 0.0f, stream);
+    return rc;
+}
+
+// ================================================================
+// Implementation roadmap (must follow this approach — see
+// megakernel_dev/notes/PATH_C_DESIGN.md for full rationale)
+// ================================================================
+//
+// CORRECT approach: reuse production CUTLASS CollectiveMma by calling
+// its public methods (load_init, load, load_tail, init_tmem_tensors,
+// mma_init, mma, slice_accumulator) from a custom megakernel struct.
+// This inherits all of production CUTLASS's multi-stage SMEM pipelining,
+// warp specialization, TMA pipelining, and cluster optimizations.
+//
+// RED LINE: do NOT hand-build a kernel from cute primitives via the
+// `cute/tutorial/blackwell/` examples.  Tutorials are correctness toys
+// that omit the multi-stage / warp-spec optimizations production
+// `CollectiveMma` already implements.  Sub-mainloop perf MUST match
+// `cutlass_fp16_sq` / `cutlass_fp16_2sm21` isolation numbers before
+// fusion can buy anything on top.
+//
+// Step 1 — single-mainloop wrapper kernel:
+//   Use cutlass::gemm::collective::CollectiveBuilder<...> to obtain a
+//   production CollectiveMma at our split-G7 tile.  Write a custom
+//   kernel struct whose operator() calls collective_mainloop.load() in
+//   producer warps and collective_mainloop.mma() in consumer warps —
+//   structurally identical to sm100_gemm_tma_warpspecialized.hpp's
+//   operator() but in our codebase so we can extend it.  Validate:
+//     cosine 1.000000 vs cutlass_fp16_sq
+//     isolation perf within 5% of cutlass_fp16_sq (~750 us at n=500)
+//
+// Step 2 — dual mainloop sharing X:
+//   Construct two CollectiveMma instances (one per W_gate, W_up).
+//   Producer warps interleave TMA loads for the two B operands; A
+//   (= X) is loaded once and shared.  Two TMEM accumulators (gate /
+//   up), no GMEM materialization.  Validate cosine 1.0 vs reference.
+//
+// Step 3 — in-SMEM GeGLU + third mainloop:
+//   Apply gelu_tanh(gate_acc) * up_acc in TMEM→RMEM path; stage the
+//   FP16 result `hid` into SMEM.  Build a third CollectiveMma whose
+//   A operand sources from SMEM (`hid`) and B = W_down.  Producer
+//   warps load W_down via TMA; consumer warps execute the final mma()
+//   to produce out_acc.  Production CollectiveEpilogue stores out_acc
+//   to GMEM.  Cosine 1.0 vs the 3-step fallback at the encoder shape.
+//
+// Step 4 — tile sweep per sub-mainloop:
+//   Each of the three CollectiveMma instances can have an independent
+//   (TILE_M, TILE_N, TILE_K, ClusterShape) selected via the CollectiveBuilder
+//   template parameters.  Hot-regime A/B-sweep them, gated on FP8 2v ≈ 44 ms.
+//
+// Phase C (production wiring) — only if hot-regime win >= 2 ms and no
+// bimodal behavior.  Squash WIP commits per feedback_commit_discipline.
+//
+// Reading materials:
+//   - cutlass/include/cutlass/gemm/kernel/sm100_gemm_tma_warpspecialized.hpp
+//     (the production kernel orchestrator — copy its operator() body
+//     as the starting point for our custom megakernel)
+//   - cutlass/include/cutlass/gemm/collective/sm100_mma_warpspecialized.hpp
+//     (the production CollectiveMma whose load/mma we will call)
+//   - cutlass/include/cutlass/epilogue/collective/sm100_epilogue_tma_warpspecialized.hpp
+//     (the production CollectiveEpilogue that will store the final
+//     out_acc; reused as-is)

--- a/csrc/gemm/mega/flashrt_megakernel_geglu.cu
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu.cu
@@ -1,0 +1,153 @@
+// ============================================================================
+// FlashRT — encoder split-G7 megakernel (Stage B prototype).
+//
+// Stage B-v2: visitor-owned SMEM (mirrors Sm90AuxStore pattern).
+//   - Phase 1 (gate) fusion = Sm90EVT<Sm100SmemAuxStore, Sm90EVT<Sm90Compute<GELU>,
+//                                     Sm90LinearCombination>>
+//     captures post-GELU to phase 1 visitor's OWN SharedStorage.
+//   - Phase 2 (up) fusion = Sm90EVT<Sm90Compute<multiplies>, Sm90LinearCombination,
+//                                   Sm100SmemAuxLoad>
+//     loads aux from phase 2 visitor's OWN SharedStorage (NOT phase 1's).
+//
+// Cross-phase data sharing is NOT YET wired at this stage — phase 1 writes
+// to phase1.epilogue.fusion.smem_aux; phase 2 reads from
+// phase2.epilogue_2.fusion.smem_aux (different memory regions).  So numerical
+// output will be wrong, but the test is: does the kernel RUN without
+// illegal address?  That validates the visitor mechanic isolated from
+// the cross-phase plumbing.
+//
+// Once kernel runs: add a kernel-body S2S copy from phase1's smem_aux to
+// phase2's smem_aux at phase transition, OR overlay the two via kernel
+// TensorStorage union.
+// ============================================================================
+
+#include "cutlass/cutlass.h"
+#include "cutlass/half.h"
+#include "cutlass/functional.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/device_memory.h"
+
+#include "cute/tensor.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/numeric/integral_constant.hpp"
+
+#include "sm100_smem_aux_visitor.hpp"
+#include "flashrt_megakernel_geglu_kernel.hpp"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+using namespace cute;
+using fp16_t = cutlass::half_t;
+
+namespace {
+
+// Stage E3 best tile: (128, 128, 128) Cluster (2,2,1) with shared SMEM_A.
+// Per-CTA (64, 64, 128) — TileK=128 (production sq's K).
+// Low Thor regime: 1.06-1.07x faster than production back-to-back.
+using Tile    = Shape<_128, _128, _128>;
+using Cluster = Shape<_2, _2, _1>;
+
+using FusionGate = flashrt::megakernel::fusion::LinCombEltActSmemAuxStore<
+    cutlass::epilogue::thread::GELU_taylor, fp16_t, float, fp16_t>;
+
+using FusionUp = flashrt::megakernel::fusion::LinCombDeEltActSmemAuxLoad<
+    cutlass::multiplies, fp16_t, float, fp16_t>;
+
+using CollectiveEpiGate = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, FusionGate>::CollectiveOp;
+
+using CollectiveEpiUp = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, FusionUp>::CollectiveOp;
+
+using CollectiveMmaGate = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCount<3>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+using CollectiveMmaUp = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCount<3>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+using GemmKernel = cutlass::gemm::kernel::FlashRtMegakernelGeGLUFusedGemm<
+    Shape<int, int, int, int>,
+    CollectiveMmaGate, CollectiveEpiGate,
+    CollectiveMmaUp,   CollectiveEpiUp,
+    void>;
+
+using GemmOp = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+}  // anonymous namespace
+
+extern "C" int flashrt_megakernel_geglu_fp16(
+    void* X, void* W_gate, void* W_up,
+    void* D_gate_scratch, void* hidden,
+    int M, int N, int K,
+    cudaStream_t stream)
+{
+    using ElementA = typename GemmOp::ElementA;
+    using ElementB = typename GemmOp::ElementB;
+    using ElementD = typename GemmOp::ElementD;
+
+    auto sA = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideA{}, {M, K, 1});
+    auto sB = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideB{}, {N, K, 1});
+    auto sD = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideD{}, {M, N, 1});
+
+    typename GemmOp::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, N, K, 1},
+        {(ElementA*)X, sA, (ElementB*)W_gate, sB},
+        {
+            // Stage B-v2: visitor has empty Arguments (owns SMEM internally)
+            { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
+            nullptr, {},
+            (ElementD*)D_gate_scratch, sD
+        },
+        {(ElementA*)X, sA, (ElementB*)W_up, sB},
+        {
+            { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
+            nullptr, {},
+            (ElementD*)hidden, sD
+        }
+    };
+
+    GemmOp gemm;
+    size_t ws_size = GemmOp::get_workspace_size(args);
+    static cutlass::device_memory::allocation<uint8_t> workspace(0);
+    if (ws_size > workspace.size()) {
+        workspace = cutlass::device_memory::allocation<uint8_t>(ws_size);
+    }
+
+    if (gemm.can_implement(args) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_geglu] cannot implement M=%d N=%d K=%d\n", M, N, K);
+        return -1;
+    }
+    if (gemm.initialize(args, workspace.get(), stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_geglu] init failed\n");
+        return -2;
+    }
+    if (gemm.run(stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_geglu] run failed\n");
+        return -3;
+    }
+    return 0;
+}

--- a/csrc/gemm/mega/flashrt_megakernel_geglu.cu
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu.cu
@@ -1,24 +1,14 @@
 // ============================================================================
-// FlashRT — encoder split-G7 megakernel (Stage B prototype).
+// FlashRT — encoder GeGLU megakernel (host-side launcher).
 //
-// Stage B-v2: visitor-owned SMEM (mirrors Sm90AuxStore pattern).
-//   - Phase 1 (gate) fusion = Sm90EVT<Sm100SmemAuxStore, Sm90EVT<Sm90Compute<GELU>,
-//                                     Sm90LinearCombination>>
-//     captures post-GELU to phase 1 visitor's OWN SharedStorage.
-//   - Phase 2 (up) fusion = Sm90EVT<Sm90Compute<multiplies>, Sm90LinearCombination,
-//                                   Sm100SmemAuxLoad>
-//     loads aux from phase 2 visitor's OWN SharedStorage (NOT phase 1's).
-//
-// Cross-phase data sharing is NOT YET wired at this stage — phase 1 writes
-// to phase1.epilogue.fusion.smem_aux; phase 2 reads from
-// phase2.epilogue_2.fusion.smem_aux (different memory regions).  So numerical
-// output will be wrong, but the test is: does the kernel RUN without
-// illegal address?  That validates the visitor mechanic isolated from
-// the cross-phase plumbing.
-//
-// Once kernel runs: add a kernel-body S2S copy from phase1's smem_aux to
-// phase2's smem_aux at phase transition, OR overlay the two via kernel
-// TensorStorage union.
+// The kernel (struct in flashrt_megakernel_geglu_kernel.hpp) uses
+// visitor-owned SMEM to fuse the gate and up GEMMs:
+//   - Phase 1 (gate) epilogue captures post-GELU into SMEM
+//     (Sm90EVT<Sm100SmemAuxStore, Sm90EVT<Sm90Compute<GELU>,
+//     Sm90LinearCombination>>).
+//   - Phase 2 (up) epilogue loads it back and fuses the gate * up multiply
+//     in-register (Sm90EVT<Sm90Compute<multiplies>, Sm90LinearCombination,
+//     Sm100SmemAuxLoad>), writing only the final hidden tensor.
 // ============================================================================
 
 #include "cutlass/cutlass.h"
@@ -46,7 +36,7 @@ using fp16_t = cutlass::half_t;
 
 namespace {
 
-// Stage E3 best tile: (128, 128, 128) Cluster (2,2,1) with shared SMEM_A.
+// Best tile: (128, 128, 128) Cluster (2,2,1) with shared SMEM_A.
 // Per-CTA (64, 64, 128) — TileK=128 (production sq's K).
 // Low Thor regime: 1.06-1.07x faster than production back-to-back.
 using Tile    = Shape<_128, _128, _128>;
@@ -117,7 +107,7 @@ extern "C" int flashrt_megakernel_geglu_fp16(
         {M, N, K, 1},
         {(ElementA*)X, sA, (ElementB*)W_gate, sB},
         {
-            // Stage B-v2: visitor has empty Arguments (owns SMEM internally)
+            // visitor has empty Arguments (owns its SMEM internally)
             { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
             nullptr, {},
             (ElementD*)D_gate_scratch, sD

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_g8.cu
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_g8.cu
@@ -1,24 +1,17 @@
 // ============================================================================
-// FlashRT — encoder split-G7 megakernel (Stage B prototype).
+// FlashRT — encoder GeGLU + down-proj megakernel (host-side launchers).
 //
-// Stage B-v2: visitor-owned SMEM (mirrors Sm90AuxStore pattern).
-//   - Phase 1 (gate) fusion = Sm90EVT<Sm100SmemAuxStore, Sm90EVT<Sm90Compute<GELU>,
-//                                     Sm90LinearCombination>>
-//     captures post-GELU to phase 1 visitor's OWN SharedStorage.
-//   - Phase 2 (up) fusion = Sm90EVT<Sm90Compute<multiplies>, Sm90LinearCombination,
-//                                   Sm100SmemAuxLoad>
-//     loads aux from phase 2 visitor's OWN SharedStorage (NOT phase 1's).
+// The GeGLU megakernel (kernel struct in flashrt_megakernel_geglu_g8_kernel.hpp)
+// uses visitor-owned SMEM to fuse the two FFN GEMMs:
+//   - Phase 1 (gate) epilogue captures post-GELU into a SharedStorage aux
+//     buffer (Sm90EVT<Sm100SmemAuxStore, Sm90EVT<Sm90Compute<GELU>,
+//     Sm90LinearCombination>>).
+//   - Phase 2 (up) epilogue loads that aux buffer and fuses the gate * up
+//     multiply in-register (Sm90EVT<Sm90Compute<multiplies>,
+//     Sm90LinearCombination, Sm100SmemAuxLoad>).
 //
-// Cross-phase data sharing is NOT YET wired at this stage — phase 1 writes
-// to phase1.epilogue.fusion.smem_aux; phase 2 reads from
-// phase2.epilogue_2.fusion.smem_aux (different memory regions).  So numerical
-// output will be wrong, but the test is: does the kernel RUN without
-// illegal address?  That validates the visitor mechanic isolated from
-// the cross-phase plumbing.
-//
-// Once kernel runs: add a kernel-body S2S copy from phase1's smem_aux to
-// phase2's smem_aux at phase transition, OR overlay the two via kernel
-// TensorStorage union.
+// This file provides the C entry points that drive that kernel and bundle
+// it with the downstream GEMMs (see per-function comments below).
 // ============================================================================
 
 #include "cutlass/cutlass.h"
@@ -46,7 +39,7 @@ using fp16_t = cutlass::half_t;
 
 namespace {
 
-// Stage E3 best tile: (128, 128, 128) Cluster (2,2,1) with shared SMEM_A.
+// Best tile: (128, 128, 128) Cluster (2,2,1) with shared SMEM_A.
 // Per-CTA (64, 64, 128) — TileK=128 (production sq's K).
 // Low Thor regime: 1.06-1.07x faster than production back-to-back.
 using Tile    = Shape<_128, _128, _128>;
@@ -98,8 +91,7 @@ using GemmOp = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
 }  // anonymous namespace
 
-// Forward decls for the existing production kernels we chain in F-2.
-// F-3+ will replace these external launches with a single fused kernel.
+// Forward decls for the production kernels chained by the bundled entries.
 extern "C" int cutlass_fp16_2sm21(void* A, void* B, void* D,
                                     int M, int N, int K,
                                     float alpha, float beta,
@@ -115,7 +107,7 @@ extern "C" int cutlass_fp16_k64(void*, void*, void*,
                                   int, int, int, float, float,
                                   cudaStream_t);
 
-// Bundle: rms_norm + QKV (k64) in one C entry.  Same pattern as F-2 bundle.
+// Bundle: rms_norm + QKV (k64) in one C entry.
 extern "C" int flashrt_rms_qkv_fp16(
     void* x,
     void* rms_weight,
@@ -135,25 +127,18 @@ extern "C" int flashrt_rms_qkv_fp16(
 }
 
 // ============================================================================
-// flashrt_megakernel_geglu_g8_fp16 — MK-2 fused entry.
+// flashrt_megakernel_geglu_g8_fp16 — fused GeGLU + down-proj entry.
 //
-// Computes  x_inout += GeGLU(X @ W_gate, X @ W_up) @ W_down
-// in one C-callable.
-//
-// Stage progression:
-//   F-1  : entry exists, signature == MK-1, internally identical (DONE).
-//   F-2  : signature extended with W_down + x_inout; internally bundles
-//          MK-1 mega + cutlass_fp16_2sm21(beta=1, D=x_inout).  Two kernel
-//          launches but bundled API (THIS COMMIT).  Functionally equiv
-//          to current Python path "mega + 2sm21_resid_fused".
-//   F-3+ : drop the second launch; persistent-CTA fused kernel.
+// Computes  x_inout += GeGLU(X @ W_gate, X @ W_up) @ W_down  in one
+// C-callable.  Runs the GeGLU megakernel, then the production 2sm21 down
+// GEMM with a beta=1 residual fold (two launches behind one bundled API).
 //
 // Arguments (M=Se, H=hidden dim, D=embed dim):
-//   X              [M, D]   fp16  (RowMajor, MK-1 input)
+//   X              [M, D]   fp16  (RowMajor, GeGLU input)
 //   W_gate         [H, D]   fp16  (RowMajor → [N,K] CUTLASS-NT)
 //   W_up           [H, D]   fp16
-//   W_down         [D, H]   fp16  (RowMajor → [D, H] = G8's [N_d, K_g8])
-//   hidden_scratch [M, H]   fp16  (scratch, gmem; F-3+ keeps it in SMEM)
+//   W_down         [D, H]   fp16  (RowMajor → [D, H] = down [N_d, K])
+//   hidden_scratch [M, H]   fp16  (gmem scratch for the GeGLU output)
 //   x_inout        [M, D]   fp16  (residual in/out, beta=1 fold)
 // ============================================================================
 extern "C" int flashrt_megakernel_geglu_g8_fp16(
@@ -167,7 +152,7 @@ extern "C" int flashrt_megakernel_geglu_g8_fp16(
     using ElementB = typename GemmOp::ElementB;
     using ElementD = typename GemmOp::ElementD;
 
-    // Phase 1+2: MK-1 mega — produces hidden = GELU(X @ W_gate) * (X @ W_up).
+    // Phase 1+2: GeGLU megakernel — produces hidden = GELU(X @ W_gate) * (X @ W_up).
     // Re-uses the same kernel class instance; problem shape (M, H, D).
     auto sA = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideA{}, {M, D, 1});
     auto sB = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideB{}, {H, D, 1});
@@ -186,18 +171,14 @@ extern "C" int flashrt_megakernel_geglu_g8_fp16(
         {
             { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
             nullptr, {},
-            (ElementD*)x_inout, sD  // phase-2 hidden gmem — reuses x_inout
-                                    // as throw-away buffer at this stage;
-                                    // overwritten by the G8 launch below.
-                                    // NOTE: F-3 will keep hidden in SMEM
-                                    // and never touch this path.
+            (ElementD*)x_inout, sD  // phase-2 hidden gmem — placeholder ptr;
+                                    // overridden below to hidden_scratch.
         }
     };
 
-    // For F-2 we still need hidden in a real gmem buffer for the 2sm21
-    // launch.  Override phase-2 epilogue's output ptr to point at the
-    // caller's hidden_scratch (same buffer phase-1 uses; phase-2 writes
-    // last so wins).  This wastes a 24 MB roundtrip — eliminated in F-3.
+    // The down GEMM reads hidden from gmem, so point the phase-2 epilogue
+    // output at the caller's hidden_scratch (same buffer phase-1 uses;
+    // phase-2 writes last so wins).
     args.epilogue_2.dD = sD;
     args.epilogue_2.ptr_D = (ElementD*)hidden_scratch;
 
@@ -220,20 +201,19 @@ extern "C" int flashrt_megakernel_geglu_g8_fp16(
         return -3;
     }
 
-    // Phase 3 (F-2 placeholder): launch the production 2sm21 G8 with
-    // resid fuse (alpha=1, beta=1, D = x_inout).  F-3+ folds this into
-    // the same kernel via persistent CTA + h_chunk loop.
+    // Phase 3: production 2sm21 down GEMM with residual fuse
+    // (alpha=1, beta=1, D = x_inout).
     return cutlass_fp16_2sm21(hidden_scratch, W_down, x_inout,
                               M, D, H, 1.0f, 1.0f, stream);
 }
 
 // ============================================================================
-// MK-2 F-3: bundled FFN-block entry (rms_norm + mega + G8 + resid)
+// flashrt_encoder_ffn_block_fp16 — bundled FFN-block entry
+// (rms_norm + GeGLU megakernel + down GEMM + residual).
 //
-// Collapses four production launches into a single C function.  Pure
-// bundling, no kernel-level fusion yet — but F-2 measurements showed
-// each removed C-boundary is worth ~0.5 ms in hot regime, so 4→1 may
-// recover ~1.5 ms on top of F-2.
+// Collapses four production launches into a single C function (pure
+// bundling, no kernel-level fusion). Each removed C boundary is worth
+// ~0.5 ms in the hot regime.
 //
 // Semantics:
 //   x_norm = rms_norm(x_resid, rms_weight, eps)

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_g8.cu
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_g8.cu
@@ -1,0 +1,316 @@
+// ============================================================================
+// FlashRT — encoder split-G7 megakernel (Stage B prototype).
+//
+// Stage B-v2: visitor-owned SMEM (mirrors Sm90AuxStore pattern).
+//   - Phase 1 (gate) fusion = Sm90EVT<Sm100SmemAuxStore, Sm90EVT<Sm90Compute<GELU>,
+//                                     Sm90LinearCombination>>
+//     captures post-GELU to phase 1 visitor's OWN SharedStorage.
+//   - Phase 2 (up) fusion = Sm90EVT<Sm90Compute<multiplies>, Sm90LinearCombination,
+//                                   Sm100SmemAuxLoad>
+//     loads aux from phase 2 visitor's OWN SharedStorage (NOT phase 1's).
+//
+// Cross-phase data sharing is NOT YET wired at this stage — phase 1 writes
+// to phase1.epilogue.fusion.smem_aux; phase 2 reads from
+// phase2.epilogue_2.fusion.smem_aux (different memory regions).  So numerical
+// output will be wrong, but the test is: does the kernel RUN without
+// illegal address?  That validates the visitor mechanic isolated from
+// the cross-phase plumbing.
+//
+// Once kernel runs: add a kernel-body S2S copy from phase1's smem_aux to
+// phase2's smem_aux at phase transition, OR overlay the two via kernel
+// TensorStorage union.
+// ============================================================================
+
+#include "cutlass/cutlass.h"
+#include "cutlass/half.h"
+#include "cutlass/functional.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/device_memory.h"
+
+#include "cute/tensor.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/numeric/integral_constant.hpp"
+
+#include "sm100_smem_aux_visitor.hpp"
+#include "flashrt_megakernel_geglu_g8_kernel.hpp"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+using namespace cute;
+using fp16_t = cutlass::half_t;
+
+namespace {
+
+// Stage E3 best tile: (128, 128, 128) Cluster (2,2,1) with shared SMEM_A.
+// Per-CTA (64, 64, 128) — TileK=128 (production sq's K).
+// Low Thor regime: 1.06-1.07x faster than production back-to-back.
+using Tile    = Shape<_128, _128, _128>;
+using Cluster = Shape<_2, _2, _1>;
+
+using FusionGate = flashrt::megakernel::fusion::LinCombEltActSmemAuxStore<
+    cutlass::epilogue::thread::GELU_taylor, fp16_t, float, fp16_t>;
+
+using FusionUp = flashrt::megakernel::fusion::LinCombDeEltActSmemAuxLoad<
+    cutlass::multiplies, fp16_t, float, fp16_t>;
+
+using CollectiveEpiGate = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, FusionGate>::CollectiveOp;
+
+using CollectiveEpiUp = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, FusionUp>::CollectiveOp;
+
+using CollectiveMmaGate = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCount<3>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+using CollectiveMmaUp = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCount<3>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+using GemmKernel = cutlass::gemm::kernel::FlashRtMegakernelGeGLUG8FusedGemm<
+    Shape<int, int, int, int>,
+    CollectiveMmaGate, CollectiveEpiGate,
+    CollectiveMmaUp,   CollectiveEpiUp,
+    void>;
+
+using GemmOp = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+}  // anonymous namespace
+
+// Forward decls for the existing production kernels we chain in F-2.
+// F-3+ will replace these external launches with a single fused kernel.
+extern "C" int cutlass_fp16_2sm21(void* A, void* B, void* D,
+                                    int M, int N, int K,
+                                    float alpha, float beta,
+                                    cudaStream_t stream);
+
+// rms_norm_fp16 — declared as a regular (non-extern-C) C++ function in
+// csrc/kernels/norm.cu.  Forward-decl with the same C++ linkage here.
+void rms_norm_fp16(const __half* x, const __half* weight,
+                    __half* out, int seq_len, int dim, float eps,
+                    cudaStream_t stream);
+
+extern "C" int cutlass_fp16_k64(void*, void*, void*,
+                                  int, int, int, float, float,
+                                  cudaStream_t);
+
+// Bundle: rms_norm + QKV (k64) in one C entry.  Same pattern as F-2 bundle.
+extern "C" int flashrt_rms_qkv_fp16(
+    void* x,
+    void* rms_weight,
+    void* x_norm_scratch,
+    void* qkv_weight,
+    void* qkv_out,
+    int M, int D, int N_qkv,
+    float rms_eps,
+    cudaStream_t stream)
+{
+    rms_norm_fp16(reinterpret_cast<const __half*>(x),
+                   reinterpret_cast<const __half*>(rms_weight),
+                   reinterpret_cast<__half*>(x_norm_scratch),
+                   M, D, rms_eps, stream);
+    return cutlass_fp16_k64(x_norm_scratch, qkv_weight, qkv_out,
+                            M, N_qkv, D, 1.0f, 0.0f, stream);
+}
+
+// ============================================================================
+// flashrt_megakernel_geglu_g8_fp16 — MK-2 fused entry.
+//
+// Computes  x_inout += GeGLU(X @ W_gate, X @ W_up) @ W_down
+// in one C-callable.
+//
+// Stage progression:
+//   F-1  : entry exists, signature == MK-1, internally identical (DONE).
+//   F-2  : signature extended with W_down + x_inout; internally bundles
+//          MK-1 mega + cutlass_fp16_2sm21(beta=1, D=x_inout).  Two kernel
+//          launches but bundled API (THIS COMMIT).  Functionally equiv
+//          to current Python path "mega + 2sm21_resid_fused".
+//   F-3+ : drop the second launch; persistent-CTA fused kernel.
+//
+// Arguments (M=Se, H=hidden dim, D=embed dim):
+//   X              [M, D]   fp16  (RowMajor, MK-1 input)
+//   W_gate         [H, D]   fp16  (RowMajor → [N,K] CUTLASS-NT)
+//   W_up           [H, D]   fp16
+//   W_down         [D, H]   fp16  (RowMajor → [D, H] = G8's [N_d, K_g8])
+//   hidden_scratch [M, H]   fp16  (scratch, gmem; F-3+ keeps it in SMEM)
+//   x_inout        [M, D]   fp16  (residual in/out, beta=1 fold)
+// ============================================================================
+extern "C" int flashrt_megakernel_geglu_g8_fp16(
+    void* X, void* W_gate, void* W_up,
+    void* W_down,
+    void* hidden_scratch, void* x_inout,
+    int M, int H, int D,
+    cudaStream_t stream)
+{
+    using ElementA = typename GemmOp::ElementA;
+    using ElementB = typename GemmOp::ElementB;
+    using ElementD = typename GemmOp::ElementD;
+
+    // Phase 1+2: MK-1 mega — produces hidden = GELU(X @ W_gate) * (X @ W_up).
+    // Re-uses the same kernel class instance; problem shape (M, H, D).
+    auto sA = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideA{}, {M, D, 1});
+    auto sB = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideB{}, {H, D, 1});
+    auto sD = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideD{}, {M, H, 1});
+
+    typename GemmOp::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, H, D, 1},
+        {(ElementA*)X, sA, (ElementB*)W_gate, sB},
+        {
+            { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
+            nullptr, {},
+            (ElementD*)hidden_scratch, sD  // phase-1 gate gmem (unused values)
+        },
+        {(ElementA*)X, sA, (ElementB*)W_up, sB},
+        {
+            { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
+            nullptr, {},
+            (ElementD*)x_inout, sD  // phase-2 hidden gmem — reuses x_inout
+                                    // as throw-away buffer at this stage;
+                                    // overwritten by the G8 launch below.
+                                    // NOTE: F-3 will keep hidden in SMEM
+                                    // and never touch this path.
+        }
+    };
+
+    // For F-2 we still need hidden in a real gmem buffer for the 2sm21
+    // launch.  Override phase-2 epilogue's output ptr to point at the
+    // caller's hidden_scratch (same buffer phase-1 uses; phase-2 writes
+    // last so wins).  This wastes a 24 MB roundtrip — eliminated in F-3.
+    args.epilogue_2.dD = sD;
+    args.epilogue_2.ptr_D = (ElementD*)hidden_scratch;
+
+    GemmOp gemm;
+    size_t ws_size = GemmOp::get_workspace_size(args);
+    static cutlass::device_memory::allocation<uint8_t> workspace(0);
+    if (ws_size > workspace.size()) {
+        workspace = cutlass::device_memory::allocation<uint8_t>(ws_size);
+    }
+    if (gemm.can_implement(args) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_geglu_g8] mega phase: cannot implement M=%d H=%d D=%d\n", M, H, D);
+        return -1;
+    }
+    if (gemm.initialize(args, workspace.get(), stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_geglu_g8] mega phase: init failed\n");
+        return -2;
+    }
+    if (gemm.run(stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_geglu_g8] mega phase: run failed\n");
+        return -3;
+    }
+
+    // Phase 3 (F-2 placeholder): launch the production 2sm21 G8 with
+    // resid fuse (alpha=1, beta=1, D = x_inout).  F-3+ folds this into
+    // the same kernel via persistent CTA + h_chunk loop.
+    return cutlass_fp16_2sm21(hidden_scratch, W_down, x_inout,
+                              M, D, H, 1.0f, 1.0f, stream);
+}
+
+// ============================================================================
+// MK-2 F-3: bundled FFN-block entry (rms_norm + mega + G8 + resid)
+//
+// Collapses four production launches into a single C function.  Pure
+// bundling, no kernel-level fusion yet — but F-2 measurements showed
+// each removed C-boundary is worth ~0.5 ms in hot regime, so 4→1 may
+// recover ~1.5 ms on top of F-2.
+//
+// Semantics:
+//   x_norm = rms_norm(x_resid, rms_weight, eps)
+//   hidden = GELU(x_norm @ W_gate) * (x_norm @ W_up)
+//   x_resid += hidden @ W_down                     (in-place residual)
+//
+// Buffers (caller-allocated):
+//   x_resid       [M, D] fp16  IN+OUT
+//   rms_weight    [D]    fp16  (typically all-ones for noweight rmsnorm)
+//   x_norm        [M, D] fp16  scratch
+//   W_gate        [H, D] fp16
+//   W_up          [H, D] fp16
+//   W_down        [D, H] fp16
+//   gate_scratch  [M, H] fp16  scratch (phase-1 epilogue throwaway)
+//   hidden_scratch[M, H] fp16  scratch (phase-2 epilogue output)
+// ============================================================================
+extern "C" int flashrt_encoder_ffn_block_fp16(
+    void* x_resid,
+    void* rms_weight,
+    void* x_norm,
+    void* W_gate, void* W_up, void* W_down,
+    void* gate_scratch, void* hidden_scratch,
+    int M, int H, int D,
+    float rms_eps,
+    cudaStream_t stream)
+{
+    // 1. rms_norm: x_resid → x_norm
+    rms_norm_fp16(reinterpret_cast<const __half*>(x_resid),
+                   reinterpret_cast<const __half*>(rms_weight),
+                   reinterpret_cast<__half*>(x_norm),
+                   M, D, rms_eps, stream);
+
+    // 2. mega GeGLU: x_norm @ W_gate / W_up → hidden_scratch
+    using ElementA = typename GemmOp::ElementA;
+    using ElementB = typename GemmOp::ElementB;
+    using ElementD = typename GemmOp::ElementD;
+    auto sA = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideA{}, {M, D, 1});
+    auto sB = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideB{}, {H, D, 1});
+    auto sD = cutlass::make_cute_packed_stride(typename GemmOp::GemmKernel::StrideD{}, {M, H, 1});
+
+    typename GemmOp::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, H, D, 1},
+        {(ElementA*)x_norm, sA, (ElementB*)W_gate, sB},
+        {
+            { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
+            nullptr, {},
+            (ElementD*)gate_scratch, sD
+        },
+        {(ElementA*)x_norm, sA, (ElementB*)W_up, sB},
+        {
+            { 1.0f, 0.0f, nullptr, nullptr, {}, {}, {} },
+            nullptr, {},
+            (ElementD*)hidden_scratch, sD
+        }
+    };
+
+    GemmOp gemm;
+    size_t ws_size = GemmOp::get_workspace_size(args);
+    static cutlass::device_memory::allocation<uint8_t> workspace(0);
+    if (ws_size > workspace.size()) {
+        workspace = cutlass::device_memory::allocation<uint8_t>(ws_size);
+    }
+    if (gemm.can_implement(args) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_encoder_ffn_block] mega: cannot implement M=%d H=%d D=%d\n", M, H, D);
+        return -1;
+    }
+    if (gemm.initialize(args, workspace.get(), stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_encoder_ffn_block] mega: init failed\n");
+        return -2;
+    }
+    if (gemm.run(stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_encoder_ffn_block] mega: run failed\n");
+        return -3;
+    }
+
+    // 3. G8 with resid fuse: x_resid += hidden @ W_down (beta=1, D=x_resid)
+    return cutlass_fp16_2sm21(hidden_scratch, W_down, x_resid,
+                              M, D, H, 1.0f, 1.0f, stream);
+}

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_g8_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_g8_kernel.hpp
@@ -32,28 +32,16 @@
 #pragma once
 
 // ============================================================================
-// FlashRtMegakernelGeGLUG8FusedGemm — the megakernel kernel struct for the
-// Pi0.5 encoder split-G7 path.
+// FlashRtMegakernelGeGLUG8FusedGemm — the GeGLU megakernel kernel struct for
+// the Pi0.5 encoder FFN.
 //
-// Stage A.0 (this commit): byte-for-byte copy of the vendored production
-// SM100 single-GEMM kernel (`flashrt_megakernel_kernel.hpp`) with ONLY the
-// class name renamed.  Functionally identical to single GEMM at this
-// stage; serves as a build/wiring scaffold.
-//
-// Stage A.1 (next): extend struct to TWO Mainloop+Epilogue template
-// params; operator() body chains phase1 (gate) + phase2 (up) serially
-// per work tile, sharing one tcgen05.alloc.  Both phases still write to
-// gmem (no SMEM_gate routing yet).
-//
-// Stage B: redirect phase1 epilogue store target from gmem D_gate to a
-// SharedStorage::smem_gate buffer (suppress TMA store).
-//
-// Stage C: add `Sm100SmemGateLoad` EVT visitor to phase2 epilogue and
-// fuse the gate × up multiply in-register.  This is the cosine-correct
-// MK-1 ship candidate.
-//
-// Stage D: share SMEM_A across phases (X is the same input for both
-// gate and up).  Performance optimization on top of Stage C.
+// Built on the vendored SM100 single-GEMM kernel, extended to two
+// Mainloop+Epilogue template params. Each work tile runs phase1 (gate)
+// then phase2 (up) serially, sharing one tcgen05.alloc and one SMEM_A
+// staging buffer (X is the same input for both). Phase1 stores its result
+// into a SharedStorage::smem_gate buffer instead of gmem; phase2's epilogue
+// uses an `Sm100SmemGateLoad` EVT visitor to fuse the gate * up multiply
+// in-register, so only the final hidden tensor is written out.
 // ============================================================================
 
 #include "cutlass/cutlass.h"
@@ -310,7 +298,7 @@ public:
       EpilogueTensorStorage   epilogue;
       EpilogueTensorStorage2  epilogue_2;
 
-      // Stage E3: shared smem_A + per-phase smem_B
+      // shared smem_A + per-phase smem_B
       using SmemAllocTypeA  = typename CollectiveMainloop::SmemAllocTypeA;
       using SmemAllocTypeB  = typename CollectiveMainloop::SmemAllocTypeB;
       using SmemAllocTypeB2 = typename CollectiveMainloop2::SmemAllocTypeB;
@@ -616,12 +604,12 @@ public:
       mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Consumer;
     }
     mainloop_pipeline_params.is_leader = lane_predicate && is_mma_leader_cta && is_participant.main_load;
-    // Stage E3: shared pipeline carries (A + B_phase1 + B_phase2) per slot.
+    // shared pipeline carries (A + B_phase1 + B_phase2) per slot.
     mainloop_pipeline_params.transaction_bytes =
         CollectiveMainloop::TmaTransactionBytesA
       + CollectiveMainloop::TmaTransactionBytesB
       + CollectiveMainloop2::TmaTransactionBytesB;
-    // Stage E3: 2 consumer groups per slot — phase 1 mma + phase 2 mma must
+    // 2 consumer groups per slot — phase 1 mma + phase 2 mma must
     // each release every slot (K-tile interleaved in MMA warp body below).
     mainloop_pipeline_params.num_consumers = 2;
     mainloop_pipeline_params.initializing_warp = 0;
@@ -781,7 +769,7 @@ public:
     // To all producers and consumer threadblocks in the cluster
     pipeline_init_arrive_relaxed(cluster_size);
 
-    // Stage E3: phase 1 and phase 2 mainloops both see shared smem_A.
+    // phase 1 and phase 2 mainloops both see shared smem_A.
     typename SharedStorage::template PhaseTensorStorageView<
         decltype(shared_storage.tensors.shared_smem_A),
         decltype(shared_storage.tensors.smem_B_phase1)>
@@ -855,7 +843,7 @@ public:
           }
         }
 
-        // -------- Stage E3: inline 3-TMA shared-pipeline main_load --------
+        // -------- inline 3-TMA shared-pipeline main_load --------
         {
           auto& tma_load_a    = params.mainloop.tma_load_a;
           auto& tma_load_b_p1 = params.mainloop.tma_load_b;
@@ -893,7 +881,7 @@ public:
             ++k_tile_iter;
           }
         }
-        (void)k_tile_prologue;  // unused in Stage E3 inline main_load
+        (void)k_tile_prologue;  // unused in the inline main_load
 
         // Sync warp to prevent non-participating threads entering next wave early
         __syncwarp();
@@ -909,7 +897,7 @@ public:
           ++clc_pipe_consumer_state;
         }
       } while (work_tile_info.is_valid());
-      // Stage E3: single shared pipeline; mainloop_pipeline_2 unused.
+      // single shared pipeline; mainloop_pipeline_2 unused.
       collective_mainloop.load_tail(mainloop_pipeline, mainloop_pipe_producer_state);
 
     }
@@ -1006,7 +994,7 @@ public:
           }
         }();
 
-        // -------- Stage E3: inline K-tile interleaved phase1+phase2 MMA --------
+        // -------- inline K-tile interleaved phase1+phase2 MMA --------
         // Single shared mainloop_pipeline.  Per K-tile slot: phase 1 mma
         // (A, B_phase1) → acc_p1, then phase 2 mma (A, B_phase2) → acc_p2.
         // Both phases release the slot each iteration so pipeline reaches

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_g8_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_g8_kernel.hpp
@@ -1,0 +1,1380 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#pragma once
+
+// ============================================================================
+// FlashRtMegakernelGeGLUG8FusedGemm — the megakernel kernel struct for the
+// Pi0.5 encoder split-G7 path.
+//
+// Stage A.0 (this commit): byte-for-byte copy of the vendored production
+// SM100 single-GEMM kernel (`flashrt_megakernel_kernel.hpp`) with ONLY the
+// class name renamed.  Functionally identical to single GEMM at this
+// stage; serves as a build/wiring scaffold.
+//
+// Stage A.1 (next): extend struct to TWO Mainloop+Epilogue template
+// params; operator() body chains phase1 (gate) + phase2 (up) serially
+// per work tile, sharing one tcgen05.alloc.  Both phases still write to
+// gmem (no SMEM_gate routing yet).
+//
+// Stage B: redirect phase1 epilogue store target from gmem D_gate to a
+// SharedStorage::smem_gate buffer (suppress TMA store).
+//
+// Stage C: add `Sm100SmemGateLoad` EVT visitor to phase2 epilogue and
+// fuse the gate × up multiply in-register.  This is the cosine-correct
+// MK-1 ship candidate.
+//
+// Stage D: share SMEM_A across phases (X is the same input for both
+// gate and up).  Performance optimization on top of Stage C.
+//
+// Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
+// ============================================================================
+
+#include "cutlass/cutlass.h"
+#include "cutlass/workspace.h"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "cutlass/detail/cluster.hpp"
+#include "cutlass/arch/grid_dependency_control.h"
+#include "cutlass/fast_math.h"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cutlass/arch/arch.h"
+#include "cutlass/arch/barrier.h"
+#include "cutlass/arch/reg_reconfig.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/detail/mainloop_fusion_helper_scale_factor.hpp"
+#include "cutlass/gemm/kernel/sm100_tile_scheduler.hpp"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/detail/sm100_tmem_helper.hpp"
+
+#include "cute/tensor.hpp"
+#include "cute/arch/tmem_allocator_sm100.hpp"
+#include "cute/atom/mma_atom.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::kernel {
+
+// Bring CUTLASS identifiers (used unqualified in the vendored kernel
+// body) into scope.  In production these are found via ADL because
+// the kernel lives in cutlass::gemm::kernel; in flashrt::megakernel
+// they need explicit using-declarations.
+using cutlass::gemm::KernelTmaWarpSpecializedSm100;
+using cutlass::gemm::KernelTmaWarpSpecializedBlockScaledSm100;
+using cutlass::NumThreadsPerWarp;
+using cutlass::MinWorkspaceAlignment;
+
+// Primary template (forward declaration).  Mirrors
+// cutlass::gemm::kernel::GemmUniversal but takes TWO mainloop+epilogue
+// collectives for the gate / up chain.  Per-phase types must be
+// structurally identical (same Tile, Cluster, TiledMma, EpilogueTile);
+// they differ only in their TMA descriptors (gate loads W_gate; up
+// loads W_up) and epilogue activation (gate=GELU, up=Identity).
+template <
+  class ProblemShape_,
+  class CollectiveMainloop_,    // phase 1 (gate)
+  class CollectiveEpilogue_,    // phase 1 (gate) — applies GELU
+  class CollectiveMainloop2_,   // phase 2 (up)
+  class CollectiveEpilogue2_,   // phase 2 (up) — Identity (no activation)
+  class TileSchedulerTag_ = void,
+  class Enable = void
+>
+class FlashRtMegakernelGeGLUG8FusedGemm;
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+  class ProblemShape_,
+  class CollectiveMainloop_,
+  class CollectiveEpilogue_,
+  class CollectiveMainloop2_,
+  class CollectiveEpilogue2_,
+  class TileSchedulerTag_
+>
+class FlashRtMegakernelGeGLUG8FusedGemm<
+  ProblemShape_,
+  CollectiveMainloop_,
+  CollectiveEpilogue_,
+  CollectiveMainloop2_,
+  CollectiveEpilogue2_,
+  TileSchedulerTag_,
+  cute::enable_if_t<
+    cute::disjunction_v<cutlass::detail::is_kernel_tag_of<typename CollectiveMainloop_::DispatchPolicy::Schedule,
+                                KernelTmaWarpSpecializedSm100>,
+    cutlass::detail::is_kernel_tag_of<typename CollectiveMainloop_::DispatchPolicy::Schedule,
+                                KernelTmaWarpSpecializedBlockScaledSm100>>>>
+{
+public:
+  //
+  // Type Aliases
+  //
+  using ProblemShape = ProblemShape_;
+  static_assert(rank(ProblemShape{}) == 3 or rank(ProblemShape{}) == 4,
+    "ProblemShape{} should be <M,N,K> or <M,N,K,L>");
+
+  // Mainloop derived types
+  using CollectiveMainloop = CollectiveMainloop_;
+  using TileShape = typename CollectiveMainloop::TileShape;
+  using TiledMma  = typename CollectiveMainloop::TiledMma;
+  using ArchTag   = typename CollectiveMainloop::ArchTag;
+  using ElementA  = typename CollectiveMainloop::ElementA;
+  using StrideA   = typename CollectiveMainloop::StrideA;
+  using ElementB  = typename CollectiveMainloop::ElementB;
+  using StrideB   = typename CollectiveMainloop::StrideB;
+  using LayoutSFA = typename cutlass::detail::LayoutSFAType<CollectiveMainloop>::type;
+  using LayoutSFB = typename cutlass::detail::LayoutSFBType<CollectiveMainloop>::type;
+  using ElementSF = typename cutlass::detail::ElementSFType<CollectiveMainloop>::type;
+  using DispatchPolicy = typename CollectiveMainloop::DispatchPolicy;
+  using ElementAccumulator = typename CollectiveMainloop::ElementAccumulator;
+  using ClusterShape = typename DispatchPolicy::ClusterShape;
+  using MainloopArguments = typename CollectiveMainloop::Arguments;
+  using MainloopParams = typename CollectiveMainloop::Params;
+  static_assert(ArchTag::kMinComputeCapability >= 100);
+
+  // Epilogue derived types
+  using CollectiveEpilogue = CollectiveEpilogue_;
+  using EpilogueTile = typename CollectiveEpilogue::EpilogueTile;
+  using ElementC = typename CollectiveEpilogue::ElementC;
+  using StrideC  = typename CollectiveEpilogue::StrideC;
+  using ElementD = typename CollectiveEpilogue::ElementD;
+  using StrideD  = typename CollectiveEpilogue::StrideD;
+  using EpilogueArguments = typename CollectiveEpilogue::Arguments;
+  using EpilogueParams = typename CollectiveEpilogue::Params;
+  static constexpr bool IsComplex = CollectiveEpilogue::NumAccumulatorMtxs == 2;
+
+  // ============================================================================
+  // Phase 2 (up) collectives.  Must match phase 1 structurally — same
+  // TileShape, ClusterShape, TiledMma, EpilogueTile, ElementA — so a
+  // single TMEM allocation can be serially reused (slice_accumulator
+  // semantics are well-defined only when the underlying acc shape is
+  // identical).  These asserts catch mismatches at compile time.
+  // ============================================================================
+  using CollectiveMainloop2 = CollectiveMainloop2_;
+  using CollectiveEpilogue2 = CollectiveEpilogue2_;
+  using MainloopArguments2 = typename CollectiveMainloop2::Arguments;
+  using MainloopParams2    = typename CollectiveMainloop2::Params;
+  using EpilogueArguments2 = typename CollectiveEpilogue2::Arguments;
+  using EpilogueParams2    = typename CollectiveEpilogue2::Params;
+
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::TileShape, TileShape>,
+                "Phase 2 mainloop TileShape must match phase 1 (shared TMEM constraint).");
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::DispatchPolicy::ClusterShape, ClusterShape>,
+                "Phase 2 mainloop ClusterShape must match phase 1.");
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::TiledMma, TiledMma>,
+                "Phase 2 mainloop TiledMma must match phase 1 (TMEM accumulator layout depends on TiledMma).");
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::ElementA, ElementA>,
+                "Phase 2 mainloop ElementA must match phase 1.");
+  static_assert(cute::is_same_v<typename CollectiveEpilogue2::EpilogueTile, EpilogueTile>,
+                "Phase 2 EpilogueTile must match phase 1.");
+
+  // CLC pipeline depth
+  // determines how many waves (stages-1) a warp can race ahead
+  static constexpr uint32_t SchedulerPipelineStageCount = DispatchPolicy::Schedule::SchedulerPipelineStageCount;
+  static constexpr uint32_t AccumulatorPipelineStageCount = DispatchPolicy::Schedule::AccumulatorPipelineStageCount;
+  static constexpr bool IsOverlappingAccum = DispatchPolicy::IsOverlappingAccum;
+
+  // TileID scheduler
+  // Get Blk and Scheduling tile shapes
+  using AtomThrShapeMNK = typename CollectiveMainloop::AtomThrShapeMNK;
+  using CtaShape_MNK = typename CollectiveMainloop::CtaShape_MNK;
+  using TileSchedulerTag = TileSchedulerTag_;
+  using TileScheduler = typename detail::TileSchedulerSelector<
+    TileSchedulerTag, ArchTag, CtaShape_MNK, ClusterShape, SchedulerPipelineStageCount>::Scheduler;
+  using TileSchedulerArguments = typename TileScheduler::Arguments;
+  using TileSchedulerParams = typename TileScheduler::Params;
+
+  static constexpr bool IsSchedDynamicPersistent = TileScheduler::IsDynamicPersistent;
+  static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+  static constexpr bool IsGdcEnabled = cutlass::arch::IsGdcGloballyEnabled;
+
+  // Warp specialization thread count per threadblock
+  static constexpr uint32_t NumSchedThreads        = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumMMAThreads          = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumMainloopLoadThreads = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumEpilogueLoadThreads = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumEpilogueThreads     = CollectiveEpilogue::ThreadCount;
+  static constexpr uint32_t NumEpilogueWarps       = NumEpilogueThreads / NumThreadsPerWarp;
+
+  static constexpr uint32_t MaxThreadsPerBlock = NumSchedThreads +
+                                                 NumMainloopLoadThreads + NumMMAThreads +
+                                                 NumEpilogueLoadThreads + NumEpilogueThreads;
+  static constexpr uint32_t MinBlocksPerMultiprocessor = 1;
+
+  static constexpr uint32_t NumEpilogueSubTiles = CollectiveEpilogue::get_load_pipe_increment(CtaShape_MNK{});
+
+  // Fixup performed for split-/stream-K is done across warps in different CTAs
+  // at epilogue subtile granularity. Thus, there must be one barrier per sub-tile per
+  // epilogue warp.
+  static constexpr uint32_t NumFixupBarriers = 1;
+  static constexpr uint32_t CLCResponseSize = sizeof(typename TileScheduler::CLCResponse);
+
+  // Phase 2 thread-count must match phase 1 for shared CLC + AccPipe arrival counts.
+  static_assert(CollectiveEpilogue2::ThreadCount == CollectiveEpilogue::ThreadCount,
+                "Phase 2 epilogue ThreadCount must match phase 1 (shared CLC pipeline arrivals).");
+
+  // Pipeline and pipeline state types — phase 1 (gate)
+  using MainloopPipeline = typename CollectiveMainloop::MainloopPipeline;
+  using MainloopPipelineState = typename CollectiveMainloop::MainloopPipelineState;
+
+  using EpiLoadPipeline = typename CollectiveEpilogue::LoadPipeline;
+  using EpiLoadPipelineState = typename CollectiveEpilogue::LoadPipelineState;
+
+  using EpiStorePipeline = typename CollectiveEpilogue::StorePipeline;
+  using EpiStorePipelineState = typename CollectiveEpilogue::StorePipelineState;
+
+  // Pipeline types — phase 2 (up).  Same template instances as phase 1
+  // when the underlying CollectiveBuilder produced compatible mainloop /
+  // epilogue collectives; the doubling is for separate SMEM rings and
+  // separate producer/consumer state machines.
+  using MainloopPipeline2 = typename CollectiveMainloop2::MainloopPipeline;
+  using MainloopPipelineState2 = typename CollectiveMainloop2::MainloopPipelineState;
+
+  using EpiLoadPipeline2 = typename CollectiveEpilogue2::LoadPipeline;
+  using EpiLoadPipelineState2 = typename CollectiveEpilogue2::LoadPipelineState;
+
+  using EpiStorePipeline2 = typename CollectiveEpilogue2::StorePipeline;
+  using EpiStorePipelineState2 = typename CollectiveEpilogue2::StorePipelineState;
+
+  using LoadOrderBarrier = cutlass::OrderedSequenceBarrier<1,2>;
+
+  using AccumulatorPipeline = cutlass::PipelineUmmaAsync<AccumulatorPipelineStageCount, AtomThrShapeMNK>;
+  using AccumulatorPipelineState = typename AccumulatorPipeline::PipelineState;
+
+  using CLCPipeline = cutlass::PipelineCLCFetchAsync<SchedulerPipelineStageCount, ClusterShape>;
+  using CLCPipelineState = typename CLCPipeline::PipelineState;
+
+  using CLCThrottlePipeline = cutlass::PipelineAsync<SchedulerPipelineStageCount>;
+  using CLCThrottlePipelineState = typename CLCThrottlePipeline::PipelineState;
+
+  using TmemAllocator = cute::conditional_t<cute::size(cute::shape<0>(typename TiledMma::ThrLayoutVMNK{})) == 1,
+      cute::TMEM::Allocator1Sm, cute::TMEM::Allocator2Sm>;
+
+  // Kernel level shared memory storage
+  struct SharedStorage {
+    struct PipelineStorage : cute::aligned_struct<16, _1> {
+      using MainloopPipelineStorage  = typename CollectiveMainloop::PipelineStorage;
+      using EpiLoadPipelineStorage   = typename CollectiveEpilogue::PipelineStorage;
+      using MainloopPipelineStorage2 = typename CollectiveMainloop2::PipelineStorage;
+      using EpiLoadPipelineStorage2  = typename CollectiveEpilogue2::PipelineStorage;
+      using LoadOrderBarrierStorage  = typename LoadOrderBarrier::SharedStorage;
+      using CLCPipelineStorage       = typename CLCPipeline::SharedStorage;
+      using AccumulatorPipelineStorage = typename AccumulatorPipeline::SharedStorage;
+      using CLCThrottlePipelineStorage = typename CLCThrottlePipeline::SharedStorage;
+
+      // Doubled (per phase) — separate SMEM rings + state machines.
+      alignas(16) MainloopPipelineStorage  mainloop;
+      alignas(16) MainloopPipelineStorage2 mainloop_2;
+      alignas(16) EpiLoadPipelineStorage   epi_load;
+      alignas(16) EpiLoadPipelineStorage2  epi_load_2;
+      // Single (shared across phases) — natural slot-wrap serialization.
+      alignas(16) LoadOrderBarrierStorage     load_order;
+      alignas(16) CLCPipelineStorage          clc;
+      alignas(16) AccumulatorPipelineStorage  accumulator;
+      alignas(16) CLCThrottlePipelineStorage  clc_throttle;
+      alignas(16) arch::ClusterBarrier        tmem_dealloc;
+    } pipelines;
+
+    alignas(16) typename TileScheduler::CLCResponse clc_response[SchedulerPipelineStageCount];
+    uint32_t tmem_base_ptr;
+
+    struct TensorStorage : cute::aligned_struct<128, _1> {
+      using EpilogueTensorStorage   = typename CollectiveEpilogue::TensorStorage;
+      using EpilogueTensorStorage2  = typename CollectiveEpilogue2::TensorStorage;
+
+      EpilogueTensorStorage   epilogue;
+      EpilogueTensorStorage2  epilogue_2;
+
+      // Stage E3: shared smem_A + per-phase smem_B
+      using SmemAllocTypeA  = typename CollectiveMainloop::SmemAllocTypeA;
+      using SmemAllocTypeB  = typename CollectiveMainloop::SmemAllocTypeB;
+      using SmemAllocTypeB2 = typename CollectiveMainloop2::SmemAllocTypeB;
+      static constexpr int SmemA_Elems  = cute::cosize_v<typename CollectiveMainloop::SmemLayoutA>;
+      static constexpr int SmemB1_Elems = cute::cosize_v<typename CollectiveMainloop::SmemLayoutB>;
+      static constexpr int SmemB2_Elems = cute::cosize_v<typename CollectiveMainloop2::SmemLayoutB>;
+
+      cute::ArrayEngine<SmemAllocTypeA,  SmemA_Elems>  shared_smem_A;
+      cute::ArrayEngine<SmemAllocTypeB,  SmemB1_Elems> smem_B_phase1;
+      cute::ArrayEngine<SmemAllocTypeB2, SmemB2_Elems> smem_B_phase2;
+    } tensors;
+
+    template <class SmemABuf, class SmemBBuf>
+    struct PhaseTensorStorageView {
+      SmemABuf& smem_A;
+      SmemBBuf& smem_B;
+    };
+  };
+
+  static constexpr int SharedStorageSize = sizeof(SharedStorage);
+
+  // Host facing host arguments
+  struct Arguments {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    // Phase 1 (gate)
+    MainloopArguments  mainloop{};
+    EpilogueArguments  epilogue{};
+    // Phase 2 (up)
+    MainloopArguments2 mainloop_2{};
+    EpilogueArguments2 epilogue_2{};
+    KernelHardwareInfo hw_info{};
+    TileSchedulerArguments scheduler{};
+  };
+
+  // Kernel device entry point API
+  struct Params {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    MainloopParams  mainloop{};
+    EpilogueParams  epilogue{};
+    MainloopParams2 mainloop_2{};
+    EpilogueParams2 epilogue_2{};
+    TileSchedulerParams scheduler{};
+    KernelHardwareInfo hw_info{};
+  };
+
+  enum class WarpCategory : int32_t {
+    MMA          = 0,
+    Sched        = 1,
+    MainloopLoad = 2,
+    EpilogueLoad = 3,
+    Epilogue     = 4
+  };
+
+  struct IsParticipant {
+    uint32_t mma       = false;
+    uint32_t sched     = false;
+    uint32_t main_load = false;
+    uint32_t epi_load  = false;
+    uint32_t epilogue  = false;
+  };
+
+  //
+  // Methods
+  //
+
+  // Convert to underlying arguments.
+  static
+  Params
+  to_underlying_arguments(Arguments const& args, void* workspace) {
+    (void) workspace;
+    auto problem_shape = args.problem_shape;
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+
+    // Get SM count if needed, otherwise use user supplied SM count
+    int sm_count = args.hw_info.sm_count;
+    if (sm_count != 0) {
+      CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
+          "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).");
+    }
+    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
+
+    // Calculate workspace pointers
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+
+    // Epilogue phase 1 (gate)
+    void* epilogue_workspace = workspace_ptr + workspace_offset;
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    // Epilogue phase 2 (up)
+    void* epilogue_workspace_2 = workspace_ptr + workspace_offset;
+    workspace_offset += CollectiveEpilogue2::get_workspace_size(args.problem_shape, args.epilogue_2);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    void* mainloop_workspace = nullptr;
+
+    // Tile scheduler
+    void* scheduler_workspace = workspace_ptr + workspace_offset;
+    workspace_offset += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    return {
+      args.mode,
+      args.problem_shape,
+      CollectiveMainloop::to_underlying_arguments(args.problem_shape, args.mainloop, mainloop_workspace, args.hw_info),
+      CollectiveEpilogue::to_underlying_arguments(args.problem_shape, args.epilogue, epilogue_workspace),
+      CollectiveMainloop2::to_underlying_arguments(args.problem_shape, args.mainloop_2, mainloop_workspace, args.hw_info),
+      CollectiveEpilogue2::to_underlying_arguments(args.problem_shape, args.epilogue_2, epilogue_workspace_2),
+      TileScheduler::to_underlying_arguments(
+        problem_shape_MNKL, TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
+        args.hw_info, args.scheduler, scheduler_workspace
+      )
+      ,args.hw_info
+    };
+  }
+
+  static bool
+  can_implement(Arguments const& args) {
+    bool implementable = (args.mode == GemmUniversalMode::kGemm) or
+        (args.mode == GemmUniversalMode::kBatched && rank(ProblemShape{}) == 4);
+    if (!implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: Arguments or Problem Shape don't meet the requirements.\n");
+      return implementable;
+    }
+    implementable &= CollectiveMainloop::can_implement(args.problem_shape, args.mainloop);
+    implementable &= CollectiveEpilogue::can_implement(args.problem_shape, args.epilogue);
+    implementable &= CollectiveMainloop2::can_implement(args.problem_shape, args.mainloop_2);
+    implementable &= CollectiveEpilogue2::can_implement(args.problem_shape, args.epilogue_2);
+    implementable &= TileScheduler::can_implement(args.scheduler);
+
+    if constexpr (IsDynamicCluster) {
+      static constexpr int MaxClusterSize = 16;
+      implementable &= size(args.hw_info.cluster_shape) <= MaxClusterSize;
+      implementable &= size(args.hw_info.cluster_shape_fallback) <= MaxClusterSize;
+      implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
+    }
+    
+    constexpr bool IsBlockscaled = !cute::is_void_v<ElementSF>;
+    if constexpr (IsBlockscaled) {
+      if constexpr (IsDynamicCluster) {
+        implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
+        // Special cluster shape check for scale factor multicasts. Due to limited size of scale factors, we can't multicast among
+        // more than 4 CTAs
+        implementable &= (args.hw_info.cluster_shape.x <= 4 && args.hw_info.cluster_shape.y <= 4 &&
+                          args.hw_info.cluster_shape_fallback.x <= 4 && args.hw_info.cluster_shape_fallback.y <= 4);
+      }
+      else {
+        // Special cluster shape check for scale factor multicasts. Due to limited size of scale factors, we can't multicast among
+        // more than 4 CTAs
+        implementable &= ((size<0>(ClusterShape{}) <= 4) && (size<1>(ClusterShape{}) <= 4));
+      }
+    }
+
+    return implementable;
+  }
+
+  static size_t
+  get_workspace_size(Arguments const& args) {
+    size_t workspace_size = 0;
+
+    // Epilogue phase 1 (gate)
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    // Epilogue phase 2 (up)
+    workspace_size += CollectiveEpilogue2::get_workspace_size(args.problem_shape, args.epilogue_2);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    // Tile scheduler
+    workspace_size += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    return workspace_size;
+  }
+
+  static cutlass::Status
+  initialize_workspace(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr,
+    CudaHostAdapter* cuda_adapter = nullptr) {
+    Status status = Status::kSuccess;
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+
+    // Epilogue phase 1 (gate)
+    status = CollectiveEpilogue::initialize_workspace(args.problem_shape, args.epilogue, workspace_ptr + workspace_offset, stream, cuda_adapter);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Epilogue phase 2 (up)
+    status = CollectiveEpilogue2::initialize_workspace(args.problem_shape, args.epilogue_2, workspace_ptr + workspace_offset, stream, cuda_adapter);
+    workspace_offset += CollectiveEpilogue2::get_workspace_size(args.problem_shape, args.epilogue_2);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Tile scheduler
+    status = TileScheduler::template initialize_workspace<ProblemShape, ElementAccumulator>(
+      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+    workspace_offset += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    return status;
+  }
+
+  // Computes the kernel launch grid shape based on runtime parameters
+  static dim3
+  get_grid_shape(Params const& params) {
+    // NOTE cluster_shape here is the major cluster shape, not fallback one
+    auto cluster_shape = cutlass::detail::select_cluster_shape(ClusterShape{}, params.hw_info.cluster_shape);
+
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    return TileScheduler::get_grid_shape(
+        params.scheduler,
+        problem_shape_MNKL,
+        TileShape{},
+        AtomThrShapeMNK{},
+        cluster_shape,
+        params.hw_info);
+  }
+
+  static dim3
+  get_block_shape() {
+    return dim3(MaxThreadsPerBlock, 1, 1);
+  }
+
+  CUTLASS_DEVICE
+  void
+  operator() (Params const& params, char* smem_buf) {
+
+    using namespace cute;
+    using X = Underscore;
+
+    static_assert(SharedStorageSize <= cutlass::arch::sm100_smem_capacity_bytes, "SMEM usage exceeded capacity.");
+    // Separate out problem shape for convenience
+    // Optionally append 1s until problem shape is rank-4 in case its is only rank-3 (MNK)
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    auto [M,N,K,L] = problem_shape_MNKL;
+
+    // Account for more than one epilogue warp
+    int warp_idx = canonical_warp_idx_sync();
+    WarpCategory warp_category = warp_idx < static_cast<int>(WarpCategory::Epilogue) ? WarpCategory(warp_idx)
+                                                                                     : WarpCategory::Epilogue;
+
+    uint32_t lane_predicate = cute::elect_one_sync();
+    auto cluster_shape = cutlass::detail::select_cluster_shape(ClusterShape{});
+    int cluster_size = size(cluster_shape);
+    uint32_t cta_rank_in_cluster = cute::block_rank_in_cluster();
+    bool is_first_cta_in_cluster = cta_rank_in_cluster == 0;
+    int cta_coord_v = cta_rank_in_cluster % size<0>(typename TiledMma::AtomThrID{});
+    bool is_mma_leader_cta = cta_coord_v == 0;
+    constexpr bool has_mma_peer_cta = size(AtomThrShapeMNK{}) == 2;
+    [[maybe_unused]] uint32_t mma_peer_cta_rank = has_mma_peer_cta ? cta_rank_in_cluster ^ 1 : cta_rank_in_cluster;
+
+    // Kernel level shared memory storage
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    // In a warp specialized kernel, collectives expose data movement and compute operations separately
+    CollectiveMainloop  collective_mainloop  (params.mainloop,   cluster_shape, cta_rank_in_cluster);
+    CollectiveEpilogue  collective_epilogue  (params.epilogue,   shared_storage.tensors.epilogue);
+    CollectiveMainloop2 collective_mainloop_2(params.mainloop_2, cluster_shape, cta_rank_in_cluster);
+    CollectiveEpilogue2 collective_epilogue_2(params.epilogue_2, shared_storage.tensors.epilogue_2);
+
+    // Issue Tma Descriptor Prefetch from a single thread (both phases).
+    if ((warp_category == WarpCategory::Sched) && lane_predicate) {
+      collective_mainloop.prefetch_tma_descriptors();
+      collective_mainloop_2.prefetch_tma_descriptors();
+    }
+    if ((warp_category == WarpCategory::EpilogueLoad) && lane_predicate) {
+      collective_epilogue.prefetch_tma_descriptors(params.epilogue);
+      collective_epilogue_2.prefetch_tma_descriptors(params.epilogue_2);
+    }
+
+    // Do we load source tensor C or other aux inputs (either phase)
+    bool is_epi_load_needed_1 = collective_epilogue.is_producer_load_needed();
+    bool is_epi_load_needed_2 = collective_epilogue_2.is_producer_load_needed();
+    bool is_epi_load_needed   = is_epi_load_needed_1 || is_epi_load_needed_2;
+    IsParticipant is_participant = {
+      (warp_category == WarpCategory::MMA),                                 // mma
+      (warp_category == WarpCategory::Sched) && is_first_cta_in_cluster,    // sched
+      (warp_category == WarpCategory::MainloopLoad),                        // main_load
+      (warp_category == WarpCategory::EpilogueLoad) && is_epi_load_needed,  // epi_load
+      (warp_category == WarpCategory::Epilogue)                             // epilogue
+    };
+
+    // Mainloop Load pipeline — phase 1 (gate)
+    typename MainloopPipeline::Params mainloop_pipeline_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::MMA == warp_category) {
+      mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Consumer;
+    }
+    mainloop_pipeline_params.is_leader = lane_predicate && is_mma_leader_cta && is_participant.main_load;
+    // Stage E3: shared pipeline carries (A + B_phase1 + B_phase2) per slot.
+    mainloop_pipeline_params.transaction_bytes =
+        CollectiveMainloop::TmaTransactionBytesA
+      + CollectiveMainloop::TmaTransactionBytesB
+      + CollectiveMainloop2::TmaTransactionBytesB;
+    // Stage E3: 2 consumer groups per slot — phase 1 mma + phase 2 mma must
+    // each release every slot (K-tile interleaved in MMA warp body below).
+    mainloop_pipeline_params.num_consumers = 2;
+    mainloop_pipeline_params.initializing_warp = 0;
+    MainloopPipeline mainloop_pipeline(shared_storage.pipelines.mainloop,
+                                       mainloop_pipeline_params,
+                                       cluster_shape,
+                                       cute::true_type{},   // Perform barrier init
+                                       cute::false_type{}); // Delay mask calculation
+
+    // Mainloop Load pipeline — phase 2 (up).  Separate SMEM ring + state
+    // machine; both producer (main_load warp) and consumer (mma warp)
+    // run their phase-2 calls right after their phase-1 calls in the
+    // same persistent loop iteration.
+    typename MainloopPipeline2::Params mainloop_pipeline_2_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      mainloop_pipeline_2_params.role = MainloopPipeline2::ThreadCategory::Producer;
+    }
+    if (WarpCategory::MMA == warp_category) {
+      mainloop_pipeline_2_params.role = MainloopPipeline2::ThreadCategory::Consumer;
+    }
+    mainloop_pipeline_2_params.is_leader = lane_predicate && is_mma_leader_cta && is_participant.main_load;
+    mainloop_pipeline_2_params.transaction_bytes = CollectiveMainloop2::TmaTransactionBytes;
+    // Use a distinct initializing_warp index (6 — outside the {0..5}
+    // already claimed by phase-1 pipelines + LoadOrder/CLC/Acc/Throttle)
+    // so two warps don't race on the same barrier init.
+    mainloop_pipeline_2_params.initializing_warp = 6;
+    MainloopPipeline2 mainloop_pipeline_2(shared_storage.pipelines.mainloop_2,
+                                          mainloop_pipeline_2_params,
+                                          cluster_shape,
+                                          cute::true_type{},
+                                          cute::false_type{});
+
+    // Epilogue Load pipeline — phase 1 (gate)
+    typename EpiLoadPipeline::Params epi_load_pipeline_params;
+    if (WarpCategory::EpilogueLoad == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Consumer;
+    }
+    epi_load_pipeline_params.dst_blockid = cta_rank_in_cluster;
+    epi_load_pipeline_params.producer_arv_count = NumEpilogueLoadThreads;
+    epi_load_pipeline_params.consumer_arv_count = NumEpilogueThreads;
+    epi_load_pipeline_params.transaction_bytes = CollectiveEpilogue::TmaTransactionBytes;
+    epi_load_pipeline_params.initializing_warp = 1;
+    EpiLoadPipeline epi_load_pipeline(shared_storage.pipelines.epi_load, epi_load_pipeline_params);
+
+    // Epilogue Load pipeline — phase 2 (up)
+    typename EpiLoadPipeline2::Params epi_load_pipeline_2_params;
+    if (WarpCategory::EpilogueLoad == warp_category) {
+      epi_load_pipeline_2_params.role = EpiLoadPipeline2::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      epi_load_pipeline_2_params.role = EpiLoadPipeline2::ThreadCategory::Consumer;
+    }
+    epi_load_pipeline_2_params.dst_blockid = cta_rank_in_cluster;
+    epi_load_pipeline_2_params.producer_arv_count = NumEpilogueLoadThreads;
+    epi_load_pipeline_2_params.consumer_arv_count = NumEpilogueThreads;
+    epi_load_pipeline_2_params.transaction_bytes = CollectiveEpilogue2::TmaTransactionBytes;
+    epi_load_pipeline_2_params.initializing_warp = 7;
+    EpiLoadPipeline2 epi_load_pipeline_2(shared_storage.pipelines.epi_load_2, epi_load_pipeline_2_params);
+
+    // Epilogue Store pipelines — local-scope, no SharedStorage state.
+    typename EpiStorePipeline::Params epi_store_pipeline_params;
+    epi_store_pipeline_params.always_wait = true;
+    EpiStorePipeline epi_store_pipeline(epi_store_pipeline_params);
+
+    typename EpiStorePipeline2::Params epi_store_pipeline_2_params;
+    epi_store_pipeline_2_params.always_wait = true;
+    EpiStorePipeline2 epi_store_pipeline_2(epi_store_pipeline_2_params);
+
+    // Load order barrier
+    typename LoadOrderBarrier::Params load_order_barrier_params;
+    load_order_barrier_params.group_id = (warp_category == WarpCategory::MainloopLoad) ? 0 : 1;
+    load_order_barrier_params.group_size = NumMainloopLoadThreads;
+    load_order_barrier_params.initializing_warp = 3;
+    LoadOrderBarrier load_order_barrier(shared_storage.pipelines.load_order, load_order_barrier_params);
+
+    // CLC pipeline
+    typename CLCPipeline::Params clc_pipeline_params;
+    if (WarpCategory::Sched == warp_category) {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::ProducerConsumer;
+    }
+    else {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::Consumer;
+    }
+    clc_pipeline_params.producer_blockid = 0;
+    clc_pipeline_params.producer_arv_count = 1;
+    clc_pipeline_params.consumer_arv_count = NumSchedThreads + cluster_size *
+                                                 (NumMainloopLoadThreads + NumEpilogueThreads + NumMMAThreads);
+    if (is_epi_load_needed) {
+      clc_pipeline_params.consumer_arv_count += cluster_size * NumEpilogueLoadThreads;
+    }
+    clc_pipeline_params.transaction_bytes = CLCResponseSize;
+    clc_pipeline_params.initializing_warp = 4;
+    CLCPipeline clc_pipeline(shared_storage.pipelines.clc, clc_pipeline_params, cluster_shape);
+
+    // Mainloop-Epilogue pipeline
+    typename AccumulatorPipeline::Params accumulator_pipeline_params;
+    if (WarpCategory::MMA == warp_category) {
+      accumulator_pipeline_params.role = AccumulatorPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      accumulator_pipeline_params.role = AccumulatorPipeline::ThreadCategory::Consumer;
+    }
+    // Only one producer thread arrives on this barrier.
+    accumulator_pipeline_params.producer_arv_count = 1;
+    accumulator_pipeline_params.consumer_arv_count = size(AtomThrShapeMNK{}) * NumEpilogueThreads;
+    accumulator_pipeline_params.initializing_warp = 5;
+    AccumulatorPipeline accumulator_pipeline(shared_storage.pipelines.accumulator,
+                                             accumulator_pipeline_params,
+                                             cluster_shape,
+                                             cute::true_type{},   // Perform barrier init
+                                             cute::false_type{}); // Delay mask calculation
+
+    // CLC throttle pipeline
+    typename CLCThrottlePipeline::Params clc_throttle_pipeline_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      clc_throttle_pipeline_params.role = CLCThrottlePipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Sched == warp_category) {
+      clc_throttle_pipeline_params.role = CLCThrottlePipeline::ThreadCategory::Consumer;
+    }
+    clc_throttle_pipeline_params.producer_arv_count = NumMainloopLoadThreads;
+    clc_throttle_pipeline_params.consumer_arv_count = NumSchedThreads;
+    clc_throttle_pipeline_params.dst_blockid = 0;
+    clc_throttle_pipeline_params.initializing_warp = 3;
+    CLCThrottlePipeline clc_throttle_pipeline(shared_storage.pipelines.clc_throttle, clc_throttle_pipeline_params);
+    CLCThrottlePipelineState clc_pipe_throttle_consumer_state;
+    CLCThrottlePipelineState clc_pipe_throttle_producer_state = cutlass::make_producer_start_state<CLCThrottlePipeline>();
+
+    // Tmem allocator
+    TmemAllocator tmem_allocator{};
+
+    // Sync allocation status between MMA and epilogue warps within CTA
+    arch::NamedBarrier tmem_allocation_result_barrier(NumMMAThreads + NumEpilogueThreads, cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
+    // Sync deallocation status between MMA warps of peer CTAs
+    arch::ClusterBarrier& tmem_deallocation_result_barrier = shared_storage.pipelines.tmem_dealloc;
+    [[maybe_unused]] uint32_t dealloc_barrier_phase = 0;
+    if (WarpCategory::MMA == warp_category) {
+      if constexpr(!IsOverlappingAccum) {
+        if (has_mma_peer_cta && lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumMMAThreads);
+        }
+      }
+      else {
+        if (has_mma_peer_cta && lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumEpilogueThreads*2);
+        }
+        else if (lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumEpilogueThreads);
+        }
+      }
+    }
+
+    // We need this to guarantee that the Pipeline init is visible
+    // To all producers and consumer threadblocks in the cluster
+    pipeline_init_arrive_relaxed(cluster_size);
+
+    // Stage E3: phase 1 and phase 2 mainloops both see shared smem_A.
+    typename SharedStorage::template PhaseTensorStorageView<
+        decltype(shared_storage.tensors.shared_smem_A),
+        decltype(shared_storage.tensors.smem_B_phase1)>
+      phase1_view{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase1};
+    typename SharedStorage::template PhaseTensorStorageView<
+        decltype(shared_storage.tensors.shared_smem_A),
+        decltype(shared_storage.tensors.smem_B_phase2)>
+      phase2_view{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase2};
+
+    auto load_inputs   = collective_mainloop.load_init  (problem_shape_MNKL, phase1_view);
+    auto load_inputs_2 = collective_mainloop_2.load_init(problem_shape_MNKL, phase2_view);
+
+    MainloopPipelineState  mainloop_pipe_consumer_state;
+    MainloopPipelineState  mainloop_pipe_producer_state   = cutlass::make_producer_start_state<MainloopPipeline>();
+    MainloopPipelineState2 mainloop_pipe_consumer_state_2;
+    MainloopPipelineState2 mainloop_pipe_producer_state_2 = cutlass::make_producer_start_state<MainloopPipeline2>();
+
+    EpiLoadPipelineState  epi_load_pipe_consumer_state;
+    EpiLoadPipelineState  epi_load_pipe_producer_state   = cutlass::make_producer_start_state<EpiLoadPipeline>();
+    EpiLoadPipelineState2 epi_load_pipe_consumer_state_2;
+    EpiLoadPipelineState2 epi_load_pipe_producer_state_2 = cutlass::make_producer_start_state<EpiLoadPipeline2>();
+
+    // epilogue store pipe is producer-only (consumer is TMA unit, waits via scoreboarding)
+    EpiStorePipelineState  epi_store_pipe_producer_state   = cutlass::make_producer_start_state<EpiStorePipeline>();
+    EpiStorePipelineState2 epi_store_pipe_producer_state_2 = cutlass::make_producer_start_state<EpiStorePipeline2>();
+
+    CLCPipelineState clc_pipe_consumer_state;
+    CLCPipelineState clc_pipe_producer_state = cutlass::make_producer_start_state<CLCPipeline>();
+
+    AccumulatorPipelineState accumulator_pipe_consumer_state;
+    AccumulatorPipelineState accumulator_pipe_producer_state = cutlass::make_producer_start_state<AccumulatorPipeline>();
+
+    dim3 block_id_in_cluster = cute::block_id_in_cluster();
+
+    // Calculate mask after cluster barrier arrival (both mainloop pipelines).
+    mainloop_pipeline.init_masks(cluster_shape, block_id_in_cluster);
+    mainloop_pipeline_2.init_masks(cluster_shape, block_id_in_cluster);
+    accumulator_pipeline.init_masks(cluster_shape, block_id_in_cluster);
+
+    // TileID scheduler
+    TileScheduler scheduler(&shared_storage.clc_response[0], params.scheduler, block_id_in_cluster);
+    typename TileScheduler::WorkTileInfo work_tile_info = scheduler.initial_work_tile_info(cluster_shape);
+    auto cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+    //
+    // TMEM "Allocation"
+    //
+    auto tmem_storage = collective_mainloop.template init_tmem_tensors<EpilogueTile, IsOverlappingAccum>(EpilogueTile{});
+
+    pipeline_init_wait(cluster_size);
+
+    if (is_participant.main_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_arrive = is_epi_load_needed;
+      bool requires_clc_query = true;
+
+      do {
+        // K-tile iterator/count: both phases share the same K dim (X has
+        // the same K both times; W_gate and W_up have the same K dim).
+        auto k_tile_iter = scheduler.get_k_tile_iterator(work_tile_info, problem_shape_MNKL, CtaShape_MNK{}, load_inputs.k_tiles);
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+        auto k_tile_prologue = min(MainloopPipeline::Stages, k_tile_count);
+
+        if constexpr (IsSchedDynamicPersistent) {
+          if (is_first_cta_in_cluster && requires_clc_query) {
+            clc_throttle_pipeline.producer_acquire(clc_pipe_throttle_producer_state);
+            clc_throttle_pipeline.producer_commit(clc_pipe_throttle_producer_state);
+            ++clc_pipe_throttle_producer_state;
+          }
+        }
+
+        // -------- Stage E3: inline 3-TMA shared-pipeline main_load --------
+        {
+          auto& tma_load_a    = params.mainloop.tma_load_a;
+          auto& tma_load_b_p1 = params.mainloop.tma_load_b;
+          auto& tma_load_b_p2 = params.mainloop_2.tma_load_b;
+
+          auto atom_thr_M = size(typename TiledMma::AtomThrID{});
+          Tensor tAgA  = load_inputs.tAgA_mkl(cute::_, get<0>(cta_coord_mnkl) / atom_thr_M, cute::_, get<3>(cta_coord_mnkl));
+          Tensor tBgB1 = load_inputs.tBgB_nkl(cute::_, get<1>(cta_coord_mnkl), cute::_, get<3>(cta_coord_mnkl));
+          Tensor tBgB2 = load_inputs_2.tBgB_nkl(cute::_, get<1>(cta_coord_mnkl), cute::_, get<3>(cta_coord_mnkl));
+
+          auto barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+          int k_remaining = k_tile_count;
+          bool did_load_order_arrive_local = false;
+
+          CUTLASS_PRAGMA_NO_UNROLL
+          while (k_remaining > 0) {
+            mainloop_pipeline.producer_acquire(mainloop_pipe_producer_state, barrier_token);
+            using BarrierType = typename MainloopPipeline::ProducerBarrierType;
+            BarrierType* tma_barrier = mainloop_pipeline.producer_get_barrier(mainloop_pipe_producer_state);
+            int write_stage = mainloop_pipe_producer_state.index();
+            ++mainloop_pipe_producer_state;
+            barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+
+            if (cute::elect_one_sync()) {
+              cute::copy(tma_load_a   .with(*tma_barrier, load_inputs.mcast_mask_a),   tAgA (cute::_, *k_tile_iter), load_inputs.tAsA (cute::_, write_stage));
+              cute::copy(tma_load_b_p1.with(*tma_barrier, load_inputs.mcast_mask_b),   tBgB1(cute::_, *k_tile_iter), load_inputs.tBsB (cute::_, write_stage));
+              cute::copy(tma_load_b_p2.with(*tma_barrier, load_inputs_2.mcast_mask_b), tBgB2(cute::_, *k_tile_iter), load_inputs_2.tBsB(cute::_, write_stage));
+            }
+            if (do_load_order_arrive && !did_load_order_arrive_local) {
+              load_order_barrier.arrive();
+              do_load_order_arrive = false;
+              did_load_order_arrive_local = true;
+            }
+            --k_remaining;
+            ++k_tile_iter;
+          }
+        }
+        (void)k_tile_prologue;  // unused in Stage E3 inline main_load
+
+        // Sync warp to prevent non-participating threads entering next wave early
+        __syncwarp();
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+        requires_clc_query = increment_pipe;
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+      } while (work_tile_info.is_valid());
+      // Stage E3: single shared pipeline; mainloop_pipeline_2 unused.
+      collective_mainloop.load_tail(mainloop_pipeline, mainloop_pipe_producer_state);
+
+    }
+
+    else if (is_participant.sched) {
+      if constexpr (IsSchedDynamicPersistent) {
+        // Whether a new CLC query must be performed.
+        // See comment below where this variable is updated for a description of
+        // why this variable is needed.
+        bool requires_clc_query = true;
+
+        cutlass::arch::wait_on_dependent_grids();
+
+        do {
+          if (requires_clc_query) {
+            // Throttle CLC query to mitigate workload imbalance caused by skews among persistent workers.
+            clc_throttle_pipeline.consumer_wait(clc_pipe_throttle_consumer_state);
+            clc_throttle_pipeline.consumer_release(clc_pipe_throttle_consumer_state);
+            ++clc_pipe_throttle_consumer_state;
+
+            // Query next clcID and update producer state
+            clc_pipe_producer_state = scheduler.advance_to_next_work(clc_pipeline, clc_pipe_producer_state);
+          }
+
+          // Fetch next work tile
+          auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info,
+            clc_pipeline,
+            clc_pipe_consumer_state
+          );
+
+          // Only perform a new CLC query if we consumed a new CLC query result in
+          // `fetch_next_work`. An example of a case in which CLC `fetch_next_work` does
+          // not consume a new CLC query response is when processing stream-K units.
+          // The current stream-K scheduler uses single WorkTileInfo to track multiple
+          // (potentially-partial) tiles to be computed via stream-K. In this case,
+          // `fetch_next_work` simply performs in-place updates on the existing WorkTileInfo,
+          // rather than consuming a CLC query response.
+          requires_clc_query = increment_pipe;
+          if (increment_pipe) {
+            ++clc_pipe_consumer_state;
+          }
+
+          work_tile_info = next_work_tile_info;
+        } while (work_tile_info.is_valid());
+        clc_pipeline.producer_tail(clc_pipe_producer_state);
+      }
+    }
+
+    else if (is_participant.mma) {
+      // TMEM allocation sequence — ONE allocate() per kernel.  Both
+      // phases re-bind their logical tmem_storage to the same base
+      // address; physical columns are time-multiplexed across phases
+      // via consecutive AccPipe slot indices.
+      tmem_allocator.allocate(TmemAllocator::Sm100TmemCapacityColumns, &shared_storage.tmem_base_ptr);
+      __syncwarp();
+      tmem_allocation_result_barrier.arrive();
+      uint32_t tmem_base_ptr = shared_storage.tmem_base_ptr;
+      collective_mainloop  .set_tmem_offsets(tmem_storage, tmem_base_ptr);
+
+      typename SharedStorage::template PhaseTensorStorageView<
+          decltype(shared_storage.tensors.shared_smem_A),
+          decltype(shared_storage.tensors.smem_B_phase1)>
+        phase1_view_mma{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase1};
+      typename SharedStorage::template PhaseTensorStorageView<
+          decltype(shared_storage.tensors.shared_smem_A),
+          decltype(shared_storage.tensors.smem_B_phase2)>
+        phase2_view_mma{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase2};
+
+      auto mma_inputs   = collective_mainloop.mma_init  (tmem_storage, phase1_view_mma);
+      auto mma_inputs_2 = collective_mainloop_2.mma_init(tmem_storage, phase2_view_mma);
+
+      do {
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        // -------- Phase 1 (gate) MMA --------
+        int acc_stage = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_producer_state.phase() ^ 1;
+          }
+          else {
+            return accumulator_pipe_producer_state.index();
+          }
+        }();
+
+        // -------- Stage E3: inline K-tile interleaved phase1+phase2 MMA --------
+        // Single shared mainloop_pipeline.  Per K-tile slot: phase 1 mma
+        // (A, B_phase1) → acc_p1, then phase 2 mma (A, B_phase2) → acc_p2.
+        // Both phases release the slot each iteration so pipeline reaches
+        // the 2x consumer arrival count and producer can wrap.
+        int acc_stage_2 = [&] () {
+          // Compute phase 2's acc slot — uses NEXT acc_pipe slot from phase 1.
+          if constexpr (IsOverlappingAccum) {
+            return ((accumulator_pipe_producer_state.phase() ^ 1) + 1) % AccumulatorPipelineStageCount;
+          }
+          else {
+            return (accumulator_pipe_producer_state.index() + 1) % AccumulatorPipelineStageCount;
+          }
+        }();
+
+        if (is_mma_leader_cta) {
+          // Acquire acc pipe slots for both phases.
+          accumulator_pipeline.producer_acquire(accumulator_pipe_producer_state);
+          AccumulatorPipelineState acc_state_p2 = accumulator_pipe_producer_state;
+          ++acc_state_p2;
+          accumulator_pipeline.producer_acquire(acc_state_p2);
+
+          // Get phase 1 and phase 2 accumulators (different TMEM column slots).
+          auto acc_p1 = get<0>(collective_mainloop.slice_accumulator(tmem_storage, acc_stage));
+          auto acc_p2 = get<0>(collective_mainloop_2.slice_accumulator(tmem_storage, acc_stage_2));
+
+          // Unpack mma_inputs.
+          auto [tiled_mma_p1, tCrA_p1, tCrB_p1] = mma_inputs;
+          auto [tiled_mma_p2, tCrA_p2, tCrB_p2] = mma_inputs_2;
+          tiled_mma_p1.accumulate_ = cute::UMMA::ScaleOut::Zero;
+          tiled_mma_p2.accumulate_ = cute::UMMA::ScaleOut::Zero;
+
+          // K-tile interleaved loop.
+          uint32_t skip_wait = k_tile_count <= 0;
+          auto barrier_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+          int k_remaining = k_tile_count;
+          CUTLASS_PRAGMA_NO_UNROLL
+          while (k_remaining > 0) {
+            mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, barrier_token);
+            int read_stage = mainloop_pipe_consumer_state.index();
+            auto cur_state = mainloop_pipe_consumer_state;
+            ++mainloop_pipe_consumer_state;
+            --k_remaining;
+            skip_wait = k_remaining <= 0;
+            barrier_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+
+            // Phase 1 tcgen05.mma (A from shared, B from smem_B_phase1)
+            CUTLASS_PRAGMA_UNROLL
+            for (int k_block = 0; k_block < size<2>(tCrA_p1); ++k_block) {
+              cute::gemm(tiled_mma_p1,
+                         tCrA_p1(cute::_, cute::_, k_block, read_stage),
+                         tCrB_p1(cute::_, cute::_, k_block, read_stage),
+                         acc_p1);
+              tiled_mma_p1.accumulate_ = cute::UMMA::ScaleOut::One;
+            }
+            // Phase 1 release this slot (1 of 2 consumer arrivals)
+            mainloop_pipeline.consumer_release(cur_state);
+
+            // Phase 2 tcgen05.mma (A from SAME shared, B from smem_B_phase2)
+            CUTLASS_PRAGMA_UNROLL
+            for (int k_block = 0; k_block < size<2>(tCrA_p2); ++k_block) {
+              cute::gemm(tiled_mma_p2,
+                         tCrA_p2(cute::_, cute::_, k_block, read_stage),
+                         tCrB_p2(cute::_, cute::_, k_block, read_stage),
+                         acc_p2);
+              tiled_mma_p2.accumulate_ = cute::UMMA::ScaleOut::One;
+            }
+            // Phase 2 release this slot (2 of 2 consumer arrivals → slot free)
+            mainloop_pipeline.consumer_release(cur_state);
+          }
+
+          // Commit both phases' acc slots.
+          accumulator_pipeline.producer_commit(accumulator_pipe_producer_state);
+          accumulator_pipeline.producer_commit(acc_state_p2);
+        }
+        // Advance acc pipe state by 2 (both phases committed) for next work tile.
+        ++accumulator_pipe_producer_state;
+        ++accumulator_pipe_producer_state;
+
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Hint on an early release of global memory resources.
+      // The timing of calling this function only influences performance,
+      // not functional correctness.
+      cutlass::arch::launch_dependent_grids();
+
+      // Release the right to allocate before deallocations so that the next CTA can rasterize
+      tmem_allocator.release_allocation_lock();
+
+      if constexpr (!IsOverlappingAccum) {
+        // Leader MMA waits for leader + peer epilogues to release accumulator stage
+        if (is_mma_leader_cta) {
+          accumulator_pipeline.producer_tail(accumulator_pipe_producer_state);
+        }
+        // Signal to peer MMA that entire tmem allocation can be deallocated
+        if constexpr (has_mma_peer_cta) {
+          // Leader does wait + arrive, follower does arrive + wait
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank, not is_mma_leader_cta);
+          tmem_deallocation_result_barrier.wait(dealloc_barrier_phase);
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank, is_mma_leader_cta);
+        }
+      }
+      else {
+        tmem_deallocation_result_barrier.wait(dealloc_barrier_phase);
+      }
+
+      // Free entire tmem allocation
+      tmem_allocator.free(tmem_base_ptr, TmemAllocator::Sm100TmemCapacityColumns);
+    }
+
+    else if (is_participant.epi_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_wait = true;
+      bool do_tail_load = false;
+      int current_wave = 0;
+
+      do {
+        bool compute_epilogue = TileScheduler::compute_epilogue(work_tile_info, params.scheduler);
+
+        // Get current work tile and fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+        work_tile_info = next_work_tile_info;
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        if (compute_epilogue) {
+          if (do_load_order_wait) {
+            load_order_barrier.wait();
+            do_load_order_wait = false;
+          }
+
+          bool reverse_epi_n = IsOverlappingAccum && (current_wave % 2 == 0);
+
+          // Phase 1 (gate) epilogue producer-load — only fires if the
+          // phase-1 epilogue actually consumes source C/aux.  For
+          // LinComb beta=0 path this is a fast no-op.
+          if (is_epi_load_needed_1) {
+            epi_load_pipe_producer_state = collective_epilogue.template load<IsOverlappingAccum>(
+              epi_load_pipeline,
+              epi_load_pipe_producer_state,
+              problem_shape_MNKL,
+              CtaShape_MNK{},
+              cta_coord_mnkl,
+              TileShape{},
+              TiledMma{},
+              shared_storage.tensors.epilogue,
+              reverse_epi_n
+            );
+          }
+
+          // Phase 2 (up) epilogue producer-load
+          if (is_epi_load_needed_2) {
+            epi_load_pipe_producer_state_2 = collective_epilogue_2.template load<IsOverlappingAccum>(
+              epi_load_pipeline_2,
+              epi_load_pipe_producer_state_2,
+              problem_shape_MNKL,
+              CtaShape_MNK{},
+              cta_coord_mnkl,
+              TileShape{},
+              TiledMma{},
+              shared_storage.tensors.epilogue_2,
+              reverse_epi_n
+            );
+          }
+
+          do_tail_load = true;
+        }
+        current_wave++;
+
+        // Calculate the cta coordinates of the next work tile
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Only perform a tail load if one of the work units processed performed
+      // an epilogue load.  Both phases drain.
+      if (do_tail_load) {
+        if (is_epi_load_needed_1) {
+          collective_epilogue.load_tail(
+            epi_load_pipeline, epi_load_pipe_producer_state,
+            epi_store_pipeline, epi_store_pipe_producer_state);
+        }
+        if (is_epi_load_needed_2) {
+          collective_epilogue_2.load_tail(
+            epi_load_pipeline_2, epi_load_pipe_producer_state_2,
+            epi_store_pipeline_2, epi_store_pipe_producer_state_2);
+        }
+      }
+    }
+
+    else if (is_participant.epilogue) {
+      // Wait for tmem allocate here
+      tmem_allocation_result_barrier.arrive_and_wait();
+      uint32_t tmem_base_ptr = shared_storage.tmem_base_ptr;
+      collective_mainloop.set_tmem_offsets(tmem_storage, tmem_base_ptr);
+
+      bool do_tail_store = false;
+      do {
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        // -------- Phase 1 (gate) epilogue --------
+        int acc_stage = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_consumer_state.phase();
+          }
+          else {
+            return accumulator_pipe_consumer_state.index();
+          }
+        }();
+
+        auto accumulator = get<0>(collective_mainloop.slice_accumulator(tmem_storage, acc_stage));
+        accumulator_pipe_consumer_state = scheduler.template fixup<IsComplex>(
+          TiledMma{},
+          work_tile_info,
+          accumulator,
+          accumulator_pipeline,
+          accumulator_pipe_consumer_state,
+          typename CollectiveEpilogue::CopyOpT2R{}
+        );
+
+        if (scheduler.compute_epilogue(work_tile_info)) {
+          auto [load_state_next, store_state_next, acc_state_next] = collective_epilogue.template store<IsOverlappingAccum>(
+            epi_load_pipeline,
+            epi_load_pipe_consumer_state,
+            epi_store_pipeline,
+            epi_store_pipe_producer_state,
+            accumulator_pipeline,
+            accumulator_pipe_consumer_state,
+            problem_shape_MNKL,
+            CtaShape_MNK{},
+            cta_coord_mnkl,
+            TileShape{},
+            TiledMma{},
+            accumulator,
+            shared_storage.tensors.epilogue
+          );
+          epi_load_pipe_consumer_state    = load_state_next;
+          epi_store_pipe_producer_state   = store_state_next;
+          accumulator_pipe_consumer_state = acc_state_next;
+          do_tail_store = true;
+        }
+
+        // -------- Cross-phase SMEM bridge --------
+        // Phase 1's Sm100SmemAuxStore visitor wrote gate values to its own
+        // SharedStorage::smem_aux (inside collective_epilogue's TensorStorage).
+        // Phase 2's Sm100SmemAuxLoad visitor reads from its own SharedStorage,
+        // which is a DIFFERENT region.  Copy phase 1 → phase 2 here.
+        // S2S is fast (~8 KB per tile).
+        {
+          // Access pointers via the FusionCallbacks visitor tree.  ops tuple
+          // ordering: children-first, node-last.  For both phases the
+          // SmemAux{Store,Load} visitor sits at ops index 1.
+          auto& aux_store = cute::get<1>(collective_epilogue.fusion_callbacks.ops);
+          auto& aux_load  = cute::get<1>(collective_epilogue_2.fusion_callbacks.ops);
+          auto* src = aux_store.smem_aux;
+          auto* dst = aux_load.smem_aux;
+          using SmemLayout = typename cute::remove_reference_t<decltype(aux_store)>::SmemLayout;
+          constexpr int N_elts = cute::cosize_v<SmemLayout>;
+          // Epilogue threads are warps 4..(NumEpilogueWarps+3) — offset by
+          // (4 * NumThreadsPerWarp).  Use epilogue-local index 0..255.
+          int local_tid = threadIdx.x - (4 * NumThreadsPerWarp);
+          // Real S2S copy: phase 1 smem_aux → phase 2 smem_aux.
+          for (int i = local_tid; i < N_elts; i += NumEpilogueThreads) {
+            dst[i] = src[i];
+          }
+          // Fence + barrier so dst writes visible before phase 2 epilogue reads.
+          // Use a barrier id distinct from CUTLASS's EpilogueBarrier (used
+          // internally by Sm100 epilogue's NamedBarrier::sync()).
+          cutlass::arch::fence_view_async_shared();
+          cutlass::arch::NamedBarrier(NumEpilogueThreads, /*barrier_id=*/0).sync();
+        }
+
+        // -------- Phase 2 (up) epilogue --------
+        // Consumer state has advanced past phase 1's slot; phase 2
+        // consumes the next AccPipe slot which holds phase 2's MMA result
+        // for this work tile.
+        int acc_stage_2 = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_consumer_state.phase();
+          }
+          else {
+            return accumulator_pipe_consumer_state.index();
+          }
+        }();
+
+        auto accumulator_2 = get<0>(collective_mainloop_2.slice_accumulator(tmem_storage, acc_stage_2));
+        accumulator_pipe_consumer_state = scheduler.template fixup<IsComplex>(
+          TiledMma{},
+          work_tile_info,
+          accumulator_2,
+          accumulator_pipeline,
+          accumulator_pipe_consumer_state,
+          typename CollectiveEpilogue2::CopyOpT2R{}
+        );
+
+        if (scheduler.compute_epilogue(work_tile_info)) {
+          auto [load_state_next, store_state_next, acc_state_next] = collective_epilogue_2.template store<IsOverlappingAccum>(
+            epi_load_pipeline_2,
+            epi_load_pipe_consumer_state_2,
+            epi_store_pipeline_2,
+            epi_store_pipe_producer_state_2,
+            accumulator_pipeline,
+            accumulator_pipe_consumer_state,
+            problem_shape_MNKL,
+            CtaShape_MNK{},
+            cta_coord_mnkl,
+            TileShape{},
+            TiledMma{},
+            accumulator_2,
+            shared_storage.tensors.epilogue_2
+          );
+          epi_load_pipe_consumer_state_2    = load_state_next;
+          epi_store_pipe_producer_state_2   = store_state_next;
+          accumulator_pipe_consumer_state   = acc_state_next;
+          do_tail_store = true;
+        }
+
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+
+      } while (work_tile_info.is_valid());
+
+      if constexpr (IsOverlappingAccum) {
+        // Signal to peer MMA that Full TMEM alloc can be deallocated
+        if constexpr (has_mma_peer_cta) {
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank);
+        }
+        tmem_deallocation_result_barrier.arrive();
+      }
+
+      // Tail store for both phases.
+      if (do_tail_store) {
+        collective_epilogue.store_tail(
+          epi_load_pipeline, epi_load_pipe_consumer_state,
+          epi_store_pipeline, epi_store_pipe_producer_state,
+          CtaShape_MNK{});
+        collective_epilogue_2.store_tail(
+          epi_load_pipeline_2, epi_load_pipe_consumer_state_2,
+          epi_store_pipeline_2, epi_store_pipe_producer_state_2,
+          CtaShape_MNK{});
+      }
+    }
+
+    else {
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass::gemm::kernel

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_g8_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_g8_kernel.hpp
@@ -54,8 +54,6 @@
 //
 // Stage D: share SMEM_A across phases (X is the same input for both
 // gate and up).  Performance optimization on top of Stage C.
-//
-// Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
 // ============================================================================
 
 #include "cutlass/cutlass.h"
@@ -453,7 +451,7 @@ public:
       implementable &= size(args.hw_info.cluster_shape_fallback) <= MaxClusterSize;
       implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
     }
-    
+
     constexpr bool IsBlockscaled = !cute::is_void_v<ElementSF>;
     if constexpr (IsBlockscaled) {
       if constexpr (IsDynamicCluster) {

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_kernel.hpp
@@ -1,0 +1,1380 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#pragma once
+
+// ============================================================================
+// FlashRtMegakernelGeGLUFusedGemm — the megakernel kernel struct for the
+// Pi0.5 encoder split-G7 path.
+//
+// Stage A.0 (this commit): byte-for-byte copy of the vendored production
+// SM100 single-GEMM kernel (`flashrt_megakernel_kernel.hpp`) with ONLY the
+// class name renamed.  Functionally identical to single GEMM at this
+// stage; serves as a build/wiring scaffold.
+//
+// Stage A.1 (next): extend struct to TWO Mainloop+Epilogue template
+// params; operator() body chains phase1 (gate) + phase2 (up) serially
+// per work tile, sharing one tcgen05.alloc.  Both phases still write to
+// gmem (no SMEM_gate routing yet).
+//
+// Stage B: redirect phase1 epilogue store target from gmem D_gate to a
+// SharedStorage::smem_gate buffer (suppress TMA store).
+//
+// Stage C: add `Sm100SmemGateLoad` EVT visitor to phase2 epilogue and
+// fuse the gate × up multiply in-register.  This is the cosine-correct
+// MK-1 ship candidate.
+//
+// Stage D: share SMEM_A across phases (X is the same input for both
+// gate and up).  Performance optimization on top of Stage C.
+//
+// Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
+// ============================================================================
+
+#include "cutlass/cutlass.h"
+#include "cutlass/workspace.h"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "cutlass/detail/cluster.hpp"
+#include "cutlass/arch/grid_dependency_control.h"
+#include "cutlass/fast_math.h"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cutlass/arch/arch.h"
+#include "cutlass/arch/barrier.h"
+#include "cutlass/arch/reg_reconfig.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/detail/mainloop_fusion_helper_scale_factor.hpp"
+#include "cutlass/gemm/kernel/sm100_tile_scheduler.hpp"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/detail/sm100_tmem_helper.hpp"
+
+#include "cute/tensor.hpp"
+#include "cute/arch/tmem_allocator_sm100.hpp"
+#include "cute/atom/mma_atom.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::kernel {
+
+// Bring CUTLASS identifiers (used unqualified in the vendored kernel
+// body) into scope.  In production these are found via ADL because
+// the kernel lives in cutlass::gemm::kernel; in flashrt::megakernel
+// they need explicit using-declarations.
+using cutlass::gemm::KernelTmaWarpSpecializedSm100;
+using cutlass::gemm::KernelTmaWarpSpecializedBlockScaledSm100;
+using cutlass::NumThreadsPerWarp;
+using cutlass::MinWorkspaceAlignment;
+
+// Primary template (forward declaration).  Mirrors
+// cutlass::gemm::kernel::GemmUniversal but takes TWO mainloop+epilogue
+// collectives for the gate / up chain.  Per-phase types must be
+// structurally identical (same Tile, Cluster, TiledMma, EpilogueTile);
+// they differ only in their TMA descriptors (gate loads W_gate; up
+// loads W_up) and epilogue activation (gate=GELU, up=Identity).
+template <
+  class ProblemShape_,
+  class CollectiveMainloop_,    // phase 1 (gate)
+  class CollectiveEpilogue_,    // phase 1 (gate) — applies GELU
+  class CollectiveMainloop2_,   // phase 2 (up)
+  class CollectiveEpilogue2_,   // phase 2 (up) — Identity (no activation)
+  class TileSchedulerTag_ = void,
+  class Enable = void
+>
+class FlashRtMegakernelGeGLUFusedGemm;
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+  class ProblemShape_,
+  class CollectiveMainloop_,
+  class CollectiveEpilogue_,
+  class CollectiveMainloop2_,
+  class CollectiveEpilogue2_,
+  class TileSchedulerTag_
+>
+class FlashRtMegakernelGeGLUFusedGemm<
+  ProblemShape_,
+  CollectiveMainloop_,
+  CollectiveEpilogue_,
+  CollectiveMainloop2_,
+  CollectiveEpilogue2_,
+  TileSchedulerTag_,
+  cute::enable_if_t<
+    cute::disjunction_v<cutlass::detail::is_kernel_tag_of<typename CollectiveMainloop_::DispatchPolicy::Schedule,
+                                KernelTmaWarpSpecializedSm100>,
+    cutlass::detail::is_kernel_tag_of<typename CollectiveMainloop_::DispatchPolicy::Schedule,
+                                KernelTmaWarpSpecializedBlockScaledSm100>>>>
+{
+public:
+  //
+  // Type Aliases
+  //
+  using ProblemShape = ProblemShape_;
+  static_assert(rank(ProblemShape{}) == 3 or rank(ProblemShape{}) == 4,
+    "ProblemShape{} should be <M,N,K> or <M,N,K,L>");
+
+  // Mainloop derived types
+  using CollectiveMainloop = CollectiveMainloop_;
+  using TileShape = typename CollectiveMainloop::TileShape;
+  using TiledMma  = typename CollectiveMainloop::TiledMma;
+  using ArchTag   = typename CollectiveMainloop::ArchTag;
+  using ElementA  = typename CollectiveMainloop::ElementA;
+  using StrideA   = typename CollectiveMainloop::StrideA;
+  using ElementB  = typename CollectiveMainloop::ElementB;
+  using StrideB   = typename CollectiveMainloop::StrideB;
+  using LayoutSFA = typename cutlass::detail::LayoutSFAType<CollectiveMainloop>::type;
+  using LayoutSFB = typename cutlass::detail::LayoutSFBType<CollectiveMainloop>::type;
+  using ElementSF = typename cutlass::detail::ElementSFType<CollectiveMainloop>::type;
+  using DispatchPolicy = typename CollectiveMainloop::DispatchPolicy;
+  using ElementAccumulator = typename CollectiveMainloop::ElementAccumulator;
+  using ClusterShape = typename DispatchPolicy::ClusterShape;
+  using MainloopArguments = typename CollectiveMainloop::Arguments;
+  using MainloopParams = typename CollectiveMainloop::Params;
+  static_assert(ArchTag::kMinComputeCapability >= 100);
+
+  // Epilogue derived types
+  using CollectiveEpilogue = CollectiveEpilogue_;
+  using EpilogueTile = typename CollectiveEpilogue::EpilogueTile;
+  using ElementC = typename CollectiveEpilogue::ElementC;
+  using StrideC  = typename CollectiveEpilogue::StrideC;
+  using ElementD = typename CollectiveEpilogue::ElementD;
+  using StrideD  = typename CollectiveEpilogue::StrideD;
+  using EpilogueArguments = typename CollectiveEpilogue::Arguments;
+  using EpilogueParams = typename CollectiveEpilogue::Params;
+  static constexpr bool IsComplex = CollectiveEpilogue::NumAccumulatorMtxs == 2;
+
+  // ============================================================================
+  // Phase 2 (up) collectives.  Must match phase 1 structurally — same
+  // TileShape, ClusterShape, TiledMma, EpilogueTile, ElementA — so a
+  // single TMEM allocation can be serially reused (slice_accumulator
+  // semantics are well-defined only when the underlying acc shape is
+  // identical).  These asserts catch mismatches at compile time.
+  // ============================================================================
+  using CollectiveMainloop2 = CollectiveMainloop2_;
+  using CollectiveEpilogue2 = CollectiveEpilogue2_;
+  using MainloopArguments2 = typename CollectiveMainloop2::Arguments;
+  using MainloopParams2    = typename CollectiveMainloop2::Params;
+  using EpilogueArguments2 = typename CollectiveEpilogue2::Arguments;
+  using EpilogueParams2    = typename CollectiveEpilogue2::Params;
+
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::TileShape, TileShape>,
+                "Phase 2 mainloop TileShape must match phase 1 (shared TMEM constraint).");
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::DispatchPolicy::ClusterShape, ClusterShape>,
+                "Phase 2 mainloop ClusterShape must match phase 1.");
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::TiledMma, TiledMma>,
+                "Phase 2 mainloop TiledMma must match phase 1 (TMEM accumulator layout depends on TiledMma).");
+  static_assert(cute::is_same_v<typename CollectiveMainloop2::ElementA, ElementA>,
+                "Phase 2 mainloop ElementA must match phase 1.");
+  static_assert(cute::is_same_v<typename CollectiveEpilogue2::EpilogueTile, EpilogueTile>,
+                "Phase 2 EpilogueTile must match phase 1.");
+
+  // CLC pipeline depth
+  // determines how many waves (stages-1) a warp can race ahead
+  static constexpr uint32_t SchedulerPipelineStageCount = DispatchPolicy::Schedule::SchedulerPipelineStageCount;
+  static constexpr uint32_t AccumulatorPipelineStageCount = DispatchPolicy::Schedule::AccumulatorPipelineStageCount;
+  static constexpr bool IsOverlappingAccum = DispatchPolicy::IsOverlappingAccum;
+
+  // TileID scheduler
+  // Get Blk and Scheduling tile shapes
+  using AtomThrShapeMNK = typename CollectiveMainloop::AtomThrShapeMNK;
+  using CtaShape_MNK = typename CollectiveMainloop::CtaShape_MNK;
+  using TileSchedulerTag = TileSchedulerTag_;
+  using TileScheduler = typename detail::TileSchedulerSelector<
+    TileSchedulerTag, ArchTag, CtaShape_MNK, ClusterShape, SchedulerPipelineStageCount>::Scheduler;
+  using TileSchedulerArguments = typename TileScheduler::Arguments;
+  using TileSchedulerParams = typename TileScheduler::Params;
+
+  static constexpr bool IsSchedDynamicPersistent = TileScheduler::IsDynamicPersistent;
+  static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+  static constexpr bool IsGdcEnabled = cutlass::arch::IsGdcGloballyEnabled;
+
+  // Warp specialization thread count per threadblock
+  static constexpr uint32_t NumSchedThreads        = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumMMAThreads          = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumMainloopLoadThreads = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumEpilogueLoadThreads = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumEpilogueThreads     = CollectiveEpilogue::ThreadCount;
+  static constexpr uint32_t NumEpilogueWarps       = NumEpilogueThreads / NumThreadsPerWarp;
+
+  static constexpr uint32_t MaxThreadsPerBlock = NumSchedThreads +
+                                                 NumMainloopLoadThreads + NumMMAThreads +
+                                                 NumEpilogueLoadThreads + NumEpilogueThreads;
+  static constexpr uint32_t MinBlocksPerMultiprocessor = 1;
+
+  static constexpr uint32_t NumEpilogueSubTiles = CollectiveEpilogue::get_load_pipe_increment(CtaShape_MNK{});
+
+  // Fixup performed for split-/stream-K is done across warps in different CTAs
+  // at epilogue subtile granularity. Thus, there must be one barrier per sub-tile per
+  // epilogue warp.
+  static constexpr uint32_t NumFixupBarriers = 1;
+  static constexpr uint32_t CLCResponseSize = sizeof(typename TileScheduler::CLCResponse);
+
+  // Phase 2 thread-count must match phase 1 for shared CLC + AccPipe arrival counts.
+  static_assert(CollectiveEpilogue2::ThreadCount == CollectiveEpilogue::ThreadCount,
+                "Phase 2 epilogue ThreadCount must match phase 1 (shared CLC pipeline arrivals).");
+
+  // Pipeline and pipeline state types — phase 1 (gate)
+  using MainloopPipeline = typename CollectiveMainloop::MainloopPipeline;
+  using MainloopPipelineState = typename CollectiveMainloop::MainloopPipelineState;
+
+  using EpiLoadPipeline = typename CollectiveEpilogue::LoadPipeline;
+  using EpiLoadPipelineState = typename CollectiveEpilogue::LoadPipelineState;
+
+  using EpiStorePipeline = typename CollectiveEpilogue::StorePipeline;
+  using EpiStorePipelineState = typename CollectiveEpilogue::StorePipelineState;
+
+  // Pipeline types — phase 2 (up).  Same template instances as phase 1
+  // when the underlying CollectiveBuilder produced compatible mainloop /
+  // epilogue collectives; the doubling is for separate SMEM rings and
+  // separate producer/consumer state machines.
+  using MainloopPipeline2 = typename CollectiveMainloop2::MainloopPipeline;
+  using MainloopPipelineState2 = typename CollectiveMainloop2::MainloopPipelineState;
+
+  using EpiLoadPipeline2 = typename CollectiveEpilogue2::LoadPipeline;
+  using EpiLoadPipelineState2 = typename CollectiveEpilogue2::LoadPipelineState;
+
+  using EpiStorePipeline2 = typename CollectiveEpilogue2::StorePipeline;
+  using EpiStorePipelineState2 = typename CollectiveEpilogue2::StorePipelineState;
+
+  using LoadOrderBarrier = cutlass::OrderedSequenceBarrier<1,2>;
+
+  using AccumulatorPipeline = cutlass::PipelineUmmaAsync<AccumulatorPipelineStageCount, AtomThrShapeMNK>;
+  using AccumulatorPipelineState = typename AccumulatorPipeline::PipelineState;
+
+  using CLCPipeline = cutlass::PipelineCLCFetchAsync<SchedulerPipelineStageCount, ClusterShape>;
+  using CLCPipelineState = typename CLCPipeline::PipelineState;
+
+  using CLCThrottlePipeline = cutlass::PipelineAsync<SchedulerPipelineStageCount>;
+  using CLCThrottlePipelineState = typename CLCThrottlePipeline::PipelineState;
+
+  using TmemAllocator = cute::conditional_t<cute::size(cute::shape<0>(typename TiledMma::ThrLayoutVMNK{})) == 1,
+      cute::TMEM::Allocator1Sm, cute::TMEM::Allocator2Sm>;
+
+  // Kernel level shared memory storage
+  struct SharedStorage {
+    struct PipelineStorage : cute::aligned_struct<16, _1> {
+      using MainloopPipelineStorage  = typename CollectiveMainloop::PipelineStorage;
+      using EpiLoadPipelineStorage   = typename CollectiveEpilogue::PipelineStorage;
+      using MainloopPipelineStorage2 = typename CollectiveMainloop2::PipelineStorage;
+      using EpiLoadPipelineStorage2  = typename CollectiveEpilogue2::PipelineStorage;
+      using LoadOrderBarrierStorage  = typename LoadOrderBarrier::SharedStorage;
+      using CLCPipelineStorage       = typename CLCPipeline::SharedStorage;
+      using AccumulatorPipelineStorage = typename AccumulatorPipeline::SharedStorage;
+      using CLCThrottlePipelineStorage = typename CLCThrottlePipeline::SharedStorage;
+
+      // Doubled (per phase) — separate SMEM rings + state machines.
+      alignas(16) MainloopPipelineStorage  mainloop;
+      alignas(16) MainloopPipelineStorage2 mainloop_2;
+      alignas(16) EpiLoadPipelineStorage   epi_load;
+      alignas(16) EpiLoadPipelineStorage2  epi_load_2;
+      // Single (shared across phases) — natural slot-wrap serialization.
+      alignas(16) LoadOrderBarrierStorage     load_order;
+      alignas(16) CLCPipelineStorage          clc;
+      alignas(16) AccumulatorPipelineStorage  accumulator;
+      alignas(16) CLCThrottlePipelineStorage  clc_throttle;
+      alignas(16) arch::ClusterBarrier        tmem_dealloc;
+    } pipelines;
+
+    alignas(16) typename TileScheduler::CLCResponse clc_response[SchedulerPipelineStageCount];
+    uint32_t tmem_base_ptr;
+
+    struct TensorStorage : cute::aligned_struct<128, _1> {
+      using EpilogueTensorStorage   = typename CollectiveEpilogue::TensorStorage;
+      using EpilogueTensorStorage2  = typename CollectiveEpilogue2::TensorStorage;
+
+      EpilogueTensorStorage   epilogue;
+      EpilogueTensorStorage2  epilogue_2;
+
+      // Stage E3: shared smem_A + per-phase smem_B
+      using SmemAllocTypeA  = typename CollectiveMainloop::SmemAllocTypeA;
+      using SmemAllocTypeB  = typename CollectiveMainloop::SmemAllocTypeB;
+      using SmemAllocTypeB2 = typename CollectiveMainloop2::SmemAllocTypeB;
+      static constexpr int SmemA_Elems  = cute::cosize_v<typename CollectiveMainloop::SmemLayoutA>;
+      static constexpr int SmemB1_Elems = cute::cosize_v<typename CollectiveMainloop::SmemLayoutB>;
+      static constexpr int SmemB2_Elems = cute::cosize_v<typename CollectiveMainloop2::SmemLayoutB>;
+
+      cute::ArrayEngine<SmemAllocTypeA,  SmemA_Elems>  shared_smem_A;
+      cute::ArrayEngine<SmemAllocTypeB,  SmemB1_Elems> smem_B_phase1;
+      cute::ArrayEngine<SmemAllocTypeB2, SmemB2_Elems> smem_B_phase2;
+    } tensors;
+
+    template <class SmemABuf, class SmemBBuf>
+    struct PhaseTensorStorageView {
+      SmemABuf& smem_A;
+      SmemBBuf& smem_B;
+    };
+  };
+
+  static constexpr int SharedStorageSize = sizeof(SharedStorage);
+
+  // Host facing host arguments
+  struct Arguments {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    // Phase 1 (gate)
+    MainloopArguments  mainloop{};
+    EpilogueArguments  epilogue{};
+    // Phase 2 (up)
+    MainloopArguments2 mainloop_2{};
+    EpilogueArguments2 epilogue_2{};
+    KernelHardwareInfo hw_info{};
+    TileSchedulerArguments scheduler{};
+  };
+
+  // Kernel device entry point API
+  struct Params {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    MainloopParams  mainloop{};
+    EpilogueParams  epilogue{};
+    MainloopParams2 mainloop_2{};
+    EpilogueParams2 epilogue_2{};
+    TileSchedulerParams scheduler{};
+    KernelHardwareInfo hw_info{};
+  };
+
+  enum class WarpCategory : int32_t {
+    MMA          = 0,
+    Sched        = 1,
+    MainloopLoad = 2,
+    EpilogueLoad = 3,
+    Epilogue     = 4
+  };
+
+  struct IsParticipant {
+    uint32_t mma       = false;
+    uint32_t sched     = false;
+    uint32_t main_load = false;
+    uint32_t epi_load  = false;
+    uint32_t epilogue  = false;
+  };
+
+  //
+  // Methods
+  //
+
+  // Convert to underlying arguments.
+  static
+  Params
+  to_underlying_arguments(Arguments const& args, void* workspace) {
+    (void) workspace;
+    auto problem_shape = args.problem_shape;
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+
+    // Get SM count if needed, otherwise use user supplied SM count
+    int sm_count = args.hw_info.sm_count;
+    if (sm_count != 0) {
+      CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
+          "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).");
+    }
+    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
+
+    // Calculate workspace pointers
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+
+    // Epilogue phase 1 (gate)
+    void* epilogue_workspace = workspace_ptr + workspace_offset;
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    // Epilogue phase 2 (up)
+    void* epilogue_workspace_2 = workspace_ptr + workspace_offset;
+    workspace_offset += CollectiveEpilogue2::get_workspace_size(args.problem_shape, args.epilogue_2);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    void* mainloop_workspace = nullptr;
+
+    // Tile scheduler
+    void* scheduler_workspace = workspace_ptr + workspace_offset;
+    workspace_offset += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    return {
+      args.mode,
+      args.problem_shape,
+      CollectiveMainloop::to_underlying_arguments(args.problem_shape, args.mainloop, mainloop_workspace, args.hw_info),
+      CollectiveEpilogue::to_underlying_arguments(args.problem_shape, args.epilogue, epilogue_workspace),
+      CollectiveMainloop2::to_underlying_arguments(args.problem_shape, args.mainloop_2, mainloop_workspace, args.hw_info),
+      CollectiveEpilogue2::to_underlying_arguments(args.problem_shape, args.epilogue_2, epilogue_workspace_2),
+      TileScheduler::to_underlying_arguments(
+        problem_shape_MNKL, TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
+        args.hw_info, args.scheduler, scheduler_workspace
+      )
+      ,args.hw_info
+    };
+  }
+
+  static bool
+  can_implement(Arguments const& args) {
+    bool implementable = (args.mode == GemmUniversalMode::kGemm) or
+        (args.mode == GemmUniversalMode::kBatched && rank(ProblemShape{}) == 4);
+    if (!implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: Arguments or Problem Shape don't meet the requirements.\n");
+      return implementable;
+    }
+    implementable &= CollectiveMainloop::can_implement(args.problem_shape, args.mainloop);
+    implementable &= CollectiveEpilogue::can_implement(args.problem_shape, args.epilogue);
+    implementable &= CollectiveMainloop2::can_implement(args.problem_shape, args.mainloop_2);
+    implementable &= CollectiveEpilogue2::can_implement(args.problem_shape, args.epilogue_2);
+    implementable &= TileScheduler::can_implement(args.scheduler);
+
+    if constexpr (IsDynamicCluster) {
+      static constexpr int MaxClusterSize = 16;
+      implementable &= size(args.hw_info.cluster_shape) <= MaxClusterSize;
+      implementable &= size(args.hw_info.cluster_shape_fallback) <= MaxClusterSize;
+      implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
+    }
+    
+    constexpr bool IsBlockscaled = !cute::is_void_v<ElementSF>;
+    if constexpr (IsBlockscaled) {
+      if constexpr (IsDynamicCluster) {
+        implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
+        // Special cluster shape check for scale factor multicasts. Due to limited size of scale factors, we can't multicast among
+        // more than 4 CTAs
+        implementable &= (args.hw_info.cluster_shape.x <= 4 && args.hw_info.cluster_shape.y <= 4 &&
+                          args.hw_info.cluster_shape_fallback.x <= 4 && args.hw_info.cluster_shape_fallback.y <= 4);
+      }
+      else {
+        // Special cluster shape check for scale factor multicasts. Due to limited size of scale factors, we can't multicast among
+        // more than 4 CTAs
+        implementable &= ((size<0>(ClusterShape{}) <= 4) && (size<1>(ClusterShape{}) <= 4));
+      }
+    }
+
+    return implementable;
+  }
+
+  static size_t
+  get_workspace_size(Arguments const& args) {
+    size_t workspace_size = 0;
+
+    // Epilogue phase 1 (gate)
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    // Epilogue phase 2 (up)
+    workspace_size += CollectiveEpilogue2::get_workspace_size(args.problem_shape, args.epilogue_2);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    // Tile scheduler
+    workspace_size += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    return workspace_size;
+  }
+
+  static cutlass::Status
+  initialize_workspace(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr,
+    CudaHostAdapter* cuda_adapter = nullptr) {
+    Status status = Status::kSuccess;
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+
+    // Epilogue phase 1 (gate)
+    status = CollectiveEpilogue::initialize_workspace(args.problem_shape, args.epilogue, workspace_ptr + workspace_offset, stream, cuda_adapter);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Epilogue phase 2 (up)
+    status = CollectiveEpilogue2::initialize_workspace(args.problem_shape, args.epilogue_2, workspace_ptr + workspace_offset, stream, cuda_adapter);
+    workspace_offset += CollectiveEpilogue2::get_workspace_size(args.problem_shape, args.epilogue_2);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Tile scheduler
+    status = TileScheduler::template initialize_workspace<ProblemShape, ElementAccumulator>(
+      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+    workspace_offset += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    return status;
+  }
+
+  // Computes the kernel launch grid shape based on runtime parameters
+  static dim3
+  get_grid_shape(Params const& params) {
+    // NOTE cluster_shape here is the major cluster shape, not fallback one
+    auto cluster_shape = cutlass::detail::select_cluster_shape(ClusterShape{}, params.hw_info.cluster_shape);
+
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    return TileScheduler::get_grid_shape(
+        params.scheduler,
+        problem_shape_MNKL,
+        TileShape{},
+        AtomThrShapeMNK{},
+        cluster_shape,
+        params.hw_info);
+  }
+
+  static dim3
+  get_block_shape() {
+    return dim3(MaxThreadsPerBlock, 1, 1);
+  }
+
+  CUTLASS_DEVICE
+  void
+  operator() (Params const& params, char* smem_buf) {
+
+    using namespace cute;
+    using X = Underscore;
+
+    static_assert(SharedStorageSize <= cutlass::arch::sm100_smem_capacity_bytes, "SMEM usage exceeded capacity.");
+    // Separate out problem shape for convenience
+    // Optionally append 1s until problem shape is rank-4 in case its is only rank-3 (MNK)
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    auto [M,N,K,L] = problem_shape_MNKL;
+
+    // Account for more than one epilogue warp
+    int warp_idx = canonical_warp_idx_sync();
+    WarpCategory warp_category = warp_idx < static_cast<int>(WarpCategory::Epilogue) ? WarpCategory(warp_idx)
+                                                                                     : WarpCategory::Epilogue;
+
+    uint32_t lane_predicate = cute::elect_one_sync();
+    auto cluster_shape = cutlass::detail::select_cluster_shape(ClusterShape{});
+    int cluster_size = size(cluster_shape);
+    uint32_t cta_rank_in_cluster = cute::block_rank_in_cluster();
+    bool is_first_cta_in_cluster = cta_rank_in_cluster == 0;
+    int cta_coord_v = cta_rank_in_cluster % size<0>(typename TiledMma::AtomThrID{});
+    bool is_mma_leader_cta = cta_coord_v == 0;
+    constexpr bool has_mma_peer_cta = size(AtomThrShapeMNK{}) == 2;
+    [[maybe_unused]] uint32_t mma_peer_cta_rank = has_mma_peer_cta ? cta_rank_in_cluster ^ 1 : cta_rank_in_cluster;
+
+    // Kernel level shared memory storage
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    // In a warp specialized kernel, collectives expose data movement and compute operations separately
+    CollectiveMainloop  collective_mainloop  (params.mainloop,   cluster_shape, cta_rank_in_cluster);
+    CollectiveEpilogue  collective_epilogue  (params.epilogue,   shared_storage.tensors.epilogue);
+    CollectiveMainloop2 collective_mainloop_2(params.mainloop_2, cluster_shape, cta_rank_in_cluster);
+    CollectiveEpilogue2 collective_epilogue_2(params.epilogue_2, shared_storage.tensors.epilogue_2);
+
+    // Issue Tma Descriptor Prefetch from a single thread (both phases).
+    if ((warp_category == WarpCategory::Sched) && lane_predicate) {
+      collective_mainloop.prefetch_tma_descriptors();
+      collective_mainloop_2.prefetch_tma_descriptors();
+    }
+    if ((warp_category == WarpCategory::EpilogueLoad) && lane_predicate) {
+      collective_epilogue.prefetch_tma_descriptors(params.epilogue);
+      collective_epilogue_2.prefetch_tma_descriptors(params.epilogue_2);
+    }
+
+    // Do we load source tensor C or other aux inputs (either phase)
+    bool is_epi_load_needed_1 = collective_epilogue.is_producer_load_needed();
+    bool is_epi_load_needed_2 = collective_epilogue_2.is_producer_load_needed();
+    bool is_epi_load_needed   = is_epi_load_needed_1 || is_epi_load_needed_2;
+    IsParticipant is_participant = {
+      (warp_category == WarpCategory::MMA),                                 // mma
+      (warp_category == WarpCategory::Sched) && is_first_cta_in_cluster,    // sched
+      (warp_category == WarpCategory::MainloopLoad),                        // main_load
+      (warp_category == WarpCategory::EpilogueLoad) && is_epi_load_needed,  // epi_load
+      (warp_category == WarpCategory::Epilogue)                             // epilogue
+    };
+
+    // Mainloop Load pipeline — phase 1 (gate)
+    typename MainloopPipeline::Params mainloop_pipeline_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::MMA == warp_category) {
+      mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Consumer;
+    }
+    mainloop_pipeline_params.is_leader = lane_predicate && is_mma_leader_cta && is_participant.main_load;
+    // Stage E3: shared pipeline carries (A + B_phase1 + B_phase2) per slot.
+    mainloop_pipeline_params.transaction_bytes =
+        CollectiveMainloop::TmaTransactionBytesA
+      + CollectiveMainloop::TmaTransactionBytesB
+      + CollectiveMainloop2::TmaTransactionBytesB;
+    // Stage E3: 2 consumer groups per slot — phase 1 mma + phase 2 mma must
+    // each release every slot (K-tile interleaved in MMA warp body below).
+    mainloop_pipeline_params.num_consumers = 2;
+    mainloop_pipeline_params.initializing_warp = 0;
+    MainloopPipeline mainloop_pipeline(shared_storage.pipelines.mainloop,
+                                       mainloop_pipeline_params,
+                                       cluster_shape,
+                                       cute::true_type{},   // Perform barrier init
+                                       cute::false_type{}); // Delay mask calculation
+
+    // Mainloop Load pipeline — phase 2 (up).  Separate SMEM ring + state
+    // machine; both producer (main_load warp) and consumer (mma warp)
+    // run their phase-2 calls right after their phase-1 calls in the
+    // same persistent loop iteration.
+    typename MainloopPipeline2::Params mainloop_pipeline_2_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      mainloop_pipeline_2_params.role = MainloopPipeline2::ThreadCategory::Producer;
+    }
+    if (WarpCategory::MMA == warp_category) {
+      mainloop_pipeline_2_params.role = MainloopPipeline2::ThreadCategory::Consumer;
+    }
+    mainloop_pipeline_2_params.is_leader = lane_predicate && is_mma_leader_cta && is_participant.main_load;
+    mainloop_pipeline_2_params.transaction_bytes = CollectiveMainloop2::TmaTransactionBytes;
+    // Use a distinct initializing_warp index (6 — outside the {0..5}
+    // already claimed by phase-1 pipelines + LoadOrder/CLC/Acc/Throttle)
+    // so two warps don't race on the same barrier init.
+    mainloop_pipeline_2_params.initializing_warp = 6;
+    MainloopPipeline2 mainloop_pipeline_2(shared_storage.pipelines.mainloop_2,
+                                          mainloop_pipeline_2_params,
+                                          cluster_shape,
+                                          cute::true_type{},
+                                          cute::false_type{});
+
+    // Epilogue Load pipeline — phase 1 (gate)
+    typename EpiLoadPipeline::Params epi_load_pipeline_params;
+    if (WarpCategory::EpilogueLoad == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Consumer;
+    }
+    epi_load_pipeline_params.dst_blockid = cta_rank_in_cluster;
+    epi_load_pipeline_params.producer_arv_count = NumEpilogueLoadThreads;
+    epi_load_pipeline_params.consumer_arv_count = NumEpilogueThreads;
+    epi_load_pipeline_params.transaction_bytes = CollectiveEpilogue::TmaTransactionBytes;
+    epi_load_pipeline_params.initializing_warp = 1;
+    EpiLoadPipeline epi_load_pipeline(shared_storage.pipelines.epi_load, epi_load_pipeline_params);
+
+    // Epilogue Load pipeline — phase 2 (up)
+    typename EpiLoadPipeline2::Params epi_load_pipeline_2_params;
+    if (WarpCategory::EpilogueLoad == warp_category) {
+      epi_load_pipeline_2_params.role = EpiLoadPipeline2::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      epi_load_pipeline_2_params.role = EpiLoadPipeline2::ThreadCategory::Consumer;
+    }
+    epi_load_pipeline_2_params.dst_blockid = cta_rank_in_cluster;
+    epi_load_pipeline_2_params.producer_arv_count = NumEpilogueLoadThreads;
+    epi_load_pipeline_2_params.consumer_arv_count = NumEpilogueThreads;
+    epi_load_pipeline_2_params.transaction_bytes = CollectiveEpilogue2::TmaTransactionBytes;
+    epi_load_pipeline_2_params.initializing_warp = 7;
+    EpiLoadPipeline2 epi_load_pipeline_2(shared_storage.pipelines.epi_load_2, epi_load_pipeline_2_params);
+
+    // Epilogue Store pipelines — local-scope, no SharedStorage state.
+    typename EpiStorePipeline::Params epi_store_pipeline_params;
+    epi_store_pipeline_params.always_wait = true;
+    EpiStorePipeline epi_store_pipeline(epi_store_pipeline_params);
+
+    typename EpiStorePipeline2::Params epi_store_pipeline_2_params;
+    epi_store_pipeline_2_params.always_wait = true;
+    EpiStorePipeline2 epi_store_pipeline_2(epi_store_pipeline_2_params);
+
+    // Load order barrier
+    typename LoadOrderBarrier::Params load_order_barrier_params;
+    load_order_barrier_params.group_id = (warp_category == WarpCategory::MainloopLoad) ? 0 : 1;
+    load_order_barrier_params.group_size = NumMainloopLoadThreads;
+    load_order_barrier_params.initializing_warp = 3;
+    LoadOrderBarrier load_order_barrier(shared_storage.pipelines.load_order, load_order_barrier_params);
+
+    // CLC pipeline
+    typename CLCPipeline::Params clc_pipeline_params;
+    if (WarpCategory::Sched == warp_category) {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::ProducerConsumer;
+    }
+    else {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::Consumer;
+    }
+    clc_pipeline_params.producer_blockid = 0;
+    clc_pipeline_params.producer_arv_count = 1;
+    clc_pipeline_params.consumer_arv_count = NumSchedThreads + cluster_size *
+                                                 (NumMainloopLoadThreads + NumEpilogueThreads + NumMMAThreads);
+    if (is_epi_load_needed) {
+      clc_pipeline_params.consumer_arv_count += cluster_size * NumEpilogueLoadThreads;
+    }
+    clc_pipeline_params.transaction_bytes = CLCResponseSize;
+    clc_pipeline_params.initializing_warp = 4;
+    CLCPipeline clc_pipeline(shared_storage.pipelines.clc, clc_pipeline_params, cluster_shape);
+
+    // Mainloop-Epilogue pipeline
+    typename AccumulatorPipeline::Params accumulator_pipeline_params;
+    if (WarpCategory::MMA == warp_category) {
+      accumulator_pipeline_params.role = AccumulatorPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      accumulator_pipeline_params.role = AccumulatorPipeline::ThreadCategory::Consumer;
+    }
+    // Only one producer thread arrives on this barrier.
+    accumulator_pipeline_params.producer_arv_count = 1;
+    accumulator_pipeline_params.consumer_arv_count = size(AtomThrShapeMNK{}) * NumEpilogueThreads;
+    accumulator_pipeline_params.initializing_warp = 5;
+    AccumulatorPipeline accumulator_pipeline(shared_storage.pipelines.accumulator,
+                                             accumulator_pipeline_params,
+                                             cluster_shape,
+                                             cute::true_type{},   // Perform barrier init
+                                             cute::false_type{}); // Delay mask calculation
+
+    // CLC throttle pipeline
+    typename CLCThrottlePipeline::Params clc_throttle_pipeline_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      clc_throttle_pipeline_params.role = CLCThrottlePipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Sched == warp_category) {
+      clc_throttle_pipeline_params.role = CLCThrottlePipeline::ThreadCategory::Consumer;
+    }
+    clc_throttle_pipeline_params.producer_arv_count = NumMainloopLoadThreads;
+    clc_throttle_pipeline_params.consumer_arv_count = NumSchedThreads;
+    clc_throttle_pipeline_params.dst_blockid = 0;
+    clc_throttle_pipeline_params.initializing_warp = 3;
+    CLCThrottlePipeline clc_throttle_pipeline(shared_storage.pipelines.clc_throttle, clc_throttle_pipeline_params);
+    CLCThrottlePipelineState clc_pipe_throttle_consumer_state;
+    CLCThrottlePipelineState clc_pipe_throttle_producer_state = cutlass::make_producer_start_state<CLCThrottlePipeline>();
+
+    // Tmem allocator
+    TmemAllocator tmem_allocator{};
+
+    // Sync allocation status between MMA and epilogue warps within CTA
+    arch::NamedBarrier tmem_allocation_result_barrier(NumMMAThreads + NumEpilogueThreads, cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
+    // Sync deallocation status between MMA warps of peer CTAs
+    arch::ClusterBarrier& tmem_deallocation_result_barrier = shared_storage.pipelines.tmem_dealloc;
+    [[maybe_unused]] uint32_t dealloc_barrier_phase = 0;
+    if (WarpCategory::MMA == warp_category) {
+      if constexpr(!IsOverlappingAccum) {
+        if (has_mma_peer_cta && lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumMMAThreads);
+        }
+      }
+      else {
+        if (has_mma_peer_cta && lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumEpilogueThreads*2);
+        }
+        else if (lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumEpilogueThreads);
+        }
+      }
+    }
+
+    // We need this to guarantee that the Pipeline init is visible
+    // To all producers and consumer threadblocks in the cluster
+    pipeline_init_arrive_relaxed(cluster_size);
+
+    // Stage E3: phase 1 and phase 2 mainloops both see shared smem_A.
+    typename SharedStorage::template PhaseTensorStorageView<
+        decltype(shared_storage.tensors.shared_smem_A),
+        decltype(shared_storage.tensors.smem_B_phase1)>
+      phase1_view{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase1};
+    typename SharedStorage::template PhaseTensorStorageView<
+        decltype(shared_storage.tensors.shared_smem_A),
+        decltype(shared_storage.tensors.smem_B_phase2)>
+      phase2_view{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase2};
+
+    auto load_inputs   = collective_mainloop.load_init  (problem_shape_MNKL, phase1_view);
+    auto load_inputs_2 = collective_mainloop_2.load_init(problem_shape_MNKL, phase2_view);
+
+    MainloopPipelineState  mainloop_pipe_consumer_state;
+    MainloopPipelineState  mainloop_pipe_producer_state   = cutlass::make_producer_start_state<MainloopPipeline>();
+    MainloopPipelineState2 mainloop_pipe_consumer_state_2;
+    MainloopPipelineState2 mainloop_pipe_producer_state_2 = cutlass::make_producer_start_state<MainloopPipeline2>();
+
+    EpiLoadPipelineState  epi_load_pipe_consumer_state;
+    EpiLoadPipelineState  epi_load_pipe_producer_state   = cutlass::make_producer_start_state<EpiLoadPipeline>();
+    EpiLoadPipelineState2 epi_load_pipe_consumer_state_2;
+    EpiLoadPipelineState2 epi_load_pipe_producer_state_2 = cutlass::make_producer_start_state<EpiLoadPipeline2>();
+
+    // epilogue store pipe is producer-only (consumer is TMA unit, waits via scoreboarding)
+    EpiStorePipelineState  epi_store_pipe_producer_state   = cutlass::make_producer_start_state<EpiStorePipeline>();
+    EpiStorePipelineState2 epi_store_pipe_producer_state_2 = cutlass::make_producer_start_state<EpiStorePipeline2>();
+
+    CLCPipelineState clc_pipe_consumer_state;
+    CLCPipelineState clc_pipe_producer_state = cutlass::make_producer_start_state<CLCPipeline>();
+
+    AccumulatorPipelineState accumulator_pipe_consumer_state;
+    AccumulatorPipelineState accumulator_pipe_producer_state = cutlass::make_producer_start_state<AccumulatorPipeline>();
+
+    dim3 block_id_in_cluster = cute::block_id_in_cluster();
+
+    // Calculate mask after cluster barrier arrival (both mainloop pipelines).
+    mainloop_pipeline.init_masks(cluster_shape, block_id_in_cluster);
+    mainloop_pipeline_2.init_masks(cluster_shape, block_id_in_cluster);
+    accumulator_pipeline.init_masks(cluster_shape, block_id_in_cluster);
+
+    // TileID scheduler
+    TileScheduler scheduler(&shared_storage.clc_response[0], params.scheduler, block_id_in_cluster);
+    typename TileScheduler::WorkTileInfo work_tile_info = scheduler.initial_work_tile_info(cluster_shape);
+    auto cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+    //
+    // TMEM "Allocation"
+    //
+    auto tmem_storage = collective_mainloop.template init_tmem_tensors<EpilogueTile, IsOverlappingAccum>(EpilogueTile{});
+
+    pipeline_init_wait(cluster_size);
+
+    if (is_participant.main_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_arrive = is_epi_load_needed;
+      bool requires_clc_query = true;
+
+      do {
+        // K-tile iterator/count: both phases share the same K dim (X has
+        // the same K both times; W_gate and W_up have the same K dim).
+        auto k_tile_iter = scheduler.get_k_tile_iterator(work_tile_info, problem_shape_MNKL, CtaShape_MNK{}, load_inputs.k_tiles);
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+        auto k_tile_prologue = min(MainloopPipeline::Stages, k_tile_count);
+
+        if constexpr (IsSchedDynamicPersistent) {
+          if (is_first_cta_in_cluster && requires_clc_query) {
+            clc_throttle_pipeline.producer_acquire(clc_pipe_throttle_producer_state);
+            clc_throttle_pipeline.producer_commit(clc_pipe_throttle_producer_state);
+            ++clc_pipe_throttle_producer_state;
+          }
+        }
+
+        // -------- Stage E3: inline 3-TMA shared-pipeline main_load --------
+        {
+          auto& tma_load_a    = params.mainloop.tma_load_a;
+          auto& tma_load_b_p1 = params.mainloop.tma_load_b;
+          auto& tma_load_b_p2 = params.mainloop_2.tma_load_b;
+
+          auto atom_thr_M = size(typename TiledMma::AtomThrID{});
+          Tensor tAgA  = load_inputs.tAgA_mkl(cute::_, get<0>(cta_coord_mnkl) / atom_thr_M, cute::_, get<3>(cta_coord_mnkl));
+          Tensor tBgB1 = load_inputs.tBgB_nkl(cute::_, get<1>(cta_coord_mnkl), cute::_, get<3>(cta_coord_mnkl));
+          Tensor tBgB2 = load_inputs_2.tBgB_nkl(cute::_, get<1>(cta_coord_mnkl), cute::_, get<3>(cta_coord_mnkl));
+
+          auto barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+          int k_remaining = k_tile_count;
+          bool did_load_order_arrive_local = false;
+
+          CUTLASS_PRAGMA_NO_UNROLL
+          while (k_remaining > 0) {
+            mainloop_pipeline.producer_acquire(mainloop_pipe_producer_state, barrier_token);
+            using BarrierType = typename MainloopPipeline::ProducerBarrierType;
+            BarrierType* tma_barrier = mainloop_pipeline.producer_get_barrier(mainloop_pipe_producer_state);
+            int write_stage = mainloop_pipe_producer_state.index();
+            ++mainloop_pipe_producer_state;
+            barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+
+            if (cute::elect_one_sync()) {
+              cute::copy(tma_load_a   .with(*tma_barrier, load_inputs.mcast_mask_a),   tAgA (cute::_, *k_tile_iter), load_inputs.tAsA (cute::_, write_stage));
+              cute::copy(tma_load_b_p1.with(*tma_barrier, load_inputs.mcast_mask_b),   tBgB1(cute::_, *k_tile_iter), load_inputs.tBsB (cute::_, write_stage));
+              cute::copy(tma_load_b_p2.with(*tma_barrier, load_inputs_2.mcast_mask_b), tBgB2(cute::_, *k_tile_iter), load_inputs_2.tBsB(cute::_, write_stage));
+            }
+            if (do_load_order_arrive && !did_load_order_arrive_local) {
+              load_order_barrier.arrive();
+              do_load_order_arrive = false;
+              did_load_order_arrive_local = true;
+            }
+            --k_remaining;
+            ++k_tile_iter;
+          }
+        }
+        (void)k_tile_prologue;  // unused in Stage E3 inline main_load
+
+        // Sync warp to prevent non-participating threads entering next wave early
+        __syncwarp();
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+        requires_clc_query = increment_pipe;
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+      } while (work_tile_info.is_valid());
+      // Stage E3: single shared pipeline; mainloop_pipeline_2 unused.
+      collective_mainloop.load_tail(mainloop_pipeline, mainloop_pipe_producer_state);
+
+    }
+
+    else if (is_participant.sched) {
+      if constexpr (IsSchedDynamicPersistent) {
+        // Whether a new CLC query must be performed.
+        // See comment below where this variable is updated for a description of
+        // why this variable is needed.
+        bool requires_clc_query = true;
+
+        cutlass::arch::wait_on_dependent_grids();
+
+        do {
+          if (requires_clc_query) {
+            // Throttle CLC query to mitigate workload imbalance caused by skews among persistent workers.
+            clc_throttle_pipeline.consumer_wait(clc_pipe_throttle_consumer_state);
+            clc_throttle_pipeline.consumer_release(clc_pipe_throttle_consumer_state);
+            ++clc_pipe_throttle_consumer_state;
+
+            // Query next clcID and update producer state
+            clc_pipe_producer_state = scheduler.advance_to_next_work(clc_pipeline, clc_pipe_producer_state);
+          }
+
+          // Fetch next work tile
+          auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info,
+            clc_pipeline,
+            clc_pipe_consumer_state
+          );
+
+          // Only perform a new CLC query if we consumed a new CLC query result in
+          // `fetch_next_work`. An example of a case in which CLC `fetch_next_work` does
+          // not consume a new CLC query response is when processing stream-K units.
+          // The current stream-K scheduler uses single WorkTileInfo to track multiple
+          // (potentially-partial) tiles to be computed via stream-K. In this case,
+          // `fetch_next_work` simply performs in-place updates on the existing WorkTileInfo,
+          // rather than consuming a CLC query response.
+          requires_clc_query = increment_pipe;
+          if (increment_pipe) {
+            ++clc_pipe_consumer_state;
+          }
+
+          work_tile_info = next_work_tile_info;
+        } while (work_tile_info.is_valid());
+        clc_pipeline.producer_tail(clc_pipe_producer_state);
+      }
+    }
+
+    else if (is_participant.mma) {
+      // TMEM allocation sequence — ONE allocate() per kernel.  Both
+      // phases re-bind their logical tmem_storage to the same base
+      // address; physical columns are time-multiplexed across phases
+      // via consecutive AccPipe slot indices.
+      tmem_allocator.allocate(TmemAllocator::Sm100TmemCapacityColumns, &shared_storage.tmem_base_ptr);
+      __syncwarp();
+      tmem_allocation_result_barrier.arrive();
+      uint32_t tmem_base_ptr = shared_storage.tmem_base_ptr;
+      collective_mainloop  .set_tmem_offsets(tmem_storage, tmem_base_ptr);
+
+      typename SharedStorage::template PhaseTensorStorageView<
+          decltype(shared_storage.tensors.shared_smem_A),
+          decltype(shared_storage.tensors.smem_B_phase1)>
+        phase1_view_mma{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase1};
+      typename SharedStorage::template PhaseTensorStorageView<
+          decltype(shared_storage.tensors.shared_smem_A),
+          decltype(shared_storage.tensors.smem_B_phase2)>
+        phase2_view_mma{shared_storage.tensors.shared_smem_A, shared_storage.tensors.smem_B_phase2};
+
+      auto mma_inputs   = collective_mainloop.mma_init  (tmem_storage, phase1_view_mma);
+      auto mma_inputs_2 = collective_mainloop_2.mma_init(tmem_storage, phase2_view_mma);
+
+      do {
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        // -------- Phase 1 (gate) MMA --------
+        int acc_stage = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_producer_state.phase() ^ 1;
+          }
+          else {
+            return accumulator_pipe_producer_state.index();
+          }
+        }();
+
+        // -------- Stage E3: inline K-tile interleaved phase1+phase2 MMA --------
+        // Single shared mainloop_pipeline.  Per K-tile slot: phase 1 mma
+        // (A, B_phase1) → acc_p1, then phase 2 mma (A, B_phase2) → acc_p2.
+        // Both phases release the slot each iteration so pipeline reaches
+        // the 2x consumer arrival count and producer can wrap.
+        int acc_stage_2 = [&] () {
+          // Compute phase 2's acc slot — uses NEXT acc_pipe slot from phase 1.
+          if constexpr (IsOverlappingAccum) {
+            return ((accumulator_pipe_producer_state.phase() ^ 1) + 1) % AccumulatorPipelineStageCount;
+          }
+          else {
+            return (accumulator_pipe_producer_state.index() + 1) % AccumulatorPipelineStageCount;
+          }
+        }();
+
+        if (is_mma_leader_cta) {
+          // Acquire acc pipe slots for both phases.
+          accumulator_pipeline.producer_acquire(accumulator_pipe_producer_state);
+          AccumulatorPipelineState acc_state_p2 = accumulator_pipe_producer_state;
+          ++acc_state_p2;
+          accumulator_pipeline.producer_acquire(acc_state_p2);
+
+          // Get phase 1 and phase 2 accumulators (different TMEM column slots).
+          auto acc_p1 = get<0>(collective_mainloop.slice_accumulator(tmem_storage, acc_stage));
+          auto acc_p2 = get<0>(collective_mainloop_2.slice_accumulator(tmem_storage, acc_stage_2));
+
+          // Unpack mma_inputs.
+          auto [tiled_mma_p1, tCrA_p1, tCrB_p1] = mma_inputs;
+          auto [tiled_mma_p2, tCrA_p2, tCrB_p2] = mma_inputs_2;
+          tiled_mma_p1.accumulate_ = cute::UMMA::ScaleOut::Zero;
+          tiled_mma_p2.accumulate_ = cute::UMMA::ScaleOut::Zero;
+
+          // K-tile interleaved loop.
+          uint32_t skip_wait = k_tile_count <= 0;
+          auto barrier_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+          int k_remaining = k_tile_count;
+          CUTLASS_PRAGMA_NO_UNROLL
+          while (k_remaining > 0) {
+            mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, barrier_token);
+            int read_stage = mainloop_pipe_consumer_state.index();
+            auto cur_state = mainloop_pipe_consumer_state;
+            ++mainloop_pipe_consumer_state;
+            --k_remaining;
+            skip_wait = k_remaining <= 0;
+            barrier_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+
+            // Phase 1 tcgen05.mma (A from shared, B from smem_B_phase1)
+            CUTLASS_PRAGMA_UNROLL
+            for (int k_block = 0; k_block < size<2>(tCrA_p1); ++k_block) {
+              cute::gemm(tiled_mma_p1,
+                         tCrA_p1(cute::_, cute::_, k_block, read_stage),
+                         tCrB_p1(cute::_, cute::_, k_block, read_stage),
+                         acc_p1);
+              tiled_mma_p1.accumulate_ = cute::UMMA::ScaleOut::One;
+            }
+            // Phase 1 release this slot (1 of 2 consumer arrivals)
+            mainloop_pipeline.consumer_release(cur_state);
+
+            // Phase 2 tcgen05.mma (A from SAME shared, B from smem_B_phase2)
+            CUTLASS_PRAGMA_UNROLL
+            for (int k_block = 0; k_block < size<2>(tCrA_p2); ++k_block) {
+              cute::gemm(tiled_mma_p2,
+                         tCrA_p2(cute::_, cute::_, k_block, read_stage),
+                         tCrB_p2(cute::_, cute::_, k_block, read_stage),
+                         acc_p2);
+              tiled_mma_p2.accumulate_ = cute::UMMA::ScaleOut::One;
+            }
+            // Phase 2 release this slot (2 of 2 consumer arrivals → slot free)
+            mainloop_pipeline.consumer_release(cur_state);
+          }
+
+          // Commit both phases' acc slots.
+          accumulator_pipeline.producer_commit(accumulator_pipe_producer_state);
+          accumulator_pipeline.producer_commit(acc_state_p2);
+        }
+        // Advance acc pipe state by 2 (both phases committed) for next work tile.
+        ++accumulator_pipe_producer_state;
+        ++accumulator_pipe_producer_state;
+
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Hint on an early release of global memory resources.
+      // The timing of calling this function only influences performance,
+      // not functional correctness.
+      cutlass::arch::launch_dependent_grids();
+
+      // Release the right to allocate before deallocations so that the next CTA can rasterize
+      tmem_allocator.release_allocation_lock();
+
+      if constexpr (!IsOverlappingAccum) {
+        // Leader MMA waits for leader + peer epilogues to release accumulator stage
+        if (is_mma_leader_cta) {
+          accumulator_pipeline.producer_tail(accumulator_pipe_producer_state);
+        }
+        // Signal to peer MMA that entire tmem allocation can be deallocated
+        if constexpr (has_mma_peer_cta) {
+          // Leader does wait + arrive, follower does arrive + wait
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank, not is_mma_leader_cta);
+          tmem_deallocation_result_barrier.wait(dealloc_barrier_phase);
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank, is_mma_leader_cta);
+        }
+      }
+      else {
+        tmem_deallocation_result_barrier.wait(dealloc_barrier_phase);
+      }
+
+      // Free entire tmem allocation
+      tmem_allocator.free(tmem_base_ptr, TmemAllocator::Sm100TmemCapacityColumns);
+    }
+
+    else if (is_participant.epi_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_wait = true;
+      bool do_tail_load = false;
+      int current_wave = 0;
+
+      do {
+        bool compute_epilogue = TileScheduler::compute_epilogue(work_tile_info, params.scheduler);
+
+        // Get current work tile and fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+        work_tile_info = next_work_tile_info;
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        if (compute_epilogue) {
+          if (do_load_order_wait) {
+            load_order_barrier.wait();
+            do_load_order_wait = false;
+          }
+
+          bool reverse_epi_n = IsOverlappingAccum && (current_wave % 2 == 0);
+
+          // Phase 1 (gate) epilogue producer-load — only fires if the
+          // phase-1 epilogue actually consumes source C/aux.  For
+          // LinComb beta=0 path this is a fast no-op.
+          if (is_epi_load_needed_1) {
+            epi_load_pipe_producer_state = collective_epilogue.template load<IsOverlappingAccum>(
+              epi_load_pipeline,
+              epi_load_pipe_producer_state,
+              problem_shape_MNKL,
+              CtaShape_MNK{},
+              cta_coord_mnkl,
+              TileShape{},
+              TiledMma{},
+              shared_storage.tensors.epilogue,
+              reverse_epi_n
+            );
+          }
+
+          // Phase 2 (up) epilogue producer-load
+          if (is_epi_load_needed_2) {
+            epi_load_pipe_producer_state_2 = collective_epilogue_2.template load<IsOverlappingAccum>(
+              epi_load_pipeline_2,
+              epi_load_pipe_producer_state_2,
+              problem_shape_MNKL,
+              CtaShape_MNK{},
+              cta_coord_mnkl,
+              TileShape{},
+              TiledMma{},
+              shared_storage.tensors.epilogue_2,
+              reverse_epi_n
+            );
+          }
+
+          do_tail_load = true;
+        }
+        current_wave++;
+
+        // Calculate the cta coordinates of the next work tile
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Only perform a tail load if one of the work units processed performed
+      // an epilogue load.  Both phases drain.
+      if (do_tail_load) {
+        if (is_epi_load_needed_1) {
+          collective_epilogue.load_tail(
+            epi_load_pipeline, epi_load_pipe_producer_state,
+            epi_store_pipeline, epi_store_pipe_producer_state);
+        }
+        if (is_epi_load_needed_2) {
+          collective_epilogue_2.load_tail(
+            epi_load_pipeline_2, epi_load_pipe_producer_state_2,
+            epi_store_pipeline_2, epi_store_pipe_producer_state_2);
+        }
+      }
+    }
+
+    else if (is_participant.epilogue) {
+      // Wait for tmem allocate here
+      tmem_allocation_result_barrier.arrive_and_wait();
+      uint32_t tmem_base_ptr = shared_storage.tmem_base_ptr;
+      collective_mainloop.set_tmem_offsets(tmem_storage, tmem_base_ptr);
+
+      bool do_tail_store = false;
+      do {
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        // -------- Phase 1 (gate) epilogue --------
+        int acc_stage = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_consumer_state.phase();
+          }
+          else {
+            return accumulator_pipe_consumer_state.index();
+          }
+        }();
+
+        auto accumulator = get<0>(collective_mainloop.slice_accumulator(tmem_storage, acc_stage));
+        accumulator_pipe_consumer_state = scheduler.template fixup<IsComplex>(
+          TiledMma{},
+          work_tile_info,
+          accumulator,
+          accumulator_pipeline,
+          accumulator_pipe_consumer_state,
+          typename CollectiveEpilogue::CopyOpT2R{}
+        );
+
+        if (scheduler.compute_epilogue(work_tile_info)) {
+          auto [load_state_next, store_state_next, acc_state_next] = collective_epilogue.template store<IsOverlappingAccum>(
+            epi_load_pipeline,
+            epi_load_pipe_consumer_state,
+            epi_store_pipeline,
+            epi_store_pipe_producer_state,
+            accumulator_pipeline,
+            accumulator_pipe_consumer_state,
+            problem_shape_MNKL,
+            CtaShape_MNK{},
+            cta_coord_mnkl,
+            TileShape{},
+            TiledMma{},
+            accumulator,
+            shared_storage.tensors.epilogue
+          );
+          epi_load_pipe_consumer_state    = load_state_next;
+          epi_store_pipe_producer_state   = store_state_next;
+          accumulator_pipe_consumer_state = acc_state_next;
+          do_tail_store = true;
+        }
+
+        // -------- Cross-phase SMEM bridge --------
+        // Phase 1's Sm100SmemAuxStore visitor wrote gate values to its own
+        // SharedStorage::smem_aux (inside collective_epilogue's TensorStorage).
+        // Phase 2's Sm100SmemAuxLoad visitor reads from its own SharedStorage,
+        // which is a DIFFERENT region.  Copy phase 1 → phase 2 here.
+        // S2S is fast (~8 KB per tile).
+        {
+          // Access pointers via the FusionCallbacks visitor tree.  ops tuple
+          // ordering: children-first, node-last.  For both phases the
+          // SmemAux{Store,Load} visitor sits at ops index 1.
+          auto& aux_store = cute::get<1>(collective_epilogue.fusion_callbacks.ops);
+          auto& aux_load  = cute::get<1>(collective_epilogue_2.fusion_callbacks.ops);
+          auto* src = aux_store.smem_aux;
+          auto* dst = aux_load.smem_aux;
+          using SmemLayout = typename cute::remove_reference_t<decltype(aux_store)>::SmemLayout;
+          constexpr int N_elts = cute::cosize_v<SmemLayout>;
+          // Epilogue threads are warps 4..(NumEpilogueWarps+3) — offset by
+          // (4 * NumThreadsPerWarp).  Use epilogue-local index 0..255.
+          int local_tid = threadIdx.x - (4 * NumThreadsPerWarp);
+          // Real S2S copy: phase 1 smem_aux → phase 2 smem_aux.
+          for (int i = local_tid; i < N_elts; i += NumEpilogueThreads) {
+            dst[i] = src[i];
+          }
+          // Fence + barrier so dst writes visible before phase 2 epilogue reads.
+          // Use a barrier id distinct from CUTLASS's EpilogueBarrier (used
+          // internally by Sm100 epilogue's NamedBarrier::sync()).
+          cutlass::arch::fence_view_async_shared();
+          cutlass::arch::NamedBarrier(NumEpilogueThreads, /*barrier_id=*/0).sync();
+        }
+
+        // -------- Phase 2 (up) epilogue --------
+        // Consumer state has advanced past phase 1's slot; phase 2
+        // consumes the next AccPipe slot which holds phase 2's MMA result
+        // for this work tile.
+        int acc_stage_2 = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_consumer_state.phase();
+          }
+          else {
+            return accumulator_pipe_consumer_state.index();
+          }
+        }();
+
+        auto accumulator_2 = get<0>(collective_mainloop_2.slice_accumulator(tmem_storage, acc_stage_2));
+        accumulator_pipe_consumer_state = scheduler.template fixup<IsComplex>(
+          TiledMma{},
+          work_tile_info,
+          accumulator_2,
+          accumulator_pipeline,
+          accumulator_pipe_consumer_state,
+          typename CollectiveEpilogue2::CopyOpT2R{}
+        );
+
+        if (scheduler.compute_epilogue(work_tile_info)) {
+          auto [load_state_next, store_state_next, acc_state_next] = collective_epilogue_2.template store<IsOverlappingAccum>(
+            epi_load_pipeline_2,
+            epi_load_pipe_consumer_state_2,
+            epi_store_pipeline_2,
+            epi_store_pipe_producer_state_2,
+            accumulator_pipeline,
+            accumulator_pipe_consumer_state,
+            problem_shape_MNKL,
+            CtaShape_MNK{},
+            cta_coord_mnkl,
+            TileShape{},
+            TiledMma{},
+            accumulator_2,
+            shared_storage.tensors.epilogue_2
+          );
+          epi_load_pipe_consumer_state_2    = load_state_next;
+          epi_store_pipe_producer_state_2   = store_state_next;
+          accumulator_pipe_consumer_state   = acc_state_next;
+          do_tail_store = true;
+        }
+
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+
+      } while (work_tile_info.is_valid());
+
+      if constexpr (IsOverlappingAccum) {
+        // Signal to peer MMA that Full TMEM alloc can be deallocated
+        if constexpr (has_mma_peer_cta) {
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank);
+        }
+        tmem_deallocation_result_barrier.arrive();
+      }
+
+      // Tail store for both phases.
+      if (do_tail_store) {
+        collective_epilogue.store_tail(
+          epi_load_pipeline, epi_load_pipe_consumer_state,
+          epi_store_pipeline, epi_store_pipe_producer_state,
+          CtaShape_MNK{});
+        collective_epilogue_2.store_tail(
+          epi_load_pipeline_2, epi_load_pipe_consumer_state_2,
+          epi_store_pipeline_2, epi_store_pipe_producer_state_2,
+          CtaShape_MNK{});
+      }
+    }
+
+    else {
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass::gemm::kernel

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_kernel.hpp
@@ -32,28 +32,16 @@
 #pragma once
 
 // ============================================================================
-// FlashRtMegakernelGeGLUFusedGemm — the megakernel kernel struct for the
-// Pi0.5 encoder split-G7 path.
+// FlashRtMegakernelGeGLUFusedGemm — the GeGLU megakernel kernel struct for
+// the Pi0.5 encoder FFN.
 //
-// Stage A.0 (this commit): byte-for-byte copy of the vendored production
-// SM100 single-GEMM kernel (`flashrt_megakernel_kernel.hpp`) with ONLY the
-// class name renamed.  Functionally identical to single GEMM at this
-// stage; serves as a build/wiring scaffold.
-//
-// Stage A.1 (next): extend struct to TWO Mainloop+Epilogue template
-// params; operator() body chains phase1 (gate) + phase2 (up) serially
-// per work tile, sharing one tcgen05.alloc.  Both phases still write to
-// gmem (no SMEM_gate routing yet).
-//
-// Stage B: redirect phase1 epilogue store target from gmem D_gate to a
-// SharedStorage::smem_gate buffer (suppress TMA store).
-//
-// Stage C: add `Sm100SmemGateLoad` EVT visitor to phase2 epilogue and
-// fuse the gate × up multiply in-register.  This is the cosine-correct
-// MK-1 ship candidate.
-//
-// Stage D: share SMEM_A across phases (X is the same input for both
-// gate and up).  Performance optimization on top of Stage C.
+// Built on the vendored SM100 single-GEMM kernel, extended to two
+// Mainloop+Epilogue template params. Each work tile runs phase1 (gate)
+// then phase2 (up) serially, sharing one tcgen05.alloc and one SMEM_A
+// staging buffer (X is the same input for both). Phase1 stores its result
+// into a SharedStorage::smem_gate buffer instead of gmem; phase2's epilogue
+// uses an `Sm100SmemGateLoad` EVT visitor to fuse the gate * up multiply
+// in-register, so only the final hidden tensor is written out.
 // ============================================================================
 
 #include "cutlass/cutlass.h"
@@ -310,7 +298,7 @@ public:
       EpilogueTensorStorage   epilogue;
       EpilogueTensorStorage2  epilogue_2;
 
-      // Stage E3: shared smem_A + per-phase smem_B
+      // shared smem_A + per-phase smem_B
       using SmemAllocTypeA  = typename CollectiveMainloop::SmemAllocTypeA;
       using SmemAllocTypeB  = typename CollectiveMainloop::SmemAllocTypeB;
       using SmemAllocTypeB2 = typename CollectiveMainloop2::SmemAllocTypeB;
@@ -616,12 +604,12 @@ public:
       mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Consumer;
     }
     mainloop_pipeline_params.is_leader = lane_predicate && is_mma_leader_cta && is_participant.main_load;
-    // Stage E3: shared pipeline carries (A + B_phase1 + B_phase2) per slot.
+    // shared pipeline carries (A + B_phase1 + B_phase2) per slot.
     mainloop_pipeline_params.transaction_bytes =
         CollectiveMainloop::TmaTransactionBytesA
       + CollectiveMainloop::TmaTransactionBytesB
       + CollectiveMainloop2::TmaTransactionBytesB;
-    // Stage E3: 2 consumer groups per slot — phase 1 mma + phase 2 mma must
+    // 2 consumer groups per slot — phase 1 mma + phase 2 mma must
     // each release every slot (K-tile interleaved in MMA warp body below).
     mainloop_pipeline_params.num_consumers = 2;
     mainloop_pipeline_params.initializing_warp = 0;
@@ -781,7 +769,7 @@ public:
     // To all producers and consumer threadblocks in the cluster
     pipeline_init_arrive_relaxed(cluster_size);
 
-    // Stage E3: phase 1 and phase 2 mainloops both see shared smem_A.
+    // phase 1 and phase 2 mainloops both see shared smem_A.
     typename SharedStorage::template PhaseTensorStorageView<
         decltype(shared_storage.tensors.shared_smem_A),
         decltype(shared_storage.tensors.smem_B_phase1)>
@@ -855,7 +843,7 @@ public:
           }
         }
 
-        // -------- Stage E3: inline 3-TMA shared-pipeline main_load --------
+        // -------- inline 3-TMA shared-pipeline main_load --------
         {
           auto& tma_load_a    = params.mainloop.tma_load_a;
           auto& tma_load_b_p1 = params.mainloop.tma_load_b;
@@ -893,7 +881,7 @@ public:
             ++k_tile_iter;
           }
         }
-        (void)k_tile_prologue;  // unused in Stage E3 inline main_load
+        (void)k_tile_prologue;  // unused in the inline main_load
 
         // Sync warp to prevent non-participating threads entering next wave early
         __syncwarp();
@@ -909,7 +897,7 @@ public:
           ++clc_pipe_consumer_state;
         }
       } while (work_tile_info.is_valid());
-      // Stage E3: single shared pipeline; mainloop_pipeline_2 unused.
+      // single shared pipeline; mainloop_pipeline_2 unused.
       collective_mainloop.load_tail(mainloop_pipeline, mainloop_pipe_producer_state);
 
     }
@@ -1006,7 +994,7 @@ public:
           }
         }();
 
-        // -------- Stage E3: inline K-tile interleaved phase1+phase2 MMA --------
+        // -------- inline K-tile interleaved phase1+phase2 MMA --------
         // Single shared mainloop_pipeline.  Per K-tile slot: phase 1 mma
         // (A, B_phase1) → acc_p1, then phase 2 mma (A, B_phase2) → acc_p2.
         // Both phases release the slot each iteration so pipeline reaches

--- a/csrc/gemm/mega/flashrt_megakernel_geglu_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_geglu_kernel.hpp
@@ -54,8 +54,6 @@
 //
 // Stage D: share SMEM_A across phases (X is the same input for both
 // gate and up).  Performance optimization on top of Stage C.
-//
-// Plan: megakernel_dev/notes/MK1_DESIGN_V2.md.
 // ============================================================================
 
 #include "cutlass/cutlass.h"
@@ -453,7 +451,7 @@ public:
       implementable &= size(args.hw_info.cluster_shape_fallback) <= MaxClusterSize;
       implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
     }
-    
+
     constexpr bool IsBlockscaled = !cute::is_void_v<ElementSF>;
     if constexpr (IsBlockscaled) {
       if constexpr (IsDynamicCluster) {

--- a/csrc/gemm/mega/flashrt_megakernel_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_kernel.hpp
@@ -248,7 +248,7 @@ public:
     MainloopParams mainloop{};
     EpilogueParams epilogue{};
     TileSchedulerParams scheduler{};
-    KernelHardwareInfo hw_info{}; 
+    KernelHardwareInfo hw_info{};
   };
 
   enum class WarpCategory : int32_t {
@@ -335,7 +335,7 @@ public:
       implementable &= size(args.hw_info.cluster_shape_fallback) <= MaxClusterSize;
       implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
     }
-    
+
     constexpr bool IsBlockscaled = !cute::is_void_v<ElementSF>;
     if constexpr (IsBlockscaled) {
       if constexpr (IsDynamicCluster) {

--- a/csrc/gemm/mega/flashrt_megakernel_kernel.hpp
+++ b/csrc/gemm/mega/flashrt_megakernel_kernel.hpp
@@ -1,0 +1,983 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/workspace.h"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "cutlass/detail/cluster.hpp"
+#include "cutlass/arch/grid_dependency_control.h"
+#include "cutlass/fast_math.h"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cutlass/arch/arch.h"
+#include "cutlass/arch/barrier.h"
+#include "cutlass/arch/reg_reconfig.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/detail/mainloop_fusion_helper_scale_factor.hpp"
+#include "cutlass/gemm/kernel/sm100_tile_scheduler.hpp"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/detail/sm100_tmem_helper.hpp"
+
+#include "cute/tensor.hpp"
+#include "cute/arch/tmem_allocator_sm100.hpp"
+#include "cute/atom/mma_atom.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::kernel {
+
+// Bring CUTLASS identifiers (used unqualified in the vendored kernel
+// body) into scope.  In production these are found via ADL because
+// the kernel lives in cutlass::gemm::kernel; in flashrt::megakernel
+// they need explicit using-declarations.
+using cutlass::gemm::KernelTmaWarpSpecializedSm100;
+using cutlass::gemm::KernelTmaWarpSpecializedBlockScaledSm100;
+using cutlass::NumThreadsPerWarp;
+using cutlass::MinWorkspaceAlignment;
+
+// Primary template (forward declaration).  Mirrors
+// cutlass::gemm::kernel::GemmUniversal from gemm_universal_decl.h.
+template <
+  class ProblemShape_,
+  class CollectiveMainloop_,
+  class CollectiveEpilogue_,
+  class TileSchedulerTag_ = void,
+  class Enable = void
+>
+class FlashRtMegakernelGemm;
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+  class ProblemShape_,
+  class CollectiveMainloop_,
+  class CollectiveEpilogue_,
+  class TileSchedulerTag_
+>
+class FlashRtMegakernelGemm<
+  ProblemShape_,
+  CollectiveMainloop_,
+  CollectiveEpilogue_,
+  TileSchedulerTag_,
+  cute::enable_if_t<
+    cute::disjunction_v<cutlass::detail::is_kernel_tag_of<typename CollectiveMainloop_::DispatchPolicy::Schedule,
+                                KernelTmaWarpSpecializedSm100>,
+    cutlass::detail::is_kernel_tag_of<typename CollectiveMainloop_::DispatchPolicy::Schedule,
+                                KernelTmaWarpSpecializedBlockScaledSm100>>>>
+{
+public:
+  //
+  // Type Aliases
+  //
+  using ProblemShape = ProblemShape_;
+  static_assert(rank(ProblemShape{}) == 3 or rank(ProblemShape{}) == 4,
+    "ProblemShape{} should be <M,N,K> or <M,N,K,L>");
+
+  // Mainloop derived types
+  using CollectiveMainloop = CollectiveMainloop_;
+  using TileShape = typename CollectiveMainloop::TileShape;
+  using TiledMma  = typename CollectiveMainloop::TiledMma;
+  using ArchTag   = typename CollectiveMainloop::ArchTag;
+  using ElementA  = typename CollectiveMainloop::ElementA;
+  using StrideA   = typename CollectiveMainloop::StrideA;
+  using ElementB  = typename CollectiveMainloop::ElementB;
+  using StrideB   = typename CollectiveMainloop::StrideB;
+  using LayoutSFA = typename cutlass::detail::LayoutSFAType<CollectiveMainloop>::type;
+  using LayoutSFB = typename cutlass::detail::LayoutSFBType<CollectiveMainloop>::type;
+  using ElementSF = typename cutlass::detail::ElementSFType<CollectiveMainloop>::type;
+  using DispatchPolicy = typename CollectiveMainloop::DispatchPolicy;
+  using ElementAccumulator = typename CollectiveMainloop::ElementAccumulator;
+  using ClusterShape = typename DispatchPolicy::ClusterShape;
+  using MainloopArguments = typename CollectiveMainloop::Arguments;
+  using MainloopParams = typename CollectiveMainloop::Params;
+  static_assert(ArchTag::kMinComputeCapability >= 100);
+
+  // Epilogue derived types
+  using CollectiveEpilogue = CollectiveEpilogue_;
+  using EpilogueTile = typename CollectiveEpilogue::EpilogueTile;
+  using ElementC = typename CollectiveEpilogue::ElementC;
+  using StrideC  = typename CollectiveEpilogue::StrideC;
+  using ElementD = typename CollectiveEpilogue::ElementD;
+  using StrideD  = typename CollectiveEpilogue::StrideD;
+  using EpilogueArguments = typename CollectiveEpilogue::Arguments;
+  using EpilogueParams = typename CollectiveEpilogue::Params;
+  static constexpr bool IsComplex = CollectiveEpilogue::NumAccumulatorMtxs == 2;
+
+  // CLC pipeline depth
+  // determines how many waves (stages-1) a warp can race ahead
+  static constexpr uint32_t SchedulerPipelineStageCount = DispatchPolicy::Schedule::SchedulerPipelineStageCount;
+  static constexpr uint32_t AccumulatorPipelineStageCount = DispatchPolicy::Schedule::AccumulatorPipelineStageCount;
+  static constexpr bool IsOverlappingAccum = DispatchPolicy::IsOverlappingAccum;
+
+  // TileID scheduler
+  // Get Blk and Scheduling tile shapes
+  using AtomThrShapeMNK = typename CollectiveMainloop::AtomThrShapeMNK;
+  using CtaShape_MNK = typename CollectiveMainloop::CtaShape_MNK;
+  using TileSchedulerTag = TileSchedulerTag_;
+  using TileScheduler = typename detail::TileSchedulerSelector<
+    TileSchedulerTag, ArchTag, CtaShape_MNK, ClusterShape, SchedulerPipelineStageCount>::Scheduler;
+  using TileSchedulerArguments = typename TileScheduler::Arguments;
+  using TileSchedulerParams = typename TileScheduler::Params;
+
+  static constexpr bool IsSchedDynamicPersistent = TileScheduler::IsDynamicPersistent;
+  static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+  static constexpr bool IsGdcEnabled = cutlass::arch::IsGdcGloballyEnabled;
+
+  // Warp specialization thread count per threadblock
+  static constexpr uint32_t NumSchedThreads        = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumMMAThreads          = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumMainloopLoadThreads = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumEpilogueLoadThreads = NumThreadsPerWarp; // 1 warp
+  static constexpr uint32_t NumEpilogueThreads     = CollectiveEpilogue::ThreadCount;
+  static constexpr uint32_t NumEpilogueWarps       = NumEpilogueThreads / NumThreadsPerWarp;
+
+  static constexpr uint32_t MaxThreadsPerBlock = NumSchedThreads +
+                                                 NumMainloopLoadThreads + NumMMAThreads +
+                                                 NumEpilogueLoadThreads + NumEpilogueThreads;
+  static constexpr uint32_t MinBlocksPerMultiprocessor = 1;
+
+  static constexpr uint32_t NumEpilogueSubTiles = CollectiveEpilogue::get_load_pipe_increment(CtaShape_MNK{});
+
+  // Fixup performed for split-/stream-K is done across warps in different CTAs
+  // at epilogue subtile granularity. Thus, there must be one barrier per sub-tile per
+  // epilogue warp.
+  static constexpr uint32_t NumFixupBarriers = 1;
+  static constexpr uint32_t CLCResponseSize = sizeof(typename TileScheduler::CLCResponse);
+
+  // Pipeline and pipeline state types
+  using MainloopPipeline = typename CollectiveMainloop::MainloopPipeline;
+  using MainloopPipelineState = typename CollectiveMainloop::MainloopPipelineState;
+
+  using EpiLoadPipeline = typename CollectiveEpilogue::LoadPipeline;
+  using EpiLoadPipelineState = typename CollectiveEpilogue::LoadPipelineState;
+
+  using EpiStorePipeline = typename CollectiveEpilogue::StorePipeline;
+  using EpiStorePipelineState = typename CollectiveEpilogue::StorePipelineState;
+
+  using LoadOrderBarrier = cutlass::OrderedSequenceBarrier<1,2>;
+
+  using AccumulatorPipeline = cutlass::PipelineUmmaAsync<AccumulatorPipelineStageCount, AtomThrShapeMNK>;
+  using AccumulatorPipelineState = typename AccumulatorPipeline::PipelineState;
+
+  using CLCPipeline = cutlass::PipelineCLCFetchAsync<SchedulerPipelineStageCount, ClusterShape>;
+  using CLCPipelineState = typename CLCPipeline::PipelineState;
+
+  using CLCThrottlePipeline = cutlass::PipelineAsync<SchedulerPipelineStageCount>;
+  using CLCThrottlePipelineState = typename CLCThrottlePipeline::PipelineState;
+
+  using TmemAllocator = cute::conditional_t<cute::size(cute::shape<0>(typename TiledMma::ThrLayoutVMNK{})) == 1,
+      cute::TMEM::Allocator1Sm, cute::TMEM::Allocator2Sm>;
+
+  // Kernel level shared memory storage
+  struct SharedStorage {
+    struct PipelineStorage : cute::aligned_struct<16, _1> {
+      using MainloopPipelineStorage = typename CollectiveMainloop::PipelineStorage;
+      using EpiLoadPipelineStorage = typename CollectiveEpilogue::PipelineStorage;
+      using LoadOrderBarrierStorage = typename LoadOrderBarrier::SharedStorage;
+      using CLCPipelineStorage = typename CLCPipeline::SharedStorage;
+      using AccumulatorPipelineStorage = typename AccumulatorPipeline::SharedStorage;
+      using CLCThrottlePipelineStorage = typename CLCThrottlePipeline::SharedStorage;
+
+      alignas(16) MainloopPipelineStorage mainloop;
+      alignas(16) EpiLoadPipelineStorage epi_load;
+      alignas(16) LoadOrderBarrierStorage load_order;
+      alignas(16) CLCPipelineStorage clc;
+      alignas(16) AccumulatorPipelineStorage accumulator;
+      alignas(16) CLCThrottlePipelineStorage clc_throttle;
+      alignas(16) arch::ClusterBarrier tmem_dealloc;
+    } pipelines;
+
+    alignas(16) typename TileScheduler::CLCResponse clc_response[SchedulerPipelineStageCount];
+    uint32_t tmem_base_ptr;
+
+    struct TensorStorage : cute::aligned_struct<128, _1> {
+      using EpilogueTensorStorage = typename CollectiveEpilogue::TensorStorage;
+      using MainloopTensorStorage = typename CollectiveMainloop::TensorStorage;
+
+      EpilogueTensorStorage epilogue;
+      MainloopTensorStorage mainloop;
+    } tensors;
+  };
+
+  static constexpr int SharedStorageSize = sizeof(SharedStorage);
+
+  // Host facing host arguments
+  struct Arguments {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    MainloopArguments mainloop{};
+    EpilogueArguments epilogue{};
+    KernelHardwareInfo hw_info{};
+    TileSchedulerArguments scheduler{};
+  };
+
+  // Kernel device entry point API
+  struct Params {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    MainloopParams mainloop{};
+    EpilogueParams epilogue{};
+    TileSchedulerParams scheduler{};
+    KernelHardwareInfo hw_info{}; 
+  };
+
+  enum class WarpCategory : int32_t {
+    MMA          = 0,
+    Sched        = 1,
+    MainloopLoad = 2,
+    EpilogueLoad = 3,
+    Epilogue     = 4
+  };
+
+  struct IsParticipant {
+    uint32_t mma       = false;
+    uint32_t sched     = false;
+    uint32_t main_load = false;
+    uint32_t epi_load  = false;
+    uint32_t epilogue  = false;
+  };
+
+  //
+  // Methods
+  //
+
+  // Convert to underlying arguments.
+  static
+  Params
+  to_underlying_arguments(Arguments const& args, void* workspace) {
+    (void) workspace;
+    auto problem_shape = args.problem_shape;
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+
+    // Get SM count if needed, otherwise use user supplied SM count
+    int sm_count = args.hw_info.sm_count;
+    if (sm_count != 0) {
+      CUTLASS_TRACE_HOST("  WARNING: SM100 tile scheduler does not allow for user specified SM counts.\n"
+          "  To restrict a kernel's resource usage, consider using CUDA driver APIs instead (green contexts).");
+    }
+    CUTLASS_TRACE_HOST("to_underlying_arguments(): Setting persistent grid SM count to " << sm_count);
+
+    // Calculate workspace pointers
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+
+    // Epilogue
+    void* epilogue_workspace = workspace_ptr + workspace_offset;
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    void* mainloop_workspace = nullptr;
+
+    // Tile scheduler
+    void* scheduler_workspace = workspace_ptr + workspace_offset;
+    workspace_offset += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+
+    return {
+      args.mode,
+      args.problem_shape,
+      CollectiveMainloop::to_underlying_arguments(args.problem_shape, args.mainloop, mainloop_workspace, args.hw_info),
+      CollectiveEpilogue::to_underlying_arguments(args.problem_shape, args.epilogue, epilogue_workspace),
+      TileScheduler::to_underlying_arguments(
+        problem_shape_MNKL, TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
+        args.hw_info, args.scheduler, scheduler_workspace
+      )
+      ,args.hw_info
+    };
+  }
+
+  static bool
+  can_implement(Arguments const& args) {
+    bool implementable = (args.mode == GemmUniversalMode::kGemm) or
+        (args.mode == GemmUniversalMode::kBatched && rank(ProblemShape{}) == 4);
+    if (!implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: Arguments or Problem Shape don't meet the requirements.\n");
+      return implementable;
+    }
+    implementable &= CollectiveMainloop::can_implement(args.problem_shape, args.mainloop);
+    implementable &= CollectiveEpilogue::can_implement(args.problem_shape, args.epilogue);
+    implementable &= TileScheduler::can_implement(args.scheduler);
+
+    if constexpr (IsDynamicCluster) {
+      static constexpr int MaxClusterSize = 16;
+      implementable &= size(args.hw_info.cluster_shape) <= MaxClusterSize;
+      implementable &= size(args.hw_info.cluster_shape_fallback) <= MaxClusterSize;
+      implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
+    }
+    
+    constexpr bool IsBlockscaled = !cute::is_void_v<ElementSF>;
+    if constexpr (IsBlockscaled) {
+      if constexpr (IsDynamicCluster) {
+        implementable &= cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
+        // Special cluster shape check for scale factor multicasts. Due to limited size of scale factors, we can't multicast among
+        // more than 4 CTAs
+        implementable &= (args.hw_info.cluster_shape.x <= 4 && args.hw_info.cluster_shape.y <= 4 &&
+                          args.hw_info.cluster_shape_fallback.x <= 4 && args.hw_info.cluster_shape_fallback.y <= 4);
+      }
+      else {
+        // Special cluster shape check for scale factor multicasts. Due to limited size of scale factors, we can't multicast among
+        // more than 4 CTAs
+        implementable &= ((size<0>(ClusterShape{}) <= 4) && (size<1>(ClusterShape{}) <= 4));
+      }
+    }
+
+    return implementable;
+  }
+
+  static size_t
+  get_workspace_size(Arguments const& args) {
+    size_t workspace_size = 0;
+
+    // Epilogue
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    // Tile scheduler
+    workspace_size += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_size = round_nearest(workspace_size,  MinWorkspaceAlignment);
+
+    return workspace_size;
+  }
+
+  static cutlass::Status
+  initialize_workspace(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr,
+    CudaHostAdapter* cuda_adapter = nullptr) {
+    Status status = Status::kSuccess;
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+
+    // Epilogue
+    status = CollectiveEpilogue::initialize_workspace(args.problem_shape, args.epilogue, workspace_ptr + workspace_offset, stream, cuda_adapter);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Tile scheduler
+    status = TileScheduler::template initialize_workspace<ProblemShape, ElementAccumulator>(
+      args.scheduler, workspace_ptr + workspace_offset, stream, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+    workspace_offset += TileScheduler::template get_workspace_size<ProblemShape, ElementAccumulator>(
+      args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset,  MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    return status;
+  }
+
+  // Computes the kernel launch grid shape based on runtime parameters
+  static dim3
+  get_grid_shape(Params const& params) {
+    // NOTE cluster_shape here is the major cluster shape, not fallback one
+    auto cluster_shape = cutlass::detail::select_cluster_shape(ClusterShape{}, params.hw_info.cluster_shape);
+
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    return TileScheduler::get_grid_shape(
+        params.scheduler,
+        problem_shape_MNKL,
+        TileShape{},
+        AtomThrShapeMNK{},
+        cluster_shape,
+        params.hw_info);
+  }
+
+  static dim3
+  get_block_shape() {
+    return dim3(MaxThreadsPerBlock, 1, 1);
+  }
+
+  CUTLASS_DEVICE
+  void
+  operator() (Params const& params, char* smem_buf) {
+
+    using namespace cute;
+    using X = Underscore;
+
+    static_assert(SharedStorageSize <= cutlass::arch::sm100_smem_capacity_bytes, "SMEM usage exceeded capacity.");
+    // Separate out problem shape for convenience
+    // Optionally append 1s until problem shape is rank-4 in case its is only rank-3 (MNK)
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    auto [M,N,K,L] = problem_shape_MNKL;
+
+    // Account for more than one epilogue warp
+    int warp_idx = canonical_warp_idx_sync();
+    WarpCategory warp_category = warp_idx < static_cast<int>(WarpCategory::Epilogue) ? WarpCategory(warp_idx)
+                                                                                     : WarpCategory::Epilogue;
+
+    uint32_t lane_predicate = cute::elect_one_sync();
+    auto cluster_shape = cutlass::detail::select_cluster_shape(ClusterShape{});
+    int cluster_size = size(cluster_shape);
+    uint32_t cta_rank_in_cluster = cute::block_rank_in_cluster();
+    bool is_first_cta_in_cluster = cta_rank_in_cluster == 0;
+    int cta_coord_v = cta_rank_in_cluster % size<0>(typename TiledMma::AtomThrID{});
+    bool is_mma_leader_cta = cta_coord_v == 0;
+    constexpr bool has_mma_peer_cta = size(AtomThrShapeMNK{}) == 2;
+    [[maybe_unused]] uint32_t mma_peer_cta_rank = has_mma_peer_cta ? cta_rank_in_cluster ^ 1 : cta_rank_in_cluster;
+
+    // Kernel level shared memory storage
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    // In a warp specialized kernel, collectives expose data movement and compute operations separately
+    CollectiveMainloop collective_mainloop(params.mainloop, cluster_shape, cta_rank_in_cluster);
+    CollectiveEpilogue collective_epilogue(params.epilogue, shared_storage.tensors.epilogue);
+
+    // Issue Tma Descriptor Prefetch from a single thread
+    if ((warp_category == WarpCategory::Sched) && lane_predicate) {
+      collective_mainloop.prefetch_tma_descriptors();
+    }
+    if ((warp_category == WarpCategory::EpilogueLoad) && lane_predicate) {
+      collective_epilogue.prefetch_tma_descriptors(params.epilogue);
+    }
+
+    // Do we load source tensor C or other aux inputs
+    bool is_epi_load_needed = collective_epilogue.is_producer_load_needed();
+    IsParticipant is_participant = {
+      (warp_category == WarpCategory::MMA),                                 // mma
+      (warp_category == WarpCategory::Sched) && is_first_cta_in_cluster,    // sched
+      (warp_category == WarpCategory::MainloopLoad),                        // main_load
+      (warp_category == WarpCategory::EpilogueLoad) && is_epi_load_needed,  // epi_load
+      (warp_category == WarpCategory::Epilogue)                             // epilogue
+    };
+
+    // Mainloop Load pipeline
+    typename MainloopPipeline::Params mainloop_pipeline_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::MMA == warp_category) {
+      mainloop_pipeline_params.role = MainloopPipeline::ThreadCategory::Consumer;
+    }
+    mainloop_pipeline_params.is_leader = lane_predicate && is_mma_leader_cta && is_participant.main_load;
+    mainloop_pipeline_params.transaction_bytes = CollectiveMainloop::TmaTransactionBytes;
+    mainloop_pipeline_params.initializing_warp = 0;
+    MainloopPipeline mainloop_pipeline(shared_storage.pipelines.mainloop,
+                                       mainloop_pipeline_params,
+                                       cluster_shape,
+                                       cute::true_type{},   // Perform barrier init
+                                       cute::false_type{}); // Delay mask calculation
+
+    // Epilogue Load pipeline
+    typename EpiLoadPipeline::Params epi_load_pipeline_params;
+    if (WarpCategory::EpilogueLoad == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Consumer;
+    }
+    epi_load_pipeline_params.dst_blockid = cta_rank_in_cluster;
+    epi_load_pipeline_params.producer_arv_count = NumEpilogueLoadThreads;
+    epi_load_pipeline_params.consumer_arv_count = NumEpilogueThreads;
+    epi_load_pipeline_params.transaction_bytes = CollectiveEpilogue::TmaTransactionBytes;
+    epi_load_pipeline_params.initializing_warp = 1;
+    EpiLoadPipeline epi_load_pipeline(shared_storage.pipelines.epi_load, epi_load_pipeline_params);
+
+    // Epilogue Store pipeline
+    typename EpiStorePipeline::Params epi_store_pipeline_params;
+    epi_store_pipeline_params.always_wait = true;
+    EpiStorePipeline epi_store_pipeline(epi_store_pipeline_params);
+
+    // Load order barrier
+    typename LoadOrderBarrier::Params load_order_barrier_params;
+    load_order_barrier_params.group_id = (warp_category == WarpCategory::MainloopLoad) ? 0 : 1;
+    load_order_barrier_params.group_size = NumMainloopLoadThreads;
+    load_order_barrier_params.initializing_warp = 3;
+    LoadOrderBarrier load_order_barrier(shared_storage.pipelines.load_order, load_order_barrier_params);
+
+    // CLC pipeline
+    typename CLCPipeline::Params clc_pipeline_params;
+    if (WarpCategory::Sched == warp_category) {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::ProducerConsumer;
+    }
+    else {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::Consumer;
+    }
+    clc_pipeline_params.producer_blockid = 0;
+    clc_pipeline_params.producer_arv_count = 1;
+    clc_pipeline_params.consumer_arv_count = NumSchedThreads + cluster_size *
+                                                 (NumMainloopLoadThreads + NumEpilogueThreads + NumMMAThreads);
+    if (is_epi_load_needed) {
+      clc_pipeline_params.consumer_arv_count += cluster_size * NumEpilogueLoadThreads;
+    }
+    clc_pipeline_params.transaction_bytes = CLCResponseSize;
+    clc_pipeline_params.initializing_warp = 4;
+    CLCPipeline clc_pipeline(shared_storage.pipelines.clc, clc_pipeline_params, cluster_shape);
+
+    // Mainloop-Epilogue pipeline
+    typename AccumulatorPipeline::Params accumulator_pipeline_params;
+    if (WarpCategory::MMA == warp_category) {
+      accumulator_pipeline_params.role = AccumulatorPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      accumulator_pipeline_params.role = AccumulatorPipeline::ThreadCategory::Consumer;
+    }
+    // Only one producer thread arrives on this barrier.
+    accumulator_pipeline_params.producer_arv_count = 1;
+    accumulator_pipeline_params.consumer_arv_count = size(AtomThrShapeMNK{}) * NumEpilogueThreads;
+    accumulator_pipeline_params.initializing_warp = 5;
+    AccumulatorPipeline accumulator_pipeline(shared_storage.pipelines.accumulator,
+                                             accumulator_pipeline_params,
+                                             cluster_shape,
+                                             cute::true_type{},   // Perform barrier init
+                                             cute::false_type{}); // Delay mask calculation
+
+    // CLC throttle pipeline
+    typename CLCThrottlePipeline::Params clc_throttle_pipeline_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      clc_throttle_pipeline_params.role = CLCThrottlePipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Sched == warp_category) {
+      clc_throttle_pipeline_params.role = CLCThrottlePipeline::ThreadCategory::Consumer;
+    }
+    clc_throttle_pipeline_params.producer_arv_count = NumMainloopLoadThreads;
+    clc_throttle_pipeline_params.consumer_arv_count = NumSchedThreads;
+    clc_throttle_pipeline_params.dst_blockid = 0;
+    clc_throttle_pipeline_params.initializing_warp = 3;
+    CLCThrottlePipeline clc_throttle_pipeline(shared_storage.pipelines.clc_throttle, clc_throttle_pipeline_params);
+    CLCThrottlePipelineState clc_pipe_throttle_consumer_state;
+    CLCThrottlePipelineState clc_pipe_throttle_producer_state = cutlass::make_producer_start_state<CLCThrottlePipeline>();
+
+    // Tmem allocator
+    TmemAllocator tmem_allocator{};
+
+    // Sync allocation status between MMA and epilogue warps within CTA
+    arch::NamedBarrier tmem_allocation_result_barrier(NumMMAThreads + NumEpilogueThreads, cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
+    // Sync deallocation status between MMA warps of peer CTAs
+    arch::ClusterBarrier& tmem_deallocation_result_barrier = shared_storage.pipelines.tmem_dealloc;
+    [[maybe_unused]] uint32_t dealloc_barrier_phase = 0;
+    if (WarpCategory::MMA == warp_category) {
+      if constexpr(!IsOverlappingAccum) {
+        if (has_mma_peer_cta && lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumMMAThreads);
+        }
+      }
+      else {
+        if (has_mma_peer_cta && lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumEpilogueThreads*2);
+        }
+        else if (lane_predicate) {
+          tmem_deallocation_result_barrier.init(NumEpilogueThreads);
+        }
+      }
+    }
+
+    // We need this to guarantee that the Pipeline init is visible
+    // To all producers and consumer threadblocks in the cluster
+    pipeline_init_arrive_relaxed(cluster_size);
+
+    auto load_inputs = collective_mainloop.load_init(
+        problem_shape_MNKL, shared_storage.tensors.mainloop);
+
+    MainloopPipelineState mainloop_pipe_consumer_state;
+    MainloopPipelineState mainloop_pipe_producer_state = cutlass::make_producer_start_state<MainloopPipeline>();
+
+    EpiLoadPipelineState epi_load_pipe_consumer_state;
+    EpiLoadPipelineState epi_load_pipe_producer_state = cutlass::make_producer_start_state<EpiLoadPipeline>();
+
+    // epilogue store pipe is producer-only (consumer is TMA unit, waits via scoreboarding)
+    EpiStorePipelineState epi_store_pipe_producer_state = cutlass::make_producer_start_state<EpiStorePipeline>();
+
+    CLCPipelineState clc_pipe_consumer_state;
+    CLCPipelineState clc_pipe_producer_state = cutlass::make_producer_start_state<CLCPipeline>();
+
+    AccumulatorPipelineState accumulator_pipe_consumer_state;
+    AccumulatorPipelineState accumulator_pipe_producer_state = cutlass::make_producer_start_state<AccumulatorPipeline>();
+
+    dim3 block_id_in_cluster = cute::block_id_in_cluster();
+
+    // Calculate mask after cluster barrier arrival
+    mainloop_pipeline.init_masks(cluster_shape, block_id_in_cluster);
+    accumulator_pipeline.init_masks(cluster_shape, block_id_in_cluster);
+
+    // TileID scheduler
+    TileScheduler scheduler(&shared_storage.clc_response[0], params.scheduler, block_id_in_cluster);
+    typename TileScheduler::WorkTileInfo work_tile_info = scheduler.initial_work_tile_info(cluster_shape);
+    auto cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+    //
+    // TMEM "Allocation"
+    //
+    auto tmem_storage = collective_mainloop.template init_tmem_tensors<EpilogueTile, IsOverlappingAccum>(EpilogueTile{});
+
+    pipeline_init_wait(cluster_size);
+
+    if (is_participant.main_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_arrive = is_epi_load_needed;
+      bool requires_clc_query = true;
+
+      do {
+        // Get the number of K tiles to compute for this work as well as the starting K tile offset of the work.
+        auto k_tile_iter = scheduler.get_k_tile_iterator(work_tile_info, problem_shape_MNKL, CtaShape_MNK{}, load_inputs.k_tiles);
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+        auto k_tile_prologue = min(MainloopPipeline::Stages, k_tile_count);
+
+        if constexpr (IsSchedDynamicPersistent) {
+          if (is_first_cta_in_cluster && requires_clc_query) {
+            clc_throttle_pipeline.producer_acquire(clc_pipe_throttle_producer_state);
+            clc_throttle_pipeline.producer_commit(clc_pipe_throttle_producer_state);
+            ++clc_pipe_throttle_producer_state;
+          }
+        }
+
+        // Start mainloop prologue loads, arrive on the epilogue residual load barrier, resume mainloop loads
+        auto [mainloop_producer_state_next, k_tile_iter_next] = collective_mainloop.load(
+          mainloop_pipeline,
+          mainloop_pipe_producer_state,
+          load_inputs,
+          cta_coord_mnkl,
+          k_tile_iter, k_tile_prologue
+        );
+        mainloop_pipe_producer_state = mainloop_producer_state_next;
+
+        if (do_load_order_arrive) {
+          load_order_barrier.arrive();
+          do_load_order_arrive = false;
+        }
+
+        auto [mainloop_producer_state_next_, unused_] = collective_mainloop.load(
+          mainloop_pipeline,
+          mainloop_pipe_producer_state,
+          load_inputs,
+          cta_coord_mnkl,
+          k_tile_iter_next, k_tile_count - k_tile_prologue
+        );
+        mainloop_pipe_producer_state = mainloop_producer_state_next_;
+
+        // Sync warp to prevent non-participating threads entering next wave early
+        __syncwarp();
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+        requires_clc_query = increment_pipe;
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+      } while (work_tile_info.is_valid());
+      collective_mainloop.load_tail(mainloop_pipeline, mainloop_pipe_producer_state);
+
+    }
+
+    else if (is_participant.sched) {
+      if constexpr (IsSchedDynamicPersistent) {
+        // Whether a new CLC query must be performed.
+        // See comment below where this variable is updated for a description of
+        // why this variable is needed.
+        bool requires_clc_query = true;
+
+        cutlass::arch::wait_on_dependent_grids();
+
+        do {
+          if (requires_clc_query) {
+            // Throttle CLC query to mitigate workload imbalance caused by skews among persistent workers.
+            clc_throttle_pipeline.consumer_wait(clc_pipe_throttle_consumer_state);
+            clc_throttle_pipeline.consumer_release(clc_pipe_throttle_consumer_state);
+            ++clc_pipe_throttle_consumer_state;
+
+            // Query next clcID and update producer state
+            clc_pipe_producer_state = scheduler.advance_to_next_work(clc_pipeline, clc_pipe_producer_state);
+          }
+
+          // Fetch next work tile
+          auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info,
+            clc_pipeline,
+            clc_pipe_consumer_state
+          );
+
+          // Only perform a new CLC query if we consumed a new CLC query result in
+          // `fetch_next_work`. An example of a case in which CLC `fetch_next_work` does
+          // not consume a new CLC query response is when processing stream-K units.
+          // The current stream-K scheduler uses single WorkTileInfo to track multiple
+          // (potentially-partial) tiles to be computed via stream-K. In this case,
+          // `fetch_next_work` simply performs in-place updates on the existing WorkTileInfo,
+          // rather than consuming a CLC query response.
+          requires_clc_query = increment_pipe;
+          if (increment_pipe) {
+            ++clc_pipe_consumer_state;
+          }
+
+          work_tile_info = next_work_tile_info;
+        } while (work_tile_info.is_valid());
+        clc_pipeline.producer_tail(clc_pipe_producer_state);
+      }
+    }
+
+    else if (is_participant.mma) {
+      // Tmem allocation sequence
+      tmem_allocator.allocate(TmemAllocator::Sm100TmemCapacityColumns, &shared_storage.tmem_base_ptr);
+      __syncwarp();
+      tmem_allocation_result_barrier.arrive();
+      uint32_t tmem_base_ptr = shared_storage.tmem_base_ptr;
+      collective_mainloop.set_tmem_offsets(tmem_storage, tmem_base_ptr);
+
+      auto mma_inputs = collective_mainloop.mma_init(
+        tmem_storage,
+        shared_storage.tensors.mainloop);
+
+      do {
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        // Accumulator stage slice
+        int acc_stage = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_producer_state.phase() ^ 1;
+          }
+          else {
+            return accumulator_pipe_producer_state.index();
+          }
+        }();
+
+        if (is_mma_leader_cta) {
+          mainloop_pipe_consumer_state = collective_mainloop.mma(
+            cute::make_tuple(mainloop_pipeline, accumulator_pipeline),
+            cute::make_tuple(mainloop_pipe_consumer_state, accumulator_pipe_producer_state),
+            collective_mainloop.slice_accumulator(tmem_storage, acc_stage),
+            mma_inputs,
+            cta_coord_mnkl,
+            k_tile_count
+            );
+          accumulator_pipeline.producer_commit(accumulator_pipe_producer_state);
+        }
+        ++accumulator_pipe_producer_state;
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Hint on an early release of global memory resources.
+      // The timing of calling this function only influences performance,
+      // not functional correctness.
+      cutlass::arch::launch_dependent_grids();
+
+      // Release the right to allocate before deallocations so that the next CTA can rasterize
+      tmem_allocator.release_allocation_lock();
+
+      if constexpr (!IsOverlappingAccum) {
+        // Leader MMA waits for leader + peer epilogues to release accumulator stage
+        if (is_mma_leader_cta) {
+          accumulator_pipeline.producer_tail(accumulator_pipe_producer_state);
+        }
+        // Signal to peer MMA that entire tmem allocation can be deallocated
+        if constexpr (has_mma_peer_cta) {
+          // Leader does wait + arrive, follower does arrive + wait
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank, not is_mma_leader_cta);
+          tmem_deallocation_result_barrier.wait(dealloc_barrier_phase);
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank, is_mma_leader_cta);
+        }
+      }
+      else {
+        tmem_deallocation_result_barrier.wait(dealloc_barrier_phase);
+      }
+
+      // Free entire tmem allocation
+      tmem_allocator.free(tmem_base_ptr, TmemAllocator::Sm100TmemCapacityColumns);
+    }
+
+    else if (is_participant.epi_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_wait = true;
+      bool do_tail_load = false;
+      int current_wave = 0;
+
+      do {
+        bool compute_epilogue = TileScheduler::compute_epilogue(work_tile_info, params.scheduler);
+
+        // Get current work tile and fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+        work_tile_info = next_work_tile_info;
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        if (compute_epilogue) {
+          if (do_load_order_wait) {
+            load_order_barrier.wait();
+            do_load_order_wait = false;
+          }
+
+          bool reverse_epi_n = IsOverlappingAccum && (current_wave % 2 == 0);
+          epi_load_pipe_producer_state = collective_epilogue.template load<IsOverlappingAccum>(
+            epi_load_pipeline,
+            epi_load_pipe_producer_state,
+            problem_shape_MNKL,
+            CtaShape_MNK{},
+            cta_coord_mnkl,
+            TileShape{},
+            TiledMma{},
+            shared_storage.tensors.epilogue,
+            reverse_epi_n
+          );
+
+          do_tail_load = true;
+        }
+        current_wave++;
+
+        // Calculate the cta coordinates of the next work tile
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Only perform a tail load if one of the work units processed performed
+      // an epilogue load. An example of a case in which a tail load should not be
+      // performed is in split-K if a cluster is only assigned non-final splits (for which
+      // the cluster does not compute the epilogue).
+      if (do_tail_load) {
+        collective_epilogue.load_tail(
+          epi_load_pipeline, epi_load_pipe_producer_state,
+          epi_store_pipeline, epi_store_pipe_producer_state);
+      }
+    }
+
+    else if (is_participant.epilogue) {
+      // Wait for tmem allocate here
+      tmem_allocation_result_barrier.arrive_and_wait();
+      uint32_t tmem_base_ptr = shared_storage.tmem_base_ptr;
+      collective_mainloop.set_tmem_offsets(tmem_storage, tmem_base_ptr);
+
+      bool do_tail_store = false;
+      do {
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+          work_tile_info,
+          clc_pipeline,
+          clc_pipe_consumer_state
+        );
+
+        if (increment_pipe) {
+          ++clc_pipe_consumer_state;
+        }
+
+        // Accumulator stage slice
+        int acc_stage = [&] () {
+          if constexpr (IsOverlappingAccum) {
+            return accumulator_pipe_consumer_state.phase();
+          }
+          else {
+            return accumulator_pipe_consumer_state.index();
+          }
+        }();
+
+        auto accumulator = get<0>(collective_mainloop.slice_accumulator(tmem_storage, acc_stage));
+        accumulator_pipe_consumer_state = scheduler.template fixup<IsComplex>(
+          TiledMma{},
+          work_tile_info,
+          accumulator,
+          accumulator_pipeline,
+          accumulator_pipe_consumer_state,
+          typename CollectiveEpilogue::CopyOpT2R{}
+        );
+
+        //
+        // Epilogue and write to gD
+        //
+        if (scheduler.compute_epilogue(work_tile_info)) {
+          auto [load_state_next, store_state_next, acc_state_next] = collective_epilogue.template store<IsOverlappingAccum>(
+            epi_load_pipeline,
+            epi_load_pipe_consumer_state,
+            epi_store_pipeline,
+            epi_store_pipe_producer_state,
+            accumulator_pipeline,
+            accumulator_pipe_consumer_state,
+            problem_shape_MNKL,
+            CtaShape_MNK{},
+            cta_coord_mnkl,
+            TileShape{},
+            TiledMma{},
+            accumulator,
+            shared_storage.tensors.epilogue
+          );
+          epi_load_pipe_consumer_state = load_state_next;
+          epi_store_pipe_producer_state = store_state_next;
+          accumulator_pipe_consumer_state = acc_state_next;
+          do_tail_store = true;
+        }
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+
+      } while (work_tile_info.is_valid());
+
+      if constexpr (IsOverlappingAccum) {
+        // Signal to peer MMA that Full TMEM alloc can be deallocated
+        if constexpr (has_mma_peer_cta) {
+          tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank);
+        }
+        tmem_deallocation_result_barrier.arrive();
+      }
+
+      // Only perform a tail store if one of the work units processed performed
+      // an epilogue. An example of a case in which a tail load should not be
+      // performed is in split-K if a cluster is only assigned non-final splits (for which
+      // the cluster does not compute the epilogue).
+      if (do_tail_store) {
+        collective_epilogue.store_tail(
+          epi_load_pipeline, epi_load_pipe_consumer_state,
+          epi_store_pipeline, epi_store_pipe_producer_state,
+          CtaShape_MNK{});
+      }
+    }
+
+    else {
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+} // namespace cutlass::gemm::kernel

--- a/csrc/gemm/mega/flashrt_megakernel_single.cu
+++ b/csrc/gemm/mega/flashrt_megakernel_single.cu
@@ -1,0 +1,127 @@
+// ================================================================
+// FlashRT — single-GEMM kernel using the vendored production
+// sm100_gemm_tma_warpspecialized.hpp kernel struct (now
+// flashrt::megakernel::FlashRtMegakernelGemm).
+//
+// Purpose: prove that vendoring the production SM100 kernel into our
+// codebase preserves its perf characteristics for a single GEMM.
+// This is the foundation for the megakernel work in subsequent
+// commits — the operator() body in flashrt_megakernel_kernel.hpp
+// will be modified to chain multiple CollectiveMma instances with
+// GeGLU in SMEM between them.  The header is a literal copy of
+// CUTLASS's production sm100_gemm_tma_warpspecialized.hpp with only
+// the namespace and class name changed; no functional modification yet.
+//
+// Validation gate: at the split-G7 shape (M=1024, K=2048, N=16384)
+// this must match cutlass_fp16_sq isolation perf (~750 us at n=500).
+// If it doesn't, the vendor port is broken and we cannot proceed
+// to megakernel extension.
+// ================================================================
+
+#include "cutlass/cutlass.h"
+#include "cutlass/half.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/device_memory.h"
+
+#include "cute/tensor.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/numeric/integral_constant.hpp"
+
+#include "flashrt_megakernel_kernel.hpp"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+using namespace cute;
+using fp16_t = cutlass::half_t;
+
+namespace {
+
+// Same tile/cluster/schedule as production sm100_fp16_sq (the current
+// split-G7 winner).  This isolates the vendor port: any perf delta
+// here is from the kernel struct itself, not the tile selection.
+using Tile    = Shape<_256, _256, _128>;
+using Cluster = Shape<_2, _2, _1>;
+
+using Fusion = cutlass::epilogue::fusion::LinCombEltAct<
+    cutlass::epilogue::thread::Identity, fp16_t, float>;
+
+using CollectiveEpi = typename cutlass::epilogue::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    Tile, Cluster, cutlass::epilogue::collective::EpilogueTileAuto,
+    float, float, fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+
+using CollectiveMma = typename cutlass::gemm::collective::CollectiveBuilder<
+    cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+    fp16_t, cutlass::layout::RowMajor, 8,
+    fp16_t, cutlass::layout::ColumnMajor, 8,
+    float, Tile, Cluster,
+    cutlass::gemm::collective::StageCountAutoCarveout<
+        static_cast<int>(sizeof(typename CollectiveEpi::SharedStorage))>,
+    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+// Use the vendored kernel struct in place of CUTLASS's GemmUniversal.
+// Note: the SFINAE enable_if_t inside FlashRtMegakernelGemm matches on
+// CollectiveMainloop's Schedule tag (KernelTmaWarpSpecializedSm100),
+// so any Sm100 TMA WS mainloop instantiation is accepted.
+using GemmKernel = cutlass::gemm::kernel::FlashRtMegakernelGemm<
+    Shape<int, int, int, int>,
+    CollectiveMma,
+    CollectiveEpi,
+    void>;  // TileSchedulerTag = void → default scheduler
+
+using GemmOp = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+}  // anonymous namespace
+
+extern "C" int flashrt_megakernel_single_fp16(
+    void* A, void* B, void* D,
+    int M, int N, int K,
+    float alpha, float beta,
+    cudaStream_t stream)
+{
+    using ElementA = typename GemmOp::ElementA;
+    using ElementB = typename GemmOp::ElementB;
+    using ElementD = typename GemmOp::ElementD;
+
+    auto sA = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideA{}, {M, K, 1});
+    auto sB = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideB{}, {N, K, 1});
+    auto sD = cutlass::make_cute_packed_stride(
+        typename GemmOp::GemmKernel::StrideD{}, {M, N, 1});
+
+    typename GemmOp::Arguments args{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {M, N, K, 1},
+        {(ElementA*)A, sA, (ElementB*)B, sB},
+        {{alpha, beta}, (ElementD*)D, sD, (ElementD*)D, sD}
+    };
+
+    GemmOp gemm;
+    size_t ws_size = GemmOp::get_workspace_size(args);
+    static cutlass::device_memory::allocation<uint8_t> workspace(0);
+    if (ws_size > workspace.size()) {
+        workspace = cutlass::device_memory::allocation<uint8_t>(ws_size);
+    }
+
+    if (gemm.can_implement(args) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_single] cannot implement M=%d N=%d K=%d\n", M, N, K);
+        return -1;
+    }
+    if (gemm.initialize(args, workspace.get(), stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_single] init failed\n");
+        return -2;
+    }
+    if (gemm.run(stream) != cutlass::Status::kSuccess) {
+        fprintf(stderr, "[flashrt_megakernel_single] run failed\n");
+        return -3;
+    }
+    return 0;
+}

--- a/csrc/gemm/mega/sm100_smem_aux_visitor.hpp
+++ b/csrc/gemm/mega/sm100_smem_aux_visitor.hpp
@@ -1,5 +1,5 @@
 // ============================================================================
-// FlashRT — MK-1 Stage B SMEM-only EVT visitors + FusionOperation tags
+// FlashRT — SMEM-only EVT visitors + FusionOperation tags
 // + FusionCallbacks specializations.
 //
 // Two visitor classes:

--- a/csrc/gemm/mega/sm100_smem_aux_visitor.hpp
+++ b/csrc/gemm/mega/sm100_smem_aux_visitor.hpp
@@ -1,0 +1,534 @@
+// ============================================================================
+// FlashRT — MK-1 Stage B SMEM-only EVT visitors + FusionOperation tags
+// + FusionCallbacks specializations.
+//
+// Two visitor classes:
+//   Sm100SmemAuxStore  — phase 1 (gate) post-activation fragment R2S-stored
+//                        to an external full-tile SMEM buffer (smem_gate),
+//                        sized by the kernel's SharedStorage.
+//   Sm100SmemAuxLoad   — phase 2 (up) epilogue previsit S2R-loads from the
+//                        same SMEM buffer.
+//
+// Two FusionOperation tags (FlashRT-specific):
+//   LinCombEltActSmemAuxStore  — `D = act(alpha*acc + beta*C)`, AND
+//                                aux = D captured into SMEM.
+//   LinCombDeEltActSmemAuxLoad — `D = activation(beta*C + alpha*acc, aux)`
+//                                with aux loaded from SMEM.
+//
+// FusionCallbacks<Sm90TmaWarpSpecialized<...>, OurOp, ...> specializations
+// stitch these into the standard CollectiveEpilogue dispatch path.  Sm100
+// dispatch inherits from Sm90 automatically (sm100_callbacks_tma_warpspecialized.hpp).
+//
+// Synchronization between phase 1 R2S complete and phase 2 S2R start is
+// the kernel body's responsibility — NamedBarrier on NumEpilogueThreads
+// between the two collective_epilogue.store() calls.
+// ============================================================================
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/fast_math.h"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/fusion/operations.hpp"
+#include "cutlass/epilogue/fusion/callbacks.hpp"
+#include "cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp"
+#include "cutlass/epilogue/fusion/sm90_visitor_load_tma_warpspecialized.hpp"
+#include "cutlass/epilogue/fusion/sm90_visitor_store_tma_warpspecialized.hpp"
+#include "cutlass/epilogue/fusion/sm90_visitor_compute_tma_warpspecialized.hpp"
+#include "cutlass/epilogue/collective/detail.hpp"
+
+#include "cute/tensor.hpp"
+
+namespace flashrt::megakernel::fusion {
+
+using namespace cute;
+using namespace cutlass::epilogue::fusion;
+
+// ============================================================================
+// Visitor 1: Sm100SmemAuxStore
+//   - In the EVT chain, sits on top of an upstream LinComb+Act node.
+//   - visit() captures the post-activation fragment into RMEM.
+//   - postreduce() R2S-stores RMEM into smem_aux at (epi_m, epi_n) within
+//     the full CTA-tile buffer.
+//   - No producer load, no TMA store.  The smem_aux buffer is OWNED by
+//     the calling kernel (not the visitor's SharedStorage) and passed
+//     via Arguments::smem_aux_ptr.
+// ============================================================================
+template <
+  class CtaTileShape_MN_,
+  class EpilogueTile_,
+  class Element_,
+  class SmemLayoutAtom_,
+  class CopyOpR2S_,
+  cutlass::FloatRoundStyle RoundStyle = cutlass::FloatRoundStyle::round_to_nearest
+>
+struct Sm100SmemAuxStore {
+  using CtaTileShape_MN = CtaTileShape_MN_;
+  using EpilogueTile = EpilogueTile_;
+  using Element      = Element_;
+  using ElementAux   = Element;
+  using SmemLayoutAtom = SmemLayoutAtom_;
+  using CopyOpR2S    = CopyOpR2S_;
+
+  using SmemLayout = decltype(tile_to_shape(
+      SmemLayoutAtom{},
+      cute::shape(CtaTileShape_MN{}),
+      Step<_1,_2>{}));
+
+  // Visitor OWNS its SMEM (mirrors Sm90AuxStore pattern).  Cross-phase
+  // sharing handled at kernel TensorStorage layout level (see kernel hdr).
+  struct SharedStorage {
+    alignas(128) cute::array_aligned<Element, cute::cosize_v<SmemLayout>> smem_aux;
+  };
+
+  struct Arguments { };
+  struct Params { };
+
+  template <class ProblemShape>
+  static constexpr Params
+  to_underlying_arguments(ProblemShape const&, Arguments const&, void*) {
+    return Params{};
+  }
+
+  template <class ProblemShape>
+  static bool can_implement(ProblemShape const&, Arguments const&) { return true; }
+
+  template <class ProblemShape>
+  static size_t get_workspace_size(ProblemShape const&, Arguments const&) { return 0; }
+
+  template <class ProblemShape>
+  static cutlass::Status
+  initialize_workspace(ProblemShape const&, Arguments const&, void*,
+                       cudaStream_t = nullptr, cutlass::CudaHostAdapter* = nullptr) {
+    return cutlass::Status::kSuccess;
+  }
+
+  CUTLASS_HOST_DEVICE Sm100SmemAuxStore() { }
+  CUTLASS_HOST_DEVICE
+  Sm100SmemAuxStore(Params const&, SharedStorage const& shared_storage)
+      : smem_aux(const_cast<Element*>(shared_storage.smem_aux.data())) { }
+
+  Element* smem_aux;
+
+  CUTLASS_DEVICE bool is_producer_load_needed() const { return false; }
+  CUTLASS_DEVICE bool is_C_load_needed() const { return false; }
+
+  template <class... Args>
+  CUTLASS_DEVICE auto
+  get_producer_load_callbacks(ProducerLoadArgs<Args...> const&) {
+    return EmptyProducerLoadCallbacks{};
+  }
+
+  template <class RTensor, class TiledR2S, class STensorR2S>
+  struct ConsumerStoreCallbacks : EmptyConsumerStoreCallbacks {
+    CUTLASS_DEVICE
+    ConsumerStoreCallbacks(RTensor&& tC_rAux_, TiledR2S tiled_r2s_, STensorR2S&& tRS_sAux_)
+      : tC_rAux(cute::forward<RTensor>(tC_rAux_)),
+        tiled_r2s(tiled_r2s_),
+        tRS_sAux(cute::forward<STensorR2S>(tRS_sAux_)) { }
+
+    RTensor    tC_rAux;
+    TiledR2S   tiled_r2s;
+    STensorR2S tRS_sAux;
+
+    template <typename ElementAccumulator, typename ElementInput, int FragmentSize>
+    CUTLASS_DEVICE auto
+    visit(cutlass::Array<ElementAccumulator, FragmentSize> const&,
+          int epi_v, int, int,
+          cutlass::Array<ElementInput, FragmentSize> const& frg_input) {
+      using ConvertInput = cutlass::NumericArrayConverter<Element, ElementInput, FragmentSize, RoundStyle>;
+      ConvertInput convert_input{};
+      Tensor tC_rAux_frg = recast<cutlass::Array<Element, FragmentSize>>(coalesce(tC_rAux));
+      tC_rAux_frg(epi_v) = convert_input(frg_input);
+      return frg_input;
+    }
+
+    CUTLASS_DEVICE void
+    postreduce(int epi_m, int epi_n, int, bool issue_smem_store) {
+      if (issue_smem_store) {
+        using RLayoutR2S = decltype(cute::layout(TiledR2S{}.get_slice(0).retile_S(RTensor{})));
+        Tensor tRS_rAux = make_tensor(tC_rAux.data(), RLayoutR2S{});
+        copy(tiled_r2s, tRS_rAux, tRS_sAux(_,_,_,epi_m,epi_n));
+      }
+    }
+  };
+
+  template <bool ReferenceSrc, class... Args>
+  CUTLASS_DEVICE auto
+  get_consumer_store_callbacks(ConsumerStoreArgs<Args...> const& args) {
+    Tensor sAux_full = cute::as_position_independent_swizzle_tensor(
+                         make_tensor(make_smem_ptr(smem_aux), SmemLayout{}));
+    Tensor sAux_epi = flat_divide(sAux_full, args.epi_tile);
+
+    auto tiled_r2s = conditional_return<ReferenceSrc>(
+        make_tiled_copy_S(Copy_Atom<CopyOpR2S, Element>{}, args.tiled_copy),
+        make_tiled_copy_D(Copy_Atom<CopyOpR2S, Element>{}, args.tiled_copy));
+
+    auto thr_r2s = tiled_r2s.get_slice(args.thread_idx);
+    Tensor tRS_sAux = thr_r2s.partition_D(sAux_epi);
+    Tensor tC_rAux = make_tensor<Element>(take<0,3>(shape(tRS_sAux)));
+
+    return ConsumerStoreCallbacks<decltype(tC_rAux), decltype(tiled_r2s), decltype(tRS_sAux)>(
+        cute::move(tC_rAux), tiled_r2s, cute::move(tRS_sAux));
+  }
+};
+
+// ============================================================================
+// Visitor 2: Sm100SmemAuxLoad
+// ============================================================================
+template <
+  class CtaTileShape_MN_,
+  class EpilogueTile_,
+  class Element_,
+  class SmemLayoutAtom_,
+  class CopyOpS2R_
+>
+struct Sm100SmemAuxLoad {
+  using CtaTileShape_MN = CtaTileShape_MN_;
+  using EpilogueTile = EpilogueTile_;
+  using Element      = Element_;
+  using ElementAux   = Element;
+  using SmemLayoutAtom = SmemLayoutAtom_;
+  using CopyOpS2R    = CopyOpS2R_;
+
+  using SmemLayout = decltype(tile_to_shape(
+      SmemLayoutAtom{},
+      cute::shape(CtaTileShape_MN{}),
+      Step<_1,_2>{}));
+
+  struct SharedStorage {
+    alignas(128) cute::array_aligned<Element, cute::cosize_v<SmemLayout>> smem_aux;
+  };
+
+  struct Arguments { };
+  struct Params { };
+
+  template <class ProblemShape>
+  static constexpr Params
+  to_underlying_arguments(ProblemShape const&, Arguments const&, void*) {
+    return Params{};
+  }
+
+  template <class ProblemShape>
+  static bool can_implement(ProblemShape const&, Arguments const&) { return true; }
+
+  template <class ProblemShape>
+  static size_t get_workspace_size(ProblemShape const&, Arguments const&) { return 0; }
+
+  template <class ProblemShape>
+  static cutlass::Status
+  initialize_workspace(ProblemShape const&, Arguments const&, void*,
+                       cudaStream_t = nullptr, cutlass::CudaHostAdapter* = nullptr) {
+    return cutlass::Status::kSuccess;
+  }
+
+  CUTLASS_HOST_DEVICE Sm100SmemAuxLoad() { }
+  CUTLASS_HOST_DEVICE
+  Sm100SmemAuxLoad(Params const&, SharedStorage const& shared_storage)
+      : smem_aux(const_cast<Element*>(shared_storage.smem_aux.data())) { }
+
+  Element* smem_aux;
+
+  CUTLASS_DEVICE bool is_producer_load_needed() const { return false; }
+  CUTLASS_DEVICE bool is_C_load_needed() const { return false; }
+
+  template <class... Args>
+  CUTLASS_DEVICE auto
+  get_producer_load_callbacks(ProducerLoadArgs<Args...> const&) {
+    return EmptyProducerLoadCallbacks{};
+  }
+
+  template <class RTensor, class TiledS2R, class STensorS2R>
+  struct ConsumerStoreCallbacks : EmptyConsumerStoreCallbacks {
+    CUTLASS_DEVICE
+    ConsumerStoreCallbacks(RTensor&& tC_rAux_, TiledS2R tiled_s2r_, STensorS2R&& tSR_sAux_)
+      : tC_rAux(cute::forward<RTensor>(tC_rAux_)),
+        tiled_s2r(tiled_s2r_),
+        tSR_sAux(cute::forward<STensorS2R>(tSR_sAux_)) { }
+
+    RTensor    tC_rAux;
+    TiledS2R   tiled_s2r;
+    STensorS2R tSR_sAux;
+
+    CUTLASS_DEVICE void
+    previsit(int epi_m, int epi_n, int, bool) {
+      using RLayoutS2R = decltype(cute::layout(TiledS2R{}.get_slice(0).retile_S(RTensor{})));
+      Tensor tSR_rAux = make_tensor(tC_rAux.data(), RLayoutS2R{});
+      copy(tiled_s2r, tSR_sAux(_,_,_,epi_m,epi_n), tSR_rAux);
+    }
+
+    template <typename ElementAccumulator, int FragmentSize>
+    CUTLASS_DEVICE cutlass::Array<Element, FragmentSize>
+    visit(cutlass::Array<ElementAccumulator, FragmentSize> const&,
+          int epi_v, int, int) {
+      Tensor tC_rAux_frg = recast<cutlass::Array<Element, FragmentSize>>(coalesce(tC_rAux));
+      return tC_rAux_frg(epi_v);
+    }
+  };
+
+  template <bool ReferenceSrc, class... Args>
+  CUTLASS_DEVICE auto
+  get_consumer_store_callbacks(ConsumerStoreArgs<Args...> const& args) {
+    Tensor sAux_full = cute::as_position_independent_swizzle_tensor(
+                         make_tensor(make_smem_ptr(smem_aux), SmemLayout{}));
+    Tensor sAux_epi = flat_divide(sAux_full, args.epi_tile);
+
+    auto tiled_s2r = conditional_return<ReferenceSrc>(
+        make_tiled_copy_S(Copy_Atom<CopyOpS2R, Element>{}, args.tiled_copy),
+        make_tiled_copy_D(Copy_Atom<CopyOpS2R, Element>{}, args.tiled_copy));
+
+    auto thr_s2r = tiled_s2r.get_slice(args.thread_idx);
+    Tensor tSR_sAux = thr_s2r.partition_S(sAux_epi);
+    Tensor tC_rAux = make_tensor<Element>(take<0,3>(shape(tSR_sAux)));
+
+    return ConsumerStoreCallbacks<decltype(tC_rAux), decltype(tiled_s2r), decltype(tSR_sAux)>(
+        cute::move(tC_rAux), tiled_s2r, cute::move(tSR_sAux));
+  }
+};
+
+// ============================================================================
+// FusionOperation tags (FlashRT-specific).
+//
+// LinCombEltActSmemAuxStore inherits from LinCombEltAct and marks
+// IsAuxOutSupported=true with ElementAux=ElementOutput so the
+// CallbacksBuilder auto-dispatcher in sm100_builder.inl picks the
+// "single aux out" specialization and routes the (SmemLayoutAtomAux,
+// SmemCopyOpAux) types into our FusionCallbacks below.
+// ============================================================================
+template<
+  template <class> class ActivationFn_,
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementAux_ = ElementOutput_,
+  class ElementSource_ = ElementOutput_,
+  class ElementScalar_ = ElementCompute_,
+  int AlignmentAux_ = 128 / cute::sizeof_bits_v<ElementAux_>,
+  cutlass::FloatRoundStyle RoundStyle_ = cutlass::FloatRoundStyle::round_to_nearest
+>
+struct LinCombEltActSmemAuxStore
+    : LinCombEltAct<ActivationFn_, ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, RoundStyle_> {
+  using ElementAux = ElementAux_;
+  using GmemLayoutTagAux = cutlass::layout::RowMajor;  // unused (SMEM-only), but required by dispatcher
+  static constexpr int AlignmentAux = AlignmentAux_;
+  static constexpr bool IsAuxOutSupported = true;
+  static constexpr bool IsAuxInSupported  = false;
+};
+
+template<
+  template <class> class ActivationFn_,
+  class ElementOutput_,
+  class ElementCompute_,
+  class ElementAux_ = ElementOutput_,
+  class ElementSource_ = ElementOutput_,
+  class ElementScalar_ = ElementCompute_,
+  int AlignmentAux_ = 128 / cute::sizeof_bits_v<ElementAux_>,
+  cutlass::FloatRoundStyle RoundStyle_ = cutlass::FloatRoundStyle::round_to_nearest
+>
+struct LinCombDeEltActSmemAuxLoad
+    : cutlass::epilogue::fusion::LinearCombination<
+          ElementOutput_, ElementCompute_, ElementSource_, ElementScalar_, RoundStyle_> {
+  using ActivationFn = ActivationFn_<ElementCompute_>;
+  static constexpr bool IsDeEltActSupported = true;
+
+  using ElementAux = ElementAux_;
+  using GmemLayoutTagAux = cutlass::layout::RowMajor;  // unused (SMEM-only), required by dispatcher
+  static constexpr int AlignmentAux = AlignmentAux_;
+  static constexpr bool IsAuxOutSupported = false;
+  static constexpr bool IsAuxInSupported  = true;
+};
+
+// ============================================================================
+// EVT tree aliases — what the FusionCallbacks specializations inherit from.
+// ============================================================================
+template <
+  class CtaTileShapeMN, class EpilogueTile,
+  class SmemLayoutAtom, class CopyOpR2S,
+  template <class> class ActivationFn,
+  class ElementOutput, class ElementCompute,
+  class ElementAux,
+  class ElementSource, class ElementScalar,
+  cutlass::FloatRoundStyle RoundStyle
+>
+using Sm100LinCombEltActSmemAuxStoreTree =
+  Sm90EVT<Sm100SmemAuxStore<CtaTileShapeMN, EpilogueTile, ElementAux, SmemLayoutAtom, CopyOpR2S, RoundStyle>,
+    Sm90EVT<Sm90Compute<ActivationFn, ElementOutput, ElementCompute, RoundStyle>,
+      Sm90LinearCombination<ElementCompute, ElementCompute, ElementSource, ElementScalar, RoundStyle>
+    >
+  >;
+
+template <
+  class CtaTileShapeMN, class EpilogueTile,
+  class SmemLayoutAtom, class CopyOpS2R,
+  template <class> class ActivationFn,
+  class ElementOutput, class ElementCompute,
+  class ElementAux,
+  class ElementSource, class ElementScalar,
+  cutlass::FloatRoundStyle RoundStyle
+>
+using Sm100LinCombDeEltActSmemAuxLoadTree =
+  Sm90EVT<Sm90Compute<ActivationFn, ElementOutput, ElementCompute, RoundStyle>,
+    Sm90LinearCombination<ElementCompute, ElementCompute, ElementSource, ElementScalar, RoundStyle>,
+    Sm100SmemAuxLoad<CtaTileShapeMN, EpilogueTile, ElementAux, SmemLayoutAtom, CopyOpS2R>
+  >;
+
+} // namespace flashrt::megakernel::fusion
+
+// ============================================================================
+// FusionCallbacks specializations — must live in
+// cutlass::epilogue::fusion namespace to be found by ADL during
+// CollectiveBuilder dispatch.
+// ============================================================================
+namespace cutlass::epilogue::fusion {
+
+// Phase 1 (gate): LinCombEltActSmemAuxStore -> EVT tree with Sm100SmemAuxStore
+template <
+  int StagesC, int StagesD, int FragmentSize, bool ReuseSmemC, bool DelayTmaStore,
+  template <class> class ActivationFn,
+  class ElementOutput, class ElementCompute,
+  class ElementAux, class ElementSource, class ElementScalar,
+  int AlignmentAux, cutlass::FloatRoundStyle RoundStyle,
+  class CtaTileShapeMNK, class EpilogueTile,
+  class SmemLayoutAtom, class CopyOpR2S
+>
+struct FusionCallbacks<
+    cutlass::epilogue::Sm90TmaWarpSpecialized<StagesC, StagesD, FragmentSize, ReuseSmemC, DelayTmaStore>,
+    flashrt::megakernel::fusion::LinCombEltActSmemAuxStore<
+        ActivationFn, ElementOutput, ElementCompute,
+        ElementAux, ElementSource, ElementScalar, AlignmentAux, RoundStyle>,
+    CtaTileShapeMNK, EpilogueTile,
+    SmemLayoutAtom, CopyOpR2S
+> : flashrt::megakernel::fusion::Sm100LinCombEltActSmemAuxStoreTree<
+        decltype(cute::take<0,2>(CtaTileShapeMNK{})),
+        EpilogueTile,
+        SmemLayoutAtom, CopyOpR2S,
+        ActivationFn, ElementOutput, ElementCompute, ElementAux,
+        ElementSource, ElementScalar, RoundStyle
+    >
+{
+  using Impl = flashrt::megakernel::fusion::Sm100LinCombEltActSmemAuxStoreTree<
+      decltype(cute::take<0,2>(CtaTileShapeMNK{})),
+      EpilogueTile, SmemLayoutAtom, CopyOpR2S,
+      ActivationFn, ElementOutput, ElementCompute, ElementAux,
+      ElementSource, ElementScalar, RoundStyle>;
+
+  using Operation = flashrt::megakernel::fusion::LinCombEltActSmemAuxStore<
+      ActivationFn, ElementOutput, ElementCompute,
+      ElementAux, ElementSource, ElementScalar, AlignmentAux, RoundStyle>;
+
+  struct Arguments {
+    ElementScalar alpha = ElementScalar(1);
+    ElementScalar beta  = ElementScalar(0);
+    ElementScalar const* alpha_ptr = nullptr;
+    ElementScalar const* beta_ptr  = nullptr;
+    using StrideAlpha = cute::Stride<cute::_0, cute::_0, int64_t>;
+    using StrideBeta  = cute::Stride<cute::_0, cute::_0, int64_t>;
+    StrideAlpha dAlpha = {cute::_0{}, cute::_0{}, 0};
+    StrideBeta  dBeta  = {cute::_0{}, cute::_0{}, 0};
+
+    using ActivationArguments =
+        typename Sm90Compute<ActivationFn, ElementOutput, ElementCompute, RoundStyle>::Arguments;
+    ActivationArguments activation = ActivationArguments();
+
+    operator typename Impl::Arguments() const {
+      // Sm90VisitorImpl<children..., node>::Arguments — children FIRST,
+      // node LAST.  Sm100SmemAuxStore now owns its SMEM via SharedStorage
+      // (no external pointer); its Arguments is empty.
+      return {
+        // child of outer tree: inner Sm90EVT (LinComb + GELU)
+        {
+          // child of inner tree: Sm90LinearCombination
+          {
+            { {beta},  {beta_ptr},  {dBeta}  },
+            {},
+            {
+              { {alpha}, {alpha_ptr}, {dAlpha} },
+              {},
+              {}
+            },
+            {}
+          },
+          activation
+        },
+        // node of outer tree: Sm100SmemAuxStore — Arguments is empty
+        {}
+      };
+    }
+  };
+
+  using Impl::Impl;
+};
+
+// Phase 2 (up): LinCombDeEltActSmemAuxLoad -> EVT tree with Sm100SmemAuxLoad
+template <
+  int StagesC, int StagesD, int FragmentSize, bool ReuseSmemC, bool DelayTmaStore,
+  template <class> class ActivationFn,
+  class ElementOutput, class ElementCompute,
+  class ElementAux, class ElementSource, class ElementScalar,
+  int AlignmentAux, cutlass::FloatRoundStyle RoundStyle,
+  class CtaTileShapeMNK, class EpilogueTile,
+  class SmemLayoutAtom, class CopyOpS2R
+>
+struct FusionCallbacks<
+    cutlass::epilogue::Sm90TmaWarpSpecialized<StagesC, StagesD, FragmentSize, ReuseSmemC, DelayTmaStore>,
+    flashrt::megakernel::fusion::LinCombDeEltActSmemAuxLoad<
+        ActivationFn, ElementOutput, ElementCompute,
+        ElementAux, ElementSource, ElementScalar, AlignmentAux, RoundStyle>,
+    CtaTileShapeMNK, EpilogueTile,
+    SmemLayoutAtom, CopyOpS2R
+> : flashrt::megakernel::fusion::Sm100LinCombDeEltActSmemAuxLoadTree<
+        decltype(cute::take<0,2>(CtaTileShapeMNK{})),
+        EpilogueTile,
+        SmemLayoutAtom, CopyOpS2R,
+        ActivationFn, ElementOutput, ElementCompute, ElementAux,
+        ElementSource, ElementScalar, RoundStyle
+    >
+{
+  using Impl = flashrt::megakernel::fusion::Sm100LinCombDeEltActSmemAuxLoadTree<
+      decltype(cute::take<0,2>(CtaTileShapeMNK{})),
+      EpilogueTile, SmemLayoutAtom, CopyOpS2R,
+      ActivationFn, ElementOutput, ElementCompute, ElementAux,
+      ElementSource, ElementScalar, RoundStyle>;
+
+  using Operation = flashrt::megakernel::fusion::LinCombDeEltActSmemAuxLoad<
+      ActivationFn, ElementOutput, ElementCompute,
+      ElementAux, ElementSource, ElementScalar, AlignmentAux, RoundStyle>;
+
+  struct Arguments {
+    ElementScalar alpha = ElementScalar(1);
+    ElementScalar beta  = ElementScalar(0);
+    ElementScalar const* alpha_ptr = nullptr;
+    ElementScalar const* beta_ptr  = nullptr;
+    using StrideAlpha = cute::Stride<cute::_0, cute::_0, int64_t>;
+    using StrideBeta  = cute::Stride<cute::_0, cute::_0, int64_t>;
+    StrideAlpha dAlpha = {cute::_0{}, cute::_0{}, 0};
+    StrideBeta  dBeta  = {cute::_0{}, cute::_0{}, 0};
+
+    using ActivationArguments =
+        typename Sm90Compute<ActivationFn, ElementOutput, ElementCompute, RoundStyle>::Arguments;
+    ActivationArguments activation = ActivationArguments();
+
+    operator typename Impl::Arguments() const {
+      return {
+        // child 0: Sm90LinearCombination
+        {
+          { {beta},  {beta_ptr},  {dBeta}  },
+          {},
+          {
+            { {alpha}, {alpha_ptr}, {dAlpha} },
+            {},
+            {}
+          },
+          {}
+        },
+        // child 1: Sm100SmemAuxLoad — empty Arguments
+        {},
+        // node: Sm90Compute<ActivationFn>
+        activation
+      };
+    }
+  };
+
+  using Impl::Impl;
+};
+
+} // namespace cutlass::epilogue::fusion

--- a/csrc/kernels/activation.cu
+++ b/csrc/kernels/activation.cu
@@ -136,6 +136,48 @@ void gate_silu_mul_merged_fp16(const __half* merged, __half* out,
     gate_silu_mul_merged_kernel<__half><<<blocks, 256, 0, stream>>>(merged, out, seq, half_dim);
 }
 
+// Vectorized 8-half / thread element-wise multiply.  BW-bound; pairs
+// with two split-G7 GEMMs in R3.1 to replace gate_silu_mul_merged_fp16.
+__global__ void mul_fp16_kernel(const __half* __restrict__ a,
+                                 const __half* __restrict__ b,
+                                 __half* __restrict__ out, int n) {
+    int i = (blockIdx.x * blockDim.x + threadIdx.x) * 8;
+    if (i + 8 > n) {
+        for (int k = 0; k < 8 && i + k < n; ++k) {
+            float av = __half2float(a[i + k]);
+            float bv = __half2float(b[i + k]);
+            out[i + k] = __float2half(av * bv);
+        }
+        return;
+    }
+    const float4* a4 = reinterpret_cast<const float4*>(a + i);
+    const float4* b4 = reinterpret_cast<const float4*>(b + i);
+    float4 av = *a4, bv = *b4;
+    __half2 ah[4], bh[4], oh[4];
+    ah[0] = *reinterpret_cast<__half2*>(&av.x);
+    ah[1] = *reinterpret_cast<__half2*>(&av.y);
+    ah[2] = *reinterpret_cast<__half2*>(&av.z);
+    ah[3] = *reinterpret_cast<__half2*>(&av.w);
+    bh[0] = *reinterpret_cast<__half2*>(&bv.x);
+    bh[1] = *reinterpret_cast<__half2*>(&bv.y);
+    bh[2] = *reinterpret_cast<__half2*>(&bv.z);
+    bh[3] = *reinterpret_cast<__half2*>(&bv.w);
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) oh[k] = __hmul2(ah[k], bh[k]);
+    float4 ov;
+    ov.x = *reinterpret_cast<float*>(&oh[0]);
+    ov.y = *reinterpret_cast<float*>(&oh[1]);
+    ov.z = *reinterpret_cast<float*>(&oh[2]);
+    ov.w = *reinterpret_cast<float*>(&oh[3]);
+    *reinterpret_cast<float4*>(out + i) = ov;
+}
+
+void mul_fp16(const __half* a, const __half* b, __half* out, int n, cudaStream_t stream) {
+    int per_block = 256 * 8;
+    int blocks = (n + per_block - 1) / per_block;
+    mul_fp16_kernel<<<blocks, 256, 0, stream>>>(a, b, out, n);
+}
+
 // ── Gate GELU Mul Merged -> FP8 ──
 // 4 elem/thread vectorized, matching production silu_mul_split_fp8_k throughput.
 // Merged layout: merged[s, 0..H-1] = gate, merged[s, H..2H-1] = up

--- a/csrc/kernels/activation.cuh
+++ b/csrc/kernels/activation.cuh
@@ -40,6 +40,12 @@ void gelu_inplace_fp16(__half* x, int n, cudaStream_t stream = 0);
 void gate_silu_mul_merged_fp16(const __half* merged, __half* out,
                                 int seq, int half_dim, cudaStream_t stream = 0);
 
+// Element-wise multiply: out[i] = a[i] * b[i] for i in [0, n).
+// FP16 inputs and output, FP32 multiply.  Used by R3.1 split-G7 path
+// to combine GELU(gate) with up after two separate GEMMs.
+void mul_fp16(const __half* a, const __half* b, __half* out,
+              int n, cudaStream_t stream = 0);
+
 void gate_silu_mul_merged_fp8_fp16(const __half* merged, __nv_fp8_e4m3* out,
                                     int seq, int half_dim,
                                     const float* d_scale, cudaStream_t stream = 0);

--- a/flash_rt/frontends/torch/_thor_spec_common.py
+++ b/flash_rt/frontends/torch/_thor_spec_common.py
@@ -39,6 +39,11 @@ def paligemma_siglip_block(
     row-major layout (the ``T()`` transpose is kept so ``gemm.fp16_nn``
     can read them directly). ``Quant()`` is dropped and ``_sig_alpha``
     is not populated.
+
+    Tested 2026-05-18: dropping T() + switching to CUTLASS NT
+    (`cutlass_fp16_wide`) gives bit-exact output (cos=1.0) but no net
+    hot-regime win at Pi0.5 SigLIP shape (3-round mean 84.13 vs 83.87
+    cublas; within ±0.5 ms noise).  Kept cuBLAS to avoid layout risk.
     """
     qkv_tx  = [T(), Quant()]              if use_fp8 else [T()]
     o_tx    = [ToFp16(), T(), Quant()]    if use_fp8 else [ToFp16(), T()]

--- a/flash_rt/frontends/torch/_thor_spec_common.py
+++ b/flash_rt/frontends/torch/_thor_spec_common.py
@@ -101,15 +101,16 @@ def paligemma_encoder_block(
       d    : ToFp16 → Quant
     Scales append to ``target._enc_w_scales`` in (q, o, gu, d) order.
 
-    When ``use_fp8=False``, ``Quant()`` is dropped and a ``T()``
-    transpose is added so weights land in ``[K, N]`` row-major (the
-    layout ``gemm.fp16_nn`` reads). FusedQKV / FusedGateUp natively
-    produce ``[N, K]``; ``T()`` flips them to the row-major NN layout.
+    When ``use_fp8=False``, both ``Quant()`` AND the ``T()`` transpose
+    are dropped — weights stay ``[N, K]`` row-major (the layout the
+    CUTLASS-FP16 NT GEMMs read, mirroring the FP8 NT convention).
+    FusedQKV / FusedGateUp natively produce ``[N, K]`` so no transform
+    is needed past ``ToFp16()`` for cast-only items.
     """
-    qkv_tx = [Quant()]            if use_fp8 else [T()]
-    o_tx   = [ToFp16(), Quant()]  if use_fp8 else [ToFp16(), T()]
-    gu_tx  = [Quant()]            if use_fp8 else [T()]
-    d_tx   = [ToFp16(), Quant()]  if use_fp8 else [ToFp16(), T()]
+    qkv_tx = [Quant()]            if use_fp8 else []
+    o_tx   = [ToFp16(), Quant()]  if use_fp8 else [ToFp16()]
+    gu_tx  = [Quant()]            if use_fp8 else []
+    d_tx   = [ToFp16(), Quant()]  if use_fp8 else [ToFp16()]
     scale_into = "_enc_w_scales" if use_fp8 else None
     ep = f"{model_root}.language_model.layers.{{i}}"
     items = [

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -223,6 +223,11 @@ def _siglip_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None)
     hidden = bufs['hidden']
     fg = bufs['fg']               # S*D fp16 scratch for O/Down GEMM output
 
+    # SigLIP FP16 weights stay in [K, N] row-major (cuBLAS NN convention).
+    # Tested 2026-05-18 swapping to CUTLASS NT (cutlass_fp16_wide) after
+    # dropping T() in the spec — bit-exact correctness (cos=1.0) but no
+    # net hot-regime win at Pi0.5 SigLIP shape (84.13 vs 83.87 cublas, in
+    # the ±0.5 ms noise band).  Keep cuBLAS for now.
     for l in range(L):
         # ── Attention LayerNorm → x_norm ──
         fvk.layer_norm_fp16(x, weights['ln_attn_w'][l], weights['ln_attn_b'][l],
@@ -289,21 +294,39 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
 
     for l in range(L):
         last = (l == L - 1)
+        import os as _os
 
-        # 1. RMSNorm (noweight via ones buf)
-        fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
+        # NOTE: last-layer QKV writes K/V cache that the DECODER reads via
+        # cross-attention.  Do NOT skip even though the encoder-side
+        # consumer is gated off — SKIP_LAST_QKV=1 was tested 2026-05-18 and
+        # showed inconsistent (sometimes reversed) timing, suggesting it
+        # also affects downstream output.  Default 0 (run as-is) for
+        # correctness; the env switch is kept for future re-verification.
+        if not last or _os.environ.get("SKIP_LAST_QKV", "0") != "1":
+            # 1+2. RMSNorm + QKV (k64) — env-switchable bundle.
+            _qkv = _os.environ.get("QKV_KERNEL", "k64")
+            if _os.environ.get("USE_RMS_QKV_BUNDLE", "1") == "1" and _qkv == "k64":
+                fvk.flashrt_rms_qkv_fp16(
+                    x, ones, x_norm,
+                    weights['qkv_w'][l], qkv,
+                    Se, D, 2560, 1e-6, stream)
+            else:
+                fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
+                if   _qkv == "sq":    fvk.cutlass_fp16_sq   (x_norm, weights['qkv_w'][l], qkv, Se, 2560, D, 1.0, 0.0, stream)
+                elif _qkv == "wide":  fvk.cutlass_fp16_wide (x_norm, weights['qkv_w'][l], qkv, Se, 2560, D, 1.0, 0.0, stream)
+                elif _qkv == "t1":    fvk.cutlass_fp16_t1   (x_norm, weights['qkv_w'][l], qkv, Se, 2560, D, 1.0, 0.0, stream)
+                elif _qkv == "plain": fvk.cutlass_fp16_plain(x_norm, weights['qkv_w'][l], qkv, Se, 2560, D, 1.0, 0.0, stream)
+                else:                 fvk.cutlass_fp16_k64  (x_norm, weights['qkv_w'][l], qkv, Se, 2560, D, 1.0, 0.0, stream)
 
-        # 2. QKV GEMM (CUTLASS FP16 sq tile)
-        fvk.cutlass_fp16_sq(x_norm, weights['qkv_w'][l], qkv,
-                             Se, 2560, D, 1.0, 0.0, stream)
-
-        # 3+4. Split+RoPE+KV
-        kv_elem_off = l * total_keys * HD
-        fvk.qkv_split_rope_kvcache_fp16(
-            qkv, weights['rope'], attn_out,
-            weights['Kc'], weights['Vc'],
-            Se, Q_dim, K_dim, HD, 2560,
-            kv_elem_off, HD, stream)
+            # 3+4. Split+RoPE+KV
+            kv_elem_off = l * total_keys * HD
+            fvk.qkv_split_rope_kvcache_fp16(
+                qkv, weights['rope'], attn_out,
+                weights['Kc'], weights['Vc'],
+                Se, Q_dim, K_dim, HD, 2560,
+                kv_elem_off, HD, stream)
+        else:
+            kv_elem_off = l * total_keys * HD  # unused but kept for code-flow parity
 
         if not last:
             # 5. Attention
@@ -316,43 +339,83 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
                                         logits, attn_out,
                                         Se, Se, NH, HD, attn_scale, stream)
 
-            # 6. O proj (square shape — R1.2 sweep winner: k64 small-K pipeline)
-            fvk.cutlass_fp16_k64(attn_out, weights['o_w'][l], fg,
-                                  Se, D, D, 1.0, 0.0, stream)
-
-            # 7. Residual + RMSNorm
-            fvk.residual_add_fp16(x, fg, Se * D, stream)
-            fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
-
-            # 8+9. R3.1 Phase 1 split-G7: GELU(X @ W_gate) -> gate_buf,
-            # X @ W_up -> up_buf, then mul into hidden. Saves the
-            # gate_up [Se, 2H] write/read traffic vs single G7+GeGLU.
-            # weights['gate_w'][l] is [2H, D] row-major; W_gate at offset 0,
-            # W_up at row offset H (byte offset H * D * 2 for FP16).
-            #
-            # Note: Phase 2 (k64_mul_aux folding the mul into up-GEMM's
-            # epilogue) is implemented but disabled — back-to-back A/B with
-            # 15-warmup (Thor hot regime) showed P1 (-3.4 ms) clearly beats
-            # P2 (+0.3 ms regression).  The Aux TMA load added enough
-            # resource pressure to keep Thor in the slower power state.
-            # Tile re-sweep on the split shape (M=1024 N=H=16384 K=2048)
-            # showed sq tile (256x256x128 C(2,2,1)) wins by 14% vs the
-            # k64 borrowed from the encoder R1 sweep (sq 606us vs k64
-            # 710us).  Both gate and up use sq; gate has GELU baked in.
+            # Env-switch ENC_PATH: "pre_mk1" runs the unfused split-G7 + 2sm21
+            # + separate residual_add (pre-MK-1 baseline).  Default "head"
+            # is MK-1 mega + A (G8 resid fuse) + D (O resid fuse) + F-2
+            # bundled entry.
+            import os as _os
+            _enc_path = _os.environ.get("ENC_PATH", "head")
             up_w_ptr = weights['gate_w'][l] + H * D * 2
-            up_buf = gate + Se * H * 2   # split the [Se,2H] gate buffer
-            fvk.cutlass_fp16_sq_gelu(x_norm, weights['gate_w'][l], gate,
-                                      Se, H, D, 1.0, 0.0, stream)
-            fvk.cutlass_fp16_sq(x_norm, up_w_ptr, up_buf,
-                                 Se, H, D, 1.0, 0.0, stream)
-            fvk.mul_fp16(gate, up_buf, hidden, Se * H, stream)
-
-            # 10. Down GEMM (wide-K — R1.2 sweep winner: 2sm21 explicit 2SM-Sm100)
-            fvk.cutlass_fp16_2sm21(hidden, weights['down_w'][l], fg,
-                                    Se, D, H, 1.0, 0.0, stream)
-
-            # 11. Residual (next layer's RMSNorm done at top of next iter)
-            fvk.residual_add_fp16(x, fg, Se * D, stream)
+            if _enc_path == "pre_mk1":
+                # 6. O proj (no resid fuse)
+                fvk.cutlass_fp16_k64(attn_out, weights['o_w'][l], fg,
+                                      Se, D, D, 1.0, 0.0, stream)
+                # 7. resid + rmsnorm
+                fvk.residual_add_fp16(x, fg, Se * D, stream)
+                fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
+                # 8. sq_gelu(x_norm @ W_gate) → gate
+                fvk.cutlass_fp16_sq_gelu(x_norm, weights['gate_w'][l],
+                                          gate, Se, H, D, 1.0, 0.0, stream)
+                # 9. sq(x_norm @ W_up) → bufs['hidden'] as up scratch
+                fvk.cutlass_fp16_sq(x_norm, up_w_ptr, hidden,
+                                     Se, H, D, 1.0, 0.0, stream)
+                # mul: gate * hidden → hidden (use hidden as in-place mul out)
+                fvk.mul_fp16(gate, hidden, hidden, Se * H, stream)
+                # 10. 2sm21 G8 (no resid fuse)
+                fvk.cutlass_fp16_2sm21(hidden, weights['down_w'][l], fg,
+                                        Se, D, H, 1.0, 0.0, stream)
+                # 11. resid add
+                fvk.residual_add_fp16(x, fg, Se * D, stream)
+            else:
+                # head: O resid fuse + (rms + mega + G8 resid fuse).
+                # plain won 2026-05-18 sweep at FP16 Pi0.5 O shape
+                # (Se=768 N=K=D=2048): -0.5 ms hot regime vs k64.
+                #
+                # USE_FFN_BLOCK=1: bundle rms+mega+G8 in one C entry
+                # (flashrt_encoder_ffn_block_fp16).  Default 0 = current
+                # head with rms separate and mega+G8 bundled.
+                _ffn_bundle = _os.environ.get("USE_FFN_BLOCK", "0") == "1"
+                _o = _os.environ.get("O_KERNEL", "plain")
+                if _o == "sq":
+                    fvk.cutlass_fp16_sq   (attn_out, weights['o_w'][l], x, Se, D, D, 1.0, 1.0, stream)
+                elif _o == "wide":
+                    fvk.cutlass_fp16_wide (attn_out, weights['o_w'][l], x, Se, D, D, 1.0, 1.0, stream)
+                elif _o == "t1":
+                    fvk.cutlass_fp16_t1   (attn_out, weights['o_w'][l], x, Se, D, D, 1.0, 1.0, stream)
+                elif _o == "plain":
+                    fvk.cutlass_fp16_plain(attn_out, weights['o_w'][l], x, Se, D, D, 1.0, 1.0, stream)
+                else:
+                    fvk.cutlass_fp16_k64  (attn_out, weights['o_w'][l], x, Se, D, D, 1.0, 1.0, stream)
+                if _ffn_bundle:
+                    fvk.flashrt_encoder_ffn_block_fp16(
+                        x, ones, x_norm,
+                        weights['gate_w'][l], up_w_ptr, weights['down_w'][l],
+                        gate, hidden,
+                        Se, H, D, 1e-6, stream)
+                    continue
+                fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
+                # MK-2 F-2 bundled: mega + G8 (2sm21 beta=1) in one C entry.
+                # Hot-regime bundle wins ~0.5 ms over the same two launches
+                # issued separately.  G8 kernel choice via env (bundled
+                # entry always uses 2sm21 internally; G8_KERNEL switches
+                # to unbundled python path with a different kernel).
+                _g8 = _os.environ.get("G8_KERNEL", "bundled")
+                if _g8 == "bundled":
+                    fvk.flashrt_megakernel_geglu_g8_fp16(
+                        x_norm, weights['gate_w'][l], up_w_ptr,
+                        weights['down_w'][l],
+                        hidden, x,
+                        Se, H, D, stream)
+                else:
+                    fvk.flashrt_megakernel_geglu_fp16(
+                        x_norm, weights['gate_w'][l], up_w_ptr,
+                        gate, hidden, Se, H, D, stream)
+                    if   _g8 == "sq":    fvk.cutlass_fp16_sq   (hidden, weights['down_w'][l], x, Se, D, H, 1.0, 1.0, stream)
+                    elif _g8 == "wide":  fvk.cutlass_fp16_wide (hidden, weights['down_w'][l], x, Se, D, H, 1.0, 1.0, stream)
+                    elif _g8 == "k64":   fvk.cutlass_fp16_k64  (hidden, weights['down_w'][l], x, Se, D, H, 1.0, 1.0, stream)
+                    elif _g8 == "plain": fvk.cutlass_fp16_plain(hidden, weights['down_w'][l], x, Se, D, H, 1.0, 1.0, stream)
+                    elif _g8 == "t1":    fvk.cutlass_fp16_t1   (hidden, weights['down_w'][l], x, Se, D, H, 1.0, 1.0, stream)
+                    else:                fvk.cutlass_fp16_2sm21(hidden, weights['down_w'][l], x, Se, D, H, 1.0, 1.0, stream)
 
 
 def encoder_forward(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None,

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -345,10 +345,10 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
                                         logits, attn_out,
                                         Se, Se, NH, HD, attn_scale, stream)
 
-            # Env-switch ENC_PATH: "pre_mk1" runs the unfused split-G7 + 2sm21
-            # + separate residual_add (pre-MK-1 baseline).  Default "head"
-            # is MK-1 mega + A (G8 resid fuse) + D (O resid fuse) + F-2
-            # bundled entry.
+            # Env-switch ENC_PATH: "pre_mk1" runs the unfused split GEMMs +
+            # separate residual_add (the pre-megakernel baseline).  Default
+            # "head" fuses the O-proj residual and runs rms + the GeGLU
+            # megakernel + down GEMM with the residual folded in.
             up_w_ptr = weights['gate_w'][l] + H * D * 2
             if enc_path == "pre_mk1":
                 # 6. O proj (no resid fuse)
@@ -398,9 +398,9 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
                         Se, H, D, 1e-6, stream)
                     continue
                 fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
-                # MK-2 F-2 bundled: mega + G8 (2sm21 beta=1) in one C entry.
-                # Hot-regime bundle wins ~0.5 ms over the same two launches
-                # issued separately.  G8 kernel choice via env (bundled
+                # Bundled GeGLU megakernel + down GEMM (2sm21 beta=1) in one C
+                # entry.  The bundle wins ~0.5 ms in the hot regime over the
+                # same two launches issued separately.  G8 kernel via env (bundled
                 # entry always uses 2sm21 internally; G8_KERNEL switches
                 # to unbundled python path with a different kernel).
                 _g8 = g8_kernel

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -324,12 +324,24 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
             fvk.residual_add_fp16(x, fg, Se * D, stream)
             fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
 
-            # 8. Gate+Up GEMM (wide-N, big GEMM — R1.2 sweep winner: k64)
-            fvk.cutlass_fp16_k64(x_norm, weights['gate_w'][l], gate,
-                                  Se, H * 2, D, 1.0, 0.0, stream)
-
-            # 9. GELU(gate) × up
-            fvk.gate_geglu_merged_fp16(gate, hidden, Se, H, stream)
+            # 8+9. R3.1 Phase 1 split-G7: GELU(X @ W_gate) -> gate_buf,
+            # X @ W_up -> up_buf, then mul into hidden. Saves the
+            # gate_up [Se, 2H] write/read traffic vs single G7+GeGLU.
+            # weights['gate_w'][l] is [2H, D] row-major; W_gate at offset 0,
+            # W_up at row offset H (byte offset H * D * 2 for FP16).
+            #
+            # Note: Phase 2 (k64_mul_aux folding the mul into up-GEMM's
+            # epilogue) is implemented but disabled — back-to-back A/B with
+            # 15-warmup (Thor hot regime) showed P1 (-3.4 ms) clearly beats
+            # P2 (+0.3 ms regression).  The Aux TMA load added enough
+            # resource pressure to keep Thor in the slower power state.
+            up_w_ptr = weights['gate_w'][l] + H * D * 2
+            up_buf = gate + Se * H * 2   # split the [Se,2H] gate buffer
+            fvk.cutlass_fp16_k64_gelu(x_norm, weights['gate_w'][l], gate,
+                                       Se, H, D, 1.0, 0.0, stream)
+            fvk.cutlass_fp16_k64(x_norm, up_w_ptr, up_buf,
+                                  Se, H, D, 1.0, 0.0, stream)
+            fvk.mul_fp16(gate, up_buf, hidden, Se * H, stream)
 
             # 10. Down GEMM (wide-K — R1.2 sweep winner: 2sm21 explicit 2SM-Sm100)
             fvk.cutlass_fp16_2sm21(hidden, weights['down_w'][l], fg,

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -335,12 +335,16 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
             # 15-warmup (Thor hot regime) showed P1 (-3.4 ms) clearly beats
             # P2 (+0.3 ms regression).  The Aux TMA load added enough
             # resource pressure to keep Thor in the slower power state.
+            # Tile re-sweep on the split shape (M=1024 N=H=16384 K=2048)
+            # showed sq tile (256x256x128 C(2,2,1)) wins by 14% vs the
+            # k64 borrowed from the encoder R1 sweep (sq 606us vs k64
+            # 710us).  Both gate and up use sq; gate has GELU baked in.
             up_w_ptr = weights['gate_w'][l] + H * D * 2
             up_buf = gate + Se * H * 2   # split the [Se,2H] gate buffer
-            fvk.cutlass_fp16_k64_gelu(x_norm, weights['gate_w'][l], gate,
-                                       Se, H, D, 1.0, 0.0, stream)
-            fvk.cutlass_fp16_k64(x_norm, up_w_ptr, up_buf,
-                                  Se, H, D, 1.0, 0.0, stream)
+            fvk.cutlass_fp16_sq_gelu(x_norm, weights['gate_w'][l], gate,
+                                      Se, H, D, 1.0, 0.0, stream)
+            fvk.cutlass_fp16_sq(x_norm, up_w_ptr, up_buf,
+                                 Se, H, D, 1.0, 0.0, stream)
             fvk.mul_fp16(gate, up_buf, hidden, Se * H, stream)
 
             # 10. Down GEMM (wide-K — R1.2 sweep winner: 2sm21 explicit 2SM-Sm100)

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -316,24 +316,24 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
                                         logits, attn_out,
                                         Se, Se, NH, HD, attn_scale, stream)
 
-            # 6. O proj (square shape — sq tile)
-            fvk.cutlass_fp16_sq(attn_out, weights['o_w'][l], fg,
-                                 Se, D, D, 1.0, 0.0, stream)
+            # 6. O proj (square shape — R1.2 sweep winner: k64 small-K pipeline)
+            fvk.cutlass_fp16_k64(attn_out, weights['o_w'][l], fg,
+                                  Se, D, D, 1.0, 0.0, stream)
 
             # 7. Residual + RMSNorm
             fvk.residual_add_fp16(x, fg, Se * D, stream)
             fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
 
-            # 8. Gate+Up GEMM (wide-N, big GEMM — t1 tile)
-            fvk.cutlass_fp16_t1(x_norm, weights['gate_w'][l], gate,
-                                 Se, H * 2, D, 1.0, 0.0, stream)
+            # 8. Gate+Up GEMM (wide-N, big GEMM — R1.2 sweep winner: k64)
+            fvk.cutlass_fp16_k64(x_norm, weights['gate_w'][l], gate,
+                                  Se, H * 2, D, 1.0, 0.0, stream)
 
             # 9. GELU(gate) × up
             fvk.gate_geglu_merged_fp16(gate, hidden, Se, H, stream)
 
-            # 10. Down GEMM (wide-K — wide tile)
-            fvk.cutlass_fp16_wide(hidden, weights['down_w'][l], fg,
-                                   Se, D, H, 1.0, 0.0, stream)
+            # 10. Down GEMM (wide-K — R1.2 sweep winner: 2sm21 explicit 2SM-Sm100)
+            fvk.cutlass_fp16_2sm21(hidden, weights['down_w'][l], fg,
+                                    Se, D, H, 1.0, 0.0, stream)
 
             # 11. Residual (next layer's RMSNorm done at top of next iter)
             fvk.residual_add_fp16(x, fg, Se * D, stream)

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -265,7 +265,10 @@ def _siglip_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None)
 
 def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None):
     """FP16-only Paligemma encoder forward. Mirrors encoder_forward
-    structure with FP8 cast/descale dropped.
+    structure with FP8 cast/descale dropped. GEMMs use the CUTLASS-FP16
+    NT path (weights stored ``[N, K]`` row-major, matching the FP8 NT
+    convention) rather than cuBLASLt; FP8-equivalent shape-specific
+    tactics (sq/t1/wide) are chosen per-GEMM.
     """
     Se = dims['Se']; D = dims['D']; H = dims['H']
     NH = dims['NH']; HD = dims['HD']; L = dims['L']
@@ -290,8 +293,9 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
         # 1. RMSNorm (noweight via ones buf)
         fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
 
-        # 2. QKV GEMM
-        gemm.fp16_nn(x_norm, weights['qkv_w'][l], qkv, Se, 2560, D, stream)
+        # 2. QKV GEMM (CUTLASS FP16 sq tile)
+        fvk.cutlass_fp16_sq(x_norm, weights['qkv_w'][l], qkv,
+                             Se, 2560, D, 1.0, 0.0, stream)
 
         # 3+4. Split+RoPE+KV
         kv_elem_off = l * total_keys * HD
@@ -312,21 +316,24 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
                                         logits, attn_out,
                                         Se, Se, NH, HD, attn_scale, stream)
 
-            # 6. O proj
-            gemm.fp16_nn(attn_out, weights['o_w'][l], fg, Se, D, D, stream)
+            # 6. O proj (square shape — sq tile)
+            fvk.cutlass_fp16_sq(attn_out, weights['o_w'][l], fg,
+                                 Se, D, D, 1.0, 0.0, stream)
 
             # 7. Residual + RMSNorm
             fvk.residual_add_fp16(x, fg, Se * D, stream)
             fvk.rms_norm_fp16(x, ones, x_norm, Se, D, 1e-6, stream)
 
-            # 8. Gate+Up GEMM
-            gemm.fp16_nn(x_norm, weights['gate_w'][l], gate, Se, H * 2, D, stream)
+            # 8. Gate+Up GEMM (wide-N, big GEMM — t1 tile)
+            fvk.cutlass_fp16_t1(x_norm, weights['gate_w'][l], gate,
+                                 Se, H * 2, D, 1.0, 0.0, stream)
 
             # 9. GELU(gate) × up
             fvk.gate_geglu_merged_fp16(gate, hidden, Se, H, stream)
 
-            # 10. Down GEMM
-            gemm.fp16_nn(hidden, weights['down_w'][l], fg, Se, D, H, stream)
+            # 10. Down GEMM (wide-K — wide tile)
+            fvk.cutlass_fp16_wide(hidden, weights['down_w'][l], fg,
+                                   Se, D, H, 1.0, 0.0, stream)
 
             # 11. Residual (next layer's RMSNorm done at top of next iter)
             fvk.residual_add_fp16(x, fg, Se * D, stream)

--- a/flash_rt/hardware/thor/shared_primitives.py
+++ b/flash_rt/hardware/thor/shared_primitives.py
@@ -42,6 +42,7 @@ NOT in scope (live elsewhere):
 """
 
 import math
+import os
 import numpy as np
 
 
@@ -292,20 +293,25 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
     fg = bufs['fg']
     ones = bufs['ones']
 
+    # Kernel-dispatch env switches, read once per call so graph capture sees
+    # a fixed path. SKIP_LAST_QKV is kept off by default: setting it to 1 was
+    # tested 2026-05-18 and showed inconsistent (sometimes reversed) timing,
+    # suggesting it also affects downstream output via the decoder's K/V cache.
+    skip_last_qkv = os.environ.get("SKIP_LAST_QKV", "0") == "1"
+    qkv_kernel = os.environ.get("QKV_KERNEL", "k64")
+    use_rms_qkv_bundle = os.environ.get("USE_RMS_QKV_BUNDLE", "1") == "1"
+    enc_path = os.environ.get("ENC_PATH", "head")
+    use_ffn_block = os.environ.get("USE_FFN_BLOCK", "0") == "1"
+    o_kernel = os.environ.get("O_KERNEL", "plain")
+    g8_kernel = os.environ.get("G8_KERNEL", "bundled")
+
     for l in range(L):
         last = (l == L - 1)
-        import os as _os
 
-        # NOTE: last-layer QKV writes K/V cache that the DECODER reads via
-        # cross-attention.  Do NOT skip even though the encoder-side
-        # consumer is gated off — SKIP_LAST_QKV=1 was tested 2026-05-18 and
-        # showed inconsistent (sometimes reversed) timing, suggesting it
-        # also affects downstream output.  Default 0 (run as-is) for
-        # correctness; the env switch is kept for future re-verification.
-        if not last or _os.environ.get("SKIP_LAST_QKV", "0") != "1":
+        if not last or not skip_last_qkv:
             # 1+2. RMSNorm + QKV (k64) — env-switchable bundle.
-            _qkv = _os.environ.get("QKV_KERNEL", "k64")
-            if _os.environ.get("USE_RMS_QKV_BUNDLE", "1") == "1" and _qkv == "k64":
+            _qkv = qkv_kernel
+            if use_rms_qkv_bundle and _qkv == "k64":
                 fvk.flashrt_rms_qkv_fp16(
                     x, ones, x_norm,
                     weights['qkv_w'][l], qkv,
@@ -343,10 +349,8 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
             # + separate residual_add (pre-MK-1 baseline).  Default "head"
             # is MK-1 mega + A (G8 resid fuse) + D (O resid fuse) + F-2
             # bundled entry.
-            import os as _os
-            _enc_path = _os.environ.get("ENC_PATH", "head")
             up_w_ptr = weights['gate_w'][l] + H * D * 2
-            if _enc_path == "pre_mk1":
+            if enc_path == "pre_mk1":
                 # 6. O proj (no resid fuse)
                 fvk.cutlass_fp16_k64(attn_out, weights['o_w'][l], fg,
                                       Se, D, D, 1.0, 0.0, stream)
@@ -374,8 +378,8 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
                 # USE_FFN_BLOCK=1: bundle rms+mega+G8 in one C entry
                 # (flashrt_encoder_ffn_block_fp16).  Default 0 = current
                 # head with rms separate and mega+G8 bundled.
-                _ffn_bundle = _os.environ.get("USE_FFN_BLOCK", "0") == "1"
-                _o = _os.environ.get("O_KERNEL", "plain")
+                _ffn_bundle = use_ffn_block
+                _o = o_kernel
                 if _o == "sq":
                     fvk.cutlass_fp16_sq   (attn_out, weights['o_w'][l], x, Se, D, D, 1.0, 1.0, stream)
                 elif _o == "wide":
@@ -399,7 +403,7 @@ def _encoder_forward_fp16(gemm, fvk, bufs, weights, dims, stream=0, *, attn=None
                 # issued separately.  G8 kernel choice via env (bundled
                 # entry always uses 2sm21 internally; G8_KERNEL switches
                 # to unbundled python path with a different kernel).
-                _g8 = _os.environ.get("G8_KERNEL", "bundled")
+                _g8 = g8_kernel
                 if _g8 == "bundled":
                     fvk.flashrt_megakernel_geglu_g8_fp16(
                         x_norm, weights['gate_w'][l], up_w_ptr,


### PR DESCRIPTION
## Summary
- Adds the SM110 (Thor) FP16 encoder GEMM path on top of the existing `use_fp8=False` baseline: CUTLASS SM100 FP16 GEMMs, tile-swept winners, split-G7 (sq tile) with GELU epilogue.
- Lands the MK-1 GeGLU megakernel + MK-2 F-2 bundle (mega geglu + G8 down-proj fused into one C entry), switchable via `G8_KERNEL` env (default `bundled`).
- Vendors the production sm100 GEMM kernel under `csrc/gemm/mega/cutlass/` (upstream `third_party/cutlass` untouched).
- 7 commits cherry-picked cleanly onto #35; the FP16 baseline (`use_fp8=False`) was already upstream.

## Results (Jetson AGX Thor, openpi-jax container)
- `g8_f2_cosine`: cos = 1.0000000000, max|diff| = 0 (bit-exact vs python chain)
- `stage_b_test`: hidden cos = 0.9999998808, PASS
- FP16 3-view: p50 85.4 ms; F-2 bundle = -0.94 ms vs unbundled two-launch (back-to-back A/B)

## Test plan
- [x] g8_f2_cosine production gate (cos = 1.0)
- [x] stage_b_test (PASS)
- [x] FP16 num_views=3 precision bench, n_warmup=15 n_trials=20 (no regression vs #35 baseline)
- [x] flash_rt_kernels builds clean on merged CMakeLists (motus + megakernel targets coexist)