### PR TITLE
fix(pi05): fix bf16 bias gelu binding shape

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -4638,7 +4638,7 @@ N must be a multiple of 32; K must be a multiple of 64.
                                 int seq_len, int dim, uintptr_t stream) {
         bias_gelu_inplace_bf16(typed_ptr<__nv_bfloat16>(x),
                                typed_ptr<__nv_bfloat16>(bias),
-                               seq_len * dim, dim, to_stream(stream));
+                               seq_len, dim, to_stream(stream));
     }, py::arg("x"), py::arg("bias"), py::arg("seq_len"), py::arg("dim"),
        py::arg("stream") = 0);
 
@@ -4646,7 +4646,7 @@ N must be a multiple of 32; K must be a multiple of 64.
                                        int seq_len, int dim, uintptr_t stream) {
         bias_gelu_inplace_bf16(typed_ptr<__nv_bfloat16>(x),
                                typed_ptr<__nv_bfloat16>(bias),
-                               seq_len * dim, dim, to_stream(stream));
+                               seq_len, dim, to_stream(stream));
     }, py::arg("x"), py::arg("bias"), py::arg("seq_len"), py::arg("dim"),
        py::arg("stream") = 0);
 


### PR DESCRIPTION
# Fix Pi0.5 BF16 Bias GELU Binding Shape

## Summary

This PR fixes the pybind wrappers for `bias_gelu_bf16` and
`bias_gelu_bf16_strict`.

Both wrappers already receive the logical BF16 activation matrix shape as
`(seq_len, dim)`, but they previously passed `(seq_len * dim, dim)` into
`bias_gelu_inplace_bf16`. That made the CUDA kernel operate on
`seq_len * dim * dim` elements instead of `seq_len * dim`, causing an
out-of-bounds write. In the Pi0.5 INT8 path, the failure surfaced later as a
cuBLAS error during vision encoder calibration.

## Change

Only the pybind argument forwarding is changed:

```diff
- seq_len * dim, dim
+ seq_len, dim
```

Affected bindings:

- `bias_gelu_bf16`
- `bias_gelu_bf16_strict`

No CUDA source, CMake target ownership, public API, or runtime routing is
changed.

## Root Cause

The CUDA helper expects a matrix shape:

```cpp
bias_gelu_inplace_bf16(x, bias, M, N, stream)
```

The Python binding receives:

```cpp
seq_len, dim
```

So the correct call is:

```cpp
bias_gelu_inplace_bf16(..., seq_len, dim, ...)
```

For Pi0.5 vision FFN, a representative INT8 activation shape is:

```text
seq_len = 512
dim = 4304
```

The old wrapper therefore described the buffer as:

```text
M = 512 * 4304
N = 4304
```

That is much larger than the allocated activation tensor.

## Why This Was Observed In INT8

The default BF16 Pi0.5 path does not use this fused wrapper. It uses separate
bias add and GELU calls:

```python
_bias_add_bf16(...)
gelu_inplace(...)
```

The full Pi0.5 INT8 path uses the fused BF16 activation wrapper after the
vision FFN up GEMM:

```python
fvk.bias_gelu_bf16_strict(..., seq, VIS_H, ...)
```

That is why the issue was exposed by INT8 testing even though the faulty
kernel operates on BF16 activation buffers.

## Validation Environment


**Hardware & System**

| Field | Value |
|---|---|
| Device | Jetson AGX Orin 32G |
| Machine | KST Jetson AGX Orin AVSAI |
| SoC | tegra234 |
| Arch | aarch64 |
| RAM | 30698 MB |
| Visible GPU memory | 29.98 GB |
| SM count | 14 |
| GPU capability | SM87 / compute capability 8.7 |

**Software Stack**

| Field | Value |
|---|---|
| L4T | R36.4.7 |
| Ubuntu | 22.04.5 LTS |
| Kernel | 5.15.148-tegra |
| CUDA Toolkit | 12.6.68 |
| Python | 3.10.12 |
| GCC/G++ | 11.4.0 |
| PyTorch | 2.8.0 |
| Torch CUDA | 12.6 |

**Pi0.5 Runtime Configuration**

| Field | Value |
|---|---|
| Runtime path | Pi0.5 RTX pipeline |
| Checkpoint | `/root/models/pi05_libero_finetuned_v044` |
| Python environment | `/root/pi0.5` |
| Build target | `flash_rt_kernels` |
| Precision mode | full Pi0.5 INT8 path (`FVK_PI05_RTX_FORCE_INT8=1`) |


## Build Validation

```bash
cmake --build build -j4 --target flash_rt_kernels
```

The target rebuilt successfully after the fix.

## Reproduction Before The Fix

To reproduce the pre-fix failure, I temporarily restored the old binding shape
forwarding and rebuilt `flash_rt_kernels`.

Command:

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
export FVK_PI05_RTX_FORCE_INT8=1
unset FVK_PI05_RTX_INT8_ENCODER_ONLY

python examples/orin/bench_pi05.py \
  --checkpoint /root/models/pi05_libero_finetuned_v044 \
  --num-views 2 \
  --pool 1 \
  --layers 27 \
  --steps 10 \
  --cache-frames 1 \
  --warmup 1 \
  --reps 1
```

Result:

```text
WARNING:flash_rt.frontends.torch.pi05_rtx:FVK_PI05_RTX_FORCE_INT8/INT8_ENCODER_ONLY set: INT8 encoder+decoder

Loading checkpoint: /root/models/pi05_libero_finetuned_v044
Calibrating...
Traceback (most recent call last):
  File "/root/FlashRT/examples/orin/bench_pi05.py", line 142, in <module>
    main()
  File "/root/FlashRT/examples/orin/bench_pi05.py", line 112, in main
    pipe.calibrate_with_real_data([obs])
  File "/root/FlashRT/flash_rt/frontends/torch/pi05_rtx.py", line 1160, in calibrate_with_real_data
    self.calibrate(sample_observations)
  File "/root/FlashRT/flash_rt/frontends/torch/pi05_rtx.py", line 1149, in calibrate
    self._calibrate_single_frame(obs_list[0])
  File "/root/FlashRT/flash_rt/frontends/torch/pi05_rtx.py", line 1187, in _calibrate_single_frame
    self.pipeline.run_pipeline(stream=stream_int)
  File "/root/FlashRT/flash_rt/models/pi05/pipeline_rtx.py", line 1648, in run_pipeline
    self.vision_encoder(stream)
  File "/root/FlashRT/flash_rt/models/pi05/pipeline_rtx.py", line 862, in vision_encoder
    self._vision_layer(i, seq, use_fp8, stream, is_last=(i == last))
  File "/root/FlashRT/flash_rt/models/pi05/pipeline_rtx.py", line 1001, in _vision_layer
    gemm.bf16_nn(
RuntimeError: cuBLAS error at /root/FlashRT/csrc/gemm/gemm_runner.cu:675 code=13
```

## Validation After The Fix

After restoring the fixed binding and rebuilding `flash_rt_kernels`, the same
command completed successfully.

Command:

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
export FVK_PI05_RTX_FORCE_INT8=1
unset FVK_PI05_RTX_INT8_ENCODER_ONLY

python examples/orin/bench_pi05.py \
  --checkpoint /root/models/pi05_libero_finetuned_v044 \
  --num-views 2 \
  --pool 1 \
  --layers 27 \
  --steps 10 \
  --cache-frames 1 \
  --warmup 1 \
  --reps 1
```

Result:

```text
WARNING:flash_rt.frontends.torch.pi05_rtx:FVK_PI05_RTX_FORCE_INT8/INT8_ENCODER_ONLY set: INT8 encoder+decoder
  autotune: tested 8 algos, best=0 (90.3232 us)
  autotune: tested 8 algos, best=2 (196.893 us)
  autotune: tested 8 algos, best=0 (78.5312 us)
  autotune: tested 8 algos, best=0 (244.461 us)
  autotune: tested 8 algos, best=1 (257.526 us)
  autotune: tested 8 algos, best=2 (128.013 us)

Loading checkpoint: /root/models/pi05_libero_finetuned_v044
Calibrating...
Warmup (1 iters)...
Measuring (1 iters)...

=======================================================
  Config : num_views=2  pool=1  layers=27  steps=10  cache_frames=1
  Actions: (10, 7)
  p50    : 164.2 ms   -> 6.09 Hz
  p95    : 164.2 ms
  min    : 164.2 ms   -> 6.09 Hz
=======================================================
```

## Additional Runtime Validation

The fixed INT8 path also completed a 300-frame LIBERO action-similarity run on
Jetson AGX Orin:

```bash
python examples/orin/eval_libero.py \
  --npz /root/pi05_eval/libero_episodes0_1_2_100frames_each.npz \
  --checkpoint /root/models/pi05_libero_finetuned_v044 \
  --frames 300 \
  --warmup 3 \
  --configs baseline,cache2 \
  --out /root/pi05_eval/flashrt_int8_after_upstream_300f.npz
```

Observed latency:

- INT8 baseline p50: approximately `163.5 ms`
- INT8 cache2 p50: approximately `104.4 ms`

## Checklist

- [x] Focused one-file runtime binding fix.
- [x] Rebased on current `upstream/main`.
- [x] Rebuilt `flash_rt_kernels` on affected hardware.
- [x] Reproduced the pre-fix failure.
- [x] Verified the fixed INT8 Pi0.5 path with `bench_pi05.py`.
- [x] Ran a longer 300-frame Pi0.5 INT8 action-similarity validation.
- [x] Did not commit generated build outputs, checkpoints, or logs.
