### PR TITLE
perf(pi05): autotune BF16 encoder and decoder GEMMs

### DIFF
--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -1753,6 +1753,30 @@ class Pi05Pipeline:
                 self._autotune_fp8_matmul(
                     act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+        # Plain encoder GEMMs fall back to BF16 when neither FP8 nor
+        # INT8 owns the encoder matmuls.
+        elif not self.use_fp8 and not self.use_int8_encoder:
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in [
+                (seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D,
+                 "encoder_x_norm", "encoder_QKV",
+                 W["encoder_attn_qkv_w"][0]),
+                (seq, ENC_D, ENC_D,
+                 "encoder_x_norm", "encoder_x_norm",
+                 W["encoder_attn_o_w"][0]),
+                (seq, ENC_H, ENC_D,
+                 "encoder_x_norm", "encoder_gate_merged",
+                 W["encoder_ffn_gate_w"][0]),
+                (seq, ENC_H, ENC_D,
+                 "encoder_x_norm", "encoder_hidden",
+                 W["encoder_ffn_up_w"][0]),
+                (seq, ENC_D, ENC_H,
+                 "encoder_hidden", "encoder_x_norm",
+                 W["encoder_ffn_down_w"][0]),
+            ]:
+                gemm.autotune_bf16_nn(
+                    B[act_key].ptr.value, weight_ptr,
+                    B[out_key].ptr.value,
+                    M_val, N_val, K_val)
 
         # Decoder FP8 shapes
         if self.use_fp8 and self.use_fp8_decoder and self.fp8_calibrated:
@@ -1768,6 +1792,40 @@ class Pi05Pipeline:
                 self._autotune_fp8_matmul(
                     act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+        # Plain decoder GEMMs fall back to BF16 when neither FP8 nor
+        # INT8 owns the decoder matmuls.
+        elif not self.use_fp8_decoder and not self.use_int8_decoder:
+            # BF16 decoder shapes dominate Orin baseline runtime. Tune them
+            # explicitly before graph capture instead of relying on the
+            # cuBLASLt heuristic top-1 selected at first use.
+            decoder_shapes = [
+                (ds, DEC_D, ACTION_DIM,
+                 "diffusion_noise", "decoder_x",
+                 W["decoder_action_in_proj_w"]),
+                (ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D,
+                 "x_normed_buf", "decoder_QKV",
+                 W["decoder_attn_qkv_w"][0]),
+                (ds, DEC_D, DEC_NH * DEC_HD,
+                 "decoder_QKV", "x_normed_buf",
+                 W["decoder_attn_o_w"][0]),
+                (ds, DEC_H, DEC_D,
+                 "x_normed_buf", "decoder_gate_merged",
+                 W["decoder_ffn_gate_w"][0]),
+                (ds, DEC_H, DEC_D,
+                 "x_normed_buf", "decoder_hidden",
+                 W["decoder_ffn_up_w"][0]),
+                (ds, DEC_D, DEC_H,
+                 "decoder_hidden", "x_normed_buf",
+                 W["decoder_ffn_down_w"][0]),
+                (ds, ACTION_DIM, DEC_D,
+                 "x_normed_buf", "decoder_action_buf",
+                 W["decoder_action_out_proj_w"]),
+            ]
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in decoder_shapes:
+                gemm.autotune_bf16_nn(
+                    B[act_key].ptr.value, weight_ptr,
+                    B[out_key].ptr.value,
+                    M_val, N_val, K_val)
 
         if self.use_int8_decoder and "decoder_attn_qkv_w_0" in self.weights.get("int8", {}):
             logger.info(


### PR DESCRIPTION
## Summary

This PR extends Pi0.5 BF16 cuBLASLt autotune coverage on the RTX/Orin pipeline. Vision BF16 GEMMs were already autotuned, while plain Gemma encoder and decoder BF16 GEMMs still used the first cuBLASLt heuristic selected at runtime.

The change only updates:

```text
flash_rt/models/pi05/pipeline_rtx.py
```

It adds BF16 autotune entries for encoder attention/FFN projections and decoder action, attention, and FFN projections. It does not change model weights, precision conversion, kernels, or action-generation control flow.

## Motivation

Jetson AGX Orin profiling showed that the Pi0.5 BF16 baseline is dominated by cuBLASLt GEMMs, including encoder and decoder GEMMs without explicit autotune coverage.

Before this PR, INT8 was faster on the same Orin setup, but a supplementary 300-frame LIBERO offline check showed a larger action deviation when INT8 was compared with the full BF16 baseline:

| Config | p50 | Hz | MAE mean | MAE p95 | Cosine mean | Cosine min | Max abs p95 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| BF16 baseline before this PR | ~242.6-243.0 ms | ~4.12 | 0 | 0 | 1.000000 | 1.000000 | 0 |
| INT8 baseline | 163.5 ms | 6.12 | 0.094455 | 0.173261 | 0.875158 | 0.150065 | 1.919478 |

The INT8 cosine mean drops to `0.875` (average angular deviation greater than 25 degrees from the BF16 baseline), and its minimum cosine similarity falls to `0.15`. This indicates both a systematic direction shift and occasional near-orthogonal action predictions relative to the BF16 baseline. This PR therefore explores a BF16 latency optimization that avoids introducing this quantization-induced action deviation.

## What Changed

Added `gemm.autotune_bf16_nn(...)` coverage in `Pi05Pipeline.autotune_gemms()` for:

- Encoder QKV, attention output, FFN gate, FFN up, and FFN down projections.
- Decoder action input, QKV, attention output, FFN gate, FFN up, FFN down, and action output projections.

The new blocks follow existing precision routing:

- Encoder BF16 autotune runs only when neither FP8 nor INT8 owns the encoder GEMMs.
- Decoder BF16 autotune runs only when neither FP8 nor INT8 owns the decoder GEMMs.
- FP8 remains on the existing FP8 autotune path.
- Full INT8 keeps using its CUTLASS INT8 path.
- FP16 uses `pipeline_rtx_fp16.py`, not this BF16 pipeline.

## Validation Environment

Validated on Jetson AGX Orin 32G:

| Field | Value |
| --- | --- |
| Device | Jetson AGX Orin 32G |
| Machine | KST Jetson AGX Orin AVSAI |
| SoC | tegra234 |
| Arch | aarch64 |
| L4T | R36.4.7 |
| Ubuntu | 22.04.5 LTS |
| Kernel | 5.15.148-tegra |
| CUDA Toolkit | 12.6.68 |
| Python | 3.10.12 |
| GCC/G++ | 11.4.0 |
| RAM | 30698 MB |
| PyTorch | 2.8.0 |
| Torch CUDA | 12.6 |
| GPU capability | SM87 / compute capability 8.7 |
| Visible GPU memory | 29.98 GB |
| SM count | 14 |

Checkpoint used for the latency benchmark:

```text
/root/models/pi05_libero_finetuned_v044
```

## Reproduction

Build the extension on the Jetson:

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
cmake --build build -j4 --target flash_rt_kernels
```

Run the existing Orin benchmark for BF16 baseline:

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
unset FVK_PI05_RTX_FORCE_INT8

python examples/orin/bench_pi05.py \
  --checkpoint /root/models/pi05_libero_finetuned_v044 \
  --num-views 2 \
  --pool 1 \
  --layers 27 \
  --steps 10 \
  --cache-frames 1 \
  --no-int8 \
  --warmup 8 \
  --reps 30
```

For BF16 `cache2`, run the same command with `--cache-frames 2`. Run both configs on the base branch and this PR branch for the before/after comparison. The benchmark prints:

```text
Config : num_views=2 pool=1 layers=27 steps=10 cache_frames=1
Actions: (10, 7)
p50    : ...
p95    : ...
min    : ...
```

## Latency Results

BF16 Pi0.5 latency on Jetson AGX Orin 32G:

| Config | Revision | p50 | p95 | Notes |
| --- | --- | ---: | ---: | --- |
| baseline | Before this PR | ~242.6-243.0 ms | ~244 ms | BF16 encoder/decoder GEMMs use first cuBLASLt heuristic |
| baseline | This PR | 215.9 ms | 217.1 ms | BF16 encoder/decoder shapes explicitly autotuned |
| cache2 | Before this PR | ~152 ms | ~243-245 ms | Temporal cache alternates refresh and reuse frames |
| cache2 | This PR | ~137 ms | ~218 ms | Full-refresh frames also benefit from BF16 GEMM autotune |

Baseline p50 improves by about `26-27 ms` (`~4.1 Hz` to `~4.6 Hz`). `cache2` p50 improves by about `15-16 ms`; its high p95 is expected because refresh frames remain much slower than reuse frames.

## Correctness Check

I also ran a supplementary Pi0.5 LIBERO action-similarity check on a 300-frame NPZ covering 3 episodes with 100 frames each. That evaluator is not included in this PR; reproducible latency validation uses `examples/orin/bench_pi05.py`. `cache2` is included because its refresh frames use the same BF16 encoder/decoder GEMM path.

BF16 `cache2` action similarity against the same-run BF16 baseline stayed within the expected run-to-run range:

| Revision | MAE mean | MAE p95 | Cosine mean | Cosine min | Max abs p95 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before this PR | 0.010613 | 0.049782 | 0.982723 | 0.478394 | 1.859494 |
| This PR | 0.010644 | 0.049523 | 0.982405 | 0.478944 | 1.859494 |

The first predicted action compared with dataset `reference_actions` also stayed aligned:

| Revision | Config | MAE mean | MAE p95 | Cosine mean | Cosine min | Max abs p95 |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Before this PR | baseline | 0.087353 | 0.132249 | 0.912225 | -0.897470 | 0.472012 |
| This PR | baseline | 0.087326 | 0.132257 | 0.912264 | -0.897294 | 0.472012 |
| Before this PR | cache2 | 0.081298 | 0.125228 | 0.938563 | -0.897470 | 0.410405 |
| This PR | cache2 | 0.081274 | 0.125360 | 0.938584 | -0.897294 | 0.410405 |

This is expected because the change only affects BF16 cuBLASLt algorithm selection during warmup/autotune.

## Checks

```bash
python -m py_compile flash_rt/models/pi05/pipeline_rtx.py
```

Jetson build and benchmark commands are listed under Reproduction.

