### PR TITLE
Experiment/pi05 rtx fp16 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,20 @@ Existing inference tooling is shaped for different workloads — TensorRT for ta
 
 ## FlashRT supports:
 
-- **VLA models**: Pi0, Pi0.5, GROOT N1.6, Pi0-FAST — all production-validated on LIBERO. BAGEL world-model (research preview) — image-gen pipeline at ~4× vs PyTorch.
-- **LLM**: **Qwen3.6-27B NVFP4 — ~100 tok/s typical / 129 tok/s peak decode, 256 K context, single RTX 5090** — speculative decoding via the FP8 ckpt's MTP head, OpenAI-compatible HTTP server.
+- **VLA models**: Pi0, Pi0.5, GROOT N1.6, Pi0-FAST — all production-validated on LIBERO. Motus RTX beta — Wan2.2-based robot policy path at ~167 ms / ~100 ms with TeaCache. BAGEL world-model (research preview) — image-gen pipeline at ~4× vs PyTorch.
+- **LLM**: **Qwen3.6-27B NVFP4 — ~100 tok/s typical / 129 tok/s peak decode, 256 K context, single RTX 5090** — speculative decoding via the FP8 ckpt's MTP head, OpenAI-compatible HTTP server. **Qwen3-8B NVFP4** text-only serving reaches **150 tok/s** warm decode.
 - **Hardware (today)**: NVIDIA Jetson AGX Thor (SM110), RTX 5090 (SM120), RTX 4090 (SM89), and SM80 / SM86 / SM89 cards (A100, RTX 3090, 4060 Ti, etc.). The kernel composition pattern is portable to other accelerators.
 - **Frameworks**: PyTorch (safetensors) + JAX (Orbax) — same compiled kernels
 
 Pi0.5: 44 ms / 23 Hz on Jetson AGX Thor (2v, FP8) · 39.78 ms / 25 Hz (2v, NVFP4) · 17.58 ms / 57 Hz on RTX 5090. Cosine ≥ 0.9996 vs the production reference. See [Performance](#performance) for the full sweep.
+
+## News
+
+- [2026/05] **Qwen3.6-27B NVFP4** is supported with 256 K context on a single RTX 5090, OpenAI-compatible serving, and **~100 tok/s typical / 129 tok/s peak** decode. See [Qwen3.6 NVFP4](docs/qwen36_nvfp4.md) and [Performance](#qwen36-performance).
+- [2026/05] **Qwen3-8B NVFP4** text-only serving is supported on RTX 5090, with **9.1 ms TTFT at P=64** and **150 tok/s** warm decode. See [Qwen3-8B NVFP4](docs/qwen3_8b_nvfp4.md) and [Performance](#qwen3-8b-performance).
+- [2026/05] Community Pi0.5 hardware benchmarks: thanks to [@cuihengrui35](https://github.com/cuihengrui35) for **RTX 5060 Ti** results (**41.4 ms / ~24 Hz**, plus LIBERO Spatial **344/350 = 98.3%**) and [@wangerforcs](https://github.com/wangerforcs) for **NVIDIA L40** results (**26.6 ms / 38 Hz**) on 2-view FP8. See [community benchmarks](#community-benchmarks).
+- [2026/05] Special thanks to [@gugudeshubao](https://github.com/gugudeshubao) for the **Pi0.5 Jetson AGX Orin (SM87) port**: INT8 W8A8 kernels, Orin tile dispatch, frame-cache inference, deployment docs, and benchmark results. Thanks also to [@strayberry](https://github.com/strayberry) for Orin BF16 Pi0.5 testing. See [Orin deployment](docs/deployment_orin.md) and [community benchmarks](#community-benchmarks).
+- [2026/05] **Motus RTX beta** lands in FlashRT: Stage3 fast profile reaches **~167 ms** E2E on RTX 5090, **~100 ms** with TeaCache, and RTC-lite supports 50 Hz action streaming. See [Motus usage](docs/motus_usage_beta.md) and [Performance](#motus-performance).
 
 ## Getting Started
 
@@ -72,6 +80,8 @@ First call: ~3 s (calibration + CUDA Graph capture). Every subsequent call: 44 m
 | **Run your first inference** | [Build & install](#build--install) — Docker and native Linux paths |
 | **See API examples for all 4 VLA models + the Qwen3.6 LLM** | [API snippets](#api-snippets) |
 | **Run Qwen3.6-27B NVFP4 (LLM, ~100 tok/s typical / 129 tok/s peak on RTX 5090)** | [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) — quickstart, K selection, measured throughput · [`docs/qwen36_usage.md`](docs/qwen36_usage.md) — full parameter reference · [`examples/qwen36_openai_server.py`](examples/qwen36_openai_server.py) — OpenAI-compatible HTTP server |
+| **Run Qwen3-8B NVFP4 text serving** | [`docs/qwen3_8b_nvfp4.md`](docs/qwen3_8b_nvfp4.md) · [`examples/qwen3_openai_server.py`](examples/qwen3_openai_server.py) |
+| **Run Motus RTX beta, TeaCache, or RTC-lite** | [`docs/motus_usage_beta.md`](docs/motus_usage_beta.md) · [`docs/rtc_lite_design.md`](docs/rtc_lite_design.md) |
 | **Look up the stable Python API surface** | [`docs/stable_api.md`](docs/stable_api.md) |
 | **Integrate a new model into FlashRT** | [`docs/adding_new_model.md`](docs/adding_new_model.md) — end-to-end walkthrough; external plugin pattern in [`docs/plugin_model_template.md`](docs/plugin_model_template.md) |
 | **Contribute a bug fix, benchmark, or model path** | [`CONTRIBUTING.md`](CONTRIBUTING.md) — development rules, validation expectations, and PR checklist |
@@ -97,11 +107,17 @@ First call: ~3 s (calibration + CUDA Graph capture). Every subsequent call: 44 m
 | **Pi0.5** | **Jetson AGX Thor** (SM110) | **44 ms** | **23 Hz** |
 | **Pi0** | **Jetson AGX Thor** (SM110) | **46 ms** | **22 Hz** |
 | **Pi0.5** | **RTX 5090** (SM120) | **17.58 ms** (2v) | **57 Hz** |
+| **Pi0.5** | **RTX 5060 Ti** (SM120, 16 GB) | **41.4 ms** (2v, FP8) | **24 Hz** |
+| **Pi0.5** | **NVIDIA L40** (SM89) | **26.6 ms** (2v, FP8) | **38 Hz** |
+| **Pi0.5** | **Jetson AGX Orin** (SM87, INT8) | **124 ms** (2v, cache_frames=1) | **8.04 Hz** |
 | **Pi0** | **RTX 5090** (SM120) | **18.43 ms** (1v) / **21.16 ms** (2v) / **24.48 ms** (3v) | **54 / 47 / 41 Hz** |
 | **GROOT N1.6** | **Jetson AGX Thor** (SM110) | **45 ms** (T=50) / **41 ms** (T=16) | **22 / 24 Hz** |
 | **GROOT N1.6** | **RTX 5090** (SM120) | **13.08 ms** (T=50, 2v) / **12.53 ms** (T=16, 2v) | **76 / 80 Hz** |
 | **Pi0-FAST** | **Jetson AGX Thor** (SM110) | **8.1 ms/token** (28 ms prefill + 8.1 × N decode) | **123 tok/s** |
 | **Pi0-FAST** | **RTX 5090** (SM120) | **2.39 ms/token** (11 ms prefill + 2.39 × N decode) | **418 tok/s** |
+| **Motus Stage3** | **RTX 5090** (SM120) | **~167 ms** (fast) / **~100 ms** (+TeaCache) | RTC-lite **50 Hz** action streaming |
+
+<a name="qwen36-performance"></a>
 
 ### LLM — Qwen3.6-27B NVFP4 (RTX 5090)
 
@@ -161,6 +177,46 @@ TTFT scales linearly at ~22 ms / prompt-token.
 The full per-prompt variance breakdown (5 prompts × NTOK 128/256 ×
 K=3/6) is in [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) §3.
 
+<a name="qwen3-8b-performance"></a>
+
+### LLM — Qwen3-8B NVFP4 (RTX 5090)
+
+Text-only OpenAI-compatible serving path for
+`Qwen3-8B-Instruct-2512-SFT-NVFP4`.
+
+| Metric | FlashRT |
+|---|---:|
+| TTFT P=64 (graph) | **9.1 ms** |
+| TTFT P=256 (graph) | **11.1 ms** |
+| TTFT P=512 (graph) | **14.2 ms** |
+| TTFT P=1024 (graph) | **24.8 ms** |
+| Decode warm graph | **150 tok/s** |
+| OAI server warm decode | **150 tok/s** |
+| VRAM @ P=1024 + N=256 | 7.30 GiB |
+
+See [`docs/qwen3_8b_nvfp4.md`](docs/qwen3_8b_nvfp4.md) for the
+quickstart, server command, architecture notes, and caveats.
+
+<a name="motus-performance"></a>
+
+### Motus Stage3 RTX beta (RTX 5090)
+
+Motus uses a Stage3 Motus checkpoint with Wan2.2-TI2V-5B, Qwen3-VL,
+and the FlashRT RTX SM120 backend. These numbers are measured on the
+RoboTwin2 mini `sample_00` bundle with the public `Motus_robotwin2`
+checkpoint:
+
+| Mode | E2E graph replay | Precision note |
+|---|---:|---|
+| `--fp4-profile fast` | **~167 ms** | action cos ~0.99993, frames cos ~0.99911 |
+| `fast` + TeaCache | **~100 ms** | training-free step cache; validate per task |
+| RTC-lite | **50 Hz action streaming** | runtime chunk prefetch; single model call latency unchanged |
+
+The unoptimized upstream-style Motus path is about **1.3 s** on the same
+task shape; the FlashRT path keeps VAE decode in the E2E number. See
+[`docs/motus_usage_beta.md`](docs/motus_usage_beta.md) for setup,
+calibration, TeaCache, and RTC-lite usage.
+
 ### VRAM footprint (inference only, 2 views on RTX 5090)
 
 Measured peak allocation during `model.predict()`:
@@ -214,9 +270,38 @@ On the same Jetson AGX Thor hardware, FlashRT goes from the original openpi JAX 
 
 FlashRT Pi0.5 Thor numbers above are the NVFP4 production preset (`use_fp4=True`); the FP8 baseline is 44.0 ms 2v / 54.8 ms 3v at the same task success (491/500). See [Latency (Thor)](#latency-thor) for the full sweep.
 
+<a name="community-benchmarks"></a>
+
+### Community benchmarks
+
+These runs are external hardware submissions using the public quickstart
+or deployment scripts. They are useful compatibility data points; exact
+latency depends on driver, CUDA, clock state, warmup count, and checkpoint.
+
+| Contributor | Hardware | Model / mode | Command shape | Result |
+|---|---|---|---|---|
+| [@cuihengrui35](https://github.com/cuihengrui35) | RTX 5060 Ti, SM120, 16 GB | Pi0.5, 2-view FP8 | `examples/quickstart.py --hardware rtx_sm120 --benchmark 20 --warmup 200` | **P50 41.4 ms**, mean 41.4, min 40.9, max 43.2, ~24 Hz |
+| [@cuihengrui35](https://github.com/cuihengrui35) | RTX 5060 Ti, SM120, 16 GB | Pi0.5 LIBERO Spatial | `examples/thor/eval_libero.py --task_suite libero_spatial --num_trials 50` | **344/350 = 98.3%** over 7 reported tasks |
+| [@wangerforcs](https://github.com/wangerforcs) | NVIDIA L40, SM89 | Pi0.5, 2-view FP8 | 20 timed iterations, 500 warmup | **P50 26.6 ms**, min 26.2, mean 26.7, max 27.3, 38 Hz |
+| [@gugudeshubao](https://github.com/gugudeshubao) | Jetson AGX Orin 64 GB, SM87 | Pi0.5 DROID, INT8, `cache_frames=1` | 2 cameras, pool=1, 27 layers, 10 steps | **124 ms**, 8.04 Hz, cosine 1.000 vs BF16 reference |
+| [@gugudeshubao](https://github.com/gugudeshubao) | Jetson AGX Orin 64 GB, SM87 | Pi0.5 DROID, INT8, `cache_frames=2` | 2 cameras, pool=1, 27 layers, 10 steps | **127 / 39 ms**, 12.2 Hz amortized, cosine 0.991 |
+| [@strayberry](https://github.com/strayberry) | Jetson AGX Orin 64 GB, SM87 | Pi0.5 BF16 reference smoke | 2 views, pool=1, 27 layers, 10 steps, cache_frames=1 | **P50 246.8 ms**, p95 247.0, 4.05 Hz |
+
+[@gugudeshubao](https://github.com/gugudeshubao)'s Orin work was a
+full SM87 enablement, not only a benchmark: it added the INT8 W8A8
+kernel path, CUTLASS SM80-family INT8 rowwise GEMMs, Orin-specific tile
+selection, fused activation / norm / quant pieces, frame-cache inference,
+and the deployment benchmark script.
+
+See [`docs/deployment_orin.md`](docs/deployment_orin.md) for the Orin
+INT8 build and reproduction commands. If you contribute a hardware
+benchmark, include the exact command, warmup count, driver/CUDA/PyTorch
+versions, and `nvidia-smi` output.
+
 ### Tested hardware + what's theoretically supported
 
-**Verified working on: RTX 5090, RTX 4090, RTX 4060 Ti, Jetson AGX Thor.**
+**Verified working on: RTX 5090, RTX 4090, RTX 5060 Ti, RTX 4060 Ti,
+NVIDIA L40, Jetson AGX Thor, and Jetson AGX Orin.**
 
 CMake's `ENABLE_FA2` gate accepts **any card in SM80 / 86 / 89 / 120**
 (Ampere through Blackwell consumer). That means A100, A10, RTX 3090,

--- a/USAGE.md
+++ b/USAGE.md
@@ -158,6 +158,55 @@ model = flash_rt.load_model(
 | `use_awq` | `bool` \| `None` | `None` | Activation-aware weight quant. Required for 18-layer FP4 scope (without it, cos collapses to ~0.33). `None` → resolved by the `use_fp4` preset. |
 | `awq_alpha` | `float` | `0.5` | AWQ scaling exponent `s[k] = (a[k]/a.mean())^alpha`. |
 | `use_p1_split_gu` | `bool` \| `None` | `None` | P1 split-GU 2-GEMM path (parity on Pi0.5, kernel reusable for Pi0.6). `None` → resolved by the `use_fp4` preset. |
+| `use_fp8` | `bool` | `True` | Enable the selected frontend's FP8 path when available. Set `False` for BF16 fallback or for the opt-in Pi0.5 RTX FP16 path. |
+| `use_fp16` | `bool` | `False` | **Pi0.5 torch RTX SM120 only.** Opt-in full-FP16 CUDA Graph path. Requires `use_fp8=False`; other hardware/configs raise a clear error. |
+| `num_steps` | `int\|None` | `None` | Pi0/Pi0.5 torch frontends. Flow-matching denoise steps; `None` uses the frontend default. |
+| `vision_pool_factor` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Spatial pooling factor for vision tokens. The FP16 RTX path currently supports only `1`. |
+| `vision_num_layers` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Number of SigLIP vision layers to run. |
+| `cache_frames` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Temporal encoder K/V cache period; `1` means no temporal reuse. |
+
+### Pi0.5 RTX 5090 full-FP16 opt-in path
+
+The default Pi0.5 RTX path remains FP8/BF16. For RTX 5090 / SM120
+experiments that need a full-FP16 baseline, explicitly disable FP8 and
+enable FP16:
+
+```python
+import flash_rt
+
+model = flash_rt.load_model(
+    "/path/to/pi05_libero_pytorch",
+    framework="torch",
+    config="pi05",
+    hardware="rtx_sm120",
+    num_views=3,
+    num_steps=10,
+    cache_frames=1,
+    use_fp8=False,
+    use_fp16=True,
+)
+
+actions = model.predict(
+    images=[base_img, wrist_img, wrist_right_img],
+    prompt="pick up the red block and place it in the tray",
+)
+```
+
+Benchmark helper:
+
+```bash
+python examples/blackwell/bench_pi05_fp16.py \
+  --checkpoint /path/to/pi05_libero_pytorch \
+  --num-views 3 \
+  --steps 10 \
+  --warmup 10 \
+  --iters 100
+```
+
+This path is intentionally isolated from Thor, Orin, RTX 4090/L40, and
+the default RTX FP8 path. Passing `use_fp16=True` without
+`use_fp8=False`, or on unsupported hardware/configs, raises a
+`ValueError`.
 
 ### `model.predict()`
 

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -444,6 +444,12 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
             self.autotune_bf16_nn(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, num_algos);
         }, py::arg("A"), py::arg("B"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"), py::arg("num_algos") = 16)
+        .def("autotune_fp16_nn", [](GemmRunner& self,
+                                     uintptr_t A, uintptr_t B, uintptr_t D,
+                                     int M, int N, int K, int num_algos) {
+            self.autotune_fp16_nn(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, num_algos);
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("num_algos") = 16)
         .def("autotune_fp8_nn_dev", [](GemmRunner& self,
                                         uintptr_t A, uintptr_t B, uintptr_t D,
                                         int M, int N, int K,
@@ -715,6 +721,25 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("style"), py::arg("out"), py::arg("gate_out"),
        py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
        py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+    m.def("gate_residual_ada_norm_fp16", [](uintptr_t residual, uintptr_t x,
+                                             uintptr_t gate, uintptr_t weight,
+                                             uintptr_t style,
+                                             uintptr_t out, uintptr_t gate_out,
+                                             int seq_len, int dim, float eps,
+                                             uintptr_t stream) {
+        gate_residual_ada_norm_fp16(reinterpret_cast<__half*>(residual),
+                                     reinterpret_cast<const __half*>(x),
+                                     reinterpret_cast<const __half*>(gate),
+                                     reinterpret_cast<const __half*>(weight),
+                                     reinterpret_cast<const __half*>(style),
+                                     reinterpret_cast<__half*>(out),
+                                     reinterpret_cast<__half*>(gate_out),
+                                     seq_len, dim, eps, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("gate"), py::arg("weight"),
+       py::arg("style"), py::arg("out"), py::arg("gate_out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("stream") = 0);
 
     // Quantize
     m.def("quantize_fp8", [](uintptr_t input, uintptr_t output,
@@ -1041,6 +1066,22 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     }, py::arg("x"), py::arg("weight"), py::arg("bias"), py::arg("out"),
        py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
 
+    m.def("ada_rms_norm_style_fp16",
+          [](uintptr_t x, uintptr_t weight, uintptr_t style,
+             uintptr_t out, uintptr_t gate_out,
+             int seq_len, int dim, float eps, uintptr_t stream) {
+        ada_rms_norm_style_fp16(
+            reinterpret_cast<const __half*>(x),
+            reinterpret_cast<const __half*>(weight),
+            reinterpret_cast<const __half*>(style),
+            reinterpret_cast<__half*>(out),
+            reinterpret_cast<__half*>(gate_out),
+            seq_len, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("weight"), py::arg("style"),
+       py::arg("out"), py::arg("gate_out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("stream") = 0);
+
     m.def("layer_norm_fp8", [](uintptr_t x, uintptr_t out, uintptr_t gamma, uintptr_t beta,
                                 int seq_len, int dim, float eps, uintptr_t stream) {
         layer_norm_fp8(reinterpret_cast<const __half*>(x), reinterpret_cast<__nv_fp8_e4m3*>(out),
@@ -1073,10 +1114,49 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     }, py::arg("residual"), py::arg("x"), py::arg("bias"),
        py::arg("seq_len"), py::arg("dim"), py::arg("stream") = 0);
 
+    m.def("bias_residual_strict_fp16",
+          [](uintptr_t residual, uintptr_t x, uintptr_t bias,
+             int seq_len, int dim, uintptr_t stream) {
+        bias_residual_strict_fp16(
+            reinterpret_cast<__half*>(residual),
+            reinterpret_cast<const __half*>(x),
+            reinterpret_cast<const __half*>(bias),
+            seq_len, dim, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("bias"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("stream") = 0);
+
+    m.def("bias_residual_layer_norm_fp16",
+          [](uintptr_t residual, uintptr_t x, uintptr_t bias_pre,
+             uintptr_t ln_weight, uintptr_t ln_bias, uintptr_t out,
+             int seq_len, int dim, float eps, uintptr_t stream) {
+        bias_residual_layer_norm_fp16(
+            reinterpret_cast<__half*>(residual),
+            reinterpret_cast<const __half*>(x),
+            reinterpret_cast<const __half*>(bias_pre),
+            reinterpret_cast<const __half*>(ln_weight),
+            reinterpret_cast<const __half*>(ln_bias),
+            reinterpret_cast<__half*>(out),
+            seq_len, dim, eps, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("bias_pre"),
+       py::arg("ln_weight"), py::arg("ln_bias"), py::arg("out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("stream") = 0);
+
     m.def("residual_add_fp16", [](uintptr_t residual, uintptr_t x, int n, uintptr_t stream) {
         residual_add_fp16(reinterpret_cast<__half*>(residual), reinterpret_cast<const __half*>(x),
                            n, to_stream(stream));
     }, py::arg("residual"), py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("gate_mul_residual_fp16",
+          [](uintptr_t residual, uintptr_t x, uintptr_t gate,
+             int n, uintptr_t stream) {
+        gate_mul_residual_fp16(
+            reinterpret_cast<__half*>(residual),
+            reinterpret_cast<const __half*>(x),
+            reinterpret_cast<const __half*>(gate),
+            n, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("gate"),
+       py::arg("n"), py::arg("stream") = 0);
 
     m.def("cfg_combine_into_residual_fp16",
           [](uintptr_t residual, uintptr_t v_cond, uintptr_t v_uncond,
@@ -1092,6 +1172,16 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     m.def("gelu_inplace_fp16", [](uintptr_t x, int n, uintptr_t stream) {
         gelu_inplace_fp16(reinterpret_cast<__half*>(x), n, to_stream(stream));
     }, py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("bias_gelu_fp16_strict", [](uintptr_t x, uintptr_t bias,
+                                       int seq_len, int dim, uintptr_t stream) {
+        cudaStream_t s = to_stream(stream);
+        add_bias_fp16(reinterpret_cast<__half*>(x),
+                      reinterpret_cast<const __half*>(bias),
+                      seq_len, dim, s);
+        gelu_inplace_fp16(reinterpret_cast<__half*>(x), seq_len * dim, s);
+    }, py::arg("x"), py::arg("bias"), py::arg("seq_len"), py::arg("dim"),
+       py::arg("stream") = 0);
 
     m.def("gate_geglu_merged_fp16", [](uintptr_t merged, uintptr_t out,
                                         int seq, int half_dim, uintptr_t stream) {

--- a/csrc/gemm/gemm_runner.cu
+++ b/csrc/gemm/gemm_runner.cu
@@ -211,6 +211,12 @@ void GemmRunner::autotune_bf16_nn(void* A, void* B, void* D,
     autotune_cached(entry, A, B, D, 1.0f, 0.0f, num_algos);
 }
 
+void GemmRunner::autotune_fp16_nn(void* A, void* B, void* D,
+                                   int M, int N, int K, int num_algos) {
+    auto& entry = get_or_create_cached(FP16_NN, M, N, K);
+    autotune_cached(entry, A, B, D, 1.0f, 0.0f, num_algos);
+}
+
 void GemmRunner::autotune_fp8_nn_dev(void* A, void* B, void* D,
                                       int M, int N, int K,
                                       float* d_scale_a, float* d_scale_b,

--- a/csrc/gemm/gemm_runner.h
+++ b/csrc/gemm/gemm_runner.h
@@ -167,6 +167,8 @@ public:
     // Call before CUDA Graph capture. Uses dummy data at the provided pointers.
     void autotune_bf16_nn(void* A, void* B, void* D,
                           int M, int N, int K, int num_algos = 16);
+    void autotune_fp16_nn(void* A, void* B, void* D,
+                          int M, int N, int K, int num_algos = 16);
     void autotune_fp8_nn_dev(void* A, void* B, void* D,
                              int M, int N, int K,
                              float* d_scale_a, float* d_scale_b,

--- a/csrc/kernels/elementwise.cu
+++ b/csrc/kernels/elementwise.cu
@@ -215,6 +215,33 @@ void bias_residual_fp16(__half* residual, const __half* x,
     bias_res_kernel<__half><<<seq_len, 256, 0, stream>>>(residual, x, bias, dim);
 }
 
+__global__ void bias_res_strict_fp16_kernel(__half* __restrict__ residual,
+                                            const __half* __restrict__ x,
+                                            const __half* __restrict__ bias,
+                                            int dim) {
+    using T2 = typename packed2<__half>::type;
+    int row = blockIdx.x;
+    T2* res2 = reinterpret_cast<T2*>(residual + row * dim);
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T2* b2 = reinterpret_cast<const T2*>(bias);
+    int dim2 = dim >> 1;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], xv = x2[i], bv = b2[i];
+        __half xb0 = from_f32<__half>(to_f32(xv.x) + to_f32(bv.x));
+        __half xb1 = from_f32<__half>(to_f32(xv.y) + to_f32(bv.y));
+        res2[i] = make_packed2<__half>(
+            from_f32<__half>(to_f32(rv.x) + to_f32(xb0)),
+            from_f32<__half>(to_f32(rv.y) + to_f32(xb1)));
+    }
+}
+
+void bias_residual_strict_fp16(__half* residual, const __half* x,
+                               const __half* bias, int seq_len, int dim,
+                               cudaStream_t stream) {
+    bias_res_strict_fp16_kernel<<<seq_len, 256, 0, stream>>>(
+        residual, x, bias, dim);
+}
+
 template<typename T>
 __global__ void bias_res_out_kernel(const T* __restrict__ residual,
                                     const T* __restrict__ x,

--- a/csrc/kernels/elementwise.cuh
+++ b/csrc/kernels/elementwise.cuh
@@ -267,6 +267,10 @@ void bias_residual_fp16(__half* residual, const __half* x,
                         const __half* bias, int seq_len, int dim,
                         cudaStream_t stream = 0);
 
+void bias_residual_strict_fp16(__half* residual, const __half* x,
+                               const __half* bias, int seq_len, int dim,
+                               cudaStream_t stream = 0);
+
 // G6.7: residual += (x + bias) * gate, in-place
 void bias_gate_mul_residual_bf16(__nv_bfloat16* residual,
                                  const __nv_bfloat16* x,

--- a/csrc/kernels/fusion.cu
+++ b/csrc/kernels/fusion.cu
@@ -89,6 +89,70 @@ void gate_residual_ada_norm_fp8_fp16(__half* residual, const __half* x,
         residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
 }
 
+// ── Fused Gate*Residual + AdaRMSNorm + Style -> FP16 ──
+// Same math as gate_mul_residual_fp16 + ada_rms_norm_style_fp16, but
+// keeps the residual update and RMS reduction in one launch.
+__global__ void gate_residual_ada_norm_fp16_kernel(
+    __half* __restrict__ residual,
+    const __half* __restrict__ x,
+    const __half* __restrict__ gate,
+    const __half* __restrict__ weight,
+    const __half* __restrict__ style,
+    __half* __restrict__ out,
+    __half* __restrict__ gate_out,
+    int dim, float eps) {
+    using T2 = typename packed2<__half>::type;
+    int row = blockIdx.x;
+    T2* res2 = reinterpret_cast<T2*>(residual + row * dim);
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T2* g2 = reinterpret_cast<const T2*>(gate + row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    const __half* style_row = style + row * 3 * dim;
+    const T2* sc2 = reinterpret_cast<const T2*>(style_row);
+    const T2* sh2 = reinterpret_cast<const T2*>(style_row + dim);
+    const T2* gt2 = reinterpret_cast<const T2*>(style_row + 2 * dim);
+    T2* out2 = reinterpret_cast<T2*>(out + row * dim);
+    T2* gate_out2 = reinterpret_cast<T2*>(gate_out + row * dim);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], xv = x2[i], gv = g2[i];
+        float r0 = to_f32(rv.x) + to_f32(xv.x) * to_f32(gv.x);
+        float r1 = to_f32(rv.y) + to_f32(xv.y) * to_f32(gv.y);
+        __half rh0 = from_f32<__half>(r0);
+        __half rh1 = from_f32<__half>(r1);
+        res2[i] = make_packed2<__half>(rh0, rh1);
+        float rr0 = to_f32(rh0);
+        float rr1 = to_f32(rh1);
+        local_sum += rr0 * rr0 + rr1 * rr1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], wv = w2[i];
+        T2 sv = sc2[i], hv = sh2[i], gv = gt2[i];
+        float n0 = to_f32(rv.x) * rms * to_f32(wv.x);
+        float n1 = to_f32(rv.y) * rms * to_f32(wv.y);
+        out2[i] = make_packed2<__half>(
+            from_f32<__half>(n0 * (1.0f + to_f32(sv.x)) + to_f32(hv.x)),
+            from_f32<__half>(n1 * (1.0f + to_f32(sv.y)) + to_f32(hv.y)));
+        gate_out2[i] = gv;
+    }
+}
+
+void gate_residual_ada_norm_fp16(__half* residual, const __half* x,
+                                  const __half* gate, const __half* weight,
+                                  const __half* style,
+                                  __half* out, __half* gate_out,
+                                  int seq_len, int dim, float eps,
+                                  cudaStream_t stream) {
+    gate_residual_ada_norm_fp16_kernel<<<seq_len, 256, 256 * sizeof(float), stream>>>(
+        residual, x, gate, weight, style, out, gate_out, dim, eps);
+}
+
 template<typename T>
 __global__ void gate_residual_ada_norm_int8_kernel(
     T* __restrict__ residual,

--- a/csrc/kernels/fusion.cuh
+++ b/csrc/kernels/fusion.cuh
@@ -28,6 +28,13 @@ void gate_residual_ada_norm_fp8_fp16(__half* residual, const __half* x,
                                       int seq_len, int dim, float eps,
                                       const float* d_scale, cudaStream_t stream = 0);
 
+void gate_residual_ada_norm_fp16(__half* residual, const __half* x,
+                                  const __half* gate, const __half* weight,
+                                  const __half* style,
+                                  __half* out, __half* gate_out,
+                                  int seq_len, int dim, float eps,
+                                  cudaStream_t stream = 0);
+
 void gate_residual_ada_norm_int8(__nv_bfloat16* residual, const __nv_bfloat16* x,
                                  const __nv_bfloat16* gate, const __nv_bfloat16* weight,
                                  const __nv_bfloat16* style,

--- a/csrc/kernels/norm.cu
+++ b/csrc/kernels/norm.cu
@@ -332,6 +332,15 @@ void ada_rms_norm_style(const __nv_bfloat16* x, const __nv_bfloat16* weight,
         x, weight, style, out, gate_out, dim, eps);
 }
 
+void ada_rms_norm_style_fp16(const __half* x, const __half* weight,
+                             const __half* style,
+                             __half* out, __half* gate_out,
+                             int seq_len, int dim, float eps,
+                             cudaStream_t stream) {
+    ada_rms_norm_style_kernel<__half><<<seq_len, 256, 256 * sizeof(float), stream>>>(
+        x, weight, style, out, gate_out, dim, eps);
+}
+
 // ── RMSNorm → FP8 ──
 template<typename T>
 __global__ void rms_norm_fp8_kernel(const T* __restrict__ x,

--- a/csrc/kernels/norm.cuh
+++ b/csrc/kernels/norm.cuh
@@ -68,6 +68,12 @@ void ada_rms_norm_style(const __nv_bfloat16* x, const __nv_bfloat16* weight,
                         int seq_len, int dim, float eps,
                         cudaStream_t stream = 0);
 
+void ada_rms_norm_style_fp16(const __half* x, const __half* weight,
+                             const __half* style,
+                             __half* out, __half* gate_out,
+                             int seq_len, int dim, float eps,
+                             cudaStream_t stream = 0);
+
 // ── Fused Norm → FP8 (with scale) ──
 
 void rms_norm_fp8_fp16(const __half* x, const __half* weight,
@@ -167,4 +173,11 @@ void bias_residual_layer_norm_bf16(
         const __nv_bfloat16* bias_pre,
         const __nv_bfloat16* ln_weight, const __nv_bfloat16* ln_bias,
         __nv_bfloat16* out, int seq_len, int dim, float eps,
+        cudaStream_t stream = 0);
+
+void bias_residual_layer_norm_fp16(
+        __half* residual, const __half* x,
+        const __half* bias_pre,
+        const __half* ln_weight, const __half* ln_bias,
+        __half* out, int seq_len, int dim, float eps,
         cudaStream_t stream = 0);

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -51,6 +51,8 @@ def load_model(
     cache_frames: int | None = None,
     # Frontends with an FP8/BF16 switch:
     use_fp8: bool = True,
+    # Pi0.5 torch RTX SM120 opt-in:
+    use_fp16: bool = False,
 ) -> VLAModel
 ```
 
@@ -69,6 +71,10 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   `cache_frames >= 1`.
 - `use_fp8=False` disables FP8 where the selected frontend exposes a
   BF16 fallback; unsupported frontends ignore it.
+- `use_fp16=True` selects the opt-in Pi0.5 torch RTX SM120 full-FP16
+  CUDA Graph path. It requires `use_fp8=False` and is currently valid
+  only for `config="pi05"`, `framework="torch"`, and
+  `hardware="rtx_sm120"`.
 - `config="motus"` is a beta RTX SM120 frontend. It expects a Motus
   checkpoint plus Wan and VLM checkpoint paths supplied to the Motus
   quickstart/frontend; see `docs/motus_usage_beta.md`.

--- a/examples/blackwell/bench_pi05_fp16.py
+++ b/examples/blackwell/bench_pi05_fp16.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Opt-in Pi0.5 RTX 5090 full-FP16 CUDA Graph benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import numpy as np
+import torch
+
+import flash_rt
+
+
+def _stats(xs: list[float]) -> str:
+    xs = sorted(float(x) for x in xs)
+    return (
+        f"n={len(xs)} "
+        f"p50={xs[int(0.50 * (len(xs) - 1))]:.3f} "
+        f"p90={xs[int(0.90 * (len(xs) - 1))]:.3f} "
+        f"p95={xs[int(0.95 * (len(xs) - 1))]:.3f} "
+        f"mean={statistics.mean(xs):.3f} "
+        f"min={xs[0]:.3f} max={xs[-1]:.3f}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--num-views", type=int, default=3)
+    parser.add_argument("--steps", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument(
+        "--prompt",
+        default="pick up the red block and place it in the tray",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+
+    images = [
+        np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8)
+        for _ in range(args.num_views)
+    ]
+
+    print("=== Pi0.5 RTX full-FP16 opt-in benchmark ===", flush=True)
+    print("device", torch.cuda.get_device_name(0), torch.cuda.get_device_capability(0), flush=True)
+    print("checkpoint", args.checkpoint, flush=True)
+    print("num_views", args.num_views, "steps", args.steps, flush=True)
+
+    t0 = time.perf_counter()
+    model = flash_rt.load_model(
+        args.checkpoint,
+        framework="torch",
+        config="pi05",
+        hardware="rtx_sm120",
+        num_views=args.num_views,
+        num_steps=args.steps,
+        cache_frames=1,
+        use_fp8=False,
+        use_fp16=True,
+    )
+    torch.cuda.synchronize()
+    print(f"load_model_s={time.perf_counter() - t0:.3f}", flush=True)
+    print("pipe", type(model._pipe).__name__, flush=True)
+
+    t0 = time.perf_counter()
+    out = model.predict(images, prompt=args.prompt)
+    torch.cuda.synchronize()
+    if not np.isfinite(out).all():
+        raise RuntimeError("FP16 output contains NaN or Inf")
+    print(
+        f"first_predict_build_s={time.perf_counter() - t0:.3f} "
+        f"actions_shape={out.shape}",
+        flush=True,
+    )
+
+    for _ in range(args.warmup):
+        out = model.predict(images)
+        if not np.isfinite(out).all():
+            raise RuntimeError("FP16 output contains NaN or Inf during warmup")
+    torch.cuda.synchronize()
+    model._pipe.latency_records.clear()
+
+    wall = []
+    for _ in range(args.iters):
+        t0 = time.perf_counter()
+        out = model.predict(images)
+        torch.cuda.synchronize()
+        if not np.isfinite(out).all():
+            raise RuntimeError("FP16 output contains NaN or Inf during benchmark")
+        wall.append((time.perf_counter() - t0) * 1000.0)
+
+    print("RESULT wall_ms", _stats(wall), flush=True)
+    print("RESULT internal_ms", _stats(list(model._pipe.latency_records)), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -184,6 +184,7 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                vision_pool_factor=None,
                vision_num_layers=None,
                cache_frames=None,
+               use_fp16=False,
                use_fp8=True):
     """Load a FlashRT model.
 
@@ -246,6 +247,8 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         use_fp8: Enable FP8 execution where the selected frontend supports
             an FP8/BF16 switch. Defaults to True to preserve existing
             performance-oriented behavior.
+        use_fp16: Experimental Pi0.5 torch RTX full-FP16 baseline. This is
+            only valid with ``use_fp8=False`` on RTX SM120.
         num_steps: Pi0/Pi0.5 torch only when supported. Number of
             flow-matching ODE steps. ``None`` uses the frontend default.
         vision_pool_factor: Pi0.5 torch RTX/Orin only. Spatial pooling factor
@@ -312,6 +315,18 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
 
     pipe_cls = resolve_pipeline_class(config, framework, arch)
+
+    if use_fp16:
+        if use_fp8:
+            raise ValueError("use_fp16=True requires use_fp8=False")
+        if config != "pi05" or framework != "torch" or arch != "rtx_sm120":
+            raise ValueError(
+                "use_fp16=True is currently experimental and only supports "
+                "config='pi05', framework='torch', hardware='rtx_sm120'")
+        from flash_rt.frontends.torch.pi05_rtx_fp16 import (
+            Pi05TorchFrontendRtxFP16,
+        )
+        pipe_cls = Pi05TorchFrontendRtxFP16
 
     # ── FP4 routing (Pi0.5 torch + Pi0.5 JAX on Thor) ──
     if use_fp4:

--- a/flash_rt/frontends/torch/pi05_rtx_fp16.py
+++ b/flash_rt/frontends/torch/pi05_rtx_fp16.py
@@ -1,0 +1,1753 @@
+"""FlashRT -- RTX Pi0.5 torch frontend.
+
+Loads HuggingFace PyTorch safetensors checkpoints + drives the
+framework-agnostic :class:`~flash_rt.models.pi05.pipeline_rtx.Pi05Pipeline`.
+
+This is the "reference" RTX frontend. The RTX JAX frontend
+(:mod:`flash_rt.frontends.jax.pi05_rtx`) mirrors this API but loads
+from Orbax and uses JAX for weight quantization.
+
+Usage::
+
+    from flash_rt.frontends.torch.pi05_rtx_fp16 import Pi05TorchFrontendRtxFP16
+    pipe = Pi05TorchFrontendRtxFP16("/path/to/pi05_libero_pytorch", num_views=2)
+    pipe.set_prompt("pick up the red block")
+    pipe.calibrate_with_real_data([obs_dict])   # once, ~1 s
+    out = pipe.infer({"image": img, "wrist_image": wrist})
+    actions = out["actions"]     # (chunk_size, 7) numpy
+"""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import logging
+import math
+import os
+import pathlib
+import time
+from typing import Optional, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from flash_rt.core.utils.actions import unnormalize_actions, LIBERO_ACTION_DIM
+from flash_rt.hardware.rtx.attn_backend import RtxFlashAttnBackend
+from flash_rt.models.pi05.pipeline_rtx_fp16 import (
+    Pi05PipelineFP16 as Pi05Pipeline,
+    VIS_L, VIS_D, VIS_H, VIS_PATCH_FLAT,
+    ENC_L, ENC_D, ENC_H,
+    DEC_L, DEC_D, DEC_H, DEC_HD,
+    ACTION_DIM, NUM_STEPS_DEFAULT,
+)
+from flash_rt.models.pi05.pipeline_rtx_cfg import Pi05CFGPipeline
+from flash_rt.models.pi05.pipeline_rtx_batched import Pi05BatchedPipeline
+from flash_rt.models.pi05.pipeline_rtx_cfg_batched import Pi05CFGBatchedPipeline
+from flash_rt.hardware.rtx.attn_backend_batched_pi05 import (
+    PI05_BATCH_SIZE,
+    RtxFlashAttnBatchedBackendPi05,
+)
+from flash_rt.core.utils.hardware import supports_fp8
+
+logger = logging.getLogger(__name__)
+
+bf16 = torch.float16
+fp8_e4m3 = torch.float8_e4m3fn
+
+CHUNK_SIZE = 10
+IMG_HW = 224
+MAX_PROMPT_LEN_DEFAULT = 48
+
+
+# ════════════════════════════════════════════════════════════════════
+#   HF safetensors → pipeline weight dict (BF16 torch tensors)
+# ════════════════════════════════════════════════════════════════════
+
+
+def _interleave_qk(w: torch.Tensor, num_heads: int) -> torch.Tensor:
+    """Interleave Q/K output dim from HF contiguous to JAX RoPE format."""
+    out_dim, in_dim = w.shape
+    head_dim = out_dim // num_heads
+    return (
+        w.reshape(num_heads, head_dim, in_dim)
+         .reshape(num_heads, 2, head_dim // 2, in_dim)
+         .permute(0, 2, 1, 3)
+         .reshape(out_dim, in_dim)
+    )
+
+
+def convert_pi05_safetensors(safetensors_path: Union[str, pathlib.Path]) -> dict:
+    """Convert a HuggingFace Pi0.5 safetensors file to BF16 torch tensor dict.
+
+    Key transformations (verified bit-exact against the openpi PyTorch
+    reference forward on LIBERO data):
+
+      - Vision attention: separate Q/K/V → merged, transposed (in, 3*out).
+      - Vision patch embedding: ``(C_out, C_in, H, W)`` → ``(H, W, C_in, C_out)``.
+      - Encoder RMSNorm fold: multiply Q/K/V/gate/up weights by ``(1 + norm_w)``
+        in FP32 to avoid bf16 rounding near -1.0.
+      - Encoder Q/K heads: interleave for fused RoPE kernel.
+      - Decoder Q/K heads: interleave (no RMS fold — AdaRMSNorm is runtime).
+      - Decoder AdaRMSNorm modulation: ``input_layernorm.dense`` →
+        ``pre_attn_norm_mod`` (kept separate, BF16).
+      - Output projection: frontend pre-scales ``decoder_action_out_proj_w/b``
+        by ``-1.0 / num_steps`` (matching the flow-matching residual accumulation).
+      - 10-step sinusoidal time embeddings.
+    """
+    from safetensors import safe_open
+    from flash_rt.executors.torch_weights import _autodetect_strip_prefix
+
+    logger.info("Loading Pi0.5 safetensors: %s", safetensors_path)
+    f = safe_open(str(safetensors_path), framework="pt")
+    # Auto-strip the lerobot HF policy ``model.`` wrap so the openpi
+    # bare-key lookups below resolve transparently on either layout.
+    _strip = _autodetect_strip_prefix(set(f.keys()))
+
+    def g(key: str) -> torch.Tensor:
+        return f.get_tensor((_strip + key) if _strip else key).to(bf16)
+
+    def g_raw(key: str) -> torch.Tensor:
+        return f.get_tensor((_strip + key) if _strip else key)
+
+    ckpt: dict = {}
+
+    # ── Vision encoder (27 SigLIP layers) ──
+    vp = "paligemma_with_expert.paligemma.model.vision_tower.vision_model"
+    pe_w = g(f"{vp}.embeddings.patch_embedding.weight")   # (1152, 3, 14, 14)
+    # Target layout (14, 14, 3, 1152) flattens contiguously to (588, 1152)
+    # row-major as (h, w, c, o) — matches the patch_im2col output order.
+    ckpt["vision_patch_embedding_w"] = pe_w.permute(2, 3, 1, 0).contiguous()
+    ckpt["vision_patch_embedding_b"] = g(f"{vp}.embeddings.patch_embedding.bias")
+    ckpt["vision_position_embedding"] = g(f"{vp}.embeddings.position_embedding.weight")
+
+    qkv_w_list, qkv_b_list = [], []
+    o_w_list, o_b_list = [], []
+    up_w_list, up_b_list = [], []
+    down_w_list, down_b_list = [], []
+    ln1_w_list, ln1_b_list = [], []
+    ln2_w_list, ln2_b_list = [], []
+
+    for i in range(VIS_L):
+        lp = f"{vp}.encoder.layers.{i}"
+        q_w = g(f"{lp}.self_attn.q_proj.weight")
+        k_w = g(f"{lp}.self_attn.k_proj.weight")
+        v_w = g(f"{lp}.self_attn.v_proj.weight")
+        qkv_w_list.append(torch.cat([q_w, k_w, v_w], dim=0).t())
+
+        q_b = g(f"{lp}.self_attn.q_proj.bias")
+        k_b = g(f"{lp}.self_attn.k_proj.bias")
+        v_b = g(f"{lp}.self_attn.v_proj.bias")
+        qkv_b_list.append(torch.cat([q_b, k_b, v_b]))
+
+        o_w_list.append(g(f"{lp}.self_attn.out_proj.weight").t())
+        o_b_list.append(g(f"{lp}.self_attn.out_proj.bias"))
+
+        up_w_list.append(g(f"{lp}.mlp.fc1.weight").t())
+        up_b_list.append(g(f"{lp}.mlp.fc1.bias"))
+
+        down_w_list.append(g(f"{lp}.mlp.fc2.weight").t())
+        down_b_list.append(g(f"{lp}.mlp.fc2.bias"))
+
+        ln1_w_list.append(g(f"{lp}.layer_norm1.weight"))
+        ln1_b_list.append(g(f"{lp}.layer_norm1.bias"))
+        ln2_w_list.append(g(f"{lp}.layer_norm2.weight"))
+        ln2_b_list.append(g(f"{lp}.layer_norm2.bias"))
+
+    ckpt["vision_attn_qkv_w"] = torch.stack(qkv_w_list)
+    ckpt["vision_attn_qkv_b"] = torch.stack(qkv_b_list)
+    ckpt["vision_attn_o_w"] = torch.stack(o_w_list)
+    ckpt["vision_attn_o_b"] = torch.stack(o_b_list)
+    ckpt["vision_ffn_up_w"] = torch.stack(up_w_list)
+    ckpt["vision_ffn_up_b"] = torch.stack(up_b_list)
+    ckpt["vision_ffn_down_w"] = torch.stack(down_w_list)
+    ckpt["vision_ffn_down_b"] = torch.stack(down_b_list)
+    ckpt["vision_pre_attn_norm_w"] = torch.stack(ln1_w_list)
+    ckpt["vision_pre_attn_norm_b"] = torch.stack(ln1_b_list)
+    ckpt["vision_pre_ffn_norm_w"] = torch.stack(ln2_w_list)
+    ckpt["vision_pre_ffn_norm_b"] = torch.stack(ln2_b_list)
+    ckpt["vision_final_norm_w"] = g(f"{vp}.post_layernorm.weight")
+    ckpt["vision_final_norm_b"] = g(f"{vp}.post_layernorm.bias")
+
+    # ── Multi-modal projector ──
+    mp = "paligemma_with_expert.paligemma.model.multi_modal_projector.linear"
+    ckpt["encoder_multi_modal_projector_w"] = g(f"{mp}.weight").t()
+    ckpt["encoder_multi_modal_projector_b"] = g(f"{mp}.bias")
+
+    # ── Encoder (18 Gemma-2B layers with RMSNorm fold) ──
+    ep = "paligemma_with_expert.paligemma.model.language_model.layers"
+    enc_qkv_list, enc_o_list = [], []
+    enc_gate_list, enc_up_list, enc_down_list = [], [], []
+
+    for i in range(ENC_L):
+        # CRITICAL: fuse in FP32 — bf16 rounds values near -1.0 to exactly
+        # -1.0, collapsing (1 + scale) to 0 and zeroing entire channels.
+        attn_scale = g_raw(f"{ep}.{i}.input_layernorm.weight").float()
+        fuse_attn = 1.0 + attn_scale  # (2048,)
+
+        q_w = g_raw(f"{ep}.{i}.self_attn.q_proj.weight").float()
+        k_w = g_raw(f"{ep}.{i}.self_attn.k_proj.weight").float()
+        v_w = g_raw(f"{ep}.{i}.self_attn.v_proj.weight").float()
+        q_w = _interleave_qk(q_w, 8)
+        k_w = _interleave_qk(k_w, 1)
+        q_w = q_w * fuse_attn.unsqueeze(0)
+        k_w = k_w * fuse_attn.unsqueeze(0)
+        v_w = v_w * fuse_attn.unsqueeze(0)
+        qkv = torch.cat([q_w, k_w, v_w], dim=0).t().to(bf16)
+        enc_qkv_list.append(qkv)
+
+        enc_o_list.append(g(f"{ep}.{i}.self_attn.o_proj.weight").t())
+
+        ffn_scale = g_raw(f"{ep}.{i}.post_attention_layernorm.weight").float()
+        fuse_ffn = 1.0 + ffn_scale
+
+        gate_w = g_raw(f"{ep}.{i}.mlp.gate_proj.weight").float() * fuse_ffn.unsqueeze(0)
+        up_w = g_raw(f"{ep}.{i}.mlp.up_proj.weight").float() * fuse_ffn.unsqueeze(0)
+        enc_gate_list.append(gate_w.t().to(bf16))
+        enc_up_list.append(up_w.t().to(bf16))
+
+        enc_down_list.append(g(f"{ep}.{i}.mlp.down_proj.weight").t())
+
+    ckpt["encoder_attn_qkv_w"] = torch.stack(enc_qkv_list)
+    ckpt["encoder_attn_o_w"] = torch.stack(enc_o_list)
+    ckpt["encoder_ffn_gate_w"] = torch.stack(enc_gate_list)
+    ckpt["encoder_ffn_up_w"] = torch.stack(enc_up_list)
+    ckpt["encoder_ffn_down_w"] = torch.stack(enc_down_list)
+
+    # ── Decoder (18 Gemma-300M layers) ──
+    dp = "paligemma_with_expert.gemma_expert.model.layers"
+    dec_qkv_list, dec_o_list = [], []
+    dec_gate_list, dec_up_list, dec_down_list = [], [], []
+    dec_attn_mod_w_list, dec_attn_mod_b_list = [], []
+    dec_ffn_mod_w_list, dec_ffn_mod_b_list = [], []
+
+    for i in range(DEC_L):
+        dec_attn_mod_w_list.append(g(f"{dp}.{i}.input_layernorm.dense.weight").t())
+        dec_attn_mod_b_list.append(g(f"{dp}.{i}.input_layernorm.dense.bias"))
+
+        q_w = g(f"{dp}.{i}.self_attn.q_proj.weight")
+        k_w = g(f"{dp}.{i}.self_attn.k_proj.weight")
+        v_w = g(f"{dp}.{i}.self_attn.v_proj.weight")
+        q_w = _interleave_qk(q_w.float(), 8).to(q_w.dtype)
+        k_w = _interleave_qk(k_w.float(), 1).to(k_w.dtype)
+        dec_qkv_list.append(torch.cat([q_w, k_w, v_w], dim=0).t())
+
+        dec_o_list.append(g(f"{dp}.{i}.self_attn.o_proj.weight").t())
+
+        dec_ffn_mod_w_list.append(
+            g(f"{dp}.{i}.post_attention_layernorm.dense.weight").t())
+        dec_ffn_mod_b_list.append(
+            g(f"{dp}.{i}.post_attention_layernorm.dense.bias"))
+
+        dec_gate_list.append(g(f"{dp}.{i}.mlp.gate_proj.weight").t())
+        dec_up_list.append(g(f"{dp}.{i}.mlp.up_proj.weight").t())
+        dec_down_list.append(g(f"{dp}.{i}.mlp.down_proj.weight").t())
+
+    ckpt["decoder_attn_qkv_w"] = torch.stack(dec_qkv_list)
+    ckpt["decoder_attn_o_w"] = torch.stack(dec_o_list)
+    ckpt["decoder_ffn_gate_w"] = torch.stack(dec_gate_list)
+    ckpt["decoder_ffn_up_w"] = torch.stack(dec_up_list)
+    if os.environ.get("FVK_PI05_FP16_MERGE_GATE_UP", "1") != "0":
+        ckpt["decoder_ffn_gate_up_w"] = torch.stack([
+            torch.cat([gate_w, up_w], dim=1).contiguous()
+            for gate_w, up_w in zip(dec_gate_list, dec_up_list)
+        ])
+    ckpt["decoder_ffn_down_w"] = torch.stack(dec_down_list)
+    ckpt["decoder_pre_attn_norm_mod_w"] = torch.stack(dec_attn_mod_w_list)
+    ckpt["decoder_pre_attn_norm_mod_b"] = torch.stack(dec_attn_mod_b_list)
+    ckpt["decoder_pre_ffn_norm_mod_w"] = torch.stack(dec_ffn_mod_w_list)
+    ckpt["decoder_pre_ffn_norm_mod_b"] = torch.stack(dec_ffn_mod_b_list)
+
+    ckpt["decoder_final_norm_mod_w"] = g(
+        "paligemma_with_expert.gemma_expert.model.norm.dense.weight").t()
+    ckpt["decoder_final_norm_mod_b"] = g(
+        "paligemma_with_expert.gemma_expert.model.norm.dense.bias")
+
+    # ── Time MLP + sinusoidal embeddings ──
+    ckpt["decoder_time_mlp_in_w"] = g("time_mlp_in.weight").t()
+    ckpt["decoder_time_mlp_in_b"] = g("time_mlp_in.bias")
+    ckpt["decoder_time_mlp_out_w"] = g("time_mlp_out.weight").t()
+    ckpt["decoder_time_mlp_out_b"] = g("time_mlp_out.bias")
+
+    num_steps = NUM_STEPS_DEFAULT
+    dt = -1.0 / num_steps
+    t = torch.tensor(1.0, dtype=torch.float32)
+    min_period, max_period = 4e-3, 4.0
+    embedding_dim = DEC_D
+    fraction = torch.linspace(0.0, 1.0, embedding_dim // 2)
+    period = min_period * (max_period / min_period) ** fraction
+    time_emb_list = []
+    for _ in range(num_steps):
+        sinusoid_input = t.unsqueeze(-1) * (1.0 / period).unsqueeze(0) * 2 * math.pi
+        time_emb_list.append(
+            torch.cat([torch.sin(sinusoid_input), torch.cos(sinusoid_input)], dim=-1).to(bf16)
+        )
+        t = t + dt
+    ckpt["decoder_time_embeds"] = torch.cat(time_emb_list, dim=0)  # (10, 1024)
+
+    # ── Action projections (pre-scaled by frontend before pipeline build) ──
+    ckpt["decoder_action_in_proj_w"] = g("action_in_proj.weight").t()
+    ckpt["decoder_action_in_proj_b"] = g("action_in_proj.bias")
+    ckpt["decoder_action_out_proj_w"] = g("action_out_proj.weight").t()
+    ckpt["decoder_action_out_proj_b"] = g("action_out_proj.bias")
+
+    # ── Embedding matrix (for prompt tokenisation) ──
+    ckpt["embedding_weight"] = g("paligemma_with_expert.paligemma.lm_head.weight")
+
+    logger.info("Converted %d weight groups", len(ckpt))
+    return ckpt
+
+
+def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
+                  max_len: int = 48) -> tuple[torch.Tensor, int]:
+    """Tokenise + embed via PaliGemma embedding table (CUDA, bf16)."""
+    # PaliGemma tokenizer resolution — see
+    # `flash_rt.utils.paligemma_tokenizer` for the search order and
+    # the download instructions emitted on failure.
+    try:
+        # Preferred: openpi's PaligemmaTokenizer (exact same vocab,
+        # same prompt prefix logic FlashRT was built against).
+        from openpi.models.tokenizer import PaligemmaTokenizer
+        tokenizer = PaligemmaTokenizer(max_len=max_len)
+        tokens_np, mask_np = tokenizer.tokenize(prompt_text)
+        prompt_len = int(mask_np.sum())
+        token_ids = torch.tensor(
+            tokens_np[:prompt_len], dtype=torch.long, device="cuda")
+    except (ImportError, FileNotFoundError, OSError, RuntimeError):
+        # Fallback: locate the SentencePiece model directly via the
+        # FlashRT helper (clear error if not found — never silent
+        # segfault).
+        from flash_rt.utils.paligemma_tokenizer import (
+            load_paligemma_sentencepiece,
+        )
+        sp = load_paligemma_sentencepiece()
+        # 108 is PaliGemma's `\n` token, used by openpi as the
+        # prompt-end separator before the action prefix.
+        tokens = [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+        token_ids = torch.tensor(tokens, dtype=torch.long, device="cuda")
+        prompt_len = len(token_ids)
+
+    if embedding_weight.device.type != "cuda":
+        embedding_weight = embedding_weight.to(device="cuda")
+
+    embeds = F.embedding(token_ids, embedding_weight)
+    embeds = embeds * float(embeds.shape[-1] ** 0.5)
+    return embeds, prompt_len
+
+
+# ════════════════════════════════════════════════════════════════════
+#   Weight FP8 quantization + precomputed decoder styles
+# ════════════════════════════════════════════════════════════════════
+
+
+def _quantize_fp8_e4m3(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-tensor symmetric FP8 E4M3 quantization."""
+    amax = w_bf16.float().abs().max().item()
+    scale = max(amax / 448.0, 1e-12)
+    w_fp8 = (w_bf16.float() / scale).clamp(-448.0, 448.0).to(fp8_e4m3)
+    scale_tensor = torch.tensor([scale], dtype=torch.float32, device="cuda")
+    return w_fp8, scale_tensor
+
+
+def _select_fp8_layout(hardware: Optional[str], fp8_layout: Optional[str]) -> str:
+    """Choose the Pi0.5 FP8 weight layout.
+
+    ``kn`` is the existing SM120 path: weights are stored as [K,N] and use
+    ``fp8_nn_dev``. ``nk`` is the SM89-compatible path: weights are stored
+    as [N,K] and use ``fp8_nt_dev``.
+    """
+    if fp8_layout is not None:
+        if fp8_layout not in ("kn", "nk"):
+            raise ValueError(f"fp8_layout must be 'kn' or 'nk', got {fp8_layout!r}")
+        return fp8_layout
+    if hardware == "rtx_sm89":
+        return "nk"
+    if hardware == "rtx_sm120":
+        return "kn"
+    try:
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability()
+            if major == 8 and minor == 9:
+                return "nk"
+    except Exception:
+        pass
+    return "kn"
+
+
+def _precompute_decoder_styles(ckpt: dict, chunk_size: int,
+                               num_steps: int = NUM_STEPS_DEFAULT) -> dict:
+    """Pre-compute the time-MLP + per-layer style modulations in torch.
+
+    Output dict has numpy arrays (dtype bf16 via torch→numpy view):
+        time_emb:    (num_steps, chunk_size, DEC_D)
+        style_attn:  (num_steps, DEC_L, chunk_size, 3 * DEC_D)
+        style_ffn:   (num_steps, DEC_L, chunk_size, 3 * DEC_D)
+        style_final: (num_steps, chunk_size, 3 * DEC_D)
+
+    All computation runs on CUDA in bf16, then is moved to CPU and viewed
+    as uint16 so it can be uploaded verbatim to CudaBuffer (bf16 = 2 bytes,
+    numpy doesn't natively support bf16 but the bytes round-trip).
+
+    Time embeddings are regenerated from scratch for the given num_steps so
+    that any step count works correctly (e.g. num_steps=5 gives
+    t=1.0, 0.8, 0.6, 0.4, 0.2 with dt=-0.2, not a truncation of the
+    10-step table stored in the checkpoint).
+    """
+    W = {k: v.to("cuda", bf16) if isinstance(v, torch.Tensor) else v
+         for k, v in ckpt.items()}
+
+    # Regenerate sinusoidal time embeddings for the given num_steps / dt.
+    # The checkpoint stores a 10-step table; generate fresh ones so any
+    # step count gets the correct (t=1, t=1-dt, …) time schedule.
+    dt = -1.0 / num_steps
+    t = torch.tensor(1.0, dtype=torch.float32)
+    min_period, max_period = 4e-3, 4.0
+    fraction = torch.linspace(0.0, 1.0, DEC_D // 2, dtype=torch.float32)
+    period = min_period * (max_period / min_period) ** fraction
+    _time_emb_rows = []
+    for _ in range(num_steps):
+        # period has shape (DEC_D//2,); t is a scalar tensor → sinusoid: (DEC_D//2,)
+        sinusoid = t * (1.0 / period) * 2 * math.pi
+        _time_emb_rows.append(
+            torch.cat([torch.sin(sinusoid), torch.cos(sinusoid)], dim=-1).to(bf16))
+        t = t + dt
+    time_emb_schedule = torch.stack(_time_emb_rows, dim=0).to("cuda")  # (steps, DEC_D)
+    t_in_w = W["decoder_time_mlp_in_w"]                       # (1024, 1024)
+    t_in_b = W["decoder_time_mlp_in_b"]                       # (1024,)
+    t_out_w = W["decoder_time_mlp_out_w"]
+    t_out_b = W["decoder_time_mlp_out_b"]
+
+    attn_mod_w = W["decoder_pre_attn_norm_mod_w"]             # (L, 1024, 3072)
+    attn_mod_b = W["decoder_pre_attn_norm_mod_b"]             # (L, 3072)
+    ffn_mod_w = W["decoder_pre_ffn_norm_mod_w"]
+    ffn_mod_b = W["decoder_pre_ffn_norm_mod_b"]
+    final_mod_w = W["decoder_final_norm_mod_w"]               # (1024, 3072)
+    final_mod_b = W["decoder_final_norm_mod_b"]               # (3072,)
+
+    time_emb_out = torch.empty(num_steps, chunk_size, DEC_D, dtype=bf16, device="cuda")
+    style_attn = torch.empty(num_steps, DEC_L, chunk_size, 3 * DEC_D, dtype=bf16, device="cuda")
+    style_ffn = torch.empty(num_steps, DEC_L, chunk_size, 3 * DEC_D, dtype=bf16, device="cuda")
+    style_final = torch.empty(num_steps, chunk_size, 3 * DEC_D, dtype=bf16, device="cuda")
+
+    for step in range(num_steps):
+        te = time_emb_schedule[step:step + 1]                 # (1, 1024)
+        tmp = te @ t_in_w + t_in_b[None, :]                   # SiLU input
+        tmp = (tmp.float() * torch.sigmoid(tmp.float())).to(bf16)
+        tmp2 = tmp @ t_out_w + t_out_b[None, :]
+        tmp2 = (tmp2.float() * torch.sigmoid(tmp2.float())).to(bf16)
+        te_expanded = tmp2.expand(chunk_size, -1).contiguous()  # (chunk, 1024)
+        time_emb_out[step] = te_expanded
+
+        for i in range(DEC_L):
+            style_attn[step, i] = te_expanded @ attn_mod_w[i] + attn_mod_b[i][None, :]
+            style_ffn[step, i] = te_expanded @ ffn_mod_w[i] + ffn_mod_b[i][None, :]
+
+        style_final[step] = te_expanded @ final_mod_w + final_mod_b[None, :]
+
+    # View as uint16 (bf16 bit pattern) so numpy can round-trip bytes.
+    def _to_np_u16(t: torch.Tensor) -> np.ndarray:
+        return t.contiguous().view(torch.uint16).cpu().numpy()
+
+    return {
+        "time_emb": _to_np_u16(time_emb_out),
+        "style_attn": _to_np_u16(style_attn),
+        "style_ffn": _to_np_u16(style_ffn),
+        "style_final": _to_np_u16(style_final),
+    }
+
+
+# ════════════════════════════════════════════════════════════════════
+#   Pi05TorchFrontendRtxFP16 frontend
+# ════════════════════════════════════════════════════════════════════
+
+
+class Pi05TorchFrontendRtxFP16:
+    """RTX consumer GPU Pi0.5 Torch frontend.
+
+    Mirrors the :class:`ThorPipelineTorch` public API (``set_prompt`` +
+    ``infer`` + ``calibrate_with_real_data`` + ``get_latency_stats``) so the
+    same eval scripts work on both hardware families.
+    """
+
+    def __init__(self,
+                 checkpoint_dir: Union[str, pathlib.Path],
+                 num_views: int = 2,
+                 chunk_size: int = CHUNK_SIZE,
+                 max_prompt_len: int = MAX_PROMPT_LEN_DEFAULT,
+                 num_steps: int = NUM_STEPS_DEFAULT,
+                 vision_pool_factor: int = 1,
+                 vision_num_layers: Optional[int] = None,
+                 cache_frames: int = 1,
+                 use_fp8: bool = False,
+                 hardware: Optional[str] = None,
+                 fp8_layout: Optional[str] = None):
+        if use_fp8:
+            raise ValueError(
+                "Pi05TorchFrontendRtxFP16 is a full-FP16 baseline and "
+                "requires use_fp8=False")
+        checkpoint_dir = pathlib.Path(checkpoint_dir)
+        self.num_views = int(num_views)
+        self.chunk_size = int(chunk_size)
+        self.max_prompt_len = int(max_prompt_len)
+        self._num_steps = int(num_steps)
+        self._vision_pool_factor = int(vision_pool_factor)
+        if self._num_steps <= 0:
+            raise ValueError(f"num_steps must be positive, got {self._num_steps}")
+        if self._vision_pool_factor != 1:
+            raise ValueError(
+                "Pi05TorchFrontendRtxFP16 currently supports only "
+                "vision_pool_factor=1; "
+                f"got {self._vision_pool_factor}")
+        # Temporal K/V caching: run full pipeline every `cache_frames` frames,
+        # intermediate frames reuse the cached encoder K/V (decoder-only).
+        # cache_frames=1 (default) = no caching, every frame is full.
+        # cache_frames=2 = full, decode, full, decode, ...
+        self._cache_frames = int(cache_frames)
+        if self._cache_frames < 1:
+            raise ValueError(f"cache_frames must be >= 1, got {self._cache_frames}")
+        self._frame_count = 0
+        from flash_rt.models.pi05.pipeline_rtx_fp16 import VIS_L as _VIS_L
+        self._vision_num_layers = _VIS_L if vision_num_layers is None else int(vision_num_layers)
+        if not 1 <= self._vision_num_layers <= _VIS_L:
+            raise ValueError(
+                f"vision_num_layers must be in [1, {_VIS_L}], "
+                f"got {self._vision_num_layers}")
+        # This experimental frontend is intentionally full FP16 only.
+        self.use_fp8 = False
+        self.fp8_layout = _select_fp8_layout(hardware, fp8_layout)
+
+        self.latency_records: list[float] = []
+        self.calibrated = False
+        self.graph_recorded = False
+        self.current_prompt_len = 0
+        self.pipeline: Optional[Pi05Pipeline] = None
+        # RL inference configuration. ``None`` = default behaviour (single
+        # forward, no advantage-conditioned prompt injection). When set
+        # by :meth:`set_rl_mode`, the next :meth:`set_prompt` call builds
+        # a Pi05CFGPipeline and runs classifier-free guidance.
+        self._rl_config: Optional[dict] = None
+        self._rl_current_prompt_text: Optional[str] = None
+        self._force_int8_decoder = False
+        # FVK_PI05_RTX_INT8_ENCODER_ONLY=1: enable INT8 for encoder (large M,
+        # 92% GPU utilisation) but keep decoder in BF16 (M=10 → INT8 CUTLASS
+        # tile waste makes it slower than cuBLASLt BF16 for small M).
+        _enc_only = False
+        # On non-FP8 GPUs (e.g. Orin SM87), enable encoder INT8 alongside
+        # decoder INT8 so all large GEMMs benefit from tensor-core acceleration.
+        self._use_int8_encoder = self._force_int8_decoder or _enc_only
+        self._int8_encoder_only = _enc_only
+        # Vision GEMMs (VIS_D=1152, seq=512): static per-tensor INT8 was
+        # measured to break encoder cosine (0.991 → 0.282) — disabled
+        # permanently. Dynamic per-row INT8 is opt-in via
+        # FVK_PI05_RTX_INT8_VISION=1 (untested at branch time; enabling
+        # it requires cosine validation on the actual deployment).
+        self._use_int8_vision = False
+        self._use_int8_vision_static = False
+        self._force_bf16 = False
+
+        # ── Load norm_stats ──
+        self._load_norm_stats(checkpoint_dir)
+
+        # ── Load + convert safetensors ──
+        safetensors_path = checkpoint_dir / "model.safetensors"
+        if not safetensors_path.exists():
+            raise FileNotFoundError(
+                f"safetensors not found at {safetensors_path} — "
+                "Pi05TorchFrontendRtxFP16 expects a HuggingFace-style PyTorch checkpoint")
+        self._checkpoint_path = str(safetensors_path)
+        raw_ckpt = convert_pi05_safetensors(safetensors_path)
+
+        # Move all tensors to CUDA bf16 (retain as member attrs so their
+        # memory stays alive across pipeline rebuilds).
+        self._ckpt_bf16 = {}
+        for k, v in raw_ckpt.items():
+            if isinstance(v, torch.Tensor):
+                self._ckpt_bf16[k] = v.to("cuda", bf16).contiguous()
+            else:
+                self._ckpt_bf16[k] = v
+        self.embedding_weight = self._ckpt_bf16["embedding_weight"]
+
+        # Pre-scale decoder action output projection by -1/num_steps.
+        # Scaling is specific to the step count (ODE integration step size).
+        num_steps = self._num_steps
+        self._ckpt_bf16["decoder_action_out_proj_w"] = \
+            self._ckpt_bf16["decoder_action_out_proj_w"] * (-1.0 / num_steps)
+        self._ckpt_bf16["decoder_action_out_proj_b"] = \
+            self._ckpt_bf16["decoder_action_out_proj_b"] * (-1.0 / num_steps)
+
+        # ── Low-precision weight stores ──
+        self._fp8_weights: dict = {}
+        self._fp8_store: list = []  # holds tensors alive
+        self._int8_weights: dict = {}
+        self._int8_store: list = []
+        self._int8_weight_scales: dict[str, torch.Tensor] = {}
+        if self.use_fp8 and not self._force_bf16 and not self._force_int8_decoder:
+            self._quantize_all_fp8()
+        if self._force_int8_decoder:
+            self._quantize_decoder_int8()
+        if self._use_int8_encoder:
+            self._quantize_encoder_int8()
+        if self._use_int8_vision:
+            self._quantize_vision_int8()
+        if self._use_int8_vision_static:
+            self._quantize_vision_int8()  # pre-quantize weights; activations use static calibrated scales
+
+        # ── Pre-compute decoder styles (time MLP + style modulation) ──
+        self._precomputed_styles = _precompute_decoder_styles(
+            self._ckpt_bf16, self.chunk_size, num_steps=self._num_steps)
+
+        # ── Attention backend (torch, owns Q/K/V/O) ──
+        enc_seq_max = self.num_views * 256 + self.max_prompt_len
+        self.attn_backend = RtxFlashAttnBackend(
+            num_views=self.num_views,
+            encoder_seq_max=enc_seq_max,
+            chunk_size=self.chunk_size,
+            num_encoder_layers=ENC_L,
+            dtype=bf16)
+
+        # ── fvk module + GemmRunner ──
+        from flash_rt import flash_rt_kernels as fvk
+        self.fvk = fvk
+        self.gemm = fvk.GemmRunner()
+
+        # ── Reusable pre-allocated input buffers (match Thor style) ──
+        self._img_buf = torch.empty(
+            self.num_views, IMG_HW, IMG_HW, 3, dtype=bf16, device="cuda")
+        self._noise_buf = torch.empty(
+            self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+        self._noise_out = torch.empty(
+            self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+        from flash_rt.core.cuda_buffer import _cudart
+        self._cudart = _cudart
+
+        logger.info(
+            "Pi05TorchFrontendRtxFP16 initialised (num_views=%d, chunk=%d, fp8_layout=%s)",
+            self.num_views, self.chunk_size, self.fp8_layout)
+
+    def _pipeline_precision_kwargs(self) -> dict:
+        return {
+            "use_fp8": False,
+            "use_fp8_decoder": False,
+            "use_int8_decoder": False,
+            "use_int8_encoder": False,
+            "use_int8_vision": False,
+            "use_int8_vision_static": False,
+        }
+
+    # -----------------------------------------------------------------
+    # Checkpoint helpers
+    # -----------------------------------------------------------------
+
+    def _load_norm_stats(self, checkpoint_dir: pathlib.Path) -> None:
+        from flash_rt.core.utils.norm_stats import (
+            load_norm_stats, pi05_candidates,
+        )
+        try:
+            self.norm_stats = load_norm_stats(
+                pi05_candidates(checkpoint_dir), checkpoint_dir=checkpoint_dir)
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"norm_stats not found near checkpoint: {e}") from e
+
+    def _quantize_all_fp8(self) -> None:
+        """Pre-quantize all large GEMM weights to FP8 E4M3."""
+        W = self._ckpt_bf16
+        store = self._fp8_store
+        fp8 = self._fp8_weights
+
+        def quant(name: str, w: torch.Tensor):
+            if self.fp8_layout == "nk":
+                w = w.t().contiguous()
+            else:
+                w = w.contiguous()
+            w_fp8, scale = _quantize_fp8_e4m3(w)
+            store.append(w_fp8)
+            store.append(scale)
+            fp8[name] = (w_fp8.data_ptr(), scale.data_ptr())
+
+        # Vision (27 layers × 4) + projector
+        for i in range(VIS_L):
+            quant(f"vision_attn_qkv_w_{i}", W["vision_attn_qkv_w"][i])
+            quant(f"vision_attn_o_w_{i}", W["vision_attn_o_w"][i])
+            quant(f"vision_ffn_up_w_{i}", W["vision_ffn_up_w"][i])
+            quant(f"vision_ffn_down_w_{i}", W["vision_ffn_down_w"][i])
+        quant("vision_projector_w", W["encoder_multi_modal_projector_w"])
+
+        # Encoder (18 layers × 4) — fuse gate+up into (D, 2H)
+        for i in range(ENC_L):
+            quant(f"encoder_attn_qkv_w_{i}", W["encoder_attn_qkv_w"][i])
+            quant(f"encoder_attn_o_w_{i}", W["encoder_attn_o_w"][i])
+            gate_up = torch.cat(
+                [W["encoder_ffn_gate_w"][i], W["encoder_ffn_up_w"][i]], dim=1
+            ).contiguous()
+            quant(f"encoder_ffn_gate_up_w_{i}", gate_up)
+            quant(f"encoder_ffn_down_w_{i}", W["encoder_ffn_down_w"][i])
+
+        # Decoder (18 layers × 4)
+        for i in range(DEC_L):
+            quant(f"decoder_attn_qkv_w_{i}", W["decoder_attn_qkv_w"][i])
+            quant(f"decoder_attn_o_w_{i}", W["decoder_attn_o_w"][i])
+            gate_up = torch.cat(
+                [W["decoder_ffn_gate_w"][i], W["decoder_ffn_up_w"][i]], dim=1
+            ).contiguous()
+            quant(f"decoder_ffn_gate_up_w_{i}", gate_up)
+            quant(f"decoder_ffn_down_w_{i}", W["decoder_ffn_down_w"][i])
+
+        logger.info("FP8 quantized %d GEMM weights (layout=%s)", len(fp8), self.fp8_layout)
+
+    def _quantize_decoder_int8(self) -> None:
+        """Pre-quantize the decoder hot-path GEMM weights to INT8."""
+        W = self._ckpt_bf16
+        store = self._int8_store
+        int8_weights = self._int8_weights
+
+        def quant(name: str, w: torch.Tensor):
+            # CUTLASS fused INT8 path expects weights as [N, K] ColumnMajor,
+            # so transpose once up front and keep per-output-channel scales.
+            w_f32 = w.float().transpose(0, 1).contiguous()
+            scale_t = torch.clamp(
+                w_f32.abs().amax(dim=1) / 127.0, min=1e-12
+            ).to(device=w.device, dtype=torch.float32).contiguous()
+            q = torch.clamp(
+                torch.round(w_f32 / scale_t[:, None]), -127, 127
+            ).to(torch.int8).contiguous()
+            store.append(q)
+            store.append(scale_t)
+            int8_weights[name] = (q.data_ptr(), scale_t.data_ptr())
+            self._int8_weight_scales[name] = scale_t
+
+        for i in range(DEC_L):
+            quant(f"decoder_attn_qkv_w_{i}", W["decoder_attn_qkv_w"][i])
+            quant(f"decoder_attn_o_w_{i}", W["decoder_attn_o_w"][i])
+            # Separate gate and up for SiLU-gated EVT fusion (same as encoder).
+            quant(f"decoder_ffn_gate_w_{i}", W["decoder_ffn_gate_w"][i])
+            quant(f"decoder_ffn_up_w_{i}", W["decoder_ffn_up_w"][i])
+            quant(f"decoder_ffn_down_w_{i}", W["decoder_ffn_down_w"][i])
+
+        logger.info("INT8 quantized %d decoder GEMM weights", len(int8_weights))
+
+    def _quantize_encoder_int8(self) -> None:
+        """Pre-quantize the Gemma-2B encoder GEMM weights to INT8.
+
+        Uses the same per-output-channel symmetric INT8 scheme as the
+        decoder path. The merged gate+up weight mirrors the FP8 path to
+        enable the single fused gate_geglu_merged → INT8 CUTLASS route.
+
+        Keys written into ``self._int8_weights`` (``encoder_`` prefix):
+            encoder_attn_qkv_w_{0..17}, encoder_attn_o_w_{0..17},
+            encoder_ffn_gate_up_w_{0..17}  (merged),
+            encoder_ffn_down_w_{0..17}
+        """
+        W = self._ckpt_bf16
+        store = self._int8_store   # shared with decoder, keeps tensors alive
+        int8_weights = self._int8_weights  # shared dict, encoder_ prefix avoids collision
+
+        def quant(name: str, w: torch.Tensor):
+            # CUTLASS rowwise INT8 expects B in [N, K] ColumnMajor layout.
+            w_f32 = w.float().transpose(0, 1).contiguous()
+            scale_t = torch.clamp(
+                w_f32.abs().amax(dim=1) / 127.0, min=1e-12
+            ).to(device=w.device, dtype=torch.float32).contiguous()
+            q = torch.clamp(
+                torch.round(w_f32 / scale_t[:, None]), -127, 127
+            ).to(torch.int8).contiguous()
+            store.append(q)
+            store.append(scale_t)
+            int8_weights[name] = (q.data_ptr(), scale_t.data_ptr())
+            self._int8_weight_scales[name] = scale_t
+
+        for i in range(ENC_L):
+            quant(f"encoder_attn_qkv_w_{i}", W["encoder_attn_qkv_w"][i])
+            quant(f"encoder_attn_o_w_{i}", W["encoder_attn_o_w"][i])
+            # Keep gate and up SEPARATE for SiLU-gated EVT fusion.
+            # The new cutlass_int8_silu_gated_bf16out kernel reads gate_buf
+            # produced by the gate GEMM and fuses SiLU(gate)*up in the
+            # epilogue, eliminating the separate gate_geglu_merged kernel.
+            quant(f"encoder_ffn_gate_w_{i}", W["encoder_ffn_gate_w"][i])
+            quant(f"encoder_ffn_up_w_{i}", W["encoder_ffn_up_w"][i])
+            quant(f"encoder_ffn_down_w_{i}", W["encoder_ffn_down_w"][i])
+
+        logger.info("INT8 quantized %d encoder GEMM weights", 5 * ENC_L)
+
+    def _quantize_vision_int8(self) -> None:
+        """Pre-quantize the SigLIP vision encoder GEMM weights to INT8.
+
+        Uses the same per-output-channel symmetric INT8 scheme.  The
+        vision GEMMs (seq=512, VIS_D=1152, VIS_H=4304) all fit inside
+        the encoder INT8 scratch buffers that ``Pi05Pipeline`` allocates,
+        so no additional device memory is needed.
+
+        Keys written into ``self._int8_weights`` (``vision_`` prefix):
+            vision_attn_qkv_w_{0..26}, vision_attn_o_w_{0..26},
+            vision_ffn_up_w_{0..26}, vision_ffn_down_w_{0..26}
+        """
+        W = self._ckpt_bf16
+        store = self._int8_store
+        int8_weights = self._int8_weights
+
+        def quant(name: str, w: torch.Tensor):
+            w_f32 = w.float().transpose(0, 1).contiguous()
+            scale_t = torch.clamp(
+                w_f32.abs().amax(dim=1) / 127.0, min=1e-12
+            ).to(device=w.device, dtype=torch.float32).contiguous()
+            q = torch.clamp(
+                torch.round(w_f32 / scale_t[:, None]), -127, 127
+            ).to(torch.int8).contiguous()
+            store.append(q)
+            store.append(scale_t)
+            int8_weights[name] = (q.data_ptr(), scale_t.data_ptr())
+            self._int8_weight_scales[name] = scale_t
+
+        for i in range(VIS_L):
+            quant(f"vision_attn_qkv_w_{i}", W["vision_attn_qkv_w"][i])
+            quant(f"vision_attn_o_w_{i}", W["vision_attn_o_w"][i])
+            quant(f"vision_ffn_up_w_{i}", W["vision_ffn_up_w"][i])
+            quant(f"vision_ffn_down_w_{i}", W["vision_ffn_down_w"][i])
+
+        logger.info("INT8 quantized %d vision GEMM weights", 4 * VIS_L)
+
+    def _build_pipeline_weights(self) -> dict:
+        """Produce the pointer dict that Pi05Pipeline expects."""
+        W = self._ckpt_bf16
+
+        def p(key: str) -> int:
+            return W[key].data_ptr()
+
+        def p_list(key: str) -> list[int]:
+            t = W[key]
+            stride = t.stride(0) * t.element_size()
+            base = t.data_ptr()
+            return [base + i * stride for i in range(t.shape[0])]
+
+        weights = {
+            # Vision BF16
+            "vision_patch_embedding_w": p("vision_patch_embedding_w"),
+            "vision_patch_embedding_b": p("vision_patch_embedding_b"),
+            "vision_position_embedding": p("vision_position_embedding"),
+            "vision_pre_attn_norm_w": p_list("vision_pre_attn_norm_w"),
+            "vision_pre_attn_norm_b": p_list("vision_pre_attn_norm_b"),
+            "vision_pre_ffn_norm_w": p_list("vision_pre_ffn_norm_w"),
+            "vision_pre_ffn_norm_b": p_list("vision_pre_ffn_norm_b"),
+            "vision_attn_qkv_w": p_list("vision_attn_qkv_w"),  # BF16 fallback
+            "vision_attn_qkv_b": p_list("vision_attn_qkv_b"),
+            "vision_attn_o_w": p_list("vision_attn_o_w"),
+            "vision_attn_o_b": p_list("vision_attn_o_b"),
+            "vision_ffn_up_w": p_list("vision_ffn_up_w"),
+            "vision_ffn_up_b": p_list("vision_ffn_up_b"),
+            "vision_ffn_down_w": p_list("vision_ffn_down_w"),
+            "vision_ffn_down_b": p_list("vision_ffn_down_b"),
+            "vision_final_norm_w": p("vision_final_norm_w"),
+            "vision_final_norm_b": p("vision_final_norm_b"),
+
+            # Encoder
+            "encoder_multi_modal_projector_w": p("encoder_multi_modal_projector_w"),
+            "encoder_multi_modal_projector_b": p("encoder_multi_modal_projector_b"),
+            "encoder_attn_qkv_w": p_list("encoder_attn_qkv_w"),
+            "encoder_attn_o_w": p_list("encoder_attn_o_w"),
+            "encoder_ffn_gate_w": p_list("encoder_ffn_gate_w"),
+            "encoder_ffn_up_w": p_list("encoder_ffn_up_w"),
+            "encoder_ffn_down_w": p_list("encoder_ffn_down_w"),
+
+            # Decoder
+            "decoder_action_in_proj_w": p("decoder_action_in_proj_w"),
+            "decoder_action_in_proj_b": p("decoder_action_in_proj_b"),
+            "decoder_action_out_proj_w": p("decoder_action_out_proj_w"),
+            "decoder_action_out_proj_b": p("decoder_action_out_proj_b"),
+            "decoder_attn_qkv_w": p_list("decoder_attn_qkv_w"),
+            "decoder_attn_o_w": p_list("decoder_attn_o_w"),
+            "decoder_ffn_gate_w": p_list("decoder_ffn_gate_w"),
+            "decoder_ffn_up_w": p_list("decoder_ffn_up_w"),
+            "decoder_ffn_down_w": p_list("decoder_ffn_down_w"),
+
+            # FP8 quantized weights
+            "fp8": self._fp8_weights,
+            "int8": self._int8_weights,
+            "fp8_layout": self.fp8_layout,
+
+            # Precomputed decoder styles (numpy bf16 as uint16 view)
+            "precomputed": self._precomputed_styles,
+        }
+        if "decoder_ffn_gate_up_w" in W:
+            weights["decoder_ffn_gate_up_w"] = p_list("decoder_ffn_gate_up_w")
+        return weights
+
+    # -----------------------------------------------------------------
+    # Public API
+    # -----------------------------------------------------------------
+
+    def set_rl_mode(
+        self,
+        *,
+        cfg_enable: bool = True,
+        cfg_beta: float = 1.5,
+        advantage_positive: bool = True,
+    ) -> None:
+        raise NotImplementedError(
+            "Pi05TorchFrontendRtxFP16 baseline supports only single-sample "
+            "inference; RL/CFG mode is not validated yet.")
+        """Enable / configure advantage-conditioned RL inference (opt-in).
+
+        Once enabled, subsequent :meth:`set_prompt` calls will build a
+        :class:`Pi05CFGPipeline` instead of the standard
+        :class:`Pi05Pipeline`. The conditioned prompt has the
+        ``"Advantage: positive"`` (or ``"negative"``) tag appended; the
+        unconditioned prompt is the original task text. Each denoising
+        step runs the action expert twice and combines the two velocity
+        predictions with strength ``cfg_beta``.
+
+        Calling this with ``cfg_enable=False`` clears any RL configuration
+        so the next :meth:`set_prompt` reverts to the standard pipeline
+        (this rebuilds the pipeline so the change takes effect).
+
+        Args:
+            cfg_enable: If ``True``, activate CFG inference. If
+                ``False``, clear any previous RL configuration.
+            cfg_beta: CFG guidance strength. Must be ``>= 1.0``. Common
+                deployment range is ``[1.5, 2.5]``. Ignored when
+                ``cfg_enable`` is ``False``.
+            advantage_positive: Whether the conditioned prompt uses the
+                positive advantage tag (the standard "select for high
+                advantage" use case). Set ``False`` only for debugging.
+        """
+        if not cfg_enable:
+            self._rl_config = None
+            # If a CFG pipeline was previously built, drop it so the
+            # next set_prompt rebuilds the standard pipeline.
+            if isinstance(self.pipeline, Pi05CFGPipeline):
+                self.pipeline = None
+                self.current_prompt_len = 0
+                self.graph_recorded = False
+                self.calibrated = False
+            return
+        if cfg_beta < 1.0:
+            raise ValueError(
+                f"cfg_beta must be >= 1.0 (1.0 disables CFG); got {cfg_beta}")
+        new_config = {
+            "cfg_beta": float(cfg_beta),
+            "advantage_positive": bool(advantage_positive),
+        }
+        if self._rl_config != new_config:
+            self._rl_config = new_config
+            # Force pipeline rebuild on next set_prompt so the new mode
+            # / beta takes effect.
+            self.pipeline = None
+            self.current_prompt_len = 0
+            self.graph_recorded = False
+            self.calibrated = False
+        logger.info(
+            "RL mode enabled: cfg_beta=%.2f, advantage_positive=%s",
+            new_config["cfg_beta"], new_config["advantage_positive"])
+
+    def set_prompt(self, prompt_text: str) -> None:
+        """Tokenise prompt + (re)build the pipeline for the exact prompt length.
+
+        When RL mode is enabled (see :meth:`set_rl_mode`), this also
+        builds the unconditioned prompt embeddings and uploads both into
+        the CFG-aware pipeline.
+        """
+        if self._rl_config is not None:
+            self._set_prompt_rl(prompt_text)
+            return
+
+        embeds, prompt_len = _embed_prompt(
+            prompt_text, self.embedding_weight, max_len=MAX_PROMPT_LEN_DEFAULT)
+
+        if self.pipeline is None or prompt_len != self.current_prompt_len:
+            logger.info("Building Pi05Pipeline for prompt_len=%d...", prompt_len)
+            # Rebuild the pipeline with the exact prompt length to avoid
+            # wasted compute on padding tokens.
+            self.current_prompt_len = prompt_len
+            self.graph_recorded = False
+            self.calibrated = False
+
+            pipeline_weights = self._build_pipeline_weights()
+            self.pipeline = Pi05Pipeline(
+                gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
+                weights=pipeline_weights,
+                num_views=self.num_views,
+                max_prompt_len=prompt_len,
+                chunk_size=self.chunk_size,
+                num_steps=self._num_steps,
+                vision_pool_factor=self._vision_pool_factor,
+                vision_num_layers=self._vision_num_layers,
+                **self._pipeline_precision_kwargs())
+            # Static INT8 vision scales are per-pipeline-instance.
+            # Reset so calibrate_single_frame collects fresh scales.
+            if self.pipeline.use_int8_vision_static:
+                self.pipeline.vis_int8_static_calibrated = False
+                self.pipeline.vis_int8_static_scales = {}
+
+        # Upload language embeds into pipeline's encoder_x slot
+        embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
+        self.pipeline.set_language_embeds(embeds_np)
+        self._frame_count = 0
+        logger.info("Set prompt: '%s' (%d tokens)", prompt_text, prompt_len)
+
+    def _set_prompt_rl(self, prompt_text: str) -> None:
+        """RL-mode set_prompt: build conditioned + unconditioned embeddings.
+
+        When batched mode is also active (Phase 3b), the pipeline type
+        is :class:`Pi05CFGBatchedPipeline` which runs cond + uncond as
+        the two slots of a B=2 fused forward. Otherwise the serial
+        :class:`Pi05CFGPipeline` runs them sequentially (Phase 1+2).
+        """
+        from flash_rt.core.rl import build_acp_tagged_task
+
+        cfg = self._rl_config
+        if cfg is None:
+            raise RuntimeError("_set_prompt_rl called without RL config")
+
+        cond_text = build_acp_tagged_task(
+            prompt_text, is_positive=cfg["advantage_positive"])
+        uncond_text = prompt_text
+
+        cond_embeds, cond_len = _embed_prompt(
+            cond_text, self.embedding_weight, max_len=MAX_PROMPT_LEN_DEFAULT)
+        uncond_embeds, uncond_len = _embed_prompt(
+            uncond_text, self.embedding_weight, max_len=MAX_PROMPT_LEN_DEFAULT)
+        target_len = max(cond_len, uncond_len)
+
+        use_batched_cfg = getattr(self, "_batched_active", False)
+
+        if use_batched_cfg:
+            expected_cls = Pi05CFGBatchedPipeline
+            cls_name = "Pi05CFGBatchedPipeline"
+        else:
+            expected_cls = Pi05CFGPipeline
+            cls_name = "Pi05CFGPipeline"
+
+        rebuild = (
+            self.pipeline is None
+            or not isinstance(self.pipeline, expected_cls)
+            or target_len != self.current_prompt_len
+            or self.pipeline.cfg_beta != cfg["cfg_beta"])
+
+        if rebuild:
+            logger.info(
+                "Building %s for prompt_len=%d (cfg_beta=%.2f)...",
+                cls_name, target_len, cfg["cfg_beta"])
+            self.current_prompt_len = target_len
+            self.graph_recorded = False
+            self.calibrated = False
+
+            pipeline_weights = self._build_pipeline_weights()
+            if use_batched_cfg:
+                # Need the batched attention backend (already set up by
+                # set_batched_mode).
+                if not isinstance(self.attn_backend,
+                                  RtxFlashAttnBatchedBackendPi05):
+                    raise RuntimeError(
+                        "batched CFG requires set_batched_mode(enable=True) "
+                        "to have been called first to install the batched "
+                        "attention backend")
+                self.pipeline = Pi05CFGBatchedPipeline(
+                    gemm=self.gemm, fvk=self.fvk,
+                    attn_backend=self.attn_backend,
+                    weights=pipeline_weights,
+                    num_views=self.num_views,
+                    max_prompt_len=target_len,
+                    chunk_size=self.chunk_size,
+                    **self._pipeline_precision_kwargs(),
+                    cfg_beta=cfg["cfg_beta"])
+            else:
+                self.pipeline = Pi05CFGPipeline(
+                    gemm=self.gemm, fvk=self.fvk,
+                    attn_backend=self.attn_backend,
+                    weights=pipeline_weights,
+                    num_views=self.num_views,
+                    max_prompt_len=target_len,
+                    chunk_size=self.chunk_size,
+                    **self._pipeline_precision_kwargs(),
+                    cfg_beta=cfg["cfg_beta"])
+
+        cond_np = cond_embeds.contiguous().view(torch.uint16).cpu().numpy()
+        uncond_np = uncond_embeds.contiguous().view(torch.uint16).cpu().numpy()
+
+        if use_batched_cfg:
+            # Pad both to target_len here (the batched set_language_embeds_batch
+            # inherited by Pi05CFGBatchedPipeline expects equal prompt lengths).
+            def _pad(arr, to_len):
+                if arr.shape[0] == to_len:
+                    return np.ascontiguousarray(arr)
+                pad = np.zeros((to_len - arr.shape[0], arr.shape[1]),
+                               dtype=arr.dtype)
+                return np.ascontiguousarray(np.concatenate([arr, pad], axis=0))
+            cond_np = _pad(cond_np, target_len)
+            uncond_np = _pad(uncond_np, target_len)
+            # Also seed parent's B=1 lang slot for the FP8 calibration pass
+            # (same pattern set_prompt_batch uses).
+            self.pipeline.set_language_embeds(cond_np)
+
+        self.pipeline.set_language_embeds_pair(cond_np, uncond_np)
+        self._rl_current_prompt_text = prompt_text
+        self._frame_count = 0
+        logger.info(
+            "Set RL prompt: '%s' (cond_len=%d, uncond_len=%d, padded=%d, batched=%s)",
+            prompt_text, cond_len, uncond_len, target_len, use_batched_cfg)
+
+    def calibrate(
+        self,
+        observations,
+        *,
+        percentile: float = 99.9,
+        max_samples: Optional[int] = None,
+        verbose: bool = False,
+    ) -> None:
+        """Unified calibration entry point (see Pi0TorchFrontendRtx.calibrate).
+
+        N=1 → single-frame path, bit-equal to legacy.
+        N>=2 → per-sample amax, reduced via ``np.percentile(..., axis=0)``.
+        """
+        if self.pipeline is None:
+            raise RuntimeError("set_prompt must be called before calibrate")
+        if self.calibrated:
+            logger.warning(
+                "calibrate() called a second time; returning without re-running.")
+            return
+
+        if isinstance(observations, dict):
+            obs_list = [observations]
+        elif isinstance(observations, list):
+            obs_list = observations
+        else:
+            obs_list = list(observations)
+        if max_samples is not None:
+            obs_list = obs_list[:max_samples]
+        n = len(obs_list)
+        if n == 0:
+            raise ValueError("observations must contain at least 1 sample")
+        if not 0.0 <= percentile <= 100.0:
+            raise ValueError(f"percentile must be in [0, 100], got {percentile}")
+
+        if getattr(self.pipeline, "use_int8_decoder", False):
+            if n > 1:
+                logger.info(
+                    "INT8 decoder path uses runtime-dynamic activation scales; "
+                    "using the first sample to warm buffers and capture the graph.")
+            self._calibrate_single_frame(obs_list[0])
+            return
+
+        if n == 1:
+            self._calibrate_single_frame(obs_list[0])
+        else:
+            self._calibrate_multi_frame(
+                obs_list, percentile=percentile, verbose=verbose)
+
+    def calibrate_with_real_data(self, sample_observations) -> None:
+        """Legacy alias for :meth:`calibrate`."""
+        self.calibrate(sample_observations)
+
+    def _calibrate_single_frame(self, sample) -> None:
+        logger.info("Preparing Pi0.5 runtime with a single real sample...")
+
+        # Create a dedicated torch stream for both the calibration pass and
+        # graph capture so flash_attn_func + our fvk kernels land on the
+        # same stream.
+        self._graph_torch_stream = torch.cuda.Stream()
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            images = self._stack_images(sample)
+            noise = torch.randn(
+                self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+
+            stream_int = self._graph_torch_stream.cuda_stream
+            self._copy_tensor_to_pipeline_buf_stream(
+                images, self.pipeline.input_images_buf, stream_int)
+            self._copy_tensor_to_pipeline_buf_stream(
+                noise, self.pipeline.input_noise_buf, stream_int)
+
+            # Batched pipelines carry their own calibrate_fp8 that drives
+            # a parent-B=1 forward internally — calling run_pipeline here
+            # would fire the batched path with only the parent's B=1
+            # slots populated. Skip the preemptive run for batched
+            # subclasses and let calibrate_fp8 do the work.
+            if not isinstance(self.pipeline, Pi05BatchedPipeline):
+                self.pipeline.run_pipeline(stream=stream_int)
+
+            self._cudart.cudaStreamSynchronize(
+                ctypes.c_void_p(stream_int))
+
+            # FP8 calibration (no-op for INT8 pipelines).
+            self.pipeline.calibrate_fp8()
+            # Static INT8 vision: the run_pipeline() call above already ran one
+            # vision forward with quantize_int8_device, writing per-site scales
+            # into vis_int8_static_scales. Flip the flag to switch to the fast
+            # static path (quantize_int8_static) for all subsequent calls.
+            if self.pipeline.use_int8_vision_static:
+                self.pipeline.vis_int8_static_calibrated = True
+                logger.info("Static INT8 vision calibrated: %d sites",
+                            len(self.pipeline.vis_int8_static_scales))
+            # Static encoder INT8 (opt-in via FVK_PI05_RTX_INT8_ENCODER_STATIC=1).
+            # After run_pipeline() above wrote per-row scales via the
+            # dynamic kernel, freeze them and flip the hot path to
+            # quantize_int8_rowwise_static (single-pass, no per-row amax
+            # reduction).
+            #
+            # WARNING — measured on Orin SM87, single-frame calibration:
+            #   * Latency saving: ~1.4 ms p50 (125.9 → 124.5 ms). Smaller
+            #     than the roofline-predicted 4-8 ms because most of the
+            #     encoder time is in the CUTLASS GEMM, not the quantize.
+            #   * Cosine vs dynamic baseline: drops from 0.991 to
+            #     ~0.93-0.98 across a 6-frame test sequence. Failed the
+            #     "lossless" bar — frozen per-row scales calibrated on
+            #     one sample don't generalize: vision-token rows whose
+            #     magnitude exceeds the calibration max get clipped.
+            # Default OFF. Opt-in only when the application explicitly
+            # accepts this trade-off (or after a future multi-sample
+            # calibration with proper safety inflation makes the cosine
+            # drop acceptable).
+            if (self.pipeline.use_int8_encoder
+                    and os.environ.get(
+                        "FVK_PI05_RTX_INT8_ENCODER_STATIC", "0") == "1"):
+                self.pipeline.int8_encoder_static_calibrated = True
+                logger.warning(
+                    "Static INT8 encoder enabled — frozen per-row scales "
+                    "from one calibration sample. Expect cosine drop "
+                    "(~0.96 vs dynamic 0.991 on test sequence). Set "
+                    "FVK_PI05_RTX_INT8_ENCODER_STATIC=0 to disable.")
+            self.pipeline.autotune_gemms()
+            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+
+        self.calibrated = True
+        self.graph_recorded = True
+        self._precision_spec = self._snapshot_precision_spec(
+            method="single_frame", n=1, percentile=None)
+        self._warn_if_scale_ceiling_exceeded()
+        logger.info("Calibration + graph capture complete")
+
+    def _calibrate_multi_frame(
+        self, obs_list, *, percentile: float, verbose: bool,
+    ) -> None:
+        from flash_rt.core.calibration import (
+            accumulate_amax,
+            format_summary,
+            summarize_amax_dispersion,
+        )
+
+        n = len(obs_list)
+        logger.info(
+            "Preparing Pi0.5 runtime across %d real samples (percentile=%.2f)...",
+            n, percentile)
+        self._graph_torch_stream = torch.cuda.Stream()
+        self.pipeline.fp8_calibrated = False
+
+        per_sample: list[np.ndarray] = []
+        names: Optional[list[str]] = None
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            stream_int = self._graph_torch_stream.cuda_stream
+            for i, obs in enumerate(obs_list):
+                images = self._stack_images(obs)
+                noise = torch.randn(
+                    self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+                self._copy_tensor_to_pipeline_buf_stream(
+                    images, self.pipeline.input_images_buf, stream_int)
+                self._copy_tensor_to_pipeline_buf_stream(
+                    noise, self.pipeline.input_noise_buf, stream_int)
+                self._zero_pipeline_scales()
+                self.pipeline.run_pipeline(stream=stream_int)
+                self._cudart.cudaStreamSynchronize(
+                    ctypes.c_void_p(stream_int))
+
+                if names is None:
+                    names = list(self.pipeline.fp8_act_scales.keys())
+                sample_vec = np.array(
+                    [float(self.pipeline.fp8_act_scales[k].download_new(
+                        (1,), np.float32)[0]) for k in names],
+                    dtype=np.float32)
+                per_sample.append(sample_vec)
+
+                if verbose and (i + 1) % max(1, n // 10) == 0:
+                    logger.info("  calibration sample %d/%d", i + 1, n)
+
+            final_amax = accumulate_amax(per_sample, percentile=percentile)
+            if verbose:
+                logger.info(format_summary(
+                    summarize_amax_dispersion(per_sample, final_amax)))
+
+            for idx, name in enumerate(names or []):
+                self.pipeline.fp8_act_scales[name].upload(
+                    np.array([final_amax[idx]], dtype=np.float32))
+
+            self.pipeline.fp8_calibrated = True
+            self.pipeline.autotune_gemms()
+            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+
+        self.calibrated = True
+        self.graph_recorded = True
+        self._precision_spec = self._snapshot_precision_spec(
+            method="percentile", n=n, percentile=percentile)
+        self._warn_if_scale_ceiling_exceeded(label=f"pi05_rtx_N{n}")
+        logger.info(
+            "Pi0.5 multi-frame calibration + graph capture complete "
+            "(N=%d, percentile=%.2f)", n, percentile)
+
+    def _zero_pipeline_scales(self) -> None:
+        for buf in self.pipeline.fp8_act_scales.values():
+            buf.zero_()
+        for buf in getattr(self.pipeline, "int8_act_scales", {}).values():
+            buf.zero_()
+
+    def _warn_if_scale_ceiling_exceeded(self, label: str = "pi05_rtx") -> None:
+        """Diagnostic warning if any FP8 scale exceeds the sanity ceiling."""
+        from flash_rt.core.calibration import check_scale_ceiling
+        scales = {
+            name: float(buf.download_new((1,), np.float32)[0])
+            for name, buf in self.pipeline.fp8_act_scales.items()
+        }
+        check_scale_ceiling(scales, label=label)
+
+    def _snapshot_precision_spec(self, *, method: str, n: int,
+                                  percentile: Optional[float]):
+        from flash_rt.core.precision_spec import (
+            ModelPrecisionSpec,
+            PrecisionSpec,
+        )
+
+        if getattr(self.pipeline, "use_int8_decoder", False):
+            spec = ModelPrecisionSpec(source="manual")
+            for name, scale_t in self._int8_weight_scales.items():
+                scale_val = scale_t.detach().cpu().numpy().astype(np.float32, copy=False)
+                entry = PrecisionSpec(
+                    dtype="int8",
+                    granularity="per_tensor",
+                    scheme="symmetric",
+                    scale_source="manual",
+                    scale=scale_val,
+                )
+                entry.validate()
+                spec.weight_specs[name] = entry
+
+            for name, buf in self.pipeline.int8_act_scales.items():
+                count = buf.nbytes // np.dtype(np.float32).itemsize
+                scale_val = buf.download_new((count,), np.float32)
+                entry = PrecisionSpec(
+                    dtype="int8",
+                    granularity="per_tensor",
+                    scheme="symmetric",
+                    scale_source="runtime_dynamic",
+                    scale=scale_val,
+                    calibration_method=method,
+                    calibration_samples=n,
+                    calibration_percentile=percentile,
+                )
+                entry.validate()
+                spec.decoder_layer_specs[name] = entry
+            return spec
+
+        spec = ModelPrecisionSpec(source="calibration")
+        for name, buf in self.pipeline.fp8_act_scales.items():
+            scale_val = float(buf.download_new((1,), np.float32)[0])
+            entry = PrecisionSpec(
+                dtype="fp8_e4m3",
+                granularity="per_tensor",
+                scheme="symmetric",
+                scale_source="calibration",
+                scale=np.array([scale_val], dtype=np.float32),
+                calibration_method=method,
+                calibration_samples=n,
+                calibration_percentile=percentile,
+            )
+            entry.validate()
+            if name.startswith("vision_"):
+                spec.activation_specs[name] = entry
+            elif name.startswith("encoder_"):
+                spec.encoder_layer_specs[name] = entry
+            elif name.startswith("decoder_") or name.startswith("action_"):
+                spec.decoder_layer_specs[name] = entry
+            else:
+                spec.activation_specs[name] = entry
+        return spec
+
+    @property
+    def precision_spec(self):
+        """:class:`ModelPrecisionSpec` captured at calibration time."""
+        return getattr(self, "_precision_spec", None)
+
+    def infer(self, observation: dict, debug: bool = False) -> dict:
+        """Run inference on a single observation.
+
+        All GPU work happens on ``self._graph_torch_stream`` — the same
+        stream the graph was captured on — so replay + pre/post D2D copies
+        are serialized correctly.
+
+        When the active pipeline is :class:`Pi05CFGBatchedPipeline`
+        (RL mode + batched mode both on), this routes through a B=2
+        forward that fuses CFG's conditioned and unconditioned branches
+        into a single captured graph. The single ``observation`` is
+        replicated across both batch slots (cond and uncond use the
+        same image / state); the two prompts differ and were already
+        uploaded by :meth:`_set_prompt_rl`.
+        """
+        if self.pipeline is None:
+            raise RuntimeError("set_prompt must be called before infer")
+
+        if isinstance(self.pipeline, Pi05CFGBatchedPipeline):
+            return self._infer_cfg_batched(observation, debug=debug)
+
+        t0 = time.perf_counter()
+
+        # Temporal K/V caching: every cache_frames-th frame runs the full
+        # pipeline (vision + encoder + decoder); intermediate frames skip
+        # vision and encoder and replay only the decoder with fresh noise,
+        # reusing the encoder K/V cache from the last full forward.
+        self._frame_count += 1
+        use_full = (self._cache_frames <= 1 or
+                    self._frame_count % self._cache_frames == 1)
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            stream_int = self._graph_torch_stream.cuda_stream
+
+            self._noise_buf.normal_()
+            self._copy_tensor_to_pipeline_buf_stream(
+                self._noise_buf, self.pipeline.input_noise_buf, stream_int)
+
+            if use_full:
+                self._fill_img_buf(observation)
+                self._copy_tensor_to_pipeline_buf_stream(
+                    self._img_buf, self.pipeline.input_images_buf, stream_int)
+                out_ptr = self.pipeline.forward()
+            else:
+                # Decode-only: skip vision+encoder, reuse cached K/V
+                out_ptr = self.pipeline.forward_decode_only()
+
+            # D2D download → staging torch tensor
+            self._cudart.cudaMemcpyAsync(
+                ctypes.c_void_p(self._noise_out.data_ptr()),
+                ctypes.c_void_p(out_ptr),
+                self._noise_out.numel() * 2, 3, stream_int)
+
+        self._cudart.cudaStreamSynchronize(
+            ctypes.c_void_p(self._graph_torch_stream.cuda_stream))
+
+        latency_ms = (time.perf_counter() - t0) * 1000
+        self.latency_records.append(latency_ms)
+
+        raw_actions = self._noise_out.float().cpu().numpy()  # (chunk, 32)
+        unnorm = unnormalize_actions(raw_actions, self.norm_stats)
+        robot_actions = unnorm[:, :LIBERO_ACTION_DIM]
+
+        if debug:
+            logger.info("Raw actions[0,:5]: %s", raw_actions[0, :5])
+            logger.info("Latency: %.1f ms", latency_ms)
+
+        return {"actions": robot_actions}
+
+    def _infer_cfg_batched(self, observation: dict,
+                           debug: bool = False) -> dict:
+        """Batched CFG inference: single obs replicated across cond + uncond slots."""
+        t0 = time.perf_counter()
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            stream_int = self._graph_torch_stream.cuda_stream
+
+            # Replicate the single observation into both batch slots.
+            stacked = self._stack_images(observation)
+            for b in range(PI05_BATCH_SIZE):
+                self._img_buf_b2[b].copy_(stacked)
+            # Each denoising step starts from independent noise in each
+            # slot; cond slot is the one CFG reads / updates. Sampling
+            # once and copying into both slots ensures the uncond slot
+            # starts at the same noise the cond does, which matches
+            # the paper-faithful CFG contract.
+            self._noise_buf.normal_()
+            for b in range(PI05_BATCH_SIZE):
+                self._noise_buf_b2[b].copy_(self._noise_buf)
+
+            self._copy_tensor_to_pipeline_buf_stream(
+                self._img_buf_b2, self.pipeline.input_images_buf_b2, stream_int)
+            self._copy_tensor_to_pipeline_buf_stream(
+                self._noise_buf_b2, self.pipeline.input_noise_buf_b2, stream_int)
+
+            # Graph replay returns the cond slot's noise pointer.
+            out_ptr = self.pipeline.forward()
+
+            # D2D download of just the cond slot (chunk * ACTION_DIM bf16)
+            self._cudart.cudaMemcpyAsync(
+                ctypes.c_void_p(self._noise_out.data_ptr()),
+                ctypes.c_void_p(out_ptr),
+                self._noise_out.numel() * 2, 3, stream_int)
+
+        self._cudart.cudaStreamSynchronize(
+            ctypes.c_void_p(self._graph_torch_stream.cuda_stream))
+
+        latency_ms = (time.perf_counter() - t0) * 1000
+        self.latency_records.append(latency_ms)
+
+        raw_actions = self._noise_out.float().cpu().numpy()
+        unnorm = unnormalize_actions(raw_actions, self.norm_stats)
+        robot_actions = unnorm[:, :LIBERO_ACTION_DIM]
+
+        if debug:
+            logger.info(
+                "CFG batched raw actions[0,:5]: %s", raw_actions[0, :5])
+            logger.info("CFG batched latency: %.1f ms", latency_ms)
+
+        return {"actions": robot_actions}
+
+    # -----------------------------------------------------------------
+    # Batched (B=2) inference path — additive, default API unchanged
+    # -----------------------------------------------------------------
+
+    def set_batched_mode(self, *, enable: bool = True) -> None:
+        raise NotImplementedError(
+            "Pi05TorchFrontendRtxFP16 baseline supports only single-sample "
+            "inference; batched mode is not validated yet.")
+        """Enable / disable the B=2 batched inference path (opt-in).
+
+        Once enabled, the next :meth:`set_prompt_batch` call builds a
+        :class:`Pi05BatchedPipeline` (with a
+        :class:`RtxFlashAttnBatchedBackendPi05` attention backend) and
+        :meth:`infer_batch` becomes available. The single-sample
+        :meth:`infer` API path remains untouched.
+
+        Disabling rebuilds the standard single-sample pipeline on the
+        next :meth:`set_prompt`.
+        """
+        if not enable:
+            if isinstance(self.pipeline, Pi05BatchedPipeline):
+                self.pipeline = None
+                self.current_prompt_len = 0
+                self.graph_recorded = False
+                self.calibrated = False
+                self._batched_active = False
+            return
+        # Switch to a batched-capable attention backend if not already.
+        if not isinstance(self.attn_backend, RtxFlashAttnBatchedBackendPi05):
+            enc_seq_max = self.num_views * 256 + self.max_prompt_len
+            self.attn_backend = RtxFlashAttnBatchedBackendPi05(
+                num_views=self.num_views,
+                encoder_seq_max=enc_seq_max,
+                chunk_size=self.chunk_size,
+                num_encoder_layers=ENC_L)
+        self._batched_active = True
+        # Force pipeline rebuild so set_prompt_batch picks the batched class.
+        if not isinstance(self.pipeline, Pi05BatchedPipeline):
+            self.pipeline = None
+            self.current_prompt_len = 0
+            self.graph_recorded = False
+            self.calibrated = False
+        # Pre-allocate batched input/output staging tensors.
+        self._img_buf_b2 = torch.empty(
+            PI05_BATCH_SIZE, self.num_views, IMG_HW, IMG_HW, 3,
+            dtype=bf16, device="cuda")
+        self._noise_buf_b2 = torch.empty(
+            PI05_BATCH_SIZE, self.chunk_size, ACTION_DIM,
+            dtype=bf16, device="cuda")
+        self._noise_out_b2 = torch.empty(
+            PI05_BATCH_SIZE, self.chunk_size, ACTION_DIM,
+            dtype=bf16, device="cuda")
+        logger.info(
+            "Pi05TorchFrontendRtxFP16: batched mode enabled (B=%d)",
+            PI05_BATCH_SIZE)
+
+    def set_prompt_batch(self, prompts: list) -> None:
+        """Set per-sample prompts for the batched pipeline.
+
+        Args:
+            prompts: list of length B (currently 2). Each entry is a
+                task description string. Prompts are individually
+                tokenised, then padded to a common length so the
+                encoder sees a fixed-shape buffer.
+        """
+        if not getattr(self, "_batched_active", False):
+            raise RuntimeError(
+                "set_batched_mode(enable=True) must be called before "
+                "set_prompt_batch")
+        if len(prompts) != PI05_BATCH_SIZE:
+            raise ValueError(
+                f"set_prompt_batch expects {PI05_BATCH_SIZE} prompts, "
+                f"got {len(prompts)}")
+        embeds_list = []
+        prompt_lens = []
+        for p in prompts:
+            e, plen = _embed_prompt(p, self.embedding_weight,
+                                    max_len=MAX_PROMPT_LEN_DEFAULT)
+            embeds_list.append(e)
+            prompt_lens.append(plen)
+        target_len = max(prompt_lens)
+
+        # Pad each embed to target_len (BF16 zeros are valid pad tokens).
+        padded_np_list = []
+        for e, plen in zip(embeds_list, prompt_lens):
+            arr = e.contiguous().view(torch.uint16).cpu().numpy()
+            if plen < target_len:
+                pad = np.zeros(
+                    (target_len - plen, arr.shape[1]), dtype=arr.dtype)
+                arr = np.concatenate([arr, pad], axis=0)
+            padded_np_list.append(np.ascontiguousarray(arr))
+
+        rebuild = (
+            self.pipeline is None
+            or not isinstance(self.pipeline, Pi05BatchedPipeline)
+            or target_len != self.current_prompt_len)
+
+        if rebuild:
+            logger.info(
+                "Building Pi05BatchedPipeline (B=%d) for prompt_len=%d...",
+                PI05_BATCH_SIZE, target_len)
+            self.current_prompt_len = target_len
+            self.graph_recorded = False
+            self.calibrated = False
+            pipeline_weights = self._build_pipeline_weights()
+            self.pipeline = Pi05BatchedPipeline(
+                gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
+                weights=pipeline_weights,
+                num_views=self.num_views,
+                max_prompt_len=target_len,
+                chunk_size=self.chunk_size,
+                **self._pipeline_precision_kwargs())
+        # B=1 pipeline path is what calibrate_fp8 uses for FP8 scale collection.
+        self.pipeline.set_language_embeds(padded_np_list[0])
+        self.pipeline.set_language_embeds_batch(padded_np_list)
+        self._frame_count = 0
+        logger.info(
+            "Set batch prompt (B=%d, padded_len=%d): %s",
+            PI05_BATCH_SIZE, target_len,
+            [p[:30] + ("…" if len(p) > 30 else "") for p in prompts])
+
+    def calibrate_batch(self, sample_observations) -> None:
+        """Calibrate FP8 scales for the batched pipeline.
+
+        Uses the parent B=1 calibration pass (per-tensor scales are
+        sample-invariant) on the first observation; the batched B=2
+        forward then reuses those scales.
+        """
+        if not isinstance(self.pipeline, Pi05BatchedPipeline):
+            raise RuntimeError(
+                "calibrate_batch requires set_prompt_batch to have built a "
+                "Pi05BatchedPipeline first")
+        if isinstance(sample_observations, dict):
+            sample_observations = [sample_observations]
+        sample = sample_observations[0]
+
+        # Mirror calibrate(): write inputs into the parent B=1 buffers,
+        # call parent's calibrate_fp8 + autotune + record graph.
+        self._graph_torch_stream = torch.cuda.Stream()
+        with torch.cuda.stream(self._graph_torch_stream):
+            stream_int = self._graph_torch_stream.cuda_stream
+            images = self._stack_images(sample)
+            noise = torch.randn(self.chunk_size, ACTION_DIM,
+                                dtype=bf16, device="cuda")
+            self._copy_tensor_to_pipeline_buf_stream(
+                images, self.pipeline.input_images_buf, stream_int)
+            self._copy_tensor_to_pipeline_buf_stream(
+                noise, self.pipeline.input_noise_buf, stream_int)
+            self.pipeline.calibrate_fp8()
+            self.pipeline.autotune_gemms()
+            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+        self.calibrated = True
+        self.graph_recorded = True
+
+    def infer_batch(self, observations: list) -> list:
+        """Run B=2 inference on two independent observations.
+
+        Args:
+            observations: list of length B (currently 2) of obs dicts
+                matching :meth:`infer`'s contract (``image``,
+                ``wrist_image`` if ``num_views >= 2``, ``state``).
+
+        Returns:
+            List of length B; each entry is ``{"actions": (action_horizon, action_dim)}``.
+        """
+        if not isinstance(self.pipeline, Pi05BatchedPipeline):
+            raise RuntimeError("set_batched_mode + set_prompt_batch required")
+        if len(observations) != PI05_BATCH_SIZE:
+            raise ValueError(
+                f"infer_batch expects {PI05_BATCH_SIZE} observations, "
+                f"got {len(observations)}")
+        t0 = time.perf_counter()
+
+        # Stage per-sample inputs into the B=2 staging tensors, then D2D.
+        for b, obs in enumerate(observations):
+            self._img_buf_b2[b].copy_(self._stack_images(obs))
+        self._noise_buf_b2.normal_()
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            stream_int = self._graph_torch_stream.cuda_stream
+            self._copy_tensor_to_pipeline_buf_stream(
+                self._img_buf_b2, self.pipeline.input_images_buf_b2, stream_int)
+            self._copy_tensor_to_pipeline_buf_stream(
+                self._noise_buf_b2, self.pipeline.input_noise_buf_b2, stream_int)
+
+            out_ptr = self.pipeline.forward()
+
+            self._cudart.cudaMemcpyAsync(
+                ctypes.c_void_p(self._noise_out_b2.data_ptr()),
+                ctypes.c_void_p(out_ptr),
+                self._noise_out_b2.numel() * 2, 3, stream_int)
+
+        self._cudart.cudaStreamSynchronize(
+            ctypes.c_void_p(self._graph_torch_stream.cuda_stream))
+
+        latency_ms = (time.perf_counter() - t0) * 1000
+        self.latency_records.append(latency_ms)
+
+        results = []
+        for b in range(PI05_BATCH_SIZE):
+            raw = self._noise_out_b2[b].float().cpu().numpy()
+            unnorm = unnormalize_actions(raw, self.norm_stats)
+            results.append({"actions": unnorm[:, :LIBERO_ACTION_DIM]})
+        return results
+
+    def get_latency_stats(self) -> dict:
+        if not self.latency_records:
+            return {}
+        lat = np.array(self.latency_records)
+        return {
+            "count": len(lat),
+            "mean_ms": float(np.mean(lat)),
+            "std_ms": float(np.std(lat)),
+            "min_ms": float(np.min(lat)),
+            "max_ms": float(np.max(lat)),
+            "p50_ms": float(np.percentile(lat, 50)),
+            "p95_ms": float(np.percentile(lat, 95)),
+            "hz": float(1000 / np.mean(lat)),
+        }
+
+    # -----------------------------------------------------------------
+    # Internals
+    # -----------------------------------------------------------------
+
+    def _stack_images(self, observation: dict) -> torch.Tensor:
+        """Stack and normalize observation images into a new bf16 tensor."""
+        if "images" in observation:
+            img_list = observation["images"]
+        else:
+            img_list = [observation["image"], observation["wrist_image"]]
+            if self.num_views >= 3 and "wrist_image_right" in observation:
+                img_list.append(observation["wrist_image_right"])
+        tensors = []
+        for im in img_list[:self.num_views]:
+            tensors.append(
+                torch.from_numpy(im.astype(np.float32) / 127.5 - 1.0).to("cuda", bf16))
+        return torch.stack(tensors)
+
+    def _fill_img_buf(self, observation: dict) -> None:
+        """Fill ``self._img_buf`` in place without allocating new tensors."""
+        if "images" in observation:
+            img_list = observation["images"]
+        else:
+            img_list = [observation["image"], observation["wrist_image"]]
+            if self.num_views >= 3 and "wrist_image_right" in observation:
+                img_list.append(observation["wrist_image_right"])
+        for v, im in enumerate(img_list[:self.num_views]):
+            norm = torch.from_numpy(im.astype(np.float32) / 127.5 - 1.0)
+            self._img_buf[v].copy_(norm.to(bf16))
+
+    def _copy_tensor_to_pipeline_buf(self, src: torch.Tensor, dst_buf) -> None:
+        """D2D cudaMemcpyAsync from a torch tensor into a CudaBuffer slot.
+
+        Uses the current torch stream so downstream ops see the copy.
+        """
+        stream_int = torch.cuda.current_stream().cuda_stream
+        self._copy_tensor_to_pipeline_buf_stream(src, dst_buf, stream_int)
+
+    def _copy_tensor_to_pipeline_buf_stream(
+            self, src: torch.Tensor, dst_buf, stream_int: int) -> None:
+        """D2D cudaMemcpyAsync on a specific stream."""
+        nbytes = src.numel() * src.element_size()
+        assert nbytes == dst_buf.nbytes, \
+            f"size mismatch: src {nbytes} vs dst {dst_buf.nbytes}"
+        self._cudart.cudaMemcpyAsync(
+            dst_buf.ptr, ctypes.c_void_p(src.data_ptr()), nbytes, 3, stream_int)

--- a/flash_rt/models/pi05/pipeline_rtx_fp16.py
+++ b/flash_rt/models/pi05/pipeline_rtx_fp16.py
@@ -1,0 +1,2136 @@
+"""FlashRT — RTX (consumer discrete GPU) Pi0.5 inference pipeline.
+
+Framework-agnostic pipeline for Pi0.5 on consumer RTX GPUs (Blackwell SM120
+/ Ada SM89, 5090 / 4090). Mirrors the ``flash_rt/hardware/thor/pipeline_pi05.py``
+design philosophy: the pipeline owns kernel composition, frontends own
+weights/framework choice.
+
+Architecture::
+
+    frontend (torch safetensors, JAX Orbax, ...)
+        │
+        ├── loads + FP8-quantizes weights into framework-native tensors
+        │   then exposes raw device pointer ints
+        │
+        ├── instantiates RtxFlashAttnBackend (owns Q/K/V/O bf16 tensors,
+        │   framework-neutral — used by both torch and jax frontends)
+        │
+        └── constructs Pi05Pipeline(gemm, fvk, attn_backend, weights_ptrs, dims)
+                │
+                ├── allocates internal working buffers as CudaBuffer (no torch)
+                ├── runs fvk kernels via pointers for all GEMM / norm / fused ops
+                ├── delegates attention to attn_backend (pluggable)
+                └── captures a CUDA graph via flash_rt.core.cuda_graph
+
+The attention kernel itself is vendored Flash-Attention 2 (see
+``csrc/attention/flash_attn_2_src/``) shipped as
+``flash_rt.flash_rt_fa2``. ``RtxFlashAttnBackend`` uses
+``torch.empty`` for the Q/K/V/O scratch tensors only — the attention
+call is framework-neutral. A future pass will swap the allocator for
+:class:`flash_rt.core.cuda_buffer.CudaBuffer` to remove that
+transitive torch dependency entirely.
+
+All activations are BF16. FP8 E4M3 quantization on weights + activations for
+the large GEMMs (vision attn/FFN, encoder attn/FFN, decoder attn/FFN); see
+``_quantize_weights_fp8`` in the frontend.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import math
+import os
+
+import numpy as np
+import ml_dtypes
+
+from flash_rt.core.cuda_buffer import CudaBuffer
+from flash_rt.core.cuda_graph import CUDAGraph
+
+logger = logging.getLogger(__name__)
+
+
+# Fixed Pi0.5 model dimensions
+VIS_L = 27           # SigLIP-L layers
+VIS_D = 1152         # SigLIP hidden dim
+VIS_H = 4304         # SigLIP FFN hidden
+VIS_NH = 16          # SigLIP num attn heads
+VIS_HD = 72          # SigLIP head dim
+VIS_SEQ_PER_VIEW = 256
+VIS_PATCH_FLAT = 14 * 14 * 3  # 588
+
+ENC_L = 18           # Gemma-2B encoder layers
+ENC_D = 2048
+ENC_H = 16384
+ENC_NH = 8           # query heads (GQA)
+ENC_NKV = 1          # kv heads (GQA)
+ENC_HD = 256
+
+DEC_L = 18           # Gemma-300M decoder layers
+DEC_D = 1024
+DEC_H = 4096
+DEC_NH = 8
+DEC_NKV = 1
+DEC_HD = 256
+
+ACTION_DIM = 32
+NUM_STEPS_DEFAULT = 10
+
+# BF16 tagging for numpy arrays. There are two cases:
+#   BF16 (np.float16): SIZING-ONLY. CudaBuffer allocations only use this
+#     to compute nbytes = count * 2, which matches BF16. Safe because
+#     the buffer is never filled with numeric values from numpy directly.
+#   BF16_NP (ml_dtypes.bfloat16): REAL BF16 with the correct bit layout.
+#     Must be used for any numpy staging array that carries meaningful
+#     numeric values (ones vector, RoPE cos/sin, ...). ``np.float16`` has
+#     the same byte width but a different exponent/mantissa layout —
+#     using it for BF16 data yields silent ~500x underflow when the
+#     BF16 kernel re-interprets the bits.
+BF16 = np.float16            # sizing placeholder only
+BF16_NP = np.float16  # real FP16 numpy dtype for numeric staging
+FP8 = np.uint8
+FP32 = np.float32
+INT8 = np.int8
+
+
+class _Fp16KernelProxy:
+    """Map Pi0.5 BF16 kernel call names to additive FP16 bindings.
+
+    The experimental FP16 pipeline is intentionally copied from the stable
+    RTX pipeline. Keeping this proxy local avoids changing existing BF16
+    call sites or kernel implementations while we bring up the baseline.
+    """
+
+    def __init__(self, fvk):
+        self._fvk = fvk
+
+    def __getattr__(self, name):
+        return getattr(self._fvk, name)
+
+    def rms_norm(self, *args, **kwargs):
+        return self._fvk.rms_norm_fp16(*args, **kwargs)
+
+    def layer_norm(self, *args, **kwargs):
+        return self._fvk.layer_norm_fp16(*args, **kwargs)
+
+    def ada_rms_norm_style(self, *args, **kwargs):
+        return self._fvk.ada_rms_norm_style_fp16(*args, **kwargs)
+
+    def qkv_split(self, *args, **kwargs):
+        return self._fvk.qkv_split_fp16(*args, **kwargs)
+
+    def qkv_split_rope(self, qkv, rope, Q, K, V, seq, q_dim, k_dim, v_dim,
+                       head_dim, stream=0):
+        if k_dim != v_dim:
+            raise ValueError("FP16 qkv_split_rope expects k_dim == v_dim")
+        return self._fvk.qkv_split_rope_kvcache_fp16(
+            qkv, rope, Q, K, V, seq, q_dim, k_dim, head_dim,
+            q_dim + k_dim + v_dim, 0, k_dim, stream)
+
+    def gate_mul_residual(self, *args, **kwargs):
+        return self._fvk.gate_mul_residual_fp16(*args, **kwargs)
+
+    def gate_residual_ada_norm(self, *args, **kwargs):
+        return self._fvk.gate_residual_ada_norm_fp16(*args, **kwargs)
+
+    def bias_residual(self, *args, **kwargs):
+        return self._fvk.bias_residual_fp16(*args, **kwargs)
+
+    def bias_residual_strict(self, *args, **kwargs):
+        return self._fvk.bias_residual_strict_fp16(*args, **kwargs)
+
+    def residual_add(self, *args, **kwargs):
+        return self._fvk.residual_add_fp16(*args, **kwargs)
+
+    def gate_geglu(self, *args, **kwargs):
+        return self._fvk.gate_geglu_fp16(*args, **kwargs)
+
+    def gate_geglu_merged(self, *args, **kwargs):
+        return self._fvk.gate_geglu_merged_fp16(*args, **kwargs)
+
+    def gelu_inplace(self, *args, **kwargs):
+        return self._fvk.gelu_inplace_fp16(*args, **kwargs)
+
+    def add_bias_bf16(self, *args, **kwargs):
+        return self._fvk.add_bias_fp16(*args, **kwargs)
+
+    def bias_residual_layer_norm_bf16(self, *args, **kwargs):
+        return self._fvk.bias_residual_layer_norm_fp16(*args, **kwargs)
+
+    def bias_gelu_bf16_strict(self, *args, **kwargs):
+        return self._fvk.bias_gelu_fp16_strict(*args, **kwargs)
+
+    def avg_pool_vision_tokens(self, *args, **kwargs):
+        return self._fvk.avg_pool_vision_tokens_fp16(*args, **kwargs)
+
+
+class Pi05PipelineFP16:
+    """Pi0.5 inference pipeline for RTX (Blackwell / Ada) consumer GPUs.
+
+    The pipeline composes ``flash_rt_kernels`` kernels + ``GemmRunner``
+    cuBLASLt calls + an injected :class:`~flash_rt.hardware.rtx.attn_backend.AttnBackend`
+    into the full SigLIP → Gemma encoder → Gemma decoder flow.
+
+    Args:
+        gemm:         ``fvk.GemmRunner()`` — cuBLASLt BF16/FP8 GEMM driver.
+        fvk:          The ``flash_rt_kernels`` module (raw pointer kernels).
+        attn_backend: Attention backend implementing the
+                      :class:`~flash_rt.hardware.rtx.attn_backend.AttnBackend`
+                      protocol (owns Q/K/V/O tensors, runs attention).
+        weights:      Dict of weight pointers — see class docstring for schema.
+        num_views:    Number of observation camera views (1/2/3).
+        max_prompt_len: Max tokenised prompt length (language embeds buffer size).
+        chunk_size:   Diffusion action chunk length (default 10).
+        use_fp8:      Enable FP8 E4M3 quantization for large GEMMs.
+        use_fp8_decoder: Enable FP8 on decoder branch (else BF16).
+        use_int8_decoder: Enable experimental decoder-only INT8 GEMMs.
+        num_steps:    Diffusion denoise steps (default 10).
+
+    Expected weights dict keys:
+        Vision BF16:
+            vision_patch_embedding_w (588,1152), vision_patch_embedding_b (1152,),
+            vision_position_embedding (256,1152),
+            vision_pre_attn_norm_w[L], vision_pre_attn_norm_b[L],
+            vision_pre_ffn_norm_w[L], vision_pre_ffn_norm_b[L],
+            vision_attn_qkv_b[L], vision_attn_o_b[L],
+            vision_ffn_up_b[L], vision_ffn_down_b[L],
+            vision_final_norm_w, vision_final_norm_b,
+            encoder_multi_modal_projector_b,
+        Vision FP8 (each entry is (fp8_ptr, scale_ptr) tuple):
+            fp8.vision_attn_qkv_w_{0..26}, fp8.vision_attn_o_w_{0..26},
+            fp8.vision_ffn_up_w_{0..26},   fp8.vision_ffn_down_w_{0..26},
+            fp8.vision_projector_w,
+        Encoder FP8:
+            fp8.encoder_attn_qkv_w_{0..17}, fp8.encoder_attn_o_w_{0..17},
+            fp8.encoder_ffn_gate_up_w_{0..17}  (merged gate+up: (D,2H)),
+            fp8.encoder_ffn_down_w_{0..17},
+        Decoder BF16:
+            decoder_time_mlp_in_w/b, decoder_time_mlp_out_w/b,
+            decoder_time_embeds (10,1024),
+            decoder_pre_attn_norm_mod_w/b[L], decoder_pre_ffn_norm_mod_w/b[L],
+            decoder_final_norm_mod_w/b,
+            decoder_action_in_proj_w/b,
+            decoder_action_out_proj_w/b   (frontend MUST pre-scale by -1/num_steps),
+        Decoder FP8:
+            fp8.decoder_attn_qkv_w_{0..17}, fp8.decoder_attn_o_w_{0..17},
+            fp8.decoder_ffn_gate_up_w_{0..17}, fp8.decoder_ffn_down_w_{0..17},
+        Decoder INT8:
+            int8.decoder_attn_qkv_w_{0..17}, int8.decoder_attn_o_w_{0..17},
+            int8.decoder_ffn_gate_w_{0..17}, int8.decoder_ffn_up_w_{0..17},
+            int8.decoder_ffn_down_w_{0..17},
+        Language (rebound per-prompt by frontend):
+            language_embeds_ptr   — pointer to bf16 (max_prompt_len, 2048) buffer
+    """
+
+    def __init__(self, gemm, fvk, attn_backend, weights, *,
+                 num_views: int, max_prompt_len: int,
+                 chunk_size: int = NUM_STEPS_DEFAULT,
+                 use_fp8: bool = True, use_fp8_decoder: bool = True,
+                 use_int8_decoder: bool = False,
+                 use_int8_encoder: bool = False,
+                 use_int8_vision: bool = False,
+                 use_int8_vision_static: bool = False,
+                 vision_pool_factor: int = 1,
+                 vision_num_layers: int = VIS_L,
+                 num_steps: int = NUM_STEPS_DEFAULT):
+        if use_fp8 or use_fp8_decoder:
+            raise ValueError("Pi05PipelineFP16 supports only use_fp8=False")
+        if use_int8_decoder or use_int8_encoder or use_int8_vision or use_int8_vision_static:
+            raise ValueError("Pi05PipelineFP16 does not support INT8 paths")
+        if int(vision_pool_factor) != 1:
+            raise ValueError("Pi05PipelineFP16 baseline currently supports vision_pool_factor=1")
+        self.gemm = gemm
+        self.fvk = _Fp16KernelProxy(fvk)
+        self.attn = attn_backend
+        self.weights = weights
+
+        self.num_views = int(num_views)
+        self.max_prompt_len = int(max_prompt_len)
+        self.chunk_size = int(chunk_size)
+        self.num_steps = int(num_steps)
+        self.use_fp8 = bool(use_fp8)
+        self.use_fp8_decoder = bool(use_fp8_decoder)
+        self.use_int8_decoder = bool(use_int8_decoder)
+        self.use_int8_encoder = bool(use_int8_encoder)
+        self.use_int8_vision = bool(use_int8_vision)
+        self._fuse_fp16_gate_residual_ada = (
+            os.environ.get("FVK_PI05_FP16_FUSE_RES_ADA", "1") != "0"
+        )
+        self._merge_fp16_decoder_gate_up = (
+            os.environ.get("FVK_PI05_FP16_MERGE_GATE_UP", "1") != "0"
+            and "decoder_ffn_gate_up_w" in weights
+        )
+        self._fuse_fp16_action_update = (
+            os.environ.get("FVK_PI05_FP16_FUSE_ACTION_UPDATE", "1") != "0"
+        )
+        # Static INT8 vision: uses pre-calibrated per-layer per-tensor scales.
+        # Eliminates the per-row amax reduction → 1 quantize kernel vs 3.
+        # Scales are collected once during calibrate_int8_vision_static().
+        self.use_int8_vision_static = bool(use_int8_vision_static)
+        self.vis_int8_static_scales: dict = {}   # name → CudaBuffer(1, FP32)
+        self.vis_int8_static_calibrated = False
+        # Encoder INT8 static-rowwise: after calibration, the per-row scale
+        # buffers populated by quantize_int8_rowwise during the calibration
+        # forward are *frozen* and reused on every subsequent inference. The
+        # hot-path quantize switches from rowwise (3-pass over data, with a
+        # per-row amax warp+block reduction) to rowwise_static (1-pass, no
+        # reduction). Saves ~4-8 ms/inference on the encoder activation
+        # quantize calls. The scales are accurate for input distributions
+        # similar to the calibration sample; for prompt rows they are exact
+        # (prompt is fixed at set_prompt time), for vision rows they assume
+        # camera-similarity. Toggle via FVK_PI05_RTX_INT8_ENCODER_STATIC=1.
+        # Default off until cosine validation passes on the target setup.
+        self.int8_encoder_static_calibrated = False
+        self.vision_pool_factor = int(vision_pool_factor)
+        self.vision_num_layers = int(vision_num_layers)
+        if self.num_steps <= 0:
+            raise ValueError(f"num_steps must be positive, got {self.num_steps}")
+        if self.vision_pool_factor not in (1, 2, 4):
+            raise ValueError(
+                "vision_pool_factor must be one of {1, 2, 4}; "
+                f"got {self.vision_pool_factor}")
+        if not 1 <= self.vision_num_layers <= VIS_L:
+            raise ValueError(
+                f"vision_num_layers must be in [1, {VIS_L}], "
+                f"got {self.vision_num_layers}")
+        self.fp8_layout = weights.get("fp8_layout", "kn")
+        if self.fp8_layout not in ("kn", "nk"):
+            raise ValueError(f"unsupported FP8 layout: {self.fp8_layout!r}")
+
+        # Derived sizes
+        # vision_seq: full SigLIP token count (pre-pooling) — used for SigLIP buffers
+        # vision_seq_enc: token count fed to the Gemma encoder (post-pooling)
+        self.vision_seq = self.num_views * VIS_SEQ_PER_VIEW
+        pf = self.vision_pool_factor
+        self.vision_seq_enc = self.vision_seq // (pf * pf)
+        self.encoder_seq_len = self.vision_seq_enc + self.max_prompt_len
+        self.total_kv = self.encoder_seq_len + self.chunk_size
+
+        # Attention pointers (owned by attn_backend)
+        self._attn_ptrs = attn_backend.get_ptrs()
+        self._enc_kv_layer_stride = self._attn_ptrs["enc_k_layer_stride_bytes"]
+
+        # Allocate internal buffers (all CudaBuffer, all BF16 unless noted)
+        self.bufs = self._allocate_buffers()
+
+        # RoPE table (max positions = encoder_seq_len + chunk_size)
+        self._build_rope_table()
+
+        # valid_encoder_len placeholder — updated per forward
+        _valid_len = np.array([self.vision_seq + 1], dtype=np.int32)
+        self.bufs["valid_encoder_len"] = CudaBuffer.from_numpy(_valid_len)
+
+        # Pre-allocated RMS norm "ones" weight vectors (REAL BF16 bit pattern)
+        _ones_2048 = np.ones(ENC_D, dtype=BF16_NP)
+        _ones_1024 = np.ones(DEC_D, dtype=BF16_NP)
+        self._rms_ones_enc = CudaBuffer.from_numpy(_ones_2048)
+        self._rms_ones_dec = CudaBuffer.from_numpy(_ones_1024)
+
+        # FP8 activation scratch buffers + per-layer static scales
+        self.fp8_act_scales = {}  # name -> CudaBuffer(1, fp32)
+        self.fp8_calibrated = False
+        self._allocate_fp8_scratch()
+        self.int8_act_scales = {}  # name -> CudaBuffer(rows, fp32), runtime-dynamic
+        self._allocate_int8_scratch()
+        self._allocate_encoder_int8_scratch()
+        self._allocate_vision_int8_static_scratch()
+
+        # Pre-computed decoder style params — frontend pre-computes these in
+        # its native framework and passes raw bf16 bytes; see frontend's
+        # ``_precompute_decoder_styles_numpy`` helper.
+        self._upload_precomputed_styles()
+
+        # CUDA graph state (set by record_infer_graph)
+        self._graph = None
+        self._decoder_only_graph = None  # for temporal K/V caching
+        self._graph_stream = None  # ctypes.c_void_p
+        from flash_rt.core.cuda_buffer import _cudart
+        self._cudart = _cudart
+
+        # Pre-expand vision position embedding across num_views (see
+        # ``vision_encoder``'s patch embed path). Blackwell uses
+        # ``torch.expand().reshape()`` which creates an ad-hoc contiguous
+        # copy; we do the same by replicating the (256, VIS_D) pos_emb
+        # ``num_views`` times into a dedicated pipeline buffer so we can
+        # feed it to the BF16 ``bias_residual`` kernel. ``fvk.patch_embed_bias_pos``
+        # is FP16-only and cannot be used for BF16 data.
+        self._build_pos_embed_expanded()
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Buffer allocation
+    # ══════════════════════════════════════════════════════════════════
+
+    def _allocate_buffers(self) -> dict:
+        """Allocate all pipeline working buffers as CudaBuffer."""
+        nv = self.num_views
+        vs = self.vision_seq
+        es = self.encoder_seq_len
+        ds = self.chunk_size
+        B = {}
+
+        # ── Vision (SigLIP) ──
+        # observation_images_normalized is the input slot; frontend writes here.
+        B["observation_images_normalized"] = CudaBuffer.device_empty(
+            nv * 224 * 224 * 3, BF16)
+        # Patch-embedded + residual stream (full pre-pool token count)
+        B["vision_x"] = CudaBuffer.device_empty(vs * VIS_D, BF16)
+        B["vision_x_norm"] = CudaBuffer.device_empty(vs * VIS_D, BF16)
+        # Pooled vision tokens fed to the Gemma encoder (== vision_x when pool_factor=1)
+        vs_enc = self.vision_seq_enc
+        if self.vision_pool_factor > 1:
+            B["vision_x_pooled"] = CudaBuffer.device_empty(vs_enc * VIS_D, BF16)
+        else:
+            B["vision_x_pooled"] = B["vision_x"]  # no-op alias
+        B["vision_QKV"] = CudaBuffer.device_empty(vs * 3 * VIS_D, BF16)
+        B["vision_hidden"] = CudaBuffer.device_empty(vs * VIS_H, BF16)
+        # Position embedding expanded (nv * 256, 1152) — built once, reused
+        B["vision_pos_embed_expanded"] = CudaBuffer.device_empty(vs * VIS_D, BF16)
+
+        # ── Encoder (Gemma-2B) ──
+        B["encoder_rope_weights"] = CudaBuffer.device_empty(es * 2 * ENC_HD // 2, BF16)
+        # (Sized conservatively: encoder_seq_len * 256 bf16 elements.)
+        B["encoder_x"] = CudaBuffer.device_empty(es * ENC_D, BF16)
+        B["encoder_x_norm"] = CudaBuffer.device_empty(es * ENC_D, BF16)
+        B["encoder_QKV"] = CudaBuffer.device_empty(es * (ENC_NH + 2 * ENC_NKV) * ENC_HD, BF16)
+        B["encoder_hidden"] = CudaBuffer.device_empty(es * ENC_H, BF16)
+        # Merged gate+up output (legacy BF16 path) or gate-only buffer for SiLU-gated.
+        B["encoder_gate_merged"] = CudaBuffer.device_empty(es * 2 * ENC_H, BF16)
+        # Gate buffer for SiLU-gated EVT fusion (encoder): (es, ENC_H) BF16
+        B["encoder_gate_buf"] = CudaBuffer.device_empty(es * ENC_H, BF16)
+
+        # ── Decoder (Gemma-300M) ──
+        B["decoder_rope_weights"] = CudaBuffer.device_empty(ds * 256, BF16)
+        B["decoder_x"] = CudaBuffer.device_empty(ds * DEC_D, BF16)
+        B["decoder_action_buf"] = CudaBuffer.device_empty(ds * ACTION_DIM, BF16)
+        # Pre-computed per-step, per-layer style params (BF16)
+        B["decoder_time_emb"] = CudaBuffer.device_empty(
+            self.num_steps * ds * DEC_D, BF16)
+        B["decoder_style_attn"] = CudaBuffer.device_empty(
+            self.num_steps * DEC_L * ds * 3 * DEC_D, BF16)
+        B["decoder_style_ffn"] = CudaBuffer.device_empty(
+            self.num_steps * DEC_L * ds * 3 * DEC_D, BF16)
+        B["decoder_style_final"] = CudaBuffer.device_empty(
+            self.num_steps * ds * 3 * DEC_D, BF16)
+        B["decoder_QKV"] = CudaBuffer.device_empty(
+            ds * (DEC_NH + 2 * DEC_NKV) * DEC_HD, BF16)
+        B["decoder_hidden"] = CudaBuffer.device_empty(ds * DEC_H, BF16)
+        B["decoder_gate_merged"] = CudaBuffer.device_empty(ds * 2 * DEC_H, BF16)
+        # Gate buffer for SiLU-gated EVT fusion (decoder): (ds, DEC_H) BF16
+        B["decoder_gate_buf"] = CudaBuffer.device_empty(ds * DEC_H, BF16)
+        B["diffusion_noise"] = CudaBuffer.device_empty(ds * ACTION_DIM, BF16)
+        # Decoder scratch for ada_rms_norm output + gate
+        B["x_normed_buf"] = CudaBuffer.device_empty(ds * DEC_D, BF16)
+        B["gate_buf"] = CudaBuffer.device_empty(ds * DEC_D, BF16)
+        # Scratch for vision patch im2col output (BF16 (nv*256, 588))
+        B["vision_patches"] = CudaBuffer.device_empty(vs * VIS_PATCH_FLAT, BF16)
+
+        return B
+
+    def _allocate_fp8_scratch(self) -> None:
+        """Allocate reusable FP8 activation scratch + scale buffers."""
+        if not self.use_fp8:
+            return
+        B = self.bufs
+        vs = self.vision_seq
+        es = self.encoder_seq_len
+        ds = self.chunk_size
+
+        # Vision FP8 scratch — sized for D=1152 and H=4304
+        B["vis_act_fp8"] = CudaBuffer.device_zeros(vs * VIS_D, FP8)
+        B["vis_act_fp8_large"] = CudaBuffer.device_zeros(vs * VIS_H, FP8)
+        B["vis_act_scale"] = CudaBuffer.device_zeros(1, FP32)
+
+        # Encoder FP8 scratch — D=2048, H_merged=32768 (2*16384)
+        B["enc_act_fp8"] = CudaBuffer.device_zeros(es * ENC_D, FP8)
+        B["enc_act_fp8_large"] = CudaBuffer.device_zeros(es * 2 * ENC_H, FP8)
+        B["enc_act_scale"] = CudaBuffer.device_zeros(1, FP32)
+
+        # Decoder FP8 scratch — D=1024, H_merged=8192
+        B["dec_act_fp8"] = CudaBuffer.device_zeros(ds * DEC_D, FP8)
+        B["dec_act_fp8_large"] = CudaBuffer.device_zeros(ds * 2 * DEC_H, FP8)
+        B["dec_act_scale"] = CudaBuffer.device_zeros(1, FP32)
+
+    def _allocate_int8_scratch(self) -> None:
+        """Allocate reusable INT8 activation scratch for the decoder path."""
+        if not self.use_int8_decoder:
+            return
+        B = self.bufs
+        ds = self.chunk_size
+        B["dec_act_int8"] = CudaBuffer.device_zeros(ds * DEC_D, INT8)
+        B["dec_act_int8_large"] = CudaBuffer.device_zeros(ds * 2 * DEC_H, INT8)
+
+    def _allocate_vision_int8_static_scratch(self) -> None:
+        """Allocate INT8 activation scratch for static-scale vision path.
+
+        Reuses the encoder INT8 scratch buffers (vision runs before encoder,
+        sizes fit: vis_seq=512 × VIS_D=1152 < enc_seq × ENC_D).
+        Only allocates the scratch if static vision INT8 is enabled.
+        """
+        if not self.use_int8_vision_static:
+            return
+        # Ensure encoder scratch exists (also needed for static vision INT8)
+        B = self.bufs
+        es = self.encoder_seq_len
+        if "enc_act_int8" not in B:
+            B["enc_act_int8"] = CudaBuffer.device_zeros(es * ENC_D, INT8)
+        if "enc_act_int8_large" not in B:
+            B["enc_act_int8_large"] = CudaBuffer.device_zeros(es * ENC_H, INT8)
+
+    def _allocate_encoder_int8_scratch(self) -> None:
+        """Allocate reusable INT8 activation scratch for encoder + vision paths.
+
+        Vision runs before encoder and reuses these same buffers (sequential,
+        never concurrent). Vision shapes always fit within the encoder-sized
+        scratch (VIS_D=1152 < ENC_D=2048, VIS_H=4304 < ENC_H=16384).
+
+        Two sizes:
+          enc_act_int8       — (es * ENC_D) INT8: covers encoder QKV/O/gate_up
+                               and vision QKV/O/up (K ≤ ENC_D)
+          enc_act_int8_large — (es * ENC_H) INT8: covers encoder down
+                               and vision down (K ≤ ENC_H)
+        """
+        if not (self.use_int8_encoder or self.use_int8_vision):
+            return
+        B = self.bufs
+        es = self.encoder_seq_len
+        B["enc_act_int8"] = CudaBuffer.device_zeros(es * ENC_D, INT8)
+        B["enc_act_int8_large"] = CudaBuffer.device_zeros(es * ENC_H, INT8)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   RoPE table
+    # ══════════════════════════════════════════════════════════════════
+
+    def _build_rope_table(self) -> None:
+        """Build the BF16 interleaved cos/sin RoPE table (max_pos, 256).
+
+        Uploaded to ``bufs['encoder_rope_weights']`` for the prefix range
+        [0 .. encoder_seq_len). The decoder RoPE slice [encoder_seq_len ..
+        encoder_seq_len+chunk_size) is set per-prompt by :meth:`forward`.
+        """
+        max_pos = self.encoder_seq_len + self.chunk_size
+        inv_freq = 1.0 / (10000 ** (np.arange(0, 256, 2, dtype=np.float64) / 256))
+        positions = np.arange(max_pos, dtype=np.float64)
+        phase = positions[:, None] * inv_freq[None, :]  # (max_pos, 128)
+        cos = np.cos(phase).astype(BF16_NP)
+        sin = np.sin(phase).astype(BF16_NP)
+        # Interleaved [cos0, sin0, cos1, sin1, ...] → (max_pos, 256)
+        interleaved = np.stack([cos, sin], axis=-1).reshape(max_pos, 256)
+        self._rope_table_np = interleaved  # keep on host for per-prompt decoder slice
+
+        # Initial encoder RoPE slice = first encoder_seq_len rows
+        enc_rope_slice = interleaved[:self.encoder_seq_len]
+        # Need to allocate a correctly-sized CudaBuffer, overwriting the placeholder
+        self.bufs["encoder_rope_weights"] = CudaBuffer.from_numpy(
+            np.ascontiguousarray(enc_rope_slice))
+
+        # Decoder RoPE: placeholder, will be overwritten per-prompt.
+        # Positions start after the pooled vision tokens + prompt — use
+        # vision_seq_enc (not vision_seq) so the rope table isn't overrun
+        # when vision_pool_factor > 1.
+        dec_rope_slice = interleaved[
+            self.vision_seq_enc - 1 : self.vision_seq_enc - 1 + self.chunk_size]
+        self.bufs["decoder_rope_weights"] = CudaBuffer.from_numpy(
+            np.ascontiguousarray(dec_rope_slice))
+
+    def _set_decoder_rope_for_prompt(self, prompt_len: int) -> None:
+        """Update ``decoder_rope_weights`` for a new prompt length."""
+        start = self.vision_seq_enc + prompt_len - 1
+        end = start + self.chunk_size
+        self.bufs["decoder_rope_weights"].upload(
+            np.ascontiguousarray(self._rope_table_np[start:end]))
+
+    def _build_pos_embed_expanded(self) -> None:
+        """Replicate (256, VIS_D) pos_emb ``num_views`` times into a pipeline buffer.
+
+        The source pos_emb comes from the frontend as a raw device pointer
+        and is BF16 ``(256, VIS_D)``. We D2D-copy it num_views times into
+        a pipeline-owned contiguous (num_views*256, VIS_D) BF16 buffer so
+        that ``bias_residual`` can read it as a flat row-major tensor.
+        """
+        pos_src_ptr = self.weights["vision_position_embedding"]
+        per_view_nbytes = VIS_SEQ_PER_VIEW * VIS_D * 2  # bf16 = 2 bytes
+        dst_buf = self.bufs["vision_pos_embed_expanded"]
+        assert dst_buf.nbytes == self.num_views * per_view_nbytes
+        for v in range(self.num_views):
+            self._cudart.cudaMemcpy(
+                ctypes.c_void_p(dst_buf.ptr.value + v * per_view_nbytes),
+                ctypes.c_void_p(pos_src_ptr),
+                per_view_nbytes, 3)  # D2D
+        self._cudart.cudaDeviceSynchronize()
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Helpers
+    # ══════════════════════════════════════════════════════════════════
+
+    @staticmethod
+    def _p(buf) -> int:
+        """Extract int pointer from a CudaBuffer."""
+        return buf.ptr.value
+
+    def _weight_fp8(self, name: str) -> tuple[int, int]:
+        """Look up an FP8-quantized weight: returns (data_ptr, scale_ptr)."""
+        return self.weights["fp8"][name]
+
+    def _weight_int8(self, name: str) -> tuple[int, int]:
+        """Look up an INT8-quantized weight: returns (data_ptr, scale_ptr)."""
+        return self.weights["int8"][name]
+
+    def _fp8_matmul(self, act_fp8_ptr: int, weight_fp8_ptr: int,
+                    out_bf16_ptr: int, M: int, N: int, K: int,
+                    act_scale_ptr: int, weight_scale_ptr: int,
+                    stream: int) -> None:
+        """Dispatch the FP8 GEMM for the selected weight layout."""
+        if self.fp8_layout == "nk":
+            self.gemm.fp8_nt_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr, stream=stream)
+        else:
+            self.gemm.fp8_nn_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr, stream=stream)
+
+    def _autotune_fp8_matmul(self, act_fp8_ptr: int, weight_fp8_ptr: int,
+                             out_bf16_ptr: int, M: int, N: int, K: int,
+                             act_scale_ptr: int, weight_scale_ptr: int) -> None:
+        """Autotune the FP8 GEMM for the selected weight layout."""
+        if self.fp8_layout == "nk":
+            self.gemm.autotune_fp8_nt_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr)
+        else:
+            self.gemm.autotune_fp8_nn_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr)
+
+    def _upload_precomputed_styles(self) -> None:
+        """Upload frontend-precomputed decoder style/time buffers.
+
+        Expects ``self.weights['precomputed']`` dict with keys (numpy
+        arrays, dtype = BF16-equivalent, 2 bytes per element):
+            time_emb      — (num_steps, chunk_size, DEC_D)
+            style_attn    — (num_steps, DEC_L, chunk_size, 3*DEC_D)
+            style_ffn     — (num_steps, DEC_L, chunk_size, 3*DEC_D)
+            style_final   — (num_steps, chunk_size, 3*DEC_D)
+        """
+        pre = self.weights["precomputed"]
+        self.bufs["decoder_time_emb"].upload(
+            np.ascontiguousarray(pre["time_emb"]))
+        self.bufs["decoder_style_attn"].upload(
+            np.ascontiguousarray(pre["style_attn"]))
+        self.bufs["decoder_style_ffn"].upload(
+            np.ascontiguousarray(pre["style_ffn"]))
+        self.bufs["decoder_style_final"].upload(
+            np.ascontiguousarray(pre["style_final"]))
+
+    def _style_slice_ptr(self, buf_name: str, step: int,
+                         layer: int | None = None) -> int:
+        """Compute the device pointer of a per-step (per-layer) style slice.
+
+        Layout (bf16, 2 bytes per element):
+            style_attn/ffn: (num_steps, DEC_L, chunk_size, 3*DEC_D)
+                            slice ``[step, layer]`` has nbytes = chunk * 3*D * 2
+            style_final:   (num_steps, chunk_size, 3*DEC_D)
+                            slice ``[step]`` has nbytes = chunk * 3*D * 2
+            time_emb:      (num_steps, chunk_size, DEC_D)
+                            slice ``[step]`` has nbytes = chunk * D * 2
+        """
+        base = self.bufs[buf_name].ptr.value
+        ds = self.chunk_size
+        if buf_name == "decoder_time_emb":
+            return base + step * ds * DEC_D * 2
+        if buf_name == "decoder_style_final":
+            return base + step * ds * 3 * DEC_D * 2
+        # style_attn / style_ffn
+        per_layer = ds * 3 * DEC_D * 2
+        per_step = DEC_L * per_layer
+        return base + step * per_step + layer * per_layer
+
+    def _enc_kv_layer_ptrs(self, layer: int, offset_tokens: int = 0) -> tuple[int, int]:
+        """Compute (K_ptr, V_ptr) for encoder/decoder cross-attn layer cache.
+
+        The attention backend owns ``enc_K`` / ``enc_V`` as
+        ``(num_enc_layers, total_kv_max, 1, HD) bf16``. We compute the
+        per-layer slice plus an optional token offset (used by the decoder
+        which writes into ``[enc_seq : enc_seq+dec_seq]``).
+        """
+        k_base = self._attn_ptrs["enc_K"]
+        v_base = self._attn_ptrs["enc_V"]
+        layer_stride = self._enc_kv_layer_stride  # bytes
+        token_offset_bytes = offset_tokens * ENC_NKV * ENC_HD * 2  # bf16
+        return (k_base + layer * layer_stride + token_offset_bytes,
+                v_base + layer * layer_stride + token_offset_bytes)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   FP8 GEMM helpers
+    # ══════════════════════════════════════════════════════════════════
+
+    def _fp8_scale_buf(self, name: str) -> CudaBuffer:
+        """Get (lazy-allocate) the per-layer FP8 activation scale buffer."""
+        buf = self.fp8_act_scales.get(name)
+        if buf is None:
+            buf = CudaBuffer.device_zeros(1, FP32)
+            self.fp8_act_scales[name] = buf
+        return buf
+
+    def _pick_fp8_scratch(self, weight_name: str, act_n: int) -> tuple[int, int]:
+        """Return (act_fp8_ptr, act_scale_ptr) scratch for the right domain.
+
+        Chooses between vision/encoder/decoder FP8 scratch buffers based on
+        the weight name prefix, and between the small and large variant
+        based on ``act_n`` (number of elements to quantize).
+        """
+        B = self.bufs
+        if weight_name.startswith("vision_") or weight_name == "vision_projector_w":
+            small = B["vis_act_fp8"]
+            large = B["vis_act_fp8_large"]
+            scratch_scale = B["vis_act_scale"]
+        elif weight_name.startswith("encoder_"):
+            small = B["enc_act_fp8"]
+            large = B["enc_act_fp8_large"]
+            scratch_scale = B["enc_act_scale"]
+        else:
+            small = B["dec_act_fp8"]
+            large = B["dec_act_fp8_large"]
+            scratch_scale = B["dec_act_scale"]
+        buf = small if act_n <= (small.nbytes // 1) else large
+        return buf.ptr.value, scratch_scale.ptr.value
+
+    def _int8_scale_buf(self, name: str, rows: int) -> CudaBuffer:
+        """Get (lazy-allocate) the per-row INT8 activation scale buffer."""
+        buf = self.int8_act_scales.get(name)
+        if buf is None:
+            buf = CudaBuffer.device_zeros(rows, FP32)
+            self.int8_act_scales[name] = buf
+        elif (buf.nbytes // np.dtype(FP32).itemsize) < rows:
+            raise ValueError(
+                f"int8 scale buffer for {name} is too small: "
+                f"{buf.nbytes // np.dtype(FP32).itemsize} < {rows}")
+        return buf
+
+    def _pick_int8_scratch(self, act_n: int) -> int:
+        """Return the decoder INT8 scratch buffer large enough for ``act_n``."""
+        B = self.bufs
+        small = B["dec_act_int8"]
+        large = B["dec_act_int8_large"]
+        buf = small if act_n <= (small.nbytes // np.dtype(INT8).itemsize) else large
+        return buf.ptr.value
+
+    def _pick_enc_int8_scratch(self, act_n: int) -> int:
+        """Return the encoder INT8 scratch buffer large enough for ``act_n``."""
+        B = self.bufs
+        small = B["enc_act_int8"]
+        large = B["enc_act_int8_large"]
+        buf = small if act_n <= (small.nbytes // np.dtype(INT8).itemsize) else large
+        return buf.ptr.value
+
+    def _vis_static_scale(self, name: str) -> CudaBuffer:
+        """Lazy-allocate per-site vision static INT8 scale buffer (1 float)."""
+        buf = self.vis_int8_static_scales.get(name)
+        if buf is None:
+            buf = CudaBuffer.device_zeros(1, FP32)
+            self.vis_int8_static_scales[name] = buf
+        return buf
+
+    def _vis_static_int8_gemm(self, x_norm_ptr: int, n: int, site_name: str,
+                               weight_name: str, out_ptr: int,
+                               M: int, N: int, K: int, stream: int) -> None:
+        """Vision static INT8 GEMM: static-scale quantize + CUTLASS INT8.
+
+        During calibration: uses quantize_int8_device (dynamic, writes scale).
+        After calibration:  uses quantize_int8_static (element-wise only, no reduction).
+
+        The enc_act_int8 scratch is reused (vision shapes fit within it).
+        """
+        act_i8_ptr = self._pick_enc_int8_scratch(n)
+        scale_buf = self._vis_static_scale(site_name)
+        fvk = self.fvk
+        if self.vis_int8_static_calibrated:
+            fvk.quantize_int8_static(
+                x_norm_ptr, act_i8_ptr, scale_buf.ptr.value, n, stream=stream)
+        else:
+            fvk.quantize_int8_device(
+                x_norm_ptr, act_i8_ptr, scale_buf.ptr.value, n, stream=stream)
+        self._int8_gemm_fused(
+            act_i8_ptr, weight_name, out_ptr, M, N, K, scale_buf.ptr.value, stream)
+
+    def calibrate_int8_vision_static(self, stream: int = 0) -> None:
+        """Run one vision forward pass to collect per-site static INT8 scales.
+
+        After this call, each vision site (QKV, O, up, down × 27 layers) has
+        a calibrated per-tensor scale stored in vis_int8_static_scales.
+        Subsequent inference calls use quantize_int8_static (1 kernel per site).
+        """
+        if self.vis_int8_static_calibrated:
+            return
+        # One forward pass with dynamic quantize_int8_device fills all scales
+        self.vis_int8_static_calibrated = False
+        self.vision_encoder(stream=stream)
+        self._cudart.cudaDeviceSynchronize()
+        self.vis_int8_static_calibrated = True
+
+    def _enc_int8_gemm(self, act_bf16_ptr: int, act_n: int, weight_name: str,
+                       out_bf16_ptr: int, M: int, N: int, K: int, stream: int) -> None:
+        """INT8 GEMM for the encoder: rowwise-quantize BF16 activation then CUTLASS.
+
+        Mirrors ``_int8_gemm`` but uses the larger encoder INT8 scratch
+        buffers so the decoder path's tiny (chunk=10) scratch is not
+        accidentally picked for encoder sequences (~560 rows).
+
+        After ``int8_encoder_static_calibrated`` flips True (set by the
+        frontend after the calibration run has populated the per-row
+        scale buffers), the hot path uses ``quantize_int8_rowwise_static``
+        — single-pass over data, no per-row amax reduction. The CUTLASS
+        GEMM still reads per-row scales from the same buffer; we just
+        stop overwriting it each call.
+        """
+        act_i8_ptr = self._pick_enc_int8_scratch(act_n)
+        layer_scale = self._int8_scale_buf(weight_name, M)
+        if self.int8_encoder_static_calibrated:
+            self.fvk.quantize_int8_rowwise_static(
+                act_bf16_ptr, act_i8_ptr, layer_scale.ptr.value, M, K, stream=stream)
+        else:
+            self.fvk.quantize_int8_rowwise(
+                act_bf16_ptr, act_i8_ptr, layer_scale.ptr.value, M, K, stream=stream)
+        self._int8_gemm_fused(
+            act_i8_ptr, weight_name, out_bf16_ptr, M, N, K,
+            layer_scale.ptr.value, stream)
+
+    def _fp8_gemm(self, act_bf16_ptr: int, act_n: int, weight_name: str,
+                  out_bf16_ptr: int, M: int, N: int, K: int, stream: int) -> None:
+        """FP8 GEMM path: dynamic-quantize activation → FP8 matmul → BF16 out.
+
+        After calibration, uses the per-layer static scale buffer (single
+        kernel path). During calibration, writes the dynamic scale into the
+        layer's static scale buffer so subsequent inference can reuse it.
+        """
+        fvk = self.fvk
+        w_fp8_ptr, w_scale_ptr = self._weight_fp8(weight_name)
+        act_fp8_ptr, _scratch_scale_ptr = self._pick_fp8_scratch(weight_name, act_n)
+
+        if self.fp8_calibrated and weight_name in self.fp8_act_scales:
+            static_scale_ptr = self.fp8_act_scales[weight_name].ptr.value
+            fvk.quantize_fp8_static(
+                act_bf16_ptr, act_fp8_ptr, static_scale_ptr, act_n, stream=stream)
+            self._fp8_matmul(
+                act_fp8_ptr, w_fp8_ptr, out_bf16_ptr,
+                M, N, K, static_scale_ptr, w_scale_ptr, stream)
+        else:
+            # Dynamic quantization path (calibration run): write the
+            # activation scale directly into the layer's *persistent* scale
+            # buffer so that when we flip fp8_calibrated=True, the scale is
+            # already there.
+            layer_scale = self._fp8_scale_buf(weight_name)
+            fvk.quantize_fp8_device(
+                act_bf16_ptr, act_fp8_ptr, layer_scale.ptr.value, act_n, stream=stream)
+            self._fp8_matmul(
+                act_fp8_ptr, w_fp8_ptr, out_bf16_ptr,
+                M, N, K, layer_scale.ptr.value, w_scale_ptr, stream)
+
+    def _fp8_gemm_fused(self, act_fp8_ptr: int, weight_name: str,
+                        out_bf16_ptr: int, M: int, N: int, K: int,
+                        act_scale_ptr: int, stream: int) -> None:
+        """FP8 GEMM with pre-quantized activation (from fused norm→FP8 kernel)."""
+        w_fp8_ptr, w_scale_ptr = self._weight_fp8(weight_name)
+        self._fp8_matmul(
+            act_fp8_ptr, w_fp8_ptr, out_bf16_ptr,
+            M, N, K, act_scale_ptr, w_scale_ptr, stream)
+
+    def _int8_gemm_fused(self, act_i8_ptr: int, weight_name: str,
+                         out_bf16_ptr: int, M: int, N: int, K: int,
+                         act_scale_ptr: int, stream: int) -> None:
+        """INT8 GEMM with pre-quantized rowwise activation."""
+        fvk = self.fvk
+        w_i8_ptr, w_scale_ptr = self._weight_int8(weight_name)
+        status = fvk.cutlass_int8_rowwise_bf16out(
+            act_i8_ptr, w_i8_ptr, act_scale_ptr, w_scale_ptr,
+            out_bf16_ptr, M, N, K, stream=stream)
+        if status != 0:
+            raise RuntimeError(
+                f"CUTLASS INT8 fused GEMM failed for {weight_name}: "
+                f"status={status} shape=({M},{N},{K})")
+
+    def _int8_gemm(self, act_bf16_ptr: int, act_n: int, weight_name: str,
+                   out_bf16_ptr: int, M: int, N: int, K: int, stream: int) -> None:
+        """INT8 GEMM path: rowwise quantize activation -> fused CUTLASS BF16 out."""
+        fvk = self.fvk
+        act_i8_ptr = self._pick_int8_scratch(act_n)
+        layer_scale = self._int8_scale_buf(weight_name, M)
+        fvk.quantize_int8_rowwise(
+            act_bf16_ptr, act_i8_ptr, layer_scale.ptr.value, M, K, stream=stream)
+        self._int8_gemm_fused(
+            act_i8_ptr, weight_name, out_bf16_ptr, M, N, K,
+            layer_scale.ptr.value, stream)
+
+    def _int8_silu_gated_gemm_fused(self, act_i8_ptr: int, up_name: str,
+                                    gate_bf16_ptr: int, out_bf16_ptr: int,
+                                    M: int, N: int, K: int,
+                                    act_scale_ptr: int, stream: int) -> None:
+        """INT8 up GEMM fused with SiLU(gate) epilogue."""
+        w_i8_ptr, w_scale_ptr = self._weight_int8(up_name)
+        status = self.fvk.cutlass_int8_silu_gated_bf16out(
+            act_i8_ptr, w_i8_ptr, act_scale_ptr, w_scale_ptr,
+            gate_bf16_ptr, out_bf16_ptr, M, N, K, stream=stream)
+        if status != 0:
+            raise RuntimeError(
+                f"CUTLASS INT8 SiLU-gated GEMM failed for {up_name}: "
+                f"status={status} shape=({M},{N},{K})")
+
+    def _bias_add_bf16(self, x_ptr: int, bias_ptr: int,
+                       seq: int, dim: int, stream: int) -> None:
+        """Broadcast-add bias to an (seq, dim) bf16 buffer in place.
+
+        TODO(v2): add a dedicated ``add_bias_bf16`` kernel to fvk. For now
+        we reuse ``bias_residual`` with a dedicated persistent zero buffer
+        as the ``x`` operand, yielding ``x += bias``. The wasted bandwidth
+        is ~0.2 ms total for vision (27 layers × 2 bias adds).
+        """
+        if not hasattr(self, "_bias_zero_buf"):
+            # Size once for the largest shape we'll ever bias-add.
+            nbytes = max(
+                self.vision_seq * 3 * VIS_D,  # vision QKV
+                self.vision_seq * VIS_H,      # vision FFN up
+            )
+            self._bias_zero_buf = CudaBuffer.device_zeros(nbytes, BF16)
+        self.fvk.bias_residual(
+            x_ptr, self._bias_zero_buf.ptr.value, bias_ptr,
+            seq, dim, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Phase A: Vision (SigLIP)
+    # ══════════════════════════════════════════════════════════════════
+
+    def vision_encoder(self, stream: int = 0) -> None:
+        """Run the full 27-layer SigLIP vision encoder.
+
+        Input:  ``bufs['observation_images_normalized']`` (num_views, 224, 224, 3) bf16
+        Output: ``bufs['vision_x']`` (num_views * 256, 1152) bf16
+        """
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        seq = self.vision_seq
+        nv = self.num_views
+        attn_ptrs = self._attn_ptrs
+
+        # A1: Patch embed — im2col + GEMM + bias + pos embed.
+        # Note: ``fvk.patch_embed_bias_pos`` is FP16-only; we use the BF16
+        # ``bias_residual`` kernel with a pre-replicated pos_emb buffer.
+        fvk.patch_im2col(
+            B["observation_images_normalized"].ptr.value,
+            B["vision_patches"].ptr.value,
+            nv, stream)
+        gemm.fp16_nn(
+            B["vision_patches"].ptr.value,
+            W["vision_patch_embedding_w"],
+            B["vision_x"].ptr.value,
+            seq, VIS_D, VIS_PATCH_FLAT, stream=stream)
+        fvk.bias_residual(
+            B["vision_x"].ptr.value,
+            B["vision_pos_embed_expanded"].ptr.value,
+            W["vision_patch_embedding_b"],
+            seq, VIS_D, stream=stream)
+
+        # A2-A6: SigLIP transformer layers (vision_num_layers ≤ VIS_L=27)
+        # Reducing layers is a quality/speed trade-off (untrained skip).
+        use_fp8 = self.use_fp8 and "vision_attn_qkv_w_0" in self.weights.get("fp8", {})
+
+        # Layer-0 pre-attn LayerNorm runs here (the rest are fused into
+        # the prior layer's post-FFN bias_residual, so each iteration
+        # arrives with vision_x_norm already containing LN of vision_x).
+        fvk.layer_norm(
+            B["vision_x"].ptr.value,
+            W["vision_pre_attn_norm_w"][0], W["vision_pre_attn_norm_b"][0],
+            B["vision_x_norm"].ptr.value,
+            seq, VIS_D, 1e-5, stream=stream)
+
+        last = self.vision_num_layers - 1
+        for i in range(self.vision_num_layers):
+            self._vision_layer(i, seq, use_fp8, stream, is_last=(i == last))
+
+        # A7 (optional): Spatial average pooling — reduce (nv*256, D) to (nv*64, D)
+        # Runs only when vision_pool_factor > 1. vision_x_pooled is a separate
+        # buffer; vision_x stays intact so this is non-destructive.
+        if self.vision_pool_factor > 1:
+            H = W_grid = 16  # 14×14 patches → 16×16 after im2col rounding? actually 16×16
+            # VIS_SEQ_PER_VIEW = 256 = 16 × 16
+            fvk.avg_pool_vision_tokens(
+                B["vision_x"].ptr.value,
+                B["vision_x_pooled"].ptr.value,
+                nv, H, H, VIS_D, self.vision_pool_factor, stream)
+
+    def _vision_layer(self, i: int, seq: int, use_fp8: bool, stream: int,
+                       is_last: bool = False) -> None:
+        """One SigLIP transformer layer (pre-norm, LayerNorm, GELU FFN).
+
+        Pre-attn LayerNorm is hoisted: layer 0's runs in
+        :meth:`vision_encoder` before the loop; layers 1..N-1's runs
+        as the LN tail of the previous layer's fused
+        bias_residual_layer_norm at the post-FFN-down position.
+        Each iteration enters with ``vision_x_norm`` already holding
+        ``LayerNorm(vision_x)`` for *this* layer's pre-attn site.
+        """
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        attn_ptrs = self._attn_ptrs
+        use_int8_vis = self.use_int8_vision
+        use_int8_vis_static = self.use_int8_vision_static
+
+        # QKV GEMM (static INT8 / dynamic INT8 / FP8 / BF16) → vision_QKV
+        if use_int8_vis_static:
+            self._vis_static_int8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vis_qkv_{i}", f"vision_attn_qkv_w_{i}",
+                B["vision_QKV"].ptr.value,
+                seq, 3 * VIS_D, VIS_D, stream)
+        elif use_int8_vis:
+            # Reuses encoder INT8 scratch (vision shapes always fit).
+            self._enc_int8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vision_attn_qkv_w_{i}",
+                B["vision_QKV"].ptr.value,
+                seq, 3 * VIS_D, VIS_D, stream)
+        elif use_fp8:
+            self._fp8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vision_attn_qkv_w_{i}",
+                B["vision_QKV"].ptr.value,
+                seq, 3 * VIS_D, VIS_D, stream)
+        else:
+            gemm.fp16_nn(
+                B["vision_x_norm"].ptr.value, W["vision_attn_qkv_w"][i],
+                B["vision_QKV"].ptr.value,
+                seq, 3 * VIS_D, VIS_D, stream=stream)
+        # add_bias_bf16 is a proper in-place add (no zero-buffer bandwidth waste)
+        fvk.add_bias_bf16(
+            B["vision_QKV"].ptr.value, W["vision_attn_qkv_b"][i],
+            seq, 3 * VIS_D, stream=stream)
+
+        # Split QKV into attn_backend's Q/K/V buffers
+        fvk.qkv_split(
+            B["vision_QKV"].ptr.value,
+            attn_ptrs["vis_Q"], attn_ptrs["vis_K"], attn_ptrs["vis_V"],
+            seq, VIS_D, VIS_D, VIS_D, stream=stream)
+
+        # Self-attention (per-view batched)
+        vis_o_ptr = self.attn.run(
+            "siglip", i, q_seq=VIS_SEQ_PER_VIEW, stream=stream)
+
+        # Attn output projection → x_norm
+        if use_int8_vis_static:
+            self._vis_static_int8_gemm(
+                vis_o_ptr, seq * VIS_D,
+                f"vis_o_{i}", f"vision_attn_o_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_D, stream)
+        elif use_int8_vis:
+            self._enc_int8_gemm(
+                vis_o_ptr, seq * VIS_D,
+                f"vision_attn_o_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_D, stream)
+        elif use_fp8:
+            self._fp8_gemm(
+                vis_o_ptr, seq * VIS_D,
+                f"vision_attn_o_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_D, stream)
+        else:
+            gemm.fp16_nn(
+                vis_o_ptr, W["vision_attn_o_w"][i],
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_D, stream=stream)
+        # x += x_norm + o_bias; x_norm = LayerNorm(x).
+        # INT8 path uses the fused bf16-strict kernel; default BF16/FP8
+        # path keeps the un-fused upstream pair so SM89/SM120 numerics
+        # match upstream/main bit-for-bit.
+        if self.use_int8_decoder:
+            fvk.bias_residual_layer_norm_bf16(
+                B["vision_x"].ptr.value,           # residual (in-place)
+                B["vision_x_norm"].ptr.value,       # x (attn output)
+                W["vision_attn_o_b"][i],            # bias_pre
+                W["vision_pre_ffn_norm_w"][i],
+                W["vision_pre_ffn_norm_b"][i],
+                B["vision_x_norm"].ptr.value,       # out
+                seq, VIS_D, 1e-5, stream=stream)
+        else:
+            fvk.bias_residual(
+                B["vision_x"].ptr.value, B["vision_x_norm"].ptr.value,
+                W["vision_attn_o_b"][i], seq, VIS_D, stream=stream)
+            fvk.layer_norm(
+                B["vision_x"].ptr.value,
+                W["vision_pre_ffn_norm_w"][i], W["vision_pre_ffn_norm_b"][i],
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, 1e-5, stream=stream)
+
+        # FFN up → hidden, + bias, + GELU
+        if use_int8_vis_static:
+            self._vis_static_int8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vis_up_{i}", f"vision_ffn_up_w_{i}",
+                B["vision_hidden"].ptr.value,
+                seq, VIS_H, VIS_D, stream)
+        elif use_int8_vis:
+            self._enc_int8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vision_ffn_up_w_{i}",
+                B["vision_hidden"].ptr.value,
+                seq, VIS_H, VIS_D, stream)
+        elif use_fp8:
+            self._fp8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vision_ffn_up_w_{i}",
+                B["vision_hidden"].ptr.value,
+                seq, VIS_H, VIS_D, stream)
+        else:
+            gemm.fp16_nn(
+                B["vision_x_norm"].ptr.value, W["vision_ffn_up_w"][i],
+                B["vision_hidden"].ptr.value,
+                seq, VIS_H, VIS_D, stream=stream)
+        # bias + GELU on the FFN-hidden buffer.
+        # INT8 path uses the fused bf16-strict kernel; default BF16/FP8
+        # path keeps the un-fused upstream pair (add_bias + gelu_inplace)
+        # so SM89/SM120 numerics match upstream/main bit-for-bit.
+        if self.use_int8_decoder:
+            fvk.bias_gelu_bf16_strict(
+                B["vision_hidden"].ptr.value, W["vision_ffn_up_b"][i],
+                seq, VIS_H, stream=stream)
+        else:
+            self._bias_add_bf16(
+                B["vision_hidden"].ptr.value, W["vision_ffn_up_b"][i],
+                seq, VIS_H, stream)
+            fvk.gelu_inplace(
+                B["vision_hidden"].ptr.value, seq * VIS_H, stream=stream)
+
+        # FFN down → x_norm, then x += x_norm + down_bias
+        if use_int8_vis_static:
+            self._vis_static_int8_gemm(
+                B["vision_hidden"].ptr.value, seq * VIS_H,
+                f"vis_down_{i}", f"vision_ffn_down_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_H, stream)
+        elif use_int8_vis:
+            self._enc_int8_gemm(
+                B["vision_hidden"].ptr.value, seq * VIS_H,
+                f"vision_ffn_down_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_H, stream)
+        elif use_fp8:
+            self._fp8_gemm(
+                B["vision_hidden"].ptr.value, seq * VIS_H,
+                f"vision_ffn_down_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_H, stream)
+        else:
+            gemm.fp16_nn(
+                B["vision_hidden"].ptr.value, W["vision_ffn_down_w"][i],
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_H, stream=stream)
+        if is_last:
+            # Last layer: just bias_residual; vision_x is the final residual,
+            # consumed by avg_pool_vision_tokens / multi-modal projector.
+            # No follow-up LN to fuse.
+            fvk.bias_residual(
+                B["vision_x"].ptr.value, B["vision_x_norm"].ptr.value,
+                W["vision_ffn_down_b"][i], seq, VIS_D, stream=stream)
+        else:
+            # Layers 0..N-2: post-FFN bias_residual + NEXT layer's pre-attn
+            # LayerNorm. INT8 path fuses both into one kernel; default
+            # BF16/FP8 path runs the un-fused upstream pair so SM89/SM120
+            # numerics match upstream/main bit-for-bit. Either way,
+            # vision_x_norm ends up holding LN(vision_x post-residual)
+            # ready for layer i+1's attn QKV.
+            if self.use_int8_decoder:
+                fvk.bias_residual_layer_norm_bf16(
+                    B["vision_x"].ptr.value,                  # residual (in-place)
+                    B["vision_x_norm"].ptr.value,              # x (FFN-down output)
+                    W["vision_ffn_down_b"][i],                 # bias_pre
+                    W["vision_pre_attn_norm_w"][i + 1],
+                    W["vision_pre_attn_norm_b"][i + 1],
+                    B["vision_x_norm"].ptr.value,              # out (next layer's LN input)
+                    seq, VIS_D, 1e-5, stream=stream)
+            else:
+                fvk.bias_residual(
+                    B["vision_x"].ptr.value, B["vision_x_norm"].ptr.value,
+                    W["vision_ffn_down_b"][i], seq, VIS_D, stream=stream)
+                fvk.layer_norm(
+                    B["vision_x"].ptr.value,
+                    W["vision_pre_attn_norm_w"][i + 1],
+                    W["vision_pre_attn_norm_b"][i + 1],
+                    B["vision_x_norm"].ptr.value,
+                    seq, VIS_D, 1e-5, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Phase B: Gemma-2B encoder
+    # ══════════════════════════════════════════════════════════════════
+
+    def transformer_encoder(self, stream: int = 0) -> None:
+        """Project vision output + language tokens through the Gemma-2B encoder.
+
+        The language embeddings have already been copied into
+        ``bufs['encoder_x'][nv*256 : nv*256+prompt_len]`` by :meth:`forward`.
+        """
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        seq = self.encoder_seq_len
+        # vs_enc: token count fed to the encoder (post-pool); equals vision_seq when no pooling
+        vs_enc = self.vision_seq_enc
+        use_fp8 = self.use_fp8
+
+        # B0: LayerNorm(vision output) → project 1152→2048 + bias → encoder_x[:vs_enc]
+        # When vision_pool_factor > 1, read from vision_x_pooled (reduced token count);
+        # otherwise vision_x_pooled aliases vision_x so behaviour is unchanged.
+        fvk.layer_norm(
+            B["vision_x_pooled"].ptr.value,
+            W["vision_final_norm_w"], W["vision_final_norm_b"],
+            B["vision_x_norm"].ptr.value,
+            vs_enc, VIS_D, 1e-5, stream=stream)
+
+        if use_fp8 and "vision_projector_w" in self.weights.get("fp8", {}):
+            self._fp8_gemm(
+                B["vision_x_norm"].ptr.value, vs_enc * VIS_D,
+                "vision_projector_w",
+                B["encoder_x"].ptr.value,
+                vs_enc, ENC_D, VIS_D, stream)
+        else:
+            gemm.fp16_nn(
+                B["vision_x_norm"].ptr.value, W["encoder_multi_modal_projector_w"],
+                B["encoder_x"].ptr.value,
+                vs_enc, ENC_D, VIS_D, stream=stream)
+        fvk.add_bias_bf16(
+            B["encoder_x"].ptr.value, W["encoder_multi_modal_projector_b"],
+            vs_enc, ENC_D, stream=stream)
+
+        # Language embeds have been written by frontend into encoder_x[vs_enc:vs_enc+lang_len]
+
+        # B1-B5: 18 encoder layers. Fuse previous B5 residual into this B1's RMS→FP8
+        fused = use_fp8 and self.fp8_calibrated
+        for i in range(ENC_L):
+            self._encoder_layer(i, seq, fuse_b1=(i > 0 and fused), stream=stream)
+
+    def _encoder_layer(self, i: int, seq: int, fuse_b1: bool, stream: int) -> None:
+        """One Gemma-2B encoder layer."""
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        attn_ptrs = self._attn_ptrs
+        fused = self.use_fp8 and self.fp8_calibrated
+        use_int8_enc = self.use_int8_encoder
+
+        # B1: RMSNorm → QKV GEMM
+        if use_int8_enc:
+            # Fused RMSNorm → INT8 (one global-memory pass, no intermediate BF16)
+            qkv_name = f"encoder_attn_qkv_w_{i}"
+            layer_scale_qkv = self._int8_scale_buf(qkv_name, seq)
+            act_i8_ptr = self._pick_enc_int8_scratch(seq * ENC_D)
+            fvk.rms_norm_int8_rowwise(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                act_i8_ptr, layer_scale_qkv.ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            self._int8_gemm_fused(
+                act_i8_ptr, qkv_name,
+                B["encoder_QKV"].ptr.value,
+                seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D,
+                layer_scale_qkv.ptr.value, stream)
+        elif fused:
+            qkv_name = f"encoder_attn_qkv_w_{i}"
+            act_scale_ptr = self.fp8_act_scales[qkv_name].ptr.value
+            if fuse_b1:
+                # Fused: previous layer B5 residual + this layer's RMSNorm → FP8
+                fvk.residual_add_rms_norm_fp8(
+                    B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                    self._rms_ones_enc.ptr.value,
+                    B["enc_act_fp8"].ptr.value,
+                    seq, ENC_D, 1e-6, act_scale_ptr, stream=stream)
+            else:
+                fvk.rms_norm_fp8(
+                    B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                    B["enc_act_fp8"].ptr.value,
+                    seq, ENC_D, 1e-6, act_scale_ptr, stream=stream)
+            self._fp8_gemm_fused(
+                B["enc_act_fp8"].ptr.value, qkv_name,
+                B["encoder_QKV"].ptr.value,
+                seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D,
+                act_scale_ptr, stream)
+        elif self.use_fp8:
+            # Pre-calibration FP8 path: separate RMSNorm + dynamic quant inside _fp8_gemm
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            self._fp8_gemm(
+                B["encoder_x_norm"].ptr.value, seq * ENC_D,
+                f"encoder_attn_qkv_w_{i}",
+                B["encoder_QKV"].ptr.value,
+                seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D, stream)
+        else:
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            gemm.fp16_nn(
+                B["encoder_x_norm"].ptr.value, W["encoder_attn_qkv_w"][i],
+                B["encoder_QKV"].ptr.value,
+                seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D, stream=stream)
+
+        # Split QKV + apply RoPE. K/V go into attn_backend's layer cache slice.
+        k_ptr, v_ptr = self._enc_kv_layer_ptrs(i, offset_tokens=0)
+        fvk.qkv_split_rope(
+            B["encoder_QKV"].ptr.value,
+            B["encoder_rope_weights"].ptr.value,
+            attn_ptrs["enc_Q"],  # (seq, 8, 256) — split from QKV into attn buf
+            k_ptr, v_ptr,
+            seq, ENC_NH * ENC_HD, ENC_NKV * ENC_HD, ENC_NKV * ENC_HD,
+            ENC_HD, stream=stream)
+
+        if i == ENC_L - 1:
+            # Last layer: no post-attn projection/FFN needed — encoder output is
+            # the K/V cache which the decoder reads. Skip to next phase.
+            return
+
+        # B2: Attention (GQA) — returns output pointer (no copy).
+        enc_o_ptr = self.attn.run("encoder", i, q_seq=seq, stream=stream)
+
+        # B3: Attn output projection → x_norm
+        if use_int8_enc:
+            self._enc_int8_gemm(
+                enc_o_ptr, seq * ENC_D,
+                f"encoder_attn_o_w_{i}",
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_D, stream)
+        elif self.use_fp8:
+            self._fp8_gemm(
+                enc_o_ptr, seq * ENC_D,
+                f"encoder_attn_o_w_{i}",
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_D, stream)
+        else:
+            gemm.fp16_nn(
+                enc_o_ptr, W["encoder_attn_o_w"][i],
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_D, stream=stream)
+
+        # B4: (residual_add + RMSNorm) fused → INT8 gate GEMM + SiLU-gated up GEMM
+        if use_int8_enc:
+            # Fused: x += x_norm (attn_o); RMSNorm(x) → INT8.
+            # Gate and up are quantized from the same activation (act_i8, act_scale).
+            # Gate GEMM writes gate_buf; up GEMM + SiLU-gated EVT writes hidden
+            # directly — eliminating the separate gate_geglu_merged kernel.
+            gate_name = f"encoder_ffn_gate_w_{i}"
+            up_name   = f"encoder_ffn_up_w_{i}"
+            act_scale = self._int8_scale_buf(gate_name, seq)
+            act_i8_ptr = self._pick_enc_int8_scratch(seq * ENC_D)
+            fvk.residual_add_rms_norm_int8_rowwise(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                self._rms_ones_enc.ptr.value,
+                act_i8_ptr, act_scale.ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            # Gate GEMM → gate_buf (seq, ENC_H)
+            self._int8_gemm_fused(
+                act_i8_ptr, gate_name,
+                B["encoder_gate_buf"].ptr.value,
+                seq, ENC_H, ENC_D,
+                act_scale.ptr.value, stream)
+            # Up GEMM + SiLU(gate)*up in EVT epilogue → encoder_hidden (seq, ENC_H)
+            self._int8_silu_gated_gemm_fused(
+                act_i8_ptr, up_name,
+                B["encoder_gate_buf"].ptr.value,
+                B["encoder_hidden"].ptr.value,
+                seq, ENC_H, ENC_D, act_scale.ptr.value, stream)
+        elif fused:
+            # Fused: residual + RMS → FP8 in one kernel, then FP8 GEMM
+            gu_name = f"encoder_ffn_gate_up_w_{i}"
+            act_scale_gu = self.fp8_act_scales[gu_name].ptr.value
+            fvk.residual_add_rms_norm_fp8(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                self._rms_ones_enc.ptr.value,
+                B["enc_act_fp8"].ptr.value,
+                seq, ENC_D, 1e-6, act_scale_gu, stream=stream)
+            self._fp8_gemm_fused(
+                B["enc_act_fp8"].ptr.value, gu_name,
+                B["encoder_gate_merged"].ptr.value,
+                seq, 2 * ENC_H, ENC_D, act_scale_gu, stream)
+        elif self.use_fp8:
+            # Pre-calibration: separate residual + rms + fp8_gemm
+            fvk.residual_add(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                seq * ENC_D, stream=stream)
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            self._fp8_gemm(
+                B["encoder_x_norm"].ptr.value, seq * ENC_D,
+                f"encoder_ffn_gate_up_w_{i}",
+                B["encoder_gate_merged"].ptr.value,
+                seq, 2 * ENC_H, ENC_D, stream)
+        else:
+            fvk.residual_add(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                seq * ENC_D, stream=stream)
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            gemm.fp16_nn(
+                B["encoder_x_norm"].ptr.value, W["encoder_ffn_gate_w"][i],
+                B["encoder_gate_merged"].ptr.value,
+                seq, ENC_H, ENC_D, stream=stream)
+            gemm.fp16_nn(
+                B["encoder_x_norm"].ptr.value, W["encoder_ffn_up_w"][i],
+                B["encoder_hidden"].ptr.value,
+                seq, ENC_H, ENC_D, stream=stream)
+
+        # SiLU(gate) * up → hidden (already done by silu_gated EVT above for INT8),
+        # then FFN down GEMM.
+        if use_int8_enc:
+            # encoder_hidden already has SiLU(gate)*up from the EVT kernel above.
+            # Just run the down projection.
+            self._enc_int8_gemm(
+                B["encoder_hidden"].ptr.value, seq * ENC_H,
+                f"encoder_ffn_down_w_{i}",
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_H, stream)
+        elif fused:
+            down_name = f"encoder_ffn_down_w_{i}"
+            act_scale_down = self.fp8_act_scales[down_name].ptr.value
+            fvk.gate_geglu_merged_fp8(
+                B["encoder_gate_merged"].ptr.value,
+                B["enc_act_fp8_large"].ptr.value,
+                seq, ENC_H, act_scale_down, stream=stream)
+            self._fp8_gemm_fused(
+                B["enc_act_fp8_large"].ptr.value, down_name,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_H, act_scale_down, stream)
+        elif self.use_fp8:
+            fvk.gate_geglu_merged(
+                B["encoder_gate_merged"].ptr.value,
+                B["encoder_hidden"].ptr.value,
+                seq, ENC_H, stream=stream)
+            self._fp8_gemm(
+                B["encoder_hidden"].ptr.value, seq * ENC_H,
+                f"encoder_ffn_down_w_{i}",
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_H, stream)
+        else:
+            fvk.gate_geglu(
+                B["encoder_gate_merged"].ptr.value,
+                B["encoder_hidden"].ptr.value,
+                B["encoder_hidden"].ptr.value,
+                seq * ENC_H, stream=stream)
+            gemm.fp16_nn(
+                B["encoder_hidden"].ptr.value, W["encoder_ffn_down_w"][i],
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_H, stream=stream)
+
+        # B5: Residual (skipped in fused mode — next layer's B1 handles it)
+        if not fused:
+            fvk.residual_add(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                seq * ENC_D, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Phase C: Gemma-300M decoder (flow matching)
+    # ══════════════════════════════════════════════════════════════════
+
+    def transformer_decoder(self, stream: int = 0) -> None:
+        """Run 10-step diffusion denoise on ``bufs['diffusion_noise']``."""
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        enc_seq = self.encoder_seq_len
+        ds = self.chunk_size
+        fused = self.use_fp8_decoder and self.fp8_calibrated
+
+        for step in range(self.num_steps):
+            plain_fp16 = (
+                self._fuse_fp16_gate_residual_ada
+                and not self.use_fp8_decoder
+                and not self.use_int8_decoder
+            )
+            # C0: Action input projection: noise (ds, 32) → decoder_x (ds, 1024)
+            gemm.fp16_nn(
+                B["diffusion_noise"].ptr.value,
+                W["decoder_action_in_proj_w"],
+                B["decoder_x"].ptr.value,
+                ds, DEC_D, ACTION_DIM, stream=stream)
+            self._bias_add_bf16(
+                B["decoder_x"].ptr.value, W["decoder_action_in_proj_b"],
+                ds, DEC_D, stream)
+
+            # 18 decoder layers
+            for i in range(DEC_L):
+                skip_c1 = (fused or self.use_int8_decoder or plain_fp16) and i > 0
+                self._decoder_layer(i, step, enc_seq, ds, skip_c1, stream)
+
+            # C8: Final AdaRMSNorm + output projection
+            if not plain_fp16:
+                fvk.ada_rms_norm_style(
+                    B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                    self._style_slice_ptr("decoder_style_final", step),
+                    B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                    ds, DEC_D, 1e-6, stream=stream)
+            gemm.fp16_nn(
+                B["x_normed_buf"].ptr.value,
+                W["decoder_action_out_proj_w"],
+                B["decoder_action_buf"].ptr.value,
+                ds, ACTION_DIM, DEC_D, stream=stream)
+            # noise += action_buf + bias (weights/bias pre-scaled by
+            # -1/num_steps by frontend). The fused path preserves the old
+            # FP16 rounding order: round(action_buf + bias), then add.
+            if self._fuse_fp16_action_update:
+                fvk.bias_residual_strict(
+                    B["diffusion_noise"].ptr.value,
+                    B["decoder_action_buf"].ptr.value,
+                    W["decoder_action_out_proj_b"],
+                    ds, ACTION_DIM, stream=stream)
+            else:
+                self._bias_add_bf16(
+                    B["decoder_action_buf"].ptr.value,
+                    W["decoder_action_out_proj_b"],
+                    ds, ACTION_DIM, stream)
+                fvk.residual_add(
+                    B["diffusion_noise"].ptr.value,
+                    B["decoder_action_buf"].ptr.value,
+                    ds * ACTION_DIM, stream=stream)
+
+    def _decoder_layer(self, i: int, step: int, enc_seq: int, ds: int,
+                       skip_c1: bool, stream: int) -> None:
+        """One Gemma-300M decoder layer."""
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        attn_ptrs = self._attn_ptrs
+        fused = self.use_fp8_decoder and self.fp8_calibrated
+        plain_fp16 = (
+            self._fuse_fp16_gate_residual_ada
+            and not self.use_fp8_decoder
+            and not self.use_int8_decoder
+        )
+
+        # C1: AdaRMSNorm with style modulation → FP8 (fused) or BF16
+        qkv_name = f"decoder_attn_qkv_w_{i}"
+        if fused:
+            act_scale_qkv = self.fp8_act_scales[qkv_name].ptr.value
+            if not skip_c1:
+                fvk.ada_rms_norm_style_fp8(
+                    B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                    self._style_slice_ptr("decoder_style_attn", step, i),
+                    B["dec_act_fp8"].ptr.value, B["gate_buf"].ptr.value,
+                    ds, DEC_D, 1e-6, act_scale_qkv, stream=stream)
+            self._fp8_gemm_fused(
+                B["dec_act_fp8"].ptr.value, qkv_name,
+                B["decoder_QKV"].ptr.value,
+                ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D,
+                act_scale_qkv, stream)
+        else:
+            if self.use_int8_decoder:
+                act_i8_ptr = B["dec_act_int8"].ptr.value
+                act_scale_qkv = self._int8_scale_buf(qkv_name, ds).ptr.value
+                if not skip_c1:
+                    fvk.ada_rms_norm_style_int8(
+                        B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                        self._style_slice_ptr("decoder_style_attn", step, i),
+                        act_i8_ptr, B["gate_buf"].ptr.value,
+                        ds, DEC_D, 1e-6, act_scale_qkv, stream=stream)
+            else:
+                if not skip_c1:
+                    fvk.ada_rms_norm_style(
+                        B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                        self._style_slice_ptr("decoder_style_attn", step, i),
+                        B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                        ds, DEC_D, 1e-6, stream=stream)
+            if self.use_fp8_decoder:
+                self._fp8_gemm(
+                    B["x_normed_buf"].ptr.value, ds * DEC_D,
+                    qkv_name,
+                    B["decoder_QKV"].ptr.value,
+                    ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D, stream)
+            elif self.use_int8_decoder:
+                self._int8_gemm_fused(
+                    B["dec_act_int8"].ptr.value, qkv_name,
+                    B["decoder_QKV"].ptr.value,
+                    ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D,
+                    self._int8_scale_buf(qkv_name, ds).ptr.value, stream)
+            else:
+                gemm.fp16_nn(
+                    B["x_normed_buf"].ptr.value, W["decoder_attn_qkv_w"][i],
+                    B["decoder_QKV"].ptr.value,
+                    ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D, stream=stream)
+
+        # C2: QKV split + RoPE. Decoder K/V write into enc cache at offset enc_seq.
+        k_ptr, v_ptr = self._enc_kv_layer_ptrs(i, offset_tokens=enc_seq)
+        fvk.qkv_split_rope(
+            B["decoder_QKV"].ptr.value,
+            B["decoder_rope_weights"].ptr.value,
+            attn_ptrs["dec_Q"],
+            k_ptr, v_ptr,
+            ds, DEC_NH * DEC_HD, DEC_NKV * DEC_HD, DEC_NKV * DEC_HD,
+            DEC_HD, stream=stream)
+
+        # C3: Cross-attention (decoder Q over enc+dec K/V cache) — returns ptr.
+        dec_o_ptr = self.attn.run(
+            "decoder", i,
+            q_seq=ds,
+            kv_seq=enc_seq + ds,
+            stream=stream,
+        )
+
+        # C4: Attn output projection
+        if self.use_fp8_decoder:
+            self._fp8_gemm(
+                dec_o_ptr, ds * DEC_NH * DEC_HD,
+                f"decoder_attn_o_w_{i}",
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_NH * DEC_HD, stream)
+        elif self.use_int8_decoder:
+            self._int8_gemm(
+                dec_o_ptr, ds * DEC_NH * DEC_HD,
+                f"decoder_attn_o_w_{i}",
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_NH * DEC_HD, stream)
+        else:
+            gemm.fp16_nn(
+                dec_o_ptr, W["decoder_attn_o_w"][i],
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_NH * DEC_HD, stream=stream)
+
+        # C4→C5: gate*residual + AdaRMSNorm + FFN gate_up (fused SiLU-gated for INT8)
+        gu_name   = f"decoder_ffn_gate_up_w_{i}"    # FP8/BF16 merged name (legacy)
+        gate_name = f"decoder_ffn_gate_w_{i}"       # INT8 separate gate
+        up_name   = f"decoder_ffn_up_w_{i}"         # INT8 separate up
+        if fused:
+            act_scale_gu = self.fp8_act_scales[gu_name].ptr.value
+            fvk.gate_residual_ada_norm_fp8(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value,
+                self._rms_ones_dec.ptr.value,
+                self._style_slice_ptr("decoder_style_ffn", step, i),
+                B["dec_act_fp8"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, act_scale_gu, stream=stream)
+            self._fp8_gemm_fused(
+                B["dec_act_fp8"].ptr.value, gu_name,
+                B["decoder_gate_merged"].ptr.value,
+                ds, 2 * DEC_H, DEC_D, act_scale_gu, stream)
+        else:
+            if self.use_int8_decoder:
+                act_i8_ptr = B["dec_act_int8"].ptr.value
+                act_scale_gate = self._int8_scale_buf(gate_name, ds).ptr.value
+                fvk.gate_residual_ada_norm_int8(
+                    B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                    B["gate_buf"].ptr.value,
+                    self._rms_ones_dec.ptr.value,
+                    self._style_slice_ptr("decoder_style_ffn", step, i),
+                    act_i8_ptr, B["gate_buf"].ptr.value,
+                    ds, DEC_D, 1e-6, act_scale_gate, stream=stream)
+            else:
+                if plain_fp16:
+                    fvk.gate_residual_ada_norm(
+                        B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                        B["gate_buf"].ptr.value,
+                        self._rms_ones_dec.ptr.value,
+                        self._style_slice_ptr("decoder_style_ffn", step, i),
+                        B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                        ds, DEC_D, 1e-6, stream=stream)
+                else:
+                    fvk.gate_mul_residual(
+                        B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                        B["gate_buf"].ptr.value, ds * DEC_D, stream=stream)
+                    fvk.ada_rms_norm_style(
+                        B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                        self._style_slice_ptr("decoder_style_ffn", step, i),
+                        B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                        ds, DEC_D, 1e-6, stream=stream)
+            if self.use_fp8_decoder:
+                self._fp8_gemm(
+                    B["x_normed_buf"].ptr.value, ds * DEC_D,
+                    gu_name,
+                    B["decoder_gate_merged"].ptr.value,
+                    ds, 2 * DEC_H, DEC_D, stream)
+            elif self.use_int8_decoder:
+                # INT8: separate gate GEMM → decoder_gate_buf,
+                #       up GEMM + SiLU-gated EVT → decoder_hidden.
+                #       Eliminates gate_geglu_merged (C6).
+                act_scale_gu_ptr = self._int8_scale_buf(gate_name, ds).ptr.value
+                act_i8 = B["dec_act_int8"].ptr.value
+                self._int8_gemm_fused(
+                    act_i8, gate_name,
+                    B["decoder_gate_buf"].ptr.value,
+                    ds, DEC_H, DEC_D,
+                    act_scale_gu_ptr, stream)
+                self._int8_silu_gated_gemm_fused(
+                    act_i8, up_name,
+                    B["decoder_gate_buf"].ptr.value,
+                    B["decoder_hidden"].ptr.value,
+                    ds, DEC_H, DEC_D, act_scale_gu_ptr, stream)
+            elif plain_fp16 and self._merge_fp16_decoder_gate_up:
+                gemm.fp16_nn(
+                    B["x_normed_buf"].ptr.value,
+                    W["decoder_ffn_gate_up_w"][i],
+                    B["decoder_gate_merged"].ptr.value,
+                    ds, 2 * DEC_H, DEC_D, stream=stream)
+            else:
+                gemm.fp16_nn(
+                    B["x_normed_buf"].ptr.value, W["decoder_ffn_gate_w"][i],
+                    B["decoder_gate_merged"].ptr.value,
+                    ds, DEC_H, DEC_D, stream=stream)
+                gemm.fp16_nn(
+                    B["x_normed_buf"].ptr.value, W["decoder_ffn_up_w"][i],
+                    B["decoder_hidden"].ptr.value,
+                    ds, DEC_H, DEC_D, stream=stream)
+
+        # C6: SiLU(gate) * up → FFN down
+        down_name = f"decoder_ffn_down_w_{i}"
+        if fused:
+            act_scale_down = self.fp8_act_scales[down_name].ptr.value
+            fvk.gate_geglu_merged_fp8(
+                B["decoder_gate_merged"].ptr.value,
+                B["dec_act_fp8_large"].ptr.value,
+                ds, DEC_H, act_scale_down, stream=stream)
+            self._fp8_gemm_fused(
+                B["dec_act_fp8_large"].ptr.value, down_name,
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_H, act_scale_down, stream)
+        elif self.use_fp8_decoder:
+            fvk.gate_geglu_merged(
+                B["decoder_gate_merged"].ptr.value,
+                B["decoder_hidden"].ptr.value,
+                ds, DEC_H, stream=stream)
+            self._fp8_gemm(
+                B["decoder_hidden"].ptr.value, ds * DEC_H,
+                down_name,
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_H, stream)
+        elif self.use_int8_decoder:
+            # decoder_hidden already filled by SiLU-gated EVT in C4→C5.
+            # Skip gate_geglu_merged — go directly to down GEMM.
+            self._int8_gemm(
+                B["decoder_hidden"].ptr.value, ds * DEC_H,
+                down_name,
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_H, stream)
+        else:
+            if plain_fp16 and self._merge_fp16_decoder_gate_up:
+                fvk.gate_geglu_merged(
+                    B["decoder_gate_merged"].ptr.value,
+                    B["decoder_hidden"].ptr.value,
+                    ds, DEC_H, stream=stream)
+            else:
+                fvk.gate_geglu(
+                    B["decoder_gate_merged"].ptr.value,
+                    B["decoder_hidden"].ptr.value,
+                    B["decoder_hidden"].ptr.value,
+                    ds * DEC_H, stream=stream)
+            gemm.fp16_nn(
+                B["decoder_hidden"].ptr.value, W["decoder_ffn_down_w"][i],
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_H, stream=stream)
+
+        # C7→C1_next: gate*residual + next layer's AdaRMSNorm → FP8 (fused)
+        if fused and i < DEC_L - 1:
+            next_qkv = f"decoder_attn_qkv_w_{i + 1}"
+            act_scale_next = self.fp8_act_scales[next_qkv].ptr.value
+            fvk.gate_residual_ada_norm_fp8(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value,
+                self._rms_ones_dec.ptr.value,
+                self._style_slice_ptr("decoder_style_attn", step, i + 1),
+                B["dec_act_fp8"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, act_scale_next, stream=stream)
+        elif self.use_int8_decoder and i < DEC_L - 1:
+            next_qkv = f"decoder_attn_qkv_w_{i + 1}"
+            act_scale_next = self._int8_scale_buf(next_qkv, ds).ptr.value
+            fvk.gate_residual_ada_norm_int8(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value,
+                self._rms_ones_dec.ptr.value,
+                self._style_slice_ptr("decoder_style_attn", step, i + 1),
+                B["dec_act_int8"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, act_scale_next, stream=stream)
+        elif plain_fp16:
+            style_key = "decoder_style_attn" if i < DEC_L - 1 else "decoder_style_final"
+            style_layer = i + 1 if i < DEC_L - 1 else None
+            style_ptr = (
+                self._style_slice_ptr(style_key, step, style_layer)
+                if style_layer is not None
+                else self._style_slice_ptr(style_key, step)
+            )
+            fvk.gate_residual_ada_norm(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value,
+                self._rms_ones_dec.ptr.value,
+                style_ptr,
+                B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, stream=stream)
+        else:
+            fvk.gate_mul_residual(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value, ds * DEC_D, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Full pipeline + calibration + graph
+    # ══════════════════════════════════════════════════════════════════
+
+    def run_pipeline(self, stream: int = 0) -> None:
+        """Run vision → encoder → decoder end-to-end on ``stream``.
+
+        Re-copies the stored language embeddings into ``encoder_x`` at the
+        prompt slot because the encoder layers overwrite that region in
+        place (residual stream). Without this, the second call on the
+        same pipeline would feed the encoder its own previous output
+        instead of fresh language tokens.
+        """
+        self._copy_lang_embeds_to_encoder_x(stream=stream)
+        self.vision_encoder(stream)
+        self.transformer_encoder(stream)
+        self.transformer_decoder(stream)
+
+    def calibrate_fp8(self) -> None:
+        """Run one forward pass with dynamic quantization to collect FP8 scales.
+
+        Equivalent to the Blackwell path: dynamic quant writes scales directly
+        into each layer's persistent scale buffer (via ``_fp8_gemm``), so
+        flipping ``fp8_calibrated = True`` afterwards enables the static-scale
+        fused kernels with zero further work.
+        """
+        if not self.use_fp8 or self.fp8_calibrated:
+            return
+
+        if len(self.fp8_act_scales) > 0:
+            self.fp8_calibrated = True
+            logger.info("FP8 reuse-from-forward: %d scales already populated",
+                        len(self.fp8_act_scales))
+            return
+
+        # Dynamic calibration pass (writes scales into fp8_act_scales as a
+        # side effect of _fp8_gemm's non-calibrated code path).
+        self.fp8_calibrated = False
+        self.run_pipeline(stream=0)
+        self._cudart.cudaDeviceSynchronize()
+        self.fp8_calibrated = True
+        logger.info("FP8 calibrated: %d activation scales collected",
+                    len(self.fp8_act_scales))
+
+    def autotune_gemms(self) -> None:
+        """Benchmark cuBLASLt algorithms for each GEMM shape and cache the best.
+
+        Call after ``calibrate_fp8()`` and before ``record_infer_graph()``.
+        """
+        B = self.bufs
+        W = self.weights
+        gemm = self.gemm
+        nv = self.num_views
+        vs = self.vision_seq
+        seq = self.encoder_seq_len
+        ds = self.chunk_size
+
+        logger.info("Autotuning GEMM algorithms...")
+
+        # Vision patch embedding (BF16)
+        gemm.autotune_fp16_nn(
+            B["vision_patches"].ptr.value,
+            W["vision_patch_embedding_w"],
+            B["vision_x"].ptr.value,
+            vs, VIS_D, VIS_PATCH_FLAT)
+
+        # Vision BF16 attention + FFN shapes (when FP8 and INT8 are both
+        # disabled, e.g. Orin SM87).  Autotuning picks the best cuBLASLt
+        # algorithm for each shape; all 27 layers share these 5 shapes so
+        # one autotune run covers the entire SigLIP stack.
+        # Output buffers must be large enough for each shape's output.
+        if not self.use_fp8 and not self.use_int8_vision:
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in [
+                (vs, 3 * VIS_D, VIS_D, "vision_x_norm", "vision_QKV",
+                 W["vision_attn_qkv_w"][0]),
+                (vs, VIS_D,     VIS_D, "vision_x_norm", "vision_x_norm",
+                 W["vision_attn_o_w"][0]),
+                (vs, VIS_H,     VIS_D, "vision_x_norm", "vision_hidden",
+                 W["vision_ffn_up_w"][0]),
+                (vs, VIS_D,     VIS_H, "vision_hidden",  "vision_x_norm",
+                 W["vision_ffn_down_w"][0]),
+                (self.vision_seq_enc, ENC_D, VIS_D, "vision_x_norm", "encoder_x",
+                 W["encoder_multi_modal_projector_w"]),
+            ]:
+                gemm.autotune_fp16_nn(
+                    B[act_key].ptr.value, weight_ptr,
+                    B[out_key].ptr.value,
+                    M_val, N_val, K_val)
+
+        # Vision FP8 shapes
+        if self.use_fp8 and self.fp8_calibrated and "vision_attn_qkv_w_0" in self.weights.get("fp8", {}):
+            for name_prefix, M_val, N_val, K_val, out_key in [
+                ("vision_attn_qkv_w_0", vs, 3 * VIS_D, VIS_D, "vision_QKV"),
+                ("vision_attn_o_w_0",   vs, VIS_D,     VIS_D, "vision_x_norm"),
+                ("vision_ffn_up_w_0",   vs, VIS_H,     VIS_D, "vision_hidden"),
+                ("vision_ffn_down_w_0", vs, VIS_D,     VIS_H, "vision_x_norm"),
+                ("vision_projector_w",  vs, ENC_D,     VIS_D, "encoder_x"),
+            ]:
+                w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
+                act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
+                if K_val == VIS_H:
+                    act_buf = B["vis_act_fp8_large"]
+                else:
+                    act_buf = B["vis_act_fp8"]
+                self._autotune_fp8_matmul(
+                    act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+
+        # Encoder FP8 shapes
+        if self.use_fp8 and self.fp8_calibrated:
+            for name_prefix, M_val, N_val, K_val, out_key in [
+                ("encoder_attn_qkv_w_0",    seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D, "encoder_QKV"),
+                ("encoder_attn_o_w_0",      seq, ENC_D,      ENC_D, "encoder_x_norm"),
+                ("encoder_ffn_gate_up_w_0", seq, 2 * ENC_H,  ENC_D, "encoder_gate_merged"),
+                ("encoder_ffn_down_w_0",    seq, ENC_D,      ENC_H, "encoder_x_norm"),
+            ]:
+                w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
+                act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
+                act_buf = B["enc_act_fp8_large"] if K_val == ENC_H else B["enc_act_fp8"]
+                self._autotune_fp8_matmul(
+                    act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+        elif not self.use_int8_encoder:
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in [
+                (seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D,
+                 "encoder_x_norm", "encoder_QKV", W["encoder_attn_qkv_w"][0]),
+                (seq, ENC_D, ENC_D,
+                 "encoder_x_norm", "encoder_x_norm", W["encoder_attn_o_w"][0]),
+                (seq, ENC_H, ENC_D,
+                 "encoder_x_norm", "encoder_gate_merged", W["encoder_ffn_gate_w"][0]),
+                (seq, ENC_H, ENC_D,
+                 "encoder_x_norm", "encoder_hidden", W["encoder_ffn_up_w"][0]),
+                (seq, ENC_D, ENC_H,
+                 "encoder_hidden", "encoder_x_norm", W["encoder_ffn_down_w"][0]),
+            ]:
+                gemm.autotune_fp16_nn(
+                    B[act_key].ptr.value, weight_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val)
+
+        # Decoder FP8 shapes
+        if self.use_fp8 and self.use_fp8_decoder and self.fp8_calibrated:
+            for name_prefix, M_val, N_val, K_val, out_key in [
+                ("decoder_attn_qkv_w_0",    ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D, "decoder_QKV"),
+                ("decoder_attn_o_w_0",      ds, DEC_D,     DEC_NH * DEC_HD, "x_normed_buf"),
+                ("decoder_ffn_gate_up_w_0", ds, 2 * DEC_H, DEC_D, "decoder_gate_merged"),
+                ("decoder_ffn_down_w_0",    ds, DEC_D,     DEC_H, "x_normed_buf"),
+            ]:
+                w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
+                act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
+                act_buf = B["dec_act_fp8_large"] if K_val == DEC_H else B["dec_act_fp8"]
+                self._autotune_fp8_matmul(
+                    act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+        elif not self.use_int8_decoder:
+            decoder_shapes = [
+                (ds, DEC_D, ACTION_DIM,
+                 "diffusion_noise", "decoder_x", W["decoder_action_in_proj_w"]),
+                (ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D,
+                 "x_normed_buf", "decoder_QKV", W["decoder_attn_qkv_w"][0]),
+                (ds, DEC_D, DEC_NH * DEC_HD,
+                 "decoder_QKV", "x_normed_buf", W["decoder_attn_o_w"][0]),
+            ]
+            if self._merge_fp16_decoder_gate_up:
+                decoder_shapes.append(
+                    (ds, 2 * DEC_H, DEC_D,
+                     "x_normed_buf", "decoder_gate_merged",
+                     W["decoder_ffn_gate_up_w"][0])
+                )
+            else:
+                decoder_shapes.extend([
+                    (ds, DEC_H, DEC_D,
+                     "x_normed_buf", "decoder_gate_merged",
+                     W["decoder_ffn_gate_w"][0]),
+                    (ds, DEC_H, DEC_D,
+                     "x_normed_buf", "decoder_hidden",
+                     W["decoder_ffn_up_w"][0]),
+                ])
+            decoder_shapes.extend([
+                (ds, DEC_D, DEC_H,
+                 "decoder_hidden", "x_normed_buf", W["decoder_ffn_down_w"][0]),
+                (ds, ACTION_DIM, DEC_D,
+                 "x_normed_buf", "decoder_action_buf",
+                 W["decoder_action_out_proj_w"]),
+            ])
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in decoder_shapes:
+                gemm.autotune_fp16_nn(
+                    B[act_key].ptr.value, weight_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val)
+
+        if self.use_int8_decoder and "decoder_attn_qkv_w_0" in self.weights.get("int8", {}):
+            logger.info(
+                "Skipping cuBLASLt INT8 autotune: decoder INT8 uses CUTLASS fused path")
+
+        self._cudart.cudaDeviceSynchronize()
+        logger.info("Autotune complete")
+
+    def record_infer_graph(self, external_stream_int: int | None = None) -> None:
+        """Capture the full pipeline as a CUDA Graph.
+
+        Because the attention backend may run framework-specific kernels
+        (e.g. ``flash_attn_func`` via PyTorch), CUDA graph capture must use
+        a stream that the backend's framework treats as "current" — otherwise
+        the backend's kernels will launch on the framework's default stream,
+        creating a cross-stream dependency that ``cudaStreamBeginCapture``
+        refuses to record.
+
+        Frontends that use a framework-aware attention backend should pass
+        ``external_stream_int`` (the raw ``cudaStream_t`` int handle of a
+        framework-owned stream) and wrap the call in their framework's
+        "current stream" context. For example, the torch frontend does::
+
+            torch_stream = torch.cuda.Stream()
+            with torch.cuda.stream(torch_stream):
+                pipeline.record_infer_graph(
+                    external_stream_int=torch_stream.cuda_stream)
+
+        If ``external_stream_int`` is ``None``, a raw cuda stream is created
+        and used directly (this works only with pure-C attention backends).
+        """
+        if self.use_fp8 and not self.fp8_calibrated:
+            self.calibrate_fp8()
+        self.autotune_gemms()
+
+        self._graph = CUDAGraph()
+        if external_stream_int is None:
+            stream = self._graph.create_stream()
+            stream_int = stream.value or 0
+            stream_handle = stream
+        else:
+            stream_int = int(external_stream_int)
+            stream_handle = ctypes.c_void_p(stream_int)
+        self._graph_stream = stream_handle
+
+        # Warmup on the capture stream to stabilize allocations
+        for _ in range(3):
+            self.run_pipeline(stream=stream_int)
+        self._cudart.cudaStreamSynchronize(stream_handle)
+
+        # Capture full pipeline
+        self._graph.begin_capture(stream_handle)
+        self.run_pipeline(stream=stream_int)
+        self._graph.end_capture(stream_handle)
+        self._cudart.cudaStreamSynchronize(stream_handle)
+        logger.info("CUDA Graph captured for Pi05Pipeline")
+
+        # Also capture a decoder-only graph for temporal K/V caching.
+        # This graph skips vision_encoder + transformer_encoder and runs only
+        # transformer_decoder, reusing the K/V cache from the last full forward.
+        # The language embeds and encoder K/V buffers are left intact.
+        self._decoder_only_graph = CUDAGraph()
+        for _ in range(3):
+            self.transformer_decoder(stream=stream_int)
+        self._cudart.cudaStreamSynchronize(stream_handle)
+        self._decoder_only_graph.begin_capture(stream_handle)
+        self.transformer_decoder(stream=stream_int)
+        self._decoder_only_graph.end_capture(stream_handle)
+        self._cudart.cudaStreamSynchronize(stream_handle)
+        logger.info("CUDA Graph captured for Pi05Pipeline (decoder-only)")
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Public API
+    # ══════════════════════════════════════════════════════════════════
+
+    # ── Input buffer handles (frontend writes to these) ──
+
+    @property
+    def input_images_buf(self) -> CudaBuffer:
+        """Pipeline input: observation images (num_views, 224, 224, 3) bf16."""
+        return self.bufs["observation_images_normalized"]
+
+    @property
+    def input_noise_buf(self) -> CudaBuffer:
+        """Pipeline input/output: diffusion noise (chunk_size, 32) bf16.
+
+        Frontend writes initial noise here before :meth:`forward`; reads
+        final actions from here after.
+        """
+        return self.bufs["diffusion_noise"]
+
+    @property
+    def input_encoder_x_buf(self) -> CudaBuffer:
+        """Pipeline input: encoder_x, with language embeds at [vs:vs+len]."""
+        return self.bufs["encoder_x"]
+
+    def set_language_embeds(self, lang_embeds_np) -> None:
+        """Store language embeddings for this prompt.
+
+        The embeds are kept as a persistent device-side copy and are
+        re-copied into ``encoder_x[vs:vs+prompt_len]`` at the start of
+        every :meth:`forward` call, because the encoder layers overwrite
+        that slot in-place during each pass (transformer residual stream).
+
+        ``lang_embeds_np`` is a numpy array of shape ``(prompt_len, ENC_D)``
+        with 2-byte (bf16) elements.
+        """
+        prompt_len = lang_embeds_np.shape[0]
+        assert prompt_len <= self.max_prompt_len, \
+            f"prompt_len {prompt_len} exceeds max_prompt_len {self.max_prompt_len}"
+        assert lang_embeds_np.shape[1] == ENC_D
+
+        # Store a persistent device copy of the (prompt_len, ENC_D) embeds.
+        arr = np.ascontiguousarray(lang_embeds_np)
+        self._lang_embeds_buf = CudaBuffer.from_numpy(arr)
+        self._current_prompt_len = prompt_len
+
+        # Update decoder RoPE slice for this prompt length
+        self._set_decoder_rope_for_prompt(prompt_len)
+
+        # Initial copy into encoder_x (so the FIRST calibration pass sees
+        # the correct lang embeds without needing a prior forward() call).
+        self._copy_lang_embeds_to_encoder_x()
+
+    def _copy_lang_embeds_to_encoder_x(self, stream: int = 0) -> None:
+        """D2D copy stored lang embeds into encoder_x[vs:vs+prompt_len]."""
+        if not hasattr(self, "_lang_embeds_buf"):
+            return  # set_language_embeds not called yet (first build)
+        start_byte = self.vision_seq_enc * ENC_D * 2  # language embeds follow pooled vision tokens
+        dst_ptr = self.bufs["encoder_x"].ptr.value + start_byte
+        self._cudart.cudaMemcpyAsync(
+            ctypes.c_void_p(dst_ptr),
+            self._lang_embeds_buf.ptr,
+            self._lang_embeds_buf.nbytes, 3, stream)  # D2D
+
+    def forward(self) -> int:
+        """Replay the captured graph (or fall back to ``run_pipeline``).
+
+        The frontend must have already written the inputs:
+            - ``input_images_buf``       (observation images)
+            - ``input_noise_buf``        (initial diffusion noise)
+            - language embeds via :meth:`set_language_embeds` (once per prompt)
+
+        After this returns, ``input_noise_buf`` contains the final actions.
+        Returns the device pointer of that buffer for the frontend to read.
+        """
+        if self._graph is not None:
+            self._graph.replay(self._graph_stream)
+            self._cudart.cudaStreamSynchronize(self._graph_stream)
+        else:
+            self.run_pipeline(stream=0)
+            self._cudart.cudaDeviceSynchronize()
+        return self.bufs["diffusion_noise"].ptr.value
+
+    def forward_decode_only(self) -> int:
+        """Replay the decoder-only graph for temporal K/V caching.
+
+        Skips vision_encoder + transformer_encoder and runs only
+        transformer_decoder, reusing the encoder K/V cache from the last
+        full :meth:`forward` call. The frontend must write fresh noise into
+        ``input_noise_buf`` before calling this.
+
+        Returns the device pointer of ``diffusion_noise`` (final actions).
+        """
+        if hasattr(self, "_decoder_only_graph") and self._decoder_only_graph is not None:
+            self._decoder_only_graph.replay(self._graph_stream)
+            self._cudart.cudaStreamSynchronize(self._graph_stream)
+        else:
+            self.transformer_decoder(stream=0)
+            self._cudart.cudaDeviceSynchronize()
+        return self.bufs["diffusion_noise"].ptr.value


### PR DESCRIPTION
## Summary

Add an opt-in full-FP16 Pi0.5 RTX SM120 path for RTX 5090 benchmarking and deployment experiments.

- Adds `use_fp16=True` routing for `config="pi05"`, `framework="torch"`, `hardware="rtx_sm120"`.
- Keeps the default Pi0.5 RTX path unchanged: FP8/BF16 remains the default.
- Adds isolated FP16 frontend/pipeline copies so Thor, Orin, RTX 4090/L40, and default RTX FP8 paths do not inherit this path.
- Adds FP16-specific fused kernels for decoder residual/AdaRMSNorm and final action update.
- Adds FP16 cuBLASLt autotune coverage for the full Pi0.5 path.
- Adds `examples/blackwell/bench_pi05_fp16.py`.
- Documents the opt-in usage in `USAGE.md` and `docs/stable_api.md`.

## Validation

- Rebuilt `flash_rt_kernels` in the StableHLO container.
- Ran syntax/API checks.
- Verified invalid configs fail clearly:
  - `use_fp16=True` with `use_fp8=True`
  - non-SM120 hardware
  - unsupported FP16 `vision_pool_factor`

RTX 5090, Pi0.5, 3 views, 10 steps:

- wall p50: `32.295 ms`
- wall p95: `32.481 ms`
- internal p50: `32.213 ms`

## Notes

This is intentionally opt-in and scoped to RTX SM120. It does not change the default Pi0.5 RTX FP8/BF16 route.