### PR TITLE
feat(lingbot-thor): LingBot-VLA Thor backend, one flash_rt_kernels.so…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,8 @@ set(FA2_DTYPES "fp16;bf16" CACHE STRING
 # Motus beta integration. Motus-specific kernels are additive and must keep
 # their symbols prefixed with ``motus_``. Keeping a build tag lets the public
 # package compile without Motus kernels when debugging unrelated model paths.
+option(FLASHRT_ENABLE_LINGBOT
+       "Build LingBot-VLA Thor (sm_110) model kernels and bindings" ON)
 option(FLASHRT_ENABLE_MOTUS
        "Build Motus-specific RTX SM120 kernels and bindings" ON)
 if(FLASHRT_ENABLE_MOTUS)
@@ -981,6 +983,29 @@ if(ENABLE_SM100_CUTLASS)
   )
   target_link_libraries(flash_rt_fp4 PRIVATE CUDA::cudart)
   install(TARGETS flash_rt_fp4 DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
+endif()
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  LingBot-VLA model-specific kernels (fused AdaRMSNorm / SwiGLU tail / QKV+RoPE).
+#  Compiled INTO flash_rt_kernels (NOT a separate .so) — same pattern as the
+#  qwen36 model kernels in csrc/kernels/. lingbot_-prefixed symbols + bindings
+#  (csrc/bindings.cpp, #ifdef ENABLE_LINGBOT). Thor-only: gated on
+#  FLASHRT_ENABLE_LINGBOT AND GPU_ARCH==110 so RTX (sm_120) / Orin / L40 builds
+#  neither compile the lingbot_* sources nor define ENABLE_LINGBOT (the bindings
+#  are #ifdef'd the same way). Disable with -DFLASHRT_ENABLE_LINGBOT=OFF.
+#  Inherits flash_rt_kernels' CUDA flags (--ftz/--prec-div=false/--prec-sqrt=false),
+#  numerically equivalent to these kernels' original --use_fast_math build.
+# ──────────────────────────────────────────────────────────────────────
+if(FLASHRT_ENABLE_LINGBOT AND GPU_ARCH STREQUAL "110")
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/kernels/lingbot_norm_fp8.cu
+    csrc/kernels/lingbot_rope_qkv.cu
+    csrc/kernels/lingbot_silu_mul_fp8.cu)
+  target_compile_definitions(flash_rt_kernels PRIVATE ENABLE_LINGBOT=1)
+  message(STATUS "LingBot-VLA kernels: compiled into flash_rt_kernels (sm_${GPU_ARCH})")
+else()
+  message(STATUS "LingBot-VLA kernels: DISABLED (Thor sm_110 only; current sm_${GPU_ARCH})")
 endif()
 
 

--- a/benchmarks/lingbot_thor_latency.py
+++ b/benchmarks/lingbot_thor_latency.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+"""LingBot-VLA (Thor sm_110) latency + accuracy benchmark.
+
+Runs the LingBot-VLA flow-matching action expert end-to-end through the
+low-level ``graph_runner.sample_actions_graph`` path (LingBot is not registered
+in ``load_model`` — see ``docs/lingbot_usage.md``) and reports, per denoise
+step count:
+
+- whether the FA4 fast path is active (vs the fmha fallback),
+- P50 CUDA-graph-replay latency,
+- cosine similarity of the action chunk vs an optional reference ``.pt``.
+
+A/B the attention path with ``FLASHRT_THOR_FA4=0`` (force fmha) vs ``=1`` (FA4).
+
+    CUTE_DSL_ARCH=sm_101a python benchmarks/lingbot_thor_latency.py \
+        --checkpoint /path/to/lingbot-vla-4b \
+        --calibration /path/to/lingbot_thor_static.json \
+        --inputs /path/to/baseline_artifacts_10/inputs \
+        --reference /path/to/baseline_artifacts_10/outputs/actions.pt \
+        --steps 50 25 10
+
+Missing checkpoint/inputs -> the benchmark prints why and exits 0 (clean skip),
+so it is safe to invoke in environments without local fixtures.
+"""
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+_INPUT_KEYS = ["images", "img_masks", "lang_tokens", "lang_masks", "state", "noise"]
+
+
+def _skip(msg: str) -> "None":
+    print(f"[lingbot-bench] SKIP: {msg}")
+    sys.exit(0)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="LingBot-VLA Thor latency + accuracy")
+    ap.add_argument("--checkpoint", help="lingbot-vla-4b dir (model.safetensors)")
+    ap.add_argument("--calibration", help="FP8 static-scale calibration JSON")
+    ap.add_argument("--inputs", help="dir with %s .pt" % "/".join(_INPUT_KEYS))
+    ap.add_argument("--reference", default=None,
+                    help="optional reference action chunk .pt for cosine")
+    ap.add_argument("--steps", type=int, nargs="+", default=[50, 25, 10])
+    ap.add_argument("--iters", type=int, default=20)
+    args = ap.parse_args()
+
+    for name, val in (("--checkpoint", args.checkpoint),
+                      ("--calibration", args.calibration),
+                      ("--inputs", args.inputs)):
+        if not val:
+            _skip(f"{name} not provided")
+        if not Path(val).exists():
+            _skip(f"{name} path does not exist: {val}")
+
+    import torch
+    from flash_rt.executors.torch_weights import SafetensorsSource
+    from flash_rt.executors.weight_loader import WeightLoader
+    from flash_rt.frontends.torch._lingbot_thor_spec import build_spec
+    from flash_rt.models.lingbot.buffer_binder import bind_target_to_device
+    from flash_rt.models.lingbot.kernel_ops import clear_fp8_weight_cache
+    from flash_rt.models.lingbot.graph_runner import sample_actions_graph
+    from flash_rt.models.lingbot import calibration as calib
+    from flash_rt.hardware.thor import fa4_backend
+
+    if not torch.cuda.is_available():
+        _skip("CUDA device not available")
+
+    print(f"[lingbot-bench] FA4 status: {fa4_backend.status()}"
+          f"  (FLASHRT_THOR_FA4={os.environ.get('FLASHRT_THOR_FA4', '1')})")
+
+    ref = None
+    if args.reference and Path(args.reference).exists():
+        ref = torch.load(args.reference).float().reshape(-1).cuda()
+
+    clear_fp8_weight_cache()
+    src = SafetensorsSource(str(Path(args.checkpoint) / "model.safetensors"),
+                            device="cpu", strip_prefix="")
+    target = SimpleNamespace()
+    WeightLoader(src, target=target, spec=build_spec()).run()
+    bind_target_to_device(target, dtype=torch.bfloat16, device="cuda")
+    calib.set_static_scales(calib.load_calibration(
+        args.calibration, device=torch.device("cuda")))
+    inp = {k: torch.load(Path(args.inputs) / f"{k}.pt").cuda() for k in _INPUT_KEYS}
+
+    print(f"[lingbot-bench] {'steps':>5} | {'P50 (ms)':>9} | {'finite':>6} | cosine vs reference")
+    for ns in args.steps:
+        replay, out, g = sample_actions_graph(
+            target=target, num_steps=ns, warmup_iters=3, **inp)
+        replay(); torch.cuda.synchronize()
+        finite = bool(torch.isfinite(out).all().item())
+        cos = "n/a"
+        if ref is not None and ref.numel() == out.numel():
+            o = out.float().reshape(-1).cuda()
+            cos = "%.6f" % float(torch.nn.functional.cosine_similarity(
+                o, ref, dim=0).item())
+        ts = []
+        for _ in range(args.iters):
+            torch.cuda.synchronize(); t0 = time.perf_counter()
+            replay(); torch.cuda.synchronize(); ts.append(time.perf_counter() - t0)
+        p50 = sorted(ts)[len(ts) // 2] * 1000
+        print(f"[lingbot-bench] {ns:>5} | {p50:>9.1f} | {str(finite):>6} | {cos}")
+        del replay, out, g
+        torch.cuda.empty_cache(); clear_fp8_weight_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/attention/flash_attn_4_src/VENDOR.md
+++ b/csrc/attention/flash_attn_4_src/VENDOR.md
@@ -1,0 +1,97 @@
+# Vendored: FlashAttention-4 (CuTe-DSL) — Thor / SM100 forward only
+
+This is a trimmed vendor of the `flash_attn/cute` (FlashAttention-4, CuTe-DSL)
+forward path, used by the LingBot-VLA Thor backend for prefix + denoise
+attention. It contains **only** what the Blackwell (SM100, including sm_110 /
+Thor) forward kernel needs for inference.
+
+## Source
+
+- Upstream:  https://github.com/Dao-AILab/flash-attention  (`flash_attn/cute/`)
+- Variant:   FlashAttention-4 CuTe-DSL implementation (Hopper + Blackwell).
+             Header dates the snapshot `2025-07-04`; authored against
+             `nvidia-cutlass-dsl` 4.2.0 (we run it on 4.5.1).
+- License:   BSD-3-Clause (see `flashrt_fa4/cute/LICENSE`, `flashrt_fa4/cute/AUTHORS`).
+
+The CuTe-DSL forward path is a Python/JIT kernel, so unlike the FA2 vendor
+there are no `.cu`/`.cpp` sources here and nothing is compiled into
+`flash_rt_kernels`. The runtime deps (`nvidia-cutlass-dsl`, `quack-kernels`)
+ship via the `thor-fa4` pip extra.
+
+## Private package name (isolation)
+
+The package is renamed `flash_attn` → **`flashrt_fa4`** so that importing it
+never shadows a pip-installed `flash_attn` (the RTX backends use
+`from flash_attn import flash_attn_func`, the FA2 wheel). All internal
+`flash_attn.cute.*` imports were rewritten to `flashrt_fa4.cute.*`. The loader
+(`flash_rt/hardware/thor/fa4_backend.py`) adds this directory to `sys.path`
+only transiently and imports `flashrt_fa4.cute`.
+
+## Scope (what was kept)
+
+Forward, SM100-class, inference only. The kept files are exactly the import
+closure of the SM100 forward kernel + the forward-only public entry:
+
+- `flash_fwd_sm100.py`            — the SM100 forward kernel
+- `flash_fwd_combine.py`          — split-KV partial-result combine
+- `pack_gqa.py`, `paged_kv.py`    — GQA packing / paged-KV
+- `mask.py`, `softmax.py`, `seqlen_info.py`, `block_info.py`
+- `block_sparsity.py`, `block_sparse_utils.py`  (imported by the fwd kernel)
+- `mma_sm100_desc.py`, `blackwell_helpers.py`, `named_barrier.py`,
+  `tile_scheduler.py`, `pipeline.py`, `barrier.py`
+- `cute_dsl_utils.py`, `cache_utils.py`, `copy_utils.py`, `utils.py`,
+  `fast_math.py`, `fa_logging.py`, `testing.py`, `ampere_helpers.py`,
+  `cute_dsl_ptxas.py`
+- `interface_fwd_sm100.py`        — **local** forward-only entry (see below)
+
+## Removed from upstream
+
+- **All backward kernels**: `flash_bwd*.py`, `flash_bwd_sm{90,100,120}.py`,
+  `flash_bwd_pre/postprocess.py`, the 2CTA backward kernels.
+- **Non-SM100 forward kernels**: `flash_fwd.py` (SM80), `flash_fwd_sm90.py`,
+  `flash_fwd_sm120.py`.
+- **MLA** forward: `flash_fwd_mla_sm100.py`, `topk_gather_kv.py`.
+- **head_dim=256 2CTA** kernels: `sm100_hd256_2cta_fmha_*.py`.
+- Benchmarks / search: `benchmark*.py`, `bench_utils.py`,
+  `sm90_config_search.py`, `compute_block_sparsity.py`.
+- All non-`cute` packages of the wheel: `models/`, `modules/`, `layers/`,
+  `losses/`, `ops/` (Triton), `utils/`, `bert_padding.py`,
+  `flash_attn_interface.py`, `flash_attn_triton*.py`, `flash_blocksparse*.py`.
+
+## Local patches
+
+1. **`flashrt_fa4/cute/interface_fwd_sm100.py`** (renamed from `interface.py`):
+   - The heavy unconditional top-level imports of the backward / SM80 / SM90 /
+     SM120 / MLA / 2CTA kernels were removed. Upstream `interface.py` imported
+     all of them at module load even for a single forward call.
+   - The removed forward classes (`FlashAttentionForwardSm80/90/120`,
+     `FlashAttentionMLAForwardSm100`, `BlackwellFusedMultiHeadAttentionForward`)
+     are replaced with stubs that raise a clear `RuntimeError`. They are only
+     referenced by dead arch-dispatch branches inside `_flash_attn_fwd`; on
+     Blackwell those branches never execute. The SM100 forward control flow is
+     **byte-identical** to upstream (verified bit-exact, see below).
+   - All `_flash_attn_bwd*` helpers were deleted; `FlashAttnFunc.backward` /
+     `FlashAttnVarlenFunc.backward` raise `NotImplementedError`.
+2. **`flashrt_fa4/cute/__init__.py`**: imports from `interface_fwd_sm100`
+   instead of the (removed) `interface`.
+3. Package rename `flash_attn` → `flashrt_fa4` (isolation; see above).
+4. Trailing whitespace was stripped from the kept `.py` files (inert for
+   Python) so the tree passes `git diff --check`.
+
+Trim result: the full `flash_attn` wheel (100+ files across `cute/`, `models/`,
+`modules/`, `layers/`, `ops/`, …) is reduced to **32 vendored files** — 30 under
+`flashrt_fa4/cute/` (27 `.py` plus `LICENSE`, `AUTHORS`, `.flake8`), the
+`flashrt_fa4/__init__.py` namespace shim, and this `VENDOR.md`. The SM100
+forward output is **bit-exact** vs the full upstream FA4 forward
+(`cosine = 1.00000000`, `max_abs_diff = 0`).
+
+## Update procedure
+
+1. Pull the desired upstream `flash_attn/cute/` snapshot.
+2. Re-apply the trim: keep the SM100-forward import closure listed above;
+   delete backward / SM80 / SM90 / SM120 / MLA / 2CTA / benchmarks / non-cute.
+3. Re-apply the three local patches (forward-only `interface_fwd_sm100.py`,
+   `__init__.py` entry, `flash_attn`→`flashrt_fa4` rename:
+   `grep -rl 'flash_attn\.cute' | xargs sed -i 's/flash_attn\.cute/flashrt_fa4.cute/g'`).
+4. Verify forward is bit-exact vs the untrimmed source on a tiny tensor, then
+   run the LingBot FA4-vs-fmha A/B (`docs/lingbot_usage.md`).

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/__init__.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/.flake8
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 100
+# W503: line break before binary operator
+ignore = E731, E741, F841, W503

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/AUTHORS
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/AUTHORS
@@ -1,0 +1,8 @@
+Tri Dao
+Jay Shah
+Ted Zadouri
+Markus Hoehnerbach
+Vijay Thakkar
+Timmy Liu
+Driss Guessous
+Reuben Stern

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/LICENSE
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, the respective contributors, as shown by the AUTHORS file.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/__init__.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/__init__.py
@@ -1,0 +1,25 @@
+"""Flash Attention CUTE (CUDA Template Engine) implementation.
+
+FlashRT vendors a forward / SM100-only subset of FlashAttention-4 for Thor
+(sm_110). The public entry point lives in ``interface_fwd_sm100`` instead of
+the upstream ``interface`` module so that importing this package does NOT pull
+in the backward, SM80/SM90/SM120, MLA, or head_dim=256 2CTA kernels (all
+removed -- see ``VENDOR.md``).
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("fa4")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+from .interface_fwd_sm100 import (
+    flash_attn_func,
+    flash_attn_varlen_func,
+)
+
+__all__ = [
+    "flash_attn_func",
+    "flash_attn_varlen_func",
+]

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/ampere_helpers.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/ampere_helpers.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2025, Tri Dao.
+from typing import Type, Callable, Optional
+
+import cutlass
+import cutlass.cute as cute
+
+
+def get_smem_layout_atom(dtype: Type[cutlass.Numeric], k_dim: int) -> cute.ComposedLayout:
+    dtype_byte = cutlass.const_expr(dtype.width // 8)
+    bytes_per_row = cutlass.const_expr(k_dim * dtype_byte)
+    smem_k_block_size = (
+        cutlass.const_expr(
+            128
+            if bytes_per_row % 128 == 0
+            else (64 if bytes_per_row % 64 == 0 else (32 if bytes_per_row % 32 == 0 else 16))
+        )
+        // dtype_byte
+    )
+    swizzle_bits = (
+        4
+        if smem_k_block_size == 128
+        else (3 if smem_k_block_size == 64 else (2 if smem_k_block_size == 32 else 1))
+    )
+    swizzle_base = 2 if dtype_byte == 4 else (3 if dtype_byte == 2 else 4)
+    return cute.make_composed_layout(
+        cute.make_swizzle(swizzle_bits, swizzle_base, swizzle_base),
+        0,
+        cute.make_ordered_layout(
+            (8 if cutlass.const_expr(k_dim % 32 == 0) else 16, smem_k_block_size), order=(1, 0)
+        ),
+    )
+
+
+@cute.jit
+def gemm(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsA: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_A: cute.TiledCopy,
+    smem_thr_copy_B: cute.TiledCopy,
+    hook_fn: Optional[Callable] = None,
+    A_in_regs: cutlass.Constexpr[bool] = False,
+    B_in_regs: cutlass.Constexpr[bool] = False,
+    swap_AB: cutlass.Constexpr[bool] = False,
+) -> None:
+    if cutlass.const_expr(swap_AB):
+        gemm(
+            tiled_mma,
+            acc,
+            tCrB,
+            tCrA,
+            tCsB,
+            tCsA,
+            smem_thr_copy_B,
+            smem_thr_copy_A,
+            hook_fn,
+            A_in_regs=B_in_regs,
+            B_in_regs=A_in_regs,
+            swap_AB=False,
+        )
+    else:
+        tCrA_copy_view = smem_thr_copy_A.retile(tCrA)
+        tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+        if cutlass.const_expr(not A_in_regs):
+            cute.copy(smem_thr_copy_A, tCsA[None, None, 0], tCrA_copy_view[None, None, 0])
+        if cutlass.const_expr(not B_in_regs):
+            cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+        for k in cutlass.range_constexpr(cute.size(tCsA.shape[2])):
+            if k < cute.size(tCsA.shape[2]) - 1:
+                if cutlass.const_expr(not A_in_regs):
+                    cute.copy(
+                        smem_thr_copy_A, tCsA[None, None, k + 1], tCrA_copy_view[None, None, k + 1]
+                    )
+                if cutlass.const_expr(not B_in_regs):
+                    cute.copy(
+                        smem_thr_copy_B, tCsB[None, None, k + 1], tCrB_copy_view[None, None, k + 1]
+                    )
+            cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+            if cutlass.const_expr(k == 0 and hook_fn is not None):
+                hook_fn()
+
+
+@cute.jit
+def gemm_rs(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_thr_copy_B: cute.TiledCopy,
+    hook_fn: Optional[Callable] = None,
+) -> None:
+    tCrB_copy_view = smem_thr_copy_B.retile(tCrB)
+    cute.copy(smem_thr_copy_B, tCsB[None, None, 0], tCrB_copy_view[None, None, 0])
+    for k in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
+        if cutlass.const_expr(k < cute.size(tCrA.shape[2]) - 1):
+            cute.copy(smem_thr_copy_B, tCsB[None, None, k + 1], tCrB_copy_view[None, None, k + 1])
+        cute.gemm(tiled_mma, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+        if cutlass.const_expr(k == 0 and hook_fn is not None):
+            hook_fn()

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/barrier.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/barrier.py
@@ -1,0 +1,71 @@
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
+
+
+@dsl_user_op
+def ld_acquire(lock_ptr: cute.Pointer, *, loc=None, ip=None) -> cutlass.Int32:
+    lock_ptr_i64 = lock_ptr.toint(loc=loc, ip=ip).ir_value()
+    state = llvm.inline_asm(
+        T.i32(),
+        [lock_ptr_i64],
+        "ld.global.acquire.gpu.b32 $0, [$1];",
+        "=r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    return cutlass.Int32(state)
+
+
+@dsl_user_op
+def red_relaxed(
+    lock_ptr: cute.Pointer, val: cutlass.Constexpr[Int32], *, loc=None, ip=None
+) -> None:
+    lock_ptr_i64 = lock_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [lock_ptr_i64, Int32(val).ir_value(loc=loc, ip=ip)],
+        "red.relaxed.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def red_release(
+    lock_ptr: cute.Pointer, val: cutlass.Constexpr[Int32], *, loc=None, ip=None
+) -> None:
+    lock_ptr_i64 = lock_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [lock_ptr_i64, Int32(val).ir_value(loc=loc, ip=ip)],
+        "red.release.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def wait_eq(lock_ptr: cute.Pointer, thread_idx: int | Int32, flag_offset: int, val: Int32) -> None:
+    flag_ptr = lock_ptr + flag_offset
+    if thread_idx == 0:
+        read_val = Int32(0)
+        while read_val != val:
+            read_val = ld_acquire(flag_ptr)
+
+
+@cute.jit
+def arrive_inc(
+    lock_ptr: cute.Pointer, thread_idx: int | Int32, flag_offset: int, val: cutlass.Constexpr[Int32]
+) -> None:
+    flag_ptr = lock_ptr + flag_offset
+    if thread_idx == 0:
+        red_release(flag_ptr, val)
+        # red_relaxed(flag_ptr, val)

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/blackwell_helpers.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/blackwell_helpers.py
@@ -1,0 +1,1113 @@
+# Copyright (c) 2025, Tri Dao.
+from typing import Optional, Tuple
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Boolean, const_expr
+from cutlass.cute.nvgpu import tcgen05
+from cutlass._mlir.dialects import llvm
+
+import flashrt_fa4.cute.mma_sm100_desc as sm100_desc
+
+
+def _tcgen05_mma_kind(op: cute.nvgpu.tcgen05.mma.MmaOp) -> str:
+    if isinstance(op, tcgen05.mma.MmaF16BF16Op):
+        return "f16"
+    if isinstance(op, tcgen05.mma.MmaTF32Op):
+        return "tf32"
+    if isinstance(op, tcgen05.mma.MmaI8Op):
+        return "i8"
+    if isinstance(op, tcgen05.mma.MmaFP8Op):
+        return "f8f6f4"
+    if isinstance(op, tcgen05.mma.MmaMXF8Op):
+        return "mxf8f6f4"
+    if isinstance(op, tcgen05.mma.MmaMXF4Op):
+        return "mxf4"
+    if isinstance(op, tcgen05.mma.MmaMXF4NVF4Op):
+        return "mxf4nvf4"
+    raise TypeError(f"Unsupported tcgen05 MMA op kind: {type(op).__name__}")
+
+
+@cute.jit
+def gemm_w_idx(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    A_idx: Optional[Int32] = None,
+    B_idx: Optional[Int32] = None,
+    zero_init: bool | Boolean = False,
+    swap_AB: bool = False,
+    num_unroll_groups: int = 1,
+) -> None:
+    if const_expr(swap_AB):
+        return gemm_w_idx(
+            tiled_mma, acc, tCrB, tCrA, B_idx, A_idx, zero_init=zero_init, swap_AB=False
+        )
+    else:
+        rA = tCrA if const_expr(A_idx is None) else tCrA[None, None, None, A_idx]
+        rB = tCrB if const_expr(B_idx is None) else tCrB[None, None, None, B_idx]
+
+        mma_atom = cute.make_mma_atom(tiled_mma.op)
+        for k in cutlass.range(
+            cute.size(tCrA.shape[2]), unroll=cute.size(tCrA.shape[2]) // num_unroll_groups
+        ):
+            mma_atom.set(tcgen05.Field.ACCUMULATE, not zero_init or k != 0)
+            cute.gemm(mma_atom, acc, rA[None, None, k], rB[None, None, k], acc)
+
+
+@cute.jit
+def gemm_ptx_w_idx(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    sA: Optional[cute.Tensor],
+    sB: cute.Tensor,
+    A_idx: Optional[Int32] = None,
+    B_idx: Optional[Int32] = None,
+    zero_init: bool | Boolean = False,
+    cta_group: int = 1,
+    **kwargs,
+) -> None:
+    rA = tCrA if const_expr(A_idx is None) else tCrA[None, None, None, A_idx]
+    rB = tCrB if const_expr(B_idx is None) else tCrB[None, None, None, B_idx]
+    sA_cur = None
+    if const_expr(sA is not None):
+        sA_cur = sA if const_expr(A_idx is None) else sA[None, None, None, A_idx]
+    sB_cur = sB if const_expr(B_idx is None) else sB[None, None, None, B_idx]
+    mma_atom = cute.make_mma_atom(tiled_mma.op)
+    acc_tmem_addr = acc.iterator.toint()
+    gemm_ptx_partial(
+        mma_atom.op,
+        acc_tmem_addr,
+        rA,
+        rB,
+        sA_cur,
+        sB_cur,
+        zero_init=zero_init,
+        cta_group=cta_group,
+        **kwargs,
+    )
+
+
+@cute.jit
+def gemm(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    zero_init: bool | Boolean = False,
+) -> None:
+    mma_atom = cute.make_mma_atom(tiled_mma.op)
+    for k in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
+        mma_atom.set(tcgen05.Field.ACCUMULATE, not zero_init or k != 0)
+        cute.gemm(mma_atom, acc, tCrA[None, None, k], tCrB[None, None, k], acc)
+
+
+def i64_to_i32x2(i: int) -> Tuple[int, int]:
+    """Convert a 64-bit integer to a tuple of two 32-bit integers."""
+    return i & 0xFFFF_FFFF, (i >> 32) & 0xFFFF_FFFF
+
+
+@cute.jit
+def gemm_ptx(
+    op: cute.nvgpu.tcgen05.mma.MmaOp,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    sA: Optional[cute.Tensor],
+    sB: cute.Tensor,
+    zero_init: bool | Boolean = False,
+) -> None:
+    is_ts = op.a_src == cute.nvgpu.tcgen05.OperandSource.TMEM
+    if const_expr(not is_ts):
+        assert sA is not None, "sA must be provided when a_src is not TMEM"
+    sA_layout = sA.layout if sA is not None else None
+    sB_layout = sB.layout
+    idesc: int = const_expr(sm100_desc.mma_op_to_idesc(op))
+    kind = _tcgen05_mma_kind(op)
+    if const_expr(not is_ts):
+        sA_swizzle = sA.iterator.type.swizzle_type
+        smem_desc_base_a: int = const_expr(
+            sm100_desc.make_smem_desc_base(
+                cute.recast_layout(128, op.a_dtype.width, sA_layout[0]),
+                sA_swizzle,
+                sm100_desc.Major.K
+                if const_expr(op.a_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+                else sm100_desc.Major.MN,
+            )
+        )
+        smem_desc_base_a_lo, smem_desc_a_hi = i64_to_i32x2(smem_desc_base_a)
+        smem_desc_base_a_lo = const_expr(smem_desc_base_a_lo)
+        smem_desc_a_hi = const_expr(smem_desc_a_hi)
+    else:
+        smem_desc_base_a = None
+        smem_desc_base_a_lo, smem_desc_a_hi = None, None
+    sB_swizzle = sB.iterator.type.swizzle_type
+    smem_desc_base_b: int = const_expr(
+        sm100_desc.make_smem_desc_base(
+            cute.recast_layout(128, op.b_dtype.width, sB_layout[0]),
+            sB_swizzle,
+            sm100_desc.Major.K
+            if const_expr(op.b_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+            else sm100_desc.Major.MN,
+        )
+    )
+    smem_desc_base_b_lo, smem_desc_b_hi = i64_to_i32x2(smem_desc_base_b)
+    smem_desc_base_b_lo = const_expr(smem_desc_base_b_lo)
+    smem_desc_b_hi = const_expr(smem_desc_b_hi)
+
+    if const_expr(not is_ts):
+        smem_desc_start_a_lo = Int32(smem_desc_base_a_lo) | sm100_desc.make_smem_desc_start_addr(
+            sA[None, None, 0].iterator
+        )
+    else:
+        smem_desc_start_a_lo = None
+    smem_desc_start_b_lo = Int32(smem_desc_base_b_lo) | sm100_desc.make_smem_desc_start_addr(
+        sB[None, None, 0].iterator
+    )
+    for k in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
+        if const_expr(not is_ts):
+            smem_desc_a_lo = smem_desc_start_a_lo + (
+                (cute.crd2idx((0, 0, k), sA_layout) * sA.element_type.width // 8) >> 4
+            )
+        smem_desc_b_lo = smem_desc_start_b_lo + (
+            (cute.crd2idx((0, 0, k), sB_layout) * sB.element_type.width // 8) >> 4
+        )
+        # with cute.arch.elect_one():
+        #     cute.printf("smem_desc_a_lo = {}, smem_desc_b_lo = {}", smem_desc_a_lo, smem_desc_b_lo)
+        #     cute.printf("smem_desc_a_lo_correct = {}, smem_desc_b_lo_correct = {}", smem_desc_a_lo_correct, smem_desc_b_lo_correct)
+        with cute.arch.elect_one():
+            if const_expr(not is_ts):
+                llvm.inline_asm(
+                    None,
+                    [
+                        acc.iterator.toint().ir_value(),
+                        smem_desc_a_lo.ir_value(),
+                        smem_desc_b_lo.ir_value(),
+                        Int32(not zero_init or k != 0).ir_value(),
+                    ],
+                    "{\n\t"
+                    ".reg .pred p;\n\t"
+                    ".reg .b64 smem_desc_a, smem_desc_b;\n\t"
+                    ".reg .b32 idesc;\n\t"
+                    f"mov.b32 idesc, {hex(idesc)};\n\t"
+                    f"mov.b64 smem_desc_a, {{$1, {hex(smem_desc_a_hi)}}};\n\t"
+                    f"mov.b64 smem_desc_b, {{$2, {hex(smem_desc_b_hi)}}};\n\t"
+                    "setp.ne.b32 p, $3, 0;\n\t"
+                    f"tcgen05.mma.cta_group::1.kind::{kind} [$0], smem_desc_a, smem_desc_b, idesc, p;\n\t"
+                    "}\n",
+                    "r,r,r,r",
+                    has_side_effects=True,
+                    is_align_stack=False,
+                    asm_dialect=llvm.AsmDialect.AD_ATT,
+                )
+            else:
+                llvm.inline_asm(
+                    None,
+                    [
+                        acc.iterator.toint().ir_value(),
+                        tCrA[None, None, k].iterator.toint().ir_value(),
+                        smem_desc_b_lo.ir_value(),
+                        Int32(not zero_init or k != 0).ir_value(),
+                    ],
+                    "{\n\t"
+                    ".reg .pred p;\n\t"
+                    ".reg .b64 smem_desc_b;\n\t"
+                    f"mov.b64 smem_desc_b, {{$2, {hex(smem_desc_b_hi)}}};\n\t"
+                    "setp.ne.b32 p, $3, 0;\n\t"
+                    f"tcgen05.mma.cta_group::1.kind::{kind} [$0], [$1], smem_desc_b, {hex(idesc)}, p;\n\t"
+                    "}\n",
+                    "r,r,r,r",
+                    has_side_effects=True,
+                    is_align_stack=False,
+                    asm_dialect=llvm.AsmDialect.AD_ATT,
+                )
+
+
+@cute.jit
+def gemm_ptx_loop(
+    op: cute.nvgpu.tcgen05.mma.MmaOp,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    sA: Optional[cute.Tensor],
+    sB: cute.Tensor,
+    zero_init: bool | Boolean = False,
+) -> None:
+    is_ts = op.a_src == cute.nvgpu.tcgen05.OperandSource.TMEM
+    if const_expr(not is_ts):
+        assert sA is not None, "sA must be provided when a_src is not TMEM"
+    sA_layout = sA.layout if sA is not None else tCrA.layout
+    sB_layout = sB.layout
+    idesc: int = const_expr(sm100_desc.mma_op_to_idesc(op))
+    kind = _tcgen05_mma_kind(op)
+    if const_expr(not is_ts):
+        sA_swizzle = sA.iterator.type.swizzle_type
+        smem_desc_base_a: int = const_expr(
+            sm100_desc.make_smem_desc_base(
+                cute.recast_layout(128, op.a_dtype.width, sA_layout[0]),
+                sA_swizzle,
+                sm100_desc.Major.K
+                if const_expr(op.a_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+                else sm100_desc.Major.MN,
+            )
+        )
+        smem_desc_base_a_lo, smem_desc_a_hi = i64_to_i32x2(smem_desc_base_a)
+        smem_desc_base_a_lo = const_expr(smem_desc_base_a_lo)
+        smem_desc_a_hi = const_expr(smem_desc_a_hi)
+    else:
+        smem_desc_base_a = None
+        smem_desc_base_a_lo, smem_desc_a_hi = None, None
+    sB_swizzle = sB.iterator.type.swizzle_type
+    smem_desc_base_b: int = const_expr(
+        sm100_desc.make_smem_desc_base(
+            cute.recast_layout(128, op.b_dtype.width, sB_layout[0]),
+            sB_swizzle,
+            sm100_desc.Major.K
+            if const_expr(op.b_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+            else sm100_desc.Major.MN,
+        )
+    )
+    smem_desc_base_b_lo, smem_desc_b_hi = i64_to_i32x2(smem_desc_base_b)
+    smem_desc_base_b_lo = const_expr(smem_desc_base_b_lo)
+    smem_desc_b_hi = const_expr(smem_desc_b_hi)
+
+    if const_expr(not is_ts):
+        offset_a = [
+            (cute.crd2idx((0, 0, k), sA_layout) * sA.element_type.width // 8) >> 4
+            for k in cutlass.range_constexpr(cute.size(tCrA.shape[2]))
+        ]
+    else:
+        offset_a = [
+            cute.crd2idx((0, 0, k), sA_layout) * op.a_dtype.width // 32
+            for k in cutlass.range_constexpr(cute.size(tCrA.shape[2]))
+        ]
+    offset_a_diff = [
+        offset_a[k] - offset_a[k - 1] for k in cutlass.range_constexpr(1, cute.size(tCrA.shape[2]))
+    ]
+    offset_b = [
+        (cute.crd2idx((0, 0, k), sB_layout) * sB.element_type.width // 8) >> 4
+        for k in cutlass.range_constexpr(cute.size(tCrB.shape[2]))
+    ]
+    offset_b_diff = [
+        offset_b[k] - offset_b[k - 1] for k in cutlass.range_constexpr(1, cute.size(tCrB.shape[2]))
+    ]
+
+    if const_expr(not is_ts):
+        smem_desc_start_a_lo = Int32(
+            smem_desc_base_a_lo | sm100_desc.make_smem_desc_start_addr(sA[None, None, 0].iterator)
+        )
+    else:
+        smem_desc_start_a_lo = None
+    smem_desc_start_b_lo = Int32(
+        smem_desc_base_b_lo | sm100_desc.make_smem_desc_start_addr(sB[None, None, 0].iterator)
+    )
+    pred_str = "p" if isinstance(zero_init, Boolean) else "0" if zero_init else "1"
+    if const_expr(not is_ts):
+        llvm.inline_asm(
+            None,
+            [
+                acc.iterator.toint().ir_value(),
+                Int32(cute.arch.make_warp_uniform(smem_desc_start_a_lo)).ir_value(),
+                Int32(cute.arch.make_warp_uniform(smem_desc_start_b_lo)).ir_value(),
+                Int32(not zero_init).ir_value(),
+            ],
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 smem_desc_a_lo, smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_a_hi, smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_a, smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            "mov.b32 smem_desc_a_lo, $1;\n\t"
+            "mov.b32 smem_desc_b_lo, $2;\n\t"
+            f"mov.b32 smem_desc_a_hi, {hex(smem_desc_a_hi)};\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_a, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $3, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [$0], smem_desc_a, smem_desc_b, idesc, {pred_str};\n\t"
+            + "".join(
+                (
+                    f"add.u32 smem_desc_a_lo, smem_desc_a_lo, {hex(offset_a_diff[k - 1])};\n\t"
+                    f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"mov.b64 smem_desc_a, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [$0], smem_desc_a, smem_desc_b, idesc, 1;\n\t"
+                )
+                for k in cutlass.range_constexpr(1, cute.size(tCrA.shape[2]))
+            )
+            + "}\n",
+            "r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    else:
+        llvm.inline_asm(
+            None,
+            [
+                acc.iterator.toint().ir_value(),
+                Int32(tCrA[None, None, 0].iterator.toint()).ir_value(),
+                Int32(smem_desc_start_b_lo).ir_value(),
+                Int32(not zero_init).ir_value(),
+            ],
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_a;\n\t"
+            ".reg .b32 smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            "mov.b32 tmem_a, $1;\n\t"
+            "mov.b32 smem_desc_b_lo, $2;\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $3, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [$0], [tmem_a], smem_desc_b, idesc, {pred_str};\n\t"
+            + "".join(
+                (
+                    # f"add.u32 tmem_a, tmem_a, {hex(offset_a_diff[k - 1])};\n\t"
+                    f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    # f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [$0], [tmem_a], smem_desc_b, idesc, 1;\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [$0], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
+                )
+                for k in cutlass.range_constexpr(1, cute.size(tCrA.shape[2]))
+            )
+            + "}\n",
+            "r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+
+@cute.jit
+def gemm_ptx_partial(
+    op: cute.nvgpu.tcgen05.mma.MmaOp,
+    acc_tmem_addr: Int32,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    sA: Optional[cute.Tensor],
+    sB: cute.Tensor,
+    mbar_ptr: Optional[cutlass.Pointer] = None,
+    mbar_phase: Optional[Int32] = None,
+    split_arrive: Optional[int] = None,
+    zero_init: bool | Boolean = False,
+    # sA_offset: Int32 = 0,
+    # acc_offset: Int32 = 0,
+    tA_addr: Optional[Int32] = None,
+    cta_group: int = 1,
+) -> None:
+    # acc_tmem_addr += acc_offset
+    is_ts = op.a_src == cute.nvgpu.tcgen05.OperandSource.TMEM
+    if const_expr(not is_ts):
+        assert sA is not None, "sA must be provided when a_src is not TMEM"
+    sA_layout = sA.layout if sA is not None else tCrA.layout
+    sB_layout = sB.layout
+    idesc: int = const_expr(sm100_desc.mma_op_to_idesc(op))
+    kind = _tcgen05_mma_kind(op)
+    if const_expr(not is_ts):
+        sA_swizzle = sA.iterator.type.swizzle_type
+        smem_desc_base_a: int = const_expr(
+            sm100_desc.make_smem_desc_base(
+                cute.recast_layout(128, op.a_dtype.width, sA_layout[0]),
+                sA_swizzle,
+                sm100_desc.Major.K
+                if const_expr(op.a_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+                else sm100_desc.Major.MN,
+            )
+        )
+        smem_desc_base_a_lo, smem_desc_a_hi = i64_to_i32x2(smem_desc_base_a)
+        smem_desc_base_a_lo = const_expr(smem_desc_base_a_lo)
+        smem_desc_a_hi = const_expr(smem_desc_a_hi)
+    else:
+        smem_desc_base_a = None
+        smem_desc_base_a_lo, smem_desc_a_hi = None, None
+    sB_swizzle = sB.iterator.type.swizzle_type
+    smem_desc_base_b: int = const_expr(
+        sm100_desc.make_smem_desc_base(
+            cute.recast_layout(128, op.b_dtype.width, sB_layout[0]),
+            sB_swizzle,
+            sm100_desc.Major.K
+            if const_expr(op.b_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+            else sm100_desc.Major.MN,
+        )
+    )
+    smem_desc_base_b_lo, smem_desc_b_hi = i64_to_i32x2(smem_desc_base_b)
+    smem_desc_base_b_lo = const_expr(smem_desc_base_b_lo)
+    smem_desc_b_hi = const_expr(smem_desc_b_hi)
+
+    tCrA_layout = (
+        tCrA.layout
+        if const_expr(not is_ts)
+        else cute.recast_layout(32, tCrA.element_type.width, tCrA.layout)
+    )
+    offset_a = [cute.crd2idx((0, 0, k), tCrA_layout) for k in range(cute.size(tCrA.shape[2]))]
+    offset_a_diff = [offset_a[k] - offset_a[k - 1] for k in range(1, cute.size(tCrA.shape[2]))]
+    offset_b = [cute.crd2idx((0, 0, k), tCrB.layout) for k in range(cute.size(tCrB.shape[2]))]
+    offset_b_diff = [offset_b[k] - offset_b[k - 1] for k in range(1, cute.size(tCrB.shape[2]))]
+
+    if const_expr(not is_ts):
+        smem_desc_start_a_lo = Int32(
+            smem_desc_base_a_lo | sm100_desc.make_smem_desc_start_addr(sA[None, None, 0].iterator)
+        )
+        # ) + sA_offset
+    else:
+        smem_desc_start_a_lo = None
+    smem_desc_start_b_lo = Int32(
+        smem_desc_base_b_lo | sm100_desc.make_smem_desc_start_addr(sB[None, None, 0].iterator)
+    )
+    pred_str = "p" if isinstance(zero_init, Boolean) else "0" if zero_init else "1"
+    if const_expr(not is_ts):
+        assert mbar_ptr is None, "mbar_ptr must be None when a_src is not TMEM"
+        llvm.inline_asm(
+            None,
+            [
+                # acc.iterator.toint().ir_value(),
+                Int32(cute.arch.make_warp_uniform(smem_desc_start_a_lo)).ir_value(),
+                Int32(cute.arch.make_warp_uniform(smem_desc_start_b_lo)).ir_value(),
+                Int32(not zero_init).ir_value(),
+                Int32(cute.arch.make_warp_uniform(acc_tmem_addr)).ir_value(),
+            ],
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_acc;\n\t"
+            ".reg .b32 smem_desc_a_lo_start, smem_desc_b_lo_start;\n\t"
+            ".reg .b32 smem_desc_a_lo, smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_a_hi, smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_a, smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            # f"mov.b32 tmem_acc, {hex(acc_tmem_addr)};\n\t"
+            f"mov.b32 tmem_acc, $3;\n\t"
+            "mov.b32 smem_desc_a_lo_start, $0;\n\t"
+            "mov.b32 smem_desc_b_lo_start, $1;\n\t"
+            f"mov.b32 smem_desc_a_hi, {hex(smem_desc_a_hi)};\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_a, {{smem_desc_a_lo_start, smem_desc_a_hi}};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo_start, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $2, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], smem_desc_a, smem_desc_b, idesc, {pred_str};\n\t"
+            + "".join(
+                (
+                    # f"add.u32 smem_desc_a_lo, smem_desc_a_lo, {hex(offset_a_diff[k - 1])};\n\t"
+                    # f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"add.u32 smem_desc_a_lo, smem_desc_a_lo_start, {hex(offset_a[k])};\n\t"
+                    f"add.u32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
+                    f"mov.b64 smem_desc_a, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], smem_desc_a, smem_desc_b, idesc, 1;\n\t"
+                )
+                for k in range(1, cute.size(tCrA.shape[2]))
+            )
+            + "}\n",
+            # "r,r,r",
+            "r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    else:
+        # For TS gemm, somehow tCrA.iterator.toint() returns 0 no matter what, so we need to
+        # explicitly pass in the tA_addr for correctness.
+        tA_addr = tCrA[None, None, 0].iterator.toint() if tA_addr is None else tA_addr
+        input_args = [
+            # Int32(cute.arch.make_warp_uniform(tCrA[None, None, 0].iterator.toint())).ir_value(),
+            Int32(cute.arch.make_warp_uniform(tA_addr)).ir_value(),
+            Int32(cute.arch.make_warp_uniform(smem_desc_start_b_lo)).ir_value(),
+            Int32(not zero_init).ir_value(),
+            Int32(cute.arch.make_warp_uniform(acc_tmem_addr)).ir_value(),
+        ]
+        if const_expr(mbar_ptr is not None):
+            assert mbar_phase is not None, "mbar_phase must be provided when mbar_ptr is not None"
+            assert split_arrive is not None, (
+                "split_arrive must be provided when mbar_ptr is not None"
+            )
+            split_arrive_idx = split_arrive // op.shape_mnk[2]
+            input_args.append(mbar_ptr.toint().ir_value())
+            input_args.append(Int32(mbar_phase).ir_value())
+            mbar_wait_str = (
+                ".reg .pred P1; \n\t"
+                "LAB_WAIT: \n\t"
+                "mbarrier.try_wait.parity.shared::cta.b64 P1, [$4], $5, 10000000; \n\t"
+                "@P1 bra DONE; \n\t"
+                "bra     LAB_WAIT; \n\t"
+                "DONE: \n\t"
+            )
+        else:
+            mbar_wait_str = ""
+        llvm.inline_asm(
+            None,
+            # [
+            #     # acc.iterator.toint().ir_value(),
+            #     Int32(tCrA[None, None, 0].iterator.toint()).ir_value(),
+            #     Int32(smem_desc_start_b_lo).ir_value(),
+            #     Int32(not zero_init).ir_value(),
+            # ],
+            input_args,
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_acc;\n\t"
+            ".reg .b32 tmem_a;\n\t"
+            ".reg .b32 smem_desc_b_lo_start;\n\t"
+            ".reg .b32 smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            # f"mov.b32 tmem_acc, {hex(acc_tmem_addr)};\n\t"
+            f"mov.b32 tmem_acc, $3;\n\t"
+            f"mov.b32 tmem_a, $0;\n\t"
+            f"mov.b32 smem_desc_b_lo_start, $1;\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo_start, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $2, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], [tmem_a], smem_desc_b, idesc, {pred_str};\n\t"
+            + "".join(
+                (
+                    # f"add.u32 tmem_a, tmem_a, {hex(offset_a_diff[k - 1])};\n\t"
+                    # f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"add.u32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    # f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], [tmem_a], smem_desc_b, idesc, 1;\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
+                )
+                for k in range(
+                    1,
+                    cute.size(tCrA.shape[2]) if const_expr(mbar_ptr is None) else split_arrive_idx,
+                )
+            )
+            + mbar_wait_str
+            + (
+                "".join(
+                    (
+                        f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                        f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                        f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
+                    )
+                    for k in range(split_arrive_idx, cute.size(tCrA.shape[2]))
+                )
+                if const_expr(mbar_ptr is not None)
+                else ""
+            )
+            + "}\n",
+            "r,r,r,r" if const_expr(mbar_ptr is None) else "r,r,r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+
+@cute.jit
+def gemm_ptx_partial1(
+    op: cute.nvgpu.tcgen05.mma.MmaOp,
+    acc_tmem_addr: cutlass.Constexpr[int],
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    sA_base_addr_for_desc: Int32,
+    sA_addr_offset_for_desc: cutlass.Constexpr[int],
+    sA_stage: Int32,
+    sB_base_addr_for_desc: Int32,
+    sB_addr_offset_for_desc: cutlass.Constexpr[int],
+    sB_stage: Int32,
+    sA_layout: Optional[cute.Layout],
+    sB_layout: Optional[cute.Layout],
+    sA_swizzle: Optional[cute.Swizzle],
+    sB_swizzle: cute.Swizzle,
+    zero_init: bool | Boolean = False,
+) -> None:
+    is_ts = op.a_src == cute.nvgpu.tcgen05.OperandSource.TMEM
+    if const_expr(not is_ts):
+        assert sA_layout is not None, "sA_layout must be provided when a_src is not TMEM"
+        assert sA_swizzle is not None, "sA_swizzle must be provided when a_src is not TMEM"
+    idesc: int = const_expr(sm100_desc.mma_op_to_idesc(op))
+    kind = _tcgen05_mma_kind(op)
+    if const_expr(not is_ts):
+        smem_desc_base_a: int = const_expr(
+            sm100_desc.make_smem_desc_base(
+                cute.recast_layout(128, op.a_dtype.width, sA_layout[0]),
+                sA_swizzle,
+                sm100_desc.Major.K
+                if const_expr(op.a_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+                else sm100_desc.Major.MN,
+            )
+        )
+        smem_desc_base_a_lo, smem_desc_a_hi = i64_to_i32x2(smem_desc_base_a)
+        smem_desc_base_a_lo = const_expr(smem_desc_base_a_lo)
+        smem_desc_a_hi = const_expr(smem_desc_a_hi)
+    else:
+        smem_desc_base_a = None
+        smem_desc_base_a_lo, smem_desc_a_hi = None, None
+    smem_desc_base_b: int = const_expr(
+        sm100_desc.make_smem_desc_base(
+            cute.recast_layout(128, op.b_dtype.width, sB_layout[0]),
+            sB_swizzle,
+            sm100_desc.Major.K
+            if const_expr(op.b_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K)
+            else sm100_desc.Major.MN,
+        )
+    )
+    smem_desc_base_b_lo, smem_desc_b_hi = i64_to_i32x2(smem_desc_base_b)
+    smem_desc_base_b_lo = const_expr(smem_desc_base_b_lo)
+    smem_desc_b_hi = const_expr(smem_desc_b_hi)
+    mask = [Int32(0)] * 4
+
+    if const_expr(not is_ts):
+        offset_a = [
+            (cute.crd2idx((0, 0, k), sA_layout) * op.a_dtype.width // 8) >> 4
+            for k in range(cute.size(tCrA.shape[2]))
+        ]
+    else:
+        offset_a = [
+            cute.crd2idx((0, 0, k), sA_layout) * op.a_dtype.width // 32
+            for k in range(cute.size(tCrA.shape[2]))
+        ]
+    offset_a_diff = [offset_a[k] - offset_a[k - 1] for k in range(1, cute.size(tCrA.shape[2]))]
+    offset_b = [
+        (cute.crd2idx((0, 0, k), sB_layout) * op.b_dtype.width // 8) >> 4
+        for k in range(cute.size(tCrB.shape[2]))
+    ]
+    offset_b_diff = [offset_b[k] - offset_b[k - 1] for k in range(1, cute.size(tCrB.shape[2]))]
+
+    if const_expr(not is_ts):
+        # smem_desc_start_a_lo = Int32(smem_desc_base_a_lo | sm100_desc.make_smem_desc_start_addr(sA[None, None, 0].iterator))
+        smem_desc_start_a_lo = const_expr(smem_desc_base_a_lo)
+    else:
+        smem_desc_start_a_lo = None
+    # smem_desc_start_b_lo = Int32(smem_desc_base_b_lo | sm100_desc.make_smem_desc_start_addr(sB[None, None, 0].iterator))
+    smem_desc_start_b_lo = const_expr(smem_desc_base_b_lo)
+    pred_str = "p" if isinstance(zero_init, Boolean) else "0" if zero_init else "1"
+    if const_expr(not is_ts):
+        llvm.inline_asm(
+            None,
+            [
+                # acc.iterator.toint().ir_value(),
+                # Int32(cute.arch.make_warp_uniform(smem_desc_start_a_lo)).ir_value(),
+                Int32(sA_base_addr_for_desc).ir_value(),
+                Int32(sA_stage).ir_value(),
+                # Int32(cute.arch.make_warp_uniform(smem_desc_start_b_lo)).ir_value(),
+                Int32(sB_base_addr_for_desc).ir_value(),
+                Int32(sB_stage).ir_value(),
+                Int32(not zero_init).ir_value(),
+                mask[0].ir_value(),
+                mask[1].ir_value(),
+                mask[2].ir_value(),
+                mask[3].ir_value(),
+            ],
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_acc;\n\t"
+            ".reg .b32 smem_desc_a_lo, smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_a_hi, smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_a, smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            f"mov.b32 tmem_acc, {hex(acc_tmem_addr)};\n\t"
+            # "mov.b32 smem_desc_a_lo, $0;\n\t"
+            # f"add.u32 smem_desc_a_lo, $0, {hex(smem_desc_start_a_lo)};\n\t"
+            f"mad.lo.u32 smem_desc_a_lo, $1, {hex(sA_addr_offset_for_desc)}, $0;\n\t"
+            # "mov.b32 smem_desc_b_lo, $2;\n\t"
+            f"mad.lo.u32 smem_desc_b_lo, $3, {hex(sB_addr_offset_for_desc)}, $2;\n\t"
+            f"mov.b32 smem_desc_a_hi, {hex(smem_desc_a_hi)};\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_a, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $4, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [tmem_acc], smem_desc_a, smem_desc_b, idesc, {{$5, $6, $7, $8}}, {pred_str};\n\t"
+            + "".join(
+                (
+                    f"add.u32 smem_desc_a_lo, smem_desc_a_lo, {hex(offset_a_diff[k - 1])};\n\t"
+                    f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"mov.b64 smem_desc_a, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [tmem_acc], smem_desc_a, smem_desc_b, idesc, {{$5, $6, $7, $8}}, 1;\n\t"
+                )
+                for k in range(1, cute.size(tCrA.shape[2]))
+            )
+            + "}\n",
+            "r,r,r,r,r,r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    else:
+        llvm.inline_asm(
+            None,
+            [
+                # acc.iterator.toint().ir_value(),
+                Int32(tCrA[None, None, 0].iterator.toint()).ir_value(),
+                Int32(smem_desc_start_b_lo).ir_value(),
+                Int32(not zero_init).ir_value(),
+                mask[0].ir_value(),
+                mask[1].ir_value(),
+                mask[2].ir_value(),
+                mask[3].ir_value(),
+            ],
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_a;\n\t"
+            ".reg .b32 smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            f"mov.b32 tmem_a, $1;\n\t"
+            f"mov.b32 smem_desc_b_lo, $2;\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $3, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [$0], [tmem_a], smem_desc_b, idesc, {{$4, $5, $6, $7}}, {pred_str};\n\t"
+            + "".join(
+                (
+                    f"add.u32 tmem_a, tmem_a, {hex(offset_a_diff[k - 1])};\n\t"
+                    f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::1.kind::{kind} [$0], [tmem_a], smem_desc_b, idesc, {{$4, $5, $6, $7}}, 1;\n\t"
+                )
+                for k in range(1, cute.size(tCrA.shape[2]))
+            )
+            + "}\n",
+            "r,r,r,r,r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+
+@cute.jit
+def gemm_ptx_precomputed(
+    acc_tmem_addr: Int32,
+    smem_desc_start_a: Int32,  # If TS, then this is the tmem start address for A
+    smem_desc_start_b: Int32,
+    idesc: int,
+    smem_desc_base_a: Optional[int],
+    smem_desc_base_b: int,
+    tCrA_layout: cute.Layout,
+    tCrB_layout: cute.Layout,
+    mbar_ptr: Optional[cutlass.Pointer] = None,
+    mbar_phase: Optional[Int32] = None,
+    zero_init: bool | Boolean = False,
+    cta_group: int = 1,
+    kind: str = "f16",
+) -> None:
+    # acc_tmem_addr += acc_offset
+    is_ts = const_expr(smem_desc_base_a is None)
+    num_k_tile = cute.size(tCrA_layout.shape[2])
+    if const_expr(not is_ts):
+        smem_desc_base_a_lo, smem_desc_a_hi = i64_to_i32x2(smem_desc_base_a)
+    else:
+        smem_desc_base_a_lo, smem_desc_a_hi = None, None
+    smem_desc_base_b_lo, smem_desc_b_hi = i64_to_i32x2(smem_desc_base_b)
+
+    tCrA_layout = (
+        tCrA_layout
+        if const_expr(not is_ts)
+        # else cute.recast_layout(32, tCrA.element_type.width, tCrA_layout)
+        # currently hard-coding the width to 16
+        else cute.recast_layout(32, 16, tCrA_layout)
+    )
+    offset_a = [cute.crd2idx((0, 0, k), tCrA_layout) for k in range(num_k_tile)]
+    offset_a_diff = [offset_a[k] - offset_a[k - 1] for k in range(1, num_k_tile)]
+    offset_b = [cute.crd2idx((0, 0, k), tCrB_layout) for k in range(num_k_tile)]
+    offset_b_diff = [offset_b[k] - offset_b[k - 1] for k in range(1, num_k_tile)]
+
+    smem_desc_start_a_lo = None
+    if const_expr(not is_ts):
+        smem_desc_start_a_lo = Int32(smem_desc_base_a_lo | smem_desc_start_a)
+        # smem_desc_start_a_lo = smem_desc_start_a
+    smem_desc_start_b_lo = Int32(smem_desc_base_b_lo | smem_desc_start_b)
+    pred_str = "p" if isinstance(zero_init, Boolean) else "0" if zero_init else "1"
+    if const_expr(not is_ts):
+        assert mbar_ptr is None, "mbar_ptr must be None when a_src is not TMEM"
+        llvm.inline_asm(
+            None,
+            [
+                # acc.iterator.toint().ir_value(),
+                Int32(cute.arch.make_warp_uniform(smem_desc_start_a_lo)).ir_value(),
+                Int32(cute.arch.make_warp_uniform(smem_desc_start_b_lo)).ir_value(),
+                Int32(not zero_init).ir_value(),
+                Int32(cute.arch.make_warp_uniform(acc_tmem_addr)).ir_value(),
+            ],
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_acc;\n\t"
+            ".reg .b32 smem_desc_a_lo_start, smem_desc_b_lo_start;\n\t"
+            ".reg .b32 smem_desc_a_lo, smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_a_hi, smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_a, smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            # f"mov.b32 tmem_acc, {hex(acc_tmem_addr)};\n\t"
+            f"mov.b32 tmem_acc, $3;\n\t"
+            "mov.b32 smem_desc_a_lo_start, $0;\n\t"
+            "mov.b32 smem_desc_b_lo_start, $1;\n\t"
+            f"mov.b32 smem_desc_a_hi, {hex(smem_desc_a_hi)};\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_a, {{smem_desc_a_lo_start, smem_desc_a_hi}};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo_start, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $2, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], smem_desc_a, smem_desc_b, idesc, {pred_str};\n\t"
+            + "".join(
+                (
+                    # f"add.u32 smem_desc_a_lo, smem_desc_a_lo, {hex(offset_a_diff[k - 1])};\n\t"
+                    # f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"add.s32 smem_desc_a_lo, smem_desc_a_lo_start, {hex(offset_a[k])};\n\t"
+                    f"add.s32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
+                    f"mov.b64 smem_desc_a, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], smem_desc_a, smem_desc_b, idesc, 1;\n\t"
+                )
+                for k in range(1, num_k_tile)
+            )
+            + "}\n",
+            # "r,r,r",
+            "r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    else:
+        input_args = [
+            Int32(cute.arch.make_warp_uniform(smem_desc_start_a)).ir_value(),
+            Int32(cute.arch.make_warp_uniform(smem_desc_start_b_lo)).ir_value(),
+            Int32(not zero_init).ir_value(),
+            Int32(cute.arch.make_warp_uniform(acc_tmem_addr)).ir_value(),
+        ]
+        if const_expr(mbar_ptr is not None):
+            assert mbar_phase is not None, "mbar_phase must be provided when mbar_ptr is not None"
+            input_args.append(mbar_ptr.toint().ir_value())
+            input_args.append(Int32(mbar_phase).ir_value())
+            mbar_wait_str = (
+                ".reg .pred P1; \n\t"
+                "LAB_WAIT: \n\t"
+                "mbarrier.try_wait.parity.shared::cta.b64 P1, [$4], $5, 10000000; \n\t"
+                "@P1 bra DONE; \n\t"
+                "bra     LAB_WAIT; \n\t"
+                "DONE: \n\t"
+            )
+        else:
+            mbar_wait_str = ""
+        llvm.inline_asm(
+            None,
+            # [
+            #     # acc.iterator.toint().ir_value(),
+            #     Int32(tCrA_layout[None, None, 0].iterator.toint()).ir_value(),
+            #     Int32(smem_desc_start_b_lo).ir_value(),
+            #     Int32(not zero_init).ir_value(),
+            # ],
+            input_args,
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_acc;\n\t"
+            ".reg .b32 tmem_a;\n\t"
+            ".reg .b32 smem_desc_b_lo_start;\n\t"
+            ".reg .b32 smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_b_hi;\n\t"
+            ".reg .b64 smem_desc_b;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            f"mov.b32 idesc, {hex(idesc)};\n\t"
+            # f"mov.b32 tmem_acc, {hex(acc_tmem_addr)};\n\t"
+            f"mov.b32 tmem_acc, $3;\n\t"
+            f"mov.b32 tmem_a, $0;\n\t"
+            f"mov.b32 smem_desc_b_lo_start, $1;\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 smem_desc_b, {{smem_desc_b_lo_start, smem_desc_b_hi}};\n\t"
+            "setp.ne.b32 p, $2, 0;\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], [tmem_a], smem_desc_b, idesc, {pred_str};\n\t"
+            + "".join(
+                (
+                    # f"add.u32 tmem_a, tmem_a, {hex(offset_a_diff[k - 1])};\n\t"
+                    # f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                    f"add.u32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
+                    f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    # f"@leader_thread tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], [tmem_a], smem_desc_b, idesc, 1;\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
+                )
+                for k in range(
+                    1,
+                    num_k_tile if const_expr(mbar_ptr is None) else num_k_tile // 4 * 3,
+                )
+            )
+            + mbar_wait_str
+            + (
+                "".join(
+                    (
+                        # f"add.u32 smem_desc_b_lo, smem_desc_b_lo, {hex(offset_b_diff[k - 1])};\n\t"
+                        f"add.u32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
+                        f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                        f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], [tmem_a + {hex(offset_a[k])}], smem_desc_b, idesc, 1;\n\t"
+                    )
+                    for k in range(num_k_tile // 4 * 3, num_k_tile)
+                )
+                if const_expr(mbar_ptr is not None)
+                else ""
+            )
+            + "}\n",
+            "r,r,r,r" if const_expr(mbar_ptr is None) else "r,r,r,r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+
+@cute.jit
+def declare_ptx_smem_desc(
+    smem_desc_start_a: Int32,  # If TS, then this is the tmem start address for A
+    smem_desc_base_a: Optional[int],
+    tCrA_layout: cute.Layout,
+    var_name_prefix: str = "smem_desc",
+) -> None:
+    is_ts = const_expr(smem_desc_base_a is None)
+    num_k_tile = cute.size(tCrA_layout.shape[2])
+    smem_desc_base_a_lo, smem_desc_a_hi = None, None
+    if const_expr(not is_ts):
+        smem_desc_base_a_lo, smem_desc_a_hi = i64_to_i32x2(smem_desc_base_a)
+    tCrA_layout = (
+        tCrA_layout
+        if const_expr(not is_ts)
+        # else cute.recast_layout(32, tCrA.element_type.width, tCrA_layout)
+        # currently hard-coding the width to 16
+        else cute.recast_layout(32, 16, tCrA_layout)
+    )
+    offset_a = [cute.crd2idx((0, 0, k), tCrA_layout) for k in range(num_k_tile)]
+    smem_desc_start_a_lo = None
+    if const_expr(not is_ts):
+        smem_desc_start_a_lo = Int32(smem_desc_base_a_lo | smem_desc_start_a)
+    if const_expr(not is_ts):
+        llvm.inline_asm(
+            None,
+            [Int32(cute.arch.make_warp_uniform(smem_desc_start_a_lo)).ir_value()],
+            f".reg .b32 {var_name_prefix}_lo;\n\t"
+            f".reg .b64 {var_name_prefix}_<{num_k_tile}>;\n\t"
+            f"mov.b64 {var_name_prefix}_0, {{$0, {hex(smem_desc_a_hi)}}};\n\t"
+            + "".join(
+                (
+                    f"add.s32 {var_name_prefix}_lo, $0, {hex(offset_a[k])};\n\t"
+                    f"mov.b64 {var_name_prefix}_{k}, {{{var_name_prefix}_lo, {hex(smem_desc_a_hi)}}};\n\t"
+                )
+                for k in range(1, num_k_tile)
+            ),
+            "r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+
+@cute.jit
+def declare_ptx_idesc(op: cute.nvgpu.tcgen05.mma.MmaOp, var_name: str = "idesc") -> None:
+    idesc = const_expr(sm100_desc.mma_op_to_idesc(op))
+    llvm.inline_asm(
+        None,
+        [],
+        f".reg .b32 {var_name};\n\t"  # noqa
+        f"mov.b32 {var_name}, {hex(idesc)};\n\t",
+        constraints="",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def gemm_ptx_precomputed_varname(
+    acc_tmem_addr: Int32,
+    smem_desc_start_b: Int32,
+    # idesc: int,
+    smem_desc_base_b: int,
+    tCrB_layout: cute.Layout,
+    smem_var_name_prefix: str,
+    idesc_var_name: str,
+    smem_offset: int,
+    zero_init: bool | Boolean = False,
+    cta_group: int = 1,
+    kind: str = "f16",
+) -> None:
+    is_ts = False
+    num_k_tile = cute.size(tCrB_layout.shape[2])
+    smem_desc_base_b_lo, smem_desc_b_hi = i64_to_i32x2(smem_desc_base_b)
+    offset_b = [cute.crd2idx((0, 0, k), tCrB_layout) for k in range(num_k_tile)]
+
+    smem_desc_start_b_lo = Int32(smem_desc_base_b_lo | smem_desc_start_b)
+    pred_str = "p" if isinstance(zero_init, Boolean) else "0" if zero_init else "1"
+    if const_expr(not is_ts):
+        llvm.inline_asm(
+            None,
+            [
+                Int32(cute.arch.make_warp_uniform(smem_desc_start_b_lo)).ir_value(),
+                Int32(not zero_init).ir_value(),
+                Int32(cute.arch.make_warp_uniform(acc_tmem_addr)).ir_value(),
+            ],
+            "{\n\t"
+            ".reg .pred leader_thread;\n\t"
+            ".reg .pred p;\n\t"
+            # ".reg .b32 idesc;\n\t"
+            ".reg .b32 tmem_acc;\n\t"
+            ".reg .b32 smem_desc_b_lo_start;\n\t"
+            ".reg .b32 smem_desc_a_lo, smem_desc_b_lo;\n\t"
+            ".reg .b32 smem_desc_a_hi, smem_desc_b_hi;\n\t"
+            # ".reg .b64 smem_desc_b;\n\t"
+            f".reg .b64 smem_desc_b_<{num_k_tile}>;\n\t"
+            "elect.sync _|leader_thread, -1;\n\t"
+            # f"mov.b32 idesc, {hex(idesc)};\n\t"
+            # f"mov.b32 tmem_acc, {hex(acc_tmem_addr)};\n\t"
+            f"mov.b32 tmem_acc, $2;\n\t"
+            "mov.b32 smem_desc_b_lo_start, $0;\n\t"
+            f"mov.b32 smem_desc_b_hi, {hex(smem_desc_b_hi)};\n\t"
+            f"mov.b64 {{smem_desc_a_lo, smem_desc_a_hi}}, {smem_var_name_prefix}_0;\n\t"
+            f"add.s32 smem_desc_a_lo, smem_desc_a_lo, {smem_offset};\n\t"
+            f"mov.b64 {smem_var_name_prefix}_0, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+            f"mov.b64 smem_desc_b_0, {{smem_desc_b_lo_start, smem_desc_b_hi}};\n\t"
+            + "".join(
+                (
+                    f"mov.b64 {{smem_desc_a_lo, smem_desc_a_hi}}, {smem_var_name_prefix}_{k};\n\t"
+                    f"add.s32 smem_desc_a_lo, smem_desc_a_lo, {smem_offset};\n\t"
+                    f"add.s32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
+                    f"mov.b64 {smem_var_name_prefix}_{k}, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+                    f"mov.b64 smem_desc_b_{k}, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                )
+                for k in range(1, num_k_tile)
+            )
+            + "setp.ne.b32 p, $1, 0;\n\t"
+            # f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], {smem_var_name_prefix}_0, smem_desc_b, idesc, {pred_str};\n\t"
+            f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], {smem_var_name_prefix}_0, smem_desc_b_0, {idesc_var_name}, {pred_str};\n\t"
+            + "".join(
+                (
+                    # f"mov.b64 {{smem_desc_a_lo, smem_desc_a_hi}}, {smem_var_name_prefix}_{k};\n\t"
+                    # f"add.s32 smem_desc_a_lo, smem_desc_a_lo, {smem_offset};\n\t"
+                    # f"add.s32 smem_desc_b_lo, smem_desc_b_lo_start, {hex(offset_b[k])};\n\t"
+                    # f"mov.b64 {smem_var_name_prefix}_{k}, {{smem_desc_a_lo, smem_desc_a_hi}};\n\t"
+                    # f"mov.b64 smem_desc_b, {{smem_desc_b_lo, smem_desc_b_hi}};\n\t"
+                    # f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], {smem_var_name_prefix}_{k}, smem_desc_b, idesc, 1;\n\t"
+                    # f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::f16 [tmem_acc], {smem_var_name_prefix}_{k}, smem_desc_b, {idesc_var_name}, 1;\n\t"
+                    f"@leader_thread tcgen05.mma.cta_group::{cta_group}.kind::{kind} [tmem_acc], {smem_var_name_prefix}_{k}, smem_desc_b_{k}, {idesc_var_name}, 1;\n\t"
+                )
+                for k in range(1, num_k_tile)
+            )
+            + "}\n",
+            "r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/block_info.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/block_info.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+from typing import Tuple, Optional
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, const_expr
+
+from flashrt_fa4.cute.seqlen_info import SeqlenInfoQK, SeqlenInfoQKNewK
+
+
+@dataclass(frozen=True)
+class BlockInfo:
+    tile_m: cutlass.Constexpr[int]
+    tile_n: cutlass.Constexpr[int]
+    is_causal: cutlass.Constexpr[bool]
+    is_local: cutlass.Constexpr[bool] = False
+    is_split_kv: cutlass.Constexpr[bool] = False
+    window_size_left: Optional[Int32] = None
+    window_size_right: Optional[Int32] = None
+    qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+
+    @cute.jit
+    def get_n_block_min_max(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        m_block: Int32,
+        split_idx: Int32 = 0,
+        num_splits: Int32 = 1,
+    ) -> Tuple[Int32, Int32]:
+        n_block_max = cute.ceil_div(seqlen_info.seqlen_k, self.tile_n)
+        if const_expr(self.is_causal or (self.is_local and self.window_size_right is not None)):
+            m_idx_max = (m_block + 1) * self.tile_m
+            if const_expr(self.qhead_per_kvhead_packgqa > 1):
+                m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
+            n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            n_idx_right = n_idx if const_expr(self.is_causal) else n_idx + self.window_size_right
+            n_block_max = min(n_block_max, cute.ceil_div(n_idx_right, self.tile_n))
+        n_block_min = 0
+        if const_expr(self.is_local and self.window_size_left is not None):
+            m_idx_min = m_block * self.tile_m
+            if const_expr(self.qhead_per_kvhead_packgqa > 1):
+                m_idx_min = m_idx_min // self.qhead_per_kvhead_packgqa
+            n_idx = m_idx_min + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            n_idx_left = n_idx - self.window_size_left
+            n_block_min = cutlass.max(n_idx_left // self.tile_n, 0)
+        if cutlass.const_expr(self.is_split_kv):
+            num_n_blocks_per_split = (
+                Int32(0)
+                if n_block_max <= n_block_min
+                else (n_block_max - n_block_min + num_splits - 1) // num_splits
+            )
+            n_block_min = n_block_min + split_idx * num_n_blocks_per_split
+            n_block_max = cutlass.min(n_block_min + num_n_blocks_per_split, n_block_max)
+        return n_block_min, n_block_max
+
+    @cute.jit
+    def get_m_block_min_max(self, seqlen_info: SeqlenInfoQK, n_block: Int32) -> Tuple[Int32, Int32]:
+        m_block_max = cute.ceil_div(seqlen_info.seqlen_q, self.tile_m)
+        m_block_min = 0
+        if const_expr(self.is_causal or (self.is_local and self.window_size_right is not None)):
+            n_idx_min = n_block * self.tile_n
+            m_idx = n_idx_min + seqlen_info.seqlen_q - seqlen_info.seqlen_k
+            m_idx_right = m_idx if const_expr(self.is_causal) else m_idx - self.window_size_right
+            m_block_min = max(m_block_min, m_idx_right // self.tile_m)
+        if const_expr(self.is_local and self.window_size_left is not None):
+            n_idx_max = (n_block + 1) * self.tile_n
+            m_idx = n_idx_max + seqlen_info.seqlen_q - seqlen_info.seqlen_k
+            m_idx_left = m_idx + self.window_size_left
+            m_block_max = min(m_block_max, cute.ceil_div(m_idx_left, self.tile_m))
+        return m_block_min, m_block_max
+
+    @cute.jit
+    def get_n_block_k_new_min_max(
+        self,
+        seqlen_info: SeqlenInfoQKNewK,
+        m_block: Int32,
+        split_idx: Int32 = 0,
+        num_splits: Int32 = 1,
+    ) -> Tuple[Int32, Int32]:
+        """Get the block range for new K tokens (append KV).
+
+        First computes the full n_block range via get_n_block_min_max, then maps
+        those blocks into the new-K index space by subtracting seqlen_k_og.
+        """
+        n_block_min, n_block_max = self.get_n_block_min_max(
+            seqlen_info,
+            m_block,
+            split_idx,
+            num_splits,
+        )
+        idx_k_new_min = cutlass.max(n_block_min * self.tile_n - seqlen_info.seqlen_k_og, 0)
+        idx_k_new_max = cutlass.min(
+            n_block_max * self.tile_n - seqlen_info.seqlen_k_og, seqlen_info.seqlen_k_new
+        )
+        n_block_new_min = idx_k_new_min // self.tile_n
+        n_block_new_max = (
+            cute.ceil_div(idx_k_new_max, self.tile_n)
+            if idx_k_new_max > idx_k_new_min
+            else n_block_new_min
+        )
+        return n_block_new_min, n_block_new_max
+
+    @cute.jit
+    def get_n_block_min_causal_local_mask(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        m_block: Int32,
+        n_block_min: Int32,
+    ) -> Int32:
+        """If we have separate iterations with causal or local masking at the start, where do we stop"""
+        m_idx_min = m_block * self.tile_m
+        if const_expr(self.qhead_per_kvhead_packgqa > 1):
+            m_idx_min = m_idx_min // self.qhead_per_kvhead_packgqa
+        n_idx = m_idx_min + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+        n_idx_right = (
+            n_idx
+            if const_expr(not self.is_local or self.window_size_right is None)
+            else n_idx + self.window_size_right
+        )
+        return cutlass.max(n_block_min, n_idx_right // self.tile_n)
+
+    @cute.jit
+    def get_n_block_min_before_local_mask(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        m_block: Int32,
+        n_block_min: Int32,
+    ) -> Int32:
+        """If we have separate iterations with local masking at the end, where do we stop the non-masked iterations"""
+        if const_expr(not self.is_local or self.window_size_left is None):
+            return n_block_min
+        else:
+            m_idx_max = (m_block + 1) * self.tile_m
+            if const_expr(self.qhead_per_kvhead_packgqa > 1):
+                m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
+            n_idx = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            n_idx_left = n_idx - self.window_size_left
+            return cutlass.max(n_block_min, cute.ceil_div(n_idx_left, self.tile_n))
+
+    @cute.jit
+    def get_n_block_max_for_m_block(
+        self,
+        seqlen_info: SeqlenInfoQK,
+        m_block: Int32,
+        n_block_global_max: Int32,
+    ) -> Int32:
+        if const_expr(self.is_causal or self.window_size_right is not None):
+            m_idx_max = (m_block + 1) * self.tile_m
+            if const_expr(self.qhead_per_kvhead_packgqa > 1):
+                m_idx_max = cute.ceil_div(m_idx_max, self.qhead_per_kvhead_packgqa)
+            n_idx_right = m_idx_max + seqlen_info.seqlen_k - seqlen_info.seqlen_q
+            if const_expr(self.window_size_right is not None):
+                n_idx_right += self.window_size_right
+            return min(n_block_global_max, cute.ceil_div(n_idx_right, self.tile_n))
+        return n_block_global_max

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/block_sparse_utils.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/block_sparse_utils.py
@@ -1,0 +1,1437 @@
+"""
+Block-sparse runtime utilities for CUTE DSL kernels.
+
+This module contains runtime execution functions for block-sparse attention kernels.
+These utilities are used by CUTE DSL kernels to produce and consume block-sparse loads.
+"""
+
+from typing import Callable, Optional
+from functools import partial
+import math
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+
+from quack import copy_utils
+
+# Import data structures from block_sparsity
+from flashrt_fa4.cute.block_sparsity import BlockSparseTensors
+from flashrt_fa4.cute.named_barrier import NamedBarrierBwd
+
+
+# NOTE [SM100 block-sparse empty tiles: mbarrier contract]
+#
+# For block-sparse SM100 forward, a given (m_block, stage) Q tile can have zero active
+# KV blocks (total_block_cnt == 0). In that case there is no seqlen_kv iteration, so
+# the softmax warp-group has no row stats to publish.
+#
+# The correction warp-group seeds fully-masked-row stats and runs the usual correction
+# epilogue so output/LSE have well-defined values. Both warp-groups must still perform
+# the softmax<->correction mbarrier handshake so phases advance correctly across
+# empty->empty and empty->non-empty tile sequences.
+#
+# In the no-sink case, this corresponds to the usual fully-masked-row convention:
+# output is zero and LSE is -inf.
+#
+# Barrier contract (each is `mbar_ptr + <offset> + stage`):
+#
+# Producer/consumer pairs:
+# - `mbar_softmax_corr_full`    : softmax arrive        -> correction wait
+# - `mbar_softmax_corr_empty`   : correction arrive     -> softmax wait
+# - `mbar_P_full_O_rescaled`    : softmax arrive (+ correction arrive) -> MMA wait
+# - `mbar_P_full_2`             : softmax arrive        -> MMA wait
+# - `mbar_corr_epi_full_/empty` : correction <-> epilogue (only when epilogue is separate)
+#
+# Empty tile (`total_block_cnt == 0`):
+# - Softmax: skips the seqlen_kv softmax path entirely (no P stores, no `mbar_P_full_*`).
+#   It only arrives `mbar_softmax_corr_full` once per stage as a synthetic "no work" signal.
+#   At the `softmax_loop` level, softmax unconditionally waits `mbar_softmax_corr_empty`
+#   before each tile (when block-sparse) to drain a prior correction arrival and keep
+#   phases aligned across non-empty -> empty transitions.
+# - Correction: waits `mbar_softmax_corr_full`, seeds stats + runs `correction_epilogue(scale=0)`,
+#   and arrives `mbar_softmax_corr_empty` (and `mbar_corr_epi_full_/empty` when applicable).
+# - No `mbar_P_full_*` barriers are arrived (no P, no MMA O); only the softmax<->correction
+#   (and correction<->epilogue) handshakes advance phases.
+#
+# Non-empty tile:
+# - Softmax: runs `softmax_step` (produces P) and uses `mbar_softmax_corr_full/empty` to
+#   publish row_max (during seqlen_kv) and final row stats (once per tile), and to advance phases;
+#   arrives `mbar_P_full_*` when P is stored.
+# - Correction: waits `mbar_softmax_corr_full`, may rescale/release O, arrives `mbar_softmax_corr_empty`
+#   to ack/advance, and arrives `mbar_P_full_O_rescaled` when MMA can proceed.
+#
+# Backward (SM100):
+# - Empty KV tile: for a given `n_block`, `total_m_block_cnt == 0` means no Q tiles contribute.
+# - Both the load and compute loops guard all pipeline work on `process_tile`, so empty tiles
+#   skip producer/consumer operations entirely (no per-tile mbarrier phase handshake like forward).
+# - In the `not dKV_postprocess` path, dK/dV for empty KV tiles are explicitly written as zeros
+#   even when `process_tile == False` (see `flash_bwd_sm100.py` `should_zero_dKV`).
+
+
+@cute.jit
+def load_block_list(
+    block_indices: cute.Tensor,
+    block_count,
+    first_block_preloaded: cutlass.Constexpr,
+    kv_producer_state,
+    load_K,
+    load_V,
+    pipeline_k,
+    pipeline_v,
+    intra_wg_overlap: cutlass.Constexpr,
+):
+    """Iterate over the sparse blocks and load K, V into the pipeline.
+    For the intra_wg_overlap case, we overlap the loads of K and V. And this
+    means we need to pipeline the last V load from the partial block case,
+    with the loads for the full blocks. Set first_block_preloaded when the
+    caller has already issued the first K load for the list.
+
+    Q is loaded separately on its own mbarrier before this function is called.
+
+    Note:
+        we iterate along the block_n indices in reverse.
+
+    Returns:
+        Updated kv_producer_state after processing the block list.
+
+    """
+    if block_count > 0:
+        if const_expr(not intra_wg_overlap):
+            for offset in cutlass.range(block_count):
+                n_block = block_indices[block_count - 1 - offset]
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block, producer_state=kv_producer_state)
+                pipeline_v.producer_acquire(kv_producer_state)
+                load_V(src_idx=n_block, producer_state=kv_producer_state)
+                kv_producer_state.advance()
+        else:
+            n_block_first = block_indices[block_count - 1]
+            if const_expr(not first_block_preloaded):
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block_first, producer_state=kv_producer_state)
+
+            for idx in cutlass.range(block_count - 1, unroll=1):
+                n_block_prev = block_indices[block_count - 1 - idx]
+                n_block = block_indices[block_count - 2 - idx]
+                kv_producer_state_prev = kv_producer_state.clone()
+                kv_producer_state.advance()
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block, producer_state=kv_producer_state)
+                pipeline_v.producer_acquire(kv_producer_state_prev)
+                load_V(src_idx=n_block_prev, producer_state=kv_producer_state_prev)
+
+    return kv_producer_state
+
+
+@cute.jit
+def finish_overlap_v_load(
+    block_indices: cute.Tensor,
+    block_count,
+    load_V,
+    pipeline_v,
+    kv_producer_state,
+):
+    """Load the final V block after overlapped K/V loads."""
+    if block_count > 0:
+        n_block_last = block_indices[0]
+        pipeline_v.producer_acquire(kv_producer_state)
+        load_V(src_idx=n_block_last, producer_state=kv_producer_state)
+        kv_producer_state.advance()
+
+    return kv_producer_state
+
+
+@cute.jit
+def sparse_tensor_m_block(
+    m_block,
+    qhead_per_kvhead: cutlass.Constexpr[int],
+    q_subtile_factor: cutlass.Constexpr[int],
+):
+    """Map packed m_block indices to block-sparse tensor indices."""
+    block = m_block
+    if const_expr(qhead_per_kvhead != 1):
+        block = block // qhead_per_kvhead
+    if const_expr(q_subtile_factor != 1):
+        block = block // q_subtile_factor
+    return block
+
+
+@cute.jit
+def produce_block_sparse_loads(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    kv_producer_state,
+    load_K,
+    load_V,
+    pipeline_k,
+    pipeline_v,
+    intra_wg_overlap: cutlass.Constexpr,
+    qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+    q_subtile_factor: cutlass.Constexpr[int] = 1,
+):
+    """Iterate over the mask and full block lists for a single tile.
+
+    Q is loaded separately on its own mbarrier before this function is called.
+
+    The masked (partial) list may leave the last V load pending when intra-warp-group
+    overlap is enabled. The first full block must consume that pending V while
+    issuing its own K load on the next pipeline stage.
+
+    In the intra-wg-overlap path, the last masked block leaves its V copy in flight
+    while we advance the producer state to start the next full K. Either the full list
+    overlaps that pending V load, or, if no full blocks exist, we explicitly drain it.
+
+    Args:
+        qhead_per_kvhead: Pack-GQA factor. When > 1, m_block is in packed space and
+            must be converted to unpacked for sparse tensor indexing.
+    """
+
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+
+    m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
+
+    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
+
+    if const_expr(full_block_cnt is not None):
+        curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
+        curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
+    else:
+        curr_full_block_cnt = Int32(0)
+        curr_full_block_idx = None
+
+    mask_empty = curr_mask_block_cnt == 0
+    full_empty = curr_full_block_cnt == 0
+
+    if mask_empty:
+        # No masked blocks: the full list owns the initial K load.
+        kv_producer_state = load_block_list(
+            curr_full_block_idx,
+            curr_full_block_cnt,
+            first_block_preloaded=False,
+            kv_producer_state=kv_producer_state,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_k=pipeline_k,
+            pipeline_v=pipeline_v,
+            intra_wg_overlap=intra_wg_overlap,
+        )
+
+        if const_expr(intra_wg_overlap) and curr_full_block_cnt > 0:
+            kv_producer_state = finish_overlap_v_load(
+                curr_full_block_idx,
+                curr_full_block_cnt,
+                load_V,
+                pipeline_v,
+                kv_producer_state,
+            )
+    else:
+        # Masked blocks present. When overlap is disabled this fully drains the list.
+        kv_producer_state = load_block_list(
+            curr_mask_block_idx,
+            curr_mask_block_cnt,
+            first_block_preloaded=False,
+            kv_producer_state=kv_producer_state,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_k=pipeline_k,
+            pipeline_v=pipeline_v,
+            intra_wg_overlap=intra_wg_overlap,
+        )
+
+        if full_empty:
+            if const_expr(intra_wg_overlap):
+                kv_producer_state = finish_overlap_v_load(
+                    curr_mask_block_idx,
+                    curr_mask_block_cnt,
+                    load_V,
+                    pipeline_v,
+                    kv_producer_state,
+                )
+        else:
+            if const_expr(intra_wg_overlap):
+                # Bridge the masked list to the full list by overlapping the pending masked V
+                # with the first full K load.
+                n_block_mask_last = curr_mask_block_idx[0]
+                n_block_full_first = curr_full_block_idx[curr_full_block_cnt - 1]
+                kv_producer_state_prev = kv_producer_state.clone()
+                kv_producer_state.advance()
+                pipeline_k.producer_acquire(kv_producer_state)
+                load_K(src_idx=n_block_full_first, producer_state=kv_producer_state)
+                pipeline_v.producer_acquire(kv_producer_state_prev)
+                load_V(src_idx=n_block_mask_last, producer_state=kv_producer_state_prev)
+
+                kv_producer_state = load_block_list(
+                    curr_full_block_idx,
+                    curr_full_block_cnt,
+                    first_block_preloaded=True,
+                    kv_producer_state=kv_producer_state,
+                    load_K=load_K,
+                    load_V=load_V,
+                    pipeline_k=pipeline_k,
+                    pipeline_v=pipeline_v,
+                    intra_wg_overlap=intra_wg_overlap,
+                )
+
+                kv_producer_state = finish_overlap_v_load(
+                    curr_full_block_idx,
+                    curr_full_block_cnt,
+                    load_V,
+                    pipeline_v,
+                    kv_producer_state,
+                )
+            else:
+                # Non-overlap path with both lists: run the full list normally.
+                kv_producer_state = load_block_list(
+                    curr_full_block_idx,
+                    curr_full_block_cnt,
+                    first_block_preloaded=False,
+                    kv_producer_state=kv_producer_state,
+                    load_K=load_K,
+                    load_V=load_V,
+                    pipeline_k=pipeline_k,
+                    pipeline_v=pipeline_v,
+                    intra_wg_overlap=intra_wg_overlap,
+                )
+
+    return kv_producer_state
+
+
+@cute.jit
+def consume_block_sparse_loads(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    seqlen,
+    kv_consumer_state,
+    mma_pv_fn,
+    mma_one_n_block,
+    process_first_half_block,
+    process_last_half_block,
+    mask_fn,
+    score_mod_fn,
+    O_should_accumulate,
+    mask_mod,
+    fastdiv_mods,
+    intra_wg_overlap: cutlass.Constexpr,
+    warp_scheduler_barrier_sync: Callable,
+    warp_scheduler_barrier_arrive: Callable,
+    qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+    q_subtile_factor: cutlass.Constexpr[int] = 1,
+):
+    """Consume the mask and full block lists for a single tile on the consumer side.
+
+    Mirrors `produce_block_sparse_loads` so that the consumer pipeline uses
+    the same sparse tensor indexing.
+
+    Args:
+        qhead_per_kvhead: Pack-GQA factor. When > 1, m_block is in packed space and
+            must be converted to unpacked for sparse tensor indexing.
+    """
+
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+
+    m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
+
+    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
+    curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
+    curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
+
+    processed_any = curr_mask_block_cnt + curr_full_block_cnt > 0
+
+    if const_expr(not intra_wg_overlap):
+        if curr_mask_block_cnt > 0:
+            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
+            warp_scheduler_barrier_sync()
+            kv_consumer_state = mma_one_n_block(
+                kv_consumer_state,
+                n_block=mask_n_block,
+                mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                mask_fn=partial(
+                    mask_fn,
+                    mask_mod=mask_mod,
+                    mask_seqlen=True,
+                    fastdiv_mods=fastdiv_mods if cutlass.const_expr(mask_mod is not None) else None,
+                ),
+                is_first_n_block=True,
+            )
+            O_should_accumulate = True
+            for i in cutlass.range(1, curr_mask_block_cnt):
+                mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=mask_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=mask_mod, mask_seqlen=False),
+                    is_first_n_block=False,
+                )
+                O_should_accumulate = True
+            if curr_full_block_cnt == 0:
+                warp_scheduler_barrier_arrive()
+
+        if curr_full_block_cnt > 0:
+            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1]
+            if curr_mask_block_cnt == 0:
+                warp_scheduler_barrier_sync()
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_seqlen=True),
+                    is_first_n_block=True,
+                )
+                O_should_accumulate = True
+                for i in cutlass.range(1, curr_full_block_cnt):
+                    full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+                    kv_consumer_state = mma_one_n_block(
+                        kv_consumer_state,
+                        n_block=full_n_block,
+                        mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                        mask_fn=partial(mask_fn, mask_seqlen=False),
+                        is_first_n_block=False,
+                    )
+                    O_should_accumulate = True
+            else:
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
+                    is_first_n_block=False,
+                )
+                O_should_accumulate = True
+                for i in cutlass.range(1, curr_full_block_cnt):
+                    full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+                    kv_consumer_state = mma_one_n_block(
+                        kv_consumer_state,
+                        n_block=full_n_block,
+                        mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                        mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=False),
+                        is_first_n_block=False,
+                    )
+                    O_should_accumulate = True
+            warp_scheduler_barrier_arrive()
+    else:
+        if curr_mask_block_cnt > 0:
+            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
+            kv_consumer_state = process_first_half_block(
+                n_block=mask_n_block,
+                seqlen=seqlen,
+                kv_consumer_state=kv_consumer_state,
+                mask_fn=partial(
+                    mask_fn,
+                    mask_mod=mask_mod,
+                    mask_seqlen=True,
+                    fastdiv_mods=fastdiv_mods if cutlass.const_expr(mask_mod is not None) else None,
+                ),
+                score_mod_fn=score_mod_fn,
+                is_first_block=True,
+            )
+            for i in cutlass.range(1, curr_mask_block_cnt):
+                mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=mask_n_block,
+                    seqlen=seqlen,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=mask_mod, mask_seqlen=False),
+                )
+                O_should_accumulate = True
+
+        if curr_full_block_cnt > 0:
+            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1]
+            if curr_mask_block_cnt == 0:
+                kv_consumer_state = process_first_half_block(
+                    n_block=full_n_block,
+                    seqlen=seqlen,
+                    kv_consumer_state=kv_consumer_state,
+                    mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
+                    score_mod_fn=score_mod_fn,
+                    is_first_block=True,
+                )
+            else:
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    seqlen=seqlen,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=True),
+                )
+                O_should_accumulate = True
+            for i in cutlass.range(1, curr_full_block_cnt):
+                full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+                kv_consumer_state = mma_one_n_block(
+                    kv_consumer_state,
+                    n_block=full_n_block,
+                    seqlen=seqlen,
+                    mma_pv_fn=partial(mma_pv_fn, zero_init=not O_should_accumulate),
+                    mask_fn=partial(mask_fn, mask_mod=None, mask_seqlen=False),
+                )
+                O_should_accumulate = True
+
+        if curr_mask_block_cnt + curr_full_block_cnt > 0:
+            kv_consumer_state = process_last_half_block(
+                kv_consumer_state=kv_consumer_state,
+                zero_init=not O_should_accumulate,
+            )
+            O_should_accumulate = True
+
+    return kv_consumer_state, O_should_accumulate, processed_any
+
+
+@cute.jit
+def load_block_list_sm100(
+    block_indices: cute.Tensor,
+    block_count,
+    load_q_with_first: cutlass.Constexpr,
+    q_stage: cutlass.Constexpr,
+    kv_producer_state,
+    load_Q,
+    load_K,
+    load_V,
+    pipeline_kv,
+):
+    """SM100 version of load_block_list (no intra_wg_overlap, no extra_tx_count)."""
+    if block_count > 0:
+        # First iteration: load Q alongside K if requested
+        n_block_first = block_indices[block_count - 1]
+
+        if const_expr(load_q_with_first):
+            # SM100 loads Q0 and optionally Q1
+            load_Q(block=0, stage=0)
+            if const_expr(q_stage == 2):
+                load_Q(block=1, stage=1)
+
+        # SM100 doesn't use producer_acquire for pipeline_kv in load path
+        # The pipeline barriers are handled inside load_KV
+        load_K(block=n_block_first, producer_state=kv_producer_state, page_idx=None)
+        kv_producer_state.advance()
+        load_V(block=n_block_first, producer_state=kv_producer_state, page_idx=None)
+        kv_producer_state.advance()
+
+        # Remaining blocks
+        for offset in cutlass.range(1, block_count):
+            n_block = block_indices[block_count - 1 - offset]
+            load_K(block=n_block, producer_state=kv_producer_state, page_idx=None)
+            kv_producer_state.advance()
+            load_V(block=n_block, producer_state=kv_producer_state, page_idx=None)
+            kv_producer_state.advance()
+
+    return kv_producer_state
+
+
+# SM100-specific tile processor using SM100 helpers
+@cute.jit
+def produce_block_sparse_loads_sm100(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    kv_producer_state,
+    load_Q,
+    load_K,
+    load_V,
+    pipeline_kv,
+    q_stage: cutlass.Constexpr,
+    q_producer_phase: Int32,
+    qhead_per_kvhead: cutlass.Constexpr,
+    q_subtile_factor: cutlass.Constexpr,
+):
+    """SM100 entry point for sparse block iteration.
+
+    SM100 uses PipelineTmaUmma which doesn't support extra_tx_count, so we use
+    simplified block processing that just calls producer_acquire without extras.
+
+    Args:
+        m_block: which tile of m we are processing
+        qhead_per_kvhead: Constexpr pack factor
+    """
+    m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
+
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+
+    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
+
+    if const_expr(full_block_cnt is not None):
+        curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
+        curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
+    else:
+        curr_full_block_cnt = Int32(0)
+        curr_full_block_idx = None
+
+    mask_empty = curr_mask_block_cnt == 0
+    full_empty = curr_full_block_cnt == 0
+
+    q_phase_flipped = False
+
+    if mask_empty:
+        # No masked blocks: process full list with Q loading
+        kv_producer_state = load_block_list_sm100(
+            curr_full_block_idx,
+            curr_full_block_cnt,
+            load_q_with_first=True,
+            q_stage=q_stage,
+            kv_producer_state=kv_producer_state,
+            load_Q=load_Q,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_kv=pipeline_kv,
+        )
+        q_phase_flipped = not full_empty
+    else:
+        # Process masked blocks with Q loading
+        kv_producer_state = load_block_list_sm100(
+            curr_mask_block_idx,
+            curr_mask_block_cnt,
+            load_q_with_first=True,
+            q_stage=q_stage,
+            kv_producer_state=kv_producer_state,
+            load_Q=load_Q,
+            load_K=load_K,
+            load_V=load_V,
+            pipeline_kv=pipeline_kv,
+        )
+        q_phase_flipped = True
+
+        if not full_empty:
+            # Process full blocks without Q loading
+            kv_producer_state = load_block_list_sm100(
+                curr_full_block_idx,
+                curr_full_block_cnt,
+                load_q_with_first=False,
+                q_stage=q_stage,
+                kv_producer_state=kv_producer_state,
+                load_Q=load_Q,
+                load_K=load_K,
+                load_V=load_V,
+                pipeline_kv=pipeline_kv,
+            )
+
+    if q_phase_flipped:
+        q_producer_phase ^= 1
+
+    return kv_producer_state, q_producer_phase
+
+
+@cute.jit
+def get_total_block_count(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    qhead_per_kvhead: cutlass.Constexpr,
+    q_subtile_factor: cutlass.Constexpr,
+):
+    m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
+
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+    if const_expr(full_block_cnt is not None):
+        return (
+            mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+            + full_block_cnt[batch_idx, head_idx, m_block_sparse]
+        )
+    else:
+        return mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+
+
+@cute.jit
+def handle_block_sparse_empty_tile_correction_sm100(
+    tidx: Int32,
+    q_stage: cutlass.Constexpr,
+    m_block_size: cutlass.Constexpr,
+    qhead_per_kvhead,
+    pack_gqa: cutlass.Constexpr,
+    is_split_kv: cutlass.Constexpr,
+    learnable_sink,
+    mLSE,
+    seqlen,
+    m_block: Int32,
+    head_idx: Int32,
+    batch_idx: Int32,
+    split_idx: Int32,
+    sScale: cute.Tensor,
+    stats: list,
+    correction_epilogue: Callable,
+    thr_mma_pv: cute.core.ThrMma,
+    tOtO: cute.Tensor,
+    sO: cute.Tensor,
+    pipeline_sm_stats: cutlass.pipeline.PipelineAsync,
+    sm_stats_barrier: cutlass.pipeline.NamedBarrier,
+    pipeline_o_epi: cutlass.pipeline.PipelineAsync,
+    sm_stats_consumer_phase: Int32,
+    o_corr_consumer_phase: Int32,
+    corr_epi_producer_phase: Int32,
+    softmax_scale_log2: Float32,
+    max_offset: Float32,
+    max_offset_scale: Float32,
+    mO_cur: Optional[cute.Tensor] = None,
+    gO: Optional[cute.Tensor] = None,
+    gmem_tiled_copy_O: Optional[cute.TiledCopy] = None,
+):
+    """Handle SM100 forward block-sparse tiles with no active KV blocks.
+
+    This path is taken when `total_block_cnt == 0`. The softmax warp-group still
+    arrives `mbar_softmax_corr_full` (synthetic "no work") so the correction
+    warp-group can:
+
+    - seed fully-masked-row stats (row_sum=1; row_max=-inf when tracked) for LSE
+    - run `correction_epilogue` with `scale=0` so the output tile is written as zeros
+      (independent of any prior tmem contents)
+    - wait on `mbar_softmax_corr_full` and arrive `mbar_softmax_corr_empty`
+      (and `mbar_corr_epi_*` when applicable) so phases stay aligned across tiles
+
+    This helper intentionally does not touch `mbar_P_full_*` since no P is produced.
+    See NOTE [SM100 block-sparse empty tiles: mbarrier contract].
+    """
+    LOG2_E = Float32(math.log2(math.e))
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+
+    for stage in cutlass.range_constexpr(q_stage):
+        row_sum_value = Float32(1.0)
+        row_max_value = (
+            -Float32.inf if const_expr(mLSE is not None or learnable_sink is not None) else None
+        )
+        if const_expr(learnable_sink is not None):
+            sink_val = -Float32.inf
+            if const_expr(not pack_gqa):
+                sink_val = Float32(learnable_sink[head_idx])
+            elif tidx < m_block_size:
+                q_head_idx = (
+                    (q_stage * m_block + stage) * m_block_size + tidx
+                ) % qhead_per_kvhead + head_idx * qhead_per_kvhead
+                sink_val = Float32(learnable_sink[q_head_idx])
+            if sink_val != -Float32.inf and (const_expr(not is_split_kv) or split_idx == 0):
+                if row_max_value == -Float32.inf:
+                    row_max_value = sink_val * (LOG2_E / softmax_scale_log2)
+                    row_sum_value = max_offset_scale
+                else:
+                    row_sum_value = row_sum_value + cute.math.exp2(
+                        sink_val * LOG2_E - row_max_value * softmax_scale_log2 + max_offset,
+                        fastmath=True,
+                    )
+        if tidx < m_block_size:
+            scale_row_idx = tidx + stage * m_block_size
+            sScale[scale_row_idx] = row_sum_value
+            if const_expr(mLSE is not None or learnable_sink is not None):
+                sScale[scale_row_idx + q_stage * m_block_size] = row_max_value
+        acc_flag = row_sum_value == Float32(0.0) or row_sum_value != row_sum_value
+        stats[stage] = (row_sum_value, row_max_value, acc_flag)
+
+        # See NOTE [SM100 block-sparse empty tiles: mbarrier contract].
+        # pipeline_sm_stats.consumer_wait_w_index_phase(stage, sm_stats_consumer_phase)
+        sm_stats_barrier.arrive_and_wait_w_index(index=stage * 4 + warp_idx)
+        pipeline_sm_stats.consumer_release_w_index(stage)
+
+        if const_expr(gmem_tiled_copy_O is None):
+            pipeline_o_epi.producer_acquire_w_index_phase(stage, corr_epi_producer_phase)
+
+        gO_stage = gO[None, None, stage] if const_expr(gO is not None) else None
+        correction_epilogue(
+            thr_mma_pv,
+            tOtO[None, None, None, stage],
+            tidx,
+            stage,
+            m_block,
+            seqlen.seqlen_q,
+            Float32(0.0),  # zero scale ensures empty tile writes zeros into staged outputs
+            sO[None, None, stage],
+            mO_cur,
+            gO_stage,
+            gmem_tiled_copy_O,
+        )
+        if const_expr(gmem_tiled_copy_O is None):
+            pipeline_o_epi.producer_commit_w_index(stage)
+
+    sm_stats_consumer_phase ^= 1
+    corr_epi_producer_phase ^= 1
+
+    return (
+        sm_stats_consumer_phase,
+        o_corr_consumer_phase,
+        corr_epi_producer_phase,
+    )
+
+
+@cute.jit
+def softmax_block_sparse_sm100(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    m_block,
+    softmax_step: Callable,
+    mask_fn: Callable,
+    mask_fn_none: Callable,
+    mma_si_consumer_phase: Int32,
+    si_corr_producer_phase: Int32,
+    s0_s1_sequence_phase: Int32,
+    pipeline_sm_stats: cutlass.pipeline.PipelineAsync,
+    sm_stats_barrier: cutlass.pipeline.NamedBarrier,
+    q_stage: cutlass.Constexpr,
+    stage_idx: Int32,
+    check_m_boundary: bool,
+    qhead_per_kvhead: cutlass.Constexpr,
+    q_subtile_factor: cutlass.Constexpr[int] = 1,
+):
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+    m_block_sparse = sparse_tensor_m_block(m_block, qhead_per_kvhead, q_subtile_factor)
+
+    mask_block_cnt, mask_block_idx, full_block_cnt, full_block_idx, *_ = blocksparse_tensors
+
+    curr_mask_block_cnt = mask_block_cnt[batch_idx, head_idx, m_block_sparse]
+    curr_mask_block_idx = mask_block_idx[batch_idx, head_idx, m_block_sparse, None]
+
+    if const_expr(full_block_cnt is not None):
+        curr_full_block_cnt = full_block_cnt[batch_idx, head_idx, m_block_sparse]
+        curr_full_block_idx = full_block_idx[batch_idx, head_idx, m_block_sparse, None]
+    else:
+        curr_full_block_cnt = Int32(0)
+        curr_full_block_idx = None
+
+    total_block_cnt = curr_mask_block_cnt + curr_full_block_cnt
+
+    if total_block_cnt == 0:
+        sm_stats_barrier.arrive_w_index(index=stage_idx * 4 + warp_idx)
+    else:
+        if curr_mask_block_cnt > 0:
+            mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1]
+            (
+                mma_si_consumer_phase,
+                si_corr_producer_phase,
+                s0_s1_sequence_phase,
+            ) = softmax_step(
+                mma_si_consumer_phase,
+                si_corr_producer_phase,
+                s0_s1_sequence_phase,
+                mask_n_block,
+                is_first=True,
+                mask_fn=partial(mask_fn, mask_seqlen=True, check_q_boundary=check_m_boundary),
+            )
+            for i in cutlass.range(1, curr_mask_block_cnt):
+                mask_n_block = curr_mask_block_idx[curr_mask_block_cnt - 1 - i]
+                (
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                ) = softmax_step(
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                    mask_n_block,
+                    mask_fn=partial(mask_fn, mask_seqlen=False, check_q_boundary=check_m_boundary),
+                )
+
+        if curr_full_block_cnt > 0:
+            full_n_block = curr_full_block_idx[curr_full_block_cnt - 1]
+            if curr_mask_block_cnt == 0:
+                (
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                ) = softmax_step(
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                    full_n_block,
+                    is_first=True,
+                    mask_fn=partial(
+                        mask_fn_none, mask_seqlen=True, check_q_boundary=check_m_boundary
+                    ),
+                )
+            else:
+                (
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                ) = softmax_step(
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                    full_n_block,
+                    is_first=False,
+                    mask_fn=partial(
+                        mask_fn_none, mask_seqlen=False, check_q_boundary=check_m_boundary
+                    ),
+                )
+            for i in cutlass.range(1, curr_full_block_cnt):
+                full_n_block = curr_full_block_idx[curr_full_block_cnt - 1 - i]
+                (
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                ) = softmax_step(
+                    mma_si_consumer_phase,
+                    si_corr_producer_phase,
+                    s0_s1_sequence_phase,
+                    full_n_block,
+                    mask_fn=partial(
+                        mask_fn_none, mask_seqlen=False, check_q_boundary=check_m_boundary
+                    ),
+                )
+
+    return (
+        mma_si_consumer_phase,
+        si_corr_producer_phase,
+        s0_s1_sequence_phase,
+        total_block_cnt == 0,
+    )
+
+
+# =============================================================================
+# Backward-specific block-sparse helpers (SM100)
+# =============================================================================
+#
+# In backward, iteration is transposed compared to forward:
+# - Forward: outer loop over m_blocks (Q tiles), inner loop over n_blocks (KV tiles)
+# - Backward: outer loop over n_blocks (KV tiles), inner loop over m_blocks (Q tiles)
+#
+# The backward block-sparse tensors use "Q direction" indexing:
+# - q_block_cnt[batch, head, n_block] → count of m_blocks to process for this KV tile
+# - q_block_idx[batch, head, n_block, :] → indices of m_blocks to process
+#
+
+
+@cute.jit
+def get_total_q_block_count_bwd(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    n_block,
+    subtile_factor: cutlass.Constexpr = 1,
+    m_block_max: int = 0,
+):
+    """Count total tile iterations for given n_block (KV tile) in backward."""
+    q_block_cnt, _, full_block_cnt, _, *_ = blocksparse_tensors
+    total = q_block_cnt[batch_idx, head_idx, n_block]
+    if const_expr(full_block_cnt is not None):
+        total = total + full_block_cnt[batch_idx, head_idx, n_block]
+    return total * subtile_factor
+
+
+@cute.jit
+def produce_block_sparse_q_loads_bwd_sm100(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    n_block,
+    # Pipeline states (will be returned after advancing)
+    producer_state_Q_LSE,
+    producer_state_dO_dPsum,
+    # Pipelines
+    pipeline_Q,
+    pipeline_LSE,
+    pipeline_dO,
+    pipeline_dPsum,
+    # Load functions
+    load_K,
+    load_V,
+    load_Q,
+    load_dO,
+    copy_stats,
+    # Global tensors for LSE/dPsum
+    gLSE,
+    sLSE,
+    gdPsum,
+    sdPsum,
+    # TMA copy bytes for extra_tx_count
+    tma_copy_bytes_K,
+    tma_copy_bytes_V,
+    # Flags for which loads to perform
+    should_load_Q: cutlass.Constexpr,
+    should_load_dO: cutlass.Constexpr,
+    # Subtiling factor and bounds
+    subtile_factor: cutlass.Constexpr = 1,
+    m_block_max: int = 0,
+):
+    """SM100 backward block sparse loading with subtiling.
+
+    Returns updated (producer_state_Q_LSE, producer_state_dO_dPsum).
+    First iteration loads K/V alongside Q/dO; subsequent iterations load only Q/dO.
+    """
+    (
+        curr_q_cnt,
+        curr_q_idx,
+        curr_full_cnt,
+        curr_full_idx,
+        loop_count,
+    ) = get_block_sparse_iteration_info_bwd(
+        blocksparse_tensors, batch_idx, head_idx, n_block, subtile_factor, m_block_max
+    )
+
+    for iter_idx in cutlass.range(loop_count, unroll=1):
+        m_block, _ = get_m_block_from_iter_bwd(
+            iter_idx,
+            curr_q_cnt,
+            curr_q_idx,
+            curr_full_cnt,
+            curr_full_idx,
+            subtile_factor,
+            m_block_max,
+        )
+        m_block_safe = m_block
+        if m_block_max > 0:
+            m_block_safe = cutlass.min(m_block, m_block_max - 1)
+
+        if iter_idx == 0:
+            # First block: load K/V alongside Q/dO
+            if const_expr(should_load_Q):
+                pipeline_Q.producer_acquire(producer_state_Q_LSE, extra_tx_count=tma_copy_bytes_K)
+                load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q_LSE))
+                load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
+                pipeline_Q.producer_commit(producer_state_Q_LSE)
+                pipeline_LSE.producer_acquire(producer_state_Q_LSE)
+                with cute.arch.elect_one():
+                    copy_stats(
+                        gLSE[None, m_block_safe],
+                        sLSE[None, producer_state_Q_LSE.index],
+                        mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
+                    )
+                producer_state_Q_LSE.advance()
+            if const_expr(should_load_dO):
+                pipeline_dO.producer_acquire(
+                    producer_state_dO_dPsum, extra_tx_count=tma_copy_bytes_V
+                )
+                load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_dPsum))
+                load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
+                pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
+                with cute.arch.elect_one():
+                    copy_stats(
+                        gdPsum[None, m_block_safe],
+                        sdPsum[None, producer_state_dO_dPsum.index],
+                        mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
+                    )
+                producer_state_dO_dPsum.advance()
+        else:
+            # Subsequent blocks: just load Q/dO (K/V already loaded)
+            if const_expr(should_load_Q):
+                pipeline_Q.producer_acquire(producer_state_Q_LSE)
+                load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
+                pipeline_Q.producer_commit(producer_state_Q_LSE)
+                pipeline_LSE.producer_acquire(producer_state_Q_LSE)
+                with cute.arch.elect_one():
+                    copy_stats(
+                        gLSE[None, m_block_safe],
+                        sLSE[None, producer_state_Q_LSE.index],
+                        mbar_ptr=pipeline_LSE.producer_get_barrier(producer_state_Q_LSE),
+                    )
+                producer_state_Q_LSE.advance()
+            if const_expr(should_load_dO):
+                pipeline_dO.producer_acquire(producer_state_dO_dPsum)
+                load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
+                pipeline_dO.producer_commit(producer_state_dO_dPsum)
+                pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
+                with cute.arch.elect_one():
+                    copy_stats(
+                        gdPsum[None, m_block_safe],
+                        sdPsum[None, producer_state_dO_dPsum.index],
+                        mbar_ptr=pipeline_dPsum.producer_get_barrier(producer_state_dO_dPsum),
+                    )
+                producer_state_dO_dPsum.advance()
+
+    return producer_state_Q_LSE, producer_state_dO_dPsum
+
+
+@cute.jit
+def get_block_sparse_iteration_info_bwd(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    n_block,
+    subtile_factor: cutlass.Constexpr = 1,
+    m_block_max: int = 0,
+):
+    """Extract block-sparse iteration info for backward pass.
+
+    Returns (curr_q_cnt, curr_q_idx, curr_full_cnt, curr_full_idx, total_count).
+    """
+    q_cnt, q_idx, full_cnt, full_idx, *_ = blocksparse_tensors
+    curr_q_cnt = q_cnt[batch_idx, head_idx, n_block]
+    curr_q_idx = q_idx[batch_idx, head_idx, n_block, None]
+
+    if const_expr(full_cnt is not None):
+        curr_full_cnt = full_cnt[batch_idx, head_idx, n_block]
+        curr_full_idx = full_idx[batch_idx, head_idx, n_block, None]
+    else:
+        curr_full_cnt = Int32(0)
+        curr_full_idx = None
+
+    sparse_block_count = curr_q_cnt
+    if const_expr(full_cnt is not None):
+        sparse_block_count = sparse_block_count + curr_full_cnt
+    total_count = sparse_block_count * subtile_factor
+
+    return curr_q_cnt, curr_q_idx, curr_full_cnt, curr_full_idx, total_count
+
+
+@cute.jit
+def get_m_block_from_iter_bwd(
+    iter_idx,
+    curr_q_cnt,
+    curr_q_idx: cute.Tensor,
+    curr_full_cnt,
+    curr_full_idx: Optional[cute.Tensor],
+    subtile_factor: cutlass.Constexpr = 1,
+    m_block_max: int = 0,
+):
+    """Derive m_block index and is_full_block flag from iteration index.
+
+    Returns (m_block, is_full_block):
+        - m_block: The actual Q-tile block index
+        - is_full_block: True if this is a full block (no mask_mod needed)
+    """
+    sparse_iter_idx = iter_idx // subtile_factor
+    subtile_offset = iter_idx % subtile_factor
+
+    sparse_m_block = Int32(0)
+    is_full_block = False
+    if const_expr(curr_full_idx is not None):
+        if sparse_iter_idx < curr_q_cnt:
+            sparse_m_block = curr_q_idx[sparse_iter_idx]
+        else:
+            sparse_m_block = curr_full_idx[sparse_iter_idx - curr_q_cnt]
+            is_full_block = True
+    else:
+        sparse_m_block = curr_q_idx[sparse_iter_idx]
+
+    return sparse_m_block * subtile_factor + subtile_offset, is_full_block
+
+
+@cute.jit
+def _load_q_do_block_sm90(
+    m_block,
+    producer_state_Q,
+    producer_state_dO,
+    pipeline_Q,
+    pipeline_dO,
+    load_K,
+    load_V,
+    load_Q,
+    load_dO,
+    load_LSE,
+    load_dPsum,
+    tma_copy_bytes_K,
+    tma_copy_bytes_V,
+    Q_stage_eq_dO_stage: cutlass.Constexpr,
+    load_kv: bool,
+):
+    """Load one Q/dO block, optionally loading K/V on first iteration."""
+    if load_kv:
+        pipeline_Q.producer_acquire(producer_state_Q, extra_tx_count=tma_copy_bytes_K)
+        load_K(tma_bar_ptr=pipeline_Q.producer_get_barrier(producer_state_Q))
+    else:
+        pipeline_Q.producer_acquire(producer_state_Q)
+    load_Q(m_block, producer_state=producer_state_Q)
+    load_LSE(m_block, producer_state=producer_state_Q)
+
+    producer_state_dO_cur = (
+        producer_state_dO if const_expr(not Q_stage_eq_dO_stage) else producer_state_Q
+    )
+    if load_kv:
+        pipeline_dO.producer_acquire(producer_state_dO_cur, extra_tx_count=tma_copy_bytes_V)
+        load_V(tma_bar_ptr=pipeline_dO.producer_get_barrier(producer_state_dO_cur))
+    else:
+        pipeline_dO.producer_acquire(producer_state_dO_cur)
+    load_dO(m_block, producer_state=producer_state_dO_cur)
+    load_dPsum(m_block, producer_state=producer_state_dO_cur)
+
+    producer_state_Q.advance()
+    producer_state_dO.advance()
+    return producer_state_Q, producer_state_dO
+
+
+@cute.jit
+def produce_block_sparse_q_loads_bwd_sm90(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    n_block,
+    producer_state_Q,
+    producer_state_dO,
+    pipeline_Q,
+    pipeline_dO,
+    load_K,
+    load_V,
+    load_Q,
+    load_dO,
+    load_LSE,
+    load_dPsum,
+    tma_copy_bytes_K,
+    tma_copy_bytes_V,
+    Q_stage_eq_dO_stage: cutlass.Constexpr,
+    subtile_factor: cutlass.Constexpr,
+    m_block_max: int,
+):
+    """SM90 backward block sparse loading with separate partial/full loops.
+
+    K/V are loaded with the first valid block. Iterates partial blocks first,
+    then full blocks, matching consumer order.
+
+    Returns updated (producer_state_Q, producer_state_dO).
+    """
+    q_cnt, q_idx, full_cnt, full_idx, *_ = blocksparse_tensors
+    curr_q_cnt = q_cnt[batch_idx, head_idx, n_block]
+    curr_q_idx = q_idx[batch_idx, head_idx, n_block, None]
+
+    if const_expr(full_cnt is not None):
+        curr_full_cnt = full_cnt[batch_idx, head_idx, n_block]
+        curr_full_idx = full_idx[batch_idx, head_idx, n_block, None]
+    else:
+        curr_full_cnt = Int32(0)
+        curr_full_idx = None
+
+    kv_loaded = False
+
+    for iter_idx in cutlass.range(curr_q_cnt * subtile_factor, unroll=1):
+        sparse_idx = iter_idx // subtile_factor
+        subtile_offset = iter_idx % subtile_factor
+        m_block = curr_q_idx[sparse_idx] * subtile_factor + subtile_offset
+
+        if m_block < m_block_max:
+            producer_state_Q, producer_state_dO = _load_q_do_block_sm90(
+                m_block,
+                producer_state_Q,
+                producer_state_dO,
+                pipeline_Q,
+                pipeline_dO,
+                load_K,
+                load_V,
+                load_Q,
+                load_dO,
+                load_LSE,
+                load_dPsum,
+                tma_copy_bytes_K,
+                tma_copy_bytes_V,
+                Q_stage_eq_dO_stage,
+                load_kv=not kv_loaded,
+            )
+            kv_loaded = True
+
+    if const_expr(full_cnt is not None):
+        for iter_idx in cutlass.range(curr_full_cnt * subtile_factor, unroll=1):
+            sparse_idx = iter_idx // subtile_factor
+            subtile_offset = iter_idx % subtile_factor
+            m_block = curr_full_idx[sparse_idx] * subtile_factor + subtile_offset
+
+            if m_block < m_block_max:
+                producer_state_Q, producer_state_dO = _load_q_do_block_sm90(
+                    m_block,
+                    producer_state_Q,
+                    producer_state_dO,
+                    pipeline_Q,
+                    pipeline_dO,
+                    load_K,
+                    load_V,
+                    load_Q,
+                    load_dO,
+                    load_LSE,
+                    load_dPsum,
+                    tma_copy_bytes_K,
+                    tma_copy_bytes_V,
+                    Q_stage_eq_dO_stage,
+                    load_kv=not kv_loaded,
+                )
+                kv_loaded = True
+
+    return producer_state_Q, producer_state_dO
+
+
+@cute.jit
+def consume_block_sparse_mma_bwd_sm90(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    n_block,
+    consumer_state_Q,
+    consumer_state_dO,
+    mma_one_m_block_fn,
+    mask,
+    mask_mod,
+    is_causal: cutlass.Constexpr,
+    is_local: cutlass.Constexpr,
+    thr_mma_SdP,
+    score_mod_fn=None,
+    score_mod_bwd_fn=None,
+    subtile_factor: cutlass.Constexpr = 1,
+    m_block_max: int = 0,
+    aux_tensors=None,
+    fastdiv_mods=(None, None),
+):
+    """SM90 backward block sparse MMA consumption with separate partial/full loops.
+
+    Partial blocks are processed first (with mask_mod applied), then full blocks
+    (without mask_mod). This ensures mask_mod is only applied where needed.
+
+    Returns updated (consumer_state_Q, consumer_state_dO).
+    """
+    q_cnt, q_idx, full_cnt, full_idx, *_ = blocksparse_tensors
+    curr_q_cnt = q_cnt[batch_idx, head_idx, n_block]
+    curr_q_idx = q_idx[batch_idx, head_idx, n_block, None]
+
+    if const_expr(full_cnt is not None):
+        curr_full_cnt = full_cnt[batch_idx, head_idx, n_block]
+        curr_full_idx = full_idx[batch_idx, head_idx, n_block, None]
+    else:
+        curr_full_cnt = Int32(0)
+        curr_full_idx = None
+
+    dKV_accumulate = False
+
+    mask_fn_partial = partial(
+        mask.apply_mask,
+        batch_idx=batch_idx,
+        head_idx=head_idx,
+        n_block=n_block,
+        thr_mma=thr_mma_SdP,
+        mask_seqlen=True,
+        mask_causal=is_causal,
+        mask_local=is_local,
+        mask_mod=mask_mod,
+        aux_tensors=aux_tensors,
+        fastdiv_mods=fastdiv_mods,
+    )
+
+    mask_fn_full = partial(
+        mask.apply_mask,
+        batch_idx=batch_idx,
+        head_idx=head_idx,
+        n_block=n_block,
+        thr_mma=thr_mma_SdP,
+        mask_seqlen=True,
+        mask_causal=is_causal,
+        mask_local=is_local,
+        aux_tensors=aux_tensors,
+        fastdiv_mods=fastdiv_mods,
+    )
+
+    for iter_idx in cutlass.range(curr_q_cnt * subtile_factor, unroll=1):
+        sparse_idx = iter_idx // subtile_factor
+        subtile_offset = iter_idx % subtile_factor
+        m_block = curr_q_idx[sparse_idx] * subtile_factor + subtile_offset
+
+        if m_block < m_block_max:
+            consumer_state_Q, consumer_state_dO = mma_one_m_block_fn(
+                m_block,
+                consumer_state_Q,
+                consumer_state_dO,
+                mask_fn=mask_fn_partial,
+                score_mod_fn=score_mod_fn,
+                score_mod_bwd_fn=score_mod_bwd_fn,
+                dKV_accumulate=dKV_accumulate,
+            )
+            dKV_accumulate = True
+
+    if const_expr(full_cnt is not None):
+        for iter_idx in cutlass.range(curr_full_cnt * subtile_factor, unroll=1):
+            sparse_idx = iter_idx // subtile_factor
+            subtile_offset = iter_idx % subtile_factor
+            m_block = curr_full_idx[sparse_idx] * subtile_factor + subtile_offset
+
+            if m_block < m_block_max:
+                consumer_state_Q, consumer_state_dO = mma_one_m_block_fn(
+                    m_block,
+                    consumer_state_Q,
+                    consumer_state_dO,
+                    mask_fn=mask_fn_full,
+                    score_mod_fn=score_mod_fn,
+                    score_mod_bwd_fn=score_mod_bwd_fn,
+                    dKV_accumulate=dKV_accumulate,
+                )
+                dKV_accumulate = True
+
+    return consumer_state_Q, consumer_state_dO
+
+
+@cute.jit
+def _store_one_dQaccum_sm90(
+    m_block,
+    sdQaccum: cute.Tensor,
+    gdQaccum: cute.Tensor,
+    num_dQ_warp_groups: cutlass.Constexpr,
+    num_threads_per_warp_group: cutlass.Constexpr,
+    tma_copy_bytes_dQ,
+):
+    """Store dQaccum for a single m_block."""
+    for warp_group_idx in cutlass.range_constexpr(num_dQ_warp_groups):
+        cute.arch.cp_async_bulk_wait_group(num_dQ_warp_groups - 1 - warp_group_idx, read=True)
+        cute.arch.barrier_arrive(
+            barrier_id=int(NamedBarrierBwd.dQEmptyWG0) + warp_group_idx,
+            number_of_threads=num_threads_per_warp_group + cute.arch.WARP_SIZE,
+        )
+    for warp_group_idx in cutlass.range_constexpr(num_dQ_warp_groups):
+        cute.arch.barrier(
+            barrier_id=int(NamedBarrierBwd.dQFullWG0) + warp_group_idx,
+            number_of_threads=num_threads_per_warp_group + cute.arch.WARP_SIZE,
+        )
+        with cute.arch.elect_one():
+            copy_utils.cpasync_reduce_bulk_add_f32(
+                sdQaccum[None, warp_group_idx].iterator,
+                gdQaccum[(None, warp_group_idx), m_block].iterator,
+                tma_copy_bytes_dQ,
+            )
+        cute.arch.cp_async_bulk_commit_group()
+
+
+@cute.jit
+def dQaccum_store_block_sparse_bwd_sm90(
+    blocksparse_tensors: BlockSparseTensors,
+    batch_idx,
+    head_idx,
+    n_block,
+    sdQaccum: cute.Tensor,
+    gdQaccum: cute.Tensor,
+    subtile_factor: cutlass.Constexpr,
+    m_block_max: int,
+    num_dQ_warp_groups: cutlass.Constexpr,
+    num_threads_per_warp_group: cutlass.Constexpr,
+    tma_copy_bytes_dQ,
+):
+    """SM90 backward block sparse dQaccum store with separate partial/full loops.
+
+    Iterates partial blocks first, then full blocks, matching producer/consumer order.
+    """
+    q_cnt, q_idx, full_cnt, full_idx, *_ = blocksparse_tensors
+    curr_q_cnt = q_cnt[batch_idx, head_idx, n_block]
+    curr_q_idx = q_idx[batch_idx, head_idx, n_block, None]
+
+    if const_expr(full_cnt is not None):
+        curr_full_cnt = full_cnt[batch_idx, head_idx, n_block]
+        curr_full_idx = full_idx[batch_idx, head_idx, n_block, None]
+    else:
+        curr_full_cnt = Int32(0)
+        curr_full_idx = None
+
+    for iter_idx in cutlass.range(curr_q_cnt * subtile_factor, unroll=1):
+        sparse_idx = iter_idx // subtile_factor
+        subtile_offset = iter_idx % subtile_factor
+        m_block = curr_q_idx[sparse_idx] * subtile_factor + subtile_offset
+
+        if m_block < m_block_max:
+            _store_one_dQaccum_sm90(
+                m_block,
+                sdQaccum,
+                gdQaccum,
+                num_dQ_warp_groups,
+                num_threads_per_warp_group,
+                tma_copy_bytes_dQ,
+            )
+
+    if const_expr(full_cnt is not None):
+        for iter_idx in cutlass.range(curr_full_cnt * subtile_factor, unroll=1):
+            sparse_idx = iter_idx // subtile_factor
+            subtile_offset = iter_idx % subtile_factor
+            m_block = curr_full_idx[sparse_idx] * subtile_factor + subtile_offset
+
+            if m_block < m_block_max:
+                _store_one_dQaccum_sm90(
+                    m_block,
+                    sdQaccum,
+                    gdQaccum,
+                    num_dQ_warp_groups,
+                    num_threads_per_warp_group,
+                    tma_copy_bytes_dQ,
+                )

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/block_sparsity.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/block_sparsity.py
@@ -1,0 +1,638 @@
+"""
+Block-sparsity utilities for FlexAttention
+"""
+
+from typing import Callable, NamedTuple, Tuple
+
+import cutlass.cute as cute
+import torch
+
+from flashrt_fa4.cute.cute_dsl_utils import get_broadcast_dims, to_cute_tensor
+
+
+def ceildiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+class BlockSparseTensors(NamedTuple):
+    mask_block_cnt: cute.Tensor
+    mask_block_idx: cute.Tensor
+    full_block_cnt: cute.Tensor | None
+    full_block_idx: cute.Tensor | None
+    dq_write_order: cute.Tensor | None = None
+    dq_write_order_full: cute.Tensor | None = None
+
+    def __new_from_mlir_values__(self, values):
+        if len(values) == 2:
+            values = (*values, None, None, None, None)
+        elif len(values) == 4:
+            values = (*values, None, None)
+        return BlockSparseTensors(*values)
+
+
+class BlockSparseTensorsTorch(NamedTuple):
+    mask_block_cnt: torch.Tensor
+    mask_block_idx: torch.Tensor
+    full_block_cnt: torch.Tensor | None = None
+    full_block_idx: torch.Tensor | None = None
+    block_size: tuple[int, int] | None = None
+    dq_write_order: torch.Tensor | None = None
+    dq_write_order_full: torch.Tensor | None = None
+    spt: bool | None = None
+
+
+def _ordered_to_dense_simple(
+    num_blocks: torch.Tensor,
+    indices: torch.Tensor,
+    num_cols: int,
+) -> torch.Tensor:
+    """Convert ordered sparse representation to dense binary matrix.
+
+    Args:
+        num_blocks: [B, H, num_rows] count of valid entries per row
+        indices: [B, H, num_rows, max_entries] column indices (valid entries packed left)
+        num_cols: total number of columns
+
+    Returns:
+        dense: [B, H, num_rows, num_cols] binary int32 matrix
+    """
+    B, H, num_rows, max_entries = indices.shape
+    device = indices.device
+    dense = torch.zeros(B, H, num_rows, num_cols + 1, dtype=torch.int32, device=device)
+    col_range = torch.arange(max_entries, device=device)
+    valid = col_range[None, None, None, :] < num_blocks[:, :, :, None]
+    safe_indices = torch.where(valid, indices.long(), num_cols)
+    row_idx = torch.arange(num_rows, device=device)[None, None, :, None].expand_as(indices)
+    b_idx = torch.arange(B, device=device)[:, None, None, None].expand_as(indices)
+    h_idx = torch.arange(H, device=device)[None, :, None, None].expand_as(indices)
+    dense[b_idx, h_idx, row_idx, safe_indices] = 1
+    return dense[:, :, :, :num_cols]
+
+
+def compute_dq_write_order(
+    fwd_mask_cnt: torch.Tensor,
+    fwd_mask_idx: torch.Tensor,
+    fwd_full_cnt: torch.Tensor | None,
+    fwd_full_idx: torch.Tensor | None,
+    bwd_mask_cnt: torch.Tensor,
+    bwd_mask_idx: torch.Tensor,
+    bwd_full_cnt: torch.Tensor | None,
+    bwd_full_idx: torch.Tensor | None,
+    spt: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Compute dQ write-order metadata for deterministic block-sparse backward.
+
+    For each (n_block, i) in the backward iteration, computes the semaphore
+    lock value: the rank of n_block in the combined (partial + full) sorted
+    contributor list for the target m_block.
+
+    Lock values are assigned in ascending n_block order (or descending if spt=True)
+    to guarantee deadlock-freedom with the CTA scheduling order.
+
+    Args:
+        fwd_mask_cnt: [B, H, num_m_blocks] partial contributor counts per m_block
+        fwd_mask_idx: [B, H, num_m_blocks, max_kv] partial contributor n_block indices (ascending)
+        fwd_full_cnt: [B, H, num_m_blocks] full contributor counts per m_block (optional)
+        fwd_full_idx: [B, H, num_m_blocks, max_kv] full contributor n_block indices (optional)
+        bwd_mask_cnt: [B, H, num_n_blocks] partial iteration counts per n_block
+        bwd_mask_idx: [B, H, num_n_blocks, max_q] partial iteration m_block indices
+        bwd_full_cnt: [B, H, num_n_blocks] full iteration counts per n_block (optional)
+        bwd_full_idx: [B, H, num_n_blocks, max_q] full iteration m_block indices (optional)
+        spt: if True, reverse ordering (highest n_block gets lock_value=0)
+
+    Returns:
+        (dq_write_order, dq_write_order_full): tensors parallel to bwd_mask_idx
+        and bwd_full_idx respectively, containing lock values.
+    """
+    device = fwd_mask_idx.device
+    B, H, num_m, max_kv_partial = fwd_mask_idx.shape
+    _, _, num_n, max_q_partial = bwd_mask_idx.shape
+
+    has_full = fwd_full_cnt is not None and fwd_full_idx is not None
+
+    dense_partial = _ordered_to_dense_simple(fwd_mask_cnt, fwd_mask_idx, num_n)
+    if has_full:
+        dense_full = _ordered_to_dense_simple(fwd_full_cnt, fwd_full_idx, num_n)
+        dense = (dense_partial + dense_full).clamp(max=1)
+    else:
+        dense = dense_partial
+
+    cumsum = dense.cumsum(dim=-1)
+    rank_table = (cumsum - dense).to(torch.int32)
+
+    if spt:
+        total_per_m = cumsum[:, :, :, -1:]
+        rank_table = (total_per_m - 1 - rank_table).to(torch.int32)
+
+    def _gather_write_order(bwd_idx, bwd_cnt):
+        b_i = torch.arange(B, device=device)[:, None, None, None].expand_as(bwd_idx)
+        h_i = torch.arange(H, device=device)[None, :, None, None].expand_as(bwd_idx)
+        n_i = torch.arange(bwd_idx.shape[2], device=device)[None, None, :, None].expand_as(bwd_idx)
+        m_vals = bwd_idx.long().clamp(0, num_m - 1)
+        return rank_table[b_i, h_i, m_vals, n_i].to(torch.int32)
+
+    dq_write_order = _gather_write_order(bwd_mask_idx, bwd_mask_cnt)
+
+    dq_write_order_full = None
+    if has_full and bwd_full_cnt is not None and bwd_full_idx is not None:
+        dq_write_order_full = _gather_write_order(bwd_full_idx, bwd_full_cnt)
+
+    return dq_write_order, dq_write_order_full
+
+
+def compute_dq_write_order_from_block_mask(
+    block_mask,
+    spt: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    (
+        _seq_q,
+        _seq_k,
+        kv_mask_cnt,
+        kv_mask_idx,
+        full_kv_cnt,
+        full_kv_idx,
+        q_mask_cnt,
+        q_mask_idx,
+        full_q_cnt,
+        full_q_idx,
+        *_,
+    ) = block_mask.as_tuple()
+    return compute_dq_write_order(
+        kv_mask_cnt,
+        kv_mask_idx,
+        full_kv_cnt,
+        full_kv_idx,
+        q_mask_cnt,
+        q_mask_idx,
+        full_q_cnt,
+        full_q_idx,
+        spt=spt,
+    )
+
+
+def get_sparse_q_block_size(
+    tensors: BlockSparseTensorsTorch | None,
+    seqlen_q: int,
+) -> int | None:
+    """Return the Q sparse block size, or None when sparsity is unset or ambiguous."""
+    if tensors is None:
+        return None
+    if tensors.block_size is not None:
+        return tensors.block_size[0]
+    num_m_blocks = tensors.mask_block_idx.shape[2]
+    min_block_size = ceildiv(seqlen_q, num_m_blocks)
+    max_block_size = seqlen_q if num_m_blocks == 1 else (seqlen_q - 1) // (num_m_blocks - 1)
+    if min_block_size != max_block_size:
+        return None
+    return min_block_size
+
+
+def _expand_sparsity_tensor(
+    tensor: torch.Tensor,
+    expected_shape: Tuple[int, ...],
+    tensor_name: str,
+    context: str | None,
+    hint: str | Callable[[], str] | None,
+) -> torch.Tensor:
+    """Check if we need to expand the tensor to expected shape, and do so if possible."""
+    needs_expand = tensor.shape != expected_shape
+    if not needs_expand:
+        return tensor
+    can_expand = all(map(lambda cur, tgt: cur == tgt or cur == 1, tensor.shape, expected_shape))
+    if not can_expand:
+        context_clause = f" ({context})" if context else ""
+        resolved_hint = hint() if callable(hint) else hint
+        hint_clause = f" Hint: {resolved_hint}" if resolved_hint else ""
+        raise ValueError(
+            f"{tensor_name}{context_clause} with shape {tensor.shape} cannot be expanded to expected shape {expected_shape}."
+            f"{hint_clause}"
+        )
+    return tensor.expand(*expected_shape)
+
+
+def _check_and_expand_block(
+    name: str,
+    cnt: torch.Tensor | None,
+    idx: torch.Tensor | None,
+    expected_count_shape: Tuple[int, int, int],
+    expected_index_shape: Tuple[int, int, int, int],
+    context: str | None,
+    hint: str | Callable[[], str] | None,
+) -> Tuple[torch.Tensor | None, torch.Tensor | None]:
+    if (cnt is None) != (idx is None):
+        raise ValueError(
+            f"{name}_block_cnt and {name}_block_idx must both be provided or both be None"
+        )
+    if cnt is None or idx is None:
+        return None, None
+    if cnt.dtype != torch.int32 or idx.dtype != torch.int32:
+        raise ValueError(f"{name}_block tensors must have dtype torch.int32")
+    if cnt.device != idx.device:
+        raise ValueError(f"{name}_block_cnt and {name}_block_idx must be on the same device")
+    if not cnt.is_cuda or not idx.is_cuda:
+        raise ValueError(f"{name}_block tensors must live on CUDA")
+    expanded_cnt = _expand_sparsity_tensor(
+        cnt, expected_count_shape, f"{name}_block_cnt", context, hint
+    )
+    # [Note] Allow Compact block sparse indices
+    # Allow the last dimension (n_blocks) of idx to be <= expected, since
+    # FA4 only accesses indices 0..cnt-1 per query tile. This enables compact
+    # index tensors that avoid O(N^2) memory at long sequence lengths.
+    if idx.ndim == 4 and idx.shape[3] <= expected_index_shape[3]:
+        expected_index_shape = (*expected_index_shape[:3], idx.shape[3])
+    expanded_idx = _expand_sparsity_tensor(
+        idx, expected_index_shape, f"{name}_block_idx", context, hint
+    )
+    return expanded_cnt, expanded_idx
+
+
+def _check_and_expand_metadata_tensor(
+    name: str,
+    tensor: torch.Tensor | None,
+    expected_shape: Tuple[int, ...],
+    context: str | None,
+    hint: str | Callable[[], str] | None,
+    device: torch.device,
+) -> torch.Tensor | None:
+    if tensor is None:
+        return None
+    if tensor.dtype != torch.int32:
+        raise ValueError(f"{name} must have dtype torch.int32")
+    if tensor.device != device:
+        raise ValueError(f"{name} must be on the same device as block sparse tensors")
+    if not tensor.is_cuda:
+        raise ValueError(f"{name} must live on CUDA")
+    return _expand_sparsity_tensor(tensor, expected_shape, name, context, hint)
+
+
+def get_block_sparse_expected_shapes(
+    batch_size: int,
+    num_head: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    m_block_size: int,
+    n_block_size: int,
+    q_stage: int,
+) -> Tuple[Tuple[int, int, int], Tuple[int, int, int, int]]:
+    """Return (expected_count_shape, expected_index_shape) for block sparse normalization."""
+    m_block_size_effective = q_stage * m_block_size
+    expected_m_blocks = ceildiv(seqlen_q, m_block_size_effective)
+    expected_n_blocks = ceildiv(seqlen_k, n_block_size)
+    expected_count_shape = (batch_size, num_head, expected_m_blocks)
+    expected_index_shape = (batch_size, num_head, expected_m_blocks, expected_n_blocks)
+    return expected_count_shape, expected_index_shape
+
+
+def infer_block_sparse_expected_shapes(
+    tensors: BlockSparseTensorsTorch,
+    *,
+    batch_size: int,
+    num_head: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    m_block_size: int,
+    n_block_size: int,
+    q_stage: int,
+    context: str,
+    sparse_block_size_q: int | None = None,
+    sparse_block_size_kv: int | None = None,
+) -> Tuple[Tuple[int, int, int], Tuple[int, int, int, int], int]:
+    """Infer shapes and scaling for block-sparse tensors.
+
+    Expectations:
+    - mask_block_cnt is (B, H, M) and mask_block_idx is (B, H, M, N).
+    - Batch/head dims may be 1 for broadcast, or match the requested sizes.
+    - sparse_block_size_kv must match tile_n.
+    - sparse_block_size_q must be a multiple of q_stage * tile_m.
+    - If sparse_block_size_q is omitted and seqlen_q/num_m_blocks is ambiguous,
+      the caller must provide block_size to disambiguate. TODO will make this required in a future PR.
+    """
+    base_m_block = q_stage * m_block_size
+    base_n_block = n_block_size
+    if sparse_block_size_kv is None:
+        sparse_block_size_kv = base_n_block
+    if sparse_block_size_kv != base_n_block:
+        raise ValueError(f"Block sparse tensors{context} require BLOCK_SIZE_KV={base_n_block}.")
+    if tensors.mask_block_idx is None:
+        raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
+    num_m_blocks = tensors.mask_block_idx.shape[2]
+
+    if sparse_block_size_q is None:
+        sparse_block_size_q = get_sparse_q_block_size(tensors, seqlen_q)
+        if sparse_block_size_q is None and base_m_block != 1:
+            raise ValueError(
+                f"Block sparse tensors{context} require explicit sparse_block_size[0] "
+                f"to disambiguate block size for seqlen_q={seqlen_q} and num_m_blocks={num_m_blocks}."
+            )
+        if sparse_block_size_q is None:
+            sparse_block_size_q = ceildiv(seqlen_q, num_m_blocks)
+
+    if sparse_block_size_q % base_m_block != 0:
+        raise ValueError(
+            f"Block sparse tensors{context} have block size {sparse_block_size_q}, "
+            f"which must be a multiple of {base_m_block}."
+        )
+
+    expected_m_blocks = ceildiv(seqlen_q, sparse_block_size_q)
+    expected_n_blocks = ceildiv(seqlen_k, sparse_block_size_kv)
+    q_subtile_factor = sparse_block_size_q // base_m_block
+    expected_count_shape = (batch_size, num_head, expected_m_blocks)
+    expected_index_shape = (batch_size, num_head, expected_m_blocks, expected_n_blocks)
+
+    mask_block_cnt = tensors.mask_block_cnt
+    mask_block_idx = tensors.mask_block_idx
+    if mask_block_cnt is None or mask_block_idx is None:
+        raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
+    if mask_block_cnt.ndim != 3 or mask_block_idx.ndim != 4:
+        raise ValueError(
+            f"Block sparse tensors{context} must have shapes (B, H, M) and (B, H, M, N)."
+        )
+    for dim_name, cur, tgt in (
+        ("batch", mask_block_cnt.shape[0], expected_count_shape[0]),
+        ("head", mask_block_cnt.shape[1], expected_count_shape[1]),
+    ):
+        if cur != tgt and cur != 1:
+            raise ValueError(f"Block sparse tensors{context} {dim_name} dim must be {tgt} or 1.")
+    for dim_name, cur, tgt in (
+        ("batch", mask_block_idx.shape[0], expected_index_shape[0]),
+        ("head", mask_block_idx.shape[1], expected_index_shape[1]),
+    ):
+        if cur != tgt and cur != 1:
+            raise ValueError(f"Block sparse tensors{context} {dim_name} dim must be {tgt} or 1.")
+    if mask_block_cnt.shape[2] != mask_block_idx.shape[2]:
+        raise ValueError(f"Block sparse tensors{context} must share the same m-block dimension.")
+    # [Note] Allow Compact block sparse indices: FA4 only accesses indices 0..cnt-1
+    # per query tile, so idx.shape[3] can be <= expected_n_blocks.
+    if mask_block_idx.shape[3] > expected_n_blocks:
+        raise ValueError(
+            f"Block sparse tensors{context} n-block dimension must be <= {expected_n_blocks}."
+        )
+    if expected_m_blocks != num_m_blocks:
+        raise ValueError(
+            f"Block sparse tensors{context} m-block dimension {num_m_blocks} does not match "
+            f"sparse_block_size_q={sparse_block_size_q}. "
+            f"Set BlockSparseTensorsTorch.block_size to match the BlockMask BLOCK_SIZE."
+        )
+    return expected_count_shape, expected_index_shape, q_subtile_factor
+
+
+def get_block_sparse_expected_shapes_bwd(
+    batch_size: int,
+    num_head: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    m_block_size: int,
+    n_block_size: int,
+    subtile_factor: int,
+) -> Tuple[Tuple[int, int, int], Tuple[int, int, int, int]]:
+    """Return (expected_count_shape, expected_index_shape) for backward block sparse normalization.
+
+    Backward uses Q-direction indexing (transposed from forward), where shapes are
+    indexed by N-blocks first, then M-blocks. The sparse_block_size_q is determined
+    by subtile_factor * m_block_size.
+    """
+    sparse_block_size_q = subtile_factor * m_block_size
+    expected_m_blocks = ceildiv(seqlen_q, sparse_block_size_q)
+    expected_n_blocks = ceildiv(seqlen_k, n_block_size)
+    expected_count_shape = (batch_size, num_head, expected_n_blocks)
+    expected_index_shape = (batch_size, num_head, expected_n_blocks, expected_m_blocks)
+    return expected_count_shape, expected_index_shape
+
+
+def normalize_block_sparse_tensors(
+    tensors: BlockSparseTensorsTorch,
+    *,
+    expected_count_shape: Tuple[int, int, int],
+    expected_index_shape: Tuple[int, int, int, int],
+    context: str | None = None,
+    hint: str | Callable[[], str] | None = None,
+) -> BlockSparseTensorsTorch:
+    if tensors.mask_block_cnt is None or tensors.mask_block_idx is None:
+        raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
+
+    mask_cnt, mask_idx = _check_and_expand_block(
+        "mask",
+        tensors.mask_block_cnt,
+        tensors.mask_block_idx,
+        expected_count_shape,
+        expected_index_shape,
+        context,
+        hint,
+    )
+    if mask_cnt is None or mask_idx is None:
+        raise ValueError("mask_block_cnt and mask_block_idx must be provided for block sparsity.")
+
+    full_cnt, full_idx = _check_and_expand_block(
+        "full",
+        tensors.full_block_cnt,
+        tensors.full_block_idx,
+        expected_count_shape,
+        expected_index_shape,
+        context,
+        hint,
+    )
+    if full_cnt is not None and mask_cnt.device != full_cnt.device:
+        raise ValueError("All block sparse tensors must be on the same device")
+
+    dq_write_order = _check_and_expand_metadata_tensor(
+        "dq_write_order",
+        tensors.dq_write_order,
+        tuple(mask_idx.shape),
+        context,
+        hint,
+        mask_cnt.device,
+    )
+    dq_write_order_full = _check_and_expand_metadata_tensor(
+        "dq_write_order_full",
+        tensors.dq_write_order_full,
+        tuple(full_idx.shape) if full_idx is not None else expected_index_shape,
+        context,
+        hint,
+        mask_cnt.device,
+    )
+    spt = tensors.spt
+    if spt is not None and not isinstance(spt, bool):
+        raise ValueError("spt must be a bool when provided")
+    if spt is not None and dq_write_order is None:
+        raise ValueError("spt requires dq_write_order to be provided")
+
+    return BlockSparseTensorsTorch(
+        mask_block_cnt=mask_cnt,
+        mask_block_idx=mask_idx,
+        full_block_cnt=full_cnt,
+        full_block_idx=full_idx,
+        block_size=tensors.block_size,
+        dq_write_order=dq_write_order,
+        dq_write_order_full=dq_write_order_full,
+        spt=spt,
+    )
+
+
+def is_block_sparsity_enabled(tensors: BlockSparseTensorsTorch) -> bool:
+    return any(t is not None for t in (tensors.full_block_cnt, tensors.mask_block_cnt))
+
+
+def get_block_sparse_broadcast_pattern(
+    tensors: BlockSparseTensorsTorch,
+) -> Tuple[Tuple[bool, ...], ...] | None:
+    """Return broadcast pattern for block sparse tensors by checking actual strides.
+
+    Returns a tuple of broadcast patterns (one per tensor) where each pattern
+    is a tuple of bools indicating which dims have stride=0.
+    This is used in compile keys to ensure kernels are recompiled when
+    broadcast patterns change, since CuTe's mark_layout_dynamic() keeps
+    stride=0 as static.
+
+    The tensors should already be expanded/normalized before calling this function.
+
+    Returns None if block sparsity is not enabled.
+    """
+    if not is_block_sparsity_enabled(tensors):
+        return None
+
+    patterns = []
+    for tensor in (
+        tensors.mask_block_cnt,
+        tensors.mask_block_idx,
+        tensors.full_block_cnt,
+        tensors.full_block_idx,
+        tensors.dq_write_order,
+        tensors.dq_write_order_full,
+    ):
+        if tensor is not None:
+            patterns.append(get_broadcast_dims(tensor))
+        else:
+            patterns.append(None)
+    return tuple(patterns)
+
+
+def normalize_block_sparse_config(
+    tensors: BlockSparseTensorsTorch,
+    *,
+    batch_size: int,
+    num_head: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    block_size: tuple[int, int],
+    q_stage: int,
+) -> tuple[BlockSparseTensorsTorch, Tuple[Tuple[bool, ...], ...] | None, int]:
+    m_block_size, n_block_size = block_size
+    if tensors.block_size is None:
+        sparse_block_size_q, sparse_block_size_kv = None, n_block_size
+    else:
+        sparse_block_size_q, sparse_block_size_kv = tensors.block_size
+    if sparse_block_size_kv != n_block_size:
+        raise ValueError(
+            f"Block sparsity requires sparse_block_size[1]={n_block_size} to match tile_n."
+        )
+    expected_count_shape, expected_index_shape, q_subtile_factor = (
+        infer_block_sparse_expected_shapes(
+            tensors,
+            batch_size=batch_size,
+            num_head=num_head,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            m_block_size=m_block_size,
+            n_block_size=n_block_size,
+            q_stage=q_stage,
+            context="forward",
+            sparse_block_size_q=sparse_block_size_q,
+            sparse_block_size_kv=sparse_block_size_kv,
+        )
+    )
+    normalized_tensors = normalize_block_sparse_tensors(
+        tensors,
+        expected_count_shape=expected_count_shape,
+        expected_index_shape=expected_index_shape,
+    )
+    return (
+        normalized_tensors,
+        get_block_sparse_broadcast_pattern(normalized_tensors),
+        q_subtile_factor,
+    )
+
+
+def normalize_block_sparse_config_bwd(
+    tensors: BlockSparseTensorsTorch,
+    *,
+    batch_size: int,
+    num_head: int,
+    seqlen_q: int,
+    seqlen_k: int,
+    block_size: tuple[int, int],
+    subtile_factor: int,
+) -> tuple[BlockSparseTensorsTorch, Tuple[Tuple[bool, ...], ...] | None]:
+    m_block_size, n_block_size = block_size
+    if tensors.block_size is None:
+        sparse_block_size_q, sparse_block_size_kv = subtile_factor * m_block_size, n_block_size
+    else:
+        sparse_block_size_q, sparse_block_size_kv = tensors.block_size
+    if sparse_block_size_q != subtile_factor * m_block_size:
+        raise ValueError(
+            f"Block sparsity expects sparse_block_size_q={subtile_factor * m_block_size} "
+            f"for subtile_factor={subtile_factor}."
+        )
+    if sparse_block_size_kv != n_block_size:
+        raise ValueError(
+            f"Block sparsity expects sparse_block_size[1]={n_block_size} to match tile_n."
+        )
+    expected_count_shape, expected_index_shape = get_block_sparse_expected_shapes_bwd(
+        batch_size,
+        num_head,
+        seqlen_q,
+        seqlen_k,
+        m_block_size,
+        n_block_size,
+        subtile_factor,
+    )
+    normalized_tensors = normalize_block_sparse_tensors(
+        tensors,
+        expected_count_shape=expected_count_shape,
+        expected_index_shape=expected_index_shape,
+        context="_flash_attn_bwd",
+        hint=lambda: (
+            f"Backward expects Q-direction block-sparse tensors (q_mask_cnt/q_mask_idx, "
+            f"and optionally full_q_cnt/full_q_idx). Regenerate the backward BlockMask with "
+            f"BLOCK_SIZE=({subtile_factor * m_block_size}, {n_block_size})."
+        ),
+    )
+    return normalized_tensors, get_block_sparse_broadcast_pattern(normalized_tensors)
+
+
+def to_cute_block_sparse_tensors(
+    tensors: BlockSparseTensorsTorch, enable_tvm_ffi: bool = True
+) -> BlockSparseTensors | None:
+    """Convert torch block sparsity tensors to CuTe tensors, optionally for tvm ffi"""
+    if not is_block_sparsity_enabled(tensors):
+        return None
+    mask_block_cnt_tensor, mask_block_idx_tensor = [
+        to_cute_tensor(t, assumed_align=4, leading_dim=-1, enable_tvm_ffi=enable_tvm_ffi)
+        for t in (tensors.mask_block_cnt, tensors.mask_block_idx)
+    ]
+    full_block_cnt_tensor, full_block_idx_tensor = [
+        to_cute_tensor(t, assumed_align=4, leading_dim=-1, enable_tvm_ffi=enable_tvm_ffi)
+        if t is not None
+        else None
+        for t in (tensors.full_block_cnt, tensors.full_block_idx)
+    ]
+    dq_write_order_tensor, dq_write_order_full_tensor = [
+        to_cute_tensor(t, assumed_align=4, leading_dim=-1, enable_tvm_ffi=enable_tvm_ffi)
+        if t is not None
+        else None
+        for t in (tensors.dq_write_order, tensors.dq_write_order_full)
+    ]
+
+    return BlockSparseTensors(
+        mask_block_cnt_tensor,
+        mask_block_idx_tensor,
+        full_block_cnt_tensor,
+        full_block_idx_tensor,
+        dq_write_order_tensor,
+        dq_write_order_full_tensor,
+    )
+
+
+def fast_sampling(mask_mod):
+    """Convenience decorator to mark mask_mod as safe for 5-point fast sampling"""
+    mask_mod.use_fast_sampling = True
+    return mask_mod

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/cache_utils.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/cache_utils.py
@@ -1,0 +1,281 @@
+# Manage Ahead-of-Time (AOT) compiled kernels
+import fcntl
+import hashlib
+import os
+import pickle
+import sys
+import tempfile
+import time
+from functools import lru_cache
+from getpass import getuser
+from pathlib import Path
+from typing import Hashable, TypeAlias
+
+import ctypes
+
+import cutlass
+import cutlass.cute as cute
+import tvm_ffi
+from cutlass.cutlass_dsl import JitCompiledFunction
+from flashrt_fa4.cute.fa_logging import fa_log
+
+# Pre-load cute DSL runtime libraries with RTLD_GLOBAL so that their symbols
+# (e.g. _cudaLibraryLoadData) are visible to .so modules loaded later via dlopen.
+# Upstream cute.runtime.load_module loads these without RTLD_GLOBAL, which causes
+# "undefined symbol" errors when loading cached kernels from disk.
+for _lib_path in cute.runtime.find_runtime_libraries(enable_tvm_ffi=False):
+    if Path(_lib_path).exists():
+        ctypes.CDLL(_lib_path, mode=ctypes.RTLD_GLOBAL)
+
+CompileKeyType: TypeAlias = tuple[Hashable, ...]
+CallableFunction: TypeAlias = JitCompiledFunction | tvm_ffi.Function
+
+# Enable cache via `FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED=1`
+CUTE_DSL_CACHE_ENABLED: bool = os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "0") == "1"
+
+
+# Customize cache dir via `FLASH_ATTENTION_CUTE_DSL_CACHE_DIR`, default is
+# `/tmp/${USER}/flash_attention_cute_dsl_cache``
+CUTE_DSL_CACHE_DIR: str | None = os.getenv("FLASH_ATTENTION_CUTE_DSL_CACHE_DIR", None)
+
+
+def get_cache_path() -> Path:
+    if CUTE_DSL_CACHE_DIR is not None:
+        cache_dir = Path(CUTE_DSL_CACHE_DIR)
+    else:
+        cache_dir = Path(tempfile.gettempdir()) / getuser() / "flash_attention_cute_dsl_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+@lru_cache(maxsize=1)
+def _compute_source_fingerprint() -> str:
+    """
+    Hash all CuTe Python sources plus runtime ABI stamps into a short fingerprint.
+
+    The fingerprint changes whenever:
+    - Any .py file under flash_attn/cute is added, removed, renamed, or modified.
+    - The Python minor version changes (e.g. 3.13 -> 3.14).
+    - The cutlass or tvm_ffi package version changes.
+
+    Computed once per process and cached.
+    """
+    cute_root = Path(__file__).resolve().parent
+    h = hashlib.sha256()
+
+    h.update(f"py{sys.version_info.major}.{sys.version_info.minor}".encode())
+    h.update(f"cutlass={cutlass.__version__}".encode())
+    h.update(f"tvm_ffi={tvm_ffi.__version__}".encode())
+
+    for src in sorted(cute_root.rglob("*.py")):
+        if not src.is_file():
+            continue
+        h.update(src.relative_to(cute_root).as_posix().encode())
+        content = src.read_bytes()
+        h.update(len(content).to_bytes(8, "little"))
+        h.update(content)
+
+    return h.hexdigest()
+
+
+class FileLock:
+    """Context manager for advisory file locks using fcntl.flock.
+
+    Supports exclusive (write) and shared (read) locks.
+    Always blocks with polling until the lock is acquired or timeout is reached.
+
+    Usage:
+        with FileLock(lock_path, exclusive=True, timeout=15, label="abc"):
+            # do work under lock
+    """
+
+    def __init__(
+        self,
+        lock_path: Path,
+        exclusive: bool,
+        timeout: float = 15,
+        label: str = "",
+    ):
+        """
+        Args:
+            lock_path: Path to the lock file on disk.
+            exclusive: True for exclusive (write) lock, False for shared (read) lock.
+            timeout: Max seconds to wait for lock acquisition before raising RuntimeError.
+            label: Optional human-readable label for error messages.
+        """
+        self.lock_path: Path = lock_path
+        self.exclusive: bool = exclusive
+        self.timeout: float = timeout
+        self.label: str = label
+        self._fd: int = -1
+
+    @property
+    def _lock_label(self) -> str:
+        kind = "exclusive" if self.exclusive else "shared"
+        return f"{kind} {self.label}" if self.label else kind
+
+    def __enter__(self) -> "FileLock":
+        open_flags = os.O_WRONLY | os.O_CREAT if self.exclusive else os.O_RDONLY | os.O_CREAT
+        lock_type = fcntl.LOCK_EX if self.exclusive else fcntl.LOCK_SH
+
+        self._fd = os.open(str(self.lock_path), open_flags)
+
+        deadline = time.monotonic() + self.timeout
+        acquired = False
+        while time.monotonic() < deadline:
+            try:
+                fcntl.flock(self._fd, lock_type | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except OSError:
+                time.sleep(0.1)
+        if not acquired:
+            os.close(self._fd)
+            self._fd = None
+            raise RuntimeError(
+                f"Timed out after {self.timeout}s waiting for "
+                f"{self._lock_label} lock: {self.lock_path}"
+            )
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._fd is not None:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None
+
+
+class JITCache:
+    """
+    In-memory cache for compiled functions.
+    """
+
+    def __init__(self):
+        self.cache: dict[CompileKeyType, CallableFunction] = {}
+
+    def __setitem__(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
+        self.cache[key] = fn
+
+    def __getitem__(self, key: CompileKeyType) -> CallableFunction:
+        return self.cache[key]
+
+    def __contains__(self, key: CompileKeyType) -> bool:
+        return key in self.cache
+
+    def clear(self) -> None:
+        """
+        Clear in-memory cache of compiled functions
+        """
+        self.cache.clear()
+
+
+class JITPersistentCache(JITCache):
+    """
+    In-memory cache for compiled functions, which is also backed by persistent storage.
+    Use cutedsl ahead-of-time (AOT) compilation, only supporting enable_tvm_ffi=True
+    """
+
+    EXPORT_FUNCTION_PREFIX = "func"
+    LOCK_TIMEOUT_SECONDS = 15
+
+    def __init__(self, cache_path: Path):
+        super().__init__()
+        cache_path.mkdir(parents=True, exist_ok=True)
+        self.cache_path: Path = cache_path
+
+    def __setitem__(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
+        JITCache.__setitem__(self, key, fn)
+        self._try_export_to_storage(key, fn)
+
+    def __getitem__(self, key: CompileKeyType) -> CallableFunction:
+        # Use __contains__ to try populating in-memory cache with persistent storage
+        self.__contains__(key)
+        return JITCache.__getitem__(self, key)
+
+    def __contains__(self, key: CompileKeyType) -> bool:
+        # Checks in-memory cache first, then tries loading from storage.
+        # When returning True, guarantees the in-memory cache is populated.
+        if JITCache.__contains__(self, key):
+            return True
+        return self._try_load_from_storage(key)
+
+    def _try_load_from_storage(self, key: CompileKeyType) -> bool:
+        """
+        Try to load a function from persistent storage into in-memory cache.
+        Returns True if loaded successfully, False if not found on disk.
+        Holds a shared lock during loading to prevent concurrent writes.
+        """
+        sha256_hex = self._key_to_hash(key)
+        obj_path = self.cache_path / f"{sha256_hex}.o"
+        with FileLock(
+            self._lock_path(sha256_hex),
+            exclusive=False,
+            timeout=self.LOCK_TIMEOUT_SECONDS,
+            label=sha256_hex,
+        ):
+            if obj_path.exists():
+                fa_log(1, f"Loading compiled function from disk: {obj_path}")
+                m = cute.runtime.load_module(str(obj_path), enable_tvm_ffi=True)
+                fn = getattr(m, self.EXPORT_FUNCTION_PREFIX)
+                JITCache.__setitem__(self, key, fn)
+                return True
+            else:
+                fa_log(1, f"Cache miss on disk for key hash {sha256_hex}")
+        return False
+
+    def _try_export_to_storage(self, key: CompileKeyType, fn: JitCompiledFunction) -> None:
+        """Export a compiled function to persistent storage under exclusive lock."""
+        sha256_hex = self._key_to_hash(key)
+        with FileLock(
+            self._lock_path(sha256_hex),
+            exclusive=True,
+            timeout=self.LOCK_TIMEOUT_SECONDS,
+            label=sha256_hex,
+        ):
+            obj_path = self.cache_path / f"{sha256_hex}.o"
+            if obj_path.exists():
+                # Another process already exported.
+                fa_log(1, f"Skipping export, already on disk: {obj_path}")
+                return
+            fa_log(1, f"Exporting compiled function to disk: {obj_path}")
+            fn.export_to_c(
+                object_file_path=str(obj_path),
+                function_name=self.EXPORT_FUNCTION_PREFIX,
+            )
+            fa_log(1, f"Successfully exported compiled function to disk: {obj_path}")
+
+    def _key_to_hash(self, key: CompileKeyType) -> str:
+        return hashlib.sha256(pickle.dumps(key)).hexdigest()
+
+    def _lock_path(self, sha256_hex: str) -> Path:
+        return self.cache_path / f"{sha256_hex}.lock"
+
+    def clear(self) -> None:
+        """
+        Not only clear the in-memory cache. Also purge persistent compilation cache.
+        """
+        fa_log(1, f"Clearing persistent cache at {self.cache_path}")
+        super().clear()
+        for child in self.cache_path.iterdir():
+            child.unlink()
+
+
+def get_jit_cache(name: str | None = None) -> JITCache:
+    """
+    JIT cache factory.
+    `name` is an optional identifier to create subdirectories to manage cache.
+
+    When persistent caching is enabled, artifacts are namespaced under a
+    source fingerprint directory so that code or dependency changes
+    automatically invalidate stale entries.
+    """
+    if CUTE_DSL_CACHE_ENABLED:
+        path = get_cache_path() / _compute_source_fingerprint()
+        if name:
+            path = path / name
+        fa_log(1, f"Creating persistent JIT cache at {path}")
+        return JITPersistentCache(path)
+    else:
+        fa_log(1, "Persistent cache disabled, using in-memory JIT cache")
+        return JITCache()

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/copy_utils.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/copy_utils.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+
+import math
+from typing import Optional, Type, Callable
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
+from cutlass.cute.nvgpu import cpasync
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import llvm
+import cutlass.pipeline
+
+
+@dsl_user_op
+def cvt_copy(
+    atom: cute.CopyAtom,
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    pred: Optional[cute.Tensor] = None,
+    loc=None,
+    ip=None,
+    **kwargs,
+) -> None:
+    assert isinstance(src.iterator, cute.Pointer) and src.memspace == cute.AddressSpace.rmem
+    if const_expr(src.element_type != dst.element_type):
+        src_cvt = cute.make_fragment_like(src, dst.element_type, loc=loc, ip=ip)
+        src_cvt.store(src.load().to(dst.element_type))
+        src = src_cvt
+    cute.copy(atom, src, dst, pred=pred, loc=loc, ip=ip, **kwargs)
+
+
+@dsl_user_op
+def load_s2r(src: cute.Tensor, *, loc=None, ip=None) -> cute.Tensor:
+    dst = cute.make_fragment_like(src, src.element_type, loc=loc, ip=ip)
+    cute.autovec_copy(src, dst, loc=loc, ip=ip)
+    return dst
+
+
+@dsl_user_op
+def get_copy_atom(
+    dtype: Type[cutlass.Numeric], num_copy_elems: int, is_async: bool = False, *, loc=None, ip=None
+) -> cute.CopyAtom:
+    num_copy_bits = const_expr(min(128, num_copy_elems * dtype.width))
+    copy_op = cpasync.CopyG2SOp() if is_async else cute.nvgpu.CopyUniversalOp()
+    return cute.make_copy_atom(copy_op, dtype, num_bits_per_copy=num_copy_bits)
+
+
+@dsl_user_op
+def make_tmem_copy(
+    tmem_copy_atom: cute.CopyAtom, num_wg: int = 1, *, loc=None, ip=None
+) -> cute.CopyAtom:
+    num_dp, num_bits, num_rep, _ = sm100_utils.get_tmem_copy_properties(tmem_copy_atom)
+    assert num_dp == 32
+    assert num_bits == 32
+    tiler_mn = (cute.make_layout((128 * num_rep * num_wg // 32, 32), stride=(32, 1)),)
+    layout_tv = cute.make_layout(
+        ((32, 4, num_wg), (num_rep, 32)), stride=((0, 1, 4 * num_rep), (4, 4 * num_rep * num_wg))
+    )
+    return cute.make_tiled_copy(tmem_copy_atom, layout_tv, tiler_mn)
+
+
+@dsl_user_op
+def copy(
+    src: cute.Tensor,
+    dst: cute.Tensor,
+    *,
+    pred: Optional[cute.Tensor] = None,
+    num_copy_elems: int = 1,
+    is_async: bool = False,
+    loc=None,
+    ip=None,
+    **kwargs,
+) -> None:
+    copy_atom = get_copy_atom(src.element_type, num_copy_elems, is_async)
+    cute.copy(copy_atom, src, dst, pred=pred, loc=loc, ip=ip, **kwargs)
+
+
+def tiled_copy_1d(
+    dtype: Type[cutlass.Numeric], num_threads: int, num_copy_elems: int = 1, is_async: bool = False
+) -> cute.TiledCopy:
+    num_copy_bits = num_copy_elems * dtype.width
+    copy_op = cpasync.CopyG2SOp() if is_async else cute.nvgpu.CopyUniversalOp()
+    copy_atom = cute.make_copy_atom(copy_op, dtype, num_bits_per_copy=num_copy_bits)
+    thr_layout = cute.make_layout(num_threads)
+    val_layout = cute.make_layout(num_copy_elems)
+    return cute.make_tiled_copy_tv(copy_atom, thr_layout, val_layout)
+
+
+def tiled_copy_2d(
+    dtype: Type[cutlass.Numeric], major_mode_size: int, num_threads: int, is_async: bool = False
+) -> cute.TiledCopy:
+    num_copy_bits = math.gcd(major_mode_size, 128 // dtype.width) * dtype.width
+    copy_elems = num_copy_bits // dtype.width
+    copy_op = cpasync.CopyG2SOp() if is_async else cute.nvgpu.CopyUniversalOp()
+    copy_atom = cute.make_copy_atom(copy_op, dtype, num_bits_per_copy=num_copy_bits)
+    gmem_threads_per_row = major_mode_size // copy_elems
+    assert num_threads % gmem_threads_per_row == 0
+    thr_layout = cute.make_ordered_layout(
+        (num_threads // gmem_threads_per_row, gmem_threads_per_row),
+        order=(1, 0),
+    )
+    val_layout = cute.make_layout((1, copy_elems))
+    return cute.make_tiled_copy_tv(copy_atom, thr_layout, val_layout)
+
+
+@dsl_user_op
+def atomic_add_fp32x4(
+    a: Float32, b: Float32, c: Float32, d: Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=None
+) -> None:
+    gmem_ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    # cache_hint = cutlass.Int64(0x12F0000000000000)
+    llvm.inline_asm(
+        None,
+        [
+            gmem_ptr_i64,
+            Float32(a).ir_value(loc=loc, ip=ip),
+            Float32(b).ir_value(loc=loc, ip=ip),
+            Float32(c).ir_value(loc=loc, ip=ip),
+            Float32(d).ir_value(loc=loc, ip=ip),
+        ],
+        # [gmem_ptr_i64, Float32(a).ir_value(loc=loc, ip=ip), cache_hint.ir_value()],
+        "{\n\t"
+        # ".reg .b128 abcd;\n\t"
+        # "mov.b128 abcd, {$1, $2, $3, $4};\n\t"
+        ".reg .v4 .f32 abcd;\n\t"
+        # "mov.b128 abcd, {$1, $2, $3, $4};\n\t"
+        "mov.f32 abcd.x, $1;\n\t"
+        "mov.f32 abcd.y, $2;\n\t"
+        "mov.f32 abcd.z, $3;\n\t"
+        "mov.f32 abcd.w, $4;\n\t"
+        "red.global.add.v4.f32 [$0], abcd;\n\t"
+        # "red.global.add.L2::cache_hint.v4.f32 [$0], abcd, 0x14F0000000000000;\n\t"
+        "}\n",
+        # "red.global.add.L2::cache_hint.f32 [$0], $1, 0x12F0000000000000;",
+        # "red.global.add.L2::cache_hint.f32 [$0], $1, $2;",
+        "l,f,f,f,f",
+        # "l,f,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def set_block_rank(
+    smem_ptr: cute.Pointer, peer_cta_rank_in_cluster: Int32, *, loc=None, ip=None
+) -> Int32:
+    """Map the given smem pointer to the address at another CTA rank in the cluster."""
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr_i32, peer_cta_rank_in_cluster.ir_value()],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def store_shared_remote_fp32x4(
+    a: Float32,
+    b: Float32,
+    c: Float32,
+    d: Float32,
+    smem_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: Int32,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    remote_smem_ptr_i32 = set_block_rank(
+        smem_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    remote_mbar_ptr_i32 = set_block_rank(
+        mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            remote_smem_ptr_i32,
+            remote_mbar_ptr_i32,
+            Float32(a).ir_value(loc=loc, ip=ip),
+            Float32(b).ir_value(loc=loc, ip=ip),
+            Float32(c).ir_value(loc=loc, ip=ip),
+            Float32(d).ir_value(loc=loc, ip=ip),
+        ],
+        "{\n\t"
+        ".reg .v4 .f32 abcd;\n\t"
+        "mov.f32 abcd.x, $2;\n\t"
+        "mov.f32 abcd.y, $3;\n\t"
+        "mov.f32 abcd.z, $4;\n\t"
+        "mov.f32 abcd.w, $5;\n\t"
+        "st.async.shared::cluster.mbarrier::complete_tx::bytes.v4.f32 [$0], abcd, [$1];\n\t"
+        "}\n",
+        "r,r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cpasync_bulk_s2cluster(
+    smem_src_ptr: cute.Pointer,
+    smem_dst_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    size: int | Int32,
+    peer_cta_rank_in_cluster: Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    smem_src_ptr_i32 = smem_src_ptr.toint(loc=loc, ip=ip).ir_value()
+    smem_dst_ptr_i32 = set_block_rank(
+        smem_dst_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    mbar_ptr_i32 = set_block_rank(mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [
+            smem_dst_ptr_i32,
+            smem_src_ptr_i32,
+            mbar_ptr_i32,
+            Int32(size).ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes [$0], [$1], $3, [$2];",
+        "r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cpasync_bulk_g2s(
+    gmem_ptr: cute.Pointer,
+    smem_ptr: cute.Pointer,
+    tma_bar_ptr: cute.Pointer,
+    size: int | Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    gmem_ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    mbar_ptr_i32 = tma_bar_ptr.toint(loc=loc, ip=ip).ir_value()
+    llvm.inline_asm(
+        None,
+        [gmem_ptr_i64, smem_ptr_i32, mbar_ptr_i32, Int32(size).ir_value()],
+        "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [$1], [$0], $3, [$2];",
+        "l,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def cpasync_reduce_bulk_add_f32(
+    smem_ptr: cute.Pointer,
+    gmem_ptr: cute.Pointer,
+    store_bytes: int | Int32,
+    *,
+    loc=None,
+    ip=None,
+):
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    # cache_hint = cutlass.Int64(0x14F0000000000000)  # EVICT_LAST
+    llvm.inline_asm(
+        None,
+        [gmem_ptr.llvm_ptr, smem_ptr_i32, Int32(store_bytes).ir_value()],
+        "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f32 [$0], [$1], $2;",
+        "l,r,r",
+        # [gmem_ptr.llvm_ptr, smem_ptr_i32, Int32(store_bytes).ir_value(), cache_hint.ir_value()],
+        # "cp.reduce.async.bulk.global.shared::cta.bulk_group.L2::cache_hint.add.f32 [$0], [$1], $2, $3;",
+        # "l,r,r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+def cpasync_bulk_get_copy_fn(
+    src_tensor: cute.Tensor,
+    dst_tensor: cute.Tensor,
+    single_stage: bool = False,
+    **kwargs,
+) -> Callable:
+    # src_is_smem = const_expr(
+    #     isinstance(src_tensor.iterator, cute.Pointer)
+    #     and src_tensor.memspace == cute.AddressSpace.smem
+    # )
+    group_rank_src = const_expr(cute.rank(src_tensor) - (1 if not single_stage else 0))
+    group_rank_dst = const_expr(cute.rank(dst_tensor) - (1 if not single_stage else 0))
+    # ((atom_v, rest_v), STAGE), ((atom_v, rest_v), RestK)
+    src = cute.group_modes(src_tensor, 0, group_rank_src)
+    dst = cute.group_modes(dst_tensor, 0, group_rank_dst)
+
+    def copy_bulk(src_idx, dst_idx, **new_kwargs):
+        size = const_expr(cute.size(src.shape[:-1]) * src.element_type.width // 8)
+        cpasync_bulk_g2s(
+            src[None, src_idx].iterator,
+            dst[None, dst_idx].iterator,
+            size=size,
+            **new_kwargs,
+            **kwargs,
+        )
+
+    def copy_bulk_single_stage(**new_kwargs):
+        size = const_expr(cute.size(src.shape) * src.element_type.width // 8)
+        cpasync_bulk_g2s(src.iterator, dst.iterator, size=size, **new_kwargs, **kwargs)
+
+    return copy_bulk if const_expr(not single_stage) else copy_bulk_single_stage
+
+
+def tma_get_copy_fn(
+    atom: cute.CopyAtom,
+    cta_coord: cute.Coord,
+    cta_layout: cute.Layout,
+    src_tensor: cute.Tensor,
+    dst_tensor: cute.Tensor,
+    filter_zeros: bool = False,
+    single_stage: bool = False,
+    **kwargs,
+) -> Callable:
+    src_is_smem = const_expr(
+        isinstance(src_tensor.iterator, cute.Pointer)
+        and src_tensor.memspace == cute.AddressSpace.smem
+    )
+    smem_tensor, gmem_tensor = (src_tensor, dst_tensor) if src_is_smem else (dst_tensor, src_tensor)
+    group_rank_smem = const_expr(cute.rank(smem_tensor) - (1 if not single_stage else 0))
+    group_rank_gmem = const_expr(cute.rank(gmem_tensor) - (1 if not single_stage else 0))
+    # ((atom_v, rest_v), STAGE), ((atom_v, rest_v), RestK)
+    s, g = cpasync.tma_partition(
+        atom,
+        cta_coord,
+        cta_layout,
+        cute.group_modes(smem_tensor, 0, group_rank_smem),
+        cute.group_modes(gmem_tensor, 0, group_rank_gmem),
+    )
+    if const_expr(filter_zeros):
+        s = cute.filter_zeros(s)
+        g = cute.filter_zeros(g)
+    src, dst = (s, g) if src_is_smem else (g, s)
+
+    def copy_tma(src_idx, dst_idx, **new_kwargs):
+        cute.copy(atom, src[None, src_idx], dst[None, dst_idx], **new_kwargs, **kwargs)
+
+    def copy_tma_single_stage(**new_kwargs):
+        cute.copy(atom, src, dst, **new_kwargs, **kwargs)
+
+    return (copy_tma if const_expr(not single_stage) else copy_tma_single_stage), s, g
+
+
+def tma_producer_copy_fn(copy: Callable, pipeline: cutlass.pipeline.PipelineAsync):
+    def copy_fn(src_idx, producer_state: cutlass.pipeline.PipelineState, **new_kwargs):
+        copy(
+            src_idx=src_idx,
+            dst_idx=producer_state.index,
+            tma_bar_ptr=pipeline.producer_get_barrier(producer_state),
+            **new_kwargs,
+        )
+
+    return copy_fn

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/cute_dsl_ptxas.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/cute_dsl_ptxas.py
@@ -1,0 +1,151 @@
+"""
+System ptxas replacement for CUTLASS DSL.
+Environment variables:
+    CUTE_DSL_PTXAS_PATH    - Path to ptxas (e.g., /usr/local/cuda/bin/ptxas)
+    CUTE_DSL_PTXAS_VERBOSE - Set to 1 for verbose output
+"""
+
+import os
+import sys
+import re
+import ctypes
+import subprocess
+from pathlib import Path
+
+import cutlass
+
+
+CUTE_DSL_PTXAS_PATH = os.environ.get("CUTE_DSL_PTXAS_PATH", None)
+VERBOSE = os.environ.get("CUTE_DSL_PTXAS_VERBOSE", "0") == "1"
+
+_original_load_cuda_library = None
+_user_wanted_ptx = False  # True if user originally set CUTE_DSL_KEEP_PTX=1
+
+
+def _log(msg):
+    if VERBOSE:
+        print(f"[ptxas] {msg}", file=sys.stderr)
+
+
+def _get_ptx(compiled_func) -> tuple[str, Path] | None:
+    """Find and read PTX file, stripping null bytes."""
+    func_name = getattr(compiled_func, "function_name", None)
+    if not func_name:
+        return None
+
+    dump_dir = os.environ.get("CUTE_DSL_DUMP_DIR", Path.cwd())
+    for ptx_path in Path(dump_dir).glob(f"*{func_name}*.ptx"):
+        content = ptx_path.read_text().rstrip("\x00")
+        if ".entry " in content and content.rstrip().endswith("}"):
+            _log(f"Found PTX: {ptx_path}")
+            return content, ptx_path
+    return None
+
+
+def _compile_ptx(ptx_path: Path, ptx_content: str) -> bytes:
+    """Compile PTX to cubin using system ptxas."""
+    # Extract arch from PTX
+    match = re.search(r"\.target\s+(sm_\d+[a-z]?)", ptx_content)
+    arch = match.group(1) if match else "sm_90a"
+
+    # Write stripped content back if needed
+    if ptx_path.read_text() != ptx_content:
+        ptx_path.write_text(ptx_content)
+
+    # Compile
+    cubin_tmp = ptx_path.with_suffix(".cubin.tmp")
+    try:
+        assert CUTE_DSL_PTXAS_PATH is not None
+        result = subprocess.run(
+            [CUTE_DSL_PTXAS_PATH, f"-arch={arch}", "-O3", "-o", str(cubin_tmp), str(ptx_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"ptxas failed: {result.stderr}")
+
+        cubin_data = cubin_tmp.read_bytes()
+        _log(f"Compiled {ptx_path.name} -> {len(cubin_data)} bytes ({arch})")
+
+        # Save cubin if CUTE_DSL_KEEP_CUBIN is set
+        if os.environ.get("CUTE_DSL_KEEP_CUBIN", "0") == "1":
+            cubin_out = ptx_path.with_suffix(".cubin")
+            cubin_out.write_bytes(cubin_data)
+            _log(f"Saved: {cubin_out}")
+
+        return cubin_data
+    finally:
+        cubin_tmp.unlink(missing_ok=True)
+
+
+def _patched_load_cuda_library(self):
+    """Replacement for _load_cuda_library that uses system ptxas."""
+
+    result = _get_ptx(self)
+    if not result:
+        _log("PTX not found, falling back to embedded ptxas")
+        return _original_load_cuda_library(self)
+
+    ptx_content, ptx_path = result
+
+    try:
+        cubin = _compile_ptx(ptx_path, ptx_content)
+    except Exception as e:
+        _log(f"Compilation failed ({e}), falling back to embedded ptxas")
+        return _original_load_cuda_library(self)
+
+    # Load cubin
+    import cuda.bindings.runtime as cuda_runtime
+
+    err, library = cuda_runtime.cudaLibraryLoadData(cubin, None, None, 0, None, None, 0)
+    if err != cuda_runtime.cudaError_t.cudaSuccess:
+        _log(f"cudaLibraryLoadData failed ({err}), falling back to embedded ptxas")
+        return _original_load_cuda_library(self)
+
+    # Register kernels on all devices
+    _, cuda_load_to_device = self._get_cuda_init_and_load()
+    lib_ptr = ctypes.c_void_p(int(library))
+    dev_id = ctypes.c_int32(0)
+    err_val = ctypes.c_int32(0)
+    args = (ctypes.c_void_p * 3)(
+        ctypes.cast(ctypes.pointer(lib_ptr), ctypes.c_void_p),
+        ctypes.cast(ctypes.pointer(dev_id), ctypes.c_void_p),
+        ctypes.cast(ctypes.pointer(err_val), ctypes.c_void_p),
+    )
+
+    for dev in range(self.num_devices):
+        dev_id.value = dev
+        cuda_load_to_device(args)
+        if err_val.value != 0:
+            _log("cuda_load_to_device failed, falling back to embedded ptxas")
+            return _original_load_cuda_library(self)
+
+    _log(f"Loaded kernel from {ptx_path.name}")
+
+    # Delete PTX if user didn't originally want it kept
+    if not _user_wanted_ptx:
+        ptx_path.unlink(missing_ok=True)
+
+    return [cuda_runtime.cudaLibrary_t(lib_ptr.value)]
+
+
+def patch():
+    """Install system ptxas hook. Call before importing cutlass."""
+    global _original_load_cuda_library, _user_wanted_ptx
+
+    assert CUTE_DSL_PTXAS_PATH is not None
+    if not os.path.isfile(CUTE_DSL_PTXAS_PATH) or not os.access(CUTE_DSL_PTXAS_PATH, os.X_OK):
+        raise RuntimeError(f"ptxas not found: {CUTE_DSL_PTXAS_PATH}")
+
+    # Track if user originally wanted PTX kept
+    _user_wanted_ptx = os.environ.get("CUTE_DSL_KEEP_PTX", "0") == "1"
+    # os.environ['CUTE_DSL_KEEP_PTX'] = '1'
+    assert os.environ.get("CUTE_DSL_KEEP_PTX", "0") == "1", (
+        "Require CUTE_DSL_KEEP_PTX=1 to use system's ptxas"
+    )
+
+    cls = cutlass.cutlass_dsl.cuda_jit_executor.CudaDialectJitCompiledFunction
+    _original_load_cuda_library = cls._load_cuda_library
+    cls._load_cuda_library = _patched_load_cuda_library
+    _log("Patch applied")
+    return

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/cute_dsl_utils.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/cute_dsl_utils.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025, Tri Dao.
+
+from typing import Tuple
+from functools import lru_cache
+
+import torch
+
+try:
+    from triton.tools.disasm import extract
+except ImportError:
+    extract = None
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import NumericMeta
+from cutlass.cute.runtime import from_dlpack
+
+StaticTypes = (cutlass.Constexpr, NumericMeta, int, bool, str, float, type(None))
+
+
+load_cubin_module_data_og = cutlass.base_dsl.runtime.cuda.load_cubin_module_data
+cute_compile_og = cute.compile
+
+
+torch2cute_dtype_map = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+    torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+    torch.float8_e5m2: cutlass.Float8E5M2,
+}
+
+
+@lru_cache
+def get_max_active_clusters(cluster_size):
+    return cutlass.utils.HardwareInfo().get_max_active_clusters(cluster_size=cluster_size)
+
+
+@lru_cache
+def get_device_capacity(device: torch.device = None) -> Tuple[int, int]:
+    return torch.cuda.get_device_capability(device)
+
+
+def assume_strides_aligned(t):
+    """Assume all strides except the last are divisible by 128 bits.
+
+    Python int strides (e.g., stride=0 from GQA expand) are kept as-is
+    since they're static and don't need alignment assumptions.
+    """
+    divby = 128 // t.element_type.width
+    strides = tuple(s if isinstance(s, int) else cute.assume(s, divby=divby) for s in t.stride[:-1])
+    return (*strides, t.stride[-1])
+
+
+def assume_tensor_aligned(t):
+    """Rebuild a tensor with 128-bit aligned stride assumptions. Passes through None."""
+    if t is None:
+        return None
+    return cute.make_tensor(t.iterator, cute.make_layout(t.shape, stride=assume_strides_aligned(t)))
+
+
+def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, enable_tvm_ffi=True):
+    """Convert torch tensor to cute tensor for TVM FFI. leading_dim=-1 defaults to t.ndim-1."""
+    # NOTE: torch 2.9.1 doesn't support fp8 via DLPack but 2.11.0 nightly does
+    # currently export raw bytes as uint8 and tell cutlass correct type
+    # can directly export as fp8 when torch supports it
+    if t.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        tensor = from_dlpack(
+            t.view(torch.uint8).detach(),
+            assumed_align=assumed_align,
+            enable_tvm_ffi=enable_tvm_ffi,
+        )
+        tensor.element_type = (
+            cutlass.Float8E4M3FN if t.dtype == torch.float8_e4m3fn else cutlass.Float8E5M2
+        )
+    else:
+        tensor = from_dlpack(t.detach(), assumed_align=assumed_align, enable_tvm_ffi=enable_tvm_ffi)
+    if fully_dynamic:
+        return tensor.mark_layout_dynamic()
+    if leading_dim == -1:
+        leading_dim = t.ndim - 1
+    return tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+
+def to_cute_aux_tensor(t, enable_tvm_ffi=True):
+    """Convert torch tensor to cute tensor for TVM FFI, tailored to FlexAttention aux tensors.
+    This allows the user to specify alignment and leading dimension for aux tensors used in
+    custom score_mod callables.
+    """
+    assumed_align: int = getattr(t, "__assumed_align__", None)
+    leading_dim: int = getattr(t, "__leading_dim__", None)
+    fully_dynamic: bool = leading_dim is None
+
+    return to_cute_tensor(
+        t,
+        assumed_align=assumed_align,
+        leading_dim=leading_dim,
+        fully_dynamic=fully_dynamic,
+        enable_tvm_ffi=enable_tvm_ffi,
+    )
+
+
+def get_aux_tensor_metadata(aux_tensors):
+    return tuple(
+        (
+            getattr(t, "__assumed_align__", 0),
+            getattr(t, "__leading_dim__", -1),
+            hasattr(t, "__leading_dim__"),
+        )
+        for t in aux_tensors
+    )
+
+
+def get_broadcast_dims(tensor: torch.Tensor) -> Tuple[bool, ...]:
+    """Return tuple of bools indicating which dims have stride=0 (broadcast).
+
+    This is useful for compile keys since CuTe's mark_layout_dynamic() keeps
+    stride=0 as static, meaning kernels compiled with different broadcast
+    patterns are not interchangeable.
+    """
+    return tuple(s == 0 for s in tensor.stride())
+
+
+# credit: monellz (https://github.com/NVIDIA/cutlass/issues/2658#issuecomment-3630564264)
+def dump_kernel_attributes(compiled_kernel):
+    from cuda.bindings import driver
+    from cutlass.utils import HardwareInfo
+    import torch
+
+    device_id = torch.cuda.current_device()
+    hardware_info = HardwareInfo(device_id=device_id)
+    cubin_data = compiled_kernel.artifacts.CUBIN
+    assert cubin_data is not None, "cubin_data is None, need '--keep-cubin' option when compiling"
+    cuda_library = hardware_info._checkCudaErrors(
+        driver.cuLibraryLoadData(cubin_data, None, None, 0, None, None, 0)
+    )
+    kernels = hardware_info._checkCudaErrors(driver.cuLibraryEnumerateKernels(1, cuda_library))
+    kernel = hardware_info._checkCudaErrors(driver.cuKernelGetFunction(kernels[0]))
+    # more metrics: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXEC.html#group__CUDA__EXEC_1g5e92a1b0d8d1b82cb00dcfb2de15961b
+    local_size_bytes = hardware_info._checkCudaErrors(
+        driver.cuFuncGetAttribute(
+            driver.CUfunction_attribute.CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES,
+            kernel,
+        )
+    )
+    num_regs = hardware_info._checkCudaErrors(
+        driver.cuFuncGetAttribute(
+            driver.CUfunction_attribute.CU_FUNC_ATTRIBUTE_NUM_REGS,
+            kernel,
+        )
+    )
+
+    print("--- Kernel Info ---")
+    print(f"local_size_bytes: {local_size_bytes}")
+    print(f"num_regs: {num_regs}")
+    print("--- End Kernel Info ---")

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/fa_logging.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/fa_logging.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, Tri Dao.
+
+"""Unified FlashAttention logging controlled by a single ``FA_LOG_LEVEL`` env var.
+
+Host-side messages go through Python ``logging`` (logger name ``flash_attn``).
+A default ``StreamHandler`` is attached automatically when ``FA_LOG_LEVEL >= 1``
+so that standalone scripts get output without extra setup; applications that
+configure their own logging can remove or replace it via the standard API.
+
+FA_LOG_LEVEL mapping::
+
+    0  off       nothing logged
+    1  host      host-side summaries only (no kernel printf)
+    2  kernel    host + curated kernel traces
+    3  max       host + all kernel traces (noisy, perf hit)
+
+Set via environment variable::
+
+    FA_LOG_LEVEL=1 python train.py
+
+Device-side ``cute.printf`` calls are compile-time eliminated via
+``cutlass.const_expr`` when the log level is below the callsite threshold,
+so there is zero performance cost when device logging is off.
+Changing the log level after kernel compilation requires a recompile
+(the level participates in the forward compile key).
+"""
+
+import logging
+import os
+import sys
+
+import cutlass.cute as cute
+from cutlass import const_expr
+
+_LOG_LEVEL_NAMES = {"off": 0, "host": 1, "kernel": 2, "max": 3}
+
+
+def _parse_log_level(raw: str) -> int:
+    if raw in _LOG_LEVEL_NAMES:
+        return _LOG_LEVEL_NAMES[raw]
+    try:
+        level = int(raw)
+    except ValueError:
+        return 0
+    return max(0, min(level, 3))
+
+
+_fa_log_level: int = _parse_log_level(os.environ.get("FA_LOG_LEVEL", "0"))
+
+_logger = logging.getLogger("flashrt_fa4")
+_logger.addHandler(logging.NullHandler())
+_default_handler: logging.Handler | None = None
+
+
+def _configure_default_handler() -> None:
+    global _default_handler
+    if _fa_log_level >= 1:
+        if _default_handler is None:
+            _default_handler = logging.StreamHandler(sys.stdout)
+            _default_handler.setFormatter(logging.Formatter("[FA] %(message)s"))
+            _logger.addHandler(_default_handler)
+        _logger.setLevel(logging.DEBUG)
+    else:
+        if _default_handler is not None:
+            _logger.removeHandler(_default_handler)
+            _default_handler = None
+        _logger.setLevel(logging.WARNING)
+
+
+_configure_default_handler()
+
+
+def get_fa_log_level() -> int:
+    return _fa_log_level
+
+
+def set_fa_log_level(level: int | str) -> None:
+    """Set the FA log level programmatically.
+
+    Host logging takes effect immediately.  Device logging changes only
+    affect kernels compiled after this call (new compile-key selection).
+    """
+    global _fa_log_level
+    if isinstance(level, str):
+        level = _parse_log_level(level)
+    _fa_log_level = max(0, min(int(level), 3))
+    _configure_default_handler()
+
+
+def fa_log(level: int, msg: str):
+    if _fa_log_level >= level:
+        _logger.info(msg)
+
+
+def fa_printf(level: int, fmt, *args):
+    if const_expr(_fa_log_level >= level):
+        cute.printf(fmt, *args)

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/fast_math.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/fast_math.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, Tri Dao.
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32
+
+
+@cute.jit
+def clz(x: Int32) -> Int32:
+    # for i in cutlass.range_constexpr(32):
+    #     if (1 << (31 - i)) & x:
+    #         return Int32(i)
+    # return Int32(32)
+    # Early exit is not supported yet
+    res = Int32(32)
+    done = False
+    for i in cutlass.range(32):
+        if ((1 << (31 - i)) & x) and not done:
+            res = Int32(i)
+            done = True
+    return res

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/flash_fwd_combine.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/flash_fwd_combine.py
@@ -1,0 +1,698 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# A reimplementation of https://github.com/Dao-AILab/flash-attention/blob/main/hopper/flash_fwd_combine_kernel.h
+# from Cutlass C++ to Cute-DSL.
+import math
+from typing import Type, Optional
+from functools import partial
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+from cutlass import Float32, Int32, Boolean, const_expr
+
+from flashrt_fa4.cute import utils
+from flashrt_fa4.cute.cute_dsl_utils import assume_tensor_aligned
+from flashrt_fa4.cute.seqlen_info import SeqlenInfo
+from cutlass.cute import FastDivmodDivisor
+
+
+class FlashAttentionForwardCombine:
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        dtype_partial: Type[cutlass.Numeric],
+        head_dim: int,
+        tile_m: int = 8,
+        k_block_size: int = 64,
+        log_max_splits: int = 4,
+        num_threads: int = 256,
+        stages: int = 4,
+    ):
+        """
+        Forward combine kernel for split attention computation.
+
+        :param dtype: output data type
+        :param dtype_partial: partial accumulation data type
+        :param head_dim: head dimension
+        :param tile_m: m block size
+        :param k_block_size: k block size
+        :param log_max_splits: log2 of maximum splits
+        :param num_threads: number of threads
+        :param varlen: whether using variable length sequences
+        :param stages: number of pipeline stages
+        """
+        self.dtype = dtype
+        self.dtype_partial = dtype_partial
+        self.head_dim = head_dim
+        self.tile_m = tile_m
+        self.k_block_size = k_block_size
+        self.max_splits = 1 << log_max_splits
+        self.num_threads = num_threads
+        self.is_even_k = head_dim % k_block_size == 0
+        self.stages = stages
+
+    @staticmethod
+    def can_implement(
+        dtype,
+        dtype_partial,
+        head_dim,
+        tile_m,
+        k_block_size,
+        log_max_splits,
+        num_threads,
+    ) -> bool:
+        """Check if the kernel can be implemented with the given parameters."""
+        if dtype not in [cutlass.Float16, cutlass.BFloat16, cutlass.Float32]:
+            return False
+        if dtype_partial not in [cutlass.Float16, cutlass.BFloat16, Float32]:
+            return False
+        if head_dim % 8 != 0:
+            return False
+        if num_threads % 32 != 0:
+            return False
+        if tile_m % 8 != 0:
+            return False
+        max_splits = 1 << log_max_splits
+        if max_splits > 256:
+            return False
+        if (tile_m * max_splits) % num_threads != 0:
+            return False
+        return True
+
+    def _setup_attributes(self):
+        # GMEM copy setup for O partial
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // self.dtype_partial.width
+        assert self.k_block_size % async_copy_elems == 0
+
+        k_block_gmem = (
+            128 if self.k_block_size % 128 == 0 else (64 if self.k_block_size % 64 == 0 else 32)
+        )
+        gmem_threads_per_row = k_block_gmem // async_copy_elems
+        assert self.num_threads % gmem_threads_per_row == 0
+
+        # Async copy atom for O partial load
+        atom_async_copy_partial = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            self.dtype_partial,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        tOpartial_layout = cute.make_ordered_layout(
+            (self.num_threads // gmem_threads_per_row, gmem_threads_per_row),
+            order=(1, 0),
+        )
+        vOpartial_layout = cute.make_layout((1, async_copy_elems))  # 4 vals per load
+        self.gmem_tiled_copy_O_partial = cute.make_tiled_copy_tv(
+            atom_async_copy_partial, tOpartial_layout, vOpartial_layout
+        )
+
+        # GMEM copy setup for final O (use universal copy for store)
+        atom_universal_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.dtype,
+            num_bits_per_copy=async_copy_elems * self.dtype.width,
+        )
+        self.gmem_tiled_copy_O = cute.make_tiled_copy_tv(
+            atom_universal_copy,
+            tOpartial_layout,
+            vOpartial_layout,  # 4 vals per store
+        )
+
+        # LSE copy setup with async copy (alignment = 1)
+        lse_copy_bits = Float32.width  # 1 element per copy, width is in bits
+        m_block_smem = (
+            128
+            if self.tile_m % 128 == 0
+            else (
+                64
+                if self.tile_m % 64 == 0
+                else (32 if self.tile_m % 32 == 0 else (16 if self.tile_m % 16 == 0 else 8))
+            )
+        )
+        gmem_threads_per_row_lse = m_block_smem
+        assert self.num_threads % gmem_threads_per_row_lse == 0
+
+        # Async copy atom for LSE load
+        atom_async_copy_lse = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.ALWAYS),
+            Float32,
+            num_bits_per_copy=lse_copy_bits,
+        )
+        tLSE_layout = cute.make_ordered_layout(
+            (self.num_threads // gmem_threads_per_row_lse, gmem_threads_per_row_lse),
+            order=(1, 0),
+        )
+        vLSE_layout = cute.make_layout(1)
+        self.gmem_tiled_copy_LSE = cute.make_tiled_copy_tv(
+            atom_async_copy_lse, tLSE_layout, vLSE_layout
+        )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Shared memory
+        # ///////////////////////////////////////////////////////////////////////////////
+
+        # Shared memory to register copy for LSE
+        self.smem_threads_per_col_lse = self.num_threads // m_block_smem
+        assert 32 % self.smem_threads_per_col_lse == 0  # Must divide warp size
+
+        s2r_layout_atom_lse = cute.make_ordered_layout(
+            (self.smem_threads_per_col_lse, self.num_threads // self.smem_threads_per_col_lse),
+            order=(0, 1),
+        )
+        self.s2r_tiled_copy_LSE = cute.make_tiled_copy_tv(
+            cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), Float32),
+            s2r_layout_atom_lse,
+            cute.make_layout(1),
+        )
+
+        # LSE shared memory layout with swizzling to avoid bank conflicts
+        # This works for kBlockMSmem = 8, 16, 32, 64, 128, no bank conflicts
+        if const_expr(m_block_smem == 8):
+            smem_lse_swizzle = cute.make_swizzle(5, 0, 5)
+        elif const_expr(m_block_smem == 16):
+            smem_lse_swizzle = cute.make_swizzle(4, 0, 4)
+        else:
+            smem_lse_swizzle = cute.make_swizzle(3, 2, 3)
+        smem_layout_atom_lse = cute.make_composed_layout(
+            smem_lse_swizzle, 0, cute.make_ordered_layout((8, m_block_smem), order=(1, 0))
+        )
+        self.smem_layout_lse = cute.tile_to_shape(
+            smem_layout_atom_lse, (self.max_splits, self.tile_m), (0, 1)
+        )
+
+        # O partial shared memory layout (simple layout for pipeline stages)
+        self.smem_layout_o = cute.make_ordered_layout(
+            (self.tile_m, self.k_block_size, self.stages), order=(1, 0, 2)
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        mO_partial: cute.Tensor,
+        mLSE_partial: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor] = None,
+        cu_seqlens: Optional[cute.Tensor] = None,
+        seqused: Optional[cute.Tensor] = None,
+        num_splits_dynamic_ptr: Optional[cute.Tensor] = None,
+        varlen_batch_idx: Optional[cute.Tensor] = None,
+        semaphore_to_reset: Optional[cute.Tensor] = None,
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        # Type checking
+        if const_expr(not (mO_partial.element_type == self.dtype_partial)):
+            raise TypeError("O partial tensor must match dtype_partial")
+        if const_expr(not (mO.element_type == self.dtype)):
+            raise TypeError("O tensor must match dtype")
+        if const_expr(mLSE_partial.element_type not in [Float32]):
+            raise TypeError("LSE partial tensor must be Float32")
+        if const_expr(mLSE is not None and mLSE.element_type not in [Float32]):
+            raise TypeError("LSE tensor must be Float32")
+
+        # Shape validation - input tensors are in user format, need to be converted to kernel format
+        if const_expr(len(mO_partial.shape) not in [4, 5]):
+            raise ValueError(
+                "O partial tensor must have 4 or 5 dimensions: (num_splits, batch, seqlen, nheads, headdim) or (num_splits, total_q, nheads, headdim)"
+            )
+        if const_expr(len(mLSE_partial.shape) not in [3, 4]):
+            raise ValueError(
+                "LSE partial tensor must have 3 or 4 dimensions: (num_splits, batch, seqlen, nheads) or (num_splits, total_q, nheads)"
+            )
+        if const_expr(len(mO.shape) not in [3, 4]):
+            raise ValueError(
+                "O tensor must have 3 or 4 dimensions: (batch, seqlen, nheads, headdim) or (total_q, nheads, headdim)"
+            )
+        if const_expr(mLSE is not None and len(mLSE.shape) not in [2, 3]):
+            raise ValueError(
+                "LSE tensor must have 2 or 3 dimensions: (batch, seqlen, nheads) or (total_q, nheads)"
+            )
+
+        mO_partial, mO = [assume_tensor_aligned(t) for t in (mO_partial, mO)]
+        # (num_splits, b, seqlen, h, d) -> (seqlen, d, num_splits, h, b)
+        # or (num_splits, total_q, h, d) -> (total_q, d, num_splits, h)
+        O_partial_layout_transpose = (
+            [2, 4, 0, 3, 1] if const_expr(cu_seqlens is None) else [1, 3, 0, 2]
+        )
+        # (b, seqlen, h, d) -> (seqlen, d, h, b) or (total_q, h, d) -> (total_q, d, h)
+        mO_partial = cute.make_tensor(
+            mO_partial.iterator, cute.select(mO_partial.layout, mode=O_partial_layout_transpose)
+        )
+        O_layout_transpose = [1, 3, 2, 0] if const_expr(cu_seqlens is None) else [0, 2, 1]
+        mO = cute.make_tensor(mO.iterator, cute.select(mO.layout, mode=O_layout_transpose))
+        # (num_splits, b, seqlen, h) -> (seqlen, num_splits, h, b)
+        # or (num_splits, total_q, h) -> (total_q, num_splits, h)
+        LSE_partial_layout_transpose = [2, 0, 3, 1] if const_expr(cu_seqlens is None) else [1, 0, 2]
+        mLSE_partial = cute.make_tensor(
+            mLSE_partial.iterator,
+            cute.select(mLSE_partial.layout, mode=LSE_partial_layout_transpose),
+        )
+        # (b, seqlen, h) -> (seqlen, h, b) or (total_q, h) -> (total_q, h)
+        LSE_layout_transpose = [1, 2, 0] if const_expr(cu_seqlens is None) else [0, 1]
+        mLSE = (
+            cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
+            if mLSE is not None
+            else None
+        )
+
+        # Determine if we have variable length sequences
+        varlen = const_expr(cu_seqlens is not None or seqused is not None)
+
+        self._setup_attributes()
+
+        @cute.struct
+        class SharedStorage:
+            sLSE: cute.struct.Align[
+                cute.struct.MemRange[Float32, cute.cosize(self.smem_layout_lse)], 128
+            ]
+            sMaxValidSplit: cute.struct.Align[cute.struct.MemRange[Int32, self.tile_m], 128]
+            sO: cute.struct.Align[
+                cute.struct.MemRange[self.dtype_partial, cute.cosize(self.smem_layout_o)], 128
+            ]
+
+        smem_size = SharedStorage.size_in_bytes()
+
+        # Grid dimensions: (ceil_div(seqlen, m_block), ceil_div(head_dim, k_block), num_head * batch)
+        seqlen = mO_partial.shape[0]
+        num_head = mO_partial.shape[3]
+        batch_size = (
+            mO_partial.shape[4]
+            if const_expr(cu_seqlens is None)
+            else Int32(cu_seqlens.shape[0] - 1)
+        )
+
+        # Create FastDivmodDivisor objects for efficient division
+        seqlen_divmod = FastDivmodDivisor(seqlen)
+        head_divmod = FastDivmodDivisor(num_head)
+
+        grid_dim = (
+            cute.ceil_div(seqlen * num_head, self.tile_m),
+            cute.ceil_div(self.head_dim, self.k_block_size),
+            batch_size,
+        )
+
+        self.kernel(
+            mO_partial,
+            mLSE_partial,
+            mO,
+            mLSE,
+            cu_seqlens,
+            seqused,
+            num_splits_dynamic_ptr,
+            varlen_batch_idx,
+            semaphore_to_reset,
+            SharedStorage,
+            self.smem_layout_lse,
+            self.smem_layout_o,
+            self.gmem_tiled_copy_O_partial,
+            self.gmem_tiled_copy_O,
+            self.gmem_tiled_copy_LSE,
+            self.s2r_tiled_copy_LSE,
+            seqlen_divmod,
+            head_divmod,
+            varlen,
+        ).launch(
+            grid=grid_dim,
+            block=[self.num_threads, 1, 1],
+            smem=smem_size,
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mO_partial: cute.Tensor,
+        mLSE_partial: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        cu_seqlens: Optional[cute.Tensor],
+        seqused: Optional[cute.Tensor],
+        num_splits_dynamic_ptr: Optional[cute.Tensor],
+        varlen_batch_idx: Optional[cute.Tensor],
+        semaphore_to_reset: Optional[cute.Tensor],
+        SharedStorage: cutlass.Constexpr,
+        smem_layout_lse: cute.Layout | cute.ComposedLayout,
+        smem_layout_o: cute.Layout,
+        gmem_tiled_copy_O_partial: cute.TiledCopy,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        gmem_tiled_copy_LSE: cute.TiledCopy,
+        s2r_tiled_copy_LSE: cute.TiledCopy,
+        seqlen_divmod: FastDivmodDivisor,
+        head_divmod: FastDivmodDivisor,
+        varlen: cutlass.Constexpr[bool],
+    ):
+        # Thread and block indices
+        tidx, _, _ = cute.arch.thread_idx()
+        m_block, k_block, maybe_virtual_batch = cute.arch.block_idx()
+
+        # Map virtual batch index to real batch index (for persistent tile schedulers)
+        batch_idx = (
+            varlen_batch_idx[maybe_virtual_batch]
+            if const_expr(varlen_batch_idx is not None)
+            else maybe_virtual_batch
+        )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        # Get shared memory buffer
+        # ///////////////////////////////////////////////////////////////////////////////
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sLSE = storage.sLSE.get_tensor(smem_layout_lse)
+        sMaxValidSplit = storage.sMaxValidSplit.get_tensor((self.tile_m,))
+        sO = storage.sO.get_tensor(smem_layout_o)
+
+        # Handle semaphore reset — wait for dependent grids first
+        if const_expr(semaphore_to_reset is not None):
+            if (
+                tidx == 0
+                and m_block == cute.arch.grid_dim()[0] - 1
+                and k_block == cute.arch.grid_dim()[1] - 1
+                and maybe_virtual_batch == cute.arch.grid_dim()[2] - 1
+            ):
+                cute.arch.griddepcontrol_wait()
+                semaphore_to_reset[0] = 0
+
+        # Get number of splits (use maybe_virtual_batch for per-batch-slot splits)
+        num_splits = (
+            num_splits_dynamic_ptr[maybe_virtual_batch]
+            if const_expr(num_splits_dynamic_ptr is not None)
+            else mLSE_partial.shape[1]
+        )
+        # Handle variable length sequences using SeqlenInfo
+        seqlen_info = SeqlenInfo.create(
+            batch_idx=batch_idx,
+            seqlen_static=mO_partial.shape[0],
+            cu_seqlens=cu_seqlens,
+            seqused=seqused,
+            # Don't need to pass in tile size since we won't use offset_padded
+        )
+        seqlen, offset = seqlen_info.seqlen, seqlen_info.offset
+
+        # Extract number of heads (head index will be determined dynamically)
+        num_head = mO_partial.shape[3]
+        max_idx = seqlen * num_head
+
+        # Early exit for single split if dynamic
+        if (const_expr(num_splits_dynamic_ptr is None) or num_splits > 1) and (
+            const_expr(not varlen) or m_block * self.tile_m < max_idx
+        ):
+            # Wait for dependent grids (e.g., the main attention kernel that produces O_partial/LSE_partial)
+            cute.arch.griddepcontrol_wait()
+
+            # ===============================
+            # Step 1: Load LSE_partial from gmem to shared memory
+            # ===============================
+
+            mLSE_partial_cur = seqlen_info.offset_batch(mLSE_partial, batch_idx, dim=3)
+            mLSE_partial_copy = cute.tiled_divide(mLSE_partial_cur, (1,))
+            gmem_thr_copy_LSE = gmem_tiled_copy_LSE.get_slice(tidx)
+            tLSEsLSE = gmem_thr_copy_LSE.partition_D(sLSE)
+            # Create identity tensor for coordinate tracking
+            cLSE = cute.make_identity_tensor((self.max_splits, self.tile_m))
+            tLSEcLSE = gmem_thr_copy_LSE.partition_S(cLSE)
+
+            # Load LSE partial values
+            for m in cutlass.range(cute.size(tLSEcLSE, mode=[2]), unroll_full=True):
+                mi = tLSEcLSE[0, 0, m][1]  # Get m coordinate
+                idx = m_block * self.tile_m + mi
+                if idx < max_idx:
+                    # Calculate actual sequence position and head using FastDivmodDivisor
+                    if const_expr(not varlen):
+                        head_idx, m_idx = divmod(idx, seqlen_divmod)
+                    else:
+                        head_idx = idx // seqlen
+                        m_idx = idx - head_idx * seqlen
+                    mLSE_partial_cur_copy = mLSE_partial_copy[None, m_idx, None, head_idx]
+                    for s in cutlass.range(cute.size(tLSEcLSE, mode=[1]), unroll_full=True):
+                        si = tLSEcLSE[0, s, 0][0]  # Get split coordinate
+                        if si < num_splits:
+                            cute.copy(
+                                gmem_thr_copy_LSE,
+                                mLSE_partial_cur_copy[None, si],
+                                tLSEsLSE[None, s, m],
+                            )
+                        else:
+                            tLSEsLSE[None, s, m].fill(-Float32.inf)
+                # Don't need to zero out the rest of the LSEs, as we will not write the output to gmem
+            cute.arch.cp_async_commit_group()
+
+            # ===============================
+            # Step 2: Load O_partial for pipeline stages
+            # ===============================
+
+            gmem_thr_copy_O_partial = gmem_tiled_copy_O_partial.get_slice(tidx)
+            cO = cute.make_identity_tensor((self.tile_m, self.k_block_size))
+            tOcO = gmem_thr_copy_O_partial.partition_D(cO)
+            tOsO_partial = gmem_thr_copy_O_partial.partition_D(sO)
+            mO_partial_cur = seqlen_info.offset_batch(mO_partial, batch_idx, dim=4)
+
+            # Precompute these values to avoid recomputing them in the loop
+            num_rows = const_expr(cute.size(tOcO, mode=[1]))
+            tOmidx = cute.make_rmem_tensor(num_rows, cutlass.Int32)
+            tOhidx = cute.make_rmem_tensor(num_rows, cutlass.Int32)
+            tOrOptr = cute.make_rmem_tensor(num_rows, cutlass.Int64)
+            for m in cutlass.range(num_rows, unroll_full=True):
+                mi = tOcO[0, m, 0][0]  # m coordinate
+                idx = m_block * self.tile_m + mi
+                if const_expr(not varlen):
+                    tOhidx[m], tOmidx[m] = divmod(idx, seqlen_divmod)
+                else:
+                    tOhidx[m] = idx // seqlen
+                    tOmidx[m] = idx - tOhidx[m] * seqlen
+                tOrOptr[m] = utils.elem_pointer(
+                    mO_partial_cur, (tOmidx[m], k_block * self.k_block_size, 0, tOhidx[m])
+                ).toint()
+                if idx >= max_idx:
+                    tOhidx[m] = -1
+
+            tOpO = None
+            if const_expr(not self.is_even_k):
+                tOpO = cute.make_rmem_tensor(cute.size(tOcO, mode=[2]), Boolean)
+                for k in cutlass.range(cute.size(tOpO), unroll_full=True):
+                    tOpO[k] = tOcO[0, 0, k][1] < mO_partial.shape[1] - k_block * self.k_block_size
+                # if cute.arch.thread_idx()[0] == 0 and k_block == 1: cute.print_tensor(tOpO)
+
+            load_O_partial = partial(
+                self.load_O_partial,
+                gmem_tiled_copy_O_partial,
+                tOrOptr,
+                tOsO_partial,
+                tOhidx,
+                tOpO,
+                tOcO,
+                mO_partial_cur.layout,
+            )
+
+            # Load first few stages of O_partial
+            for stage in cutlass.range(self.stages - 1, unroll_full=True):
+                if stage < num_splits:
+                    load_O_partial(stage, stage)
+                cute.arch.cp_async_commit_group()
+
+            # ===============================
+            # Step 3: Load and transpose LSE from smem to registers
+            # ===============================
+
+            # Wait for LSE and initial O partial stages to complete
+            cute.arch.cp_async_wait_group(self.stages - 1)
+            cute.arch.sync_threads()
+            # if cute.arch.thread_idx()[0] == 0:
+            #     # cute.print_tensor(sLSE)
+            #     for i in range(64):
+            #         cute.printf("sLSE[%d, 0] = %f", i, sLSE[i, 0])
+            # cute.arch.sync_threads()
+
+            s2r_thr_copy_LSE = s2r_tiled_copy_LSE.get_slice(tidx)
+            ts2rsLSE = s2r_thr_copy_LSE.partition_S(sLSE)
+            ts2rrLSE = cute.make_rmem_tensor_like(ts2rsLSE)
+            cute.copy(s2r_tiled_copy_LSE, ts2rsLSE, ts2rrLSE)
+
+            # ===============================
+            # Step 4: Compute final LSE along split dimension
+            # ===============================
+
+            lse_sum = cute.make_rmem_tensor(cute.size(ts2rrLSE, mode=[2]), Float32)
+            ts2rcLSE = s2r_thr_copy_LSE.partition_D(cLSE)
+            # We compute the max valid split for each row to short-circuit the computation later
+            max_valid_split = cute.make_rmem_tensor(cute.size(ts2rrLSE, mode=[2]), Int32)
+            assert cute.size(ts2rrLSE, mode=[0]) == 1
+            # Compute max, scales, and final LSE for each row
+            for m in cutlass.range(cute.size(ts2rrLSE, mode=[2]), unroll_full=True):
+                # Find max LSE value across splits
+                threads_per_col = const_expr(self.smem_threads_per_col_lse)
+                lse_max = cute.arch.warp_reduction_max(
+                    ts2rrLSE[None, None, m]
+                    .load()
+                    .reduce(cute.ReductionOp.MAX, init_val=-Float32.inf, reduction_profile=0),
+                    threads_in_group=threads_per_col,
+                )
+                # if cute.arch.thread_idx()[0] == 0: cute.printf(lse_max)
+                # Find max valid split index
+                max_valid_idx = -1
+                for s in cutlass.range(cute.size(ts2rrLSE, mode=[1]), unroll_full=True):
+                    if ts2rrLSE[0, s, m] != -Float32.inf:
+                        max_valid_idx = ts2rcLSE[0, s, 0][0]  # Get split coordinate
+                # if cute.arch.thread_idx()[0] < 32: cute.printf(max_valid_idx)
+                max_valid_split[m] = cute.arch.warp_reduction_max(
+                    max_valid_idx, threads_in_group=threads_per_col
+                )
+                # Compute exp scales and sum
+                lse_max_cur = (
+                    0.0 if lse_max == -Float32.inf else lse_max
+                )  # In case all local LSEs are -inf
+                LOG2_E = math.log2(math.e)
+                lse_sum_cur = 0.0
+                for s in cutlass.range(cute.size(ts2rrLSE, mode=[1]), unroll_full=True):
+                    scale = cute.math.exp2(
+                        ts2rrLSE[0, s, m] * LOG2_E - (lse_max_cur * LOG2_E), fastmath=True
+                    )
+                    lse_sum_cur += scale
+                    ts2rrLSE[0, s, m] = scale  # Store scale for later use
+                lse_sum_cur = cute.arch.warp_reduction_sum(
+                    lse_sum_cur, threads_in_group=threads_per_col
+                )
+                lse_sum[m] = cute.math.log(lse_sum_cur, fastmath=True) + lse_max
+                # Normalize scales
+                inv_sum = (
+                    0.0 if (lse_sum_cur == 0.0 or lse_sum_cur != lse_sum_cur) else 1.0 / lse_sum_cur
+                )
+                ts2rrLSE[None, None, m].store(ts2rrLSE[None, None, m].load() * inv_sum)
+            # Store the scales exp(lse - lse_logsum) back to smem
+            cute.copy(s2r_tiled_copy_LSE, ts2rrLSE, ts2rsLSE)
+
+            # Store max valid split to smem
+            for m in cutlass.range(cute.size(ts2rrLSE, mode=[2]), unroll_full=True):
+                if ts2rcLSE[0, 0, m][0] == 0:  # Only thread responsible for s=0 writes
+                    mi = ts2rcLSE[0, 0, m][1]
+                    if mi < self.tile_m:
+                        sMaxValidSplit[mi] = max_valid_split[m]
+
+            # ===============================
+            # Step 5: Store final LSE to gmem
+            # ===============================
+
+            if const_expr(mLSE is not None):
+                if const_expr(cu_seqlens is None):
+                    mLSE_cur = mLSE[None, None, batch_idx]
+                else:
+                    mLSE_cur = cute.domain_offset((offset, 0), mLSE)
+                if k_block == 0:  # Only first k_block writes LSE when mLSE is provided
+                    for m in cutlass.range(cute.size(ts2rrLSE, mode=[2]), unroll_full=True):
+                        if ts2rcLSE[0, 0, m][0] == 0:  # Only thread responsible for s=0 writes
+                            mi = ts2rcLSE[0, 0, m][1]
+                            idx = m_block * self.tile_m + mi
+                            if idx < max_idx:
+                                if const_expr(not varlen):
+                                    head_idx, m_idx = divmod(idx, seqlen_divmod)
+                                else:
+                                    head_idx = idx // seqlen
+                                    m_idx = idx - head_idx * seqlen
+                                mLSE_cur[m_idx, head_idx] = lse_sum[m]
+
+            # ===============================
+            # Step 6: Read O_partial and accumulate final O
+            # ===============================
+
+            cute.arch.sync_threads()
+
+            # Get max valid split for this thread
+            thr_max_valid_split = sMaxValidSplit[tOcO[0, 0, 0][0]]
+            for m in cutlass.range(1, cute.size(tOcO, mode=[1]), unroll_full=True):
+                thr_max_valid_split = max(thr_max_valid_split, sMaxValidSplit[tOcO[0, m, 0][0]])
+
+            tOrO_partial = cute.make_rmem_tensor_like(tOsO_partial[None, None, None, 0])
+            tOrO = cute.make_rmem_tensor_like(tOrO_partial, Float32)
+            tOrO.fill(0.0)
+
+            stage_load = self.stages - 1
+            stage_compute = 0
+
+            # Main accumulation loop
+            for s in cutlass.range(thr_max_valid_split + 1, unroll=4):
+                # Get scales for this split
+                scale = cute.make_rmem_tensor(num_rows, Float32)
+                for m in cutlass.range(num_rows, unroll_full=True):
+                    scale[m] = sLSE[s, tOcO[0, m, 0][0]]  # Get scale from smem
+
+                # Load next stage if needed
+                split_to_load = s + self.stages - 1
+                if split_to_load <= thr_max_valid_split:
+                    load_O_partial(split_to_load, stage_load)
+                cute.arch.cp_async_commit_group()
+                stage_load = 0 if stage_load == self.stages - 1 else stage_load + 1
+
+                # Wait for the current stage to be ready
+                cute.arch.cp_async_wait_group(self.stages - 1)
+                # We don't need __syncthreads() because each thread is just reading its own data from smem
+                # Copy from smem to registers
+                cute.autovec_copy(tOsO_partial[None, None, None, stage_compute], tOrO_partial)
+                stage_compute = 0 if stage_compute == self.stages - 1 else stage_compute + 1
+
+                # Accumulate scaled partial results
+                for m in cutlass.range(num_rows, unroll_full=True):
+                    if tOhidx[m] >= 0 and scale[m] > 0.0:
+                        tOrO[None, m, None].store(
+                            tOrO[None, m, None].load()
+                            + scale[m] * tOrO_partial[None, m, None].load().to(Float32)
+                        )
+
+            # ===============================
+            # Step 7: Write final O to gmem
+            # ===============================
+
+            rO = cute.make_rmem_tensor_like(tOrO, self.dtype)
+            rO.store(tOrO.load().to(self.dtype))
+            mO_cur = seqlen_info.offset_batch(mO, batch_idx, dim=3)
+            if const_expr(cu_seqlens is None):
+                mO_cur = mO[None, None, None, batch_idx]
+            else:
+                mO_cur = cute.domain_offset((offset, 0, 0), mO)
+            mO_cur = utils.domain_offset_aligned((0, k_block * self.k_block_size, 0), mO_cur)
+            elems_per_store = const_expr(cute.size(gmem_tiled_copy_O.layout_tv_tiled[1]))
+            # mO_cur_copy = cute.tiled_divide(mO_cur, (1, elems_per_store,))
+            gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+            # Write final results
+            for m in cutlass.range(num_rows, unroll_full=True):
+                if tOhidx[m] >= 0:
+                    mO_cur_copy = cute.tiled_divide(
+                        mO_cur[tOmidx[m], None, tOhidx[m]], (elems_per_store,)
+                    )
+                    for k in cutlass.range(cute.size(tOcO, mode=[2]), unroll_full=True):
+                        k_idx = tOcO[0, 0, k][1] // elems_per_store
+                        if const_expr(self.is_even_k) or tOpO[k]:
+                            cute.copy(gmem_thr_copy_O, rO[None, m, k], mO_cur_copy[None, k_idx])
+
+    @cute.jit
+    def load_O_partial(
+        self,
+        gmem_tiled_copy_O_partial: cute.TiledCopy,
+        tOrOptr: cute.Tensor,
+        tOsO_partial: cute.Tensor,
+        tOhidx: cute.Tensor,
+        tOpO: Optional[cute.Tensor],
+        tOcO: cute.Tensor,
+        mO_cur_partial_layout: cute.Layout,
+        split: Int32,
+        stage: Int32,
+    ) -> None:
+        elems_per_load = const_expr(cute.size(gmem_tiled_copy_O_partial.layout_tv_tiled[1]))
+        tOsO_partial_cur = tOsO_partial[None, None, None, stage]
+        for m in cutlass.range(cute.size(tOcO, [1]), unroll_full=True):
+            if tOhidx[m] >= 0:
+                o_gmem_ptr = cute.make_ptr(
+                    tOsO_partial.element_type, tOrOptr[m], cute.AddressSpace.gmem, assumed_align=16
+                )
+                mO_partial_cur = cute.make_tensor(
+                    o_gmem_ptr, cute.slice_(mO_cur_partial_layout, (0, None, None, 0))
+                )
+                mO_partial_cur_copy = cute.tiled_divide(mO_partial_cur, (elems_per_load,))
+                for k in cutlass.range(cute.size(tOcO, mode=[2]), unroll_full=True):
+                    k_idx = tOcO[0, 0, k][1] // elems_per_load
+                    if const_expr(tOpO is None) or tOpO[k]:
+                        cute.copy(
+                            gmem_tiled_copy_O_partial,
+                            mO_partial_cur_copy[None, k_idx, split],
+                            tOsO_partial_cur[None, m, k],
+                        )

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/flash_fwd_sm100.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/flash_fwd_sm100.py
@@ -1,0 +1,3102 @@
+# Supported features:
+# - BF16 & FP16 dtype
+# - noncausal & causal attention
+# - MHA, GQA, MQA
+# - hdim 64, 96, 128, (192, 128).
+# - varlen
+# - sliding window
+# - split-kv
+# Unsupported features that will be added later:
+# - page size != 128
+# - more hdim (192, 256)
+# Based on the cutlass example and cute-dsl example:
+# https://github.com/NVIDIA/cutlass/tree/main/examples/77_blackwell_fmha
+# https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/blackwell/fmha.py
+
+import math
+from typing import Tuple, Callable, Optional, Literal, NamedTuple
+from functools import partial
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Int64, Boolean, const_expr
+from cutlass.cute.nvgpu import cpasync
+import cutlass.cute.nvgpu.tcgen05 as tcgen05
+import cutlass.utils.blackwell_helpers as sm100_utils_basic
+from cutlass import pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+from cutlass.utils import ClcDynamicPersistentTileScheduler
+from cutlass.base_dsl.arch import Arch
+from cutlass.cutlass_dsl import BaseDSL
+
+from quack import copy_utils, layout_utils
+
+from flashrt_fa4.cute.paged_kv import PagedKVManager
+from flashrt_fa4.cute.cute_dsl_utils import assume_tensor_aligned
+from flashrt_fa4.cute import utils
+import flashrt_fa4.cute.pipeline as pipeline_custom
+import cutlass.pipeline as cutlass_pipeline
+from flashrt_fa4.cute.mask import AttentionMask
+from flashrt_fa4.cute.softmax import SoftmaxSm100, apply_score_mod_inner
+from flashrt_fa4.cute.seqlen_info import SeqlenInfoQK
+from flashrt_fa4.cute.block_info import BlockInfo
+from flashrt_fa4.cute.block_sparsity import BlockSparseTensors
+from flashrt_fa4.cute.block_sparse_utils import (
+    get_total_block_count,
+    produce_block_sparse_loads_sm100,
+    softmax_block_sparse_sm100,
+    handle_block_sparse_empty_tile_correction_sm100,
+)
+from flashrt_fa4.cute.pack_gqa import PackGQA, pack_gqa_layout
+from flashrt_fa4.cute import mma_sm100_desc as sm100_desc
+from flashrt_fa4.cute import blackwell_helpers as sm100_utils
+from flashrt_fa4.cute.named_barrier import NamedBarrierFwdSm100
+from cutlass.cute import FastDivmodDivisor
+from quack.cute_dsl_utils import ParamsBase
+from flashrt_fa4.cute.tile_scheduler import (
+    ClcState,
+    SchedulingMode,
+    TileSchedulerArguments,
+    TileSchedulerProtocol,
+    SingleTileScheduler,
+    StaticPersistentTileScheduler,
+    SingleTileLPTScheduler,
+    SingleTileVarlenScheduler,
+)
+from flashrt_fa4.cute.fa_logging import fa_log, fa_printf
+from flashrt_fa4.cute.utils import smid
+
+# === TUNING KNOBS (agent-editable) ===
+# Keys: (use_2cta_instrs: bool, is_causal: bool, head_dim_padded: int, is_sm103: bool)
+# Values:
+#   ex2_emu_freq: int — how often to use emulated exp2 (0=all hardware exp2, higher=more emulation).
+#                        SM103 has fast native exp2, so set freq=0 there.
+#   ex2_emu_res: int — (hd256 only) number of fragment-pairs per freq period to emulate.
+#   ex2_emu_start_frg: int — fragment index to start emulation from
+#   num_regs_softmax: int — register count for softmax warps (multiple of 8)
+#   num_regs_correction: int — register count for correction warps (multiple of 8)
+#   num_regs_other is derived: 512 - num_regs_softmax * 2 - num_regs_correction
+#                  (hd256 exception: num_regs_other is fixed at 32, not derived)
+_TUNING_CONFIG = {
+    (True, False, 128, False): {"ex2_emu_freq": 10, "ex2_emu_start_frg": 1, "num_regs_softmax": 176, "num_regs_correction": 88},
+    (False, True, 128, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 1, "num_regs_softmax": 192, "num_regs_correction": 72},
+    (True, False, 192, False): {"ex2_emu_freq": 16, "ex2_emu_start_frg": 0, "num_regs_softmax": 184, "num_regs_correction": 80},
+    (False, True, 192, False): {"ex2_emu_freq": 32, "ex2_emu_start_frg": 1, "num_regs_softmax": 192, "num_regs_correction": 72},
+    (True, False, 128, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 80},
+    (False, True, 128, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 64},
+    (True, False, 192, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 64},
+    (False, True, 192, True): {"ex2_emu_freq": 0, "ex2_emu_start_frg": 0, "num_regs_softmax": 176, "num_regs_correction": 72},
+    (True, False, 256, False): {"ex2_emu_freq": 14, "ex2_emu_res": 6, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
+    (True, True, 256, False): {"ex2_emu_freq": 14, "ex2_emu_res": 6, "ex2_emu_start_frg": 0, "num_regs_softmax": 256, "num_regs_correction": 160},
+}
+_FP8_TUNING_CONFIG = {
+    (True, False, 128, False): {'ex2_emu_freq': 10, 'ex2_emu_start_frg': 1, 'num_regs_softmax': 160, 'num_regs_correction': 72},
+}
+_FP8_SMALL_HDIM_REGS = {
+    False: {"num_regs_softmax": 168, "num_regs_correction": 96, "num_regs_other": 80},
+    True: {"num_regs_softmax": 152, "num_regs_correction": 96, "num_regs_other": 112},
+}
+# === END TUNING KNOBS ===
+
+
+class DescaleTensors(NamedTuple):
+    q_descale: Optional[cute.Tensor] = None
+    k_descale: Optional[cute.Tensor] = None
+    v_descale: Optional[cute.Tensor] = None
+
+    def __new_from_mlir_values__(self, values):
+        return DescaleTensors(*((*values, None, None, None)[:3]))
+
+
+class FlashAttentionForwardSm100:
+
+    def __init__(
+        self,
+        # dtype: Type[cutlass.Numeric],
+        head_dim: int,
+        head_dim_v: Optional[int] = None,
+        qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+        is_causal: bool = False,
+        is_local: bool = False,
+        is_split_kv: bool = False,
+        pack_gqa: bool = False,
+        q_subtile_factor: int | None = None,
+        m_block_size: int = 128,
+        n_block_size: int = 128,
+        q_stage: cutlass.Constexpr[int] = 2,
+        is_persistent: bool = True,
+        score_mod: cutlass.Constexpr | None = None,
+        mask_mod: cutlass.Constexpr | None = None,
+        has_aux_tensors: cutlass.Constexpr = False,
+        paged_kv_non_tma: bool = False,
+        is_varlen_q: bool = False,
+        use_2cta_instrs: bool = False,
+        use_clc_scheduler: bool = False,
+    ):
+        self.use_tma_KV = not paged_kv_non_tma
+        # self.dtype = dtype
+        # padding head_dim to a multiple of 16 as k_block_size
+        hdim_multiple_of = 16
+        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+        self.same_hdim_kv = head_dim == head_dim_v
+        self.head_dim_v_padded = int(math.ceil(head_dim_v / hdim_multiple_of) * hdim_multiple_of)
+        self.same_hdim_kv_padded = self.head_dim_padded == self.head_dim_v_padded
+        self.check_hdim_oob = head_dim != self.head_dim_padded
+        self.check_hdim_v_oob = head_dim_v != self.head_dim_v_padded
+        self.m_block_size = m_block_size
+        self.n_block_size = n_block_size
+        self.q_stage = q_stage
+        assert self.q_stage in [1, 2]
+        self.use_2cta_instrs = use_2cta_instrs
+        # If split_P_arrive, the softmax warps write some columns of P first, signal to the MMA warp
+        # to being the P @ V MMA, then write the rest of P and signal again. This allows some overlap
+        # between compute the last couple columns of P and the P @ V MMA.
+        self.split_P_arrive = n_block_size // 4 * 3
+        self.split_P_arrive = int(self.split_P_arrive / 32) * 32  # multiple of 32
+        assert self.split_P_arrive % 32 == 0
+        assert self.split_P_arrive < self.n_block_size
+        self.arch = BaseDSL._get_dsl().get_arch_enum()
+        assert self.arch >= Arch.sm_100 and self.arch <= Arch.sm_110f, "Only SM 10.x and 11.x are supported"
+
+        self.cta_group_size = 2 if self.use_2cta_instrs else 1
+        # cta_tiler M includes only 1 CTA, the scheduler will take into account the cluster shape
+        self.cta_tiler = (self.q_stage * m_block_size, n_block_size, self.head_dim_padded)
+        # With 2CTA, the MMA tiler M covers both CTAs, so it's cta_group_size * m_block_size.
+        # Each CTA owns m_block_size rows; the 2CTA MMA instruction spans both.
+        self.mma_tiler_qk = (self.cta_group_size * m_block_size, n_block_size, self.head_dim_padded)
+        self.mma_tiler_pv = (self.cta_group_size * m_block_size, self.head_dim_v_padded, n_block_size)
+        self.qk_acc_dtype = Float32
+        self.pv_acc_dtype = Float32
+        self.cluster_shape_mn = (2, 1) if self.use_2cta_instrs else (1, 1)
+        self.is_persistent = is_persistent
+        self.is_causal = is_causal
+        self.is_local = is_local
+        self.is_varlen_q = is_varlen_q
+        self.use_correction_warps_for_epi = is_varlen_q
+        self.qhead_per_kvhead = qhead_per_kvhead
+        self.is_split_kv = is_split_kv
+        self.pack_gqa = pack_gqa
+        self.q_subtile_factor = q_subtile_factor
+        assert not (self.is_split_kv and self.head_dim_v_padded >= 192), (
+            "SplitKV is not supported for hdim >= 192"
+        )
+        self.score_mod = score_mod
+        self.mask_mod = mask_mod
+        self.vec_size: cutlass.Constexpr = getattr(
+            score_mod, "__vec_size__", 1 if cutlass.const_expr(has_aux_tensors) else 2
+        )
+        # Does S1 need to wait for S0 to finish
+        # self.s0_s1_barrier = self.head_dim_padded in [64, 96] and (not self.is_causal and not self.is_local)
+        is_sm103 = self.arch >= Arch.sm_103 and self.arch <= Arch.sm_103f
+        self.is_sm103 = is_sm103
+        # enable_ex2_emu is derived: True if tuning config has freq > 0, else fallback to default logic
+        _default_enable_ex2_emu = (self.head_dim_padded <= 128 or (self.head_dim_padded == 192 and self.use_2cta_instrs and not self.is_causal and not self.is_local)) and not is_sm103
+        self.enable_ex2_emu = _default_enable_ex2_emu
+        self.s0_s1_barrier = False
+        self.overlap_sO_sQ = (
+            (self.head_dim_padded == 192 and self.head_dim_v_padded >= 64) or
+            (self.head_dim_v_padded >= 128 and self.is_split_kv)
+        )
+        if self.overlap_sO_sQ:
+            self.is_persistent = False
+
+        assert self.use_tma_KV or not (self.check_hdim_oob or self.check_hdim_v_oob), (
+            "Paged KV does not support irregular head dim"
+        )
+
+        # ClC does not compose with these other features, so disable even if requested
+        self.use_clc_scheduler = (
+            use_clc_scheduler
+            and self.use_tma_KV
+            and not self.overlap_sO_sQ
+        )
+        self.sched_stages = 1
+        if self.use_clc_scheduler:
+            assert self.cluster_shape_mn[1] == 1, f"CLC requires cluster N == 1: {self.cluster_shape_mn}"
+            assert self.cluster_shape_mn[0] in (1, 2), f"bad CLC cluster M: {self.cluster_shape_mn}"
+            assert self.cluster_shape_mn[0] == self.cta_group_size, (
+                f"CLC cluster M != cta_group_size: {self.cluster_shape_mn}, {self.cta_group_size}"
+            )
+
+        self.scheduling_mode = SchedulingMode.CLC if self.use_clc_scheduler else SchedulingMode.STATIC
+
+        if is_varlen_q:
+            self.TileScheduler = SingleTileVarlenScheduler
+        elif self.is_causal or self.is_local or self.use_clc_scheduler:
+            self.TileScheduler = SingleTileLPTScheduler
+        elif self.is_persistent:
+            self.TileScheduler = StaticPersistentTileScheduler
+        else:
+            self.TileScheduler = SingleTileScheduler
+
+        fa_log(1, f"TileScheduler={self.TileScheduler.__name__}, scheduling_mode={self.scheduling_mode.name}, USE_2CTA={self.use_2cta_instrs}")
+
+        self.softmax0_warp_ids = (0, 1, 2, 3)
+        self.softmax1_warp_ids = (4, 5, 6, 7)
+        self.correction_warp_ids = (8, 9, 10, 11)
+        self.mma_warp_id = 12
+        self.epilogue_warp_ids = (13,)
+        self.load_warp_ids = (14,)
+        self.empty_warp_ids = (15,)
+        self.tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
+
+        self.threads_per_cta = cute.arch.WARP_SIZE * len(
+            (
+                *self.softmax0_warp_ids,
+                *self.softmax1_warp_ids,
+                *self.correction_warp_ids,
+                self.mma_warp_id,
+                *self.load_warp_ids,
+                *self.epilogue_warp_ids,
+                *self.empty_warp_ids,
+            )
+        )
+
+        self.use_tma_Q = not (self.pack_gqa and self.m_block_size % self.qhead_per_kvhead != 0)
+
+        if self.q_stage == 1:
+            if not self.use_tma_KV or not self.use_tma_Q:
+                self.empty_warp_ids = self.empty_warp_ids + self.load_warp_ids
+                self.load_warp_ids = self.softmax1_warp_ids
+            else:
+                self.empty_warp_ids = self.empty_warp_ids + self.softmax1_warp_ids
+            self.softmax1_warp_ids = ()
+        elif not self.use_tma_KV:
+            self.load_warp_ids = (14, 15)
+            self.empty_warp_ids = ()
+
+        if self.use_correction_warps_for_epi:
+            self.empty_warp_ids = self.empty_warp_ids + self.epilogue_warp_ids
+            self.epilogue_warp_ids = self.correction_warp_ids
+        elif self.is_varlen_q: # fallback
+            self.epilogue_warp_ids = (13, 14)
+
+        self.clc_scheduler_warp_id = self.empty_warp_ids[0] if self.use_clc_scheduler else None
+
+        self.tmem_s_offset = [0, self.n_block_size]  # e.g., 0, 128
+        self.tmem_o_offset = [
+            self.tmem_s_offset[-1] + self.n_block_size + i * self.head_dim_v_padded
+            for i in range(self.q_stage)
+        ]  # e.g., 256, 384
+        self.tmem_total = self.tmem_o_offset[-1] + self.head_dim_v_padded
+        assert self.tmem_total <= self.tmem_alloc_cols
+        self.tmem_s_to_p_offset = self.n_block_size // 2
+        self.tmem_p_offset = [
+            self.tmem_s_offset[i] + self.tmem_s_to_p_offset for i in range(2)
+        ]  # 0, 128
+
+        # vec buffer for row_max & row_sum
+        self.tmem_vec_offset = self.tmem_s_offset
+
+        # Look up tuning config for register counts and ex2_emu params
+        _tune_key = (self.use_2cta_instrs, self.is_causal, self.head_dim_padded, self.is_sm103)
+        self._tune = _TUNING_CONFIG.get(_tune_key, {})
+        if "ex2_emu_freq" in self._tune:
+            self.enable_ex2_emu = self._tune["ex2_emu_freq"] > 0
+        if self.head_dim_padded < 96:
+            self.num_regs_softmax = 200 if not paged_kv_non_tma else 184
+            self.num_regs_correction = 64
+            self.num_regs_other = 48 if not paged_kv_non_tma else 80
+        else:
+            if not paged_kv_non_tma and "num_regs_softmax" in self._tune:
+                self.num_regs_softmax = self._tune["num_regs_softmax"]
+                self.num_regs_correction = self._tune["num_regs_correction"]
+            elif not paged_kv_non_tma:
+                self.num_regs_softmax = 192
+                self.num_regs_correction = 80
+            else:
+                self.num_regs_softmax = 184
+                self.num_regs_correction = 64
+            self.num_regs_other = 512 - self.num_regs_softmax * 2 - self.num_regs_correction
+
+        self.buffer_align_bytes = 1024
+
+    def _setup_attributes(self):
+        """Set up configurations and parameters for the FMHA kernel operation.
+
+        This method initializes and configures various attributes required for the
+        execution of the fused multi-head attention kernel, mainly about the pipeline stages:
+
+        - Sets up staging parameters for Q, K, V inputs and accumulator data
+        - Configures pipeline stages for softmax, correction, and epilogue operations
+        """
+
+        smem_size_q = self.q_stage * self.m_block_size * self.head_dim_padded * self.q_dtype.width // 8
+        smem_size_o = self.q_stage * self.m_block_size * self.head_dim_v_padded * self.o_dtype.width // 8
+        smem_size_q_o = smem_size_q + smem_size_o if not self.overlap_sO_sQ else max(smem_size_q, smem_size_o)
+        smem_size_k_per_stage = self.n_block_size * self.head_dim_padded * self.k_dtype.width // 8
+        smem_size_v_per_stage = self.n_block_size * self.head_dim_v_padded * self.v_dtype.width // 8
+        smem_size_kv_per_stage = max(smem_size_k_per_stage, smem_size_v_per_stage) // self.cta_group_size
+        kv_stage = (224 * 1024 - smem_size_q_o) // smem_size_kv_per_stage
+        if self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and kv_stage == 2:
+            # For hdim 192,128, we can fit 3 stages if we use uneven_kv_smem
+             kv_stage = 3
+        self.kv_stage = kv_stage
+        # print("kv_stage", self.kv_stage)
+        self.s_stage = 2
+        assert self.s_stage >= self.q_stage
+        # For hdim 192,128 1CTA, we don't have enough smem to store all 3 stages of KV:
+        # 128 x 192 x 2 bytes x 3 stages = 144KB, and we need 96KB for Q.
+        # Instead we store smem as [smem_large, smem_small, smem_large], where smem_large is
+        # 128 x 192 and smem_small is 128 x 128. We set the stride between the stages to be
+        # 128 * 160, so that indexing the 0th and 2nd stages will get the right address,
+        # but for the 1st stage we need to add or subtract (depending on phase) 128 x 64.
+        self.uneven_kv_smem = (
+            self.head_dim_padded == 192 and self.head_dim_v_padded == 128 and self.kv_stage == 3
+        )
+        self.uneven_kv_smem_offset = (
+            self.n_block_size * (self.head_dim_padded - self.head_dim_v_padded) // 2
+            if self.uneven_kv_smem
+            else 0
+        )
+        assert self.uneven_kv_smem_offset % 1024 == 0
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,  # (b, s_q, h, d) or (total_q, h, d) if there is cu_seqlens_q
+        mK: cute.Tensor,  # (b_k, s_k, h_k, d) or (total_k, h_k, d) if there is cu_seqlens_k or (num_pages, page_size, h_k, d) if there is page_table
+        mV: cute.Tensor,  # (b_k, s_k, h_k, dv) or (total_k, h_k, dv) if there is cu_seqlens_k or (num_pages, page_size, h_k, dv) if there is page_table
+        mO: cute.Tensor,  # (b, s_q, h, dv) or (total_q, h, dv) if there is cu_seqlens_q
+        mLSE: Optional[cute.Tensor],
+        softmax_scale: Float32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mPageTable: Optional[cute.Tensor] = None,  # (b_k, max_num_pages_per_seq)
+        window_size_left: Int32 | int | None = None,
+        window_size_right: Int32 | int | None = None,
+        learnable_sink: Optional[cute.Tensor] = None,
+        descale_tensors: Optional[DescaleTensors] = None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        aux_tensors: Optional[list] = None,
+        # Always keep stream as the last parameter (EnvStream: obtained implicitly via TVM FFI).
+        stream: cuda.CUstream = None,
+    ):
+        """Execute the Fused Multi-Head Attention operation on the provided tensors.
+
+        This method prepares the input tensors for processing, validates their shapes and types,
+        configures the computation parameters, and launches the CUDA kernel.
+
+        The method handles:
+        1. Tensor layout transformations for specific memory access patterns
+        2. Validation of tensor shapes and data types
+        3. Initialization of hardware-specific parameters and memory layouts
+        4. Configuration of TMA (Tensor Memory Access) operations
+        5. Grid and work scheduling computation
+        6. Kernel launch with appropriate parameters
+        """
+        # setup static attributes before smem/grid/tma computation
+        self.q_dtype = mQ.element_type
+        self.k_dtype = mK.element_type
+        self.v_dtype = mV.element_type
+        self.o_dtype = mO.element_type
+        mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
+        Q_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+        mQ = cute.make_tensor(mQ.iterator, cute.select(mQ.layout, mode=Q_layout_transpose))
+        # (s_k, d, h_k, b_k) or (total_k, d, h_k) if there's cu_seqlens_k or (page_size, d, h_k, num_pages) if there's page_table
+        KV_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensK is None) else [0, 2, 1]
+        mK, mV = [
+            cute.make_tensor(t.iterator, cute.select(t.layout, mode=KV_layout_transpose))
+            for t in (mK, mV)
+        ]
+        if const_expr(self.is_split_kv):
+            O_layout_transpose = [2, 4, 3, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 3, 2, 0]
+            LSE_layout_transpose = [3, 2, 1, 0] if const_expr(mCuSeqlensQ is None) else [2, 1, 0]
+            num_splits = mO.shape[0]
+        else:
+            O_layout_transpose = [1, 3, 2, 0] if const_expr(mCuSeqlensQ is None) else [0, 2, 1]
+            LSE_layout_transpose = [2, 1, 0] if const_expr(mCuSeqlensQ is None) else [1, 0]
+            num_splits = Int32(1)
+        mO = cute.make_tensor(mO.iterator, cute.select(mO.layout, mode=O_layout_transpose))
+        mLSE = (
+            cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose))
+            if const_expr(mLSE is not None)
+            else None
+        )
+        # (s, d, h, b) -> (d, s, h, b)
+        V_layout_transpose = [1, 0, 2, 3] if const_expr(mCuSeqlensK is None) else [1, 0, 2]
+        mV = cute.make_tensor(mV.iterator, cute.select(mV.layout, mode=V_layout_transpose))
+
+        # check type consistency
+        if const_expr(self.q_dtype != self.k_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
+        if const_expr(self.q_dtype != self.v_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
+        if const_expr(self.q_dtype.width == 8):
+            paged_kv_non_tma = not self.use_tma_KV
+            if const_expr(self.head_dim_padded < 96):
+                fp8_regs = _FP8_SMALL_HDIM_REGS[paged_kv_non_tma]
+                self.num_regs_softmax = fp8_regs["num_regs_softmax"]
+                self.num_regs_correction = fp8_regs["num_regs_correction"]
+                self.num_regs_other = fp8_regs["num_regs_other"]
+            else:
+                fp8_tune = _FP8_TUNING_CONFIG.get(
+                    (self.use_2cta_instrs, self.is_causal, self.head_dim_padded, self.is_sm103), {}
+                )
+                if const_expr("ex2_emu_freq" in fp8_tune):
+                    self._tune = {**self._tune, **fp8_tune}
+                    self.enable_ex2_emu = self._tune["ex2_emu_freq"] > 0
+                if const_expr(not paged_kv_non_tma and "num_regs_softmax" in fp8_tune):
+                    self.num_regs_softmax = fp8_tune["num_regs_softmax"]
+                    self.num_regs_correction = fp8_tune["num_regs_correction"]
+                    self.num_regs_other = 512 - self.num_regs_softmax * 2 - self.num_regs_correction
+        self._setup_attributes()
+        self.use_tma_O = (
+            self.arch >= Arch.sm_90
+            and mCuSeqlensQ is None
+            and mSeqUsedQ is None
+            and not (self.pack_gqa and self.m_block_size % self.qhead_per_kvhead != 0)
+            and not (self.pack_gqa and self.is_split_kv)
+        )
+        self.ex2_emu_freq = 0
+        self.ex2_emu_start_frg = self._tune.get("ex2_emu_start_frg", 1)
+        if const_expr(self.enable_ex2_emu):
+            self.ex2_emu_freq = self._tune.get("ex2_emu_freq", 16)
+            if const_expr(
+                self.pack_gqa and self.head_dim_padded > 64 and not self.is_causal and not self.is_local
+            ):
+                self.ex2_emu_freq = 32 if mCuSeqlensQ is not None or mSeqUsedQ is not None else self._tune.get("ex2_emu_freq", 10)
+
+        cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        q_major_mode = tcgen05.OperandMajorMode.K
+        k_major_mode = tcgen05.OperandMajorMode.K
+        v_major_mode = tcgen05.OperandMajorMode.MN
+        self.o_layout = cutlass.utils.LayoutEnum.from_tensor(mO)
+        # the intermediate tensor p is from tmem & mK-major
+        p_source = tcgen05.OperandSource.TMEM
+        p_major_mode = tcgen05.OperandMajorMode.K
+        tiled_mma_qk = sm100_utils_basic.make_trivial_tiled_mma(
+            self.q_dtype,
+            q_major_mode,
+            k_major_mode,
+            self.qk_acc_dtype,
+            cta_group,
+            self.mma_tiler_qk[:2],
+        )
+        tiled_mma_pv = sm100_utils_basic.make_trivial_tiled_mma(
+            self.v_dtype,
+            p_major_mode,
+            v_major_mode,
+            self.pv_acc_dtype,
+            cta_group,
+            self.mma_tiler_pv[:2],
+            p_source,
+        )
+
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
+        cta_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk), (tiled_mma_qk.thr_id.shape,)
+        )
+
+        # epi_tile is per-CTA (not full 2CTA) since each CTA writes its own O portion
+        self.epi_tile = (self.m_block_size, self.head_dim_v_padded)
+
+        sQ_layout = sm100_utils_basic.make_smem_layout_a(
+            tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.q_stage
+        )
+        sK_layout = sm100_utils_basic.make_smem_layout_b(
+            tiled_mma_qk, self.mma_tiler_qk, self.k_dtype, self.kv_stage
+        )
+        tP_layout = sm100_utils_basic.make_smem_layout_a(
+            tiled_mma_pv, self.mma_tiler_pv, self.q_dtype, self.s_stage
+        )
+        sV_layout = sm100_utils_basic.make_smem_layout_b(
+            tiled_mma_pv, self.mma_tiler_pv, self.v_dtype, self.kv_stage
+        )
+        sO_layout = sm100_utils_basic.make_smem_layout_epi(
+            self.o_dtype, self.o_layout, self.epi_tile, self.q_stage
+        )
+        if const_expr(not self.same_hdim_kv_padded):
+            # sK and sV are using the same physical smem so we need to adjust the stride so that they line up
+            stride_sK = const_expr(
+                max(sK_layout.outer.stride[-1], 0)
+            )  # take max to turn tuple to Int32
+            stride_sV = const_expr(max(sV_layout.outer.stride[-1], 0))
+            stage_stride = const_expr(
+                max(stride_sK, stride_sV)
+                if not self.uneven_kv_smem
+                else (stride_sK + stride_sV) // 2
+            )
+            sK_layout = cute.make_composed_layout(
+                sK_layout.inner,
+                0,
+                cute.make_layout(
+                    (*sK_layout.outer.shape[:-1], self.kv_stage),
+                    stride=(*sK_layout.outer.stride[:-1], stage_stride),
+                ),
+            )
+            sV_layout = cute.make_composed_layout(
+                sV_layout.inner,
+                0,
+                cute.make_layout(
+                    (*sV_layout.outer.shape[:-1], self.kv_stage),
+                    stride=(*sV_layout.outer.stride[:-1], stage_stride),
+                ),
+            )
+
+        if const_expr(self.pack_gqa):
+            nheads_kv = mK.shape[2]
+            mQ = pack_gqa_layout(mQ, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            mO = pack_gqa_layout(mO, self.qhead_per_kvhead, nheads_kv, head_idx=2)
+            if const_expr(mLSE is not None):
+                mLSE = pack_gqa_layout(mLSE, self.qhead_per_kvhead, nheads_kv, head_idx=1)
+
+        self.tma_copy_bytes = {
+            name: cute.size_in_bytes(mX.element_type, cute.select(layout, mode=[0, 1, 2]))
+            for name, mX, layout in [
+                ("Q", mQ, sQ_layout),
+                ("K", mK, sK_layout),
+                ("V", mV, sV_layout),
+            ]
+        }
+        for name in ("Q", "K", "V"):
+            self.tma_copy_bytes[name] *= self.cta_group_size
+
+        # TMA load for Q
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
+
+        if const_expr(self.use_tma_Q):
+            tma_atom_Q, mQ = cute.nvgpu.make_tiled_tma_atom_A(
+                tma_load_op,
+                mQ,
+                cute.select(sQ_layout, mode=[0, 1, 2]),
+                self.mma_tiler_qk,
+                tiled_mma_qk,
+                cta_layout_vmnk.shape,
+            )
+            gmem_tiled_copy_Q = None
+        else:
+            tma_atom_Q = None
+            async_copy_elems = 128 // self.q_dtype.width
+            num_load_threads = cute.arch.WARP_SIZE * len(self.load_warp_ids)
+            threads_per_row = math.gcd(self.head_dim_padded // async_copy_elems, num_load_threads)
+            gmem_tiled_copy_Q = copy_utils.tiled_copy_2d(
+                self.q_dtype, threads_per_row, num_load_threads, async_copy_elems, is_async=True
+            )
+
+        tma_atom_K = None
+        tma_atom_V = None
+        if const_expr(self.use_tma_KV):
+            # TMA load for K
+            tma_atom_K, mK = cute.nvgpu.make_tiled_tma_atom_B(
+                tma_load_op,
+                mK,
+                cute.select(sK_layout, mode=[0, 1, 2]),
+                self.mma_tiler_qk,
+                tiled_mma_qk,
+                cta_layout_vmnk.shape,
+            )
+            # TMA load for V
+            tma_atom_V, mV = cute.nvgpu.make_tiled_tma_atom_B(
+                tma_load_op,
+                mV,
+                cute.select(sV_layout, mode=[0, 1, 2]),
+                self.mma_tiler_pv,
+                tiled_mma_pv,
+                cta_layout_vmnk.shape,
+            )
+
+        self.num_epilogue_threads = cute.arch.WARP_SIZE * len(self.epilogue_warp_ids)
+        if const_expr(self.use_tma_O):
+            tma_atom_O, mO = cpasync.make_tiled_tma_atom(
+                tma_store_op, mO, cute.select(sO_layout, mode=[0, 1]), self.epi_tile
+            )
+            gmem_tiled_copy_O = None
+        else:
+            tma_atom_O = None
+            universal_copy_bits = 128
+            async_copy_elems = universal_copy_bits // self.o_dtype.width
+            atom_universal_copy = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                self.o_dtype,
+                num_bits_per_copy=universal_copy_bits,
+            )
+            tO_shape_dim_1 = sO_layout.outer.shape[1][0] // async_copy_elems
+            tO_layout = cute.make_ordered_layout(
+                (self.num_epilogue_threads // tO_shape_dim_1, tO_shape_dim_1),
+                order=(1, 0),
+            )
+            # So that we don't have to check if we overshoot kBlockM when we store O
+            assert self.m_block_size % tO_layout.shape[0] == 0
+            vO_layout = cute.make_layout((1, async_copy_elems))
+            gmem_tiled_copy_O = cute.make_tiled_copy_tv(atom_universal_copy, tO_layout, vO_layout)
+
+        TileScheduler = self.TileScheduler
+        _num_block_divisor = self.cta_tiler[0] * (self.cta_group_size if not self.is_persistent and self.cta_group_size > 1 else 1)
+        tile_sched_args = TileSchedulerArguments(
+            cute.ceil_div(cute.size(mQ.shape[0]), _num_block_divisor),
+            cute.size(mQ.shape[2]),
+            cute.size(mQ.shape[3])
+            if const_expr(mCuSeqlensQ is None)
+            else cute.size(mCuSeqlensQ.shape[0] - 1),
+            num_splits,
+            cute.size(mK.shape[0])
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
+            mQ.shape[1],
+            mV.shape[0],  # Note that this is different from Sm90 since we transpose mV in Sm100
+            total_q=cute.size(mQ.shape[0])
+            if const_expr(mCuSeqlensQ is not None)
+            else cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            tile_shape_mn=self.cta_tiler[:2],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mSeqUsedQ=mSeqUsedQ,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+            element_size=self.k_dtype.width // 8,
+            is_persistent=self.is_persistent,
+            lpt=self.is_causal or self.is_local,
+            is_split_kv=self.is_split_kv,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_cluster_idx=not self.is_persistent and self.cta_group_size > 1,
+        )
+        tile_sched_params = TileScheduler.to_underlying_arguments(
+            tile_sched_args, scheduling_mode=self.scheduling_mode
+        )
+        self.tile_scheduler_cls = TileScheduler
+        grid_dim = TileScheduler.get_grid_shape(tile_sched_params)
+
+        sO_size = cute.cosize(sO_layout) if const_expr(not self.overlap_sO_sQ) else 0
+        sQ_size = (
+            cute.cosize(sQ_layout) if const_expr(not self.overlap_sO_sQ) else
+            cutlass.max(cute.cosize(sQ_layout), cute.cosize(sO_layout) * self.o_dtype.width // self.q_dtype.width)
+        )
+
+        clc_response_size = self.sched_stages * 4 if self.use_clc_scheduler else 0
+        clc_mbar_size = self.sched_stages * 2 if self.use_clc_scheduler else 0
+
+        @cute.struct
+        class SharedStorage:
+            # m_barriers for pipelines
+            mbar_load_Q: cute.struct.MemRange[Int64, self.q_stage * 2]
+            mbar_load_KV: cute.struct.MemRange[Int64, self.kv_stage * 2]
+            mbar_S_full_P_full_O_rescaled: cute.struct.MemRange[Int64, self.q_stage * 2]
+            mbar_P_full_lastsplit: cute.struct.MemRange[Int64, self.q_stage * 2]
+            mbar_O_full: cute.struct.MemRange[Int64, self.q_stage * 2]
+            mbar_softmax_stats: cute.struct.MemRange[Int64, self.q_stage * 2]
+            # mbar_softmax_stats: cute.struct.MemRange[Int64, self.q_stage * 4 * 2]
+            mbar_O_epi: cute.struct.MemRange[Int64, self.q_stage * 2]
+            mbar_s0_s1_sequence: cute.struct.MemRange[Int64, 2 * 2]
+            # Tmem dealloc cluster barrier
+            tmem_dealloc_mbar_ptr: Int64
+            # Tmem holding buffer
+            tmem_holding_buf: Int32
+            # Smem tensors
+            # store row max and row sum
+            sScale: cute.struct.MemRange[Float32, self.q_stage * self.m_block_size * 2]
+            # CLC buffers placed here to utilize padding before sO's 1024-byte alignment.
+            # This avoids adding bytes at the end when we're at the smem limit.
+            # PipelineClcFetchAsync expects 2 * sched_stages mbarriers (full + empty).
+            clc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, clc_mbar_size]
+            # CLC response storage (16 bytes per stage, stored as 4 Int32s).
+            clc_response: cute.struct.MemRange[Int32, clc_response_size]
+            # Large TMA buffers with 1024-byte alignment
+            sO: cute.struct.Align[
+                cute.struct.MemRange[self.o_dtype, sO_size], self.buffer_align_bytes
+            ]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, sQ_size], self.buffer_align_bytes
+            ]
+            sK: cute.struct.Align[
+                # cute.cosize(sK_layout) is correct even in the case of self.uneven_kv_smem
+                cute.struct.MemRange[self.k_dtype, cute.cosize(sK_layout)],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        softmax_scale_log2, softmax_scale = utils.compute_softmax_scale_log2(softmax_scale, self.score_mod)
+        window_size_left = Int32(window_size_left) if window_size_left is not None else None
+        window_size_right = Int32(window_size_right) if window_size_right is not None else None
+        fastdiv_mods = utils.compute_fastdiv_mods(mQ, mK, self.qhead_per_kvhead, self.pack_gqa, aux_tensors, mPageTable)
+
+        head_divmod = None
+        if cutlass.const_expr(self.pack_gqa):
+            head_divmod = FastDivmodDivisor(self.qhead_per_kvhead)
+
+        self.use_block_sparsity = cutlass.const_expr(blocksparse_tensors is not None)
+        if cutlass.const_expr(self.use_block_sparsity and mPageTable is not None):
+            raise NotImplementedError("Block sparsity + paged KV not supported on SM100")
+
+        # Launch the kernel synchronously
+        self.kernel(
+            mQ,
+            mK,
+            mV,
+            mO,
+            mLSE,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            mSeqUsedQ,
+            mSeqUsedK,
+            mPageTable,
+            tma_atom_Q,
+            tma_atom_K,
+            tma_atom_V,
+            tma_atom_O,
+            softmax_scale_log2,
+            softmax_scale,
+            window_size_left,
+            window_size_right,
+            learnable_sink,
+            descale_tensors,
+            blocksparse_tensors,
+            sQ_layout,
+            sK_layout,
+            tP_layout,
+            sV_layout,
+            sO_layout,
+            gmem_tiled_copy_Q,
+            gmem_tiled_copy_O,
+            tiled_mma_qk,
+            tiled_mma_pv,
+            tile_sched_params,
+            num_splits,
+            aux_tensors,
+            fastdiv_mods,
+            head_divmod,
+        ).launch(
+            grid=grid_dim,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk if cute.size(self.cluster_shape_mnk) > 1 else None,
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    #  GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,  # (s_q, d, h, b) or (total_q, d, h) if there is cu_seqlens_q
+        mK: cute.Tensor,  # (s_k, d, h_k, b_k) or (total_k, d, h_k) if there is cu_seqlens_k or (page_size, d, h_k, num_pages) if there is page_table
+        mV: cute.Tensor,  # (d, s_k, h_k, b_k) or (d, total_k, h_k) if there is cu_seqlens_k or (d, page_size, h_k, num_pages) if there is page_table
+        mO: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        mCuSeqlensQ: Optional[cute.Tensor],
+        mCuSeqlensK: Optional[cute.Tensor],
+        mSeqUsedQ: Optional[cute.Tensor],
+        mSeqUsedK: Optional[cute.Tensor],
+        mPageTable: Optional[cute.Tensor],
+        tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_K: Optional[cute.CopyAtom],
+        tma_atom_V: Optional[cute.CopyAtom],
+        tma_atom_O: Optional[cute.CopyAtom],
+        softmax_scale_log2: Float32,
+        softmax_scale: Float32 | None,
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        learnable_sink: Optional[cute.Tensor],
+        descale_tensors: Optional[DescaleTensors],
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        tP_layout: cute.ComposedLayout,
+        sV_layout: cute.ComposedLayout,
+        sO_layout: cute.ComposedLayout,
+        gmem_tiled_copy_Q: Optional[cute.TiledCopy],
+        gmem_tiled_copy_O: Optional[cute.TiledCopy],
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        tile_sched_params: ParamsBase,
+        num_splits: Int32,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+    ):
+        """The device kernel implementation of the Fused Multi-Head Attention.
+
+        This kernel coordinates multiple specialized warps to perform different phases of the FMHA computation:
+        1. Load warp: Loads Q, K, V data from global memory to shared memory using TMA
+        2. MMA warp: Performs matrix multiplications (Q*K^T and P*V)
+        3. Softmax warps: Compute softmax normalization on attention scores
+        4. Correction warps: Apply adjustments to intermediate results
+        5. Epilogue warp: Handles final output transformation and storage
+
+        The kernel implements a complex pipeline with overlapping computation and memory operations,
+        using tensor memory access (TMA) for efficient data loading, warp specialization for different
+        computation phases, and optional attention masking.
+        """
+
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+
+        # Prefetch tma descriptor
+        if warp_idx == 0:
+            for tma_atom in (tma_atom_Q, tma_atom_K, tma_atom_V, tma_atom_O):
+                if const_expr(tma_atom is not None):
+                    cpasync.prefetch_descriptor(tma_atom)
+
+        cta_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk), (tiled_mma_qk.thr_id.shape,)
+        )
+        # Setup cta/thread coordinates
+        bidx, _, _ = cute.arch.block_idx()
+        if const_expr(cute.size(tiled_mma_qk.thr_id.shape) == 1):
+            mma_tile_coord_v = 0
+        else:
+            mma_tile_coord_v = bidx % cute.size(tiled_mma_qk.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+
+        # Alloc
+        smem = cutlass.utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=int(NamedBarrierFwdSm100.TmemPtr),
+            num_threads=cute.arch.WARP_SIZE * len(
+                (self.mma_warp_id,
+                 *self.softmax0_warp_ids,
+                 *self.softmax1_warp_ids,
+                 *self.correction_warp_ids)
+            ),
+        )
+        # Tensor memory dealloc barrier init
+        tmem = cutlass.utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.mma_warp_id,
+            is_two_cta=self.use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+        )
+
+        ThreadCooperativeGroup = partial(pipeline.CooperativeGroup, pipeline.Agent.Thread)
+        mma_warp = ThreadCooperativeGroup(len([self.mma_warp_id]))
+        tma_warp = ThreadCooperativeGroup(1)
+        load_threads = ThreadCooperativeGroup(len(self.load_warp_ids) * cute.arch.WARP_SIZE)
+        softmax_warps = ThreadCooperativeGroup(len(self.softmax0_warp_ids))
+        softmax_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.softmax0_warp_ids))
+        # softmax_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE)
+        correction_threads = ThreadCooperativeGroup(
+            cute.arch.WARP_SIZE * len(self.correction_warp_ids)
+        )
+        # correction_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE)
+        softmax_correction_threads = ThreadCooperativeGroup(
+            cute.arch.WARP_SIZE * len(self.softmax0_warp_ids + self.correction_warp_ids)
+        )
+        epilogue_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.epilogue_warp_ids))
+        # For UMMA-bridging pipelines: the non-MMA side spans both CTAs in the cluster,
+        # so the thread count must include warps from both CTAs.
+        softmax_warps_cluster = ThreadCooperativeGroup(
+            len(self.softmax0_warp_ids) * self.cta_group_size
+        )
+        correction_threads_cluster = ThreadCooperativeGroup(
+            cute.arch.WARP_SIZE * len(self.correction_warp_ids) * self.cta_group_size
+        )
+        softmax_correction_threads_cluster = ThreadCooperativeGroup(
+            cute.arch.WARP_SIZE * len(self.softmax0_warp_ids + self.correction_warp_ids) * self.cta_group_size
+        )
+        if const_expr(self.use_tma_Q):
+            pipeline_q = pipeline_custom.PipelineTmaUmma.create(
+                barrier_storage=storage.mbar_load_Q.data_ptr(),
+                num_stages=self.q_stage,
+                producer_group=tma_warp,
+                consumer_group=mma_warp,
+                tx_count=self.tma_copy_bytes["Q"],
+                cta_layout_vmnk=cta_layout_vmnk,
+                defer_sync=True,
+            )
+        else:
+            pipeline_q = pipeline_custom.PipelineAsyncUmma.create(
+                barrier_storage=storage.mbar_load_Q.data_ptr(),
+                num_stages=self.q_stage,
+                producer_group=load_threads,
+                consumer_group=mma_warp,
+                cta_layout_vmnk=cta_layout_vmnk,
+                defer_sync=True,
+            )
+        if const_expr(self.use_tma_KV):
+            pipeline_kv = pipeline_custom.PipelineTmaUmma.create(
+                barrier_storage=storage.mbar_load_KV.data_ptr(),
+                num_stages=self.kv_stage,
+                producer_group=tma_warp,
+                consumer_group=mma_warp,
+                tx_count=self.tma_copy_bytes["K"],
+                cta_layout_vmnk=cta_layout_vmnk,
+                defer_sync=True,
+            )
+        else:
+            pipeline_kv = pipeline.PipelineAsyncUmma.create(
+                barrier_storage=storage.mbar_load_KV.data_ptr(),
+                num_stages=self.kv_stage,
+                producer_group=load_threads,
+                consumer_group=mma_warp,
+                cta_layout_vmnk=cta_layout_vmnk,
+                defer_sync=True,
+            )
+        # This pipeline is not the typical producer-consumer pipeline. The "producer" mma warp
+        # uses it to signal that S is ready, and the softmax threads wait for S to be ready.
+        # When softmax threads write P to tmem and the correction threads have rescaled O, they
+        # signal as "consumer". The mma warp then waits for that signal to do the P @ V gemm.
+        pipeline_s_p_o = pipeline_custom.PipelineUmmaAsync.create(
+            barrier_storage=storage.mbar_S_full_P_full_O_rescaled.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=mma_warp,
+            consumer_group=softmax_correction_threads_cluster,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_p_lastsplit = pipeline_custom.PipelineAsyncUmma.create(
+            barrier_storage=storage.mbar_P_full_lastsplit.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=softmax_warps_cluster,
+            consumer_group=mma_warp,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        # MMA warp uses this to signal to the correction warps that O is ready.
+        pipeline_o_acc = pipeline_custom.PipelineUmmaAsync.create(
+            barrier_storage=storage.mbar_O_full.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=mma_warp,
+            consumer_group=correction_threads_cluster,
+            cta_layout_vmnk=cta_layout_vmnk,
+            defer_sync=True,
+        )
+        pipeline_s0_s1_sequence = None
+        if const_expr(self.s0_s1_barrier and self.q_stage > 1):
+            # This is not a typical producer-consumer pipeline. We will directly use
+            # pipeline_s0_s1_sequence.sync_object_full and will not use
+            # pipeline_s0_s1_sequence.sync_object_empty.
+            pipeline_s0_s1_sequence = pipeline_custom.PipelineAsync.create(
+                barrier_storage=storage.mbar_s0_s1_sequence.data_ptr(),
+                num_stages=2,
+                producer_group=softmax_threads,
+                consumer_group=softmax_threads,
+                defer_sync=True,
+            )
+        pipeline_sm_stats = pipeline_custom.PipelineAsync.create(
+            barrier_storage=storage.mbar_softmax_stats.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=softmax_threads,
+            consumer_group=correction_threads,
+            defer_sync=True,
+        )
+        # Should put the NamedBarrier inside the pipeline class so we'll just have pipeline_sm_stats
+        sm_stats_barrier = pipeline_custom.NamedBarrier(
+            barrier_id=int(NamedBarrierFwdSm100.SoftmaxStatsW0), num_threads=cute.arch.WARP_SIZE * 2
+        )
+        pipeline_o_epi = None
+        if const_expr(not self.use_correction_warps_for_epi):
+            pipeline_o_epi = pipeline_custom.PipelineAsync.create(
+                barrier_storage=storage.mbar_O_epi.data_ptr(),
+                num_stages=self.q_stage,
+                producer_group=correction_threads,
+                consumer_group=epilogue_threads,
+                defer_sync=True,
+            )
+
+        # Cluster arrive after barrier init
+        pipeline_init_arrive(cluster_shape_mn=cta_layout_vmnk, is_relaxed=True)
+
+        #  Generate smem tensor Q/K/V/O
+        # (MMA, MMA_Q, MMA_D, PIPE)
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        # Strip swizzle info to reuse smem
+        sV = cute.make_tensor(cute.recast_ptr(sK.iterator, sV_layout.inner), sV_layout.outer)
+        if const_expr(not self.overlap_sO_sQ):
+            sO = storage.sO.get_tensor(sO_layout.outer, swizzle=sO_layout.inner)
+        else:
+            sO = cute.make_tensor(cute.recast_ptr(sQ.iterator, sO_layout.inner, self.o_dtype), sO_layout.outer)
+
+        sScale = storage.sScale.get_tensor(cute.make_layout(self.q_stage * self.m_block_size * 2))
+
+        thr_mma_qk = tiled_mma_qk.get_slice(mma_tile_coord_v)
+        thr_mma_pv = tiled_mma_pv.get_slice(mma_tile_coord_v)
+
+        qk_acc_shape = thr_mma_qk.partition_shape_C(self.mma_tiler_qk[:2])
+        # This is a fake tensor, by right we need to retrieve tmem_ptr. But we know that we always
+        # request 512 columns of tmem, so we know that it starts at 0.
+        tStS = thr_mma_qk.make_fragment_C(cute.append(qk_acc_shape, self.s_stage))
+        pv_acc_shape = thr_mma_pv.partition_shape_C(self.mma_tiler_pv[:2])
+        tOtO = thr_mma_pv.make_fragment_C(cute.append(pv_acc_shape, self.q_stage))
+        tOtO = cute.make_tensor(tOtO.iterator + self.tmem_o_offset[0], tOtO.layout)
+        tP = cute.make_tensor(tStS.iterator, tP_layout.outer)
+        tOrP = thr_mma_pv.make_fragment_A(tP)[None, None, None, 0]
+        # Need to multiply by width ratio bc tP is in v_dtype but tmem offsets are in FP32
+        tP_width_ratio = Float32.width // self.v_dtype.width
+        # Need to adjust the stage stride manually since the two stages aren't contiguous in tmem
+        tP_stage_stride = (self.tmem_p_offset[1] - self.tmem_p_offset[0]) * tP_width_ratio
+        tOrP = cute.make_tensor(
+            tOrP.iterator + self.tmem_p_offset[0] * tP_width_ratio,
+            cute.append(tOrP.layout, cute.make_layout((self.s_stage,), stride=(tP_stage_stride,)))
+        )
+
+        block_info = BlockInfo(
+            # This is cta_tiler, not mma_tiler_qk, since we move by block by (2 * mma_tiler[0], mma_tiler[1])
+            self.cta_tiler[0],
+            self.cta_tiler[1],
+            self.is_causal,
+            self.is_local,
+            self.is_split_kv,
+            window_size_left,
+            window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        SeqlenInfoCls = partial(
+            SeqlenInfoQK.create,
+            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
+            seqlen_k_static=mK.shape[0]
+            if const_expr(mPageTable is None)
+            else mK.shape[0] * mPageTable.shape[1],
+            mCuSeqlensQ=mCuSeqlensQ,
+            mCuSeqlensK=mCuSeqlensK,
+            mSeqUsedQ=mSeqUsedQ,
+            mSeqUsedK=mSeqUsedK,
+        )
+        AttentionMaskCls = partial(
+            AttentionMask,
+            self.m_block_size,
+            self.n_block_size,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+        )
+        # Cluster wait before tensor memory alloc
+        pipeline_init_wait(cluster_shape_mn=cta_layout_vmnk)
+
+        if const_expr(self.use_clc_scheduler):
+            clc_response_ptr = storage.clc_response.data_ptr()
+            clc_mbar_ptr = storage.clc_mbar_ptr.data_ptr()
+
+            clc_pipeline_producer_group = cutlass_pipeline.CooperativeGroup(
+                cutlass_pipeline.Agent.Thread
+            )
+            num_clc_consumer_warps_per_cta = self.threads_per_cta // cute.arch.WARP_SIZE
+            # NB on CTA0 warp15 == scheduler on CTA1 == empty but still both consume
+            num_clc_consumer_warps = num_clc_consumer_warps_per_cta * self.cta_group_size
+            clc_pipeline_consumer_group = cutlass_pipeline.CooperativeGroup(
+                cutlass_pipeline.Agent.Thread, cute.arch.WARP_SIZE * num_clc_consumer_warps
+            )
+
+            block_idx = cute.arch.block_idx()
+            clc = ClcState.create(
+                hw_scheduler=ClcDynamicPersistentTileScheduler.create(
+                    self.tile_scheduler_cls.clc_problem_shape(tile_sched_params),
+                    block_idx,
+                    cute.arch.grid_dim(),
+                    clc_response_ptr,
+                ),
+                pipeline=cutlass_pipeline.PipelineClcFetchAsync.create(
+                    barrier_storage=clc_mbar_ptr,
+                    num_stages=self.sched_stages,
+                    producer_group=clc_pipeline_producer_group,
+                    consumer_group=clc_pipeline_consumer_group,
+                    tx_count=16,
+                    cta_layout_vmnk=cta_layout_vmnk,
+                ),
+                consumer_state=cutlass_pipeline.make_pipeline_state(
+                    cutlass_pipeline.PipelineUserType.Consumer, self.sched_stages
+                ),
+                producer_state=cutlass_pipeline.make_pipeline_state(
+                    cutlass_pipeline.PipelineUserType.Producer, self.sched_stages
+                ),
+            )
+            tile_scheduler = self.tile_scheduler_cls.create(tile_sched_params, clc=clc)
+        else:
+            tile_scheduler = self.tile_scheduler_cls.create(tile_sched_params)
+        assert isinstance(tile_scheduler, TileSchedulerProtocol), f"tile_scheduler is not a TileSchedulerProtocol: {type(tile_scheduler)}"
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  EMPTY / CLC SCHEDULER WARP
+        # ///////////////////////////////////////////////////////////////////////////////
+        if const_expr(self.use_clc_scheduler):
+            if warp_idx == self.clc_scheduler_warp_id:
+                cute.arch.setmaxregister_decrease(self.num_regs_other)
+                if is_leader_cta:
+                    self.clc_scheduler_warp(tile_scheduler)
+                else:
+                    self.empty_warp(tile_scheduler)
+            for i in cutlass.range_constexpr(len(self.empty_warp_ids)):
+                if warp_idx == self.empty_warp_ids[i] and warp_idx != self.clc_scheduler_warp_id:
+                    cute.arch.setmaxregister_decrease(self.num_regs_other)
+                    self.empty_warp(tile_scheduler)
+        else:
+            for i in cutlass.range_constexpr(len(self.empty_warp_ids)):
+                if warp_idx == self.empty_warp_ids[i]:
+                    cute.arch.setmaxregister_decrease(self.num_regs_other)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx >= self.load_warp_ids[0] and warp_idx <= self.load_warp_ids[-1]:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            self.load(
+                thr_mma_qk,
+                thr_mma_pv,
+                mQ,
+                mK,
+                mV,
+                sQ,
+                sK,
+                sV,
+                mPageTable,
+                tma_atom_Q,
+                tma_atom_K,
+                tma_atom_V,
+                gmem_tiled_copy_Q,
+                pipeline_q,
+                pipeline_kv,
+                block_info,
+                num_splits,
+                SeqlenInfoCls,
+                blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            # Alloc tensor memory buffer
+            tmem.allocate(cute.arch.get_max_tmem_alloc_cols("sm_100"))
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            self.mma(
+                tiled_mma_qk,
+                tiled_mma_pv,
+                sQ,
+                sK,
+                sV,
+                tStS,
+                tOtO,
+                tOrP,
+                pipeline_q,
+                pipeline_kv,
+                pipeline_s_p_o,
+                pipeline_p_lastsplit,
+                pipeline_o_acc,
+                is_leader_cta,
+                block_info,
+                num_splits,
+                SeqlenInfoCls,
+                blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
+            # Dealloc the tensor memory buffer
+            tmem.relinquish_alloc_permit()
+            tmem_alloc_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Epilogue
+        # ///////////////////////////////////////////////////////////////////////////////
+        if const_expr(not self.use_correction_warps_for_epi):
+            if warp_idx >= self.epilogue_warp_ids[0] and warp_idx <= self.epilogue_warp_ids[-1]:
+                cute.arch.setmaxregister_decrease(self.num_regs_other)
+                self.epilogue_s2g(
+                    mO,
+                    sO,
+                    gmem_tiled_copy_O,
+                    tma_atom_O,
+                    pipeline_o_epi,
+                    block_info,
+                    num_splits,
+                    SeqlenInfoCls,
+                    mma_tile_coord_v,
+                    tile_scheduler=tile_scheduler,
+                )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Softmax
+        # ///////////////////////////////////////////////////////////////////////////////
+        if (
+            (const_expr(self.q_stage == 2) and warp_idx <= self.softmax1_warp_ids[-1]) or
+            (const_expr(self.q_stage == 1) and warp_idx <= self.softmax0_warp_ids[-1])
+        ):
+            # increase register after decreasing
+            cute.arch.setmaxregister_increase(self.num_regs_softmax)
+            # sync with mma warp before retrieving tmem ptr
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            softmax_loop = partial(
+                self.softmax_loop,
+                softmax_scale_log2=softmax_scale_log2,
+                softmax_scale=softmax_scale,
+                descale_tensors=descale_tensors,
+                thr_mma_qk=thr_mma_qk,
+                sScale=sScale,
+                mLSE=mLSE,
+                pipeline_s_p_o=pipeline_s_p_o,
+                pipeline_p_lastsplit=pipeline_p_lastsplit,
+                pipeline_sm_stats=pipeline_sm_stats,
+                sm_stats_barrier=sm_stats_barrier,
+                pipeline_s0_s1_sequence=pipeline_s0_s1_sequence,
+                learnable_sink=learnable_sink,
+                block_info=block_info,
+                num_splits=num_splits,
+                SeqlenInfoCls=SeqlenInfoCls,
+                AttentionMaskCls=AttentionMaskCls,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=fastdiv_mods,
+                head_divmod=head_divmod,
+                blocksparse_tensors=blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
+
+            if const_expr(not self.s0_s1_barrier):
+                stage = Int32(0 if const_expr(self.q_stage == 1) or warp_idx < self.softmax1_warp_ids[0] else 1)
+                softmax_loop(stage=stage, tStS=tStS)
+            else:
+                # If there's s0_s1_barrier, it's faster to have 2 WGs having different code
+                if warp_idx < self.softmax1_warp_ids[0]:
+                    softmax_loop(stage=0, tStS=tStS)
+                if warp_idx < self.correction_warp_ids[0] and warp_idx >= self.softmax1_warp_ids[0]:
+                    softmax_loop(stage=1, tStS=tStS)
+
+            tmem_alloc_barrier.arrive()
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Correction
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_correction)
+            # sync with mma warp before retrieving tmem ptr
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            self.correction_loop(
+                thr_mma_qk,
+                thr_mma_pv,
+                tStS,
+                tOtO,
+                sScale,
+                mO,
+                mLSE,
+                sO,
+                pipeline_s_p_o,
+                pipeline_o_acc,
+                pipeline_sm_stats,
+                sm_stats_barrier,
+                pipeline_o_epi,
+                learnable_sink,
+                descale_tensors,
+                gmem_tiled_copy_O,
+                tma_atom_O,
+                softmax_scale_log2,
+                block_info,
+                num_splits,
+                SeqlenInfoCls,
+                blocksparse_tensors,
+                tile_scheduler=tile_scheduler,
+            )
+            tmem_alloc_barrier.arrive()
+
+        return
+
+    @cute.jit
+    def load(
+        self,
+        thr_mma_qk: cute.core.ThrMma,
+        thr_mma_pv: cute.core.ThrMma,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        mPageTable: Optional[cute.Tensor],
+        tma_atom_Q: Optional[cute.CopyAtom],
+        tma_atom_K: Optional[cute.CopyAtom],
+        tma_atom_V: Optional[cute.CopyAtom],
+        gmem_tiled_copy_Q: Optional[cute.TiledCopy],
+        pipeline_q: pipeline.PipelineAsync,
+        pipeline_kv: pipeline.PipelineAsync,
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        tile_scheduler: TileSchedulerProtocol,
+    ):
+        num_load_threads = len(self.load_warp_ids) * cute.arch.WARP_SIZE
+        tidx = cute.arch.thread_idx()[0] % num_load_threads
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        issue_kv_for_this_warp = (
+            const_expr(not self.use_tma_KV or len(self.load_warp_ids) == 1) or
+            warp_idx == self.load_warp_ids[0]
+        )
+        issue_q_for_this_warp = (
+            const_expr(not self.use_tma_Q or len(self.load_warp_ids) == 1) or
+            warp_idx == self.load_warp_ids[0]
+        )
+        q_producer_phase = Int32(1)
+        kv_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.kv_stage
+        )
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
+
+            head_idx_kv = (
+                head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
+            )
+            if const_expr(mPageTable is None):
+                if const_expr(not seqlen.has_cu_seqlens_k):
+                    mK_cur, mV_cur = [t[None, None, head_idx_kv, batch_idx] for t in (mK, mV)]
+                else:
+                    mK_cur = cute.domain_offset((seqlen.offset_k, 0), mK[None, None, head_idx_kv])
+                    mV_cur = cute.domain_offset((0, seqlen.offset_k), mV[None, None, head_idx_kv])
+                gK = cute.local_tile(mK_cur, cute.select(self.mma_tiler_qk, mode=[1, 2]), (None, 0))
+                gV = cute.local_tile(mV_cur, cute.select(self.mma_tiler_pv, mode=[1, 2]), (0, None))
+            else:
+                # Need to keep batch coord None since we'll index into it with page idx
+                mK_cur, mV_cur = [t[None, None, head_idx_kv, None] for t in (mK, mV)]
+                gK = cute.local_tile(
+                    mK_cur, cute.select(self.mma_tiler_qk, mode=[1, 2]), (None, 0, None)
+                )
+                gV = cute.local_tile(
+                    mV_cur, cute.select(self.mma_tiler_pv, mode=[1, 2]), (0, None, None)
+                )
+            tSgK = thr_mma_qk.partition_B(gK)
+            tOgV = thr_mma_pv.partition_B(gV)
+            if const_expr(self.use_tma_Q):
+                tiler_gQ = ((self.mma_tiler_qk[0] * self.q_stage), self.head_dim_padded)
+                gQ = cute.local_tile(mQ_cur, tiler_gQ, (m_block, 0))  # (128 * 2, 128)
+                gQ = layout_utils.select(
+                    cute.flat_divide(gQ, (self.mma_tiler_qk[0],)), mode=[0, 2, 1]
+                )  # (128, 128, 2)
+                tSgQ = thr_mma_qk.partition_A(gQ)
+                load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(
+                    tma_atom_Q, 0, cute.make_layout(1), tSgQ, sQ
+                )
+                load_Q = partial(self.load_Q, load_Q_fn, pipeline_q=pipeline_q, phase=q_producer_phase)
+            else:
+                assert gmem_tiled_copy_Q is not None
+                load_Q = partial(
+                    self.load_Q_non_tma,
+                    mQ_cur,
+                    sQ,
+                    gmem_tiled_copy_Q,
+                    pipeline_q,
+                    tidx,
+                    seqlen.seqlen_q,
+                    m_block,
+                    phase=q_producer_phase,
+                )
+
+            if const_expr(self.use_tma_KV):
+                tKsK, tKgK = cpasync.tma_partition(
+                    tma_atom_K,
+                    0,  # no multicast
+                    cute.make_layout(1),
+                    cute.group_modes(sK, 0, 3),
+                    cute.group_modes(tSgK, 0, 3),
+                )
+                tVsV, tVgV = cpasync.tma_partition(
+                    tma_atom_V,
+                    0,  # no multicast
+                    cute.make_layout(1),
+                    cute.group_modes(sV, 0, 3),
+                    cute.group_modes(tOgV, 0, 3),
+                )
+                paged_kv_manager = None
+            else:
+                page_size = mK.shape[0]
+                paged_kv_manager = PagedKVManager.create(
+                    mPageTable,
+                    mK,
+                    mV,
+                    FastDivmodDivisor(page_size),
+                    batch_idx,
+                    head_idx_kv,
+                    tidx,
+                    seqlen.seqlen_k,
+                    0,  # leftpad_k
+                    self.n_block_size,
+                    self.head_dim_padded,
+                    self.head_dim_v_padded,
+                    num_load_threads,
+                    mK.element_type,
+                )
+                tKsK, tKgK = None, None
+                tVsV, tVgV = None, None
+
+            load_K = partial(
+                self.load_KV,
+                tma_atom_K,
+                tKgK,
+                tKsK,
+                paged_kv_manager,
+                sK,
+                pipeline_kv=pipeline_kv,
+                K_or_V="K",
+            )
+            load_V = partial(
+                self.load_KV,
+                tma_atom_V,
+                tVgV,
+                tVsV,
+                paged_kv_manager,
+                sV,
+                pipeline_kv=pipeline_kv,
+                K_or_V="V",
+            )
+
+            if const_expr(not self.use_block_sparsity):
+                n_block_min, n_block_max = block_info.get_n_block_min_max(
+                    seqlen, m_block, split_idx, num_splits
+                )
+                if const_expr(not self.is_split_kv) or n_block_min < n_block_max:
+                    n_block_first = n_block_max - 1 if n_block_max > 0 else 0
+                    page_idx = (
+                        mPageTable[batch_idx, n_block_first]
+                        if const_expr(mPageTable is not None and self.use_tma_KV)
+                        else None
+                    )
+                    if const_expr(not self.use_tma_KV):
+                        paged_kv_manager.load_page_table(n_block_first)
+                    if issue_kv_for_this_warp:
+                        load_K(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)  # K0
+                    # load_K(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx, extra_tx_count=self.tma_copy_bytes["Q"])  # K0
+                    if issue_q_for_this_warp:
+                        load_Q(block=0, stage=0)
+                    if issue_kv_for_this_warp:
+                        kv_producer_state.advance()
+                    if const_expr(self.q_stage == 2) and issue_q_for_this_warp:
+                        load_Q(block=1, stage=1)
+                    q_producer_phase ^= 1
+                    if issue_kv_for_this_warp:
+                        load_V(block=n_block_max - 1, producer_state=kv_producer_state, page_idx=page_idx)  # V0
+                        kv_producer_state.advance()
+                    for i in cutlass.range(n_block_max - 1 - n_block_min, unroll=1):
+                        n_block = n_block_max - 2 - i
+                        page_idx = (
+                            mPageTable[batch_idx, n_block]
+                            if const_expr(mPageTable is not None and self.use_tma_KV)
+                            else None
+                        )
+                        if const_expr(not self.use_tma_KV):
+                            paged_kv_manager.load_page_table(n_block)
+                    # if cute.arch.thread_idx()[0] % 32 == 0: cute.printf("n_block = {}, page_idx = {}", n_block, page_idx)
+                        if issue_kv_for_this_warp:
+                            load_K(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)  # Ki
+                            kv_producer_state.advance()
+                            load_V(block=n_block, producer_state=kv_producer_state, page_idx=page_idx)  # Vi
+                            kv_producer_state.advance()
+
+            else:
+                kv_producer_state, q_producer_phase = produce_block_sparse_loads_sm100(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    kv_producer_state,
+                    load_Q,
+                    load_K,
+                    load_V,
+                    pipeline_kv,
+                    self.q_stage,
+                    q_producer_phase,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                )
+
+
+            work_tile = tile_scheduler.advance_to_next_work()
+            # End of persistent scheduler loop
+
+        if issue_kv_for_this_warp:
+            pipeline_kv.producer_tail(kv_producer_state)
+        # This is equivalent to pipeline_q.producer_tail for the TMA-Q producer warp.
+        if issue_q_for_this_warp:
+            pipeline_q.producer_acquire_w_index_phase(self.q_stage - 1, q_producer_phase)
+
+    @cute.jit
+    def mma(
+        self,
+        tiled_mma_qk: cute.core.ThrMma,
+        tiled_mma_pv: cute.core.ThrMma,
+        sQ: cute.Tensor,
+        sK: cute.Tensor,
+        sV: cute.Tensor,
+        tStS: cute.Tensor,
+        tOtO: cute.Tensor,
+        tOrP: cute.Tensor,
+        pipeline_q: pipeline.PipelineAsync,
+        pipeline_kv: pipeline.PipelineAsync,
+        pipeline_s_p_o: pipeline.PipelineAsync,
+        pipeline_p_lastsplit: pipeline.PipelineAsync,
+        pipeline_o_acc: pipeline.PipelineAsync,
+        is_leader_cta: Boolean,
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors],
+        tile_scheduler=None,
+    ):
+        tSrQ = tiled_mma_qk.make_fragment_A(sQ)
+        tSrK = tiled_mma_qk.make_fragment_B(sK)
+        tOrV = tiled_mma_pv.make_fragment_B(sV)
+        if const_expr(self.q_stage == 2):
+            tSrQs = (tSrQ[None, None, None, 0], tSrQ[None, None, None, 1])
+        else:
+            tSrQs = (tSrQ[None, None, None, 0],)
+
+        qk_mma_op, pv_mma_op = tiled_mma_qk.op, tiled_mma_pv.op
+        qk_mma_idesc, pv_mma_idesc = sm100_desc.mma_op_to_idesc(qk_mma_op), sm100_desc.mma_op_to_idesc(pv_mma_op)
+        qk_mma_kind = sm100_utils._tcgen05_mma_kind(qk_mma_op)
+        q_smem_base = sm100_desc.smem_desc_base_from_tensor(sQ, sm100_desc.Major.K)
+        k_smem_base = sm100_desc.smem_desc_base_from_tensor(sK, sm100_desc.Major.K)
+        v_smem_base = sm100_desc.smem_desc_base_from_tensor(sV, sm100_desc.Major.MN)
+        q_smem_start = [sm100_desc.make_smem_desc_start_addr(sQ[None, None, None, stage].iterator) for stage in range(self.q_stage)]
+
+        sm100_utils.declare_ptx_smem_desc(q_smem_start[self.q_stage - 1], q_smem_base, tSrQ[None, None, None, 0].layout, var_name_prefix="fa_fwd_q_smem_desc")
+        sm100_utils.declare_ptx_idesc(qk_mma_op, var_name="fa_fwd_qk_mma_idesc")
+        sm100_utils.declare_ptx_idesc(pv_mma_op, var_name="fa_fwd_pv_mma_idesc")
+
+        sQ_stage_stride = (sQ.layout.stride[-1] * sQ.element_type.width // 8) >> 4
+        if const_expr(self.q_stage == 1):
+            sQ_stage_stride = 0
+        gemm_Si = [
+            partial(
+                # sm100_utils.gemm_ptx_precomputed,
+                # self.tmem_s_offset[stage],
+                # smem_desc_start_a=q_smem_start[stage],
+                # idesc=qk_mma_idesc,
+                # smem_desc_base_a=q_smem_base,
+                # smem_desc_base_b=k_smem_base,
+                # tCrA_layout=tSrQ[None, None, None, 0].layout,
+                sm100_utils.gemm_ptx_precomputed_varname,
+                self.tmem_s_offset[stage],
+                # idesc=qk_mma_idesc,
+                smem_desc_base_b=k_smem_base,
+                tCrB_layout=tSrK[None, None, None, 0].layout,
+                smem_var_name_prefix="fa_fwd_q_smem_desc",
+                idesc_var_name="fa_fwd_qk_mma_idesc",
+                kind=qk_mma_kind,
+                smem_offset=-sQ_stage_stride if stage == 0 else sQ_stage_stride,
+                zero_init=True,
+                cta_group=self.cta_group_size,
+            )
+            for stage in range(self.q_stage)
+        ]
+        # gemm_Si = [
+        #     partial(
+        #         sm100_utils.gemm,
+        #         tiled_mma_qk,
+        #         tStS[None, None, None, stage],
+        #         tCrA=tSrQ[None, None, None, stage],
+        #         zero_init=True,
+        #     )
+        #     for stage in range(self.q_stage)
+        # ]
+        gemm_Pi = [
+            partial(
+                # sm100_utils.gemm_ptx_precomputed,
+                sm100_utils.gemm_ptx_partial,
+                pv_mma_op,
+                self.tmem_o_offset[stage],
+                tOrP[None, None, None, stage],
+                sA=None,
+                split_arrive=self.split_P_arrive if self.split_P_arrive > 0 else None,
+                # smem_desc_start_a=tOrP[None, None, None, stage].iterator.toint(),
+                # smem_desc_start_a=self.tmem_p_offset[stage],
+                # idesc=pv_mma_idesc,
+                # smem_desc_base_a=None,
+                # smem_desc_base_b=v_smem_base,
+                # tCrA_layout=tOrP[None, None, None, 0].layout,
+                # tCrB_layout=tOrV[None, None, None, 0].layout
+                cta_group=self.cta_group_size,
+            )
+            for stage in range(self.q_stage)
+        ]
+        # gemm_Pi = [
+        #     partial(
+        #         sm100_utils.gemm, tOtO[None, None, None, stage], tCrA=tOrP[None, None, None, stage]
+        #     )
+        #     for stage in range(self.q_stage)
+        # ]
+
+        mma_q_consumer_phase = Int32(0)
+        mma_kv_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.kv_stage
+        )
+        P_full_O_rescaled_phase = Int32(0)
+
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+
+            block_iter_count = Int32(0)
+            process_tile = False
+
+            if const_expr(self.use_block_sparsity):
+                block_iter_count = get_total_block_count(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                )
+                process_tile = block_iter_count > Int32(0)
+            else:
+                n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+                block_iter_count = n_block_max - n_block_min
+                if const_expr(not self.is_split_kv):
+                    process_tile = True
+                else:
+                    process_tile = n_block_min < n_block_max
+
+            if process_tile and is_leader_cta:
+                for stage in cutlass.range_constexpr(self.q_stage):
+                    # GEMM_QK00 (Q0 * K0 -> S0) or GEMM_QK01 (Q1 * K0 -> S1)
+                    # 1. wait for Q0 / Q1
+                    pipeline_q.consumer_wait_w_index_phase(stage, mma_q_consumer_phase)
+                    # 2. wait for K0
+                    if const_expr(stage == 0):
+                        pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                    tSrKi = tSrK[None, None, None, Ki_index]
+                    # We don't need to acquire empty S0 / S1.
+                    # For the first iteration, we don't need to wait as we're guaranteed S0 / S1
+                    # are empty. For subsequent iterations, the wait happened at the end
+                    # of the while loop.
+                    # 3. gemm
+                    # sm100_utils.gemm(tiled_mma_qk, tStS[None, None, None, stage], tSrQ[None, None, None, stage], tSrKi, zero_init=True)
+                    sK_cur = sK[None, None, None, Ki_index]
+                    if const_expr(self.uneven_kv_smem):
+                        sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
+                    # gemm_Si[stage](tCrB=tSrKi, sB=sK_cur)
+                    gemm_Si[stage](
+                        smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator)
+                    )
+                    # gemm_Si[stage](tCrB=tSrKi)
+                    # 4. release S0 / S1
+                    pipeline_s_p_o.producer_commit_w_index(stage)
+                mma_q_consumer_phase ^= 1
+                # 5. release K0
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+                # End of GEMM (Q1 * K0 -> S1)
+                # Note: Q0 & Q1 are still needed in the seqlen_kv loop
+                # so we need to release them after the seqlen_kv loop
+
+                # O hasn't been accumulated yet, its first MMA calculation doesn't need to accumulate
+                block_loop_count = block_iter_count - 1
+                O_should_accumulate = False
+                for i in cutlass.range(block_loop_count, unroll=1):
+                    # GEMM_PV00 (P0 * V0 -> O0_partial), O0 needs to be accumulated in the seqlen_kv loop
+                    # 1. wait for V0
+                    pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                    mma_kv_release_state = mma_kv_consumer_state.clone()
+                    Vi_index, Vi_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                    tOrVi = tOrV[None, None, None, Vi_index]
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        # 2. acquire corrected O0/O1_partial and P0 / P1
+                        # For the first iteration in this work tile, waiting for O0/O1_partial
+                        # means that the correction warps has finished reading tO during
+                        # the last iteration of the previous work tile.
+                        pipeline_s_p_o.producer_acquire_w_index_phase(stage, P_full_O_rescaled_phase)
+                        # 3. gemm
+                        # sm100_utils.gemm(tiled_mma_pv, tOtO0, tOrP0, tOrVi, zero_init=True)
+                        # gemm_Pi[stage](tCrB=tOrVi, sB=sV[None, None, None, Vi_index], zero_init=not O_should_accumulate)
+                        sV_cur = sV[None, None, None, Vi_index]
+                        if const_expr(self.uneven_kv_smem):
+                            sV_cur = self.offset_kv_smem(sV_cur, Vi_index, Vi_phase)
+                        gemm_Pi[stage](
+                            tCrB=tOrVi,
+                            sB=sV_cur,
+                            # smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sV_cur.iterator),
+                            zero_init=not O_should_accumulate,
+                            mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(stage) if self.split_P_arrive > 0 else None,
+                            mbar_phase=P_full_O_rescaled_phase,
+                        )
+                        # Don't need to signal O_full to the correction warps since the
+                        # correction warps wait for the softmax warps anyway. By the time the softmax
+                        # warps finished, S_i for the next iteration must have been done, so O_i-1
+                        # must have been done as well.
+                        # pipeline_o_acc.producer_commit_w_index(stage)
+                        # 4. release V(i-1)
+                        if const_expr(stage == self.q_stage - 1):
+                            pipeline_kv.consumer_release(mma_kv_release_state)
+                            mma_kv_release_state.advance()
+                        # End of GEMM_PV00 (P0 * V0 -> O0_partial)
+
+                        # GEMM_QK0i (Q0 * Ki -> S0)
+                        # 1. wait for Ki
+                        if const_expr(stage == 0):
+                            mma_kv_consumer_state.advance()
+                            pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                        Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                        # 2. gemm
+                        # Don't need to wait for the softmax warp to have finished reading the previous
+                        # Si, since this gemm is scheduled after the PV gemm, which guaranteed that Si
+                        # has been read and Pi has been written.
+                        # sm100_utils.gemm(tiled_mma_qk, tStS[None, None, None, stage], tSrQ[None, None, None, stage], tSrK[None, None, None, Ki_index], zero_init=True)
+                        sK_cur = sK[None, None, None, Ki_index]
+                        if const_expr(self.uneven_kv_smem):
+                            sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
+                        # gemm_Si[stage](tCrB=tSrK[None, None, None, Ki_index], sB=sK_cur)
+                        gemm_Si[stage](
+                            smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator)
+                        )
+                        # gemm_Si[stage](tCrB=tSrK[None, None, None, Ki_index])
+                        # 3. release S0 / S1
+                        pipeline_s_p_o.producer_commit_w_index(stage)
+                        # End of GEMM_QK0i (Q0 * Ki -> S0)
+                    # 4. release Ki
+                    pipeline_kv.consumer_release(mma_kv_consumer_state)
+                    mma_kv_consumer_state.advance()
+                    P_full_O_rescaled_phase ^= 1
+                    O_should_accumulate = True
+                # End of seqlen_kv loop
+
+                # release Q0 & Q1
+                for stage in cutlass.range(self.q_stage):
+                    pipeline_q.consumer_release_w_index(stage)
+
+                # GEMM_PV00 (P0 * V0 -> O0_partial), O0 needs to be accumulated in the seqlen_kv loop
+                # 1. wait for V0
+                pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                Vi_index, Vi_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                tOrVi = tOrV[None, None, None, Vi_index]
+                for stage in cutlass.range_constexpr(self.q_stage):
+                    # 2. acquire corrected Oi_partial and Pi
+                    pipeline_s_p_o.producer_acquire_w_index_phase(stage, P_full_O_rescaled_phase)
+                    # 3. gemm
+                    # sm100_utils.gemm(tiled_mma_pv, tOtO0, tOrP0, tOrVi, zero_init=True)
+                    # gemm_Pi[stage](tCrB=tOrVi, sB=sV[None, None, None, Vi_index], zero_init=not O_should_accumulate)
+                    sV_cur = sV[None, None, None, Vi_index]
+                    if const_expr(self.uneven_kv_smem):
+                        sV_cur = self.offset_kv_smem(sV_cur, Vi_index, Vi_phase)
+                    gemm_Pi[stage](
+                        tCrB=tOrVi,
+                        sB=sV_cur,
+                        # smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sV_cur.iterator),
+                        zero_init=not O_should_accumulate,
+                        mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(stage) if self.split_P_arrive > 0 else None,
+                        mbar_phase=P_full_O_rescaled_phase,
+                    )
+                    # 4. release accumulated O0_partial
+                    # We do need O_full here since for the last tile, by the time the softmax warp
+                    # has signaled to the correction warps, the softmax warp has just finished
+                    # computing the row sum of the current tile. It does not guarantee that the 1st
+                    # tile of the next work tile has been computed yet.
+                    pipeline_o_acc.producer_commit_w_index(stage)
+                    # End of GEMM_PV00 (P0 * V0 -> O0_partial)
+                P_full_O_rescaled_phase ^= 1
+                # 5. release Vi_end
+                pipeline_kv.consumer_release(mma_kv_consumer_state)
+                mma_kv_consumer_state.advance()
+                # End of GEMM_PV1(i_end) (P1 * Vi_end -> O1)
+
+            # Advance to next tile
+            work_tile = tile_scheduler.advance_to_next_work()
+        # End of persistent scheduler loop
+
+        # We don't need pipeline_s_p_o.producer_tail() since there's no dangling mbarrier at the end
+        # pipeline_s_p_o.producer_acquire_w_index_phase(self.q_stage - 1, P_full_O_rescaled_phase)
+        # We don't need pipeline_o_acc.producer_tail() since we don't call
+        # pipeline_o_acc.producer_acquire() inside the loop.
+
+    # for both softmax0 and softmax1 warp group
+    @cute.jit
+    def _kv_head_idx(self, head_idx: Int32) -> Int32:
+        """Map query-head tile index -> KV-head index (FA3 descale semantics)."""
+        if cutlass.const_expr(self.pack_gqa):
+            return head_idx
+        return head_idx // self.qhead_per_kvhead
+
+    @cute.jit
+    def _load_effective_descales(
+        self,
+        descale_tensors: Optional[DescaleTensors],
+        batch_idx: Int32,
+        kv_head_idx: Int32,
+    ) -> Tuple[Float32, Float32]:
+        """Load effective QK and V descales, defaulting unspecified tensors to identity."""
+        qk_descale = Float32(1.0)
+        v_descale = Float32(1.0)
+        if cutlass.const_expr(descale_tensors is not None):
+            if cutlass.const_expr(descale_tensors.q_descale is not None):
+                qk_descale = qk_descale * Float32(descale_tensors.q_descale[batch_idx, kv_head_idx])
+            if cutlass.const_expr(descale_tensors.k_descale is not None):
+                qk_descale = qk_descale * Float32(descale_tensors.k_descale[batch_idx, kv_head_idx])
+            if cutlass.const_expr(descale_tensors.v_descale is not None):
+                v_descale = Float32(descale_tensors.v_descale[batch_idx, kv_head_idx])
+        return qk_descale, v_descale
+
+    @cute.jit
+    def softmax_loop(
+        self,
+        stage: int | Int32,
+        softmax_scale_log2: Float32,
+        softmax_scale: Float32 | None,
+        descale_tensors: Optional[DescaleTensors],
+        thr_mma_qk: cute.core.ThrMma,
+        tStS: cute.Tensor,  # ((TILE_M, TILE_N), 1, 1, q_stage)
+        sScale: cute.Tensor,
+        mLSE: Optional[cute.Tensor],
+        pipeline_s_p_o: pipeline.PipelineAsync,
+        pipeline_p_lastsplit: pipeline.PipelineAsync,
+        pipeline_sm_stats: pipeline.PipelineAsync,
+        sm_stats_barrier: pipeline.NamedBarrier,
+        pipeline_s0_s1_sequence: Optional[pipeline.PipelineAsync],
+        learnable_sink: Optional[cute.Tensor],
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        AttentionMaskCls: Callable,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        tile_scheduler=None,
+    ):
+        """Compute softmax on attention scores from QK matrix multiplication.
+
+        This method handles the softmax computation for either the first or second half of the
+        attention matrix, depending on the 'stage' parameter. It calculates row-wise maximum
+        and sum values needed for stable softmax computation, applies optional masking, and
+        transforms raw attention scores into probability distributions.
+
+        The implementation uses specialized memory access patterns and efficient math operations
+        for computing exp(x) using exp2 functions. It also coordinates pipeline
+        synchronization between MMA, correction, and sequence processing stages.
+        """
+        tidx = cute.arch.thread_idx()[0] % (
+            cute.arch.WARP_SIZE
+            # * (len(self.softmax0_warp_ids) if stage == 0 else len(self.softmax1_warp_ids)
+            * (len(self.softmax0_warp_ids))
+        )
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+
+        cta_qk_tiler = (self.mma_tiler_qk[0] // thr_mma_qk.thr_id.shape, self.mma_tiler_qk[1])
+        tSAcc = tStS[(None, None), 0, 0, stage]  # (128, 128)
+        tStScale = cute.composition(tSAcc, cute.make_layout((self.m_block_size, 1)))
+        tScS = thr_mma_qk.partition_C(cute.make_identity_tensor(self.mma_tiler_qk[:2]))
+        tScS = tScS[(None, None), 0, 0]  # (128, 128)
+        tScScale = cute.composition(tScS, cute.make_layout((self.m_block_size, 1)))
+
+        tilePlikeFP32 = self.mma_tiler_qk[1] // Float32.width * self.v_dtype.width
+        tStP_layout = cute.composition(
+            tSAcc.layout, cute.make_layout((self.m_block_size, tilePlikeFP32))
+        )
+        tStP = cute.make_tensor(tSAcc.iterator + self.tmem_s_to_p_offset, tStP_layout)
+
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)), self.qk_acc_dtype
+        )
+        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tSAcc).get_slice(tidx)
+        tStS_t2r = thr_tmem_load.partition_S(tSAcc)  # (((32,32),1),1,4)
+
+        tmem_store_scale_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(1)), Float32
+        )
+        thr_tmem_store_scale = tcgen05.make_tmem_copy(tmem_store_scale_atom, tStScale).get_slice(
+            tidx
+        )
+        tStScale_r2t = thr_tmem_store_scale.partition_D(tStScale)
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(
+                tcgen05.copy.Repetition(8 if const_expr(self.q_dtype.width == 8) else 16)
+            ),
+            Float32,
+        )
+        thr_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tStP).get_slice(tidx)
+        tStP_r2t = thr_tmem_store.partition_D(tStP)  # (((16,32),1),1,4)
+
+        mma_si_consumer_phase = Int32(0)
+        sm_stats_producer_phase = Int32(1)
+        s0_s1_sequence_phase = Int32(1 if stage == 0 else 0)
+
+        # self.warp_scheduler_barrier_init()
+
+        warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            kv_head_idx = self._kv_head_idx(head_idx)
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+
+            mask = AttentionMaskCls(seqlen)
+            shared_mask_kwargs = dict(
+                m_block=(self.q_stage * m_block + stage) * self.cta_group_size,
+                thr_mma=thr_mma_qk,
+                thr_tmem_load=thr_tmem_load,
+                mask_causal=self.is_causal,
+                mask_local=self.is_local,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                aux_tensors=aux_tensors,
+            )
+
+            # Recompute fastdiv_mods if necessary
+            recompute_fastdiv_mods_q = cutlass.const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_q or seqlen.has_seqused_q)
+            )
+            recompute_fastdiv_mods_k = cutlass.const_expr(
+                aux_tensors is not None and (seqlen.has_cu_seqlens_k or seqlen.has_seqused_k)
+            )
+
+            if cutlass.const_expr(fastdiv_mods is not None):
+                seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                fastdiv_mods = (
+                    seqlen_q_divmod
+                    if not recompute_fastdiv_mods_q
+                    else FastDivmodDivisor(seqlen.seqlen_q),
+                    seqlen_k_divmod
+                    if not recompute_fastdiv_mods_k
+                    else FastDivmodDivisor(seqlen.seqlen_k),
+                )
+
+            mask_mod = self.mask_mod if const_expr(self.mask_mod is not None) else None
+            mask_fn = partial(
+                mask.apply_mask_sm100,
+                mask_mod=mask_mod,
+                fastdiv_mods=fastdiv_mods,
+                head_divmod=head_divmod,
+                **shared_mask_kwargs,
+            )
+            if const_expr(self.use_block_sparsity):
+                #  Full blocks dont need mask_mod
+                mask_fn_none = partial(
+                    mask.apply_mask_sm100,
+                    mask_mod=None,
+                    fastdiv_mods=fastdiv_mods,
+                    head_divmod=head_divmod,
+                    **shared_mask_kwargs,
+                )
+            else:
+                mask_fn_none = None
+
+            qk_descale, _ = self._load_effective_descales(descale_tensors, batch_idx, kv_head_idx)
+
+            max_offset = 8 if cutlass.const_expr(self.q_dtype.width == 8) else 0
+            if const_expr(self.score_mod is None):
+                softmax_scale_log2_eff = softmax_scale_log2 * qk_descale
+                softmax_scale_eff = None
+            else:
+                softmax_scale_log2_eff = softmax_scale_log2
+                softmax_scale_eff = softmax_scale * qk_descale
+
+            rescale_threshold = (
+                8.0 if const_expr(self.q_dtype.width == 16) else
+                4.0 if const_expr(self.q_dtype.width == 8) else
+                0.0
+            )
+            softmax = SoftmaxSm100.create(
+                softmax_scale_log2_eff,
+                rescale_threshold=rescale_threshold,
+                softmax_scale=softmax_scale_eff,
+                max_offset=max_offset,
+            )
+            softmax.reset()
+
+            if const_expr(self.use_block_sparsity):
+                tile_block_count = get_total_block_count(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                )
+                has_work = tile_block_count > Int32(0)
+            else:
+                tile_block_count = n_block_max - n_block_min
+                has_work = const_expr(not self.is_split_kv) or tile_block_count > Int32(0)
+
+            softmax_step = partial(
+                self.softmax_step,
+                softmax=softmax,
+                thr_mma_qk=thr_mma_qk,
+                pipeline_s_p_o=pipeline_s_p_o,
+                pipeline_p_lastsplit=pipeline_p_lastsplit,
+                pipeline_sm_stats=pipeline_sm_stats,
+                sm_stats_barrier=sm_stats_barrier,
+                pipeline_s0_s1_sequence=pipeline_s0_s1_sequence,
+                thr_tmem_load=thr_tmem_load,
+                thr_tmem_store=thr_tmem_store,
+                thr_tmem_store_scale=thr_tmem_store_scale,
+                tStS_t2r=tStS_t2r,
+                tStScale_r2t=tStScale_r2t,
+                tStP_r2t=tStP_r2t,
+                sScale=sScale,
+                stage=stage,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                m_block=(self.q_stage * m_block + stage) * self.cta_group_size,
+                seqlen=seqlen,
+                aux_tensors=aux_tensors,
+                fastdiv_mods=fastdiv_mods,
+                head_divmod=head_divmod,
+            )
+
+            if const_expr(self.use_block_sparsity) or has_work:
+                pipeline_sm_stats.producer_acquire_w_index_phase(stage, sm_stats_producer_phase)
+                sm_stats_producer_phase ^= 1
+
+            # Block sparse or dense iteration
+            if const_expr(self.use_block_sparsity):
+                # When aux_tensors exist, Q indices beyond seqlen_q must be wrapped to avoid
+                # OOB aux_tensor access. Only edge tiles (where m_tile_end > seqlen_q) need this.
+                if const_expr(aux_tensors is not None):
+                    m_tile_end = ((self.q_stage * m_block + stage + 1) * self.cta_group_size) * self.m_block_size
+                    check_m_boundary = m_tile_end > seqlen.seqlen_q
+                else:
+                    check_m_boundary = False
+                (
+                    mma_si_consumer_phase,
+                    sm_stats_producer_phase,
+                    s0_s1_sequence_phase,
+                    empty_tile,
+                ) = softmax_block_sparse_sm100(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    softmax_step,
+                    mask_fn,
+                    mask_fn_none,
+                    mma_si_consumer_phase,
+                    sm_stats_producer_phase,
+                    s0_s1_sequence_phase,
+                    pipeline_sm_stats,
+                    sm_stats_barrier,
+                    self.q_stage,
+                    Int32(stage),
+                    check_m_boundary,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                )
+                if not empty_tile:
+                    sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
+                    if const_expr(mLSE is not None or learnable_sink is not None):
+                        sScale[
+                            tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
+                        ] = softmax.row_max[0]
+                    # if tidx == 0:
+                    #     cute.printf("softmax row sum stage %d: %f, row_max = %f\n", stage, softmax.row_sum[0], softmax.row_max[0])
+                    # See block_sparse_utils.py NOTE [SM100 block-sparse empty tiles: mbarrier contract].
+                    # pipeline_sm_stats.producer_commit_w_index(stage)
+                    sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
+                    # if tidx == 0: cute.printf("softmax row sum stage %d: %f\n", stage, softmax.row_sum[0])
+            else:
+                if const_expr(not self.is_split_kv) or tile_block_count > Int32(0):
+                    mma_si_consumer_phase, sm_stats_producer_phase, s0_s1_sequence_phase = softmax_step(
+                        mma_si_consumer_phase,
+                        sm_stats_producer_phase,
+                        s0_s1_sequence_phase,
+                        n_block_max - 1,
+                        is_first=True,
+                        mask_fn=partial(mask_fn, mask_seqlen=True),
+                    )
+                    n_block_max -= 1
+                    # Next couple of iterations with causal masking
+                    if const_expr(self.is_causal or self.is_local):
+                        n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
+                            seqlen, m_block, n_block_min
+                        )
+                        for n_tile in cutlass.range(n_block_max - n_block_min_causal_local_mask, unroll=1):
+                            n_block = n_block_max - 1 - n_tile
+                            mma_si_consumer_phase, sm_stats_producer_phase, s0_s1_sequence_phase = (
+                                softmax_step(
+                                    mma_si_consumer_phase,
+                                    sm_stats_producer_phase,
+                                    s0_s1_sequence_phase,
+                                    n_block,
+                                    mask_fn=partial(mask_fn, mask_seqlen=False),
+                                )
+                            )
+                        n_block_max = cutlass.min(n_block_max, n_block_min_causal_local_mask)
+                    # The remaining iterations have no masking (but may still need mask_mod)
+                    n_block_min_before_local_mask = block_info.get_n_block_min_before_local_mask(
+                        seqlen, m_block, n_block_min
+                    )
+                    for n_tile in cutlass.range(n_block_max - n_block_min_before_local_mask, unroll=1):
+                        n_block = n_block_max - n_tile - 1
+                        if const_expr(self.mask_mod is not None):
+                            mma_si_consumer_phase, sm_stats_producer_phase, s0_s1_sequence_phase = softmax_step(
+                                mma_si_consumer_phase, sm_stats_producer_phase, s0_s1_sequence_phase, n_block,
+                                mask_fn=partial(mask_fn, mask_seqlen=False),
+                            )
+                        else:
+                            mma_si_consumer_phase, sm_stats_producer_phase, s0_s1_sequence_phase = softmax_step(
+                                mma_si_consumer_phase, sm_stats_producer_phase, s0_s1_sequence_phase, n_block,
+                            )
+                    # Separate iterations with local masking on the left
+                    if const_expr(self.is_local and block_info.window_size_left is not None):
+                        n_block_max = cutlass.min(n_block_max, n_block_min_before_local_mask)
+                        for n_tile in cutlass.range(0, n_block_max - n_block_min, unroll=1):
+                            n_block = n_block_max - 1 - n_tile
+                            mma_si_consumer_phase, sm_stats_producer_phase, s0_s1_sequence_phase = (
+                                softmax_step(
+                                    mma_si_consumer_phase,
+                                    sm_stats_producer_phase,
+                                    s0_s1_sequence_phase,
+                                    n_block,
+                                    mask_fn=partial(mask_fn, mask_seqlen=False),
+                                )
+                            )
+                            # Now that we no longer already have the 1st iteration, need mask_seqlen=True here
+
+                    # Dense path always writes scale / signals
+                    sScale[tidx + stage * self.m_block_size] = softmax.row_sum[0]
+                    if const_expr(mLSE is not None or learnable_sink is not None):
+                        sScale[
+                            tidx + stage * self.m_block_size + self.q_stage * self.m_block_size
+                        ] = softmax.row_max[0]
+                    # pipeline_sm_stats.producer_commit_w_index(stage)
+                    sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
+
+            # # Write LSE to gmem
+            # if const_expr(mLSE is not None):
+            #     acc_O_mn_row_is_zero_or_nan = softmax.row_sum[0] == 0.0 or softmax.row_sum[0] != softmax.row_sum[0]
+            #     scale = (
+            #         cute.arch.rcp_approx(softmax.row_sum[0] if not acc_O_mn_row_is_zero_or_nan else 1.0)
+            #     )
+            #     LN2 = math.log(2.0)
+            #     lse = (
+            #         (softmax.row_max[0] * softmax.scale_log2 + cute.math.log2(softmax.row_sum[0], fastmath=True)) * LN2
+            #         if not acc_O_mn_row_is_zero_or_nan else -Float32.inf
+            #     )
+            #     if const_expr(not seqlen.has_cu_seqlens_q):
+            #         mLSE_cur = mLSE[None, head_idx, batch_idx]
+            #     else:
+            #         mLSE_cur = cute.domain_offset((seqlen.offset_q,), mLSE[None, head_idx])
+            #     gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (m_block * 2 + stage,))
+            #     if tidx < seqlen.seqlen_q - (m_block * 2 + stage) * self.m_block_size:
+            #         gLSE[tidx] = lse
+
+            # Advance to next tile
+            work_tile = tile_scheduler.advance_to_next_work()
+        # End of persistent scheduler loop
+
+        # This is equivalent to pipeline_sm_stats.producer_tail
+        pipeline_sm_stats.producer_acquire_w_index_phase(stage, sm_stats_producer_phase)
+        # This is equivalent to pipeline_s0_s1.producer_tail
+        if const_expr(self.s0_s1_barrier):
+            if stage == 0:
+                pipeline_s0_s1_sequence.sync_object_full.wait(stage, s0_s1_sequence_phase)
+
+    @cute.jit
+    def softmax_step(
+        self,
+        mma_si_consumer_phase: Int32,
+        sm_stats_producer_phase: Int32,
+        s0_s1_sequence_phase: Int32,
+        n_block: Int32,
+        softmax: SoftmaxSm100,
+        thr_mma_qk: cute.core.ThrMma,
+        pipeline_s_p_o: pipeline.PipelineAsync,
+        pipeline_p_lastsplit: pipeline.PipelineAsync,
+        pipeline_sm_stats: pipeline.PipelineAsync,
+        sm_stats_barrier: pipeline.NamedBarrier,
+        pipeline_s0_s1_sequence: Optional[pipeline.PipelineAsync],
+        thr_tmem_load: cute.CopyAtom,
+        thr_tmem_store: cute.CopyAtom,
+        thr_tmem_store_scale: cute.CopyAtom,
+        tStS_t2r: cute.Tensor,
+        tStScale_r2t: cute.Tensor,
+        tStP_r2t: cute.Tensor,
+        sScale: cute.Tensor,
+        stage: int | Int32,
+        batch_idx: Int32,
+        head_idx: Int32,
+        m_block: Int32,
+        seqlen,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+        mask_fn: Optional[Callable] = None,
+        is_first: bool = False,
+    ) -> Tuple[cute.Int32, cute.Int32, cute.Int32]:
+        """Perform a single step of the softmax computation on a block of attention scores.
+
+        This method processes one block of the attention matrix, computing numerically stable
+        softmax by first finding the row maximum, subtracting it from all elements, applying
+        exponential function, and then normalizing by the sum of exponentials. It also handles
+        optional masking of attention scores.
+
+        The method involves several key operations:
+        1. Loading attention scores from tensor memory
+        2. Applying optional masking based on position
+        3. Computing row-wise maximum values for numerical stability
+        4. Transforming scores using exp2(x*scale - max*scale)
+        5. Computing row sums for normalization
+        6. Coordinating pipeline synchronization between different processing stages
+        """
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+        tilePlikeFP32 = self.mma_tiler_qk[1] // Float32.width * self.v_dtype.width
+        tScS = thr_mma_qk.partition_C(cute.make_identity_tensor(self.mma_tiler_qk[:2]))
+        tScS = tScS[(None, None), 0, 0]  # (128, 128)
+        # tScScale = cute.composition(tScS, cute.make_layout((self.m_block_size, 1)))
+        cta_qk_tiler = (self.mma_tiler_qk[0] // thr_mma_qk.thr_id.shape, self.mma_tiler_qk[1])
+        tScS_shape = cta_qk_tiler  # (128, 128)
+        tScP_shape = (tScS_shape[0], tilePlikeFP32)  # (128, 64)
+
+        # Wait for Si
+        pipeline_s_p_o.consumer_wait_w_index_phase(stage, mma_si_consumer_phase)
+        tSrS_t2r = cute.make_fragment(thr_tmem_load.partition_D(tScS).shape, self.qk_acc_dtype)
+        cute.copy(thr_tmem_load, tStS_t2r, tSrS_t2r)
+        # tSrS_t2r = copy_utils.load_t2r(thr_tmem_load, tScS_shape, tStS_t2r)
+        if cutlass.const_expr(self.score_mod is not None):
+            self.apply_score_mod(
+                tSrS_t2r,
+                thr_tmem_load,
+                thr_mma_qk,
+                batch_idx,
+                head_idx,
+                m_block,
+                n_block,
+                softmax,
+                seqlen,
+                aux_tensors,
+                fastdiv_mods,
+                head_divmod,
+            )
+
+        if const_expr(mask_fn is not None):
+            mask_fn(tSrS_t2r, n_block=n_block)
+        row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
+
+        if const_expr(not is_first):
+            # tSrScale_r2t = cute.make_fragment(thr_tmem_store_scale.partition_S(tScScale).shape, Float32)
+            # tSrScale_r2t[0] = acc_scale
+            # cute.copy(thr_tmem_store_scale, tSrScale_r2t, tStScale_r2t)
+            # cute.arch.fence_view_async_tmem_store()
+            thread_idx = thr_tmem_load.thr_idx
+            sScale[thread_idx + stage * self.m_block_size] = acc_scale
+            # if thread_idx == 0: cute.printf("softmax acc_scale stage %d: %f, row_max = %f\n", stage, acc_scale, row_max)
+        # Notify correction wg that row_max is ready
+        # pipeline_sm_stats.producer_commit_w_index(stage)
+        sm_stats_barrier.arrive_w_index(index=stage * 4 + warp_idx)
+
+        # if thread_idx == 0 and stage == 0: cute.print_tensor(tSrS_t2r)
+        softmax.scale_subtract_rowmax(tSrS_t2r, row_max)
+        # Sequence barrier wait
+        if const_expr(self.s0_s1_barrier):
+            pipeline_s0_s1_sequence.sync_object_full.wait(stage, s0_s1_sequence_phase)
+        tSrP_r2t_f32 = cute.make_fragment(
+            thr_tmem_store.partition_S(cute.make_identity_tensor(tScP_shape)).shape, Float32
+        )
+        tSrP_r2t = cute.make_tensor(
+            cute.recast_ptr(tSrP_r2t_f32.iterator, dtype=self.q_dtype), tSrS_t2r.layout
+        )
+        # softmax.scale_apply_exp2_convert(tSrS_t2r, row_max, tSrP_r2t)
+        softmax.apply_exp2_convert(
+            tSrS_t2r,
+            tSrP_r2t,
+            ex2_emu_freq=self.ex2_emu_freq if const_expr(mask_fn is None) else 0,
+            ex2_emu_start_frg=self.ex2_emu_start_frg,
+        )
+        # Sequence barrier arrive
+        if const_expr(self.s0_s1_barrier):
+            pipeline_s0_s1_sequence.sync_object_full.arrive(1 - stage, dst=None)
+        # print(tSrP_r2t_f32, tStP_r2t)
+        # cute.copy(thr_tmem_store, tSrP_r2t_f32, tStP_r2t)
+        for i in cutlass.range_constexpr(cute.size(tStP_r2t.shape[2])):
+            cute.copy(thr_tmem_store, tSrP_r2t_f32[None, None, i], tStP_r2t[None, None, i])
+            if const_expr(self.split_P_arrive > 0):
+                split_P_arrive_idx = cute.size(tStP_r2t.shape[2]) * self.split_P_arrive // self.n_block_size
+                if const_expr(i + 1 == split_P_arrive_idx):
+                    # Notify mma warp that the 1st half of P is ready
+                    cute.arch.fence_view_async_tmem_store()
+                    pipeline_s_p_o.consumer_release_w_index(stage)
+        # Notify mma warp that the 2nd half of P is ready
+        cute.arch.fence_view_async_tmem_store()
+        if const_expr(self.split_P_arrive > 0):
+            cute.arch.sync_warp()
+            with cute.arch.elect_one():
+                pipeline_p_lastsplit.producer_commit_w_index(stage)
+        else:
+            pipeline_s_p_o.consumer_release_w_index(stage)
+        pipeline_sm_stats.producer_acquire_w_index_phase(stage, sm_stats_producer_phase)
+        softmax.update_row_sum(tSrS_t2r.load(), acc_scale, is_first)
+        # acc_scale = cute.math.exp2(acc_scale_, fastmath=True)
+        return mma_si_consumer_phase ^ 1, sm_stats_producer_phase ^ 1, s0_s1_sequence_phase ^ 1
+
+    @cute.jit
+    def correction_loop(
+        self,
+        thr_mma_qk: cute.core.ThrMma,
+        thr_mma_pv: cute.core.ThrMma,
+        tStS: cute.Tensor,
+        tOtO: cute.Tensor,
+        sScale: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        sO: cute.Tensor,
+        pipeline_s_p_o: pipeline.PipelineAsync,
+        pipeline_o_acc: pipeline.PipelineAsync,
+        pipeline_sm_stats: pipeline.PipelineAsync,
+        sm_stats_barrier: pipeline.NamedBarrier,
+        pipeline_o_epi: pipeline.PipelineAsync,
+        learnable_sink: Optional[cute.Tensor],
+        descale_tensors: Optional[DescaleTensors],
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: cute.CopyAtom,
+        softmax_scale_log2: Float32,
+        block_info: BlockInfo,
+        num_splits: Int32,
+        SeqlenInfoCls: Callable,
+        blocksparse_tensors: Optional[BlockSparseTensors] = None,
+        tile_scheduler=None,
+    ):
+        tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.correction_warp_ids))
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+        mma_tile_coord_v = thr_mma_qk.thr_idx
+
+        tScS = thr_mma_qk.partition_C(cute.make_identity_tensor(self.mma_tiler_qk[:2]))
+        tStScale_layout = cute.composition(tStS.layout, cute.make_layout((self.m_block_size, 1)))
+        tStScales = tuple(
+            cute.make_tensor(tStS.iterator + self.tmem_vec_offset[stage], tStScale_layout)
+            for stage in range(self.q_stage)
+        )
+        tScScale = cute.composition(tScS, cute.make_layout((self.m_block_size, 1)))
+        tmem_load_v_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(1)), self.qk_acc_dtype
+        )
+        thr_tmem_load_vec = tcgen05.make_tmem_copy(tmem_load_v_atom, tStScales[0]).get_slice(tidx)
+
+        tStScales_t2r = [thr_tmem_load_vec.partition_S(tStScales[stage]) for stage in range(self.q_stage)]
+        tSrScale_t2r_shape = thr_tmem_load_vec.partition_D(tScScale).shape
+
+        # First iter: no correction is required
+        # Notify mma warp that O has been rescaled
+        for stage in cutlass.range(self.q_stage):
+            pipeline_s_p_o.consumer_release_w_index(stage)
+
+        sm_stats_consumer_phase = Int32(0)
+        o_corr_consumer_phase = Int32(0)
+        corr_epi_producer_phase = Int32(1)
+
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            kv_head_idx = self._kv_head_idx(head_idx)
+            qk_descale, v_descale = self._load_effective_descales(descale_tensors, batch_idx, kv_head_idx)
+            if const_expr(self.score_mod is None):
+                softmax_scale_log2_eff = softmax_scale_log2 * qk_descale
+            else:
+                softmax_scale_log2_eff = softmax_scale_log2
+
+            max_offset = Float32(8.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(0.0)
+            max_offset_scale = (
+                Float32(256.0) if cutlass.const_expr(self.q_dtype.width == 8) else Float32(1.0)
+            )
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+
+            if const_expr(self.is_split_kv):
+                mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx, split_idx]
+            else:
+                mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx]
+            gO = None
+            if const_expr(self.use_tma_O or not self.pack_gqa):
+                tiler_gO = ((self.mma_tiler_pv[0] * self.q_stage), self.head_dim_v_padded)
+                gO = cute.local_tile(mO_cur, tiler_gO, (m_block, 0))  # (128 * 2, 128)
+                gO = layout_utils.select(
+                    cute.flat_divide(gO, (self.mma_tiler_pv[0],)), mode=[0, 2, 1]
+                )  # (128, 128, 2)
+                gO = cute.flat_divide(gO, (self.mma_tiler_pv[0] // self.cta_group_size,))[None, mma_tile_coord_v, None, None]
+
+            # Default LSE to -inf for invalid split_idx tiles
+            stats = [(0.0, -Float32.inf if const_expr(mLSE is not None or learnable_sink is not None) else None, True)] * self.q_stage
+
+            if const_expr(self.use_block_sparsity):
+                total_block_count = get_total_block_count(
+                    blocksparse_tensors,
+                    batch_idx,
+                    head_idx,
+                    m_block,
+                    self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
+                    self.q_subtile_factor if self.q_subtile_factor is not None else 1,
+                )
+                has_work = total_block_count > Int32(0)
+            else:
+                total_block_count = n_block_max - n_block_min
+                has_work = const_expr(not self.is_split_kv) or total_block_count > Int32(0)
+
+            if has_work:
+                # Ignore first signal from softmax as no correction is required
+                # pipeline_sm_stats.consumer_wait_w_index_phase(0, sm_stats_consumer_phase)
+                sm_stats_barrier.arrive_and_wait_w_index(index=0 * 4 + warp_idx)
+                pipeline_sm_stats.consumer_release_w_index(0)
+                if const_expr(self.q_stage == 2):
+                    # pipeline_sm_stats.consumer_wait_w_index_phase(1, sm_stats_consumer_phase)
+                    sm_stats_barrier.arrive_and_wait_w_index(index=1 * 4 + warp_idx)
+                sm_stats_consumer_phase ^= 1
+
+                tSrScale_t2r = cute.make_fragment(tSrScale_t2r_shape, Float32)
+                for i in cutlass.range(total_block_count - 1, unroll=1):
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        # wait for S0 / S1
+                        # pipeline_sm_stats.consumer_wait_w_index_phase(stage, sm_stats_consumer_phase)
+                        sm_stats_barrier.arrive_and_wait_w_index(index=stage * 4 + warp_idx)
+                        # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
+                        # cute.arch.fence_view_async_tmem_load()
+                        # scale = tSrScale_t2r[0]
+                        scale = sScale[tidx + stage * self.m_block_size]
+                        should_rescale = cute.arch.vote_ballot_sync(scale < 1.0) != 0
+                        # should_rescale = True
+                        # if tidx == 0: cute.printf("Correction scale i = %d, for stage %d: %f, should_rescale = %d\n", i, stage, scale, should_rescale)
+                        # Don't need O_full anymore, since by the time softmax has signaled the correction
+                        # warps, S_i must have been done, so O_i-1 must have been done as well.
+                        # pipeline_o_acc.consumer_wait_w_index_phase(stage, o_corr_consumer_phase)
+                        if should_rescale:
+                            self.correction_rescale(thr_mma_pv, tOtO[None, None, None, stage], tidx, scale)
+                        # Notify mma warp that O has been rescaled
+                        pipeline_s_p_o.consumer_release_w_index(stage)
+                        pipeline_sm_stats.consumer_release_w_index(self.q_stage - 1 - stage)
+                    sm_stats_consumer_phase ^= 1
+                    # o_corr_consumer_phase ^= 1
+                if const_expr(self.q_stage == 2):
+                    pipeline_sm_stats.consumer_release_w_index(1)
+                # End of seqlen_corr_loop_steps
+
+                # Even in the case of self.overlap_sO_sQ, we can write to stage 0 of sO without
+                # additional sync because the MMA in the top half must have been done.
+                # Similarly we can write to stage 1 of sO without additional sync.
+                learnable_sink_val = [None] * self.q_stage
+                if const_expr(learnable_sink is not None):
+                    if const_expr(not self.pack_gqa):
+                        sink_val = Float32(learnable_sink[head_idx])
+                        learnable_sink_val = [sink_val] * self.q_stage
+                    else:  # Each thread might have a different sink value due to different q_head
+                        for stage in cutlass.range_constexpr(self.q_stage):
+                            q_head_idx = (
+                                ((m_block * self.q_stage + stage) * self.cta_group_size + mma_tile_coord_v) * self.m_block_size + tidx
+                            ) % self.qhead_per_kvhead + head_idx * self.qhead_per_kvhead
+                            learnable_sink_val[stage] = Float32(learnable_sink[q_head_idx])
+                for stage in cutlass.range_constexpr(self.q_stage):
+                    # pipeline_sm_stats.consumer_wait_w_index_phase(stage, sm_stats_consumer_phase)
+                    sm_stats_barrier.arrive_and_wait_w_index(index=stage * 4 + warp_idx)
+                    # cute.copy(tiled_tmem_load_vec, tStScales_t2r[stage], tSrScale_t2r)
+                    # cute.arch.fence_view_async_tmem_load()
+                    # scale = tSrScale_t2r[0]
+                    row_sum = sScale[tidx + stage * self.m_block_size]
+                    if const_expr(mLSE is not None or learnable_sink is not None):
+                        row_max = sScale[tidx + stage * self.m_block_size + self.q_stage * self.m_block_size]
+                    else:
+                        row_max = None
+                    pipeline_sm_stats.consumer_release_w_index(stage)
+                    if const_expr(learnable_sink is not None):
+                        LOG2_E = math.log2(math.e)
+                        sink_val = learnable_sink_val[stage]
+                        if const_expr(not self.is_split_kv) or split_idx == 0:
+                            if row_max == -Float32.inf:
+                                # It's possible to have an empty row with splitKV.
+                                row_max = sink_val * (LOG2_E / softmax_scale_log2_eff)
+                                row_sum = max_offset_scale
+                            else:
+                                row_sum += cute.math.exp2(
+                                    sink_val * LOG2_E - row_max * softmax_scale_log2_eff + max_offset, fastmath=True
+                                )
+                    acc_O_mn_row_is_zero_or_nan = row_sum == 0.0 or row_sum != row_sum
+                    stats[stage] = (row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
+                    scale = cute.arch.rcp_approx(row_sum if not acc_O_mn_row_is_zero_or_nan else 1.0)
+                    scale = scale * v_descale
+                    # Wait for the last O to be ready from the MMA warp
+                    pipeline_o_acc.consumer_wait_w_index_phase(stage, o_corr_consumer_phase)
+                    if const_expr(not self.use_correction_warps_for_epi):
+                        pipeline_o_epi.producer_acquire_w_index_phase(stage, corr_epi_producer_phase)
+                    gO_stage = gO[None, None, stage] if const_expr(gO is not None) else None
+                    self.correction_epilogue(
+                        thr_mma_pv,
+                        tOtO[None, None, None, stage],
+                        tidx,
+                        stage,
+                        m_block,
+                        seqlen.seqlen_q,
+                        scale,
+                        sO[None, None, stage],
+                        mO_cur,
+                        gO_stage,
+                        gmem_tiled_copy_O,
+                    )
+                    # Signal for the next work tile that O buffers in tmem are already read, so
+                    # mma warp can write to them
+                    pipeline_s_p_o.consumer_release_w_index(stage)
+                    if const_expr(not self.use_correction_warps_for_epi):
+                        pipeline_o_epi.producer_commit_w_index(stage)
+                    # if tidx == 0: cute.printf("Correction final scale for stage %d: %f\n", stage, scale)
+
+                o_corr_consumer_phase ^= 1
+                sm_stats_consumer_phase ^= 1
+                corr_epi_producer_phase ^= 1
+            else:
+                gmem_tiled_copy_O_for_empty_tile = None
+                if const_expr(self.use_correction_warps_for_epi):
+                    gmem_tiled_copy_O_for_empty_tile = gmem_tiled_copy_O
+                if const_expr(self.use_block_sparsity):
+                    (
+                        sm_stats_consumer_phase,
+                        o_corr_consumer_phase,
+                        corr_epi_producer_phase,
+                    ) = handle_block_sparse_empty_tile_correction_sm100(
+                        tidx,
+                        self.q_stage,
+                        self.m_block_size,
+                        self.qhead_per_kvhead,
+                        self.pack_gqa,
+                        self.is_split_kv,
+                        learnable_sink,
+                        mLSE,
+                        seqlen,
+                        m_block,
+                        head_idx,
+                        batch_idx,
+                        split_idx,
+                        sScale,
+                        stats,
+                        self.correction_epilogue,
+                        thr_mma_pv,
+                        tOtO,
+                        sO,
+                        pipeline_sm_stats,
+                        sm_stats_barrier,
+                        pipeline_o_epi,
+                        sm_stats_consumer_phase,
+                        o_corr_consumer_phase,
+                        corr_epi_producer_phase,
+                        softmax_scale_log2_eff,
+                        max_offset,
+                        max_offset_scale,
+                        mO_cur,
+                        gO,
+                        gmem_tiled_copy_O_for_empty_tile,
+                    )
+
+            if const_expr(mLSE is not None):
+                if const_expr(not seqlen.has_cu_seqlens_q):
+                    if const_expr(self.is_split_kv):
+                        mLSE_cur = mLSE[None, head_idx, batch_idx, split_idx]
+                    else:
+                        mLSE_cur = mLSE[None, head_idx, batch_idx]
+                else:
+                    offset = (
+                        seqlen.offset_q if const_expr(not self.pack_gqa) else (0, seqlen.offset_q)
+                    )
+                    if const_expr(self.is_split_kv):
+                        mLSE_cur = cute.domain_offset((offset,), mLSE[None, head_idx, split_idx])
+                    else:
+                        mLSE_cur = cute.domain_offset((offset,), mLSE[None, head_idx])
+                for stage in cutlass.range_constexpr(self.q_stage):
+                    m_tile_idx = (m_block * self.q_stage + stage) * self.cta_group_size + mma_tile_coord_v
+                    row_sum, row_max, acc_O_mn_row_is_zero_or_nan = stats[stage]
+                    # if tidx == 0 and stage <= 1:
+                    #     cute.printf("row_sum = {}, row_max = {}, acc_O_mn_row_is_zero_or_nan = {}\n", row_sum, row_max, acc_O_mn_row_is_zero_or_nan)
+                    LN2 = math.log(2.0)
+                    lse = (
+                        (row_max * softmax_scale_log2_eff + (cute.math.log2(row_sum, fastmath=True) - max_offset)) * LN2
+                        if not acc_O_mn_row_is_zero_or_nan
+                        else -Float32.inf
+                    )
+                    seqlen_q = (
+                        seqlen.seqlen_q
+                        if const_expr(not self.pack_gqa)
+                        else seqlen.seqlen_q * self.qhead_per_kvhead
+                    )
+                    if const_expr(not self.pack_gqa or self.m_block_size % self.qhead_per_kvhead == 0):
+                        gLSE = cute.local_tile(mLSE_cur, (self.m_block_size,), (m_tile_idx,))
+                        if tidx < seqlen_q - m_tile_idx * self.m_block_size:
+                            # This actually just works with PackGQA too
+                            gLSE[tidx] = lse
+                    else:
+                        idx = m_tile_idx * self.m_block_size + tidx
+                        if idx < seqlen_q:
+                            m_idx = idx // self.qhead_per_kvhead
+                            h_idx = idx - m_idx * self.qhead_per_kvhead
+                            lse_ptr_i64 = utils.elem_pointer(mLSE_cur, ((h_idx, m_idx),)).toint()
+                            lse_gmem_ptr = cute.make_ptr(
+                                mLSE_cur.element_type, lse_ptr_i64, cute.AddressSpace.gmem, assumed_align=4
+                            )
+                            cute.make_tensor(lse_gmem_ptr, (1,))[0] = lse
+
+            # Advance to next tile
+            work_tile = tile_scheduler.advance_to_next_work()
+        # End of persistent scheduler loop
+
+        # This is equivalent to pipeline_o_epi.consumer_tail() for the correction warps
+        if const_expr(not self.use_correction_warps_for_epi):
+            pipeline_o_epi.producer_acquire_w_index_phase(self.q_stage - 1, corr_epi_producer_phase)
+
+    @cute.jit
+    def correction_rescale(
+        self,
+        thr_mma: cute.core.ThrMma,
+        tOtO: cute.Tensor,
+        tidx: Int32,
+        scale: Float32,
+    ):
+        """Rescale intermediate attention results based on softmax normalization factor.
+
+        This method performs a crucial correction step in the attention computation pipeline.
+        When processing attention in blocks, the softmax normalization factors may change
+        as new blocks are processed. This method rescales previously computed partial
+        output values to account for updated normalization factors.
+
+        The implementation uses efficient tensor memory operations to:
+        1. Load existing partial attention output from tensor memory
+        2. Apply the scaling factor to all elements
+        3. Store the rescaled results back to tensor memory
+        """
+        tOcO = thr_mma.partition_C(cute.make_identity_tensor(self.mma_tiler_pv[:2]))
+        corr_tile_size = 16  # tuneable parameter
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)), self.pv_acc_dtype
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.pv_acc_dtype,
+        )
+        tOtO_i = cute.composition(tOtO, cute.make_layout((self.m_block_size, corr_tile_size)))
+        tOcO_i = cute.composition(tOcO, cute.make_layout((self.m_block_size, corr_tile_size)))
+        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tOtO_i).get_slice(tidx)
+        thr_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOtO_i).get_slice(tidx)
+        tOtO_t2r = thr_tmem_load.partition_S(tOtO_i)
+        tOrO_t2r_shape = thr_tmem_load.partition_D(tOcO_i).shape
+        tOtO_r2t = thr_tmem_store.partition_D(tOtO_i)
+
+        frg_count = self.head_dim_v_padded // corr_tile_size
+        tOrO_frg = cute.make_fragment((tOrO_t2r_shape, frg_count), self.pv_acc_dtype)
+        for i in cutlass.range_constexpr(frg_count):
+            tOrO_frg = cute.make_fragment(tOrO_t2r_shape, self.pv_acc_dtype)
+            tOtO_t2r_i = cute.make_tensor(tOtO_t2r.iterator + i * corr_tile_size, tOtO_t2r.layout)
+            cute.copy(thr_tmem_load, tOtO_t2r_i, tOrO_frg)
+            for j in cutlass.range(0, cute.size(tOrO_frg), 2, unroll_full=True):
+                tOrO_frg[j], tOrO_frg[j + 1] = cute.arch.mul_packed_f32x2(
+                    (tOrO_frg[j], tOrO_frg[j + 1]), (scale, scale)
+                )
+            tOtO_r2t_i = cute.make_tensor(tOtO_r2t.iterator + i * corr_tile_size, tOtO_r2t.layout)
+            cute.copy(thr_tmem_store, tOrO_frg, tOtO_r2t_i)
+        cute.arch.fence_view_async_tmem_store()
+
+    @cute.jit
+    def correction_epilogue(
+        self,
+        thr_mma: cute.core.ThrMma,
+        tOtO: cute.Tensor,
+        tidx: Int32,
+        stage: Int32,
+        m_block: Int32,
+        seqlen_q: Int32,
+        scale: Float32,
+        sO: cute.Tensor,
+        mO_cur: Optional[cute.Tensor] = None,
+        gO: Optional[cute.Tensor] = None,
+        gmem_tiled_copy_O: Optional[cute.TiledCopy] = None,
+    ):
+        """Apply final scaling and transformation to attention output before writing to global memory.
+
+        This correction_epilogue function handles the final processing step for attention output values.
+        It applies a scaling factor to the accumulated attention results and prepares the
+        data for efficient transfer back to global memory.
+
+        The method performs:
+        1. Loading of accumulated attention results from tensor memory
+        2. Application of the final output scaling factor
+        3. Type conversion if necessary (typically from higher precision accumulator to output precision)
+        4. Reorganization of data for optimal memory access patterns
+        5. Preparation for efficient TMA store operations
+
+        :param thr_mma: Thread MMA operation for the computation
+        :type thr_mma: cute.core.ThrMma
+        :param tOtO: Tensor containing accumulated attention output
+        :type tOtO: cute.Tensor
+        :param scale: Final scaling factor to apply to the output
+        :type scale: Float32
+        :param sO: Shared memory tensor for the final output
+        :type sO: cute.Tensor
+        """
+
+        corr_tile_size = 8 * 32 // self.o_dtype.width
+        # Use CTA 0 mapping for smem partitioning since sO is per-CTA sized
+        tOsO = thr_mma.get_slice(0).partition_C(sO)
+        tOcO = thr_mma.partition_C(cute.make_identity_tensor(self.mma_tiler_pv[:2]))
+
+        tOtO_i = cute.logical_divide(tOtO, cute.make_layout((self.m_block_size, corr_tile_size)))
+        tOcO_i = cute.logical_divide(tOcO, cute.make_layout((self.m_block_size, corr_tile_size)))
+        tOsO_i = cute.logical_divide(tOsO, cute.make_layout((self.m_block_size, corr_tile_size)))
+
+        epi_subtile = (self.epi_tile[0], corr_tile_size)
+        tmem_copy_atom = sm100_utils_basic.get_tmem_load_op(
+            self.mma_tiler_pv,
+            self.o_layout,
+            self.o_dtype,
+            self.pv_acc_dtype,
+            epi_subtile,
+            use_2cta_instrs=self.use_2cta_instrs,
+        )
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_i[(None, None), 0])
+        thr_tmem_load = tiled_tmem_load.get_slice(tidx)
+        smem_copy_atom = sm100_utils_basic.get_smem_store_op(
+            self.o_layout, self.o_dtype, self.pv_acc_dtype, tiled_tmem_load
+        )
+        tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+
+        tOtO_t2r = thr_tmem_load.partition_S(tOtO_i[(None, None), None])
+        tOsO_s2r = copy_utils.partition_D_position_independent(thr_tmem_load, tOsO_i[(None, None), None])
+        tOcO_t2r = thr_tmem_load.partition_D(tOcO_i[(None, None), None])
+        for i in cutlass.range(self.head_dim_v_padded // corr_tile_size, unroll_full=True):
+            tOtO_t2r_i = tOtO_t2r[None, 0, 0, i]
+            tOsO_r2s_i = tOsO_s2r[None, 0, 0, i]
+            tOrO_frg = cute.make_fragment(tOcO_t2r[None, 0, 0, i].shape, self.pv_acc_dtype)
+            cute.copy(tiled_tmem_load, tOtO_t2r_i, tOrO_frg)
+            for j in cutlass.range(0, cute.size(tOrO_frg), 2, unroll_full=True):
+                tOrO_frg[j], tOrO_frg[j + 1] = cute.arch.mul_packed_f32x2(
+                    (tOrO_frg[j], tOrO_frg[j + 1]), (scale, scale)
+                )
+            copy_utils.cvt_copy(tiled_smem_store, tOrO_frg, tOsO_r2s_i)
+        cute.arch.fence_view_async_shared()
+
+        if const_expr(self.use_correction_warps_for_epi):
+            assert(not self.use_tma_O)
+            assert(gmem_tiled_copy_O is not None)
+            cute.arch.barrier(barrier_id=int(NamedBarrierFwdSm100.Epilogue),
+                              number_of_threads=len(self.epilogue_warp_ids) * cute.arch.WARP_SIZE)
+            mma_tile_coord_v = thr_mma.thr_idx
+            m_tile_idx = (m_block * self.q_stage + stage) * self.cta_group_size + mma_tile_coord_v
+            self._store_O_to_gmem(
+                sO, gO, mO_cur, gmem_tiled_copy_O, tidx, seqlen_q, m_tile_idx
+            )
+
+    @cute.jit
+    def _store_O_to_gmem(
+        self,
+        sO_stage: cute.Tensor,
+        gO: Optional[cute.Tensor],
+        mO_cur: cute.Tensor,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tidx: Int32,
+        seqlen_q: Int32,
+        m_tile_idx: Int32,
+    ):
+        """Copy a single stage of O from smem to gmem via registers."""
+        gmem_thr_copy_O = gmem_tiled_copy_O.get_slice(tidx)
+        tOsO = gmem_thr_copy_O.partition_S(sO_stage)
+        cO = cute.make_identity_tensor((self.m_block_size, self.head_dim_v_padded))
+        tOcO = gmem_thr_copy_O.partition_S(cO)
+        t0OcO = gmem_tiled_copy_O.get_slice(0).partition_S(cO)
+        tOpO = copy_utils.predicate_k(tOcO, limit=mO_cur.shape[1])
+        pack_gqa = PackGQA(
+            self.m_block_size,
+            self.head_dim_v_padded,
+            self.check_hdim_v_oob,
+            self.qhead_per_kvhead,
+        )
+
+        # load acc O from smem to rmem for wider vectorization
+        tOrO = cute.make_fragment_like(tOsO, self.o_dtype)
+        cute.autovec_copy(tOsO, tOrO)
+        # copy acc O from rmem to gmem
+        if const_expr(not self.pack_gqa):
+            assert gO is not None
+            tOgO = gmem_thr_copy_O.partition_D(gO)
+            for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+                if (
+                    t0OcO[0, rest_m, 0][0] < seqlen_q - m_tile_idx * self.m_block_size - tOcO[0][0]
+                ):
+                    cute.copy(
+                        gmem_tiled_copy_O,
+                        tOrO[None, rest_m, None],
+                        tOgO[None, rest_m, None],
+                        pred=tOpO[None, rest_m, None]
+                        if const_expr(self.check_hdim_v_oob)
+                        else None,
+                    )
+        else:
+            pack_gqa.store_O(
+                mO_cur, tOrO, gmem_tiled_copy_O, tidx, m_tile_idx, seqlen_q
+            )
+
+    @cute.jit
+    def epilogue_s2g(
+        self,
+        mO: cute.Tensor,
+        sO: cute.Tensor,
+        gmem_tiled_copy_O: cute.TiledCopy,
+        tma_atom_O: Optional[cute.CopyAtom],
+        pipeline_o_epi: pipeline.PipelineAsync,
+        block_info: BlockInfo,
+        num_splits: int,
+        SeqlenInfoCls: Callable,
+        mma_tile_coord_v: Int32 = 0,
+        tile_scheduler=None,
+    ):
+        epi_consumer_phase = Int32(0)
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
+            seqlen = SeqlenInfoCls(batch_idx)
+            n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen, m_block, split_idx, num_splits)
+
+            if const_expr(not self.is_split_kv) or n_block_min < n_block_max:
+                if const_expr(self.is_split_kv):
+                    mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx, split_idx]
+                else:
+                    mO_cur = seqlen.offset_batch_Q(mO, batch_idx, dim=3)[None, None, head_idx]
+                gO = None
+                if const_expr(self.use_tma_O or not self.pack_gqa):
+                    tiler_gO = ((self.mma_tiler_pv[0] * self.q_stage), self.head_dim_v_padded)
+                    gO = cute.local_tile(mO_cur, tiler_gO, (m_block, 0))  # (128 * 2, 128)
+                    gO = layout_utils.select(
+                        cute.flat_divide(gO, (self.mma_tiler_pv[0],)), mode=[0, 2, 1]
+                    )  # (128, 128, 2)
+                    gO = cute.flat_divide(gO, (self.mma_tiler_pv[0] // self.cta_group_size,))[None, mma_tile_coord_v, None, None]
+
+                if const_expr(self.use_tma_O):
+                    store_O, _, _ = copy_utils.tma_get_copy_fn(
+                        tma_atom_O, 0, cute.make_layout(1), sO, gO
+                    )
+                    for stage in cutlass.range(self.q_stage, unroll_full=True):
+                        # wait from corr, issue tma store on smem
+                        # 1. wait for O0 / O1 final
+                        pipeline_o_epi.consumer_wait_w_index_phase(stage, epi_consumer_phase)
+                        # 2. copy O0 / O1 to gmem
+                        store_O(src_idx=stage, dst_idx=stage)
+                        cute.arch.cp_async_bulk_commit_group()
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        # Ensure O0 / O1 buffer is ready to be released
+                        cute.arch.cp_async_bulk_wait_group(self.q_stage - 1 - stage, read=True)
+                        pipeline_o_epi.consumer_release_w_index(stage)
+                else:
+                    tidx = cute.arch.thread_idx()[0] % (
+                        cute.arch.WARP_SIZE * len(self.epilogue_warp_ids)
+                    )
+                    for stage in cutlass.range_constexpr(self.q_stage):
+                        # wait from corr, issue tma store on smem
+                        # 1. wait for O0 / O1 final
+                        pipeline_o_epi.consumer_wait_w_index_phase(stage, epi_consumer_phase)
+                        # 2. copy O0 / O1 to gmem
+                        m_tile_idx = (m_block * self.q_stage + stage) * self.cta_group_size + mma_tile_coord_v
+                        gO_stage = gO[None, None, stage] if const_expr(gO is not None) else None
+                        self._store_O_to_gmem(
+                            sO[None, None, stage], gO_stage, mO_cur, gmem_tiled_copy_O,
+                            tidx, seqlen.seqlen_q, m_tile_idx,
+                        )
+                        pipeline_o_epi.consumer_release_w_index(stage)
+
+                epi_consumer_phase ^= 1
+
+            # Advance to next tile
+            work_tile = tile_scheduler.advance_to_next_work()
+
+    @cute.jit
+    def clc_scheduler_warp(
+        self,
+        tile_scheduler: TileSchedulerProtocol,
+    ):
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            tile_scheduler.prefetch_next_work()
+            work_tile = tile_scheduler.advance_to_next_work()
+            if cute.arch.thread_idx()[0] == self.clc_scheduler_warp_id * cute.arch.WARP_SIZE:
+                fa_printf(
+                    3,
+                    "[CLC] query sm={} cta={} (m_blk={},h={},b={},s={}) valid={}\n",
+                    smid(),
+                    cute.arch.block_idx()[0],
+                    work_tile.tile_idx[0],
+                    work_tile.tile_idx[1],
+                    work_tile.tile_idx[2],
+                    work_tile.tile_idx[3],
+                    work_tile.is_valid_tile,
+                )
+        tile_scheduler.producer_tail()
+
+    @cute.jit
+    def empty_warp(
+        self,
+        tile_scheduler: TileSchedulerProtocol,
+    ):
+        work_tile = tile_scheduler.initial_work_tile_info()
+        while work_tile.is_valid_tile:
+            work_tile = tile_scheduler.advance_to_next_work()
+
+    def load_Q(
+        self,
+        load_Q_fn: Callable,
+        pipeline_q: pipeline.PipelineAsync,
+        block: Int32,
+        stage: int,
+        phase: Int32,
+    ):
+        pipeline_q.producer_acquire_w_index_phase(stage, phase)
+        load_Q_fn(src_idx=block, dst_idx=stage, tma_bar_ptr=pipeline_q.sync_object_full.get_barrier(stage))
+
+    def load_Q_non_tma(
+        self,
+        mQ: cute.Tensor,
+        sQ: cute.Tensor,
+        gmem_tiled_copy_Q: cute.TiledCopy,
+        pipeline_q: pipeline.PipelineAsync,
+        tidx: Int32,
+        seqlen_q: Int32,
+        m_block: Int32,
+        block: Int32,
+        stage: int,
+        phase: Int32,
+    ):
+        assert self.cta_group_size == 1, "cta_group_size must be 1 for non-tma Q load"
+        pipeline_q.producer_acquire_w_index_phase(stage, phase)
+        pack_gqa = PackGQA(
+            self.m_block_size,
+            self.head_dim_padded,
+            self.check_hdim_oob,
+            self.qhead_per_kvhead,
+        )
+        sQ_stage = sQ[None, None, None, stage]
+        sQ_pi = cute.make_tensor(
+            sQ_stage.iterator,
+            cute.make_layout(
+                (sQ_stage.shape[0][0], (sQ_stage.shape[0][1], sQ_stage.shape[2])),
+                stride=(sQ_stage.stride[0][0], (sQ_stage.stride[0][1], sQ_stage.stride[2])),
+            ),
+        )
+        pack_gqa.load_Q(mQ, sQ_pi, gmem_tiled_copy_Q, tidx, m_block * self.q_stage + block, seqlen_q)
+        cute.arch.cp_async_commit_group()
+        pipeline_q.sync_object_full.arrive_cp_async_mbarrier(stage)
+
+    @cute.jit
+    def load_KV(
+        self,
+        tma_atom: Optional[cute.CopyAtom],
+        tXgX: Optional[cute.Tensor],
+        tXsX: Optional[cute.Tensor],
+        paged_kv_manager: Optional[PagedKVManager],
+        sX: cute.Tensor,
+        block: Int32,
+        pipeline_kv: pipeline.PipelineAsync,
+        producer_state: pipeline.PipelineState,
+        K_or_V: Literal["K", "V"],
+        page_idx: Optional[Int32] = None,
+        extra_tx_count: Optional[Int32] = None,
+    ):
+        assert K_or_V in ("K", "V")
+        stage, phase = producer_state.index, producer_state.phase
+        extra_tx_count_kv = self.tma_copy_bytes[K_or_V] - self.tma_copy_bytes["K"]
+        extra_tx_count = (
+            extra_tx_count_kv + (extra_tx_count if extra_tx_count is not None else 0) if const_expr(self.use_tma_KV)
+            else None
+        )
+        extra_kwargs = {"extra_tx_count": extra_tx_count} if const_expr(self.use_tma_KV) else {}
+        pipeline_kv.producer_acquire(producer_state, **extra_kwargs)
+        if const_expr(K_or_V == "K" and self.uneven_kv_smem):
+            # Before this round, the smem location was occupied by V, which is smaller than
+            # K. So we need to wait for the stage after that (stage 1) to be empty as well.
+            if stage == 0:
+                pipeline_kv.sync_object_empty.wait(1, phase)
+
+        if const_expr(self.use_tma_KV):
+            assert tXgX is not None and tXsX is not None and tma_atom is not None
+            tXsX_cur = tXsX[None, stage]
+            if const_expr(self.uneven_kv_smem):
+                # Since this is the producer_state, the phase starts at 1, so we have to invert it
+                tXsX_cur = self.offset_kv_smem(tXsX_cur, stage, phase ^ 1)
+            # Currently we assume that page_size == n_block_size so we index into tXgX with block = 0
+            tXgX_cur = tXgX[None, block] if const_expr(page_idx is None) else tXgX[None, 0, page_idx]
+            cute.copy(tma_atom, tXgX_cur, tXsX_cur, tma_bar_ptr=pipeline_kv.producer_get_barrier(producer_state))
+        else:
+            assert paged_kv_manager is not None
+            assert extra_tx_count is None
+            sX_cur = sX[None, None, None, stage]
+            if const_expr(self.uneven_kv_smem):
+                sX_cur = self.offset_kv_smem(sX_cur, stage, phase ^ 1)
+            paged_kv_manager.load_KV(block, sX_cur, K_or_V)
+            cute.arch.cp_async_commit_group()
+            pipeline_kv.sync_object_full.arrive_cp_async_mbarrier(stage)
+
+    @cute.jit
+    def offset_kv_smem(self, sX: cute.Tensor, stage: Int32, phase: Int32):
+        if const_expr(self.uneven_kv_smem):
+            # smem layout is [smem_large, smem_small, smem_large], and the current stride is
+            # (smem_large + smem_small) // 2. So for stage == 1, move right by offset if
+            # phase == 0, or left by offset if phase == 1.
+            offset = 0 if stage != 1 else self.uneven_kv_smem_offset * (1 - 2 * phase)
+            # Hint that the offset is 128-bit aligned so that
+            # ptr + offset preserves the alignment needed by cp.async.
+            offset = cute.assume(offset, divby=128 // self.k_dtype.width)
+            return cute.make_tensor(sX.iterator + offset, sX.layout)
+        else:
+            return sX
+
+    # @cute.jit
+    # def warp_scheduler_barrier_init(self):
+    #     warp_group_idx = utils.canonical_warp_group_idx(sync=False)
+    #     if warp_group_idx == 0:
+    #         cute.arch.barrier_arrive(
+    #             barrier_id=int(NamedBarrierFwdSm100.WarpSchedulerWG1), number_of_threads=2 * 128,
+    #         )
+
+    # def warp_scheduler_barrier_sync(self):
+    #     cute.arch.barrier(
+    #         barrier_id=int(NamedBarrierFwdSm100.WarpSchedulerWG1) + utils.canonical_warp_group_idx(sync=False),
+    #         number_of_threads=2 * 128
+    #     )
+
+    # def warp_scheduler_barrier_arrive(self):
+    #     cur_wg = utils.canonical_warp_group_idx(sync=False)
+    #     next_wg = 1 - cur_wg
+    #     cute.arch.barrier_arrive(
+    #         barrier_id=int(NamedBarrierFwdSm100.WarpSchedulerWG1) + next_wg, number_of_threads=2 * 128,
+    #     )
+
+    @cute.jit
+    def apply_score_mod(
+        self,
+        tSrS_t2r,
+        thr_tmem_load,
+        thr_mma_qk,
+        batch_idx,
+        head_idx,
+        m_block,
+        n_block,
+        softmax,
+        seqlen: SeqlenInfoQK,
+        aux_tensors=None,
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+    ):
+        """Apply score modification for SM100 (constant q_idx)."""
+        # Prepare index tensor with extra partition
+        cS = cute.make_identity_tensor((self.m_block_size, self.n_block_size))
+        cS = cute.domain_offset((m_block * self.m_block_size, n_block * self.n_block_size), cS)
+        tScS = thr_mma_qk.partition_C(cS)
+        tScS = tScS[(None, None), 0, 0]
+        tScS_t2r = thr_tmem_load.partition_D(tScS)
+
+        # Shared q_idx for all scores
+        q_idx_logical = tScS_t2r[0][0]
+
+        # For Pack-GQA, compute the logical head index for this tile
+        if cutlass.const_expr(self.pack_gqa):
+            assert head_divmod is not None
+            # Building up the logical q_head idx: final_q_head = kv_head * qhead_per_kvhead + (q_physical % qhead_per_kvhead)
+            q_physical = q_idx_logical
+            q_idx_logical, head_offset = divmod(q_physical, head_divmod)
+            head_idx = head_idx * self.qhead_per_kvhead + head_offset
+
+        if cutlass.const_expr(aux_tensors is not None):
+            seqlen_q_divmod, _ = fastdiv_mods
+            _, q_idx_logical = divmod(q_idx_logical, seqlen_q_divmod)
+
+        apply_score_mod_inner(
+            tSrS_t2r,
+            tScS_t2r,
+            self.score_mod,
+            batch_idx,
+            head_idx,
+            softmax.softmax_scale,
+            self.vec_size,
+            self.qk_acc_dtype,
+            aux_tensors,
+            fastdiv_mods,
+            seqlen_info=seqlen,
+            constant_q_idx=q_idx_logical,
+            qhead_per_kvhead=self.qhead_per_kvhead if cutlass.const_expr(self.pack_gqa) else 1,
+        )

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/interface_fwd_sm100.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/interface_fwd_sm100.py
@@ -1,0 +1,1583 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+# [2025-07-04] Version in Cute-DSL, for Hopper and Blackwell. You'll need install nvidia-cutlass-dsl==4.2.0.
+
+import os
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional, Tuple, Callable
+
+import torch
+
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, Float32
+from quack.compile_utils import make_fake_tensor as fake_tensor
+from flashrt_fa4.cute.cache_utils import get_jit_cache
+from flashrt_fa4.cute.testing import is_fake_mode
+
+
+if os.environ.get("CUTE_DSL_PTXAS_PATH", None) is not None:
+    from flashrt_fa4.cute import cute_dsl_ptxas  # noqa: F401
+
+    # Patch to dump ptx and then use system ptxas to compile to cubin
+    cute_dsl_ptxas.patch()
+
+
+from flashrt_fa4.cute import utils
+from flashrt_fa4.cute import fa_logging
+from flashrt_fa4.cute.cute_dsl_utils import (
+    to_cute_tensor, to_cute_aux_tensor, get_aux_tensor_metadata, get_broadcast_dims,
+)
+from flashrt_fa4.cute.flash_fwd_sm100 import FlashAttentionForwardSm100, DescaleTensors
+from flashrt_fa4.cute.flash_fwd_combine import FlashAttentionForwardCombine
+
+# --- FlashRT Thor vendor: forward / SM100-only trim -------------------------
+# This vendored copy keeps ONLY the SM100 (Blackwell, including sm_110/Thor)
+# forward kernel. The SM80/SM90/SM120 forward kernels, every backward kernel,
+# the MLA forward kernel, and the head_dim=256 2CTA kernels were removed (see
+# VENDOR.md). The names below are still referenced by dead arch-dispatch
+# branches inside `_flash_attn_fwd`; on Blackwell those branches never run. If
+# one is reached on unsupported hardware it raises a clear error instead of an
+# obscure NameError. Backward is not provided (inference / forward only).
+def _fa4_trimmed(_name):
+    def _raise(*_a, **_k):
+        raise RuntimeError(
+            f"{_name} was removed from FlashRT's forward/SM100-only FA4 vendor. "
+            "This build supports Blackwell SM100/SM110 forward attention only; "
+            "use upstream flash-attn for other architectures or training."
+        )
+    return _raise
+
+FlashAttentionForwardSm80 = _fa4_trimmed("FlashAttentionForwardSm80")
+FlashAttentionForwardSm90 = _fa4_trimmed("FlashAttentionForwardSm90")
+FlashAttentionForwardSm120 = _fa4_trimmed("FlashAttentionForwardSm120")
+FlashAttentionMLAForwardSm100 = _fa4_trimmed("FlashAttentionMLAForwardSm100")
+BlackwellFusedMultiHeadAttentionForward = _fa4_trimmed("BlackwellFusedMultiHeadAttentionForward")
+
+from flashrt_fa4.cute.block_sparsity import (
+    BlockSparseTensorsTorch,
+    get_sparse_q_block_size,
+    to_cute_block_sparse_tensors,
+    normalize_block_sparse_config,
+    normalize_block_sparse_config_bwd,
+)
+
+def _parse_arch_str(arch_str):
+    """Parse arch string (e.g. 'sm_80', 'sm_90a', '80', '100') to int (e.g. 80, 90, 100)."""
+    import re
+    match = re.match(r"^(?:sm_?|SM_?)?(\d+)(\d)([af]?)$", arch_str)
+    if not match:
+        raise ValueError(f"Invalid arch format: {arch_str}")
+    major, minor, _ = match.groups()
+    return int(major) * 10 + int(minor)
+
+
+@lru_cache(maxsize=None)
+def _get_device_arch():
+    """Cached device arch check.
+
+    Override with FLASH_ATTENTION_ARCH (e.g. 'sm_80' or '80') to select which
+    kernel path to use (SM80/SM90/SM100/SM120) independently of the compilation
+    target (CUTE_DSL_ARCH).
+
+    For CPU-only compilation (no GPU), set both:
+      FLASH_ATTENTION_ARCH=sm_80  (kernel selection)
+      CUTE_DSL_ARCH=sm_80         (compilation target)
+    """
+    arch_override = os.environ.get("FLASH_ATTENTION_ARCH", None)
+    if arch_override is not None:
+        return _parse_arch_str(arch_override)
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + int(minor)
+
+
+def _validate_head_dims(head_dim: int, head_dim_v: int, compute_capability: int, alignment: int) -> None:
+    """Validate head dimension constraints based on compute capability."""
+    is_deepseek_shape = head_dim == 192 and head_dim_v == 128
+    is_deepseek_mla_absorbed_shape = head_dim == 64 and head_dim_v == 512
+    is_dedicate_kernel_shape = head_dim == 256 and head_dim_v == 256
+    is_standard_range = 8 <= head_dim <= 128 and 8 <= head_dim_v <= 128
+
+    is_sm90_range = 8 <= head_dim <= 256 and 8 <= head_dim_v <= 256
+    if compute_capability == 9:
+        assert is_sm90_range and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
+            f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM90. "
+            f"head_dim and head_dim_v must be between 8 and 256 and divisible by {alignment}."
+        )
+    elif compute_capability in [10, 11]:
+        assert (is_standard_range or is_deepseek_shape or is_deepseek_mla_absorbed_shape or is_dedicate_kernel_shape) and head_dim % alignment == 0 and head_dim_v % alignment == 0, (
+            f"(head_dim, head_dim_v)=({head_dim}, {head_dim_v}) is not supported on SM100/SM110. "
+            f"head_dim and head_dim_v must be between 8 and 128 and divisible by {alignment}, or (192, 128) for DeepSeek, or (256, 256) for hd256."
+        )
+
+
+@dataclass(frozen=True)
+class FwdConfig:
+    m_block_size: int
+    n_block_size: int
+    mma_pv_is_rs: bool
+    intra_wg_overlap: bool
+
+
+def _tile_size_fwd_sm90(head_dim, head_dim_v, is_causal, is_local, sparse_block_size_q=None):
+    """Return FwdConfig for SM90 forward.
+
+    Tile sizes and flags based on tile_size_fwd_sm90 in hopper/tile_size.h, adjusted
+    for the Python kernel's different register/smem tradeoffs (benchmarked on H100 SXM).
+
+    When sparse_block_size_q is set, tile_m must divide it. For head_dim <= 96 the
+    optimal tile_m=192 is used when compatible, otherwise we fall back to 128.
+    """
+    if head_dim <= 64:
+        # C++: 192×192 non-causal, 192×128 causal/local.
+        # Python: 192×128 RS+OL is consistently best across seqlens.
+        if sparse_block_size_q is not None and sparse_block_size_q % 192 != 0:
+            return FwdConfig(128, 128, True, True)
+        return FwdConfig(192, 128, True, True)
+    elif head_dim <= 96:
+        # C++: 192×144 noRS+OL for all cases.
+        # Python: RS is catastrophic with 192× tiles (~300 vs ~600 TFLOPS).
+        # noRS+OL is always required. Causal: 192×128 slightly better short seqlen.
+        if sparse_block_size_q is not None and sparse_block_size_q % 192 != 0:
+            return FwdConfig(128, 128, False, True)
+        if is_causal or is_local:
+            return FwdConfig(192, 128, False, True)
+        else:
+            return FwdConfig(192, 144, False, True)
+    elif head_dim <= 128:
+        return FwdConfig(128, 128, True, True)
+    elif head_dim <= 192:
+        tile_n = 96 if is_local else (128 if head_dim_v <= 128 else 112)
+        return FwdConfig(128, tile_n, True, True)
+    else:  # hdim 256
+        tile_n = 64 if is_local else 80
+        return FwdConfig(128, tile_n, True, True)
+
+@dataclass(frozen=True)
+class BwdConfig:
+    m_block_size: int
+    n_block_size: int
+    num_stages_Q: int
+    num_stages_dO: int
+    num_stages_PdS: int
+    SdP_swapAB: bool
+    dKV_swapAB: bool
+    dQ_swapAB: bool
+    AtomLayoutMSdP: int
+    AtomLayoutNdKV: int
+    AtomLayoutMdQ: int
+    num_wg: int = 2  # MMA warp groups (total threads = (num_wg + 1) * 128)
+    dQ_single_wg: bool = False
+
+
+def _tile_size_bwd_sm90(head_dim, head_dim_v, causal, local, sparse_block_size_q=None):
+    """Return BwdConfig for SM90.
+
+    Configs based on C++ FA3 hopper/flash_bwd_launch_template.h,
+    benchmarked on H100 SXM.
+    """
+    if head_dim <= 64:
+        # C++ FA3: 128, 128, 64, ..., 2, 2, true, false, false, 2, 1, 2, 2
+        return BwdConfig(
+            m_block_size=128, n_block_size=128,
+            num_stages_Q=2, num_stages_dO=2, num_stages_PdS=2,
+            SdP_swapAB=True, dKV_swapAB=False, dQ_swapAB=False,
+            AtomLayoutMSdP=1, AtomLayoutNdKV=2, AtomLayoutMdQ=2,
+        )
+    elif head_dim <= 96:
+        # C++ FA3: 64, 128, 96, dQ_swapAB=False
+        return BwdConfig(
+            m_block_size=64, n_block_size=128,
+            num_stages_Q=2, num_stages_dO=2, num_stages_PdS=2,
+            SdP_swapAB=True, dKV_swapAB=False, dQ_swapAB=False,
+            AtomLayoutMSdP=1, AtomLayoutNdKV=2, AtomLayoutMdQ=1,
+            dQ_single_wg=True,
+        )
+    elif head_dim <= 128:
+        # C++ FA3: causal/local: 64, 128; non-causal: 80, 128 with dQ_swapAB
+        is_causal_or_local = causal or local
+        m_block_size = 64 if is_causal_or_local else 80
+        if sparse_block_size_q is not None and sparse_block_size_q % m_block_size != 0:
+            m_block_size = 64
+        return BwdConfig(
+            m_block_size=m_block_size,
+            n_block_size=128,
+            num_stages_Q=2, num_stages_dO=2, num_stages_PdS=2,
+            SdP_swapAB=True, dKV_swapAB=False,
+            dQ_swapAB=m_block_size % 64 != 0,
+            AtomLayoutMSdP=1, AtomLayoutNdKV=2, AtomLayoutMdQ=1,
+        )
+    elif head_dim <= 192:
+        hdimv128 = head_dim_v <= 128
+        if hdimv128:
+            return BwdConfig(
+                m_block_size=64, n_block_size=96,
+                num_stages_Q=2, num_stages_dO=2, num_stages_PdS=1,
+                SdP_swapAB=False, dKV_swapAB=True, dQ_swapAB=False,
+                AtomLayoutMSdP=1, AtomLayoutNdKV=2, AtomLayoutMdQ=1,
+                num_wg=2,
+            )
+        else:
+            return BwdConfig(
+                m_block_size=64, n_block_size=96,
+                num_stages_Q=2, num_stages_dO=1, num_stages_PdS=1,
+                SdP_swapAB=False, dKV_swapAB=True, dQ_swapAB=False,
+                AtomLayoutMSdP=1, AtomLayoutNdKV=2, AtomLayoutMdQ=1,
+                num_wg=2,
+            )
+    else:
+        # hdim 256
+        return BwdConfig(
+            m_block_size=64, n_block_size=64,
+            num_stages_Q=1, num_stages_dO=1, num_stages_PdS=1,
+            SdP_swapAB=False, dKV_swapAB=False, dQ_swapAB=False,
+            AtomLayoutMSdP=1, AtomLayoutNdKV=1, AtomLayoutMdQ=1,
+        )
+
+
+
+def maybe_contiguous(x):
+    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+
+
+def _validate_tensor(t, name, expected_shape, expected_dtype, expected_device):
+    assert t.shape == expected_shape, f"{name} shape {t.shape} != expected {expected_shape}"
+    assert t.dtype == expected_dtype, f"{name} dtype {t.dtype} != expected {expected_dtype}"
+    assert t.device == expected_device, f"{name} device {t.device} != expected {expected_device}"
+    if not is_fake_mode():
+        assert t.is_cuda, f"{name} must be on CUDA"
+
+torch2cute_dtype_map = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+    torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+    torch.float8_e5m2: cutlass.Float8E5M2,
+}
+
+
+def num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, max_splits):
+    # If num_n_blocks is too small, use 1 split. For example, we never split for hdim = 128 and seqlen_k = 512.
+    if num_n_blocks <= 4:
+        return 1
+
+    # NOTE: We should revisit this heuristic after persistence is supported for split KV.
+    # Sometimes, it's ideal to over-schedule splits for better efficiency.
+    return min(num_SMs // total_mblocks, max_splits, num_n_blocks)
+
+
+def _resolve_causal_local_window(causal, window_size_left, window_size_right, mask_mod=None):
+    """Resolve causal/local/window settings into canonical form.
+
+    Returns (causal, local, window_size_left, window_size_right).
+    """
+    if mask_mod is not None:
+        return False, False, window_size_left, window_size_right
+    if causal:
+        window_size_right = 0
+    if window_size_left is not None and window_size_right is not None and window_size_left + window_size_right < 0:
+        window_size_left = None
+        window_size_right = None
+    if window_size_left is not None or window_size_right is not None:
+        if window_size_left is None and window_size_right == 0:
+            causal, local = True, False
+            window_size_right = None
+        else:
+            causal, local = False, True
+    else:
+        local = False
+    return causal, local, window_size_left, window_size_right
+
+def _flash_attn_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    qv: Optional[torch.Tensor] = None,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    max_seqlen_k: Optional[int] = None,
+    min_seqlen_k: Optional[int] = None,
+    page_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    softcap: Optional[float] = None,
+    window_size_left: Optional[int] = None,
+    window_size_right: Optional[int] = None,
+    learnable_sink: Optional[torch.Tensor] = None,
+    tile_mn: Optional[Tuple[int, int]] = None,
+    mma_pv_is_rs: Optional[bool] = None,
+    intra_wg_overlap: Optional[bool] = None,
+    num_threads: int = 384,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    _arch: Optional[int] = None,
+    score_mod: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    return_lse: bool = False,
+    out: Optional[torch.Tensor] = None,
+    lse: Optional[torch.Tensor] = None,
+    aux_tensors: Optional[list[torch.Tensor]] = None,
+    q_descale: Optional[torch.Tensor] = None,
+    k_descale: Optional[torch.Tensor] = None,
+    v_descale: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Forward pass for FlashAttention.
+
+    Args:
+        ...
+        score_mod: A callable that takes the attention scores and applies a modification.
+        mask_mod: A callable that takes token position information and selectively masks
+        block_sparse_tensors: A tuple of tensors used for block sparsity.
+        return_lse: Whether to return the log softmax of the attention scores. If set to True will always calculate
+            The returned LSE supports taking gradient.
+        out: Optional pre-allocated output tensor. If None, will be allocated internally.
+        lse: Optional pre-allocated log-sum-exp tensor. If None, will be allocated when needed.
+        aux_tensors: Some score_mods will want to read from global aux_tensors. This is how we thread them through to the inner kernel.
+    """
+    q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
+    q_descale, k_descale, v_descale = [maybe_contiguous(t) for t in (q_descale, k_descale, v_descale)]
+    num_head, head_dim = q.shape[-2:]
+    if cu_seqlens_q is None:
+        batch_size, seqlen_q = q.shape[:2]
+        total_q = batch_size * seqlen_q
+    else:
+        batch_size = cu_seqlens_q.shape[0] - 1
+        seqlen_q = None
+        total_q = q.shape[0]
+    if page_table is not None:
+        assert cu_seqlens_k is None, "page_table is not supported with cu_seqlens_k"
+        assert page_table.dtype == torch.int32, "page_table must be int32"
+        assert page_table.stride(-1) == 1, "page_table must be contiguous in the last dimension"
+        max_num_pages_per_seq = page_table.shape[1]
+        assert page_table.shape == (batch_size, max_num_pages_per_seq)
+        num_pages, page_size = k.shape[:2]
+        seqlen_k = num_pages * page_size
+    else:
+        num_pages, page_size = None, None
+        seqlen_k = k.shape[-3]
+    num_head_kv = k.shape[-2]
+    head_dim_v = v.shape[-1]
+    if cu_seqlens_k is None:
+        if page_table is None:
+            assert k.shape == (batch_size, seqlen_k, num_head_kv, head_dim)
+            assert v.shape == (batch_size, seqlen_k, num_head_kv, head_dim_v)
+        else:
+            assert k.shape == (num_pages, page_size, num_head_kv, head_dim)
+            assert v.shape == (num_pages, page_size, num_head_kv, head_dim_v)
+    else:
+        assert k.shape == (seqlen_k, num_head_kv, head_dim)
+        assert v.shape == (seqlen_k, num_head_kv, head_dim_v)
+        assert cu_seqlens_k.shape == (batch_size + 1,), (
+            "cu_seqlens_k must have shape (batch_size + 1,)"
+        )
+
+    if cu_seqlens_q is not None:
+        assert cu_seqlens_q.shape == (batch_size + 1,), (
+            "cu_seqlens_q must have shape (batch_size + 1,)"
+        )
+    assert seqused_q is None or seqused_q.shape == (batch_size,), (
+        "seqused_q must have shape (batch_size,)"
+    )
+    assert seqused_k is None or seqused_k.shape == (batch_size,), (
+        "seqused_k must have shape (batch_size,)"
+    )
+    assert q.dtype in [torch.float16, torch.bfloat16, torch.float8_e4m3fn, torch.float8_e5m2], (
+        "inputs must be float16, bfloat16, fp8 e4m3fn, or fp8 e5m2"
+    )
+    assert q.dtype == k.dtype == v.dtype, "inputs must have the same dtype"
+    for t in [cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k]:
+        if t is not None:
+            assert t.dtype == torch.int32, (
+                "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be int32"
+            )
+            assert t.stride(0) == 1, (
+                "cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k must be contiguous"
+            )
+    if learnable_sink is not None:
+        assert learnable_sink.shape == (num_head,)
+        assert learnable_sink.dtype == torch.bfloat16, "learnable_sink must be bfloat16"
+
+    if not is_fake_mode():
+        assert all(
+            t is None or t.is_cuda
+            for t in (
+                q,
+                k,
+                v,
+                q_descale,
+                k_descale,
+                v_descale,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                page_table,
+                learnable_sink,
+            )
+        ), "inputs must be on CUDA device"
+    arch = _get_device_arch() if _arch is None else _arch
+    assert arch // 10 in [8, 9, 10, 11, 12], "Unsupported compute capability. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
+    assert num_head % num_head_kv == 0, "num_head must be divisible by num_head_kv"
+    alignment = 16 // q.element_size()
+    if arch // 10 not in [8, 12]:
+        _validate_head_dims(head_dim, head_dim_v, arch // 10, alignment)
+    if softmax_scale is None:
+        softmax_scale = 1.0 / math.sqrt(head_dim) if qv is None else 1.0 / math.sqrt(head_dim + head_dim_v)
+    if softcap == 0.0:
+        softcap = None
+    qhead_per_kvhead = num_head // num_head_kv
+    if pack_gqa is None:
+        pack_gqa = qhead_per_kvhead > 1
+
+    is_fp8 = q.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    if is_fp8 and (q.requires_grad or k.requires_grad or v.requires_grad):
+        raise NotImplementedError("FA4 CuTe FP8 backward is not supported yet (forward-only).")
+    out_torch_dtype = torch.bfloat16 if is_fp8 else q.dtype
+    device = q.device
+    q_batch_seqlen_shape = (batch_size, seqlen_q) if cu_seqlens_q is None else (total_q,)
+    lse_shape = (batch_size, num_head, seqlen_q) if cu_seqlens_q is None else (num_head, total_q)
+    requires_grad = q.requires_grad or k.requires_grad or v.requires_grad
+
+    if out is None:
+        out = torch.empty(
+            *q_batch_seqlen_shape, num_head, head_dim_v, dtype=out_torch_dtype, device=device
+        )
+    else:
+        _validate_tensor(out, "out", (*q_batch_seqlen_shape, num_head, head_dim_v), out_torch_dtype, device)
+
+    if lse is None:
+        lse = (
+            torch.empty(lse_shape, dtype=torch.float32, device=device)
+            if requires_grad or return_lse
+            else None
+        )
+    elif lse is not None:
+        _validate_tensor(lse, "lse", lse_shape, torch.float32, device)
+
+    if seqlen_k == 0:
+        out.zero_()
+        if lse is not None:
+            lse.fill_(float("-inf"))
+        return out, lse
+
+    if is_fp8:
+        for t, name in ((q_descale, "q_descale"), (k_descale, "k_descale"), (v_descale, "v_descale")):
+            if t is not None:
+                _validate_tensor(t, name, (batch_size, num_head_kv), torch.float32, device)
+    else:
+        assert q_descale is None and k_descale is None and v_descale is None, (
+            "q_descale/k_descale/v_descale are only supported for FP8 inputs"
+        )
+
+    dtype = torch2cute_dtype_map[q.dtype]
+    if is_fp8:
+        assert arch // 10 == 10, "FP8 is only supported on SM100 (compute capability 10.x) for FA4 CuTe."
+    use_block_sparsity = block_sparse_tensors is not None
+
+    causal, local, window_size_left, window_size_right = _resolve_causal_local_window(
+        causal, window_size_left, window_size_right, mask_mod
+    )
+
+    requested_use_clc_scheduler = utils._get_use_clc_scheduler_default()
+    requested_disable_2cta = utils._get_disable_2cta_default()
+
+    current_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    # SM80/SM120: uses SM80 MMA, 128 threads (4 warps)
+    if arch // 10 in [8, 12]:
+        num_threads = 128
+
+    fwd_cfg = FwdConfig(128, 128, True, True)  # default
+    if tile_mn is None:
+        if arch // 10 == 12:
+            # SM120 tile sizes tuned for 99 KB SMEM capacity:
+            # D<=64:  128x128 → 48 KB (good occupancy)
+            # D>64:   128x64  → 64 KB (128x128 would use 96 KB, hurting occupancy)
+            if head_dim <= 64:
+                fwd_cfg = FwdConfig(128, 128, True, True)
+            else:
+                fwd_cfg = FwdConfig(128, 64, True, True)
+        elif arch // 10 == 8:
+            fwd_cfg = FwdConfig(128, 64, True, True)  # SM80, should tune
+        elif arch // 10 == 9:
+            sparse_q = get_sparse_q_block_size(block_sparse_tensors, seqlen_q)
+            fwd_cfg = _tile_size_fwd_sm90(head_dim, head_dim_v, causal, local, sparse_block_size_q=sparse_q)
+    else:
+        fwd_cfg = FwdConfig(tile_mn[0], tile_mn[1], fwd_cfg.mma_pv_is_rs, fwd_cfg.intra_wg_overlap)
+    tile_m, tile_n = fwd_cfg.m_block_size, fwd_cfg.n_block_size
+    if mma_pv_is_rs is None:
+        mma_pv_is_rs = fwd_cfg.mma_pv_is_rs
+    if intra_wg_overlap is None:
+        intra_wg_overlap = fwd_cfg.intra_wg_overlap
+
+    # TODO: fix GQA + SplitKV + non-varlen
+    if pack_gqa and num_splits != 1 and cu_seqlens_q is None:
+        pack_gqa = False
+
+    if pack_gqa and qv is not None and 128 % qhead_per_kvhead != 0:
+        pack_gqa = False
+
+    if max_seqlen_q is None:
+        max_seqlen_q = seqlen_q if cu_seqlens_q is None else total_q
+    if max_seqlen_k is None:
+        max_seqlen_k = seqlen_k
+    if cu_seqlens_k is None and seqused_k is None:
+        min_seqlen_k = seqlen_k
+    seqlen_q_packgqa = max_seqlen_q * qhead_per_kvhead
+    if arch // 10 == 10:
+        q_stage = 2 if seqlen_q_packgqa > tile_m else 1
+    else:
+        q_stage = 1
+
+    m_block_size_effective = q_stage * tile_m
+    seqlen_k_loaded = max_seqlen_k if not local else max(0, min(max_seqlen_k, (window_size_right or max_seqlen_k) + (window_size_left or max_seqlen_k) + 1 + tile_m))
+    num_m_blocks = (seqlen_q_packgqa + m_block_size_effective - 1) // m_block_size_effective
+    total_mblocks = batch_size * num_head_kv * num_m_blocks
+    num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+    num_SMs = 132 if is_fake_mode() else torch.cuda.get_device_properties(device).multi_processor_count
+    if num_splits < 1:
+        num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
+
+    # SplitKV uses float32 partial output, which doubles the O buffer size
+    # in shared memory, causing OOM for diff-headdim (192, 128)
+    if arch // 10 in [10, 11] and head_dim != head_dim_v and num_splits > 1:
+        if num_n_blocks >= 64 and head_dim_v != 512:
+            tile_n = 64
+            num_n_blocks = (seqlen_k_loaded + tile_n - 1) // tile_n
+            num_splits = num_splits_heuristic(total_mblocks, num_SMs, num_n_blocks, 128)
+        else:
+            num_splits = 1
+
+    is_split_kv = num_splits > 1
+    if is_split_kv:
+        out_partial = torch.empty(num_splits, *q_batch_seqlen_shape, num_head, head_dim_v, dtype=torch.float32, device=device)
+        lse_partial = torch.empty(num_splits, *lse_shape, dtype=torch.float32, device=device)
+
+    use_2cta_instrs = (
+        arch // 10 in [10, 11]
+        and not requested_disable_2cta
+        and not causal
+        and not local
+        and not is_split_kv
+        and cu_seqlens_q is None
+        and seqused_q is None
+        and not use_block_sparsity
+        and page_size in [None, 128]
+        and int(math.ceil(head_dim / 16) * 16) in [128, 192]
+        and int(math.ceil(head_dim_v / 16) * 16) == 128
+        and seqlen_q_packgqa > 2 * tile_m
+        and (tile_m % qhead_per_kvhead == 0 or not pack_gqa)
+    )
+
+    # hd=256 2CTA forward uses dedicated kernel (SM100 only)
+    use_dedicated_hd256_kernel = arch // 10 == 10 and head_dim == 256 and head_dim_v == 256
+    use_2cta_instrs = use_2cta_instrs or use_dedicated_hd256_kernel
+
+    if softcap is not None:
+        assert score_mod is None, "softcap and score_mod cannot be used together"
+        score_mod = utils.create_softcap_scoremod(softcap)
+    elif score_mod is not None:
+        if arch // 10 == 8:
+            raise NotImplementedError("Custom user-provided score_mod is not supported on SM8x architectures.")
+
+    # hash score and mask mods for compile cache
+    score_mod_hash = utils.hash_callable(score_mod) if score_mod is not None else False
+    mask_mod_hash = utils.hash_callable(mask_mod) if mask_mod is not None else False
+
+    is_varlen = (
+        cu_seqlens_q is not None
+        or cu_seqlens_k is not None
+        or seqused_q is not None
+        or seqused_k is not None
+    )
+
+    # CLC regressed for varlen MHA and dense noncausal. Imbalanced varlen shapes
+    # keep more K/V blocks in flight and hurt L2; dense noncausal mostly just
+    # pays work-stealing overhead.
+    is_varlen_mha = is_varlen and qhead_per_kvhead == 1
+    is_dense_noncausal = not is_varlen and not causal and not local
+    use_clc_scheduler = requested_use_clc_scheduler and not is_varlen_mha and not is_dense_noncausal
+
+    if mask_mod is not None:
+        if is_varlen:
+            raise NotImplementedError(
+                "mask_mod with aux_tensors is not yet supported for varlen sequences. This will be fixed in a future PR."
+            )
+
+    if use_block_sparsity:
+        if is_varlen:
+            raise NotImplementedError(
+                "Block sparsity is not yet supported for varlen sequences. This will be fixed in a future PR."
+            )
+        # NB: pack_gqa requires block sparse head dim == 1 (broadcasted)
+        if pack_gqa and block_sparse_tensors.mask_block_cnt.shape[1] != 1:
+            pack_gqa = False
+        if is_split_kv:
+            raise NotImplementedError(
+                "Block sparsity is not yet supported with SplitKV. TODO: partition sparse block lists per split."
+            )
+
+    # See get_broadcast_dims for why this is needed in compile key
+    block_sparse_broadcast_pattern = None
+    normalized_block_sparse_tensors = None
+    q_subtile_factor = None
+    if block_sparse_tensors is not None:
+        if seqlen_q is None:
+            raise ValueError("Block sparsity requires fixed-length sequences (seqlen_q must be known).")
+        (
+            normalized_block_sparse_tensors,
+            block_sparse_broadcast_pattern,
+            q_subtile_factor,
+        ) = normalize_block_sparse_config(
+            block_sparse_tensors,
+            batch_size=batch_size,
+            num_head=num_head,
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            block_size=(tile_m, tile_n),
+            q_stage=q_stage,
+        )
+    if aux_tensors is not None:
+        aux_tensor_metadata = get_aux_tensor_metadata(aux_tensors)
+    else:
+        aux_tensor_metadata = None
+
+    if qv is not None:
+        assert arch // 10 in [10, 11], "only support Blackwell arch with qv"
+        assert qv.shape[:-1] == q.shape[:-1]
+        assert qv.shape[-1] == head_dim_v
+        assert head_dim == 64 and head_dim_v == 512, "only support MLA weight absorbed shape with qv"
+        assert not local, "local not yet supported with qv"
+        assert page_table is None, "page table not yet supported with qv"
+        assert q_descale is None and k_descale is None and v_descale is None, (
+            "q_descale/k_descale/v_descale are not yet supported with qv"
+        )
+
+        assert not is_split_kv, "split kv not supported with qv"
+        assert learnable_sink is None
+        assert softcap is None
+        assert score_mod is None
+        assert mask_mod is None
+
+        qv = maybe_contiguous(qv)
+
+        gather_kv_length = 2048
+        sparse_kv = gather_kv_indices is not None
+        disable_sparse_kv_bitmask = False
+        if sparse_kv:
+            assert gather_kv_indices.shape[:-1] == q.shape[:-2]
+            gather_kv_length = gather_kv_indices.shape[-1]
+            assert gather_kv_length % 256 == 0
+            if min_seqlen_k is None or causal:
+                disable_sparse_kv_bitmask = False
+            else:
+                # seqlen_k_boundary = min_seqlen_k - max_seqlen_q + 1 if causal else min_seqlen_k
+                seqlen_k_boundary = min_seqlen_k
+                disable_sparse_kv_bitmask = seqlen_k_boundary >= gather_kv_length
+    else:
+        assert gather_kv_indices is None, "gather_kv_indices is only supported with qv"
+        gather_kv_length = None
+        sparse_kv = None
+        disable_sparse_kv_bitmask = None
+
+    compile_key = (
+        dtype,
+        head_dim,
+        head_dim_v,
+        qhead_per_kvhead,
+        causal,
+        score_mod_hash,
+        mask_mod_hash,
+        use_block_sparsity,
+        block_sparse_broadcast_pattern,
+        aux_tensor_metadata,
+        lse is None,
+        cu_seqlens_q is None,
+        cu_seqlens_k is None,
+        seqused_q is None,
+        seqused_k is None,
+        page_table is not None,
+        window_size_left is not None,
+        window_size_right is not None,
+        learnable_sink is not None,
+        q_descale is not None,
+        k_descale is not None,
+        v_descale is not None,
+        tile_m,
+        tile_n,
+        q_stage,
+        num_threads,
+        is_split_kv,
+        pack_gqa,
+        arch,
+        page_size not in [None, tile_n],  # paged KV non-TMA
+        use_2cta_instrs,
+        q_subtile_factor,
+        mma_pv_is_rs,
+        intra_wg_overlap,
+        use_clc_scheduler,
+        qv is not None,
+        gather_kv_length,
+        sparse_kv,
+        disable_sparse_kv_bitmask,
+        fa_logging.get_fa_log_level(),
+    )
+
+    if compile_key not in _flash_attn_fwd.compile_cache:
+        (
+            cu_seqlens_q_tensor,
+            cu_seqlens_k_tensor,
+            seqused_q_tensor,
+            seqused_k_tensor,
+            learnable_sink_tensor,
+        ) = [
+            to_cute_tensor(t, assumed_align=4, leading_dim=0)
+            if t is not None
+            else None
+            for t in (cu_seqlens_q, cu_seqlens_k, seqused_q, seqused_k, learnable_sink)
+        ]
+        page_table_tensor = (
+            to_cute_tensor(page_table, assumed_align=4, leading_dim=1)
+            if page_table is not None
+            else None
+        )
+        q_tensor, k_tensor, v_tensor, o_tensor = [
+            to_cute_tensor(t) for t in (q, k, v, out if not is_split_kv else out_partial)
+        ]
+        if is_split_kv:
+            lse_tensor = to_cute_tensor(lse_partial, assumed_align=4)
+        elif lse is not None:
+            lse_tensor = to_cute_tensor(lse, assumed_align=4)
+        else:
+            lse_tensor = None
+
+        q_descale_tensor = (
+            to_cute_tensor(q_descale, assumed_align=4, leading_dim=1)
+            if q_descale is not None
+            else None
+        )
+        k_descale_tensor = (
+            to_cute_tensor(k_descale, assumed_align=4, leading_dim=1)
+            if k_descale is not None
+            else None
+        )
+        v_descale_tensor = (
+            to_cute_tensor(v_descale, assumed_align=4, leading_dim=1)
+            if v_descale is not None
+            else None
+        )
+        descale_tensors_tensor = (
+            DescaleTensors(
+                q_descale=q_descale_tensor,
+                k_descale=k_descale_tensor,
+                v_descale=v_descale_tensor,
+            )
+            if q_descale_tensor is not None
+            or k_descale_tensor is not None
+            or v_descale_tensor is not None
+            else None
+        )
+
+        sparse_tensors = None
+        if normalized_block_sparse_tensors is not None:
+            sparse_tensors = to_cute_block_sparse_tensors(normalized_block_sparse_tensors)
+
+        cute_aux_tensors = None
+        aux_tensor_metadata = None
+        if aux_tensors is not None:
+            cute_aux_tensors = [to_cute_aux_tensor(buf) for buf in aux_tensors]
+
+        qv_tensor = to_cute_tensor(qv) if qv is not None else None
+        gather_kv_indices_tensor = to_cute_tensor(gather_kv_indices) if gather_kv_indices is not None else None
+
+        if arch // 10 == 8:
+            assert page_table is None, "paged KV not supported on SM 8.0"
+            assert not is_split_kv, "SplitKV not supported on SM 8.0"
+            fa_fwd = FlashAttentionForwardSm80(
+                dtype,
+                head_dim,
+                head_dim_v,
+                qhead_per_kvhead,
+                is_causal=causal,
+                is_local=local,
+                pack_gqa=pack_gqa,
+                tile_m=tile_m,
+                tile_n=tile_n,
+                num_stages=1,
+                num_threads=num_threads,
+                Q_in_regs=False,
+                score_mod=score_mod,
+                mask_mod=mask_mod,
+                has_aux_tensors=aux_tensors is not None,
+            )
+        elif arch // 10 == 9:
+            assert not is_split_kv, "SplitKV not supported on SM 9.0"
+            fa_fwd = FlashAttentionForwardSm90(
+                dtype,
+                head_dim,
+                head_dim_v,
+                qhead_per_kvhead,
+                is_causal=causal,
+                is_local=local,
+                pack_gqa=pack_gqa,
+                tile_m=tile_m,
+                tile_n=tile_n,
+                # num_stages=1,
+                num_stages=2,
+                num_threads=num_threads,
+                Q_in_regs=False,
+                intra_wg_overlap=intra_wg_overlap,
+                mma_pv_is_rs=mma_pv_is_rs,
+                mask_mod=mask_mod,
+                score_mod=score_mod,
+                has_aux_tensors=aux_tensors is not None,
+                q_subtile_factor=q_subtile_factor,
+                paged_kv_non_tma=page_size not in [None, tile_n],
+            )
+        elif arch // 10 in [10, 11]:
+            if qv is not None:
+                fa_fwd = FlashAttentionMLAForwardSm100(
+                    is_causal=causal,
+                    use_cpasync_load_KV=sparse_kv,
+                    topk_length=gather_kv_length,
+                    is_topk_gather=sparse_kv,
+                    pack_gqa=pack_gqa,
+                    qhead_per_kvhead=qhead_per_kvhead,
+                    nheads_kv=num_head_kv,
+                    is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
+                    disable_bitmask=disable_sparse_kv_bitmask,
+                )
+            else:
+                if use_dedicated_hd256_kernel:
+                    # hd=256 2CTA forward: check for currently unsupported features
+                    assert softcap is None, "SM100 forward with head_dim=256 does not support softcap"
+                    assert not use_block_sparsity, \
+                        "SM100 forward with head_dim=256 does not support block sparsity"
+                    assert learnable_sink is None, \
+                        "SM100 forward with head_dim=256 does not support learnable_sink"
+                    assert seqused_q is None and seqused_k is None, \
+                        "SM100 forward with head_dim=256 does not support seqused_q/seqused_k"
+                    if page_table is not None:
+                        assert max_seqlen_k % page_size == 0, (
+                            f"SM100 hd256 2CTA paged KV requires max_seqlen_k divisible by "
+                            f"page_size ({page_size}), got max_seqlen_k={max_seqlen_k}"
+                        )
+                        assert page_table.shape[1] == max_seqlen_k // page_size, (
+                            f"SM100 hd256 2CTA paged KV requires page_table.shape[1] == "
+                            f"max_seqlen_k // page_size ({max_seqlen_k} // {page_size} = "
+                            f"{max_seqlen_k // page_size}), got {page_table.shape[1]}; "
+                            f"pass page_table[:, :{max_seqlen_k // page_size}] to slice to "
+                            f"the actual sequence length"
+                        )
+                        assert page_table.stride(0) == page_table.shape[1], (
+                            f"SM100 hd256 2CTA paged KV requires a fully contiguous page_table "
+                            f"(stride(0)={page_table.stride(0)} must equal "
+                            f"shape[1]={page_table.shape[1]})"
+                        )
+                    # pack_gqa is an auto-selected optimization; disable it for hd256 kernel
+                    pack_gqa = False
+
+                flash_fwd_obj_cls = (
+                    BlackwellFusedMultiHeadAttentionForward
+                    if use_dedicated_hd256_kernel
+                    else FlashAttentionForwardSm100
+                )
+
+                fa_fwd = flash_fwd_obj_cls(
+                    head_dim,
+                    head_dim_v,
+                    qhead_per_kvhead=qhead_per_kvhead,
+                    is_causal=causal,
+                    is_local=local,
+                    is_split_kv=is_split_kv,
+                    pack_gqa=pack_gqa,
+                    m_block_size=tile_m,
+                    n_block_size=tile_n,
+                    q_stage=q_stage,
+                    is_persistent=not causal
+                        and not local
+                        and cu_seqlens_q is None
+                        and seqused_q is None
+                        and not is_split_kv,
+                    score_mod=score_mod,
+                    mask_mod=mask_mod,
+                    has_aux_tensors=aux_tensors is not None,
+                    paged_kv_non_tma=page_size not in [None, tile_n],
+                    is_varlen_q=cu_seqlens_q is not None or seqused_q is not None,
+                    q_subtile_factor=q_subtile_factor,
+                    use_2cta_instrs=use_2cta_instrs,
+                    use_clc_scheduler=use_clc_scheduler,
+                )
+        elif arch // 10 == 12:
+            # SM120 (Blackwell GeForce / DGX Spark): uses SM80 MMA with SM120 SMEM capacity
+            assert not use_block_sparsity, "Block sparsity not supported on SM 12.0"
+            assert page_table is None, "Paged KV not supported on SM 12.0 in this PR"
+            assert not is_split_kv, "SplitKV not supported on SM 12.0 in this PR"
+            fa_fwd = FlashAttentionForwardSm120(
+                dtype,
+                head_dim,
+                head_dim_v,
+                qhead_per_kvhead,
+                is_causal=causal,
+                is_local=local,
+                pack_gqa=pack_gqa,
+                tile_m=tile_m,
+                tile_n=tile_n,
+                num_stages=1,
+                num_threads=num_threads,
+                Q_in_regs=False,
+                score_mod=score_mod,
+                mask_mod=mask_mod,
+                has_aux_tensors=aux_tensors is not None,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported compute capability: {arch}. Supported: 8.x, 9.x, 10.x, 11.x, 12.x"
+            )
+        # TODO: check @can_implement
+        if qv is not None:
+            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(
+                fa_fwd,
+                q_tensor,
+                qv_tensor,
+                k_tensor,
+                v_tensor,
+                o_tensor,
+                lse_tensor,
+                softmax_scale,
+                cu_seqlens_q_tensor,
+                cu_seqlens_k_tensor,
+                seqused_q_tensor,
+                seqused_k_tensor,
+                gather_kv_indices_tensor,
+                page_table_tensor,
+                window_size_left,
+                window_size_right,
+                current_stream,
+                options="--enable-tvm-ffi",
+            )
+        else:
+            compile_args = [
+                fa_fwd,
+                q_tensor,
+                k_tensor,
+                v_tensor,
+                o_tensor,
+                lse_tensor,
+                softmax_scale,
+                cu_seqlens_q_tensor,
+                cu_seqlens_k_tensor,
+                seqused_q_tensor,
+                seqused_k_tensor,
+                page_table_tensor,
+                window_size_left,
+                window_size_right,
+                learnable_sink_tensor,
+                sparse_tensors,
+                cute_aux_tensors,
+                current_stream,
+            ]
+            if arch // 10 in [10, 11]:
+                compile_args.insert(-3, descale_tensors_tensor)
+            _flash_attn_fwd.compile_cache[compile_key] = cute.compile(*compile_args, options="--enable-tvm-ffi")
+
+    if not is_fake_mode():
+        q_call, k_call, v_call = q.detach(), k.detach(), v.detach()
+        qv_call = qv.detach() if qv is not None else None
+        if is_fp8:
+            # need uint8 workaround until we pin torch >= 2.11.0 where fp8 export is supported
+            q_call = q_call.view(torch.uint8)
+            k_call = k_call.view(torch.uint8)
+            v_call = v_call.view(torch.uint8)
+            if qv_call is not None:
+                qv_call = qv_call.view(torch.uint8)
+        descale_tensors = (
+            DescaleTensors(q_descale=q_descale, k_descale=k_descale, v_descale=v_descale)
+            if q_descale is not None or k_descale is not None or v_descale is not None
+            else None
+        )
+        if qv is not None:
+            _flash_attn_fwd.compile_cache[compile_key](
+                q_call,
+                qv_call,
+                k_call,
+                v_call,
+                out.detach(),
+                lse,
+                softmax_scale,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                gather_kv_indices,
+                page_table,
+                window_size_left,
+                window_size_right,
+            )
+        else:
+            call_args = [
+                q_call,
+                k_call,
+                v_call,
+                out.detach() if not is_split_kv else out_partial,
+                lse_partial if is_split_kv else lse,
+                softmax_scale,
+                cu_seqlens_q,
+                cu_seqlens_k,
+                seqused_q,
+                seqused_k,
+                page_table,
+                window_size_left,
+                window_size_right,
+                learnable_sink,
+            ]
+            if arch // 10 in [10, 11]:
+                call_args.append(descale_tensors)
+            call_args.extend([
+                (
+                    normalized_block_sparse_tensors.mask_block_cnt,
+                    normalized_block_sparse_tensors.mask_block_idx,
+                    normalized_block_sparse_tensors.full_block_cnt,
+                    normalized_block_sparse_tensors.full_block_idx,
+                    normalized_block_sparse_tensors.dq_write_order,
+                    normalized_block_sparse_tensors.dq_write_order_full,
+                )
+                if normalized_block_sparse_tensors is not None
+                else None,
+                aux_tensors,
+            ])
+            _flash_attn_fwd.compile_cache[compile_key](*call_args)
+    if is_split_kv:
+        _flash_attn_fwd_combine(
+            out_partial,
+            lse_partial.transpose(-1, -2),
+            out,
+            lse.transpose(-1, -2) if lse is not None else None,
+            cu_seqlens_q,
+            seqused_q,
+        )
+    return out, lse
+
+
+_flash_attn_fwd.compile_cache = get_jit_cache("fwd")
+
+
+class FlashAttnFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        qv: Optional[torch.Tensor] = None,
+        gather_kv_indices: Optional[torch.Tensor] = None,
+        softmax_scale: Optional[float] = None,
+        causal: bool = False,
+        window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+        learnable_sink: Optional[torch.Tensor] = None,
+        softcap: float = 0.0,
+        num_splits: int = 1,
+        pack_gqa: Optional[bool] = None,
+        deterministic: bool = False,
+        score_mod: Optional[Callable] = None,
+        score_mod_bwd: Optional[Callable] = None,
+        mask_mod: Optional[Callable] = None,
+        aux_tensors: Optional[list] = None,
+        block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+        block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
+        return_lse: bool = False,
+    ):
+        out, lse = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            qv=qv,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size[0],
+            window_size_right=window_size[1],
+            learnable_sink=learnable_sink,
+            softcap=softcap,
+            num_splits=num_splits,
+            pack_gqa=pack_gqa,
+            score_mod=score_mod,
+            mask_mod=mask_mod,
+            aux_tensors=aux_tensors,
+            block_sparse_tensors=block_sparse_tensors,
+            return_lse=return_lse,
+            gather_kv_indices=gather_kv_indices,
+        )
+        ctx.save_for_backward(q, k, v, out, lse, *(aux_tensors or ()))
+        ctx.softmax_scale = softmax_scale
+        ctx.causal = causal
+        ctx.window_size = window_size
+        ctx.softcap = softcap
+        ctx.deterministic = deterministic
+        ctx.return_lse = return_lse
+        ctx.score_mod = score_mod
+        ctx.score_mod_bwd = score_mod_bwd
+        ctx.mask_mod = mask_mod
+        ctx.block_sparse_tensors_bwd = block_sparse_tensors_bwd
+        ctx.set_materialize_grads(False)
+        return out, lse
+
+    @staticmethod
+    def backward(ctx, dout, dlse):
+        raise NotImplementedError(
+            "FlashRT's FA4 vendor is forward / inference-only; the backward "
+            "kernels were removed (see VENDOR.md)."
+        )
+
+
+class FlashAttnVarlenFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        qv: Optional[torch.Tensor] = None,
+        cu_seqlens_q: Optional[torch.Tensor] = None,
+        cu_seqlens_k: Optional[torch.Tensor] = None,
+        seqused_q: Optional[torch.Tensor] = None,
+        seqused_k: Optional[torch.Tensor] = None,
+        max_seqlen_q: Optional[int] = None,
+        max_seqlen_k: Optional[int] = None,
+        min_seqlen_k: Optional[int] = None,
+        gather_kv_indices: Optional[torch.Tensor] = None,
+        page_table: Optional[torch.Tensor] = None,
+        softmax_scale: Optional[float] = None,
+        causal: bool = False,
+        window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+        learnable_sink: Optional[torch.Tensor] = None,
+        softcap: float = 0.0,
+        num_splits: int = 1,
+        pack_gqa: Optional[bool] = None,
+        deterministic: bool = False,
+        score_mod: Optional[Callable] = None,
+        score_mod_bwd: Optional[Callable] = None,
+        aux_tensors: Optional[list] = None,
+        return_lse: bool = False,
+    ):
+        out, lse = _flash_attn_fwd(
+            q,
+            k,
+            v,
+            qv=qv,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            seqused_q=seqused_q,
+            seqused_k=seqused_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            min_seqlen_k=min_seqlen_k,
+            page_table=page_table,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=window_size[0],
+            window_size_right=window_size[1],
+            learnable_sink=learnable_sink,
+            softcap=softcap,
+            num_splits=num_splits,
+            pack_gqa=pack_gqa,
+            score_mod=score_mod,
+            aux_tensors=aux_tensors,
+            return_lse=return_lse,
+            gather_kv_indices=gather_kv_indices,
+        )
+        ctx.save_for_backward(
+            q,
+            k,
+            v,
+            out,
+            lse,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_q,
+            seqused_k,
+            *(aux_tensors or ()),
+        )
+        ctx.softmax_scale = softmax_scale
+        ctx.causal = causal
+        ctx.window_size = window_size
+        ctx.softcap = softcap
+        ctx.deterministic = deterministic
+        ctx.max_seqlen_q = max_seqlen_q
+        ctx.max_seqlen_k = max_seqlen_k
+        ctx.return_lse = return_lse
+        ctx.score_mod = score_mod
+        ctx.score_mod_bwd = score_mod_bwd
+        ctx.set_materialize_grads(False)
+        return out, lse
+
+    @staticmethod
+    def backward(ctx, dout, dlse):
+        raise NotImplementedError(
+            "FlashRT's FA4 vendor is forward / inference-only; the backward "
+            "kernels were removed (see VENDOR.md)."
+        )
+
+
+def flash_attn_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    qv: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    learnable_sink: Optional[torch.Tensor] = None,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    deterministic: bool = False,
+    score_mod: Optional[Callable] = None,
+    score_mod_bwd: Optional[Callable] = None,
+    mask_mod: Optional[Callable] = None,
+    aux_tensors: Optional[list] = None,
+    block_sparse_tensors: Optional[BlockSparseTensorsTorch] = None,
+    block_sparse_tensors_bwd: Optional[BlockSparseTensorsTorch] = None,
+    return_lse: bool = False,
+):
+    return FlashAttnFunc.apply(
+        q,
+        k,
+        v,
+        qv,
+        gather_kv_indices,
+        softmax_scale,
+        causal,
+        window_size,
+        learnable_sink,
+        softcap,
+        num_splits,
+        pack_gqa,
+        deterministic,
+        score_mod,
+        score_mod_bwd,
+        mask_mod,
+        aux_tensors,
+        block_sparse_tensors,
+        block_sparse_tensors_bwd,
+        return_lse,
+    )
+
+
+def flash_attn_varlen_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    qv: Optional[torch.Tensor] = None,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cu_seqlens_k: Optional[torch.Tensor] = None,
+    max_seqlen_q: Optional[int] = None,
+    max_seqlen_k: Optional[int] = None,
+    min_seqlen_k: Optional[int] = None,
+    seqused_q: Optional[torch.Tensor] = None,
+    seqused_k: Optional[torch.Tensor] = None,
+    gather_kv_indices: Optional[torch.Tensor] = None,
+    page_table: Optional[torch.Tensor] = None,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+    window_size: Tuple[Optional[int], Optional[int]] = (None, None),
+    learnable_sink: Optional[torch.Tensor] = None,
+    softcap: float = 0.0,
+    num_splits: int = 1,
+    pack_gqa: Optional[bool] = None,
+    deterministic: bool = False,
+    score_mod: Optional[Callable] = None,
+    score_mod_bwd: Optional[Callable] = None,
+    aux_tensors: Optional[list] = None,
+    return_lse: bool = False,
+):
+    """
+    Explanation of some optional arguments:
+
+    qv: we write the MLA weight absorbed formula as
+        O = softmax(scale * (Q @ K.T + Qv @ V.T)) @ V
+        where Q = q_pe, Qv = q_nope, K = pe_cache, V = kv_cache.
+
+    gather_kv_indices: a tensor of shape (batch, seqlen_q, gather_kv_length) or
+        (total_q, gather_kv_length) if there is cu_seqlens_q.
+        Currently, only used for topk sparsity with MLA absorption kernel.
+
+    min_seqlen_k: for varlen, specifies the minimum kv sequence length for any batch.
+        Used with gather_kv_indices to determine if we need oob masking.
+    """
+    return FlashAttnVarlenFunc.apply(
+        q,
+        k,
+        v,
+        qv,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqused_q,
+        seqused_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        min_seqlen_k,
+        gather_kv_indices,
+        page_table,
+        softmax_scale,
+        causal,
+        window_size,
+        learnable_sink,
+        softcap,
+        num_splits,
+        pack_gqa,
+        deterministic,
+        score_mod,
+        score_mod_bwd,
+        aux_tensors,
+        return_lse,
+    )
+
+
+def _compile_fwd_combine(
+    dtype, dtype_partial, head_dim, tile_m, k_block_size, log_max_splits,
+    has_cu_seqlens, has_seqused, has_lse, has_varlen_batch_idx,
+):
+    """Compile fwd combine kernel using cute fake tensors (no real GPU tensors needed)."""
+    sym = cute.sym_int
+    div = 128 // dtype_partial.width  # 16-byte alignment in elements
+
+    fa_combine = FlashAttentionForwardCombine(
+        dtype=dtype,
+        dtype_partial=dtype_partial,
+        head_dim=head_dim,
+        tile_m=tile_m,
+        k_block_size=k_block_size,
+        log_max_splits=log_max_splits,
+    )
+    if not fa_combine.can_implement(
+        dtype, dtype_partial, head_dim, tile_m, k_block_size, log_max_splits,
+        num_threads=256,
+    ):
+        raise RuntimeError(
+            "FlashAttention combine kernel cannot be implemented with given parameters"
+        )
+
+    if has_cu_seqlens:
+        # Varlen: (num_splits, total_q, nheads, headdim)
+        num_splits, total_q, nheads = sym(), sym(), sym()
+        mO_partial = fake_tensor(dtype_partial, (num_splits, total_q, nheads, head_dim), divisibility=div)
+        mLSE_partial = fake_tensor(Float32, (num_splits, total_q, nheads), divisibility=1, leading_dim=1)
+        mO = fake_tensor(dtype, (total_q, nheads, head_dim), divisibility=div)
+        mLSE = fake_tensor(Float32, (total_q, nheads), divisibility=1, leading_dim=0) if has_lse else None
+    else:
+        # Batched: (num_splits, batch, seqlen, nheads, headdim)
+        num_splits, batch, seqlen, nheads = sym(), sym(), sym(), sym()
+        mO_partial = fake_tensor(dtype_partial, (num_splits, batch, seqlen, nheads, head_dim), divisibility=div)
+        mLSE_partial = fake_tensor(Float32, (num_splits, batch, seqlen, nheads), divisibility=1, leading_dim=2)
+        mO = fake_tensor(dtype, (batch, seqlen, nheads, head_dim), divisibility=div)
+        mLSE = fake_tensor(Float32, (batch, seqlen, nheads), divisibility=1, leading_dim=1) if has_lse else None
+        batch = mO_partial.shape[1]
+
+    batch_for_1d = batch if not has_cu_seqlens else sym()
+    batchp1 = sym()
+    mCuSeqlens = fake_tensor(Int32, (batchp1,), divisibility=1) if has_cu_seqlens else None
+    mSeqused = fake_tensor(Int32, (batch_for_1d,), divisibility=1) if has_seqused else None
+    mNumSplitsDynamic = None  # Not parametrized in compile_key
+    mVarlenBatchIdx = fake_tensor(Int32, (batch_for_1d,), divisibility=1) if has_varlen_batch_idx else None
+    mSemaphore = None  # Not parametrized in compile_key
+
+    return cute.compile(
+        fa_combine,
+        mO_partial, mLSE_partial, mO, mLSE,
+        mCuSeqlens, mSeqused, mNumSplitsDynamic, mVarlenBatchIdx, mSemaphore,
+        cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True),
+        options="--enable-tvm-ffi",
+    )
+
+
+def _flash_attn_fwd_combine(
+    out_partial: torch.Tensor,
+    lse_partial: torch.Tensor,
+    out: torch.Tensor,
+    lse: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    seqused: Optional[torch.Tensor] = None,
+    num_splits_dynamic_ptr: Optional[torch.Tensor] = None,
+    varlen_batch_idx: Optional[torch.Tensor] = None,
+    semaphore_to_reset: Optional[torch.Tensor] = None,
+) -> None:
+    """Forward combine kernel for split attention computation.
+
+    Combines partial outputs and log-sum-exp values from multiple splits
+    of attention computation into final outputs.
+
+    Args:
+        out_partial: Partial outputs tensor (num_splits, batch, seqlen, nheads, headdim) or
+                                            (num_splits, total_q, nheads, headdim) if there's cu_seqlens
+        lse_partial: Partial LSE tensor (num_splits, batch, seqlen, nheads) or
+                                       (num_splits, total_q, nheads) if there's cu_seqlens
+        out: Output tensor (batch, seqlen, nheads, headdim) or (total_q, nheads, headdim) if there's cu_seqlens
+        lse: Output LSE tensor (batch, seqlen, nheads) or (total_q, nheads) if there's cu_seqlens.
+        cu_seqlens: Cumulative sequence lengths for variable length sequences
+        seqused: Used sequence lengths for each batch
+        num_splits_dynamic_ptr: Dynamic number of splits per batch
+        semaphore_to_reset: Semaphore for synchronization
+        k_block_size: Block size for head dimension
+
+    Returns:
+        None
+    """
+    assert out_partial.dtype in [torch.float16, torch.bfloat16, torch.float32], (
+        "out_partial must be fp16, bf16, or fp32"
+    )
+    if not is_fake_mode():
+        assert out_partial.is_cuda and lse_partial.is_cuda, "tensors must be on CUDA device"
+    # Determine if this is variable length based on dimensions
+    is_varlen = out_partial.dim() == 4
+    # Validate optional tensors
+    for t, name in [
+        (cu_seqlens, "cu_seqlens"),
+        (seqused, "seqused"),
+        (num_splits_dynamic_ptr, "num_splits_dynamic_ptr"),
+    ]:
+        if t is not None:
+            if not is_fake_mode():
+                assert t.is_cuda, f"{name} must be on CUDA device"
+            assert t.is_contiguous(), f"{name} must be contiguous"
+    head_dim = out_partial.shape[-1]
+    num_splits = out_partial.shape[0]
+    assert num_splits <= 256
+    # If hdim is 96 or 192, it's faster to round them to 128 or 256 respectively
+    # so that kBlockM is smaller and we have more parallelism.
+    k_block_size = 64 if head_dim <= 64 else 128
+    # We want kBlockM to be as small as possible to maximize parallelism.
+    # E.g., if hdim is 64, we want kBlockM to be 16 so that we can use 256 threads, each reading 4 elements (floats).
+    tile_m = 8 if k_block_size % 128 == 0 else (16 if k_block_size % 64 == 0 else 32)
+    log_max_splits = max(math.ceil(math.log2(num_splits)), 4)
+    if tile_m == 8:
+        # If kBlockM == 8 then the minimum number of splits is 32.
+        # TODO: we can deal w this by using 128 threads instead
+        log_max_splits = max(log_max_splits, 5)
+
+    # Create combine kernel configuration
+    dtype = torch2cute_dtype_map[out.dtype]
+    dtype_partial = torch2cute_dtype_map[out_partial.dtype]
+    compile_key = (
+        dtype,
+        dtype_partial,
+        head_dim,
+        tile_m,
+        k_block_size,
+        log_max_splits,
+        cu_seqlens is not None,
+        seqused is not None,
+        lse is not None,
+        varlen_batch_idx is not None,
+    )
+    if compile_key not in _flash_attn_fwd_combine.compile_cache:
+        _flash_attn_fwd_combine.compile_cache[compile_key] = _compile_fwd_combine(
+            *compile_key
+        )
+    if not is_fake_mode():
+        _flash_attn_fwd_combine.compile_cache[compile_key](
+            out_partial, lse_partial, out, lse,
+            cu_seqlens, seqused, num_splits_dynamic_ptr, varlen_batch_idx,
+            semaphore_to_reset,
+        )
+
+
+_flash_attn_fwd_combine.compile_cache = get_jit_cache("fwd_combine")
+
+
+def flash_attn_combine(
+    out_partial: torch.Tensor,
+    lse_partial: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    out_dtype: Optional[torch.dtype] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    seqused: Optional[torch.Tensor] = None,
+    varlen_batch_idx: Optional[torch.Tensor] = None,
+    return_lse: bool = True,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Flash Attention combine function for split attention computation.
+
+    Combines partial outputs and log-sum-exp values from multiple splits
+    of attention computation into final outputs. This is the main user-facing
+    interface for the combine kernel.
+
+    Args:
+        out_partial: Partial outputs tensor with shape:
+            - (num_splits, batch_size, seqlen, num_heads, head_size) for regular batched input
+            - (num_splits, total_q, num_heads, head_size) for variable length input
+        lse_partial: Partial LSE tensor with shape:
+            - (num_splits, batch_size, seqlen, num_heads) for regular batched input
+            - (num_splits, total_q, num_heads) for variable length input
+        out: Optional output tensor. If None, will be created automatically.
+        out_dtype: Optional output dtype. If None, will use fp16/bf16 based on input.
+        cu_seqlens: Cumulative sequence lengths for variable length sequences
+        seqused: Used sequence lengths for each batch
+        varlen_batch_idx: Optional mapping from virtual batch index to real batch index
+            (int32 tensor of shape (batch_size,)). Used by persistent tile schedulers
+            that reorder batch processing for load balancing.
+        return_lse: Whether to return the combined LSE tensor. Default is True.
+
+    Returns:
+        Tuple of (out, lse) where:
+        - out: Combined output tensor with shape (batch_size, seqlen, num_heads, head_size)
+              or (total_q, num_heads, head_size) for varlen
+        - lse: Combined log-sum-exp tensor with shape (batch_size, seqlen, num_heads)
+              or (total_q, num_heads) for varlen. None if return_lse=False
+
+    Note:
+        This function expects the input tensors to be in the format produced by
+        split attention computation, where the first dimension is num_splits.
+        The permuting from user format to kernel format is now done inside the kernel.
+    """
+    # Input validation
+    assert out_partial.dim() in [4, 5], "out_partial must have 4 or 5 dimensions"
+    # Determine if this is variable length based on dimensions
+    is_varlen = out_partial.dim() == 4
+    if is_varlen:
+        # Variable length: (num_splits, total_q, num_heads, head_size)
+        num_splits, total_q, num_heads, head_size = out_partial.shape
+        batch_size = 1  # Treat as single batch for varlen
+        seqlen = total_q
+    else:
+        # Regular batched: (num_splits, batch_size, seqlen, num_heads, head_size)
+        num_splits, batch_size, seqlen, num_heads, head_size = out_partial.shape
+    # Determine output dtype
+    if out_dtype is None:
+        out_dtype = out_partial.dtype
+    # Create output if not provided
+    device = out_partial.device
+    if out is None:
+        if is_varlen:
+            out = torch.empty(total_q, num_heads, head_size, dtype=out_dtype, device=device)
+        else:
+            out = torch.empty(
+                batch_size, seqlen, num_heads, head_size, dtype=out_dtype, device=device
+            )
+    # Create lse output only if requested
+    if return_lse:
+        if is_varlen:
+            lse = torch.empty(num_heads, total_q, dtype=torch.float32, device=device)
+        else:
+            lse = torch.empty(batch_size, num_heads, seqlen, dtype=torch.float32, device=device)
+        lse = lse.transpose(-1, -2)
+    else:
+        lse = None
+    _flash_attn_fwd_combine(
+        out_partial,
+        lse_partial,
+        out,
+        lse,
+        cu_seqlens,
+        seqused,
+        varlen_batch_idx=varlen_batch_idx,
+    )
+    return out, lse

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/mask.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/mask.py
@@ -1,0 +1,1470 @@
+# Copyright (c) 2025, Tri Dao.
+
+from typing import Optional, Callable, TypeAlias, Tuple
+from dataclasses import dataclass
+import enum
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Int32, Uint32, const_expr
+from cutlass.cutlass_dsl import min as dsl_min
+
+from quack import layout_utils
+import flashrt_fa4.cute.utils as utils
+from flashrt_fa4.cute.block_info import BlockInfo
+from flashrt_fa4.cute.seqlen_info import SeqlenInfoQK
+
+MaskGenFn: TypeAlias = Callable[[int], Uint32]
+MASK_R2P_CHUNK_SIZE: int = 32
+
+
+@cute.jit
+def r2p_bitmask_below(limit: Int32, s: int) -> Uint32:
+    """32-bit R2P bitmask keeping positions < limit (exclusive upper bound).
+
+    Positions 0..limit-1 in chunk `s` get bit=1 (keep), the rest bit=0 (mask).
+    Uses inline PTX to avoid shift-by-type-width UB.
+    """
+    m = max((s + 1) * MASK_R2P_CHUNK_SIZE - limit, 0)
+    return utils.shr_u32(Uint32(0xFFFFFFFF), Uint32(m))
+
+
+@cute.jit
+def r2p_bitmask_above(limit: Int32, s: int) -> Uint32:
+    """32-bit R2P bitmask keeping positions >= limit (inclusive lower bound).
+
+    Positions limit..31 in chunk `s` get bit=1 (keep), the rest bit=0 (mask).
+    Uses inline PTX to avoid shift-by-type-width UB.
+    """
+    n = max(limit - s * MASK_R2P_CHUNK_SIZE, 0)
+    return utils.shl_u32(Uint32(0xFFFFFFFF), Uint32(n))
+
+
+@cute.jit
+def mask_r2p_lambda(
+    X: cute.Tensor,
+    mask_gen_fn: cutlass.Constexpr[MaskGenFn],
+    rank1: bool = False,
+) -> None:
+    """Apply R2P masking with a custom bitmask generator.
+
+    mask_gen_fn(chunk_idx: constexpr int) -> Uint32:
+        Returns a 32-bit bitmask for the chunk. Bit i set means column
+        chunk_idx * chunk_size + i is KEPT; bit i clear means masked to -inf.
+    """
+    ncol = const_expr(cute.size(X.shape[cute.rank(X) - 1]) if not rank1 else cute.size(X.shape))
+    # 32-column chunks. The mask_gen_fn returns a Uint32 bitmask (1=keep).
+    CHUNK_SIZE = MASK_R2P_CHUNK_SIZE
+    for s in cutlass.range_constexpr(cute.ceil_div(ncol, CHUNK_SIZE)):
+        mask = mask_gen_fn(s)
+        # This needs to be range_constexpr, o/w the compiler can't generate the R2P instruction
+        for i in cutlass.range_constexpr(min(CHUNK_SIZE, ncol - s * CHUNK_SIZE)):
+            in_bound = cutlass.Boolean(mask & (Uint32(1) << i))
+            c = s * CHUNK_SIZE + i
+            if const_expr(rank1):
+                X[c] = X[c] if in_bound else -Float32.inf
+            else:
+                for r in cutlass.range_constexpr(cute.size(X.shape[0])):
+                    X[r, c] = X[r, c] if in_bound else -Float32.inf
+
+
+@cute.jit
+def sm90_col_to_r2p_idx(col_limit: Int32) -> Int32:
+    """Transform SM90 MMA column coordinate to R2P element index.
+
+    SM90 MMA accumulator column indices are non-contiguous: 0, 1, 8, 9, 16, 17, ...
+    Element indices are contiguous: 0, 1, 2, 3, 4, 5, ...
+    This converts a column-space threshold to element-space for r2p_bitmask_below/above.
+    """
+    return col_limit // 8 * 2 + min(col_limit % 8, 2)
+
+
+@cute.jit
+def row_to_r2p_idx(x: Int32, num_rep: int, num_wg: int) -> Int32:
+    """Convert a row coordinate to an R2P element index in the warp-group interleaved layout.
+
+    In the SM100 backward pass, 2 warp groups share TMEM. The TMEM load atom
+    distributes rows in an interleaved pattern: elements 0..num_rep-1 map to
+    rows 0..num_rep-1 (warp group 0), elements num_rep..2*num_rep-1 map to
+    rows num_rep*num_wg..num_rep*num_wg+num_rep-1 (warp group 1), and so on.
+    Row-coordinate thresholds (causal limits, window bounds, uih_len) must be
+    converted to element indices before use with r2p_bitmask_above/below.
+
+    Rows not owned by this thread (in the gap between warp groups) are clamped
+    to the boundary element index, which is safe because R2P thresholds are
+    monotonic.
+
+    Example with num_rep=16, num_wg=2:
+        row  0 -> elem  0,  row 15 -> elem 15,
+        row 16 -> elem 16 (clamped), row 31 -> elem 16 (clamped),
+        row 32 -> elem 16, row 33 -> elem 17, row 47 -> elem 31.
+    """
+    return x // (num_rep * num_wg) * num_rep + min(x % (num_rep * num_wg), num_rep)
+
+
+@dataclass(frozen=True)
+class AttentionMask:
+    tile_m: cutlass.Constexpr[int]
+    tile_n: cutlass.Constexpr[int]
+    seqlen_info: SeqlenInfoQK
+    window_size_left: Optional[Int32] = None
+    window_size_right: Optional[Int32] = None
+    qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1  # only pass in if we're doing PackGQA
+    swap_AB: cutlass.Constexpr[bool] = False
+
+    @property
+    def seqlen_q(self) -> Int32:
+        return self.seqlen_info.seqlen_q
+
+    @property
+    def seqlen_k(self) -> Int32:
+        return self.seqlen_info.seqlen_k
+
+    @cute.jit
+    def apply_mask(
+        self,
+        acc_S: cute.Tensor,
+        batch_idx: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        m_block: cutlass.Int32,
+        n_block: cutlass.Int32,
+        thr_mma: cute.TiledMma,
+        mask_seqlen: cutlass.Constexpr[bool],
+        mask_causal: cutlass.Constexpr[bool],
+        mask_local: cutlass.Constexpr[bool] = False,
+        mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+    ) -> None:
+        assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S, transpose=self.swap_AB)
+        acc_shape = (self.tile_m, self.tile_n)
+        cS = cute.make_identity_tensor(acc_shape if not self.swap_AB else acc_shape[::-1])
+        tScS_mn = layout_utils.reshape_acc_to_mn(thr_mma.partition_C(cS), transpose=self.swap_AB)
+        # We use t0ScS as these indices are known at compile time. We then must subtract the
+        # column limit by the thread column offset.
+        t0ScS_mn = layout_utils.reshape_acc_to_mn(
+            thr_mma.get_slice(0).partition_C(cS), transpose=self.swap_AB
+        )
+        ROW = 0 if const_expr(not self.swap_AB) else 1
+        COL = 1 if const_expr(not self.swap_AB) else 0
+        thr_col_offset = tScS_mn[0][COL]
+        # To handle edge cases of completely masked out rows where n_block_max = 0,
+        # we treat negative n_blocks as 0th n_block
+        # TODO: find more transparent solution
+        if n_block < 0:
+            n_block = 0
+        seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n - thr_col_offset
+        if const_expr(not mask_causal and not mask_local and mask_mod is None):
+            if const_expr(mask_seqlen):
+                r2p = const_expr(not self.swap_AB)
+                if const_expr(not r2p):
+                    # traverse column index.
+                    for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                        oob = t0ScS_mn[0, c][COL] >= seqlenk_col_limit
+                        for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+                            acc_S_mn[r, c] = -Float32.inf if oob else acc_S_mn[r, c]
+                else:
+                    seqlenk_col_limit_r2p = sm90_col_to_r2p_idx(seqlenk_col_limit)
+                    mask_r2p_lambda(acc_S_mn, lambda s: r2p_bitmask_below(seqlenk_col_limit_r2p, s))
+
+        elif const_expr(
+            not mask_causal and not mask_local and mask_mod is not None
+        ):  # FlexAttention mask mod
+            nrow = const_expr(cute.size(tScS_mn.shape[0]))
+            ncol = const_expr(cute.size(tScS_mn.shape[1]))
+            has_fastdiv = const_expr(
+                fastdiv_mods is not None
+                and fastdiv_mods[0] is not None
+                and fastdiv_mods[1] is not None
+            )
+            wrap_aux_indices = const_expr(
+                has_fastdiv and mask_seqlen and const_expr(aux_tensors is not None)
+            )
+
+            for r in cutlass.range_constexpr(nrow):
+                # Respect swap_AB: ROW/COL determine which coordinate component corresponds to Q/KV.
+                local_row = tScS_mn[r, 0][ROW]
+                global_row_idx = local_row + m_block * self.tile_m
+                row_for_mod = global_row_idx
+                head_idx_for_mod = head_idx
+                if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                    head_offset = global_row_idx % self.qhead_per_kvhead_packgqa
+                    head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
+                    row_for_mod = global_row_idx // self.qhead_per_kvhead_packgqa
+                row_for_seqlen = row_for_mod
+                if const_expr(wrap_aux_indices):
+                    _, row_for_mod = divmod(row_for_mod, fastdiv_mods[0])
+
+                for col in cutlass.range_constexpr(ncol):
+                    col_idx_local = t0ScS_mn[0, col][COL]
+                    # Convert to absolute column index
+                    global_col_idx = thr_col_offset + col_idx_local + n_block * self.tile_n
+                    col_for_mod = global_col_idx
+                    if const_expr(wrap_aux_indices):
+                        _, col_for_mod = divmod(global_col_idx, fastdiv_mods[1])
+
+                    batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
+                    head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
+                    q_idx_ssa = utils.scalar_to_ssa(row_for_mod, cutlass.Int32)
+                    kv_idx_ssa = utils.scalar_to_ssa(col_for_mod, cutlass.Int32)
+                    mask_value = mask_mod(
+                        batch_idx_ssa,
+                        head_idx_ssa,
+                        q_idx_ssa,
+                        kv_idx_ssa,
+                        self.seqlen_info,
+                        aux_tensors,
+                    )
+                    cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
+                    if const_expr(mask_seqlen):
+                        out_of_bounds = (row_for_seqlen >= self.seqlen_q) or (
+                            global_col_idx >= self.seqlen_k
+                        )
+                        if out_of_bounds:
+                            acc_S_mn[r, col] = -cutlass.Float32.inf
+                        else:
+                            acc_S_mn[r, col] = acc_S_mn[r, col] if cond else -cutlass.Float32.inf
+                    else:
+                        acc_S_mn[r, col] = acc_S_mn[r, col] if cond else -cutlass.Float32.inf
+
+        else:  # Causal or local
+            if const_expr(not self.swap_AB):
+                # If PackGQA, we split the work of compute divmod among threads in the same row
+                threads_per_row = thr_mma.tv_layout_C.shape[0][0]
+                mma_m_idx = None
+                if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                    assert not self.swap_AB, "swap_AB with PackGQA not supported yet"
+                    assert cute.arch.WARP_SIZE % threads_per_row == 0, (
+                        "threads_per_row must divide WARP_SIZE"
+                    )
+                    assert cute.size(acc_S_mn.shape[0]) <= threads_per_row
+                    tidx = thr_mma.thr_idx
+                    mma_m_idx = (
+                        m_block * self.tile_m + tScS_mn[tidx % threads_per_row, 0][0]
+                    ) // self.qhead_per_kvhead_packgqa
+                causal_row_offset = (
+                    1 + self.seqlen_k - n_block * self.tile_n - self.seqlen_q - thr_col_offset
+                )
+                if const_expr(mask_causal):
+                    r2p = const_expr(not self.swap_AB)  # R2P trick, see apply_mask_sm100
+                    for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+                        # get the column index limit based on current row. Only consider the row index, so the column index sets to 0.
+                        if const_expr(self.qhead_per_kvhead_packgqa == 1):
+                            row_idx = tScS_mn[r, 0][0] + m_block * self.tile_m
+                        else:
+                            row_idx = utils.shuffle_sync(
+                                mma_m_idx, r % threads_per_row, width=threads_per_row
+                            )
+                        col_limit_right = row_idx + causal_row_offset
+                        if const_expr(mask_seqlen):
+                            col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
+                        if const_expr(not r2p):
+                            # traverse column index.
+                            for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                                acc_S_mn[r, c] = (
+                                    -Float32.inf
+                                    if t0ScS_mn[0, c][1] >= col_limit_right
+                                    else acc_S_mn[r, c]
+                                )
+                        else:
+                            col_limit_r2p = sm90_col_to_r2p_idx(col_limit_right)
+                            mask_r2p_lambda(
+                                acc_S_mn[r, None],
+                                lambda s: r2p_bitmask_below(col_limit_r2p, s),
+                                rank1=True,
+                            )
+                else:  # Local
+                    local_row_offset_right = (
+                        causal_row_offset + self.window_size_right
+                        if const_expr(self.window_size_right is not None)
+                        else None
+                    )
+                    local_row_offset_left = (
+                        causal_row_offset - 1 - self.window_size_left
+                        if const_expr(self.window_size_left is not None)
+                        else None
+                    )
+                    r2p_local = const_expr(not self.swap_AB)
+                    for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+                        if const_expr(self.qhead_per_kvhead_packgqa == 1):
+                            row_idx = tScS_mn[r, 0][0] + m_block * self.tile_m
+                        else:
+                            row_idx = utils.shuffle_sync(
+                                mma_m_idx, r % threads_per_row, width=threads_per_row
+                            )
+                        if const_expr(self.window_size_right is not None):
+                            col_limit_right = row_idx + local_row_offset_right
+                        else:
+                            col_limit_right = self.tile_n
+                        if const_expr(mask_seqlen):
+                            col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
+                        col_limit_left = (
+                            row_idx + local_row_offset_left
+                            if const_expr(self.window_size_left is not None)
+                            else 0
+                        )
+                        if const_expr(not r2p_local):
+                            # traverse column index.
+                            for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                                col_idx = t0ScS_mn[0, c][1]
+                                if col_idx >= col_limit_right or col_idx < col_limit_left:
+                                    acc_S_mn[r, c] = -Float32.inf
+                        else:
+                            col_limit_right_r2p = sm90_col_to_r2p_idx(col_limit_right)
+                            col_limit_left_r2p = sm90_col_to_r2p_idx(col_limit_left)
+
+                            def mask_gen_fn(s: int) -> Uint32:
+                                return r2p_bitmask_below(
+                                    col_limit_right_r2p, s
+                                ) & r2p_bitmask_above(col_limit_left_r2p, s)
+
+                            mask_r2p_lambda(acc_S_mn[r, None], mask_gen_fn, rank1=True)
+            else:  # swap_AB
+                assert self.qhead_per_kvhead_packgqa == 1
+                thr_row_offset = tScS_mn[0][ROW]
+                causal_row_offset = (
+                    seqlenk_col_limit - self.seqlen_q + m_block * self.tile_m + thr_row_offset
+                )
+                if const_expr(mask_causal):
+                    for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                        col0 = t0ScS_mn[0, c][COL]
+                        # If col0 is beyond the column limit, we want to mask out the entire
+                        # column, by setting row limit to be self.tile_m.
+                        row_limit_top = (
+                            self.tile_m
+                            if col0 >= seqlenk_col_limit and mask_seqlen
+                            else col0 - causal_row_offset
+                        )
+                        for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+                            acc_S_mn[r, c] = (
+                                -Float32.inf
+                                if t0ScS_mn[r, 0][ROW] < row_limit_top
+                                else acc_S_mn[r, c]
+                            )
+                else:
+                    for c in cutlass.range(cute.size(tScS_mn.shape[1]), unroll_full=True):
+                        col0 = t0ScS_mn[0, c][COL]
+                        # If col0 is beyond the column limit, we want to mask out the entire
+                        # column, by setting row limit to be self.tile_m.
+                        row_limit_top = (
+                            self.tile_m
+                            if col0 >= seqlenk_col_limit and mask_seqlen
+                            else (
+                                col0 - causal_row_offset - self.window_size_right
+                                if const_expr(self.window_size_right is not None)
+                                else 0
+                            )
+                        )
+                        row_limit_bot = (
+                            col0 - causal_row_offset + self.window_size_left
+                            if const_expr(self.window_size_left is not None)
+                            else self.tile_m
+                        )
+                        for r in cutlass.range(cute.size(tScS_mn.shape[0]), unroll_full=True):
+                            row_idx = t0ScS_mn[r, 0][ROW]
+                            acc_S_mn[r, c] = (
+                                -Float32.inf
+                                if row_idx < row_limit_top or row_idx > row_limit_bot
+                                else acc_S_mn[r, c]
+                            )
+
+    @cute.jit
+    def apply_mask_sm100(
+        self,
+        acc_S: cute.Tensor,
+        m_block: Int32,
+        n_block: Int32,
+        thr_mma: cute.TiledMma,
+        thr_tmem_load: cute.TiledCopy,
+        mask_seqlen: cutlass.Constexpr[bool],
+        mask_causal: cutlass.Constexpr[bool],
+        mask_local: cutlass.Constexpr[bool] = False,
+        mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
+        batch_idx: Int32 = None,
+        head_idx: Int32 = None,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+        head_divmod=None,
+        check_q_boundary: bool = False,
+        r2p: bool = True,
+        rBitmask: Optional[cute.Tensor] = None,
+    ) -> None:
+        assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
+        acc_shape = (self.tile_m, self.tile_n)
+        cS = cute.make_identity_tensor(acc_shape if not self.swap_AB else acc_shape[::-1])
+        tScS = thr_mma.partition_C(cS)
+        tScS = tScS[(None, None), 0, 0]
+        tScS_t2r = thr_tmem_load.partition_D(tScS)
+        # To handle edge cases of completely masked out rows where n_block_max = 0,
+        # we treat negative n_blocks as 0th n_block
+        # TODO: find more transparent solution
+        if n_block < 0:
+            n_block = 0
+        seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n
+
+        if const_expr(rBitmask is not None):
+            ncol_packed = const_expr(cute.size(rBitmask.shape[0]))
+            for i in cutlass.range_constexpr(ncol_packed):
+                col_start = 32 * i  # mask is bit-packed into uint32
+                curr_mask_val = rBitmask[i]
+                for j in cutlass.range_constexpr(32):
+                    curr_col = col_start + j
+                    mask = (curr_mask_val >> j) & 1
+                    acc_S[curr_col] = acc_S[curr_col] if cutlass.Boolean(mask) else -Float32.inf
+
+        elif const_expr(not mask_causal and not mask_local and mask_mod is None):
+            if const_expr(mask_seqlen):
+                if const_expr(not r2p):
+                    for i in cutlass.range(cute.size(tScS_t2r.shape), unroll_full=True):
+                        # if tScS_t2r[i][1] >= seqlenk_col_limit:
+                        #     acc_S[i] = -Float32.inf
+                        # For some reason the 2 lines above generate really bad SASS
+                        acc_S[i] = -Float32.inf if tScS_t2r[i][1] >= seqlenk_col_limit else acc_S[i]
+                else:
+                    mask_r2p_lambda(
+                        acc_S,
+                        lambda s: r2p_bitmask_below(seqlenk_col_limit, s),
+                        rank1=True,
+                    )
+
+        elif const_expr(not mask_causal and not mask_local and mask_mod is not None):
+            # Block sparse case w/ mask_mod
+            has_fastdiv = const_expr(
+                fastdiv_mods is not None
+                and fastdiv_mods[0] is not None
+                and fastdiv_mods[1] is not None
+            )
+            batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
+
+            ncol = const_expr(cute.size(tScS_t2r.shape))
+            for i in cutlass.range_constexpr(ncol):
+                row_coord = tScS_t2r[i][0] if not self.swap_AB else tScS_t2r[i][1]
+                col_coord = tScS_t2r[i][1] if not self.swap_AB else tScS_t2r[i][0]
+                global_row = row_coord + m_block * self.tile_m
+                global_col = col_coord + n_block * self.tile_n
+
+                if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                    assert head_divmod is not None
+                    mask_row, head_offset = divmod(global_row, head_divmod)
+                    head_idx_for_mod = head_idx * self.qhead_per_kvhead_packgqa + head_offset
+                else:
+                    head_idx_for_mod = head_idx
+                    mask_row = global_row
+
+                mask_row_for_mod = mask_row
+                if const_expr(has_fastdiv and aux_tensors is not None):
+                    if check_q_boundary:
+                        _, mask_row_for_mod = divmod(mask_row, fastdiv_mods[0])
+                global_col_for_mod = global_col
+                if const_expr(has_fastdiv and mask_seqlen and aux_tensors is not None):
+                    _, global_col_for_mod = divmod(global_col, fastdiv_mods[1])
+
+                head_idx_ssa = utils.scalar_to_ssa(head_idx_for_mod, cutlass.Int32)
+                mask_row_ssa = utils.scalar_to_ssa(mask_row_for_mod, cutlass.Int32)
+                kv_idx_ssa = utils.scalar_to_ssa(global_col_for_mod, cutlass.Int32)
+                mask_value = mask_mod(
+                    batch_idx_ssa,
+                    head_idx_ssa,
+                    mask_row_ssa,
+                    kv_idx_ssa,
+                    self.seqlen_info,
+                    aux_tensors,
+                )
+                cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
+                acc_S[i] = acc_S[i] if cond else -Float32.inf
+                if const_expr(mask_seqlen):
+                    acc_S[i] = -Float32.inf if global_col >= self.seqlen_k else acc_S[i]
+                if check_q_boundary:
+                    acc_S[i] = -Float32.inf if mask_row >= self.seqlen_q else acc_S[i]
+
+        else:  # Causal or local
+            causal_row_offset = self.seqlen_k - n_block * self.tile_n - self.seqlen_q
+            row_idx = tScS_t2r[0][0] + m_block * self.tile_m
+            if const_expr(self.qhead_per_kvhead_packgqa != 1):
+                row_idx = row_idx // self.qhead_per_kvhead_packgqa
+            if const_expr(mask_causal):
+                col_limit_right = row_idx + causal_row_offset + 1
+                if const_expr(mask_seqlen):
+                    col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
+                # if cute.arch.thread_idx()[0] % 32 == 0:
+                #     cute.printf("tidx = %d, tidx tmem = %d, row_idx = %d, col_limit_right = %d, causal_row_offset = %d\n", cute.arch.thread_idx()[0], thr_tmem_load.thr_idx, row_idx, col_limit_right, causal_row_offset)
+                ncol = const_expr(cute.size(tScS_t2r.shape))
+                if const_expr(not r2p):
+                    for i in cutlass.range(ncol, unroll_full=True):
+                        acc_S[i] = -Float32.inf if tScS_t2r[i][1] >= col_limit_right else acc_S[i]
+                else:
+                    mask_r2p_lambda(
+                        acc_S,
+                        lambda s: r2p_bitmask_below(col_limit_right, s),
+                        rank1=True,
+                    )
+            else:
+                local_row_offset_right = (
+                    causal_row_offset + 1 + self.window_size_right
+                    if const_expr(self.window_size_right is not None)
+                    else None
+                )
+                local_row_offset_left = (
+                    causal_row_offset - self.window_size_left
+                    if const_expr(self.window_size_left is not None)
+                    else None
+                )
+                if const_expr(self.window_size_right is not None):
+                    col_limit_right = row_idx + local_row_offset_right
+                else:
+                    col_limit_right = self.tile_n
+                if const_expr(mask_seqlen):
+                    col_limit_right = cutlass.min(col_limit_right, seqlenk_col_limit)
+                col_limit_left = (
+                    row_idx + local_row_offset_left
+                    if const_expr(self.window_size_left is not None)
+                    else 0
+                )
+                if const_expr(not r2p):
+                    # if cute.arch.thread_idx()[0] == 0 or cute.arch.thread_idx()[0] == 128: cute.printf("m_block = {}, n_block = {}, row_idx = {}, causal_row_offset = {}, col_limit_right = {}, col_limit_left = {}", m_block, n_block, row_idx, causal_row_offset, col_limit_right, col_limit_left)
+                    for i in cutlass.range(cute.size(tScS_t2r.shape), unroll_full=True):
+                        col_idx = tScS_t2r[i][1]
+                        acc_S[i] = (
+                            -Float32.inf
+                            if col_idx >= col_limit_right or col_idx < col_limit_left
+                            else acc_S[i]
+                        )
+                else:
+                    # Dual-bound R2P masking for SM100.
+                    # Masks elements where: NOT (col_limit_left <= col < col_limit_right)
+
+                    def mask_gen_fn(s: int) -> Uint32:
+                        return r2p_bitmask_below(col_limit_right, s) & r2p_bitmask_above(
+                            col_limit_left, s
+                        )
+
+                    mask_r2p_lambda(acc_S, mask_gen_fn, rank1=True)
+
+    @cute.jit
+    def apply_mask_sm100_transposed(
+        self,
+        acc_S: cute.Tensor,
+        tScS_t2r: cute.Tensor,
+        t0ScS_t2r: cute.Tensor,
+        m_block: cutlass.Int32,
+        n_block: cutlass.Int32,
+        mask_seqlen: cutlass.Constexpr,
+        mask_causal: cutlass.Constexpr,
+        mask_local: cutlass.Constexpr,
+        mask_mod: cutlass.Constexpr[Optional[Callable]] = None,
+        batch_idx: Int32 = None,
+        head_idx: Int32 = None,
+        aux_tensors: Optional[list] = None,
+        fastdiv_mods=(None, None),
+        is_full_block: bool = False,
+        check_m_boundary: bool = True,
+    ) -> None:
+        """
+        Backward pass: mask S = K @ Q.T where n_block tiles seqlen_k and m_block tiles seqlen_q.
+
+        Coordinate convention:
+        - ROW corresponds to Q (m_block)
+        - COL corresponds to KV (n_block)
+
+        is_full_block: If True, skip mask_mod (all elements valid). Only apply seqlen masking.
+        check_m_boundary: If False, skip seqlen_q boundary check (optimization for non-boundary m_blocks).
+                          When iterating m_blocks in forward order, only the last m_block may be partial.
+        """
+        assert not (mask_causal and mask_local), "mask_causal and mask_local cannot be both True"
+        ROW = 0 if const_expr(not self.swap_AB) else 1
+        COL = 1 if const_expr(not self.swap_AB) else 0
+        # assert t0ScS_t2r[0][COL] == 0, "col0 == 0" # tmp comment for 2-cta bwd
+        thr_col_offset = tScS_t2r[0][COL]
+        seqlenk_col_limit = self.seqlen_k - n_block * self.tile_n - thr_col_offset
+
+        if const_expr(not mask_causal and not mask_local and mask_mod is not None):
+            # Block sparse case with mask_mod (backward)
+            #
+            # Coordinate convention: ROW → Q (m_block), COL → KV (n_block).
+            # These already account for swap_AB.
+            #
+            # FULL blocks: mask_mod returns True for all elements, so skip it.
+            #   Still need seqlen bounds check (elements may be OOB on last m_block).
+            # PARTIAL blocks: apply mask_mod element-wise, then seqlen bounds.
+            if is_full_block:
+                if const_expr(mask_seqlen):
+                    if seqlenk_col_limit <= 0:
+                        # Entire tile is OOB for K
+                        for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
+                            acc_S[i] = -cutlass.Float32.inf
+                    elif check_m_boundary:
+                        # Last m_block: check Q and K boundaries
+                        ncol = const_expr(cute.size(tScS_t2r.shape))
+                        for i in cutlass.range_constexpr(ncol):
+                            row_coord = tScS_t2r[i][ROW]
+                            col_coord = tScS_t2r[i][COL]
+                            global_q = row_coord + m_block * self.tile_m
+                            global_kv = col_coord + n_block * self.tile_n
+                            q_out_of_bounds = global_q >= self.seqlen_q
+                            kv_out_of_bounds = global_kv >= self.seqlen_k
+                            out_of_bounds = q_out_of_bounds or kv_out_of_bounds
+                            acc_S[i] = -cutlass.Float32.inf if out_of_bounds else acc_S[i]
+            else:
+                # Partial block
+                has_fastdiv = const_expr(
+                    fastdiv_mods is not None
+                    and fastdiv_mods[0] is not None
+                    and fastdiv_mods[1] is not None
+                )
+                wrap_aux_indices = const_expr(
+                    has_fastdiv and mask_seqlen and const_expr(aux_tensors is not None)
+                )
+                batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32)
+                head_idx_ssa = utils.scalar_to_ssa(head_idx, cutlass.Int32)
+
+                ncol = const_expr(cute.size(tScS_t2r.shape))
+                for i in cutlass.range_constexpr(ncol):
+                    row_coord = tScS_t2r[i][ROW]
+                    col_coord = tScS_t2r[i][COL]
+                    global_q = row_coord + m_block * self.tile_m
+                    global_kv = col_coord + n_block * self.tile_n
+
+                    q_idx_for_mod = global_q
+                    kv_idx_for_mod = global_kv
+                    if const_expr(wrap_aux_indices):
+                        _, q_idx_for_mod = divmod(global_q, fastdiv_mods[0])
+                        _, kv_idx_for_mod = divmod(global_kv, fastdiv_mods[1])
+
+                    q_idx_ssa = utils.scalar_to_ssa(q_idx_for_mod, cutlass.Int32)
+                    kv_idx_ssa = utils.scalar_to_ssa(kv_idx_for_mod, cutlass.Int32)
+
+                    mask_value = mask_mod(
+                        batch_idx_ssa,
+                        head_idx_ssa,
+                        q_idx_ssa,
+                        kv_idx_ssa,
+                        self.seqlen_info,
+                        aux_tensors,
+                    )
+                    cond = cutlass.Boolean(utils.ssa_to_scalar(mask_value))
+                    acc_S[i] = acc_S[i] if cond else -cutlass.Float32.inf
+
+                    if const_expr(mask_seqlen):
+                        # check_m_boundary=False skips q check for non-boundary m_blocks
+                        q_out_of_bounds = check_m_boundary and (global_q >= self.seqlen_q)
+                        kv_out_of_bounds = global_kv >= self.seqlen_k
+                        out_of_bounds = q_out_of_bounds or kv_out_of_bounds
+                        acc_S[i] = -cutlass.Float32.inf if out_of_bounds else acc_S[i]
+
+        elif const_expr(not mask_causal and not mask_local):
+            if const_expr(mask_seqlen):
+                if seqlenk_col_limit <= 0:
+                    for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
+                        acc_S[i] = -cutlass.Float32.inf
+        else:  # Causal or local
+            thr_row_offset = tScS_t2r[0][ROW]
+            seqlenq_row_limit = self.seqlen_q - m_block * self.tile_m - thr_row_offset
+            causal_offset = seqlenq_row_limit - seqlenk_col_limit
+            if const_expr(mask_causal):
+                # tidx = cute.arch.thread_idx()[0] % 256
+                # if tidx < 32:
+                #     cute.printf("tidx = {}, {} {}, {} {}", tidx, tScS_t2r[0][0], tScS_t2r[0][1], tScS_t2r[1][0], tScS_t2r[1][1])
+                row_limit_top = causal_offset
+                if const_expr(mask_seqlen):
+                    # If col is beyond the column limit, we want to mask out the entire
+                    # column, by setting row limit to be self.tile_m.
+                    if seqlenk_col_limit <= 0:
+                        row_limit_top = self.tile_m
+                r2p = True
+                if const_expr(not r2p):
+                    for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
+                        acc_S[i] = (
+                            -cutlass.Float32.inf if t0ScS_t2r[i][ROW] < row_limit_top else acc_S[i]
+                        )
+                else:
+                    num_rep = cute.size(tScS_t2r, mode=[0])  # 16 or 32
+                    num_wg = 2
+                    row_limit = row_to_r2p_idx(row_limit_top, num_rep, num_wg)
+                    mask_r2p_lambda(
+                        acc_S,
+                        lambda s: r2p_bitmask_above(row_limit, s),
+                        rank1=True,
+                    )
+            else:
+                if const_expr(self.window_size_right is not None):
+                    row_limit_top = causal_offset - self.window_size_right
+                else:
+                    row_limit_top = 0
+                if const_expr(self.window_size_left is not None):
+                    row_limit_bot = causal_offset + self.window_size_left
+                if const_expr(mask_seqlen):
+                    if seqlenk_col_limit <= 0:
+                        row_limit_top = self.tile_m
+                r2p = True
+                if const_expr(not r2p):
+                    for i in cutlass.range(cute.size(acc_S.shape), unroll_full=True):
+                        row_idx = t0ScS_t2r[i][ROW]
+                        local_mask = row_idx < row_limit_top
+                        if const_expr(self.window_size_left is not None):
+                            local_mask |= row_idx > row_limit_bot
+                        acc_S[i] = -cutlass.Float32.inf if local_mask else acc_S[i]
+                else:
+
+                    def mask_gen_fn(s: int) -> Uint32:
+                        num_rep = cute.size(tScS_t2r, mode=[0])
+                        num_wg = 2
+
+                        row_limit = row_to_r2p_idx(row_limit_top, num_rep, num_wg)
+                        mask = r2p_bitmask_above(row_limit, s)
+
+                        if const_expr(self.window_size_left is not None):
+                            row_limit_bottom = row_to_r2p_idx(row_limit_bot + 1, num_rep, num_wg)
+                            mask = mask & r2p_bitmask_below(row_limit_bottom, s)
+
+                        return mask
+
+                    mask_r2p_lambda(
+                        acc_S,
+                        mask_gen_fn,
+                        rank1=True,
+                    )
+
+
+# -----------------------------------------------------------------------------
+# SM100 FMHA fused-mask policy layer (separate from generic mask primitives).
+# -----------------------------------------------------------------------------
+
+
+class Sm100MaskEnum(enum.Enum):
+    """Enumeration of mask types for FMHA operations.
+
+    - RESIDUAL_MASK: Residual mask for handling variable sequence lengths
+    - WINDOW_MASK: Window mask for attention which also includes causal and no mask
+    - WINDOW_MASK_INFERENCE: Same as the window mask, but has the limitation that the end of q is aligned with the end of k
+    - WINDOW_MASK_BWD: Window mask for backward pass
+    - WINDOW_MASK_BWD_INFERENCE: Same as the window mask for backward pass, but has the limitation that the end of q is aligned with the end of k
+    """
+
+    NO_MASK = enum.auto()
+    RESIDUAL_MASK = enum.auto()
+    CAUSAL_MASK = enum.auto()
+    WINDOW_MASK = enum.auto()
+    WINDOW_MASK_INFERENCE = enum.auto()
+    # Deprecated the following types
+    WINDOW_MASK_BWD = enum.auto()
+    WINDOW_MASK_BWD_INFERENCE = enum.auto()
+    RESIDUAL_MASK_BWD = enum.auto()
+
+
+class Sm100FusedMask:
+    """A fused mask implementation for FMHA operations.
+
+    This class handles different types of attention masks including no mask,
+    residual mask for variable sequence lengths, and causal mask for
+    autoregressive attention patterns.
+
+    The class provides methods to:
+    - Calculate trip counts for different mask types
+    - Apply masks to attention scores
+    - Handle masked and unmasked trip calculations
+    """
+
+    def get_trip_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of trips needed for the current block.
+
+        The trip count depends on the mask type and the block coordinates.
+        For causal masks, it considers the autoregressive constraint.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of trips needed.
+        :rtype: Int32
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(mask_type == Sm100MaskEnum.RESIDUAL_MASK):
+            result = cute.ceil_div(seqlen_k, tile_shape[1])
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.RESIDUAL_MASK_BWD):
+            result = cute.ceil_div(seqlen_q, tile_shape[0])
+        if cutlass.const_expr(
+            mask_type == Sm100MaskEnum.WINDOW_MASK
+            or mask_type == Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is None):
+                result = cute.ceil_div(seqlen_k, tile_shape[1])
+            else:
+                max_idx_q = (blk_coord[0] + 1) * tile_shape[0]
+                idx_k = max_idx_q + offset + window_size_right
+                tmp_blocks_k = cute.ceil_div(idx_k, tile_shape[1])
+                max_blocks_k = cute.ceil_div(seqlen_k, tile_shape[1])
+                result = dsl_min(max_blocks_k, tmp_blocks_k)
+        if cutlass.const_expr(
+            mask_type == Sm100MaskEnum.WINDOW_MASK_BWD
+            or mask_type == Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is None):
+                result = cute.ceil_div(seqlen_q, tile_shape[0])
+            else:
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1]
+                idx_k = max_idx_k + offset + window_size_left
+                tmp_blocks_q = cute.ceil_div(idx_k, tile_shape[0])
+                max_blocks_q = cute.ceil_div(seqlen_q, tile_shape[0])
+                result = dsl_min(max_blocks_q, tmp_blocks_q)
+        start_block = Sm100FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        result = result - start_block
+        return result
+
+    @cute.jit
+    def get_trip_start_count_via_block_info(
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        is_causal: cutlass.Constexpr[bool] = False,
+        is_local: cutlass.Constexpr[bool] = False,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        block_info = BlockInfo(
+            tile_m=tile_shape[0],
+            tile_n=tile_shape[1],
+            is_causal=is_causal,
+            is_local=is_local and not is_causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+        )
+
+        seqlen_info = SeqlenInfoQK(
+            offset_q=Int32(0),
+            offset_k=Int32(0),
+            padded_offset_q=Int32(0),
+            padded_offset_k=Int32(0),
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            has_cu_seqlens_q=False,
+            has_cu_seqlens_k=False,
+            has_seqused_q=False,
+            has_seqused_k=False,
+        )
+        n_block_min, n_block_max = block_info.get_n_block_min_max(seqlen_info, blk_coord[0])
+        return n_block_min, n_block_max - n_block_min
+
+    @cute.jit
+    def get_trip_mask_bounds_via_block_info(
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        is_causal: cutlass.Constexpr[bool] = False,
+        is_local: cutlass.Constexpr[bool] = False,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        """Return SM100-style mask boundaries for dense iteration.
+
+        Returns:
+          - n_block_min_causal_local_mask: right-side masked region start
+          - n_block_min_before_local_mask: start of fully unmasked middle region
+        """
+        block_info = BlockInfo(
+            tile_m=tile_shape[0],
+            tile_n=tile_shape[1],
+            is_causal=is_causal,
+            is_local=is_local and not is_causal,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+        )
+        seqlen_info = SeqlenInfoQK(
+            offset_q=Int32(0),
+            offset_k=Int32(0),
+            padded_offset_q=Int32(0),
+            padded_offset_k=Int32(0),
+            seqlen_q=seqlen_q,
+            seqlen_k=seqlen_k,
+            has_cu_seqlens_q=False,
+            has_cu_seqlens_k=False,
+            has_seqused_q=False,
+            has_seqused_k=False,
+        )
+        n_block_min, _ = block_info.get_n_block_min_max(seqlen_info, blk_coord[0])
+        n_block_min_causal_local_mask = block_info.get_n_block_min_causal_local_mask(
+            seqlen_info, blk_coord[0], n_block_min
+        )
+        n_block_min_before_local_mask = block_info.get_n_block_min_before_local_mask(
+            seqlen_info, blk_coord[0], n_block_min
+        )
+        return n_block_min_causal_local_mask, n_block_min_before_local_mask
+
+    @cute.jit
+    def get_trip_start(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Get the start of the trip for the current block.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0]
+                idx_k = min_idx_q + offset - window_size_left
+                tmp_blocks_k = idx_k // tile_shape[1]
+                result = max(tmp_blocks_k, result)
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK_BWD
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1]
+                idx_q = min_idx_k + offset - window_size_right
+                tmp_blocks_q = idx_q // tile_shape[0]
+                result = max(tmp_blocks_q, result)
+        return result
+
+    @cute.jit
+    def get_leading_mask_id(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        """
+        Get the begin and end tile idx for the leading mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the leading mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        leading_mask_begin = Sm100FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = Sm100FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        leading_mask_end = leading_mask_begin
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = (blk_coord[0] + 1) * tile_shape[0] + offset - window_size_left
+                leading_mask_end = dsl_min(
+                    cute.ceil_div(min_idx_q, tile_shape[1]) - 1,
+                    trip_count + leading_mask_begin - 1,
+                )
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        elif cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK_BWD
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset - window_size_right
+                leading_mask_end = cute.ceil_div(min_idx_k, tile_shape[0]) - 1
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        return leading_mask_begin, leading_mask_end
+
+    @cute.jit
+    def get_trailing_mask_id(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Optional[Int32], Optional[Int32]]:
+        """
+        Get the begin and end tile idx for the trailing mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the trailing mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        trip_start = Sm100FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = Sm100FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        trailing_mask_begin, trailing_mask_end = None, None
+        if cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0] + offset + window_size_right
+                trailing_mask_begin = dsl_min(
+                    min_idx_q // tile_shape[1], trip_count + trip_start - 1
+                )
+                trailing_mask_end = trip_count + trip_start - 1
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+        else:
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1] + offset + window_size_left + 1
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset + window_size_left
+                trailing_mask_begin = dsl_min(
+                    cute.ceil_div(min_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+                trailing_mask_end = dsl_min(
+                    cute.ceil_div(max_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+
+        return trailing_mask_begin, trailing_mask_end
+
+    @cute.jit
+    def get_masked_leading_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the leading mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+        if cutlass.const_expr(
+            mask_type is not Sm100MaskEnum.RESIDUAL_MASK
+            and mask_type is not Sm100MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                leading_mask_begin, leading_mask_end = Sm100FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                result = max(leading_mask_end - leading_mask_begin + 1, 0)
+
+        return result
+
+    @cute.jit
+    def get_masked_trailing_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        rem_count: Optional[Int32] = 0,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the trailing mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param rem_count: Remaining count from previous calculations.
+        :type rem_count: Int32
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+
+        if cutlass.const_expr(
+            mask_type is not Sm100MaskEnum.RESIDUAL_MASK
+            and mask_type is not Sm100MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                trailing_mask_begin, trailing_mask_end = Sm100FusedMask.get_trailing_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                leading_mask_begin, leading_mask_end = Sm100FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                if cutlass.const_expr(
+                    trailing_mask_begin is not None and trailing_mask_end is not None
+                ):
+                    if trailing_mask_begin <= leading_mask_end:
+                        result = max(trailing_mask_end - leading_mask_end, 0)
+                    else:
+                        result = max(trailing_mask_end - trailing_mask_begin + 1, 0)
+        else:
+            if seqlen_k % tile_shape[1] != 0:
+                result = 1
+            else:
+                result = 0
+
+        return result + rem_count
+
+    @cute.jit
+    def get_unmasked_trip_count(
+        mask_type: Sm100MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of unmasked trips for the current block.
+
+        This represents the number of trips that don't require special
+        masking treatment.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of unmasked trips.
+        :rtype: Int32
+        """
+        result = (
+            Sm100FusedMask.get_trip_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - Sm100FusedMask.get_masked_leading_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - Sm100FusedMask.get_masked_trailing_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+                0,
+            )
+        )
+        return result
+
+    @cute.jit
+    def apply_mask(
+        mask_type: Sm100MaskEnum,
+        acc_qk: cute.Tensor,
+        index_qk: cute.Tensor,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[int] = None,
+        window_size_right: Optional[int] = None,
+        index_transform: cutlass.Constexpr = lambda index_q, index_k: (
+            index_q,
+            index_k,
+        ),
+    ):
+        """
+        Apply the appropriate mask to the attention scores.
+
+        This method modifies the attention scores (acc_qk) based on the mask type
+        and the positions in the index tensor.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.Sm100MaskEnum
+        :param acc_qk: Accumulated QK attention scores tensor.
+        :type acc_qk: cute.Tensor
+        :param index_qk: Index tensor containing position information.
+        :type index_qk: cute.Tensor
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Optional[int]
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[int]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[int]
+        """
+        offset = 0
+        # NOTE: causal masking in this repo aligns the *end* of Q with the *end* of K
+        # when seqlen_k != seqlen_q (same as the test/reference implementation):
+        #   k_index <= q_index + (seqlen_k - seqlen_q) + window_right
+        # In our kernels, causal is represented by (window_left is None, window_right is not None).
+        if cutlass.const_expr(window_size_left is None and window_size_right is not None):
+            offset = seqlen_k - seqlen_q
+        elif cutlass.const_expr(
+            mask_type is Sm100MaskEnum.WINDOW_MASK_INFERENCE
+            or mask_type is Sm100MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            offset = seqlen_k - seqlen_q
+        for i in cutlass.range_constexpr(cute.size(acc_qk), unroll_full=True):
+            index_q, index_k = index_transform(*index_qk[i])
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                if cutlass.const_expr(window_size_left is None):
+                    if index_q + offset + window_size_right < index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                elif cutlass.const_expr(window_size_right is None):
+                    if index_q + offset - window_size_left > index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                else:
+                    max_K_index = dsl_min(index_q + offset + window_size_right, seqlen_k)
+                    min_K_index = max(0, index_q + offset - window_size_left)
+                    if index_k > max_K_index or index_k < min_K_index:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+
+            if cutlass.const_expr(
+                mask_type == Sm100MaskEnum.RESIDUAL_MASK
+                or mask_type == Sm100MaskEnum.RESIDUAL_MASK_BWD
+            ):
+                if index_k >= seqlen_k or index_q >= seqlen_q:
+                    acc_qk[i] = -Float32.inf
+
+    @cute.jit
+    def apply_mask_via_causal_local(
+        acc_qk: cute.Tensor,
+        index_qk: cute.Tensor,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        apply_semantic_window: cutlass.Constexpr[bool] = True,
+        is_causal: cutlass.Constexpr[bool] = False,
+        is_local: cutlass.Constexpr[bool] = False,
+        window_size_left: Optional[int] = None,
+        window_size_right: Optional[int] = None,
+        index_transform: cutlass.Constexpr = lambda index_q, index_k: (
+            index_q,
+            index_k,
+        ),
+    ):
+        """Apply forward mask without mask_type.
+
+        - If apply_semantic_window=True, apply causal/local window constraints.
+        - Always apply residual OOB masking (index_k>=seqlen_k or index_q>=seqlen_q).
+        """
+        offset = 0
+        if cutlass.const_expr(apply_semantic_window):
+            # Match WINDOW_MASK_INFERENCE semantics: end-align Q/K when lengths differ.
+            offset = seqlen_k - seqlen_q
+        for i in cutlass.range_constexpr(cute.size(acc_qk), unroll_full=True):
+            index_q, index_k = index_transform(*index_qk[i])
+            if cutlass.const_expr(apply_semantic_window):
+                if cutlass.const_expr(is_causal and not is_local):
+                    # Pure causal; tolerate both external forms:
+                    # - (None, None) from interface
+                    # - (None, 0) from fused-mask-style callers
+                    right = 0 if const_expr(window_size_right is None) else window_size_right
+                    if index_q + offset + right < index_k:
+                        acc_qk[i] = -Float32.inf
+                elif cutlass.const_expr(
+                    is_local or window_size_left is not None or window_size_right is not None
+                ):
+                    if cutlass.const_expr(window_size_left is None):
+                        if index_q + offset + window_size_right < index_k:
+                            acc_qk[i] = -Float32.inf
+                    elif cutlass.const_expr(window_size_right is None):
+                        if index_q + offset - window_size_left > index_k:
+                            acc_qk[i] = -Float32.inf
+                    else:
+                        max_K_index = dsl_min(index_q + offset + window_size_right, seqlen_k)
+                        min_K_index = max(0, index_q + offset - window_size_left)
+                        if index_k > max_K_index or index_k < min_K_index:
+                            acc_qk[i] = -Float32.inf
+            # Residual mask is always needed for boundary protection.
+            if index_k >= seqlen_k or index_q >= seqlen_q:
+                acc_qk[i] = -Float32.inf

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/mma_sm100_desc.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/mma_sm100_desc.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2025, Tri Dao.
+# Ported Cutlass code from C++ to Python:
+# https://github.com/NVIDIA/cutlass/blob/main/include/cute/arch/mma_sm100_desc.hpp
+# https://github.com/NVIDIA/cutlass/blob/main/include/cute/atom/mma_traits_sm100.hpp
+
+from enum import IntEnum
+
+import cutlass
+import cutlass.cute as cute
+
+# ---------------------------------------------------------------------------
+# Enumerations that match the HW encodings (values MUST stay identical)
+# ---------------------------------------------------------------------------
+
+
+class Major(IntEnum):  # matrix “layout” in the ISA docs
+    K = 0
+    MN = 1
+
+
+class ScaleIn(IntEnum):  # negate flags
+    One = 0
+    Neg = 1
+
+
+class Saturate(IntEnum):
+    False_ = 0
+    True_ = 1
+
+
+class CFormat(IntEnum):  # 2-bit field (bits 4-5)
+    F16 = 0
+    F32 = 1
+    S32 = 2
+
+
+class F16F32Format(IntEnum):  # 3-bit field (A/B element type)
+    F16 = 0
+    BF16 = 1
+    TF32 = 2
+
+
+class S8Format(IntEnum):
+    UINT8 = 0
+    INT8 = 1
+
+
+class MXF8F6F4Format(IntEnum):
+    E4M3 = 0
+    E5M2 = 1
+    E2M3 = 3
+    E3M2 = 4
+    E2M1 = 5
+
+
+class MaxShift(IntEnum):
+    NoShift = 0
+    MaxShift8 = 1
+    MaxShift16 = 2
+    MaxShift32 = 3
+
+
+# ---------------------------------------------------------------------------
+# CUTLASS-type → encoding helpers
+# ---------------------------------------------------------------------------
+
+
+def to_UMMA_format(cutlass_type) -> int:
+    """
+    Map a CUTLASS scalar class to the 3-bit encoding for Matrix A/B.
+    """
+    if cutlass_type is cutlass.Int8:
+        return S8Format.INT8
+    # Unsigned 8-bit (if available in your CUTLASS build)
+    if cutlass_type is cutlass.Uint8:
+        return S8Format.UINT8
+    # FP-16 / BF-16
+    if cutlass_type is cutlass.Float16:
+        return F16F32Format.F16
+    if cutlass_type is cutlass.BFloat16:
+        return F16F32Format.BF16
+    # TensorFloat-32 (8-bit exponent, 10-bit mantissa packed in 19 bits)
+    if cutlass_type is cutlass.TFloat32:
+        return F16F32Format.TF32
+    # Float-8 / Float-6 / Float-4 – add whenever CUTLASS exposes them
+    if cutlass_type is cutlass.Float8E4M3FN:
+        return MXF8F6F4Format.E4M3
+    if cutlass_type is cutlass.Float8E5M2:
+        return MXF8F6F4Format.E5M2
+    raise TypeError(f"Unsupported CUTLASS scalar type for A/B: {cutlass_type!r}")
+
+
+def to_C_format(cutlass_type) -> int:
+    """
+    Map a CUTLASS scalar class to the 2-bit accumulator encoding.
+    """
+    if cutlass_type is cutlass.Float16:
+        return CFormat.F16
+    if cutlass_type is cutlass.Float32:
+        return CFormat.F32
+    if cutlass_type is cutlass.Int32:
+        return CFormat.S32
+    raise TypeError(f"Unsupported CUTLASS scalar type for accumulator: {cutlass_type!r}")
+
+
+# ---------------------------------------------------------------------------
+# The constructor – accepts only CUTLASS scalar classes
+# ---------------------------------------------------------------------------
+
+
+def make_instr_desc(
+    a_type,  # CUTLASS scalar class, e.g. cutlass.Int8
+    b_type,
+    c_type,
+    M: int,  # 64, 128 or 256
+    N: int,  # 8 … 256 (multiple of 8)
+    a_major: Major,
+    b_major: Major,
+    a_neg: ScaleIn = ScaleIn.One,
+    b_neg: ScaleIn = ScaleIn.One,
+    c_sat: Saturate = Saturate.False_,
+    is_sparse: bool = False,
+    max_shift: MaxShift = MaxShift.NoShift,
+) -> int:
+    """
+    Build the 32-bit instruction descriptor for Blackwell MMA.
+    All matrix/accumulator **types must be CUTLASS scalar classes** –
+    passing integers is forbidden.
+    """
+    # --- encode element formats -------------------------------------------------
+    a_fmt = int(to_UMMA_format(a_type))
+    b_fmt = int(to_UMMA_format(b_type))
+    c_fmt = int(to_C_format(c_type))
+
+    # --- range checks on M/N -----------------------------------------------------
+    if M not in (64, 128, 256):
+        raise ValueError("M must be 64, 128 or 256")
+    if N < 8 or N > 256 or (N & 7):
+        raise ValueError("N must be a multiple of 8 in the range 8…256")
+
+    m_dim = M >> 4  # 5-bit field
+    n_dim = N >> 3  # 6-bit field
+
+    # fmt: off
+    # --- pack the bit-fields -----------------------------------------------------
+    desc = 0
+    desc |= (0                 & 0x3) << 0        # sparse_id2 (always 0 here)
+    desc |= (int(is_sparse)    & 0x1) << 2        # sparse_flag
+    desc |= (int(c_sat)        & 0x1) << 3        # saturate
+    desc |= (c_fmt             & 0x3) << 4        # c_format
+    desc |= (a_fmt             & 0x7) << 7        # a_format
+    desc |= (b_fmt             & 0x7) << 10       # b_format
+    desc |= (int(a_neg)        & 0x1) << 13       # a_negate
+    desc |= (int(b_neg)        & 0x1) << 14       # b_negate
+    desc |= (int(a_major)      & 0x1) << 15       # a_major
+    desc |= (int(b_major)      & 0x1) << 16       # b_major
+    desc |= (n_dim             & 0x3F) << 17      # n_dim (6 bits)
+    desc |= (m_dim             & 0x1F) << 24      # m_dim (5 bits)
+    desc |= (int(max_shift)    & 0x3) << 30       # max_shift (2 bits)
+    # fmt: on
+
+    return desc & 0xFFFF_FFFF  # ensure 32-bit result
+
+
+def mma_op_to_idesc(op: cute.nvgpu.tcgen05.mma.MmaOp):
+    return make_instr_desc(
+        op.a_dtype,
+        op.b_dtype,
+        op.acc_dtype,
+        op.shape_mnk[0],
+        op.shape_mnk[1],
+        Major.K if op.a_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K else Major.MN,
+        Major.K if op.b_major_mode == cute.nvgpu.tcgen05.mma.OperandMajorMode.K else Major.MN,
+    )
+
+
+class LayoutType(IntEnum):  # occupies the top-3 bits [61:64)
+    SWIZZLE_NONE = 0  # (a.k.a. “INTERLEAVE” in older docs)
+    SWIZZLE_128B_BASE32B = 1
+    SWIZZLE_128B = 2
+    SWIZZLE_64B = 4
+    SWIZZLE_32B = 6
+    # values 3,5,7 are reserved / illegal for UMMA
+
+
+# ---------------------------------------------------------------------------
+#  Helpers – figure out the SWIZZLE_* family from the tensor layout
+# ---------------------------------------------------------------------------
+
+
+def _layout_type(swizzle: cute.Swizzle) -> LayoutType:
+    B, M, S = swizzle.num_bits, swizzle.num_base, swizzle.num_shift
+
+    if M == 4:  # Swizzle<*,4,3>
+        if S != 3:
+            raise ValueError("Unexpected swizzle shift – want S==3 for M==4")
+        return {
+            0: LayoutType.SWIZZLE_NONE,
+            1: LayoutType.SWIZZLE_32B,
+            2: LayoutType.SWIZZLE_64B,
+            3: LayoutType.SWIZZLE_128B,
+        }[B]  # KeyError ⇒ invalid B→ raise
+    if M == 5:  # Swizzle<2,5,2> (the only legal triple for M==5)
+        if (B, S) != (2, 2):
+            raise ValueError("Only Swizzle<2,5,2> supported for 128B_BASE32B")
+        return LayoutType.SWIZZLE_128B_BASE32B
+
+    # Any other (M,B,S) triple is not a UMMA-legal shared-memory layout
+    raise ValueError("Unsupported swizzle triple for UMMA smem descriptor")
+
+
+def make_smem_desc_base(layout: cute.Layout, swizzle: cute.Swizzle, major: Major) -> int:
+    """
+    Convert a 2-D *shared-memory* Cute layout into the Blackwell 64-bit
+    smem-descriptor, without the smem start address.
+    layout must correspond to layout of an uint128 tensor.
+    """
+    # ------------------------------------------------------------------ meta
+    layout_type = _layout_type(swizzle)  # resolve SWIZZLE_* family
+
+    VERSION = 1  # bits 46–47
+    LBO_MODE = 0  # bit  52
+    BASE_OFFSET = 0  # bits 49–51   (CUTLASS always 0)
+
+    # ---------------------------------------------------------- strides  (units: uint128_t = 16 B)
+    swizzle_atom_mn_size = {
+        LayoutType.SWIZZLE_NONE: 1,
+        LayoutType.SWIZZLE_32B: 2,
+        LayoutType.SWIZZLE_64B: 4,
+        LayoutType.SWIZZLE_128B: 8,
+        LayoutType.SWIZZLE_128B_BASE32B: 8,
+    }[layout_type]
+
+    if major is Major.MN:
+        swizzle_atom_k_size = 4 if layout_type is LayoutType.SWIZZLE_128B_BASE32B else 8
+        canonical_layout = cute.logical_divide(layout, (swizzle_atom_mn_size, swizzle_atom_k_size))
+        if not cute.is_congruent(canonical_layout, ((1, 1), (1, 1))):
+            raise ValueError("Not a canonical UMMA_MN Layout: Expected profile failure.")
+        stride_00 = canonical_layout.stride[0][0]
+        if layout_type is not LayoutType.SWIZZLE_NONE and stride_00 != 1:
+            raise ValueError("Not a canonical UMMA_MN Layout: Expected stride failure.")
+        stride_10 = canonical_layout.stride[1][0]
+        if stride_10 != swizzle_atom_mn_size:
+            raise ValueError("Not a canonical UMMA_MN Layout: Expected stride failure.")
+        stride_01, stride_11 = canonical_layout.stride[0][1], canonical_layout.stride[1][1]
+        if layout_type is LayoutType.SWIZZLE_NONE:
+            stride_byte_offset, leading_byte_offset = stride_01, stride_11
+        else:
+            stride_byte_offset, leading_byte_offset = stride_11, stride_01
+    else:
+        if layout_type == LayoutType.SWIZZLE_128B_BASE32B:
+            raise ValueError("SWIZZLE_128B_BASE32B is invalid for Major-K")
+        if not cute.size(layout.shape[0]) % 8 == 0:
+            raise ValueError("Not a canonical UMMA_K Layout: Expected MN-size multiple of 8.")
+        canonical_layout = cute.logical_divide(layout, (8, 2))
+        if not cute.is_congruent(canonical_layout, ((1, 1), (1, 1))):
+            raise ValueError("Not a canonical UMMA_K Layout: Expected profile failure.")
+        stride_00 = canonical_layout.stride[0][0]
+        if stride_00 != swizzle_atom_mn_size:
+            raise ValueError("Not a canonical UMMA_K Layout: Expected stride failure.")
+        stride_10 = canonical_layout.stride[1][0]
+        if layout_type is not LayoutType.SWIZZLE_NONE and stride_10 != 1:
+            raise ValueError("Not a canonical UMMA_K Layout: Expected stride failure.")
+        stride_01 = canonical_layout.stride[0][1]
+        stride_byte_offset, leading_byte_offset = stride_01, stride_10
+
+    # ------------------------------------------------------------------ pack
+    desc = 0
+    # leading_byte_offset_  [16:30)
+    desc |= (leading_byte_offset & 0x3FFF) << 16
+    # stride_byte_offset_   [32:46)
+    desc |= (stride_byte_offset & 0x3FFF) << 32
+    # version_             [46:48)
+    desc |= (VERSION & 0x3) << 46
+    # base_offset_         [49:52)
+    desc |= (BASE_OFFSET & 0x7) << 49
+    # lbo_mode_            [52:53)
+    desc |= (LBO_MODE & 0x1) << 52
+    # layout_type_         [61:64)
+    desc |= (int(layout_type) & 0x7) << 61
+
+    return desc & 0xFFFF_FFFF_FFFF_FFFF  # force 64-bit width
+
+
+def make_smem_desc_start_addr(start_addr: cute.Pointer) -> cutlass.Int32:
+    # 14 bits, remove 4 LSB (bits 0-13 in desc)
+    return (start_addr.toint() & 0x3FFFF) >> 4
+
+
+def smem_desc_base_from_tensor(sA: cute.Tensor, major: Major) -> int:
+    sA_swizzle = sA.iterator.type.swizzle_type
+    return make_smem_desc_base(
+        cute.recast_layout(128, sA.element_type.width, sA.layout[0]),
+        sA_swizzle,
+        major,
+    )

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/named_barrier.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/named_barrier.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
+
+import enum
+
+
+class NamedBarrierFwd(enum.IntEnum):
+    Epilogue = enum.auto()  # starts from 1 as barrier 0 is reserved for sync_threads()
+    WarpSchedulerWG1 = enum.auto()
+    WarpSchedulerWG2 = enum.auto()
+    WarpSchedulerWG3 = enum.auto()
+    PFull = enum.auto()
+    PEmpty = enum.auto()
+
+
+class NamedBarrierFwdSm100(enum.IntEnum):
+    Epilogue = enum.auto()  # starts from 1 as barrier 0 is reserved for sync_threads()
+    TmemPtr = enum.auto()
+    SoftmaxStatsW0 = enum.auto()
+    SoftmaxStatsW1 = enum.auto()
+    SoftmaxStatsW2 = enum.auto()
+    SoftmaxStatsW3 = enum.auto()
+    SoftmaxStatsW4 = enum.auto()
+    SoftmaxStatsW5 = enum.auto()
+    SoftmaxStatsW6 = enum.auto()
+    SoftmaxStatsW7 = enum.auto()
+
+
+class NamedBarrierBwd(enum.IntEnum):
+    Epilogue = enum.auto()
+    WarpSchedulerWG1 = enum.auto()
+    WarpSchedulerWG2 = enum.auto()
+    WarpSchedulerWG3 = enum.auto()
+    PdS = enum.auto()
+    dQFullWG0 = enum.auto()
+    dQFullWG1 = enum.auto()
+    dQFullWG2 = enum.auto()
+    dQEmptyWG0 = enum.auto()
+    dQEmptyWG1 = enum.auto()
+    dQEmptyWG2 = enum.auto()
+
+
+class NamedBarrierBwdSm100(enum.IntEnum):
+    EpilogueWG1 = enum.auto()
+    EpilogueWG2 = enum.auto()
+    Compute = enum.auto()
+    dQaccReduce = enum.auto()
+    TmemPtr = enum.auto()
+
+
+class NamedBarrierFwdSm100_MLA2CTA(enum.IntEnum):
+    Epilogue = enum.auto()
+    TmemPtr = enum.auto()
+    Cpasync = enum.auto()
+    Softmax = enum.auto()
+    SoftmaxStatsFull = enum.auto()
+    SoftmaxStatsEmpty = enum.auto()

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/pack_gqa.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/pack_gqa.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2025, Tri Dao.
+
+from dataclasses import dataclass
+from typing import Union, Tuple
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+
+
+from quack import layout_utils
+import flashrt_fa4.cute.utils as utils
+
+
+def pack_gqa_layout(T, qhead_per_kvhead, nheads_kv, head_idx):
+    """Reshape a tensor to fold qhead_per_kvhead into the seqlen dimension (mode 0).
+
+    The head dimension is at mode ``head_idx``.  Modes before it (1..head_idx-1)
+    are kept as-is (e.g. headdim for Q/O tensors), and modes after it are kept
+    as-is (e.g. batch).
+
+    For Q/O tensors (head_idx=2):
+        (seqlen_q, headdim, nheads, batch, ...) -> ((qhead_per_kvhead, seqlen_q), headdim, nheads_kv, batch, ...)
+    For LSE tensors (head_idx=1):
+        (seqlen_q, nheads, batch, ...) -> ((qhead_per_kvhead, seqlen_q), nheads_kv, batch, ...)
+    """
+    head_stride = T.stride[head_idx]
+    shape_packed = (
+        (qhead_per_kvhead, T.shape[0]),
+        *[T.shape[i] for i in range(1, head_idx)],
+        nheads_kv,
+        *[T.shape[i] for i in range(head_idx + 1, len(T.shape))],
+    )
+    stride_packed = (
+        (head_stride, T.stride[0]),
+        *[T.stride[i] for i in range(1, head_idx)],
+        head_stride * qhead_per_kvhead,
+        *[T.stride[i] for i in range(head_idx + 1, len(T.shape))],
+    )
+    return cute.make_tensor(T.iterator, cute.make_layout(shape_packed, stride=stride_packed))
+
+
+def make_packgqa_tiled_tma_atom(
+    op: cute.atom.CopyOp,
+    gmem_tensor: cute.Tensor,
+    smem_layout: Union[cute.Layout, cute.ComposedLayout],
+    cta_tiler: Tuple[int, int],
+    qhead_per_kvhead: int,
+    head_idx: int,
+):
+    # This packing and unpacking of the layout is so that we keep the same TMA dimension as usual.
+    # e.g. for (seqlen, d, nheads, b) layout, we still have 4D TMA after packing to
+    # ((nheads, seqlen), d, b).
+    # If we instead pack directly to ((qhead_per_kvhead, seqlen), d, nheads_kv, b) we'd have 5D TMA.
+    # Pack headdim and seqlen dim into 1: (seqlen, d, nheads, b) -> ((nheads, seqlen), d, b)
+    gmem_tensor = layout_utils.select(
+        gmem_tensor, [head_idx, *range(head_idx), *range(head_idx + 1, cute.rank(gmem_tensor))]
+    )
+    gmem_tensor = cute.group_modes(gmem_tensor, 0, 2)
+    assert cta_tiler[0] % qhead_per_kvhead == 0, (
+        "CTA tile size in the seqlen dimension must be divisible by qhead_per_kvhead"
+    )
+    tma_atom, tma_tensor = cpasync.make_tiled_tma_atom(
+        op,
+        gmem_tensor,
+        smem_layout,
+        ((qhead_per_kvhead, cta_tiler[0] // qhead_per_kvhead), cta_tiler[1]),  # No mcast
+    )
+    # Unpack from ((nheads, seqlen), d, b) -> ((qhead_per_kvhead, seqlen), d, nheads_kv, b)
+    T = tma_tensor
+    shape_packed = (
+        (qhead_per_kvhead, T.shape[0][1]),
+        *[T.shape[i] for i in range(1, head_idx)],
+        T.shape[0][0] // qhead_per_kvhead,
+        *[T.shape[i] for i in range(head_idx, len(T.shape))],
+    )
+    stride_packed = (
+        *[T.stride[i] for i in range(head_idx)],
+        T.stride[0][0] * qhead_per_kvhead,
+        *[T.stride[i] for i in range(head_idx, len(T.shape))],
+    )
+    tma_tensor = cute.make_tensor(T.iterator, cute.make_layout(shape_packed, stride=stride_packed))
+    return tma_atom, tma_tensor
+
+
+def unpack_gqa_layout(T, qhead_per_kvhead, head_idx):
+    """Reverse of pack_gqa_layout: unfold qhead_per_kvhead from the seqlen dimension (mode 0).
+
+    The head dimension is at mode ``head_idx``.  Modes before it (1..head_idx-1)
+    are kept as-is (e.g. headdim for Q/O tensors), and modes after it are kept
+    as-is (e.g. batch).
+
+    For Q/O tensors (head_idx=2):
+        ((qhead_per_kvhead, seqlen_q), headdim, nheads_kv, batch, ...) -> (seqlen_q, headdim, nheads, batch, ...)
+    For LSE tensors (head_idx=1):
+        ((qhead_per_kvhead, seqlen_q), nheads_kv, batch, ...) -> (seqlen_q, nheads, batch, ...)
+    """
+    seqlen_stride = T.stride[0][1]
+    head_stride = T.stride[0][0]
+    shape_unpacked = (
+        T.shape[0][1],
+        *[T.shape[i] for i in range(1, head_idx)],
+        T.shape[head_idx] * qhead_per_kvhead,
+        *[T.shape[i] for i in range(head_idx + 1, len(T.shape))],
+    )
+    stride_unpacked = (
+        seqlen_stride,
+        *[T.stride[i] for i in range(1, head_idx)],
+        head_stride,
+        *[T.stride[i] for i in range(head_idx + 1, len(T.shape))],
+    )
+    return cute.make_tensor(T.iterator, cute.make_layout(shape_unpacked, stride=stride_unpacked))
+
+
+@dataclass
+class PackGQA:
+    m_block_size: cutlass.Constexpr[int]
+    head_dim_padded: cutlass.Constexpr[int]
+    check_hdim_oob: cutlass.Constexpr[bool]
+    qhead_per_kvhead: cutlass.Constexpr[bool]
+
+    @cute.jit
+    def compute_ptr(
+        self,
+        tensor: cute.Tensor,
+        cRows: cute.Tensor,
+        tidx: cutlass.Int32,
+        block: cutlass.Int32,
+        threads_per_row: cutlass.Constexpr[int],
+        num_threads: cutlass.Constexpr[int],
+    ):
+        num_ptr_per_thread = cute.ceil_div(cute.size(cRows), threads_per_row)
+        tPrPtr = cute.make_fragment(num_ptr_per_thread, cutlass.Int64)
+        for i in cutlass.range_constexpr(num_ptr_per_thread):
+            row = i * num_threads + cRows[tidx % threads_per_row][0]
+            idx = block * self.m_block_size + row
+            m_idx = idx // self.qhead_per_kvhead
+            h_idx = idx - m_idx * self.qhead_per_kvhead
+            tPrPtr[i] = utils.elem_pointer(tensor, ((h_idx, m_idx),)).toint()
+        return tPrPtr
+
+    @cute.jit
+    def load_Q(
+        self,
+        mQ: cute.Tensor,  # ((qhead_per_kvhead, seqlen_q), headdim)
+        sQ: cute.Tensor,  # (m_block_size, head_dim_padded)
+        gmem_tiled_copy: cute.TiledCopy,
+        tidx: cutlass.Int32,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        gmem_thr_copy = gmem_tiled_copy.get_slice(tidx)
+        cQ = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
+        tQsQ = gmem_thr_copy.partition_D(sQ)
+        tQcQ = gmem_thr_copy.partition_S(cQ)
+        t0QcQ = gmem_thr_copy.get_slice(0).partition_S(cQ)
+        tQpQ = utils.predicate_k(tQcQ, limit=mQ.shape[1])
+        tQcQ_row = tQcQ[0, None, 0]
+        threads_per_row = gmem_tiled_copy.layout_tv_tiled.shape[0][0]
+        assert cute.arch.WARP_SIZE % threads_per_row == 0, "threads_per_row must divide WARP_SIZE"
+        num_threads = gmem_tiled_copy.size
+        tPrQPtr = self.compute_ptr(mQ[None, 0], tQcQ_row, tidx, block, threads_per_row, num_threads)
+        for m in cutlass.range_constexpr(cute.size(tQsQ.shape[1])):
+            q_ptr_i64 = utils.shuffle_sync(
+                tPrQPtr[m // threads_per_row], m % threads_per_row, width=threads_per_row
+            )
+            q_gmem_ptr = cute.make_ptr(
+                mQ.element_type, q_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+            )
+            if (
+                t0QcQ[0, m, 0][0]
+                < seqlen * self.qhead_per_kvhead - block * self.m_block_size - tQcQ_row[0][0]
+            ):
+                mQ_cur = cute.make_tensor(q_gmem_ptr, (self.head_dim_padded,))
+                elems_per_load = cute.size(tQsQ.shape[0][0])
+                mQ_cur_copy = cute.tiled_divide(mQ_cur, (elems_per_load,))
+                for k in cutlass.range_constexpr(cute.size(tQsQ.shape[2])):
+                    ki = tQcQ[0, 0, k][1] // elems_per_load
+                    cute.copy(
+                        gmem_thr_copy,
+                        mQ_cur_copy[None, ki],
+                        tQsQ[None, m, k],
+                        pred=tQpQ[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                    )
+            # We don't need to clear the sQ smem tiles since we'll only write out the valid outputs
+
+    @cute.jit
+    def store_LSE(
+        self,
+        mLSE: cute.Tensor,  # (qhead_per_kvhead, seqlen_q)
+        tLSErLSE: cute.Tensor,  # (m_block_size, head_dim_padded)
+        tiled_mma: cute.TiledMma,
+        tidx: cutlass.Int32,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        thr_mma = tiled_mma.get_slice(tidx)
+        caccO = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
+        taccOcO = thr_mma.partition_C(caccO)
+        taccOcO_row = layout_utils.reshape_acc_to_mn(taccOcO)[None, 0]
+        assert cute.size(tLSErLSE) == cute.size(taccOcO_row)
+        threads_per_row = tiled_mma.tv_layout_C.shape[0][0]
+        assert cute.arch.WARP_SIZE % threads_per_row == 0, "threads_per_row must divide WARP_SIZE"
+        assert cute.size(tLSErLSE) <= threads_per_row
+        num_threads = tiled_mma.size
+        tPrLSEPtr = self.compute_ptr(mLSE, taccOcO_row, tidx, block, threads_per_row, num_threads)
+        for m in cutlass.range_constexpr(cute.size(tLSErLSE)):
+            lse_ptr_i64 = utils.shuffle_sync(
+                tPrLSEPtr[m // threads_per_row],
+                m % threads_per_row,
+                width=threads_per_row,
+            )
+            lse_gmem_ptr = cute.make_ptr(
+                mLSE.element_type, lse_ptr_i64, cute.AddressSpace.gmem, assumed_align=4
+            )
+            row = block * self.m_block_size + taccOcO_row[m][0]
+            # Only the thread corresponding to column 0 writes out the lse to gmem
+            if taccOcO[0][1] == 0 and row < seqlen * self.qhead_per_kvhead:
+                mLSE_copy = cute.make_tensor(lse_gmem_ptr, (1,))
+                mLSE_copy[0] = tLSErLSE[m]
+
+    @cute.jit
+    def store_O(
+        self,
+        mO: cute.Tensor,  # ((qhead_per_kvhead, seqlen_q), headdim)
+        tOrO: cute.Tensor,  # (m_block_size, head_dim_padded) split across threads according to gmem_tiled_copy
+        gmem_tiled_copy: cute.TiledCopy,
+        tidx: cutlass.Int32,
+        block: cutlass.Int32,
+        seqlen: cutlass.Int32,
+    ):
+        gmem_thr_copy = gmem_tiled_copy.get_slice(tidx)
+        cO = cute.make_identity_tensor((self.m_block_size, self.head_dim_padded))
+        tOcO = gmem_thr_copy.partition_S(cO)
+        t0OcO = gmem_thr_copy.get_slice(0).partition_S(cO)
+        tOpO = utils.predicate_k(tOcO, limit=mO.shape[1])
+        tOcO_row = tOcO[0, None, 0]
+        threads_per_row = gmem_tiled_copy.layout_tv_tiled.shape[0][0]
+        assert cute.arch.WARP_SIZE % threads_per_row == 0, "threads_per_row must divide WARP_SIZE"
+        num_threads = gmem_tiled_copy.size
+        tPrOPtr = self.compute_ptr(mO[None, 0], tOcO_row, tidx, block, threads_per_row, num_threads)
+        for m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+            o_ptr_i64 = utils.shuffle_sync(
+                tPrOPtr[m // threads_per_row], m % threads_per_row, width=threads_per_row
+            )
+            o_gmem_ptr = cute.make_ptr(
+                mO.element_type, o_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+            )
+            if (
+                t0OcO[0, m, 0][0]
+                < seqlen * self.qhead_per_kvhead - block * self.m_block_size - tOcO_row[0][0]
+            ):
+                mO_cur = cute.make_tensor(o_gmem_ptr, (self.head_dim_padded,))
+                elems_per_load = cute.size(tOrO.shape[0][0])
+                mO_cur_copy = cute.tiled_divide(mO_cur, (elems_per_load,))
+                for k in cutlass.range_constexpr(cute.size(tOrO.shape[2])):
+                    ki = tOcO[0, 0, k][1] // elems_per_load
+                    cute.copy(
+                        gmem_thr_copy,
+                        tOrO[None, m, k],
+                        mO_cur_copy[None, ki],
+                        pred=tOpO[None, m, k] if cutlass.const_expr(self.check_hdim_oob) else None,
+                    )

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/paged_kv.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/paged_kv.py
@@ -1,0 +1,246 @@
+from typing import Type
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import cpasync
+from cutlass import Int32, const_expr
+
+from flashrt_fa4.cute import utils
+from quack.cute_dsl_utils import ParamsBase
+from cutlass.cute import FastDivmodDivisor
+
+import math
+
+
+@dataclass
+class PagedKVManager(ParamsBase):
+    mPageTable: cute.Tensor
+    mK_paged: cute.Tensor
+    mV_paged: cute.Tensor
+    thread_idx: Int32
+
+    page_size_divmod: FastDivmodDivisor
+    seqlen_k: Int32
+    leftpad_k: Int32
+    n_block_size: Int32
+    num_threads: cutlass.Constexpr[Int32]
+    head_dim_padded: cutlass.Constexpr[Int32]
+    head_dim_v_padded: cutlass.Constexpr[Int32]
+
+    arch: cutlass.Constexpr[Int32]
+    v_gmem_transposed: cutlass.Constexpr[bool]
+
+    gmem_threads_per_row: cutlass.Constexpr[Int32]
+    page_entry_per_thread: Int32
+    async_copy_elems: Int32
+
+    gmem_tiled_copy_KV: cute.TiledCopy
+    gmem_thr_copy_KV: cute.TiledCopy
+    tPrPage: cute.Tensor
+    tPrPageOffset: cute.Tensor
+    tKpK: cute.Tensor
+    tVpV: cute.Tensor
+
+    @staticmethod
+    def create(
+        mPageTable: cute.Tensor,
+        mK_paged: cute.Tensor,
+        mV_paged: cute.Tensor,
+        page_size_divmod: FastDivmodDivisor,
+        bidb: Int32,
+        bidh: Int32,
+        thread_idx: Int32,
+        seqlen_k: Int32,
+        leftpad_k: Int32,
+        n_block_size: cutlass.Constexpr[Int32],
+        head_dim_padded: cutlass.Constexpr[Int32],
+        head_dim_v_padded: cutlass.Constexpr[Int32],
+        num_threads: cutlass.Constexpr[Int32],
+        dtype: Type[cutlass.Numeric],
+        arch: cutlass.Constexpr[int] = 100,
+    ):
+        # SM100 transposes V in gmem to (dv, page_size, num_pages);
+        # SM90 keeps V as (page_size, dv, num_pages), same layout as K.
+        v_gmem_transposed = arch != 90
+        universal_copy_bits = 128
+        async_copy_elems = universal_copy_bits // dtype.width
+        dtype_bytes = dtype.width // 8
+        gmem_k_block_size = math.gcd(
+            head_dim_padded,
+            head_dim_v_padded,
+            128 // dtype_bytes,
+        )
+        assert gmem_k_block_size % async_copy_elems == 0
+        gmem_threads_per_row = gmem_k_block_size // async_copy_elems
+        assert cute.arch.WARP_SIZE % gmem_threads_per_row == 0
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            dtype,
+            num_bits_per_copy=universal_copy_bits,
+        )
+        thr_layout = cute.make_ordered_layout(
+            (num_threads // gmem_threads_per_row, gmem_threads_per_row),
+            order=(1, 0),
+        )
+        val_layout = cute.make_layout((1, async_copy_elems))
+        gmem_tiled_copy_KV = cute.make_tiled_copy_tv(atom_async_copy, thr_layout, val_layout)
+        gmem_thr_copy_KV = gmem_tiled_copy_KV.get_slice(thread_idx)
+        page_entry_per_thread = n_block_size // num_threads
+
+        tPrPage = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
+        tPrPageOffset = cute.make_rmem_tensor((page_entry_per_thread,), Int32)
+
+        mPageTable = mPageTable[bidb, None]
+        mK_paged = mK_paged[None, None, bidh, None]
+        mV_paged = mV_paged[None, None, bidh, None]
+
+        cK = cute.make_identity_tensor((n_block_size, head_dim_padded))
+        tKcK = gmem_thr_copy_KV.partition_S(cK)
+        tKpK = utils.predicate_k(tKcK, limit=mK_paged.shape[1])
+
+        if const_expr(head_dim_padded == head_dim_v_padded):
+            tVpV = tKpK
+        else:
+            cV = cute.make_identity_tensor((n_block_size, head_dim_v_padded))
+            tVcV = gmem_thr_copy_KV.partition_S(cV)
+            # When V is transposed in gmem, dv is shape[0]; otherwise dv is shape[1] (same as K)
+            tVpV = utils.predicate_k(tVcV, limit=mV_paged.shape[0 if v_gmem_transposed else 1])
+
+        return PagedKVManager(
+            mPageTable,
+            mK_paged,
+            mV_paged,
+            thread_idx,
+            page_size_divmod,
+            seqlen_k,
+            leftpad_k,
+            n_block_size,
+            num_threads,
+            head_dim_padded,
+            head_dim_v_padded,
+            arch,
+            v_gmem_transposed,
+            gmem_threads_per_row,
+            page_entry_per_thread,
+            async_copy_elems,
+            gmem_tiled_copy_KV,
+            gmem_thr_copy_KV,
+            tPrPage,
+            tPrPageOffset,
+            tKpK,
+            tVpV,
+        )
+
+    @cute.jit
+    def load_page_table(self, n_block: Int32):
+        for i in cutlass.range(self.page_entry_per_thread, unroll=1):
+            row = (
+                i * self.num_threads
+                + (self.thread_idx % self.gmem_threads_per_row)
+                * (self.num_threads // self.gmem_threads_per_row)
+                + (self.thread_idx // self.gmem_threads_per_row)
+            )
+            row_idx = n_block * self.n_block_size + row
+
+            page_idx, page_offset = divmod(row_idx + self.leftpad_k, self.page_size_divmod)
+
+            is_valid = (
+                (i + 1) * self.num_threads <= self.n_block_size or row < self.n_block_size
+            ) and row_idx < self.seqlen_k
+            page = self.mPageTable[page_idx] if is_valid else 0
+
+            self.tPrPage[i] = page
+            self.tPrPageOffset[i] = page_offset
+
+    @cute.jit
+    def compute_X_ptr(self, K_or_V: str):
+        tPrXPtr = cute.make_rmem_tensor((self.page_entry_per_thread,), cutlass.Int64)
+        mX = self.mK_paged if const_expr(K_or_V == "K") else self.mV_paged
+        # K is always (page_size, d, num_pages). V matches K when not transposed,
+        # but is (dv, page_size, num_pages) when transposed (SM100).
+        transposed = const_expr(K_or_V == "V" and self.v_gmem_transposed)
+        for i in cutlass.range(self.page_entry_per_thread, unroll=1):
+            page = self.tPrPage[i]
+            page_offset = self.tPrPageOffset[i]
+            if const_expr(transposed):
+                tPrXPtr[i] = utils.elem_pointer(mX, (0, page_offset, page)).toint()
+            else:
+                tPrXPtr[i] = utils.elem_pointer(mX, (page_offset, 0, page)).toint()
+        return tPrXPtr
+
+    @cute.jit
+    def _flatten_smem_sm100(self, sX: cute.Tensor, K_or_V: str):
+        """Flatten SM100 smem ((a,b), cta_split, k) to (a,(b,k)); transpose V to (d,page_size)."""
+        sX_pi = cute.make_tensor(
+            sX.iterator,
+            cute.make_layout(
+                (sX.shape[0][0], (sX.shape[0][1], sX.shape[2])),
+                stride=(sX.stride[0][0], (sX.stride[0][1], sX.stride[2])),
+            ),
+        )
+        if const_expr(K_or_V == "V"):
+            sX_pi = cute.make_tensor(sX_pi.iterator, cute.select(sX_pi.layout, mode=[1, 0]))
+        return sX_pi
+
+    @cute.jit
+    def _copy_row_async(
+        self,
+        tXsX: cute.Tensor,
+        tXcX: cute.Tensor,
+        mX_paged_cur_copy: cute.Tensor,
+        m: Int32,
+        should_load: cute.Tensor,
+    ):
+        """Issue cp.async copies for one row across all k-tiles."""
+        for k in cutlass.range_constexpr(cute.size(tXsX, mode=[2])):
+            ki = tXcX[0, 0, k][1] // self.async_copy_elems
+            mX_paged_cur_copy_ki = mX_paged_cur_copy[None, ki]
+            tXsX_k = tXsX[None, m, k]
+            mX_paged_cur_copy_ki = cute.make_tensor(mX_paged_cur_copy_ki.iterator, tXsX_k.layout)
+            cute.copy(
+                self.gmem_tiled_copy_KV,
+                mX_paged_cur_copy_ki,
+                tXsX_k,
+                pred=should_load,
+            )
+
+    @cute.jit
+    def load_KV(self, n_block: Int32, sX: cute.Tensor, K_or_V: str):
+        assert K_or_V in ("K", "V")
+
+        tPrXPtr = self.compute_X_ptr(K_or_V)
+
+        if const_expr(self.arch == 90):
+            # SM90: sX is already stage-sliced by caller (sK[None, None, stage]).
+            # Flatten hierarchical modes to get (n_block_size, head_dim).
+            sX_pi = cute.group_modes(sX, 0, 1)
+            # SM90 does NOT transpose V here (it's transposed via utils.transpose_view before MMA)
+        else:
+            sX_pi = self._flatten_smem_sm100(sX, K_or_V)
+
+        head_dim = self.head_dim_v_padded if const_expr(K_or_V == "V") else self.head_dim_padded
+        cX = cute.make_identity_tensor((self.n_block_size, head_dim))
+        tXsX = self.gmem_thr_copy_KV.partition_D(sX_pi)
+        tXcX = self.gmem_thr_copy_KV.partition_S(cX)
+        tXc0X = self.gmem_thr_copy_KV.get_slice(0).partition_S(cX)
+
+        seqlenk_row_limit = (
+            self.seqlen_k - n_block * self.n_block_size - tXcX[0][0] if n_block >= 0 else 0
+        )
+        for m in cutlass.range_constexpr(cute.size(tXsX, mode=[1])):
+            row_valid = tXc0X[0, m, 0][0] < seqlenk_row_limit
+            should_load = cute.make_fragment_like(tXsX[(0, None), m, 0], cute.Boolean)
+            should_load.fill(row_valid)
+
+            x_ptr_i64 = utils.shuffle_sync(
+                tPrXPtr[m // self.gmem_threads_per_row],
+                m % self.gmem_threads_per_row,
+                width=self.gmem_threads_per_row,
+            )
+            x_gmem_ptr = cute.make_ptr(
+                self.mK_paged.element_type, x_ptr_i64, cute.AddressSpace.gmem, assumed_align=16
+            )
+            mX_paged_cur = cute.make_tensor(x_gmem_ptr, cute.make_layout((head_dim,)))
+            mX_paged_cur_copy = cute.tiled_divide(mX_paged_cur, (self.async_copy_elems,))
+            self._copy_row_async(tXsX, tXcX, mX_paged_cur_copy, m, should_load)

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/pipeline.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/pipeline.py
@@ -1,0 +1,402 @@
+# Copyright (c) 2025, Tri Dao.
+
+from typing import Optional
+from dataclasses import dataclass
+
+import cutlass.cute as cute
+from cutlass import Boolean, Int32, const_expr
+from cutlass.cutlass_dsl import if_generate, dsl_user_op
+from cutlass.pipeline import PipelineState
+from cutlass.pipeline import PipelineUserType
+from cutlass.pipeline import NamedBarrier as NamedBarrierOg
+from cutlass.pipeline import PipelineAsync as PipelineAsyncOg
+from cutlass.pipeline import PipelineCpAsync as PipelineCpAsyncOg
+from cutlass.pipeline import PipelineTmaAsync as PipelineTmaAsyncOg
+from cutlass.pipeline import PipelineTmaUmma as PipelineTmaUmmaOg
+from cutlass.pipeline import PipelineUmmaAsync as PipelineUmmaAsyncOg
+from cutlass.pipeline import PipelineAsyncUmma as PipelineAsyncUmmaOg
+
+
+def _override_create(parent_cls, child_cls):
+    """Create a static factory that constructs parent_cls then re-classes to child_cls."""
+
+    @staticmethod
+    def create(*args, **kwargs):
+        obj = parent_cls.create(*args, **kwargs)
+        # Can't assign to __class__ directly since the dataclass is frozen
+        object.__setattr__(obj, "__class__", child_cls)
+        return obj
+
+    return create
+
+
+def _make_state(index: Int32, phase: Int32) -> PipelineState:
+    """Construct a PipelineState from index and phase (count/stages unused by callers)."""
+    return PipelineState(stages=0, count=Int32(0), index=index, phase=phase)
+
+
+class PipelineStateSimple:
+    """
+    Pipeline state contains an index and phase bit corresponding to the current position in the circular buffer.
+    Use a single Int32 to store both the index and phase bit, then we use divmod to get the
+    index and phase. If stages is a power of 2, divmod turns into bit twiddling.
+    """
+
+    def __init__(self, stages: int, phase_index: Int32):
+        self._stages = stages
+        self._phase_index = phase_index
+
+    def clone(self) -> "PipelineStateSimple":
+        return PipelineStateSimple(self.stages, self._phase_index)
+
+    @property
+    def stages(self) -> int:
+        return self._stages
+
+    @property
+    def index(self) -> Int32:
+        if const_expr(self._stages == 1):
+            return Int32(0)
+        else:
+            return self._phase_index % self._stages
+
+    @property
+    def phase(self) -> Int32:
+        # PTX docs say that the phase parity needs to be 0 or 1, so by right we need to
+        # take modulo 2. But in practice just passing the phase in without modulo works fine.
+        if const_expr(self._stages == 1):
+            return self._phase_index
+        else:
+            return self._phase_index // self._stages
+
+    def advance(self):
+        if const_expr(self._stages == 1):
+            self._phase_index ^= 1
+        else:
+            self._phase_index += 1
+
+    def __extract_mlir_values__(self):
+        phase_index = self._phase_index
+        return [phase_index.ir_value()]
+
+    def __new_from_mlir_values__(self, values):
+        return PipelineStateSimple(self.stages, Int32(values[0]))
+
+
+def make_pipeline_state(type: PipelineUserType, stages: int):
+    """
+    Creates a pipeline state. Producers are assumed to start with an empty buffer and have a flipped phase bit of 1.
+    """
+    if type is PipelineUserType.Producer:
+        return PipelineStateSimple(stages, Int32(stages))
+    elif type is PipelineUserType.Consumer:
+        return PipelineStateSimple(stages, Int32(0))
+    else:
+        assert False, "Error: invalid PipelineUserType specified for make_pipeline_state."
+
+
+# ── Shared helpers ───────────────────────────────────────────────────────────
+
+
+def _call_with_elect_one(parent_method, self, state, elect_one, syncwarp, loc, ip):
+    """Optionally wrap a parent pipeline method call in sync_warp + elect_one."""
+    if const_expr(elect_one):
+        if const_expr(syncwarp):
+            cute.arch.sync_warp()
+        with cute.arch.elect_one():
+            parent_method(self, state, loc=loc, ip=ip)
+    else:
+        parent_method(self, state, loc=loc, ip=ip)
+
+
+# ── Mixin: _w_index / _w_index_phase variants that delegate to parent ───────
+# Each parent class has PipelineState-based methods (producer_acquire, producer_commit,
+# consumer_wait, consumer_release). The _w_index_phase variants just construct a
+# PipelineState from (index, phase) and delegate.
+
+
+class _PipelineIndexPhaseMixin:
+    """Mixin providing _w_index_phase / _w_index methods that delegate to PipelineState-based parents."""
+
+    @dsl_user_op
+    def producer_acquire_w_index_phase(
+        self,
+        index: Int32,
+        phase: Int32,
+        try_acquire_token: Optional[Boolean] = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        state = _make_state(index, phase)
+        # Call the parent's producer_acquire (which takes PipelineState)
+        self.producer_acquire(state, try_acquire_token, loc=loc, ip=ip)
+
+    @dsl_user_op
+    def producer_commit_w_index(self, index: Int32, *, loc=None, ip=None):
+        state = _make_state(index, Int32(0))
+        self.producer_commit(state, loc=loc, ip=ip)
+
+    @dsl_user_op
+    def consumer_wait_w_index_phase(
+        self,
+        index: Int32,
+        phase: Int32,
+        try_wait_token: Optional[Boolean] = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        state = _make_state(index, phase)
+        self.consumer_wait(state, try_wait_token, loc=loc, ip=ip)
+
+    @dsl_user_op
+    def consumer_release_w_index(self, index: Int32, *, loc=None, ip=None):
+        state = _make_state(index, Int32(0))
+        self.consumer_release(state, loc=loc, ip=ip)
+
+
+# ── NamedBarrier ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class NamedBarrier(NamedBarrierOg):
+    create = _override_create(NamedBarrierOg, None)  # patched below
+
+    @dsl_user_op
+    def arrive_w_index(self, index: Int32, *, loc=None, ip=None) -> None:
+        """
+        The aligned flavor of arrive is used when all threads in the CTA will execute the
+        same instruction. See PTX documentation.
+        """
+        cute.arch.barrier_arrive(
+            barrier_id=self.barrier_id + index,
+            number_of_threads=self.num_threads,
+            loc=loc,
+            ip=ip,
+        )
+
+    @dsl_user_op
+    def arrive_and_wait_w_index(self, index: Int32, *, loc=None, ip=None) -> None:
+        cute.arch.barrier(
+            barrier_id=self.barrier_id + index,
+            number_of_threads=self.num_threads,
+            loc=loc,
+            ip=ip,
+        )
+
+
+NamedBarrier.create = _override_create(NamedBarrierOg, NamedBarrier)
+
+
+# ── PipelineAsync ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PipelineAsync(_PipelineIndexPhaseMixin, PipelineAsyncOg):
+    """
+    PipelineAsync with optional elect_one for producer_commit and consumer_release.
+
+    When elect_one_*=True (set at create time), only one elected thread per warp
+    signals the barrier arrive. This is useful when the mask count is set to 1 per warp.
+
+    Args (to create):
+        elect_one_commit: If True, only elected thread signals producer_commit.
+        syncwarp_before_commit: If True (default), issue syncwarp before elect_one.
+        elect_one_release: If True, only elected thread signals consumer_release.
+        syncwarp_before_release: If True (default), issue syncwarp before elect_one.
+            Set syncwarp to False when threads are already converged (e.g. after wgmma wait_group).
+    """
+
+    _elect_one_commit: bool = False
+    _syncwarp_before_commit: bool = True
+    _elect_one_release: bool = False
+    _syncwarp_before_release: bool = True
+
+    @staticmethod
+    def create(
+        *args,
+        elect_one_commit: bool = False,
+        syncwarp_before_commit: bool = True,
+        elect_one_release: bool = False,
+        syncwarp_before_release: bool = True,
+        **kwargs,
+    ):
+        obj = PipelineAsyncOg.create(*args, **kwargs)
+        object.__setattr__(obj, "__class__", PipelineAsync)
+        object.__setattr__(obj, "_elect_one_commit", elect_one_commit)
+        object.__setattr__(obj, "_syncwarp_before_commit", syncwarp_before_commit)
+        object.__setattr__(obj, "_elect_one_release", elect_one_release)
+        object.__setattr__(obj, "_syncwarp_before_release", syncwarp_before_release)
+        return obj
+
+    @dsl_user_op
+    def producer_commit(self, state: PipelineState, *, loc=None, ip=None):
+        _call_with_elect_one(
+            PipelineAsyncOg.producer_commit,
+            self,
+            state,
+            self._elect_one_commit,
+            self._syncwarp_before_commit,
+            loc,
+            ip,
+        )
+
+    @dsl_user_op
+    def consumer_release(self, state: PipelineState, *, loc=None, ip=None):
+        _call_with_elect_one(
+            PipelineAsyncOg.consumer_release,
+            self,
+            state,
+            self._elect_one_release,
+            self._syncwarp_before_release,
+            loc,
+            ip,
+        )
+
+    # _w_index variants inherited from _PipelineIndexPhaseMixin, which delegate
+    # to producer_commit / consumer_release above.
+
+
+# ── PipelineCpAsync ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PipelineCpAsync(_PipelineIndexPhaseMixin, PipelineCpAsyncOg):
+    _elect_one_release: bool = False
+    _syncwarp_before_release: bool = True
+
+    @staticmethod
+    def create(
+        *args,
+        elect_one_release: bool = False,
+        syncwarp_before_release: bool = True,
+        **kwargs,
+    ):
+        obj = PipelineCpAsyncOg.create(*args, **kwargs)
+        object.__setattr__(obj, "__class__", PipelineCpAsync)
+        object.__setattr__(obj, "_elect_one_release", elect_one_release)
+        object.__setattr__(obj, "_syncwarp_before_release", syncwarp_before_release)
+        return obj
+
+    @dsl_user_op
+    def consumer_release(self, state: PipelineState, *, loc=None, ip=None):
+        _call_with_elect_one(
+            PipelineCpAsyncOg.consumer_release,
+            self,
+            state,
+            self._elect_one_release,
+            self._syncwarp_before_release,
+            loc,
+            ip,
+        )
+
+    # _w_index variants inherited from _PipelineIndexPhaseMixin.
+
+
+# ── PipelineTmaAsync ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PipelineTmaAsync(_PipelineIndexPhaseMixin, PipelineTmaAsyncOg):
+    """Override producer_acquire to take in extra_tx_count parameter."""
+
+    @dsl_user_op
+    def producer_acquire(
+        self,
+        state: PipelineState,
+        try_acquire_token: Optional[Boolean] = None,
+        extra_tx_count: int = 0,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        TMA producer commit conditionally waits on buffer empty and sets the transaction barrier for leader threadblocks.
+        """
+        if_generate(
+            try_acquire_token is None or try_acquire_token == 0,
+            lambda: self.sync_object_empty.wait(state.index, state.phase, loc=loc, ip=ip),
+            loc=loc,
+            ip=ip,
+        )
+        if const_expr(extra_tx_count == 0):
+            self.sync_object_full.arrive(state.index, self.producer_mask, loc=loc, ip=ip)
+        else:
+            tx_count = self.sync_object_full.tx_count + extra_tx_count
+            self.sync_object_full.arrive_and_expect_tx(state.index, tx_count, loc=loc, ip=ip)
+
+
+PipelineTmaAsync.create = _override_create(PipelineTmaAsyncOg, PipelineTmaAsync)
+
+
+# ── PipelineTmaUmma ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PipelineTmaUmma(_PipelineIndexPhaseMixin, PipelineTmaUmmaOg):
+    """Override producer_acquire to take in extra_tx_count parameter."""
+
+    @dsl_user_op
+    def producer_acquire(
+        self,
+        state: PipelineState,
+        try_acquire_token: Optional[Boolean] = None,
+        extra_tx_count: int = 0,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        TMA producer commit conditionally waits on buffer empty and sets the transaction barrier for leader threadblocks.
+        """
+        if_generate(
+            try_acquire_token is None or try_acquire_token == 0,
+            lambda: self.sync_object_empty.wait(state.index, state.phase, loc=loc, ip=ip),
+            loc=loc,
+            ip=ip,
+        )
+        if const_expr(extra_tx_count == 0):
+            if_generate(
+                self.is_leader_cta,
+                lambda: self.sync_object_full.arrive(
+                    state.index, self.producer_mask, loc=loc, ip=ip
+                ),
+                loc=loc,
+                ip=ip,
+            )
+        else:
+            tx_count = self.sync_object_full.tx_count + extra_tx_count
+            if_generate(
+                self.is_leader_cta,
+                lambda: self.sync_object_full.arrive_and_expect_tx(
+                    state.index, tx_count, loc=loc, ip=ip
+                ),
+                loc=loc,
+                ip=ip,
+            )
+
+
+PipelineTmaUmma.create = _override_create(PipelineTmaUmmaOg, PipelineTmaUmma)
+
+
+# ── PipelineUmmaAsync ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PipelineUmmaAsync(_PipelineIndexPhaseMixin, PipelineUmmaAsyncOg):
+    pass
+
+
+PipelineUmmaAsync.create = _override_create(PipelineUmmaAsyncOg, PipelineUmmaAsync)
+
+
+# ── PipelineAsyncUmma ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PipelineAsyncUmma(_PipelineIndexPhaseMixin, PipelineAsyncUmmaOg):
+    pass
+
+
+PipelineAsyncUmma.create = _override_create(PipelineAsyncUmmaOg, PipelineAsyncUmma)

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/seqlen_info.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/seqlen_info.py
@@ -1,0 +1,287 @@
+from typing import Optional
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Int32, const_expr
+
+from quack import copy_utils
+
+"""
+This consolidates all the info related to sequence length. This is so that we can do all
+the gmem reads once at the beginning of each tile, rather than having to repeat these reads
+to compute various things like n_block_min, n_block_max, etc.
+"""
+
+
+@dataclass(frozen=True)
+class SeqlenInfo:
+    offset: Int32
+    offset_padded: Int32
+    seqlen: Int32
+    has_cu_seqlens: cutlass.Constexpr[bool] = False
+
+    @staticmethod
+    def create(
+        batch_idx: Int32,
+        seqlen_static: Int32,
+        cu_seqlens: Optional[cute.Tensor] = None,
+        seqused: Optional[cute.Tensor] = None,
+        tile: cutlass.Constexpr[int] = 128,
+    ):
+        offset = 0 if const_expr(cu_seqlens is None) else cu_seqlens[batch_idx]
+        offset_padded = (
+            0
+            if const_expr(cu_seqlens is None)
+            # Add divby so that the compiler knows the alignment when moving by offset_padded
+            else cute.assume((offset + batch_idx * tile) // tile * tile, divby=tile)
+        )
+        if const_expr(seqused is not None):
+            seqlen = seqused[batch_idx]
+        elif const_expr(cu_seqlens is not None):
+            seqlen = cu_seqlens[batch_idx + 1] - cu_seqlens[batch_idx]
+        else:
+            seqlen = seqlen_static
+        return SeqlenInfo(offset, offset_padded, seqlen, has_cu_seqlens=cu_seqlens is not None)
+
+    def offset_batch(
+        self,
+        mT: cute.Tensor,
+        batch_idx: Int32,
+        dim: int,
+        padded: cutlass.Constexpr[bool] = False,
+        multiple: int = 1,
+    ) -> cute.Tensor:
+        """Offset a tensor by batch index. batch dim is at position `dim`, seqlen is at dim=0."""
+        if const_expr(not self.has_cu_seqlens):
+            idx = (None,) * dim + (batch_idx,) + (None,) * (cute.rank(mT) - 1 - dim)
+            return mT[idx]
+        else:
+            off = multiple * (self.offset if const_expr(not padded) else self.offset_padded)
+            offset = off if const_expr(cute.rank(mT.shape[0]) == 1) else (0, off)
+            idx = (offset,) + (None,) * (cute.rank(mT) - 1)
+            return cute.domain_offset(idx, mT)
+
+
+@dataclass(frozen=True)
+class SeqlenInfoQK:
+    offset_q: Int32
+    offset_k: Int32
+    padded_offset_q: Int32
+    padded_offset_k: Int32
+    seqlen_q: Int32
+    seqlen_k: Int32
+    has_cu_seqlens_q: cutlass.Constexpr[bool]
+    has_cu_seqlens_k: cutlass.Constexpr[bool]
+    has_seqused_q: cutlass.Constexpr[bool]
+    has_seqused_k: cutlass.Constexpr[bool]
+
+    @staticmethod
+    def create(
+        batch_idx: Int32,
+        seqlen_q_static: Int32,
+        seqlen_k_static: Int32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        tile_m: cutlass.Constexpr[Int32] = 128,
+        tile_n: cutlass.Constexpr[Int32] = 128,
+    ):
+        offset_q = 0 if const_expr(mCuSeqlensQ is None) else mCuSeqlensQ[batch_idx]
+        offset_k = 0 if const_expr(mCuSeqlensK is None) else mCuSeqlensK[batch_idx]
+        padded_offset_q = (
+            0
+            if const_expr(mCuSeqlensQ is None)
+            else cute.assume((offset_q + batch_idx * tile_m) // tile_m * tile_m, divby=tile_m)
+        )
+        padded_offset_k = (
+            0
+            if const_expr(mCuSeqlensK is None)
+            else cute.assume((offset_k + batch_idx * tile_n) // tile_n * tile_n, divby=tile_n)
+        )
+        if const_expr(mSeqUsedQ is not None):
+            seqlen_q = mSeqUsedQ[batch_idx]
+        else:
+            seqlen_q = (
+                seqlen_q_static
+                if const_expr(mCuSeqlensQ is None)
+                else mCuSeqlensQ[batch_idx + 1] - offset_q
+            )
+        if const_expr(mSeqUsedK is not None):
+            seqlen_k = mSeqUsedK[batch_idx]
+        else:
+            seqlen_k = (
+                seqlen_k_static
+                if const_expr(mCuSeqlensK is None)
+                else mCuSeqlensK[batch_idx + 1] - offset_k
+            )
+        return SeqlenInfoQK(
+            offset_q,
+            offset_k,
+            padded_offset_q,
+            padded_offset_k,
+            seqlen_q,
+            seqlen_k,
+            has_cu_seqlens_q=mCuSeqlensQ is not None,
+            has_cu_seqlens_k=mCuSeqlensK is not None,
+            has_seqused_q=mSeqUsedQ is not None,
+            has_seqused_k=mSeqUsedK is not None,
+        )
+
+    def offset_batch_Q(
+        self,
+        mQ: cute.Tensor,
+        batch_idx: Int32,
+        dim: int,
+        padded: cutlass.Constexpr[bool] = False,
+        ragged: cutlass.Constexpr[bool] = False,
+    ) -> cute.Tensor:
+        """Seqlen must be the first dimension of mQ"""
+        if const_expr(not ragged):
+            if const_expr(not self.has_cu_seqlens_q):
+                idx = (None,) * dim + (batch_idx,) + (None,) * (cute.rank(mQ) - 1 - dim)
+                return mQ[idx]
+            else:
+                offset_q = self.offset_q if const_expr(not padded) else self.padded_offset_q
+                offset_q = offset_q if const_expr(cute.rank(mQ.shape[0]) == 1) else (None, offset_q)
+                idx = (offset_q,) + (None,) * (cute.rank(mQ) - 1)
+                return cute.domain_offset(idx, mQ)
+        else:
+            if const_expr(not self.has_cu_seqlens_q):
+                offset_q = 0
+                idx = (None,) * dim + (batch_idx,) + (None,) * (cute.rank(mQ) - 1 - dim)
+                mQ = mQ[idx]
+            else:
+                offset_q = self.offset_q if const_expr(not padded) else self.padded_offset_q
+            if const_expr(cute.rank(mQ.shape[0]) == 1):
+                return copy_utils.offset_ragged_tensor(
+                    mQ, offset_q, self.seqlen_q, ragged_dim=0, ptr_shift=True
+                )
+            else:  # PackGQA
+                assert cute.rank(mQ.shape[0]) == 2
+                # Unpack before calling offset_ragged_tensor, then pack
+                idx = ((None, None),) + (None,) * (cute.rank(mQ) - 1)
+                mQ = mQ[idx]
+                mQ = copy_utils.offset_ragged_tensor(
+                    mQ, offset_q, self.seqlen_q, ragged_dim=1, ptr_shift=True
+                )
+                return cute.group_modes(mQ, 0, 2)
+
+    def offset_batch_K(
+        self,
+        mK: cute.Tensor,
+        batch_idx: Int32,
+        dim: int,
+        padded: cutlass.Constexpr[bool] = False,
+        ragged: cutlass.Constexpr[bool] = False,
+        multiple: int = 1,
+    ) -> cute.Tensor:
+        """Seqlen must be the first dimension of mK"""
+        if const_expr(not ragged):
+            if const_expr(not self.has_cu_seqlens_k):
+                idx = (None,) * dim + (batch_idx,) + (None,) * (cute.rank(mK) - 1 - dim)
+                return mK[idx]
+            else:
+                offset_k = self.offset_k if const_expr(not padded) else self.padded_offset_k
+                offset_k *= multiple
+                idx = (offset_k,) + (None,) * (cute.rank(mK) - 1)
+                return cute.domain_offset(idx, mK)
+        else:
+            if const_expr(not self.has_cu_seqlens_k):
+                offset_k = 0
+                idx = (None,) * dim + (batch_idx,) + (None,) * (cute.rank(mK) - 1 - dim)
+                mK = mK[idx]
+            else:
+                offset_k = self.offset_k if const_expr(not padded) else self.padded_offset_k
+                offset_k *= multiple
+            return copy_utils.offset_ragged_tensor(
+                mK, offset_k, self.seqlen_k, ragged_dim=0, ptr_shift=True
+            )
+
+
+@dataclass(frozen=True)
+class SeqlenInfoQKNewK:
+    """Sequence length info for append-KV with left-padding and new K support.
+
+    Extends SeqlenInfoQK with:
+    - leftpad_k: left padding for K (tokens to skip at the start of the KV cache)
+    - offset_k_new: offset into the new K tensor
+    - seqlen_k_og: original K length (before appending new K), excluding leftpad
+    - seqlen_k_new: length of new K to append
+    - seqlen_k: total K length (seqlen_k_og + seqlen_k_new)
+    - seqlen_rotary: position for rotary embedding computation
+    """
+
+    leftpad_k: Int32
+    offset_q: Int32
+    offset_k: Int32
+    offset_k_new: Int32
+    seqlen_q: Int32
+    seqlen_k_og: Int32
+    seqlen_k_new: Int32
+    seqlen_k: Int32
+    seqlen_rotary: Int32
+
+    @staticmethod
+    def create(
+        batch_idx: Int32,
+        seqlen_q_static: Int32,
+        seqlen_k_static: Int32,
+        shape_K_new_0: Int32,
+        mCuSeqlensQ: Optional[cute.Tensor] = None,
+        mCuSeqlensK: Optional[cute.Tensor] = None,
+        mCuSeqlensKNew: Optional[cute.Tensor] = None,
+        mSeqUsedQ: Optional[cute.Tensor] = None,
+        mSeqUsedK: Optional[cute.Tensor] = None,
+        mLeftpadK: Optional[cute.Tensor] = None,
+        mSeqlensRotary: Optional[cute.Tensor] = None,
+    ):
+        leftpad_k = 0 if const_expr(mLeftpadK is None) else mLeftpadK[batch_idx]
+        offset_q = 0 if const_expr(mCuSeqlensQ is None) else mCuSeqlensQ[batch_idx]
+        if const_expr(mCuSeqlensK is not None):
+            offset_k = mCuSeqlensK[batch_idx] + leftpad_k
+        else:
+            offset_k = leftpad_k if const_expr(mCuSeqlensQ is not None) else 0
+        offset_k_new = 0 if const_expr(mCuSeqlensKNew is None) else mCuSeqlensKNew[batch_idx]
+        # seqlen_q
+        if const_expr(mSeqUsedQ is not None):
+            seqlen_q = mSeqUsedQ[batch_idx]
+        elif const_expr(mCuSeqlensQ is not None):
+            seqlen_q = mCuSeqlensQ[batch_idx + 1] - mCuSeqlensQ[batch_idx]
+        else:
+            seqlen_q = seqlen_q_static
+        # seqlen_k_og: original K length (excluding leftpad)
+        if const_expr(mSeqUsedK is not None):
+            seqlen_k_og = mSeqUsedK[batch_idx] - leftpad_k
+        elif const_expr(mCuSeqlensK is not None):
+            seqlen_k_og = mCuSeqlensK[batch_idx + 1] - mCuSeqlensK[batch_idx] - leftpad_k
+        else:
+            seqlen_k_og = (
+                seqlen_k_static - leftpad_k
+                if const_expr(mCuSeqlensQ is not None)
+                else seqlen_k_static
+            )
+        # seqlen_k_new
+        if const_expr(mCuSeqlensKNew is None):
+            seqlen_k_new = 0 if const_expr(mCuSeqlensQ is None) else shape_K_new_0
+        else:
+            seqlen_k_new = mCuSeqlensKNew[batch_idx + 1] - mCuSeqlensKNew[batch_idx]
+        seqlen_k = seqlen_k_og if const_expr(mCuSeqlensQ is None) else seqlen_k_og + seqlen_k_new
+
+        # seqlen_rotary: defaults to seqlen_k_og + leftpad_k unless explicitly provided
+        if const_expr(mSeqlensRotary is not None):
+            seqlen_rotary = mSeqlensRotary[batch_idx]
+        else:
+            seqlen_rotary = seqlen_k_og + leftpad_k
+        return SeqlenInfoQKNewK(
+            leftpad_k,
+            offset_q,
+            offset_k,
+            offset_k_new,
+            seqlen_q,
+            seqlen_k_og,
+            seqlen_k_new,
+            seqlen_k,
+            seqlen_rotary,
+        )

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/softmax.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/softmax.py
@@ -1,0 +1,628 @@
+# Copyright (c) 2025, Tri Dao.
+
+import math
+import operator
+from typing import Tuple
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32, Boolean
+
+from quack import layout_utils
+import flashrt_fa4.cute.utils as utils
+from quack.cute_dsl_utils import ParamsBase
+from flashrt_fa4.cute.seqlen_info import SeqlenInfoQK
+
+
+@dataclass
+class Softmax(ParamsBase):
+    scale_log2: Float32
+    num_rows: cutlass.Constexpr[int]
+    row_max: cute.Tensor
+    row_sum: cute.Tensor
+    arch: cutlass.Constexpr[int] = 80
+    softmax_scale: Float32 | None = None
+
+    @staticmethod
+    def create(
+        scale_log2: Float32,
+        num_rows: cutlass.Constexpr[int],
+        arch: cutlass.Constexpr[int] = 80,
+        softmax_scale: Float32 | None = None,
+    ):
+        row_max = cute.make_rmem_tensor(num_rows, Float32)
+        row_sum = cute.make_rmem_tensor(num_rows, Float32)
+        return Softmax(scale_log2, num_rows, row_max, row_sum, arch, softmax_scale)
+
+    def reset(self) -> None:
+        self.row_max.fill(-Float32.inf)
+        self.row_sum.fill(0.0)
+
+    def _compute_row_max(
+        self, acc_S_row: cute.TensorSSA, init_val: float | Float32 | None = None
+    ) -> Float32:
+        return utils.fmax_reduce(acc_S_row, init_val, arch=self.arch)
+
+    def _compute_row_sum(
+        self, acc_S_row_exp: cute.TensorSSA, init_val: float | Float32 | None = None
+    ) -> Float32:
+        return utils.fadd_reduce(acc_S_row_exp, init_val, arch=self.arch)
+
+    @cute.jit
+    def online_softmax(
+        self,
+        acc_S: cute.Tensor,
+        is_first: cutlass.Constexpr[bool] = False,
+        check_inf: cutlass.Constexpr[bool] = True,
+    ) -> cute.Tensor:
+        """Apply online softmax and return the row_scale to rescale O.
+
+        :param acc_S: acc_S tensor
+        :type acc_S: cute.Tensor
+        :param is_first: is first n_block
+        :type is_first: cutlass.Constexpr
+        """
+        # Change acc_S to M,N layout view.
+        acc_S_mn = layout_utils.reshape_acc_to_mn(acc_S)
+        row_scale = cute.make_fragment_like(self.row_max, Float32)
+
+        row_max = self.row_max
+        row_sum = self.row_sum
+        scale_log2 = self.scale_log2
+        arch = self.arch
+
+        # Each iteration processes one row of acc_S
+        for r in cutlass.range(cute.size(row_max), unroll_full=True):
+            acc_S_row = acc_S_mn[r, None].load()  # (n_block_size)
+
+            row_max_cur = utils.fmax_reduce(
+                acc_S_row,
+                init_val=row_max[r] if cutlass.const_expr(not is_first) else None,
+                arch=arch,
+            )
+
+            row_max_cur = cute.arch.warp_reduction_max(row_max_cur, threads_in_group=4)
+            # Update row_max before changing row_max_cur to safe value for -inf
+            row_max_prev = row_max[r]
+            row_max[r] = row_max_cur
+
+            if cutlass.const_expr(check_inf):
+                row_max_cur = 0.0 if row_max_cur == -Float32.inf else row_max_cur
+
+            if cutlass.const_expr(is_first):
+                row_max_cur_scaled = row_max_cur * scale_log2
+                acc_S_row_exp = cute.math.exp2(
+                    acc_S_row * scale_log2 - row_max_cur_scaled, fastmath=True
+                )
+                acc_S_row_sum = utils.fadd_reduce(acc_S_row_exp, init_val=None, arch=arch)
+                row_scale[r] = 1.0
+            else:
+                row_max_cur_scaled = row_max_cur * scale_log2
+                acc_S_row_exp = cute.math.exp2(
+                    acc_S_row * scale_log2 - row_max_cur_scaled, fastmath=True
+                )
+                # row_scale[r] = cute.math.exp2(row_max_prev * self.scale_log2 - row_max_cur_scaled)
+                row_scale[r] = cute.math.exp2(
+                    (row_max_prev - row_max_cur) * scale_log2, fastmath=True
+                )
+                acc_S_row_sum = utils.fadd_reduce(
+                    acc_S_row_exp, init_val=row_sum[r] * row_scale[r], arch=arch
+                )
+
+            row_sum[r] = acc_S_row_sum
+            acc_S_mn[r, None].store(acc_S_row_exp)
+
+        return row_scale
+
+    @cute.jit
+    def finalize(
+        self, final_scale: Float32 = 1.0, sink_val: Float32 | cute.Tensor | None = None
+    ) -> cute.Tensor:
+        """Finalize the online softmax by computing the scale and logsumexp."""
+        if cutlass.const_expr(sink_val is not None and isinstance(sink_val, cute.Tensor)):
+            assert cute.size(sink_val) == cute.size(self.row_sum)
+        row_sum = self.row_sum
+        row_max = self.row_max
+        scale_log2 = self.scale_log2
+
+        # quad reduction for row_sum as we didn't do it during each iteration of online softmax
+        row_sum.store(utils.warp_reduce(row_sum.load(), operator.add, width=4))
+        row_scale = cute.make_fragment_like(row_max, Float32)
+
+        for r in cutlass.range(cute.size(row_sum), unroll_full=True):
+            if cutlass.const_expr(sink_val is not None):
+                sink_val_cur = sink_val if not isinstance(sink_val, cute.Tensor) else sink_val[r]
+                LOG2_E = math.log2(math.e)
+                row_sum[r] += cute.math.exp2(
+                    sink_val_cur * LOG2_E - row_max[r] * scale_log2, fastmath=True
+                )
+
+            # if row_sum is zero or nan, set acc_O_mn_row to 1.0
+            acc_O_mn_row_is_zero_or_nan = row_sum[r] == 0.0 or row_sum[r] != row_sum[r]
+            row_scale[r] = (
+                cute.arch.rcp_approx(row_sum[r] if not acc_O_mn_row_is_zero_or_nan else 1.0)
+            ) * final_scale
+            row_sum_cur = row_sum[r]
+            LN2 = math.log(2.0)
+            row_sum[r] = (
+                (row_max[r] * scale_log2 + cute.math.log2(row_sum_cur, fastmath=True)) * LN2
+                if not acc_O_mn_row_is_zero_or_nan
+                else -Float32.inf
+            )
+        return row_scale
+
+    @cute.jit
+    def rescale_O(self, acc_O: cute.Tensor, row_scale: cute.Tensor) -> None:
+        """Scale each row of acc_O by the given scale tensor.
+        :param acc_O: input tensor
+        :type acc_O: cute.Tensor
+        :param row_scale: row_scale tensor
+        :type row_scale: cute.Tensor
+        """
+        acc_O_mn = layout_utils.reshape_acc_to_mn(acc_O)
+        assert cute.size(row_scale) == cute.size(acc_O_mn, mode=[0])
+        for r in cutlass.range(cute.size(row_scale), unroll_full=True):
+            acc_O_mn[r, None].store(acc_O_mn[r, None].load() * row_scale[r])
+
+
+@dataclass
+class SoftmaxSm100(Softmax):
+    rescale_threshold: cutlass.Constexpr[float] = 0.0
+    max_offset: cutlass.Constexpr[int] = 0
+
+    @staticmethod
+    def create(
+        scale_log2: Float32,
+        rescale_threshold: cutlass.Constexpr[float] = 0.0,
+        softmax_scale: Float32 | None = None,
+        max_offset: cutlass.Constexpr[int] = 0,
+    ):
+        num_rows = 1
+        arch = 100
+        row_max = cute.make_rmem_tensor(num_rows, Float32)
+        row_sum = cute.make_rmem_tensor(num_rows, Float32)
+        return SoftmaxSm100(
+            scale_log2,
+            num_rows,
+            row_max,
+            row_sum,
+            arch,
+            softmax_scale,
+            rescale_threshold=rescale_threshold,
+            max_offset=max_offset,
+        )
+
+    @cute.jit
+    def compute_row_max_local(self, acc_S_row: cute.TensorSSA, is_first: Boolean) -> Float32:
+        if cutlass.const_expr(is_first):
+            row_max_new = self._compute_row_max(acc_S_row)
+        else:
+            row_max_old = self.row_max[0]
+            row_max_new = self._compute_row_max(acc_S_row, init_val=row_max_old)
+        return row_max_new
+
+    @cute.jit
+    def update_row_max_from_local(
+        self,
+        row_max_new: Float32,
+        is_first: Boolean,
+    ) -> Tuple[Float32, Float32]:
+        if cutlass.const_expr(is_first):
+            row_max_safe = row_max_new if row_max_new != -cutlass.Float32.inf else 0.0
+            acc_scale = 0.0
+        else:
+            row_max_old = self.row_max[0]
+            row_max_safe = row_max_new if row_max_new != -cutlass.Float32.inf else 0.0
+            acc_scale_ = (row_max_old - row_max_safe) * self.scale_log2
+            acc_scale = cute.math.exp2(acc_scale_)
+            if cutlass.const_expr(self.rescale_threshold > 0.0):
+                if acc_scale_ >= -self.rescale_threshold:
+                    row_max_new = row_max_old
+                    row_max_safe = row_max_old
+                    acc_scale = 1.0
+        self.row_max[0] = row_max_new
+        return row_max_safe, acc_scale
+
+    @cute.jit
+    def update_row_max(self, acc_S_row: cute.TensorSSA, is_first: int) -> Tuple[Float32, Float32]:
+        if cutlass.const_expr(is_first):
+            row_max_new = self._compute_row_max(acc_S_row)
+            row_max_safe = row_max_new if row_max_new != -cutlass.Float32.inf else 0.0
+            acc_scale = 0.0
+        else:
+            row_max_old = self.row_max[0]
+            row_max_new = self._compute_row_max(acc_S_row, init_val=row_max_old)
+            row_max_safe = row_max_new if row_max_new != -cutlass.Float32.inf else 0.0
+            acc_scale_ = (row_max_old - row_max_safe) * self.scale_log2
+            acc_scale = cute.math.exp2(acc_scale_, fastmath=True)
+            if cutlass.const_expr(self.rescale_threshold > 0.0):
+                if acc_scale_ >= -self.rescale_threshold:
+                    row_max_new = row_max_old
+                    row_max_safe = row_max_old
+                    acc_scale = 1.0
+        self.row_max[0] = row_max_new
+        return row_max_safe, acc_scale
+
+    def update_row_sum(
+        self, acc_S_row_exp: cute.TensorSSA, row_scale: Float32, is_first: int = False
+    ) -> None:
+        init_val = self.row_sum[0] * row_scale if cutlass.const_expr(not is_first) else None
+        # self.row_sum[0] = self._compute_row_sum(acc_S_row_exp, init_val=self.row_sum[0] * row_scale)
+        self.row_sum[0] = self._compute_row_sum(acc_S_row_exp, init_val=init_val)
+        # tmp = self._compute_row_sum(acc_S_row_exp)
+        # self.row_sum[0] = self.row_sum[0] * row_scale + tmp
+
+    @cute.jit
+    def scale_subtract_rowmax(
+        self,
+        acc_S_row: cute.Tensor,
+        row_max: Float32,
+    ):
+        assert cute.size(acc_S_row.shape) % 2 == 0, "acc_S_row must have an even number of elements"
+        row_max_scaled = row_max * self.scale_log2
+        max_offset = Float32(self.max_offset)
+        bias = max_offset - row_max_scaled
+        for i in cutlass.range(0, cute.size(acc_S_row.shape), 2, unroll_full=True):
+            acc_S_row[i], acc_S_row[i + 1] = cute.arch.fma_packed_f32x2(
+                (acc_S_row[i], acc_S_row[i + 1]),
+                (self.scale_log2, self.scale_log2),
+                (bias, bias),
+            )
+
+    @cute.jit
+    def apply_exp2_convert(
+        self,
+        acc_S_row: cute.Tensor,
+        acc_S_row_converted: cute.Tensor,
+        ex2_emu_freq: cutlass.Constexpr[int] = 0,
+        ex2_emu_res: cutlass.Constexpr[int] = 4,
+        ex2_emu_start_frg: cutlass.Constexpr[int] = 0,
+    ):
+        assert cute.size(acc_S_row.shape) % 2 == 0, "acc_S_row must have an even number of elements"
+        frg_tile = 32
+        assert frg_tile % 2 == 0
+        frg_cnt = cute.size(acc_S_row) // frg_tile
+        assert cute.size(acc_S_row) % frg_tile == 0
+        acc_S_row_frg = cute.logical_divide(acc_S_row, cute.make_layout(frg_tile))
+        acc_S_row_converted_frg = cute.logical_divide(
+            acc_S_row_converted, cute.make_layout(frg_tile)
+        )
+        for j in cutlass.range_constexpr(frg_cnt):
+            for k in cutlass.range_constexpr(0, cute.size(acc_S_row_frg, mode=[0]), 2):
+                # acc_S_row_frg[k, j] = cute.math.exp2(acc_S_row_frg[k, j], fastmath=True)
+                # acc_S_row_frg[k + 1, j] = cute.math.exp2(acc_S_row_frg[k + 1, j], fastmath=True)
+                if cutlass.const_expr(ex2_emu_freq == 0):
+                    acc_S_row_frg[k, j] = cute.math.exp2(acc_S_row_frg[k, j], fastmath=True)
+                    acc_S_row_frg[k + 1, j] = cute.math.exp2(acc_S_row_frg[k + 1, j], fastmath=True)
+                else:
+                    if cutlass.const_expr(
+                        k % ex2_emu_freq < ex2_emu_freq - ex2_emu_res
+                        or j >= frg_cnt - 1
+                        or j < ex2_emu_start_frg
+                    ):
+                        acc_S_row_frg[k, j] = cute.math.exp2(acc_S_row_frg[k, j], fastmath=True)
+                        acc_S_row_frg[k + 1, j] = cute.math.exp2(
+                            acc_S_row_frg[k + 1, j], fastmath=True
+                        )
+                    else:
+                        # acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j] = utils.e2e_asm2(acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j])
+                        acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j] = utils.ex2_emulation_2(
+                            acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j]
+                        )
+            acc_S_row_converted_frg[None, j].store(
+                acc_S_row_frg[None, j].load().to(acc_S_row_converted.element_type)
+            )
+
+    @cute.jit
+    def scale_apply_exp2_convert(
+        self,
+        acc_S_row: cute.Tensor,
+        row_max: Float32,
+        acc_S_row_converted: cute.Tensor,
+    ):
+        assert cute.size(acc_S_row.shape) % 2 == 0, "acc_S_row must have an even number of elements"
+        minus_row_max_scaled = -row_max * self.scale_log2
+        for i in cutlass.range_constexpr(0, cute.size(acc_S_row.shape), 2):
+            acc_S_row[i], acc_S_row[i + 1] = cute.arch.fma_packed_f32x2(
+                (acc_S_row[i], acc_S_row[i + 1]),
+                (self.scale_log2, self.scale_log2),
+                (minus_row_max_scaled, minus_row_max_scaled),
+            )
+
+        # for i in cutlass.range_constexpr(0, cute.size(acc_S_row.shape), 2):
+        #     acc_S_row[i], acc_S_row[i + 1] = cute.arch.fma_packed_f32x2(
+        #         (acc_S_row[i], acc_S_row[i + 1]),
+        #         (self.scale_log2, self.scale_log2),
+        #         (minus_row_max_scaled, minus_row_max_scaled),
+        #     )
+        #     acc_S_row[i] = cute.math.exp2(acc_S_row[i], fastmath=True)
+        #     acc_S_row[i + 1] = cute.math.exp2(acc_S_row[i + 1], fastmath=True)
+
+        frg_tile = 32
+        assert frg_tile % 2 == 0
+        frg_cnt = cute.size(acc_S_row) // frg_tile
+        assert cute.size(acc_S_row) % frg_tile == 0
+        acc_S_row_frg = cute.logical_divide(acc_S_row, cute.make_layout(frg_tile))
+        acc_S_row_converted_frg = cute.logical_divide(
+            acc_S_row_converted, cute.make_layout(frg_tile)
+        )
+        for j in cutlass.range_constexpr(frg_cnt):
+            for k in cutlass.range_constexpr(0, cute.size(acc_S_row_frg, mode=[0]), 2):
+                # acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j] = (
+                #     cute.arch.fma_packed_f32x2(
+                #         (acc_S_row_frg[k, j], acc_S_row_frg[k + 1, j]),
+                #         (self.scale_log2, self.scale_log2),
+                #         (minus_row_max_scaled, minus_row_max_scaled),
+                #     )
+                # )
+                # acc_S_row_frg[k, j] = cute.math.exp2(acc_S_row_frg[k, j], fastmath=True)
+                # acc_S_row_frg[k + 1, j] = cute.math.exp2(acc_S_row_frg[k + 1, j], fastmath=True)
+                acc_S_row_frg[k, j] = cute.math.exp2(acc_S_row_frg[k, j], fastmath=True)
+                acc_S_row_frg[k + 1, j] = cute.math.exp2(acc_S_row_frg[k + 1, j], fastmath=True)
+            acc_S_row_converted_frg[None, j].store(
+                acc_S_row_frg[None, j].load().to(acc_S_row_converted.element_type)
+            )
+
+
+@cute.jit
+def floor_if_packed(
+    q_idx,
+    qhead_per_kvhead: cutlass.Constexpr[int],
+) -> cute.Tensor:
+    """Convert q_idx to packed format for Pack-GQA."""
+    if cutlass.const_expr(qhead_per_kvhead == 1):
+        return q_idx
+    return q_idx // qhead_per_kvhead
+
+
+@cute.jit
+def apply_score_mod_inner(
+    score_tensor,
+    index_tensor,
+    score_mod: cutlass.Constexpr,
+    batch_idx,
+    head_idx,
+    softmax_scale,
+    vec_size: cutlass.Constexpr,
+    qk_acc_dtype: cutlass.Constexpr,
+    aux_tensors,
+    fastdiv_mods,
+    seqlen_info: SeqlenInfoQK,
+    constant_q_idx: cutlass.Constexpr,
+    qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+    transpose_indices: cutlass.Constexpr[bool] = False,
+):
+    """Shared implementation for applying score modification.
+
+    Args:
+        score_tensor: The scores to modify (acc_S for flash_fwd, tSrS_t2r for sm100)
+        index_tensor: Index positions (tScS for flash_fwd, tScS_t2r for sm100)
+        score_mod: The score modification function to apply
+        batch_idx: Batch index
+        head_idx: Head index
+        softmax_scale: Scale to apply
+        vec_size: Vector size for processing elements
+        qk_acc_dtype: Data type for accumulator
+        aux_tensors: Optional aux_tensors for FlexAttention
+        fastdiv_mods: Tuple of (seqlen_q_divmod, seqlen_k_divmod) for wrapping
+        seqlen_info: Sequence length info
+        constant_q_idx: If provided, use this constant for all q_idx values
+                        If None, compute q_idx per-element
+        qhead_per_kvhead_packgqa: Pack-GQA replication factor. Divide q_idx by this
+                                  when greater than 1 so score mods see logical heads.
+        transpose_indices: If True, swap q_idx/kv_idx in index_tensor (for bwd kernel where S is transposed)
+    """
+    # Index positions in the index_tensor tuple
+    # Forward: index_tensor[...][0] = q_idx, index_tensor[...][1] = kv_idx
+    # Backward (transposed): index_tensor[...][0] = kv_idx, index_tensor[...][1] = q_idx
+    if cutlass.const_expr(transpose_indices):
+        q_idx_pos = cutlass.const_expr(1)
+        kv_idx_pos = cutlass.const_expr(0)
+    else:
+        q_idx_pos = cutlass.const_expr(0)
+        kv_idx_pos = cutlass.const_expr(1)
+
+    n_vals = cutlass.const_expr(cute.size(score_tensor.shape))
+    score_vec = cute.make_rmem_tensor(vec_size, qk_acc_dtype)
+    kv_idx_vec = cute.make_rmem_tensor(vec_size, cutlass.Int32)
+
+    # SSA values for batch (constant across all elements)
+    batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32).broadcast_to((vec_size,))
+
+    # Handle q_idx based on whether it's constant
+    q_idx_vec = cute.make_rmem_tensor(vec_size, cutlass.Int32)
+
+    # For Pack-GQA with non-constant q_idx, we need per-element head indices
+    # since a thread may process multiple query head indices
+    if cutlass.const_expr(qhead_per_kvhead > 1 and constant_q_idx is None):
+        head_idx_vec = cute.make_rmem_tensor(vec_size, cutlass.Int32)
+
+    for i in cutlass.range(0, n_vals, vec_size, unroll_full=True):
+        for j in cutlass.range(vec_size, unroll_full=True):
+            score_vec[j] = score_tensor[i + j] * softmax_scale
+
+            # Extract head offset from packed q_idx for Pack-GQA
+            if cutlass.const_expr(qhead_per_kvhead > 1 and constant_q_idx is None):
+                q_idx_packed = index_tensor[i + j][q_idx_pos]
+                # Building up the logical q_head idx: final_q_head = kv_head * qhead_per_kvhead + (q_physical % qhead_per_kvhead)
+                q_idx_logical = q_idx_packed // qhead_per_kvhead
+                head_offset = q_idx_packed - q_idx_logical * qhead_per_kvhead
+                head_idx_vec[j] = head_idx * qhead_per_kvhead + head_offset
+
+            # If we will do loads we mod, in order to not read OOB
+            if cutlass.const_expr(aux_tensors is not None and fastdiv_mods is not None):
+                if cutlass.const_expr(constant_q_idx is None):
+                    seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                    q_idx_floored = floor_if_packed(
+                        index_tensor[i + j][q_idx_pos], qhead_per_kvhead
+                    )
+                    _, q_idx_wrapped = divmod(q_idx_floored, seqlen_q_divmod)
+                    q_idx_vec[j] = q_idx_wrapped
+                else:
+                    _, seqlen_k_divmod = fastdiv_mods
+
+                _, kv_idx_wrapped = divmod(index_tensor[i + j][kv_idx_pos], seqlen_k_divmod)
+                kv_idx_vec[j] = kv_idx_wrapped
+            else:
+                # No bounds checking - direct indexing
+                if constant_q_idx is None:
+                    q_idx_vec[j] = floor_if_packed(index_tensor[i + j][q_idx_pos], qhead_per_kvhead)
+                kv_idx_vec[j] = index_tensor[i + j][kv_idx_pos]
+
+        # Convert to SSA for score_mod call
+        score_ssa = score_vec.load()
+        kv_idx_ssa = kv_idx_vec.load()
+        if cutlass.const_expr(constant_q_idx is None):
+            q_idx_ssa = q_idx_vec.load()
+        else:
+            # NB we do not apply Pack-GQA division here, as constant_q_idx is assumed to already be logical
+            q_idx_const = constant_q_idx
+            q_idx_ssa = utils.scalar_to_ssa(q_idx_const, cutlass.Int32).broadcast_to((vec_size,))
+
+        # Compute head_idx_ssa: per-element for Pack-GQA with non-constant q_idx, constant otherwise
+        if cutlass.const_expr(qhead_per_kvhead > 1 and constant_q_idx is None):
+            head_idx_ssa = head_idx_vec.load()
+        else:
+            head_idx_ssa = utils.scalar_to_ssa(head_idx, cutlass.Int32).broadcast_to((vec_size,))
+
+        aux_args = []
+        if cutlass.const_expr(aux_tensors is not None):
+            aux_args = aux_tensors
+
+        post_mod_scores = score_mod(
+            score_ssa,
+            batch_idx_ssa,
+            head_idx_ssa,
+            q_idx=q_idx_ssa,
+            kv_idx=kv_idx_ssa,
+            seqlen_info=seqlen_info,
+            aux_tensors=aux_args,
+        )
+
+        # Write back modified scores
+        score_vec.store(post_mod_scores)
+        for j in cutlass.range(vec_size, unroll_full=True):
+            score_tensor[i + j] = score_vec[j]
+
+
+@cute.jit
+def apply_score_mod_bwd_inner(
+    grad_tensor,
+    score_tensor,
+    index_tensor,
+    score_mod_bwd: cutlass.Constexpr,
+    batch_idx,
+    head_idx,
+    softmax_scale,
+    vec_size: cutlass.Constexpr,
+    qk_acc_dtype: cutlass.Constexpr,
+    aux_tensors,
+    fastdiv_mods,
+    seqlen_info,
+    constant_q_idx: cutlass.Constexpr,
+    qhead_per_kvhead: cutlass.Constexpr[int] = 1,
+    transpose_indices: cutlass.Constexpr[bool] = False,
+):
+    """Apply backward score modification (joint graph).
+
+    Args:
+        grad_tensor: in/out: dlogits rewritten in-place with d(scaled_scores)
+        score_tensor: pre-mod scores (unscaled QK tile), scaled by softmax_scale internally
+        index_tensor: Index positions (same as forward)
+        score_mod_bwd: The backward score modification function (joint graph)
+        batch_idx: Batch index
+        head_idx: Head index
+        softmax_scale: Scale to apply to score_tensor
+        vec_size: Vector size for processing elements
+        qk_acc_dtype: Data type for accumulator
+        aux_tensors: Optional aux_tensors for FlexAttention
+        fastdiv_mods: Tuple of (seqlen_q_divmod, seqlen_k_divmod) for wrapping
+        seqlen_info: Sequence length info
+        constant_q_idx: If provided, use this constant for all q_idx values
+        qhead_per_kvhead: Pack-GQA replication factor
+        transpose_indices: If True, swap q_idx/kv_idx in index_tensor
+    """
+    # Index positions in the index_tensor tuple
+    # Forward: index_tensor[...][0] = q_idx, index_tensor[...][1] = kv_idx
+    # Backward (transposed): index_tensor[...][0] = kv_idx, index_tensor[...][1] = q_idx
+    if cutlass.const_expr(transpose_indices):
+        q_idx_pos = cutlass.const_expr(1)
+        kv_idx_pos = cutlass.const_expr(0)
+    else:
+        q_idx_pos = cutlass.const_expr(0)
+        kv_idx_pos = cutlass.const_expr(1)
+    n_vals = cutlass.const_expr(cute.size(grad_tensor.shape))
+    grad_vec = cute.make_fragment(vec_size, qk_acc_dtype)
+    score_vec = cute.make_fragment(vec_size, qk_acc_dtype)
+    kv_idx_vec = cute.make_fragment(vec_size, cutlass.Int32)
+    batch_idx_ssa = utils.scalar_to_ssa(batch_idx, cutlass.Int32).broadcast_to((vec_size,))
+    q_idx_vec = cute.make_fragment(vec_size, cutlass.Int32)
+
+    # For Pack-GQA with non-constant q_idx, we need per-element head indices
+    if cutlass.const_expr(qhead_per_kvhead > 1 and constant_q_idx is None):
+        head_idx_vec = cute.make_fragment(vec_size, cutlass.Int32)
+
+    for i in cutlass.range(0, n_vals, vec_size, unroll_full=True):
+        for j in cutlass.range(vec_size, unroll_full=True):
+            grad_vec[j] = grad_tensor[i + j]
+            # Scale score so joint graph sees same value as forward score_mod
+            score_vec[j] = score_tensor[i + j] * softmax_scale
+
+            if cutlass.const_expr(qhead_per_kvhead > 1 and constant_q_idx is None):
+                q_idx_packed = index_tensor[i + j][q_idx_pos]
+                q_idx_logical = q_idx_packed // qhead_per_kvhead
+                head_offset = q_idx_packed - q_idx_logical * qhead_per_kvhead
+                head_idx_vec[j] = head_idx * qhead_per_kvhead + head_offset
+
+            if cutlass.const_expr(aux_tensors is not None and fastdiv_mods is not None):
+                if cutlass.const_expr(constant_q_idx is None):
+                    seqlen_q_divmod, seqlen_k_divmod = fastdiv_mods
+                    q_idx_floored = floor_if_packed(
+                        index_tensor[i + j][q_idx_pos], qhead_per_kvhead
+                    )
+                    _, q_idx_wrapped = divmod(q_idx_floored, seqlen_q_divmod)
+                    q_idx_vec[j] = q_idx_wrapped
+                else:
+                    _, seqlen_k_divmod = fastdiv_mods
+
+                _, kv_idx_wrapped = divmod(index_tensor[i + j][kv_idx_pos], seqlen_k_divmod)
+                kv_idx_vec[j] = kv_idx_wrapped
+            else:
+                # No bounds checking - direct indexing
+                if constant_q_idx is None:
+                    q_idx_vec[j] = floor_if_packed(index_tensor[i + j][q_idx_pos], qhead_per_kvhead)
+                kv_idx_vec[j] = index_tensor[i + j][kv_idx_pos]
+
+        grad_ssa = grad_vec.load()
+        score_ssa = score_vec.load()
+        kv_idx_ssa = kv_idx_vec.load()
+
+        if cutlass.const_expr(constant_q_idx is None):
+            q_idx_ssa = q_idx_vec.load()
+        else:
+            q_idx_ssa = utils.scalar_to_ssa(constant_q_idx, cutlass.Int32).broadcast_to((vec_size,))
+
+        if cutlass.const_expr(qhead_per_kvhead > 1 and constant_q_idx is None):
+            head_idx_ssa = head_idx_vec.load()
+        else:
+            head_idx_ssa = utils.scalar_to_ssa(head_idx, cutlass.Int32).broadcast_to((vec_size,))
+
+        aux_args = []
+        if cutlass.const_expr(aux_tensors is not None):
+            aux_args = aux_tensors
+
+        grad_out_ssa = score_mod_bwd(
+            grad_ssa,
+            score_ssa,
+            batch_idx_ssa,
+            head_idx_ssa,
+            q_idx=q_idx_ssa,
+            kv_idx=kv_idx_ssa,
+            seqlen_info=seqlen_info,
+            aux_tensors=aux_args,
+        )
+
+        grad_vec.store(grad_out_ssa)
+        for j in cutlass.range(vec_size, unroll_full=True):
+            grad_tensor[i + j] = grad_vec[j]

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/testing.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/testing.py
@@ -1,0 +1,476 @@
+import math
+from contextlib import nullcontext
+from functools import wraps
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange, repeat
+from torch._guards import active_fake_mode
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+
+class IndexFirstAxis(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input, indices):
+        ctx.save_for_backward(indices)
+        assert input.ndim >= 2
+        ctx.first_axis_dim, other_shape = input.shape[0], input.shape[1:]
+        second_dim = other_shape.numel()
+        return torch.gather(
+            rearrange(input, "b ... -> b (...)"),
+            0,
+            repeat(indices, "z -> z d", d=second_dim),
+        ).reshape(-1, *other_shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (indices,) = ctx.saved_tensors
+        assert grad_output.ndim >= 2
+        other_shape = grad_output.shape[1:]
+        grad_output = rearrange(grad_output, "b ... -> b (...)")
+        grad_input = torch.zeros(
+            [ctx.first_axis_dim, grad_output.shape[1]],
+            device=grad_output.device,
+            dtype=grad_output.dtype,
+        )
+        grad_input.scatter_(0, repeat(indices, "z -> z d", d=grad_output.shape[1]), grad_output)
+        return grad_input.reshape(ctx.first_axis_dim, *other_shape), None
+
+
+index_first_axis = IndexFirstAxis.apply
+
+
+class IndexPutFirstAxis(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, values, indices, first_axis_dim):
+        ctx.save_for_backward(indices)
+        assert indices.ndim == 1
+        assert values.ndim >= 2
+        output = torch.zeros(
+            first_axis_dim, *values.shape[1:], device=values.device, dtype=values.dtype
+        )
+        output[indices] = values
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (indices,) = ctx.saved_tensors
+        grad_values = grad_output[indices]
+        return grad_values, None, None
+
+
+index_put_first_axis = IndexPutFirstAxis.apply
+
+
+def unpad_input(hidden_states, attention_mask, unused_mask=None):
+    all_masks = (attention_mask + unused_mask) if unused_mask is not None else attention_mask
+    seqlens_in_batch = all_masks.sum(dim=-1, dtype=torch.int32)
+    used_seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+    in_fake_mode = active_fake_mode() is not None
+    if not in_fake_mode:
+        indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
+        max_seqlen_in_batch = seqlens_in_batch.max().item()
+    else:
+        # torch.nonzero and .item() are not supported in FakeTensorMode
+        batch_size, seqlen = attention_mask.shape
+        indices = torch.arange(batch_size * seqlen, device=hidden_states.device)
+        max_seqlen_in_batch = seqlen
+    cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+    return (
+        index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices),
+        indices,
+        cu_seqlens,
+        max_seqlen_in_batch,
+        used_seqlens_in_batch,
+    )
+
+
+def pad_input(hidden_states, indices, batch, seqlen):
+    output = index_put_first_axis(hidden_states, indices, batch * seqlen)
+    return rearrange(output, "(b s) ... -> b s ...", b=batch)
+
+
+def generate_random_padding_mask(
+    max_seqlen, batch_size, device, mode="random", zero_lengths=False, min_seqlen=None
+):
+    assert mode in ["full", "random", "third"]
+    min_seqlen = min_seqlen if min_seqlen is not None else 0 if zero_lengths else 1
+    if mode == "full":
+        lengths = torch.full((batch_size, 1), max_seqlen, device=device, dtype=torch.int32)
+    elif mode == "random":
+        lengths = torch.randint(
+            max(min_seqlen, max_seqlen - 20),
+            max_seqlen + 1,
+            (batch_size, 1),
+            device=device,
+        )
+    else:
+        lengths = torch.randint(
+            max(min_seqlen, max_seqlen // 3),
+            max_seqlen + 1,
+            (batch_size, 1),
+            device=device,
+        )
+
+    if zero_lengths:
+        for i in range(batch_size):
+            if i % 5 == 0:
+                lengths[i] = 0
+        lengths[-1] = 0
+    padding_mask = (
+        repeat(torch.arange(max_seqlen, device=device), "s -> b s", b=batch_size) < lengths
+    )
+    return padding_mask
+
+
+def generate_qkv(
+    q,
+    k,
+    v,
+    query_padding_mask=None,
+    key_padding_mask=None,
+    qv=None,
+    kvpacked=False,
+    qkvpacked=False,
+    query_unused_mask=None,
+    key_unused_mask=None,
+):
+    assert not (kvpacked and qkvpacked)
+    batch_size, seqlen_q, nheads, d = q.shape
+    d_v = v.shape[-1]
+    _, seqlen_k, nheads_k, _ = k.shape
+    assert k.shape == (batch_size, seqlen_k, nheads_k, d)
+    assert v.shape == (batch_size, seqlen_k, nheads_k, d_v)
+    if query_unused_mask is not None or key_unused_mask is not None:
+        assert not kvpacked
+        assert not qkvpacked
+
+    if query_padding_mask is not None:
+        q_unpad, indices_q, cu_seqlens_q, max_seqlen_q, seqused_q = unpad_input(
+            q, query_padding_mask, query_unused_mask
+        )
+        output_pad_fn = lambda output_unpad: pad_input(
+            output_unpad, indices_q, batch_size, seqlen_q
+        )
+        qv_unpad = rearrange(qv, "b s ... -> (b s) ...")[indices_q] if qv is not None else None
+    else:
+        q_unpad = rearrange(q, "b s h d -> (b s) h d")
+        cu_seqlens_q = torch.arange(
+            0, (batch_size + 1) * seqlen_q, step=seqlen_q, dtype=torch.int32, device=q_unpad.device
+        )
+        seqused_q = None
+        max_seqlen_q = seqlen_q
+        output_pad_fn = lambda output_unpad: rearrange(
+            output_unpad, "(b s) h d -> b s h d", b=batch_size
+        )
+        qv_unpad = rearrange(qv, "b s ... -> (b s) ...") if qv is not None else None
+
+    if key_padding_mask is not None:
+        k_unpad, indices_k, cu_seqlens_k, max_seqlen_k, seqused_k = unpad_input(
+            k, key_padding_mask, key_unused_mask
+        )
+        v_unpad, *_ = unpad_input(v, key_padding_mask, key_unused_mask)
+    else:
+        k_unpad = rearrange(k, "b s h d -> (b s) h d")
+        v_unpad = rearrange(v, "b s h d -> (b s) h d")
+        cu_seqlens_k = torch.arange(
+            0, (batch_size + 1) * seqlen_k, step=seqlen_k, dtype=torch.int32, device=k_unpad.device
+        )
+        seqused_k = None
+        max_seqlen_k = seqlen_k
+
+    if qkvpacked:
+        assert (query_padding_mask == key_padding_mask).all()
+        assert nheads == nheads_k
+        qkv_unpad = torch.stack([q_unpad, k_unpad, v_unpad], dim=1)
+        qkv = torch.stack([q, k, v], dim=2)
+        if query_padding_mask is not None:
+            dqkv_pad_fn = lambda dqkv_unpad: pad_input(dqkv_unpad, indices_q, batch_size, seqlen_q)
+        else:
+            dqkv_pad_fn = lambda dqkv_unpad: rearrange(
+                dqkv_unpad, "(b s) t h d -> b s t h d", b=batch_size
+            )
+        return (
+            qkv_unpad.detach().requires_grad_(),
+            cu_seqlens_q,
+            max_seqlen_q,
+            qkv.detach().requires_grad_(),
+            output_pad_fn,
+            dqkv_pad_fn,
+        )
+    elif kvpacked:
+        kv_unpad = torch.stack([k_unpad, v_unpad], dim=1)
+        kv = torch.stack([k, v], dim=2)
+        dq_pad_fn = output_pad_fn
+        if key_padding_mask is not None:
+            dkv_pad_fn = lambda dkv_unpad: pad_input(dkv_unpad, indices_k, batch_size, seqlen_k)
+        else:
+            dkv_pad_fn = lambda dkv_unpad: rearrange(
+                dkv_unpad, "(b s) t h d -> b s t h d", b=batch_size
+            )
+        return (
+            q_unpad.detach().requires_grad_(),
+            kv_unpad.detach().requires_grad_(),
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            q.detach().requires_grad_(),
+            kv.detach().requires_grad_(),
+            output_pad_fn,
+            dq_pad_fn,
+            dkv_pad_fn,
+        )
+    else:
+        dq_pad_fn = output_pad_fn
+        if key_padding_mask is not None:
+            dk_pad_fn = lambda dk_unpad: pad_input(dk_unpad, indices_k, batch_size, seqlen_k)
+        else:
+            dk_pad_fn = lambda dk_unpad: rearrange(dk_unpad, "(b s) h d -> b s h d", b=batch_size)
+        return (
+            q_unpad.detach().requires_grad_(),
+            k_unpad.detach().requires_grad_(),
+            v_unpad.detach().requires_grad_(),
+            qv_unpad.detach() if qv is not None else None,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            seqused_q,
+            seqused_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            q.detach().requires_grad_(),
+            k.detach().requires_grad_(),
+            v.detach().requires_grad_(),
+            qv.detach() if qv is not None else None,
+            output_pad_fn,
+            dq_pad_fn,
+            dk_pad_fn,
+        )
+
+
+def construct_local_mask(
+    seqlen_q,
+    seqlen_k,
+    window_size=(None, None),
+    sink_token_length=0,
+    query_padding_mask=None,
+    key_padding_mask=None,
+    key_leftpad=None,
+    device=None,
+):
+    row_idx = rearrange(torch.arange(seqlen_q, device=device, dtype=torch.long), "s -> s 1")
+    col_idx = torch.arange(seqlen_k, device=device, dtype=torch.long)
+    if key_leftpad is not None:
+        key_leftpad = rearrange(key_leftpad, "b -> b 1 1 1")
+        col_idx = repeat(col_idx, "s -> b 1 1 s", b=key_leftpad.shape[0])
+        col_idx = torch.where(col_idx >= key_leftpad, col_idx - key_leftpad, 2**32)
+    sk = (
+        seqlen_k
+        if key_padding_mask is None
+        else rearrange(key_padding_mask.sum(-1), "b -> b 1 1 1")
+    )
+    sq = (
+        seqlen_q
+        if query_padding_mask is None
+        else rearrange(query_padding_mask.sum(-1), "b -> b 1 1 1")
+    )
+    if window_size[0] is None:
+        return col_idx > row_idx + sk - sq + window_size[1]
+    else:
+        sk = torch.full_like(col_idx, seqlen_k) if key_padding_mask is None else sk
+        if window_size[1] is None:
+            local_mask_left = col_idx > sk
+        else:
+            local_mask_left = col_idx > torch.minimum(row_idx + sk - sq + window_size[1], sk)
+        return torch.logical_or(
+            local_mask_left,
+            torch.logical_and(
+                col_idx < row_idx + sk - sq - window_size[0], col_idx >= sink_token_length
+            ),
+        )
+
+
+def construct_chunk_mask(
+    seqlen_q,
+    seqlen_k,
+    attention_chunk,
+    query_padding_mask=None,
+    key_padding_mask=None,
+    key_leftpad=None,
+    device=None,
+):
+    row_idx = rearrange(torch.arange(seqlen_q, device=device, dtype=torch.long), "s -> s 1")
+    col_idx = torch.arange(seqlen_k, device=device, dtype=torch.long)
+    if key_leftpad is not None:
+        key_leftpad = rearrange(key_leftpad, "b -> b 1 1 1")
+        col_idx = repeat(col_idx, "s -> b 1 1 s", b=key_leftpad.shape[0])
+        col_idx = torch.where(col_idx >= key_leftpad, col_idx - key_leftpad, 2**32)
+    sk = (
+        seqlen_k
+        if key_padding_mask is None
+        else rearrange(key_padding_mask.sum(-1), "b -> b 1 1 1")
+    )
+    sq = (
+        seqlen_q
+        if query_padding_mask is None
+        else rearrange(query_padding_mask.sum(-1), "b -> b 1 1 1")
+    )
+    sk = torch.full_like(col_idx, seqlen_k) if key_padding_mask is None else sk
+    col_limit_left_chunk = row_idx + sk - sq - (row_idx + sk - sq) % attention_chunk
+    return torch.logical_or(
+        col_idx < col_limit_left_chunk, col_idx >= col_limit_left_chunk + attention_chunk
+    )
+
+
+def attention_ref(
+    q,
+    k,
+    v,
+    query_padding_mask=None,
+    key_padding_mask=None,
+    key_leftpad=None,
+    attn_bias=None,
+    dropout_p=0.0,
+    dropout_mask=None,
+    causal=False,
+    qv=None,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+    window_size=(None, None),
+    attention_chunk=0,
+    sink_token_length=0,
+    learnable_sink: Optional[torch.Tensor] = None,
+    softcap=0.0,
+    upcast=True,
+    reorder_ops=False,
+    intermediate_dtype=None,
+    return_lse=False,
+    gather_kv_indices=None,
+):
+    if causal:
+        window_size = (window_size[0], 0)
+    dtype_og = q.dtype
+    if upcast:
+        q, k, v = q.float(), k.float(), v.float()
+        qv = qv.float() if qv is not None else None
+    if q_descale is not None:
+        q_descale = repeat(q_descale, "b h -> b 1 (h g) 1", g=q.shape[2] // k.shape[2])
+        q = (q.float() * q_descale).to(q.dtype)
+        qv = (qv.float() * q_descale).to(qv.dtype) if qv is not None else None
+    if k_descale is not None:
+        k = (k.float() * rearrange(k_descale, "b h -> b 1 h 1")).to(dtype=k.dtype)
+    if v_descale is not None:
+        v = (v.float() * rearrange(v_descale, "b h -> b 1 h 1")).to(dtype=v.dtype)
+    seqlen_q, seqlen_k = q.shape[1], k.shape[1]
+    k = repeat(k, "b s h d -> b s (h g) d", g=q.shape[2] // k.shape[2])
+    v = repeat(v, "b s h d -> b s (h g) d", g=q.shape[2] // v.shape[2])
+    d = q.shape[-1]
+    dv = v.shape[-1]
+    softmax_scale = 1.0 / math.sqrt(d if qv is None else d + dv)
+    if not reorder_ops:
+        scores = torch.einsum("bthd,bshd->bhts", q * softmax_scale, k)
+    else:
+        scores = torch.einsum("bthd,bshd->bhts", q, k * softmax_scale)
+    if qv is not None:
+        scores = scores + torch.einsum("bthd,bshd->bhts", qv * softmax_scale, v)
+    if softcap > 0:
+        scores = torch.tanh(scores / softcap) * softcap
+    if key_padding_mask is not None:
+        scores.masked_fill_(rearrange(~key_padding_mask, "b s -> b 1 1 s"), float("-inf"))
+    local_mask = None
+    if window_size[0] is not None or window_size[1] is not None:
+        local_mask = construct_local_mask(
+            seqlen_q,
+            seqlen_k,
+            window_size,
+            sink_token_length,
+            query_padding_mask,
+            key_padding_mask,
+            key_leftpad=key_leftpad,
+            device=q.device,
+        )
+    if attention_chunk > 0:
+        chunk_mask = construct_chunk_mask(
+            seqlen_q,
+            seqlen_k,
+            attention_chunk,
+            query_padding_mask,
+            key_padding_mask,
+            key_leftpad=key_leftpad,
+            device=q.device,
+        )
+        local_mask = (
+            torch.logical_or(local_mask, chunk_mask) if local_mask is not None else chunk_mask
+        )
+    if gather_kv_indices is not None:
+        batch = q.shape[0]
+        topk_len = gather_kv_indices.shape[2]
+        if topk_len < seqlen_k:
+            topk_index_mask = torch.full(
+                (batch, seqlen_q, seqlen_k), False, device="cuda"
+            ).scatter_(-1, gather_kv_indices, True)
+            scores.masked_fill_(rearrange(~topk_index_mask, "b t s -> b 1 t s"), float("-inf"))
+    if local_mask is not None:
+        scores.masked_fill_(local_mask, float("-inf"))
+    if attn_bias is not None:
+        scores = scores + attn_bias
+    # After all masks are applied, before softmax:
+    # scores shape: [b, h, t, s]
+    lse = torch.logsumexp(scores, dim=-1)  # [b, h, t]
+    if learnable_sink is None:
+        attention = torch.softmax(scores, dim=-1).to(v.dtype)
+    else:
+        scores_fp32 = scores.to(torch.float32)
+        logits_max = torch.amax(scores_fp32, dim=-1, keepdim=True)
+        learnable_sink = rearrange(learnable_sink, "h -> h 1 1")
+        logits_or_sinks_max = torch.maximum(learnable_sink, logits_max)
+        unnormalized_scores = torch.exp(scores_fp32 - logits_or_sinks_max)
+        normalizer = unnormalized_scores.sum(dim=-1, keepdim=True) + torch.exp(
+            learnable_sink - logits_or_sinks_max
+        )
+        # LSE with sink: log(Z) = log(normalizer) + max
+        lse = (torch.log(normalizer.squeeze(-1)) + logits_or_sinks_max.squeeze(-1)).to(dtype_og)
+        attention = (unnormalized_scores / normalizer).to(v.dtype)
+    if query_padding_mask is not None:
+        attention = attention.masked_fill(rearrange(~query_padding_mask, "b s -> b 1 s 1"), 0.0)
+    if key_padding_mask is not None:
+        attention = attention.masked_fill(rearrange(~key_padding_mask, "b s -> b 1 1 s"), 0.0)
+    if local_mask is not None:
+        attention = attention.masked_fill(torch.all(local_mask, dim=-1, keepdim=True), 0.0)
+    dropout_scaling = 1.0 / (1 - dropout_p)
+    if dropout_mask is not None:
+        attention_drop = attention.masked_fill(~dropout_mask, 0.0)
+    else:
+        attention_drop = attention
+    if intermediate_dtype is not None:
+        attention_drop = attention_drop.to(intermediate_dtype).to(attention_drop.dtype)
+    output = torch.einsum("bhts,bshd->bthd", attention_drop, v * dropout_scaling)
+    if query_padding_mask is not None:
+        output.masked_fill_(rearrange(~query_padding_mask, "b s -> b s 1 1"), 0.0)
+    if return_lse:
+        return output.to(dtype_og), attention.to(dtype_og), lse.to(dtype_og)
+    return output.to(dtype=dtype_og), attention.to(dtype=dtype_og)
+
+
+def maybe_fake_tensor_mode(fake: bool = True):
+    """
+    One way to populate/pre-compile cache is to use torch fake tensor mode,
+    which does not allocate actual GPU tensors but retains tensor shape/dtype
+    metadata for cute.compile.
+    """
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            with FakeTensorMode() if fake else nullcontext():
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def is_fake_mode() -> bool:
+    return active_fake_mode() is not None

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/tile_scheduler.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/tile_scheduler.py
@@ -1,0 +1,1636 @@
+# Copyright (c) 2025, Tri Dao, Siyu Wang, Shengbin Di, Yuxi Chi, Johnsonms, Linfeng Zheng, Haoyan Huang, Lanbo Li, Yun Zhong, Man Yuan, Minmin Sun, Yong Li, Wei Lin.
+
+from enum import IntEnum, auto
+from typing import Optional, Tuple, Protocol, runtime_checkable
+from dataclasses import dataclass
+
+try:
+    from typing import override
+except ImportError:  # Python < 3.12
+    from typing_extensions import override
+
+import cutlass
+from cutlass.pipeline import PipelineClcFetchAsync, PipelineState
+from cutlass._mlir import ir
+import cutlass.cute as cute
+from cutlass import Int32, const_expr
+from cutlass.cute import FastDivmodDivisor
+from cutlass.utils import ClcDynamicPersistentTileScheduler, ClcDynamicPersistentTileSchedulerParams
+from cutlass.cute.typing import Boolean
+from cutlass.cutlass_dsl import (
+    min as dsl_min,
+    extract_mlir_values,
+    new_from_mlir_values,
+)
+from cutlass.utils.hardware_info import HardwareInfo
+
+from quack.cute_dsl_utils import ParamsBase
+
+import flashrt_fa4.cute.utils as utils
+from flashrt_fa4.cute.fast_math import clz
+
+
+class SchedulingMode(IntEnum):
+    NONE = auto()
+    STATIC = auto()
+    DYNAMIC = auto()
+    CLC = auto()
+
+
+@dataclass
+class ClcState(ParamsBase):
+    """Owns the runtime state shared by CLC-capable tile schedulers.
+
+    `FlashAttentionForwardSm100` constructs this state because it owns the CLC
+    response buffer, mbarrier storage, and launch geometry needed to initialize
+    the hardware scheduler and async pipeline. Individual tile schedulers then
+    consume this state and map the returned hardware work tiles into their own
+    logical `WorkTileInfo` coordinates.
+
+    To add CLC support to a scheduler:
+    - implement `clc_problem_shape(params)` so the kernel can create the hardware scheduler
+    - accept `clc: ClcState | None` in `create(...)` / `__init__`
+    - map `clc.initial_work_tile_info()` and `clc.get_current_work()` into scheduler coordinates
+    """
+
+    _hw_scheduler: ClcDynamicPersistentTileScheduler
+    _pipeline: PipelineClcFetchAsync
+    _consumer_state: PipelineState
+    _producer_state: PipelineState
+
+    @staticmethod
+    def create(
+        *,
+        hw_scheduler: ClcDynamicPersistentTileScheduler,
+        pipeline: PipelineClcFetchAsync,
+        consumer_state: PipelineState,
+        producer_state: PipelineState,
+    ) -> "ClcState":
+        return ClcState(hw_scheduler, pipeline, consumer_state, producer_state)
+
+    def initial_work_tile_info(self):
+        return self._hw_scheduler.initial_work_tile_info()
+
+    def get_current_work(self):
+        return self._hw_scheduler.get_current_work()
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        self._pipeline.producer_acquire(self._producer_state, loc=loc, ip=ip)
+        mbarrier_addr = self._pipeline.producer_get_barrier(self._producer_state, loc=loc, ip=ip)
+        self._hw_scheduler.advance_to_next_work(mbarrier_addr, loc=loc, ip=ip)
+        self._producer_state.advance(loc=loc, ip=ip)
+
+    def consumer_wait(self, *, loc=None, ip=None):
+        self._pipeline.consumer_wait(self._consumer_state, loc=loc, ip=ip)
+
+    def consumer_release(self, *, loc=None, ip=None):
+        self._pipeline.consumer_release(self._consumer_state, loc=loc, ip=ip)
+        self._consumer_state.advance(loc=loc, ip=ip)
+
+    def producer_tail(self, *, loc=None, ip=None):
+        self._pipeline.producer_tail(self._producer_state, loc=loc, ip=ip)
+
+
+class WorkTileInfo(cutlass.utils.WorkTileInfo):
+    """Altered WorkTileInfo which includes four axes: (block, head, batch, split)"""
+
+    @override
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "WorkTileInfo":
+        assert len(values) == 5
+        new_tile_idx = cutlass.new_from_mlir_values(self._tile_idx, values[:-1])
+        new_is_valid_tile = cutlass.new_from_mlir_values(self._is_valid_tile, [values[-1]])
+        return WorkTileInfo(new_tile_idx, new_is_valid_tile)
+
+
+@runtime_checkable
+class TileSchedulerProtocol(Protocol):
+    """Protocol defining the interface all tile schedulers must implement.
+
+    Schedulers are responsible for:
+    1. Coordinate mapping: linear tile index -> (m_block, head, batch, split)
+    2. Work distribution: how to get the next tile (static grid-stride vs CLC dynamic)
+    """
+
+    def get_current_work(self) -> WorkTileInfo:
+        """Get the current work tile coordinates."""
+        ...
+
+    def initial_work_tile_info(self) -> WorkTileInfo:
+        """Get the initial work tile for this CTA."""
+        ...
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        """Consumer-side advance: move to next tile and return it.
+
+        For static schedulers: grid-stride increment + get_current_work.
+        For CLC schedulers: consumer wait + get_current_work + consumer release + state advance.
+        """
+        ...
+
+    def prefetch_next_work(self, *, loc=None, ip=None) -> None:
+        """Producer-side prefetch of next work tile (no-op for static schedulers).
+
+        For CLC schedulers: producer acquire + issue CLC query + producer state advance.
+        Only called by the scheduler warp.
+        """
+        ...
+
+    def producer_tail(self, *, loc=None, ip=None) -> None:
+        """Producer-side cleanup after the last tile.
+
+        No-op for static schedulers. For CLC schedulers: pipeline producer_tail.
+        """
+        ...
+
+
+@dataclass
+class TileSchedulerArguments(ParamsBase):
+    num_block: Int32
+    num_head: Int32
+    num_batch: Int32
+    num_splits: Int32
+    seqlen_k: Int32
+    headdim: Int32
+    headdim_v: Int32
+    total_q: Int32
+    tile_shape_mn: cutlass.Constexpr[Tuple[int, int]]
+    cluster_shape_mn: cutlass.Constexpr[Tuple[int, int]] = (1, 1)
+    mCuSeqlensQ: Optional[cute.Tensor] = None
+    mSeqUsedQ: Optional[cute.Tensor] = None
+    qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+    element_size: cutlass.Constexpr[int] = 2
+    is_persistent: cutlass.Constexpr[bool] = False
+    lpt: cutlass.Constexpr[bool] = False
+    is_split_kv: cutlass.Constexpr[bool] = False
+    head_swizzle: cutlass.Constexpr[bool] = False
+    use_cluster_idx: cutlass.Constexpr[bool] = False
+
+
+class SingleTileScheduler:
+    @dataclass
+    class Params(ParamsBase):
+        num_block: Int32
+        num_head: Int32
+        num_batch: Int32
+        num_splits: Int32
+        num_splits_divmod: FastDivmodDivisor
+        is_split_kv: cutlass.Constexpr[bool] = False
+        cluster_shape_mn: cutlass.Constexpr[Tuple[int, int]] = (1, 1)
+        use_cluster_idx: cutlass.Constexpr[bool] = False
+
+        @staticmethod
+        def create(
+            args: TileSchedulerArguments, *, loc=None, ip=None
+        ) -> "SingleTileScheduler.Params":
+            return SingleTileScheduler.Params(
+                args.num_block,
+                args.num_head,
+                args.num_batch,
+                args.num_splits,
+                FastDivmodDivisor(args.num_splits),
+                args.is_split_kv,
+                args.cluster_shape_mn,
+                args.use_cluster_idx,
+            )
+
+    def __init__(self, params: Params, blk_coord: cute.Coord, *, loc=None, ip=None):
+        self.params = params
+        self._blk_coord = blk_coord
+        self._is_first_block = True
+        self._loc = loc
+        self._ip = ip
+
+    @staticmethod
+    def to_underlying_arguments(
+        args: TileSchedulerArguments,
+        *,
+        scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+        loc=None,
+        ip=None,
+    ) -> Params:
+        assert scheduling_mode == SchedulingMode.STATIC, (
+            f"SingleTileScheduler only supports STATIC, got {scheduling_mode!r}"
+        )
+        return SingleTileScheduler.Params.create(args, loc=loc, ip=ip)
+
+    @staticmethod
+    def create(
+        params: Params, clc: ClcState | None = None, *, loc=None, ip=None
+    ) -> "SingleTileScheduler":
+        if const_expr(cute.size(params.cluster_shape_mn) == 1 or not params.use_cluster_idx):
+            blk_coord = cute.arch.block_idx()
+        else:
+            blk_coord = cute.arch.cluster_idx()
+        return SingleTileScheduler(params, blk_coord, loc=loc, ip=ip)
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: Params,
+        *,
+        loc=None,
+        ip=None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        # TODO: this hard-codes the fact that we only use cluster = (1, 1) or (2, 1)
+        assert params.cluster_shape_mn[1] == 1, "Only cluster_shape_mn[1] == 1 is supported"
+        if const_expr(params.use_cluster_idx):
+            # Grid must have num_block * cluster_m physical blocks so that there are num_block clusters
+            grid_x = params.num_block * params.cluster_shape_mn[0]
+        else:
+            grid_x = cute.round_up(params.num_block, params.cluster_shape_mn[0])
+        return (
+            grid_x,
+            params.num_head * params.num_splits,
+            params.num_batch,
+        )
+
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        block_idx, head_idx, batch_idx = self._blk_coord
+        if const_expr(self.params.is_split_kv):
+            head_idx, split_idx = divmod(head_idx, self.params.num_splits_divmod)
+        else:
+            split_idx = Int32(0)
+        return WorkTileInfo(
+            (block_idx, head_idx, batch_idx, split_idx),
+            self._is_first_block,
+        )
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        pass
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        self._is_first_block = False
+        return self.get_current_work()
+
+    def producer_tail(self, *, loc=None, ip=None):
+        pass
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.params, self._blk_coord]:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.params, self._blk_coord], self._values_pos):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return SingleTileScheduler(*(tuple(obj_list)), loc=self._loc)
+
+
+class StaticPersistentTileScheduler:
+    @dataclass
+    class Params(ParamsBase):
+        num_block_cluster_divmod: FastDivmodDivisor
+        num_head_divmod: FastDivmodDivisor
+        total_blocks_cluster: Int32
+        cluster_shape_m: cutlass.Constexpr[int] = 1
+
+        @staticmethod
+        def create(
+            args: TileSchedulerArguments, *, loc=None, ip=None
+        ) -> "StaticPersistentTileScheduler.Params":
+            num_block_cluster = cute.ceil_div(args.num_block, cute.size(args.cluster_shape_mn))
+            total_blocks_cluster = num_block_cluster * args.num_head * args.num_batch
+            return StaticPersistentTileScheduler.Params(
+                FastDivmodDivisor(num_block_cluster),
+                FastDivmodDivisor(args.num_head),
+                total_blocks_cluster,
+                cluster_shape_m=args.cluster_shape_mn[0],
+            )
+
+    def __init__(self, params: Params, tile_idx: Int32, *, loc=None, ip=None):
+        self.params = params
+        self._tile_idx = tile_idx
+        self._loc = loc
+        self._ip = ip
+
+    @staticmethod
+    def to_underlying_arguments(
+        args: TileSchedulerArguments,
+        *,
+        scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+        loc=None,
+        ip=None,
+    ) -> Params:
+        assert scheduling_mode == SchedulingMode.STATIC, (
+            f"StaticPersistentTileScheduler only supports STATIC, got {scheduling_mode!r}"
+        )
+        return StaticPersistentTileScheduler.Params.create(args, loc=loc, ip=ip)
+
+    @staticmethod
+    def create(
+        params: Params, clc: ClcState | None = None, *, loc=None, ip=None
+    ) -> "StaticPersistentTileScheduler":
+        if const_expr(cute.size(params.cluster_shape_m) == 1):
+            tile_idx = cute.arch.block_idx()[0]
+        else:
+            tile_idx = cute.arch.cluster_idx()[0]
+        return StaticPersistentTileScheduler(params, tile_idx, loc=loc, ip=ip)
+
+    @staticmethod
+    def get_grid_shape(
+        params: Params,
+        *,
+        loc=None,
+        ip=None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        hardware_info = cutlass.utils.HardwareInfo()
+        sm_count = hardware_info.get_device_multiprocessor_count()
+        max_ctas = (sm_count // params.cluster_shape_m) * params.cluster_shape_m
+        grid_x = cutlass.min(max_ctas, params.total_blocks_cluster * params.cluster_shape_m)
+        return (grid_x, Int32(1), Int32(1))
+
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        hn_idx, block_idx = divmod(self._tile_idx, self.params.num_block_cluster_divmod)
+        batch_idx, head_idx = divmod(hn_idx, self.params.num_head_divmod)
+        is_valid = self._tile_idx < self.params.total_blocks_cluster
+        return WorkTileInfo(
+            (Int32(block_idx), Int32(head_idx), Int32(batch_idx), Int32(0)), is_valid
+        )
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        pass
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        if const_expr(self.params.cluster_shape_m == 1):
+            self._tile_idx += cute.arch.grid_dim()[0]
+        else:
+            self._tile_idx += cute.arch.cluster_dim()[0]
+        return self.get_current_work()
+
+    def producer_tail(self, *, loc=None, ip=None):
+        pass
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.params, self._tile_idx]:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip(
+            [self.params, self._tile_idx],
+            self._values_pos,
+        ):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return StaticPersistentTileScheduler(*(tuple(obj_list)), loc=self._loc)
+
+
+class SingleTileLPTScheduler:
+    @dataclass
+    class Params(ParamsBase):
+        total_blocks: Int32
+        num_splits: Int32
+        num_block: Int32
+        num_head: Int32
+        num_batch: Int32
+        l2_minor: Int32
+        num_head_divmod: FastDivmodDivisor
+        l2_minor_divmod: FastDivmodDivisor
+        l2_major_divmod: FastDivmodDivisor
+        l2_minor_residual_divmod: FastDivmodDivisor
+        num_hb_quotient: Int32
+        num_splits_divmod: FastDivmodDivisor
+        is_split_kv: cutlass.Constexpr[bool] = False
+        cluster_shape_m: cutlass.Constexpr[int] = 1
+        scheduling_mode: cutlass.Constexpr[SchedulingMode] = SchedulingMode.STATIC
+        lpt: cutlass.Constexpr[bool] = True
+        use_cluster_idx: cutlass.Constexpr[bool] = True
+
+        @staticmethod
+        @cute.jit
+        def create(
+            args: TileSchedulerArguments,
+            *,
+            scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+            loc=None,
+            ip=None,
+        ) -> "SingleTileLPTScheduler.Params":
+            assert scheduling_mode in (SchedulingMode.STATIC, SchedulingMode.CLC), (
+                f"Only STATIC and CLC are supported, got {scheduling_mode!r}"
+            )
+            size_one_kv_head = args.seqlen_k * (args.headdim + args.headdim_v) * args.element_size
+            size_one_head = size_one_kv_head
+            size_l2 = 50 * 1024 * 1024  # 40 MB for K & V
+            # Swizzle is the size of each "section". Round swizzle to a power of 2
+            # Need to be careful about the case where only one head will fit
+            # swizzle is how many heads can fit in L2
+            # Seems faster if swizzle is a power of 2
+            log2_floor = lambda n: 31 - clz(n)
+            swizzle = 1 if size_l2 < size_one_head else (1 << log2_floor(size_l2 // size_one_head))
+            # If we're in the last section (called residual), we don't want to divide by
+            # swizzle. Instead we want to divide by the remainder.
+            num_hb_quotient = (args.num_head * args.num_batch) // swizzle
+            num_hb_remainder = (args.num_head * args.num_batch) % swizzle
+            return SingleTileLPTScheduler.Params(
+                total_blocks=args.num_block * args.num_head * args.num_batch,
+                num_block=args.num_block,
+                num_head=args.num_head,
+                num_batch=args.num_batch,
+                l2_minor=Int32(swizzle),
+                num_head_divmod=FastDivmodDivisor(args.num_head),
+                l2_minor_divmod=FastDivmodDivisor(swizzle),
+                l2_major_divmod=FastDivmodDivisor(swizzle * args.num_block),
+                l2_minor_residual_divmod=FastDivmodDivisor(max(num_hb_remainder, 1)),
+                num_hb_quotient=Int32(num_hb_quotient),
+                num_splits=args.num_splits,
+                num_splits_divmod=FastDivmodDivisor(args.num_splits),
+                is_split_kv=args.is_split_kv,
+                cluster_shape_m=args.cluster_shape_mn[0],
+                scheduling_mode=scheduling_mode,
+                lpt=args.lpt,
+                use_cluster_idx=args.use_cluster_idx,
+            )
+
+    def __init__(
+        self,
+        params: Params,
+        tile_idx: Int32,
+        split_idx: Int32,
+        clc: ClcState | None = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.params = params
+        self._tile_idx = tile_idx
+        self._split_idx = split_idx
+        self.clc = clc
+        self._loc = loc
+        self._ip = ip
+
+    @staticmethod
+    def to_underlying_arguments(
+        args: TileSchedulerArguments,
+        *,
+        scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+        loc=None,
+        ip=None,
+    ) -> Params:
+        return SingleTileLPTScheduler.Params.create(
+            args, scheduling_mode=scheduling_mode, loc=loc, ip=ip
+        )
+
+    @staticmethod
+    def _clc_grid_shape(params: Params):
+        num_batch_splits = (
+            params.num_batch * params.num_splits
+            if const_expr(params.is_split_kv)
+            else params.num_batch
+        )
+        return (
+            cute.round_up(params.num_block, params.cluster_shape_m),
+            params.num_head,
+            num_batch_splits,
+        )
+
+    @staticmethod
+    @cute.jit
+    def clc_problem_shape(params: Params):
+        return ClcDynamicPersistentTileSchedulerParams(
+            problem_shape_ntile_mnl=SingleTileLPTScheduler._clc_grid_shape(params),
+            cluster_shape_mnk=(params.cluster_shape_m, 1, 1),
+        )
+
+    @staticmethod
+    @cute.jit
+    def create(
+        params: Params, clc: ClcState | None = None, *, loc=None, ip=None
+    ) -> "SingleTileLPTScheduler":
+        if const_expr(params.scheduling_mode == SchedulingMode.CLC):
+            return SingleTileLPTScheduler(
+                params, cute.arch.block_idx()[0], Int32(0), clc, loc=loc, ip=ip
+            )
+        tile_idx, split_idx, _ = cute.arch.block_idx()
+        return SingleTileLPTScheduler(params, tile_idx, split_idx, loc=loc, ip=ip)
+
+    @staticmethod
+    def get_grid_shape(
+        params: Params,
+        *,
+        loc=None,
+        ip=None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        if const_expr(params.scheduling_mode == SchedulingMode.CLC):
+            return SingleTileLPTScheduler._clc_grid_shape(params)
+        return (params.total_blocks, params.num_splits, Int32(1))
+
+    @cute.jit
+    def clc_work_to_coords(self, work) -> WorkTileInfo:
+        """Convert CLC response (block, head, batch_split) to WorkTileInfo.
+
+        CLC returns raw grid coordinates — no L2 swizzle (hardware decides order).
+        We only apply cluster division, optional LPT block reversal, and split_kv unpacking.
+        """
+        block_idx = work.tile_idx[0]
+        if const_expr(self.params.cluster_shape_m > 1):
+            block_idx = block_idx // self.params.cluster_shape_m
+        if const_expr(self.params.lpt):
+            # Longest-processing-time-first: reverse block order
+            if const_expr(self.params.cluster_shape_m > 1 and not self.params.use_cluster_idx):
+                num_block = self.params.num_block // self.params.cluster_shape_m
+            else:
+                num_block = self.params.num_block
+            block_idx = num_block - 1 - block_idx
+        split_idx = Int32(0)
+        if const_expr(self.params.is_split_kv):
+            batch_idx, split_idx = divmod(work.tile_idx[2], self.params.num_splits_divmod)
+        else:
+            batch_idx = work.tile_idx[2]
+        if const_expr(self.params.cluster_shape_m > 1 and not self.params.use_cluster_idx):
+            bidx_in_cluster = cute.arch.block_in_cluster_idx()
+            block_idx = block_idx * self.params.cluster_shape_m + bidx_in_cluster[0]
+        return WorkTileInfo(
+            (Int32(block_idx), Int32(work.tile_idx[1]), Int32(batch_idx), Int32(split_idx)),
+            work.is_valid_tile,
+        )
+
+    @cute.jit
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            work = self.clc.get_current_work()
+            self._tile_idx = work.tile_idx[0]
+            return self.clc_work_to_coords(work)
+        # Static path: L2-swizzled coordinate mapping
+        params = self.params
+        # Implement LPT scheduling coordinate calculation
+        bidhb, l2_mod = divmod(self._tile_idx, params.l2_major_divmod)
+        # If we're in the last section (called residual), we don't want to divide by
+        # swizzle. Instead we want to divide by the remainder.
+        block, bidhb_residual = 0, 0
+        if bidhb < params.num_hb_quotient:
+            block, bidhb_residual = divmod(l2_mod, params.l2_minor_divmod)
+        else:
+            block, bidhb_residual = divmod(l2_mod, params.l2_minor_residual_divmod)
+        bidhb_actual = bidhb * params.l2_minor + bidhb_residual
+        batch_idx, head_idx = divmod(bidhb_actual, params.num_head_divmod)
+        # Longest-processing-time-first
+        if const_expr(params.lpt):
+            block = params.num_block - 1 - block
+        is_valid = self._tile_idx < params.total_blocks
+        return WorkTileInfo(
+            (Int32(block), Int32(head_idx), Int32(batch_idx), Int32(self._split_idx)), is_valid
+        )
+
+    @cute.jit
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            work = self.clc.initial_work_tile_info()
+            self._tile_idx = work.tile_idx[0]
+            return self.clc_work_to_coords(work)
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            self.clc.prefetch_next_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            self.clc.consumer_wait(loc=loc, ip=ip)
+            work = self.get_current_work()
+            self.clc.consumer_release(loc=loc, ip=ip)
+            return work
+        # Single tile scheduler - set to invalid tile_idx to indicate no more work
+        self._tile_idx = self.params.total_blocks
+        return self.get_current_work()
+
+    def producer_tail(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            self.clc.producer_tail(loc=loc, ip=ip)
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        objs = [self.params, self._tile_idx, self._split_idx]
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            objs += [self.clc]
+        for obj in objs:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        objs = [self.params, self._tile_idx, self._split_idx]
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            objs += [self.clc]
+        for obj, n_items in zip(objs, self._values_pos):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return self.__class__(*obj_list, loc=self._loc)
+
+
+class SingleTileLPTBwdScheduler:
+    @dataclass
+    class Params(ParamsBase):
+        total_blocks: Int32
+        num_block: Int32
+        l2_minor: Int32
+        num_head_divmod: FastDivmodDivisor
+        l2_minor_divmod: FastDivmodDivisor
+        l2_major_divmod: FastDivmodDivisor
+        l2_minor_residual_divmod: FastDivmodDivisor
+        num_hb_quotient: Int32
+        cluster_shape_mn: cutlass.Constexpr[Tuple[int, int]] = (1, 1)
+        spt: cutlass.Constexpr[bool] = True
+
+        @staticmethod
+        @cute.jit
+        def create(
+            args: TileSchedulerArguments, *, loc=None, ip=None
+        ) -> "SingleTileLPTBwdScheduler.Params":
+            size_l2 = 50 * 1024 * 1024
+            size_one_qdo_head = args.seqlen_k * (args.headdim + args.headdim_v) * args.element_size
+            size_one_dqaccum_head = args.seqlen_k * (args.headdim) * 4
+            # size_one_dqaccum_head = 0
+            size_one_head = size_one_qdo_head + size_one_dqaccum_head
+            log2_floor = lambda n: 31 - clz(n)
+            swizzle = 1 if size_l2 < size_one_head else (1 << log2_floor(size_l2 // size_one_head))
+            # swizzle = 8
+            # If we're in the last section (called residual), we don't want to divide by
+            # swizzle. Instead we want to divide by the remainder.
+            num_hb_quotient = (args.num_head * args.num_batch) // swizzle
+            num_hb_remainder = (args.num_head * args.num_batch) % swizzle
+            num_block = cute.ceil_div(args.num_block, args.cluster_shape_mn[0])
+            return SingleTileLPTBwdScheduler.Params(
+                total_blocks=(num_block * args.cluster_shape_mn[0])
+                * args.num_head
+                * args.num_batch,
+                num_block=num_block,
+                l2_minor=Int32(swizzle),
+                num_head_divmod=FastDivmodDivisor(args.num_head),
+                l2_minor_divmod=FastDivmodDivisor(swizzle),
+                l2_major_divmod=FastDivmodDivisor(swizzle * num_block),
+                l2_minor_residual_divmod=FastDivmodDivisor(
+                    max(num_hb_remainder, 1)
+                ),  # don't divide by 0
+                num_hb_quotient=Int32(num_hb_quotient),
+                cluster_shape_mn=args.cluster_shape_mn,
+                spt=args.lpt,
+            )
+
+    def __init__(self, params: Params, tile_idx: Int32, *, loc=None, ip=None):
+        self.params = params
+        self._tile_idx = tile_idx
+        self._loc = loc
+        self._ip = ip
+
+    @staticmethod
+    def to_underlying_arguments(
+        args: TileSchedulerArguments,
+        *,
+        scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+        loc=None,
+        ip=None,
+    ) -> Params:
+        assert scheduling_mode == SchedulingMode.STATIC, (
+            f"SingleTileLPTBwdScheduler only supports STATIC, got {scheduling_mode!r}"
+        )
+        return SingleTileLPTBwdScheduler.Params.create(args, loc=loc, ip=ip)
+
+    @staticmethod
+    @cute.jit
+    def create(params: Params, *, loc=None, ip=None) -> "SingleTileLPTBwdScheduler":
+        tile_idx = cute.arch.block_idx()[0]
+        return SingleTileLPTBwdScheduler(params, tile_idx, loc=loc, ip=ip)
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: Params,
+        *,
+        loc=None,
+        ip=None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        return (params.total_blocks, Int32(1), Int32(1))
+
+    @cute.jit
+    def get_current_work(self, *, loc=None, ip=None) -> cutlass.utils.WorkTileInfo:
+        cluster_idx = self._tile_idx // self.params.cluster_shape_mn[0]
+        params = self.params
+        # Implement LPT scheduling coordinate calculation
+        bidhb, l2_mod = divmod(cluster_idx, params.l2_major_divmod)
+        # If we're in the last section (called residual), we don't want to divide by
+        # swizzle. Instead we want to divide by the remainder.
+        block, bidhb_residual = 0, 0
+        if bidhb < params.num_hb_quotient:
+            block, bidhb_residual = divmod(l2_mod, params.l2_minor_divmod)
+        else:
+            block, bidhb_residual = divmod(l2_mod, params.l2_minor_residual_divmod)
+        bidhb_actual = bidhb * params.l2_minor + bidhb_residual
+        batch_idx, head_idx = divmod(bidhb_actual, params.num_head_divmod)
+        if cutlass.const_expr(params.spt):
+            block = params.num_block - 1 - block
+        if cutlass.const_expr(params.cluster_shape_mn[0] > 1):
+            bidx_in_cluster = cute.arch.block_in_cluster_idx()
+            block = block * params.cluster_shape_mn[0] + bidx_in_cluster[0]
+        is_valid = self._tile_idx < params.total_blocks
+        return WorkTileInfo((Int32(block), Int32(head_idx), Int32(batch_idx), Int32(0)), is_valid)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        pass
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        # Single tile scheduler - set to invalid tile_idx to indicate no more work
+        self._tile_idx = self.params.total_blocks
+        return self.get_current_work()
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.params, self._tile_idx]:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.params, self._tile_idx], self._values_pos):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return self.__class__(*(tuple(obj_list)), loc=self._loc)
+
+
+class SingleTileVarlenScheduler:
+    @dataclass
+    class Params(ParamsBase):
+        num_head: Int32
+        num_batch: Int32
+        total_q: Int32
+        num_splits: Int32
+        max_kvblock_in_l2: Int32
+        tile_shape_mn: cutlass.Constexpr[Tuple[int, int]]
+        mCuSeqlensQ: Optional[cute.Tensor] = None
+        mSeqUsedQ: Optional[cute.Tensor] = None
+        qhead_per_kvhead_packgqa: cutlass.Constexpr[int] = 1
+        lpt: cutlass.Constexpr[bool] = False
+        is_split_kv: cutlass.Constexpr[bool] = False
+        head_swizzle: cutlass.Constexpr[bool] = False
+        cluster_shape_m: cutlass.Constexpr[int] = 1
+        scheduling_mode: cutlass.Constexpr[SchedulingMode] = SchedulingMode.STATIC
+
+        @staticmethod
+        @cute.jit
+        def create(
+            args: TileSchedulerArguments,
+            *,
+            scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+            loc=None,
+            ip=None,
+        ) -> "SingleTileVarlenScheduler.Params":
+            assert scheduling_mode in (SchedulingMode.STATIC, SchedulingMode.CLC), (
+                f"Only STATIC and CLC are supported, got {scheduling_mode!r}"
+            )
+            size_l2 = 50 * 1024 * 1024  # 50 MB for K & V
+            # if backward, this is qdo block size
+            kv_block_size = (
+                (args.headdim + args.headdim_v) * args.element_size * args.tile_shape_mn[1]
+            )
+            # if backward, add dqaccum block size to calculate swizzle
+            if args.head_swizzle:
+                kv_block_size += args.headdim * 4 * args.tile_shape_mn[1]
+            max_kvblock_in_l2 = size_l2 // kv_block_size
+            assert args.mCuSeqlensQ is not None or args.mSeqUsedQ is not None, (
+                "At least one of mCuSeqlensQ or mSeqUsedQ must be provided"
+            )
+            assert args.cluster_shape_mn[1] == 1, "Only cluster_shape_mn[1] == 1 is supported"
+            # TODO: Support varlen CLC with cluster_shape_m > 1 by refactoring the
+            # flattened-tile decode so cluster unpacking semantics are explicit.
+            assert scheduling_mode != SchedulingMode.CLC or args.cluster_shape_mn[0] == 1, (
+                "Varlen CLC currently requires cluster_shape_mn[0] == 1"
+            )
+            return SingleTileVarlenScheduler.Params(
+                num_head=args.num_head,
+                num_batch=args.num_batch,
+                total_q=args.total_q,
+                num_splits=args.num_splits,
+                max_kvblock_in_l2=max_kvblock_in_l2,
+                tile_shape_mn=args.tile_shape_mn,
+                mCuSeqlensQ=args.mCuSeqlensQ,
+                mSeqUsedQ=args.mSeqUsedQ,
+                qhead_per_kvhead_packgqa=args.qhead_per_kvhead_packgqa,
+                lpt=args.lpt,
+                is_split_kv=args.is_split_kv,
+                head_swizzle=args.head_swizzle,
+                cluster_shape_m=args.cluster_shape_mn[0],
+                scheduling_mode=scheduling_mode,
+            )
+
+    def __init__(
+        self,
+        params: Params,
+        tile_idx: Int32,
+        split_idx: Int32,
+        clc: ClcState | None = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.params = params
+        self._tile_idx = tile_idx
+        self._split_idx = split_idx
+        self._is_first_block = True
+        self.clc = clc
+        self._loc = loc
+        self._ip = ip
+
+    @staticmethod
+    def to_underlying_arguments(
+        args: TileSchedulerArguments,
+        *,
+        scheduling_mode: SchedulingMode = SchedulingMode.STATIC,
+        loc=None,
+        ip=None,
+    ) -> Params:
+        return SingleTileVarlenScheduler.Params.create(
+            args, scheduling_mode=scheduling_mode, loc=loc, ip=ip
+        )
+
+    @staticmethod
+    @cute.jit
+    def clc_problem_shape(params: Params):
+        return ClcDynamicPersistentTileSchedulerParams(
+            problem_shape_ntile_mnl=SingleTileVarlenScheduler.get_grid_shape(params),
+            cluster_shape_mnk=(1, 1, 1),
+        )
+
+    @staticmethod
+    @cute.jit
+    def create(
+        params: Params, clc: ClcState | None = None, *, loc=None, ip=None
+    ) -> "SingleTileVarlenScheduler":
+        if const_expr(params.scheduling_mode == SchedulingMode.CLC):
+            block_idx = cute.arch.block_idx()
+            split_idx = Int32(0)
+            if const_expr(params.is_split_kv):
+                split_idx = block_idx[1]
+            return SingleTileVarlenScheduler(
+                params,
+                block_idx[0],
+                split_idx,
+                clc,
+                loc=loc,
+                ip=ip,
+            )
+        tile_idx, split_idx, _ = cute.arch.block_idx()
+        return SingleTileVarlenScheduler(params, tile_idx, split_idx, loc=loc, ip=ip)
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: Params,
+        *,
+        loc=None,
+        ip=None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        total_blocks_max = (
+            params.total_q
+            + params.num_batch * (params.cluster_shape_m * params.tile_shape_mn[0] - 1)
+        ) // params.tile_shape_mn[0]
+        # Round down to nearest multiple of cluster since odd excess is always padding.
+        total_blocks_max = total_blocks_max // params.cluster_shape_m * params.cluster_shape_m
+        return (total_blocks_max * params.num_head, params.num_splits, Int32(1))
+
+    @cute.jit
+    def _get_num_m_blocks(self, lane: Int32, bidb_start: Int32) -> Int32:
+        params = self.params
+        batch_idx = lane + bidb_start
+        if cutlass.const_expr(params.mSeqUsedQ is not None):
+            seqlen = Int32(0)
+            if batch_idx < params.num_batch:
+                seqlen = params.mSeqUsedQ[batch_idx]
+        else:
+            assert params.mCuSeqlensQ is not None
+            cur_cu_seqlen = Int32(0)
+            if batch_idx <= params.num_batch:
+                cur_cu_seqlen = params.mCuSeqlensQ[batch_idx]
+            next_cu_seqlen = cute.arch.shuffle_sync_down(cur_cu_seqlen, offset=1)
+            seqlen = next_cu_seqlen - cur_cu_seqlen
+        if cutlass.const_expr(params.qhead_per_kvhead_packgqa > 1):
+            seqlen *= params.qhead_per_kvhead_packgqa
+        return (
+            cute.ceil_div(cute.ceil_div(seqlen, params.tile_shape_mn[0]), params.cluster_shape_m)
+            if batch_idx < params.num_batch and lane < cute.arch.WARP_SIZE - 1
+            else Int32(0)
+        )
+
+    @cute.jit
+    def _varlen_coord_map(self) -> WorkTileInfo:
+        """Map self._tile_idx to (block, head, batch) via warp-level prefix sums."""
+        params = self.params
+        lane_idx = cute.arch.lane_idx()
+        num_m_blocks = self._get_num_m_blocks(lane_idx, bidb_start=0)
+        num_m_blocks_cumulative = utils.warp_prefix_sum(num_m_blocks, lane_idx)
+        # Total number of blocks for the next 31 batches
+        m_blocks_in_group = cute.arch.shuffle_sync(num_m_blocks_cumulative, cute.arch.WARP_SIZE - 1)
+        # Same for all lanes
+        group_end_tile = m_blocks_in_group * params.num_head
+        # if cute.arch.thread_idx()[0] == 128 + 31: cute.printf("SingleTileVarlenScheduler: tile_idx=%d, group_end_tile = %d, num_m_blocks=%d, num_m_blocks_cumulative = %d, m_blocks_in_group = %d", self._tile_idx, group_end_tile, num_m_blocks, num_m_blocks_cumulative, m_blocks_in_group)
+        block, head_idx, batch_idx = Int32(0), Int32(0), Int32(0)
+        next_tile_idx = self._tile_idx // params.cluster_shape_m
+        while group_end_tile <= next_tile_idx:
+            batch_idx += cute.arch.WARP_SIZE - 1
+            if batch_idx >= params.num_batch:
+                batch_idx = Int32(params.num_batch)
+                group_end_tile = next_tile_idx + 1
+            else:
+                num_m_blocks = self._get_num_m_blocks(lane_idx, bidb_start=batch_idx)
+                num_m_blocks_cumulative = utils.warp_prefix_sum(num_m_blocks, lane_idx)
+                m_blocks_in_group = cute.arch.shuffle_sync(
+                    num_m_blocks_cumulative, cute.arch.WARP_SIZE - 1
+                )
+                group_end_tile += m_blocks_in_group * params.num_head
+        is_valid = False
+        if batch_idx >= params.num_batch:
+            block, head_idx, batch_idx = Int32(0), Int32(0), Int32(params.num_batch)
+        else:
+            group_start_tile = group_end_tile - m_blocks_in_group * params.num_head
+            # if cute.arch.thread_idx()[0] == 128 + 31: cute.printf("SingleTileVarlenScheduler: tile_idx=%d, group_end_tile = %d, num_m_blocks=%d, batch_idx = %d", self._tile_idx, group_end_tile, num_m_blocks, batch_idx)
+            # The next problem to process is the first one that does not have ending tile position
+            # that is greater than or equal to tile index.
+            batch_idx_in_group = cute.arch.popc(
+                cute.arch.vote_ballot_sync(
+                    group_start_tile + num_m_blocks_cumulative * params.num_head <= next_tile_idx
+                )
+            )
+            batch_idx += batch_idx_in_group
+            num_m_blocks_prev_lane = (
+                0
+                if batch_idx_in_group == 0
+                else cute.arch.shuffle_sync(num_m_blocks_cumulative, batch_idx_in_group - 1)
+            )
+            num_m_blocks = cute.arch.shuffle_sync(num_m_blocks, batch_idx_in_group)
+            mh_block = next_tile_idx - group_start_tile - num_m_blocks_prev_lane * params.num_head
+            if cutlass.const_expr(params.lpt or params.head_swizzle):
+                # This is a version of the SingleTileLPTScheduler, complicated by the fact that
+                # the seqlen can vary per batch.
+                # TODO: is there any case where num_m_blocks is 0?
+                # TODO: by right we should read the seqlen_kv but we're assuming seqlen_q == seqlen_k here
+                num_n_blocks = (
+                    num_m_blocks
+                    * params.tile_shape_mn[0]
+                    * params.cluster_shape_m
+                    // params.qhead_per_kvhead_packgqa
+                    // params.tile_shape_mn[1]
+                )
+                # nheads_in_l2 = min(max(self.max_kvblock_in_l2 // num_n_blocks, 1), self.num_head)
+                # Seems faster to have this be a power of 2
+                nheads_in_l2 = (
+                    16
+                    if num_n_blocks * 16 <= params.max_kvblock_in_l2
+                    else (
+                        8
+                        if num_n_blocks * 8 <= params.max_kvblock_in_l2
+                        else (
+                            4
+                            if num_n_blocks * 4 <= params.max_kvblock_in_l2
+                            else (2 if num_n_blocks * 2 <= params.max_kvblock_in_l2 else 1)
+                        )
+                    )
+                )
+                nheads_in_l2 = min(nheads_in_l2, params.num_head)
+                mh_in_l2 = nheads_in_l2 * num_m_blocks
+                section_idx = mh_block // mh_in_l2
+                l2_mod = mh_block - section_idx * mh_in_l2
+                # Deal with tail section
+                nheads_in_this_section = (
+                    nheads_in_l2
+                    if nheads_in_l2 * (section_idx + 1) <= params.num_head
+                    else params.num_head - section_idx * nheads_in_l2
+                )
+                block = l2_mod // nheads_in_this_section
+                head_idx_residual = l2_mod - block * nheads_in_this_section
+                head_idx = section_idx * nheads_in_l2 + head_idx_residual
+                if cutlass.const_expr(params.lpt):
+                    block = num_m_blocks - 1 - block
+            else:
+                head_idx = mh_block // num_m_blocks
+                block = mh_block - head_idx * num_m_blocks
+            is_valid = self._is_first_block and batch_idx < params.num_batch
+            if cutlass.const_expr(params.cluster_shape_m > 1):
+                bidx_in_cluster = cute.arch.block_in_cluster_idx()
+                block = block * params.cluster_shape_m + bidx_in_cluster[0]
+        # if cute.arch.thread_idx()[0] == 128: cute.printf("SingleTileVarlenScheduler: tile_idx=%d, batch_idx=%d, head_idx=%d, block=%d, is_valid = %d", self._tile_idx, batch_idx, head_idx, block, is_valid)
+        split_idx = self._split_idx if const_expr(params.is_split_kv) else Int32(0)
+        return WorkTileInfo((Int32(block), Int32(head_idx), Int32(batch_idx), split_idx), is_valid)
+
+    @cute.jit
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            clc_work = self.clc.get_current_work()
+            # Default to grid_dim (one past last valid flat index) so _varlen_coord_map
+            # returns is_valid=False when CLC is exhausted. CLC tile_idx is garbage when
+            # invalid, so we can't trust it. Local-then-assign avoids CuTe DSL structural
+            # mismatch on self inside the runtime if.
+            new_tile_idx = cute.arch.grid_dim()[0]
+            new_split_idx = Int32(0)
+            if clc_work.is_valid_tile:
+                new_tile_idx = clc_work.tile_idx[0]
+                if const_expr(self.params.is_split_kv):
+                    new_split_idx = clc_work.tile_idx[1]
+            self._tile_idx = new_tile_idx
+            self._split_idx = new_split_idx
+        return self._varlen_coord_map()
+
+    @cute.jit
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            clc_work = self.clc.initial_work_tile_info()
+            # See get_current_work for why grid_dim and local-then-assign.
+            new_tile_idx = cute.arch.grid_dim()[0]
+            new_split_idx = Int32(0)
+            if clc_work.is_valid_tile:
+                new_tile_idx = clc_work.tile_idx[0]
+                if const_expr(self.params.is_split_kv):
+                    new_split_idx = clc_work.tile_idx[1]
+            self._tile_idx = new_tile_idx
+            self._split_idx = new_split_idx
+        return self._varlen_coord_map()
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            self.clc.prefetch_next_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            self.clc.consumer_wait(loc=loc, ip=ip)
+            work = self.get_current_work()
+            self.clc.consumer_release(loc=loc, ip=ip)
+            return work
+        self._is_first_block = False
+        return self.get_current_work()
+
+    def producer_tail(self, *, loc=None, ip=None):
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            self.clc.producer_tail(loc=loc, ip=ip)
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        objs = [self.params, self._tile_idx, self._split_idx]
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            objs += [self.clc]
+        for obj in objs:
+            obj_values = cutlass.extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        objs = [self.params, self._tile_idx, self._split_idx]
+        if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
+            objs += [self.clc]
+        for obj, n_items in zip(objs, self._values_pos):
+            obj_list.append(cutlass.new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return self.__class__(*obj_list, loc=self._loc)
+
+
+# -----------------------------------------------------------------------------
+# SM100 FMHA-specific schedulers (kept separate from generic schedulers).
+# -----------------------------------------------------------------------------
+
+
+class Sm100FmhaStaticTileSchedulerParams:
+    """A class to represent parameters for the FMHA (Fused Multi-Head Attention) static tile scheduler.
+
+    This class holds the configuration parameters needed to initialize and configure
+    the tile scheduler for FMHA operations.
+
+    :ivar is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :ivar problem_shape_mbh: Problem shape in (M, B, H) format.
+    :type problem_shape_mbh: cute.Shape
+    """
+
+    def __init__(
+        self,
+        is_persistent: bool,
+        problem_shape_mbh: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the Sm100FmhaStaticTileSchedulerParams with the given parameters.
+
+        :param is_persistent: Whether to use persistent kernel mode.
+        :type is_persistent: bool
+        :param problem_shape_mbh: Problem shape in (M, B, H) format.
+        :type problem_shape_mbh: cute.Shape
+        """
+        self.is_persistent = is_persistent
+        self.problem_shape_mbh = problem_shape_mbh
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.problem_shape_mbh]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.problem_shape_mbh], self._values_pos):
+            obj_list.append(new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return Sm100FmhaStaticTileSchedulerParams(
+            self.is_persistent, *(tuple(obj_list)), loc=self._loc
+        )
+
+
+class Sm100FmhaStaticTileScheduler:
+    """A static tile scheduler for FMHA (Fused Multi-Head Attention) operations.
+
+    This class manages the scheduling of work tiles for FMHA kernels, supporting
+    both persistent and non-persistent kernel modes. It tracks the current work
+    position and advances through the problem space efficiently.
+
+    :ivar _params: Scheduler parameters.
+    :type _params: Sm100FmhaStaticTileSchedulerParams
+    :ivar _blk_coord: Block coordinates.
+    :type _blk_coord: cute.Coord
+    :ivar _grid_shape: Grid shape for the kernel.
+    :type _grid_shape: cute.Shape
+    :ivar _is_persistent: Whether to use persistent kernel mode.
+    :type _is_persistent: bool
+    :ivar _current_work_linear_idx: Current linear work index.
+    :type _current_work_linear_idx: Int32
+    :ivar _problem_shape_mbh: Problem shape in (M, B, H) format.
+    :type _problem_shape_mbh: cute.Layout
+    :ivar _num_blocks: Number of blocks in the problem.
+    :type _num_blocks: Int32
+    :ivar _is_first_block: Whether this is the first block.
+    :type _is_first_block: bool
+    :ivar num_persistent_sm: Number of persistent SMs.
+    :type num_persistent_sm: Int32
+    """
+
+    def __init__(
+        self,
+        params: Sm100FmhaStaticTileSchedulerParams,
+        current_work_linear_idx: Int32,
+        blk_coord: cute.Coord,
+        grid_shape: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the Sm100FmhaStaticTileScheduler with the given parameters.
+
+        :param params: Scheduler parameters.
+        :type params: Sm100FmhaStaticTileSchedulerParams
+        :param current_work_linear_idx: Current linear work index.
+        :type current_work_linear_idx: Int32
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param grid_shape: Grid shape for the kernel.
+        :type grid_shape: cute.Shape
+        """
+        self._params = params
+        self._blk_coord = blk_coord
+        self._grid_shape = grid_shape
+        self._is_persistent = params.is_persistent
+        self._current_work_linear_idx = current_work_linear_idx
+        self._problem_shape_mbh = cute.make_layout(params.problem_shape_mbh, loc=loc, ip=ip)
+        self._num_blocks = cute.size(self._problem_shape_mbh, loc=loc, ip=ip)
+        self._is_first_block = True
+        self.num_persistent_sm = cute.size(grid_shape, loc=loc, ip=ip)
+        self._loc = loc
+        self._ip = ip
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: Sm100FmhaStaticTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cute.Shape:
+        """
+        Determine the grid shape for the FMHA kernel.
+
+        For persistent kernels, the grid shape is limited by the number of SMs
+        (Streaming Multiprocessors) available on the device. For non-persistent
+        kernels, the grid shape matches the problem shape.
+
+        :param params: Scheduler parameters.
+        :type params: Sm100FmhaStaticTileSchedulerParams
+
+        :return: Grid shape as (M, B, H) tuple.
+        :rtype: cute.Shape
+        """
+        if params.is_persistent:
+            hardware_info = HardwareInfo()
+            sm_count = hardware_info.get_device_multiprocessor_count()
+            return (
+                dsl_min(sm_count, cute.size(params.problem_shape_mbh, loc=loc, ip=ip)),
+                1,
+                1,
+            )
+        else:
+            return params.problem_shape_mbh
+
+    @staticmethod
+    def check_valid_work_for_seqlen_q(
+        q_tiler: int,
+        current_idx: Int32,
+        seqlen_q: Int32,
+    ) -> Boolean:
+        """
+        Check if the current work index is valid for the given query sequence length.
+
+        This method verifies that the current work tile index multiplied by the
+        query tiler size is within the bounds of the query sequence length.
+
+        :param q_tiler: Query tiler size.
+        :type q_tiler: int
+        :param current_idx: Current work index.
+        :type current_idx: Int32
+        :param seqlen_q: Query sequence length.
+        :type seqlen_q: Int32
+
+        :return: True if the work is valid, False otherwise.
+        :rtype: Boolean
+        """
+        return current_idx * q_tiler < seqlen_q
+
+    def get_current_work(self, *, loc=None, ip=None) -> cutlass.utils.WorkTileInfo:
+        """
+        Get information about the current work tile.
+
+        Determines if the current work is valid and computes the tile coordinates
+        based on whether the kernel is persistent or non-persistent.
+
+        :return: WorkTileInfo containing tile coordinates and validity flag.
+        :rtype: WorkTileInfo
+        """
+        is_valid = (
+            self._current_work_linear_idx < self._num_blocks
+            if self._is_persistent
+            else self._is_first_block
+        )
+
+        blk_coord = (0, 0, 0)
+        if self._is_persistent:
+            blk_coord = self._problem_shape_mbh.get_hier_coord(
+                self._current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            blk_coord = self._blk_coord
+
+        # cur_tile_coord is (mid, 0, (bid, hid))
+        cur_tile_coord = (
+            blk_coord[0],
+            0,
+            (blk_coord[1], blk_coord[2]),
+        )
+
+        return cutlass.utils.WorkTileInfo(cur_tile_coord, is_valid)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        """
+        Get the initial work tile information.
+
+        :return: Initial WorkTileInfo.
+        :rtype: WorkTileInfo
+        """
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, advance_count=1, loc=None, ip=None):
+        """
+        Advance to the next work tile and return it.
+
+        For persistent kernels, advances by the number of persistent SMs.
+        For non-persistent kernels, marks that the first block has been processed.
+        """
+        if self._is_persistent:
+            self._current_work_linear_idx += advance_count * self.num_persistent_sm
+        self._is_first_block = False
+        return self.get_current_work()
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        """No-op for static scheduler."""
+        pass
+
+    def producer_tail(self, *, loc=None, ip=None):
+        """No-op for static scheduler."""
+        pass
+
+    def __extract_mlir_values__(self):
+        values = extract_mlir_values(self._params)
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self._blk_coord))
+        values.extend(extract_mlir_values(self._grid_shape))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        assert len(values) == 10
+        new_params = new_from_mlir_values(self._params, values[0:3])
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[3]]
+        )
+        new_blk_coord = new_from_mlir_values(self._blk_coord, values[4:7])
+        new_grid_shape = new_from_mlir_values(self._grid_shape, values[7:])
+        return Sm100FmhaStaticTileScheduler(
+            new_params, new_current_work_linear_idx, new_blk_coord, new_grid_shape
+        )
+
+
+def compute_sm100_fmha_grid(
+    o_shape: cute.Shape,
+    cta_tiler: Tuple[int, int, int],
+    is_persistent: bool,
+) -> Tuple[Sm100FmhaStaticTileSchedulerParams, Tuple[int, int, int]]:
+    """Compute grid parameters for FMHA (static scheduler).
+
+    The output tensor o has shape (s, d, ((h_r, h_k), b)).
+    """
+    tile_sched_params = Sm100FmhaStaticTileSchedulerParams(
+        is_persistent,
+        (
+            cute.ceil_div(cute.size(o_shape[0]), cta_tiler[0]),
+            cute.size(o_shape[2][0]),
+            cute.size(o_shape[2][1]),
+        ),
+    )
+    grid = Sm100FmhaStaticTileScheduler.get_grid_shape(tile_sched_params)
+    return tile_sched_params, grid
+
+
+##############################################################################
+# Fmha CLC dynamic tile scheduler
+##############################################################################
+
+
+class Sm100FmhaClcDynamicTileSchedulerParams:
+    """Parameters for FMHA CLC dynamic persistent tile scheduler.
+
+    This class manages the layout of tiles for CLC (Cluster Launch Control)
+    based dynamic scheduling, adapted for FMHA's (M, B, H) problem shape.
+
+    :ivar problem_shape_mbh: Problem shape in (M, B, H) format.
+    :type problem_shape_mbh: cute.Shape
+    :ivar cluster_shape_mnk: Cluster shape in (M, N, K) format.
+    :type cluster_shape_mnk: cute.Shape
+    """
+
+    def __init__(
+        self,
+        problem_shape_mbh: cute.Shape,
+        cluster_shape_mnk: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.problem_shape_mbh = problem_shape_mbh
+        self._cluster_shape_mnk = cluster_shape_mnk
+        self.cluster_shape_mn = cluster_shape_mnk[:2]
+        self._loc = loc
+        self._ip = ip
+
+        # FMHA uses linear indexing over (M, B, H), convert to (M, N, L) style
+        # For FMHA: M dim is tile count along sequence, N=1, L=(B*H)
+        self.problem_shape_ntile_mnl = (
+            problem_shape_mbh[0],  # M tiles
+            1,  # N tiles (always 1 for FMHA)
+            problem_shape_mbh[1] * problem_shape_mbh[2],  # L = B * H
+        )
+
+        # Create layout for cluster-to-tile mapping
+        self.problem_layout_ncluster_mnl = cute.make_layout(
+            cute.ceil_div(self.problem_shape_ntile_mnl, cluster_shape_mnk[:2]),
+            loc=loc,
+            ip=ip,
+        )
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [
+            self.problem_shape_mbh,
+            self._cluster_shape_mnk,
+        ]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        values_copy = list(values)
+        for obj, n_items in zip(
+            [self.problem_shape_mbh, self._cluster_shape_mnk],
+            self._values_pos,
+        ):
+            obj_list.append(new_from_mlir_values(obj, values_copy[:n_items]))
+            values_copy = values_copy[n_items:]
+        return Sm100FmhaClcDynamicTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
+
+    def get_grid_shape(self, *, loc=None, ip=None) -> Tuple[int, int, int]:
+        """Compute grid shape aligned with cluster shape."""
+        return cute.round_up(self.problem_shape_ntile_mnl, self._cluster_shape_mnk)
+
+    def clc_hw_params(self) -> ClcDynamicPersistentTileSchedulerParams:
+        """Return params for the upstream CLC hardware scheduler."""
+        return ClcDynamicPersistentTileSchedulerParams(
+            problem_shape_ntile_mnl=self.problem_shape_ntile_mnl,
+            cluster_shape_mnk=self._cluster_shape_mnk,
+        )
+
+
+class Sm100FmhaClcDynamicTileScheduler:
+    """CLC dynamic persistent tile scheduler for FMHA.
+
+    This scheduler uses Blackwell's Cluster Launch Control hardware mechanism
+    for dynamic tile distribution, providing automatic load balancing.
+    Adapted for FMHA's (M, B, H) problem shape.
+    """
+
+    def __init__(
+        self,
+        params: Sm100FmhaClcDynamicTileSchedulerParams,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+        clc_response_ptr: cute.Pointer,
+        block_idx: Tuple,
+        clc: ClcState = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        self.params = params
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self._num_tiles_executed = num_tiles_executed
+        self._clc_response_ptr = clc_response_ptr
+        self._block_idx = block_idx
+        self.clc = clc
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values = extract_mlir_values(self.cta_id_in_cluster)
+        values.extend(extract_mlir_values(self._num_tiles_executed))
+        values.extend(extract_mlir_values(self._clc_response_ptr))
+        values.extend(extract_mlir_values(self._block_idx))
+        if self.clc is not None:
+            values.extend(extract_mlir_values(self.clc))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        new_cta_id_in_cluster = new_from_mlir_values(self.cta_id_in_cluster, values[0:3])
+        new_num_tiles_executed = new_from_mlir_values(self._num_tiles_executed, [values[3]])
+        new_clc_response_ptr = new_from_mlir_values(self._clc_response_ptr, [values[4]])
+        new_block_idx = new_from_mlir_values(self._block_idx, values[5:8])
+        new_clc = None
+        if self.clc is not None:
+            new_clc = new_from_mlir_values(self.clc, values[8:])
+        return Sm100FmhaClcDynamicTileScheduler(
+            self.params,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+            new_clc_response_ptr,
+            new_block_idx,
+            new_clc,
+        )
+
+    @staticmethod
+    def create(
+        params: Sm100FmhaClcDynamicTileSchedulerParams,
+        block_idx: Tuple,
+        grid_dim: Tuple,
+        clc_response_ptr: cute.Pointer,
+        clc: ClcState = None,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """Create a CLC dynamic tile scheduler instance."""
+        bidx, bidy, bidz = block_idx
+
+        # CTA id in cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+
+        num_tiles_executed = Int32(0)
+
+        return Sm100FmhaClcDynamicTileScheduler(
+            params,
+            cta_id_in_cluster,
+            num_tiles_executed,
+            clc_response_ptr,
+            block_idx,
+            clc,
+        )
+
+    @staticmethod
+    def get_grid_shape(
+        params: Sm100FmhaClcDynamicTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> Tuple[int, int, int]:
+        """Get grid shape for kernel launch."""
+        return params.get_grid_shape(loc=loc, ip=ip)
+
+    def work_tile_info_from_clc_response(self, result_addr: cute.Pointer, *, loc=None, ip=None):
+        """Parse CLC response and convert to FMHA tile coordinates."""
+        m_idx, n_idx, l_idx, vld = cute.arch.clc_response(result_addr, loc=loc, ip=ip)
+        cute.arch.fence_proxy("async.shared", space="cta")
+
+        # CLC returns first CTA coordinates: m_idx=x, l_idx=z
+        # l_idx is the L (batch) dimension; decode to (bid, hid)
+        hid = l_idx % self.params.problem_shape_mbh[2]
+        bid = l_idx // self.params.problem_shape_mbh[2]
+
+        cta_idx_in_cluster, cta_idy_in_cluster, _ = self.cta_id_in_cluster
+        cur_tile_coord = (
+            m_idx + cta_idx_in_cluster,  # M dimension
+            0,  # N always 0 for FMHA
+            (bid, hid),  # (B, H) packed
+        )
+
+        return cutlass.utils.WorkTileInfo(cur_tile_coord, vld)
+
+    def get_current_work(self, *, loc=None, ip=None):
+        """Get current work tile from CLC response."""
+        return self.work_tile_info_from_clc_response(self._clc_response_ptr, loc=loc, ip=ip)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        """Get initial work tile based on block index."""
+        bidx, bidy, bidz = self._block_idx
+        # bidz is the L (batch) dimension; decode to (bid, hid)
+        hid = bidz % self.params.problem_shape_mbh[2]
+        bid = bidz // self.params.problem_shape_mbh[2]
+        return cutlass.utils.WorkTileInfo((bidx, 0, (bid, hid)), True)
+
+    def advance_to_next_work(self, *, loc=None, ip=None):
+        """Consumer-side advance: wait for next tile, read coordinates, release."""
+        self.clc.consumer_wait(loc=loc, ip=ip)
+        work = self.get_current_work(loc=loc, ip=ip)
+        self.clc.consumer_release(loc=loc, ip=ip)
+        self._num_tiles_executed += Int32(1)
+        return work
+
+    def prefetch_next_work(self, *, loc=None, ip=None):
+        """Producer-side: issue CLC query for next tile."""
+        self.clc.prefetch_next_work(loc=loc, ip=ip)
+
+    def producer_tail(self, *, loc=None, ip=None):
+        """Producer-side cleanup after last tile."""
+        self.clc.producer_tail(loc=loc, ip=ip)
+
+    @property
+    def num_tiles_executed(self) -> Int32:
+        return self._num_tiles_executed
+
+
+def compute_sm100_fmha_grid_clc(
+    o_shape: cute.Shape,
+    cta_tiler: Tuple[int, int, int],
+    cluster_shape_mnk: Tuple[int, int, int],
+) -> Tuple[Sm100FmhaClcDynamicTileSchedulerParams, Tuple[int, int, int]]:
+    """Compute grid parameters for FMHA with CLC dynamic scheduling."""
+    problem_shape_mbh = (
+        cute.ceil_div(cute.size(o_shape[0]), cta_tiler[0]),
+        cute.size(o_shape[2][0]),
+        cute.size(o_shape[2][1]),
+    )
+    tile_sched_params = Sm100FmhaClcDynamicTileSchedulerParams(problem_shape_mbh, cluster_shape_mnk)
+    grid = Sm100FmhaClcDynamicTileScheduler.get_grid_shape(tile_sched_params)
+    return tile_sched_params, grid
+
+
+##############################################################################
+# Fused Mask
+##############################################################################
+
+
+def make_sm100_thread_cooperative_group(size: int):
+    return cutlass.pipeline.CooperativeGroup(cutlass.pipeline.Agent.Thread, size)
+
+
+SM100_TMEM_CAPACITY_COLUMNS = 512

--- a/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/utils.py
+++ b/csrc/attention/flash_attn_4_src/flashrt_fa4/cute/utils.py
@@ -1,0 +1,948 @@
+# Copyright (c) 2025, Tri Dao.
+
+import math
+import hashlib
+import inspect
+import os
+from functools import partial
+from typing import Type, Callable, Optional, Tuple, overload
+
+import cutlass
+import cutlass.cute as cute
+
+from cutlass import Float32, Int32, const_expr
+from cutlass.cute import FastDivmodDivisor
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass._mlir.dialects import nvvm, llvm
+from cutlass.cute.runtime import from_dlpack
+
+
+import quack.activation
+
+_MIXER_ATTRS = ("__vec_size__",)
+
+# Obtained from sollya:
+# fpminimax(exp(x * log(2.0)), 1, [|1,24...|],[0;1],relative);
+POLY_EX2 = {
+    0: (1.0),
+    1: (
+        1.0,
+        0.922497093677520751953125,
+    ),
+    2: (
+        1.0,
+        0.6657850742340087890625,
+        0.330107033252716064453125,
+    ),
+    3: (
+        1.0,
+        0.695146143436431884765625,
+        0.227564394474029541015625,
+        0.077119089663028717041015625,
+    ),
+    4: (
+        1.0,
+        0.693042695522308349609375,
+        0.2412912547588348388671875,
+        5.2225358784198760986328125e-2,
+        1.3434938155114650726318359375e-2,
+    ),
+    5: (
+        1.0,
+        0.693151414394378662109375,
+        0.24016360938549041748046875,
+        5.5802188813686370849609375e-2,
+        9.01452265679836273193359375e-3,
+        1.86810153536498546600341796875e-3,
+    ),
+}
+
+_fa_clc_enabled: bool = os.environ.get("FA_CLC", "0") == "1"
+_fa_disable_2cta_enabled: bool = os.environ.get("FA_DISABLE_2CTA", "0") == "1"
+
+
+def _is_cuda_12() -> bool:
+    """Check if the CUDA toolkit version is 12.x.
+
+    2CTA forward non-causal has a codegen regression on CUDA 12 that causes
+    ~18% slowdown compared to 1CTA. This is fixed in CUDA 13.x.
+    """
+    try:
+        import torch
+
+        cuda_version = torch.version.cuda
+        if cuda_version is not None:
+            major = cuda_version.split(".")[0]
+            return int(major) == 12
+    except Exception:
+        pass
+    return False
+
+
+_fa_disable_2cta_cuda12: bool = _is_cuda_12()
+
+
+def _get_use_clc_scheduler_default() -> bool:
+    return _fa_clc_enabled
+
+
+def _get_disable_2cta_default() -> bool:
+    return _fa_disable_2cta_enabled or _fa_disable_2cta_cuda12
+
+
+def _compute_base_hash(func: Callable) -> str:
+    """Compute hash from source code or bytecode and closure values."""
+    try:
+        data = inspect.getsource(func).encode()
+    except (OSError, TypeError):
+        if hasattr(func, "__code__") and func.__code__ is not None:
+            data = func.__code__.co_code
+        else:
+            data = repr(func).encode()
+
+    hasher = hashlib.sha256(data)
+
+    if hasattr(func, "__closure__") and func.__closure__ is not None:
+        for cell in func.__closure__:
+            hasher.update(repr(cell.cell_contents).encode())
+
+    return hasher.hexdigest()
+
+
+def hash_callable(
+    func: Callable, mixer_attrs: Tuple[str] = _MIXER_ATTRS, set_cute_hash: bool = True
+) -> str:
+    """Hash a callable based on the source code or bytecode and closure values.
+    Fast-path: if the callable (or its __wrapped__ base) has a ``__cute_hash__``
+    attribute, that value is returned immediately as the base hash, then
+    metadata dunders are mixed in to produce the final dict-key hash.
+    set_cute_hash: whether or not to set func.__cute_hash__
+    """
+    # Resolve base hash
+    if hasattr(func, "__cute_hash__"):
+        base_hash = func.__cute_hash__
+    else:
+        # Unwrap decorated functions (e.g., cute.jit wrappers).
+        base_func = getattr(func, "__wrapped__", func)
+
+        if hasattr(base_func, "__cute_hash__"):
+            base_hash = base_func.__cute_hash__
+        else:
+            base_hash = _compute_base_hash(base_func)
+
+            if set_cute_hash:
+                base_func.__cute_hash__ = base_hash
+
+    # Mix in mutable metadata dunders
+    mixer_values = tuple(getattr(func, attr, None) for attr in mixer_attrs)
+
+    if all(v is None for v in mixer_values):
+        return base_hash
+
+    hasher = hashlib.sha256(base_hash.encode())
+
+    for attr, val in zip(_MIXER_ATTRS, mixer_values):
+        hasher.update(f"{attr}={val!r}".encode())
+
+    return hasher.hexdigest()
+
+
+def create_softcap_scoremod(softcap_val):
+    @cute.jit
+    def scoremod_premask_fn(
+        acc_S_SSA, batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+    ):
+        scores = acc_S_SSA / softcap_val
+        return softcap_val * cute.math.tanh(scores, fastmath=True)
+
+    return scoremod_premask_fn
+
+
+def create_softcap_scoremod_bwd(softcap_val):
+    @cute.jit
+    def scoremod_bwd_fn(
+        grad_out_SSA, score_SSA, batch_idx, head_idx, q_idx, kv_idx, seqlen_info, aux_tensors
+    ):
+        scores = score_SSA / softcap_val
+        tanh_scores = cute.math.tanh(scores, fastmath=True)
+        return grad_out_SSA * (1.0 - tanh_scores * tanh_scores)
+
+    return scoremod_bwd_fn
+
+
+LOG2_E = math.log2(math.e)
+
+
+def compute_softmax_scale_log2(softmax_scale, score_mod):
+    """Compute softmax_scale_log2 and adjusted softmax_scale based on whether score_mod is used.
+
+    When score_mod is None, fold the log2(e) factor into softmax_scale_log2 and set softmax_scale
+    to None. When score_mod is present, keep softmax_scale separate so it can be applied before
+    the score_mod, and set softmax_scale_log2 to just the change-of-base constant.
+
+    Returns (softmax_scale_log2, softmax_scale).
+    """
+    if const_expr(score_mod is None):
+        return softmax_scale * LOG2_E, None
+    else:
+        return LOG2_E, softmax_scale
+
+
+def compute_fastdiv_mods(mQ, mK, qhead_per_kvhead, pack_gqa, aux_tensors, mPageTable=None):
+    """Compute FastDivmodDivisor pairs for aux_tensors index computation.
+
+    Returns a (seqlen_q_divmod, seqlen_k_divmod) tuple, or None if aux_tensors is None.
+    """
+    if const_expr(aux_tensors is None):
+        return None
+    seqlen_q = cute.size(mQ.shape[0]) // (qhead_per_kvhead if const_expr(pack_gqa) else 1)
+    seqlen_k = (
+        cute.size(mK.shape[0])
+        if const_expr(mPageTable is None)
+        else mK.shape[0] * mPageTable.shape[1]
+    )
+    return (FastDivmodDivisor(seqlen_q), FastDivmodDivisor(seqlen_k))
+
+
+def convert_from_dlpack(x, leading_dim, alignment=16, divisibility=1) -> cute.Tensor:
+    return (
+        from_dlpack(x, assumed_align=alignment)
+        .mark_layout_dynamic(leading_dim=leading_dim)
+        .mark_compact_shape_dynamic(
+            mode=leading_dim, stride_order=x.dim_order(), divisibility=divisibility
+        )
+    )
+
+
+def convert_from_dlpack_compact_dynamic(
+    x,
+    *,
+    dynamic_modes: tuple[int, ...],
+    alignment: int = 16,
+    stride_order=None,
+    divisibility: int = 1,
+    enable_tvm_ffi: bool = False,
+) -> cute.Tensor:
+    """Convert via DLPack and mark selected compact dimensions as dynamic."""
+    if isinstance(dynamic_modes, int):
+        dynamic_modes = (dynamic_modes,)
+    if stride_order is None:
+        stride_order = x.dim_order()
+    t = (
+        from_dlpack(x, assumed_align=alignment, enable_tvm_ffi=True)
+        if enable_tvm_ffi
+        else from_dlpack(x, assumed_align=alignment)
+    )
+    for mode in dynamic_modes:
+        t = t.mark_compact_shape_dynamic(
+            mode=mode,
+            stride_order=stride_order,
+            divisibility=divisibility,
+        )
+    return t
+
+
+def convert_from_dlpack_leading_static(
+    x, leading_dim, alignment=16, static_modes=None, stride_order=None
+) -> cute.Tensor:
+    if stride_order is None:
+        stride_order = x.dim_order()
+    x_ = from_dlpack(x, assumed_align=alignment)
+    for i in range(x.ndim):
+        if i != leading_dim and (static_modes is None or i not in static_modes):
+            x_ = x_.mark_compact_shape_dynamic(mode=i, stride_order=stride_order)
+    return x_
+
+
+def make_tiled_copy_A(
+    copy_atom: cute.CopyAtom, tiled_mma: cute.TiledMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.TiledCopy:
+    if const_expr(swapAB):
+        return cute.make_tiled_copy_B(copy_atom, tiled_mma)
+    else:
+        return cute.make_tiled_copy_A(copy_atom, tiled_mma)
+
+
+def make_tiled_copy_B(
+    copy_atom: cute.CopyAtom, tiled_mma: cute.TiledMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.TiledCopy:
+    if const_expr(swapAB):
+        return cute.make_tiled_copy_A(copy_atom, tiled_mma)
+    else:
+        return cute.make_tiled_copy_B(copy_atom, tiled_mma)
+
+
+def mma_make_fragment_A(
+    smem: cute.Tensor, thr_mma: cute.core.ThrMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.Tensor:
+    if const_expr(swapAB):
+        return mma_make_fragment_B(smem, thr_mma)
+    else:
+        return thr_mma.make_fragment_A(thr_mma.partition_A(smem))
+
+
+def mma_make_fragment_B(
+    smem: cute.Tensor, thr_mma: cute.core.ThrMma, swapAB: cutlass.Constexpr[bool] = False
+) -> cute.Tensor:
+    if const_expr(swapAB):
+        return mma_make_fragment_A(smem, thr_mma)
+    else:
+        return thr_mma.make_fragment_B(thr_mma.partition_B(smem))
+
+
+def get_smem_store_atom(
+    arch: cutlass.Constexpr[int], element_type: Type[cute.Numeric], transpose: bool = False
+) -> cute.CopyAtom:
+    if const_expr(arch < 90 or element_type.width != 16):
+        return cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            element_type,
+            num_bits_per_copy=2 * element_type.width,
+        )
+    else:
+        return cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(transpose=transpose, num_matrices=4),
+            element_type,
+        )
+
+
+@cute.jit
+def warp_reduce(
+    val: cute.TensorSSA | cute.Numeric,
+    op: Callable,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.TensorSSA | cute.Numeric:
+    if const_expr(isinstance(val, cute.TensorSSA)):
+        res = cute.make_fragment(val.shape, val.dtype)
+        res.store(val)
+        for i in cutlass.range_constexpr(cute.size(val.shape)):
+            res[i] = warp_reduce(res[i], op, width)
+        return res.load()
+    else:
+        for i in cutlass.range_constexpr(int(math.log2(width))):
+            val = op(val, cute.arch.shuffle_sync_bfly(val, offset=1 << i))
+    return val
+
+
+@dsl_user_op
+def smid(*, loc=None, ip=None) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [],
+            "mov.u32 $0, %smid;",
+            "=r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def fmax(
+    a: float | Float32, b: float | Float32, c: float | Float32 | None = None, *, loc=None, ip=None
+) -> Float32:
+    from cutlass import CUDA_VERSION
+
+    # * NVVM call based on nvvm version
+    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9:
+        # Old API: requires explicit result type as first positional argument
+        return Float32(
+            nvvm.fmax(
+                T.f32(),
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+    else:
+        # New API: infers result type automatically
+        return Float32(
+            nvvm.fmax(
+                Float32(a).ir_value(loc=loc, ip=ip),
+                Float32(b).ir_value(loc=loc, ip=ip),
+                c=Float32(c).ir_value(loc=loc, ip=ip) if c is not None else None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+
+
+@cute.jit
+def fmax_reduce(
+    x: cute.TensorSSA, init_val: float | Float32 | None = None, arch: cutlass.Constexpr[int] = 80
+) -> Float32:
+    if const_expr(arch < 100 or cute.size(x.shape) % 8 != 0):
+        # if const_expr(init_val is None):
+        #     init_val = -cutlass.Float32.if
+        # return x.reduce(cute.ReductionOp.MAX, init_val, 0)
+        res = cute.make_fragment(x.shape, Float32)
+        res.store(x)
+        # local_max = [res[0], res[1]]
+        # for i in cutlass.range_constexpr(2, cute.size(x.shape), 2):
+        #     local_max[0] = fmax(local_max[0], res[i + 0])
+        #     local_max[1] = fmax(local_max[1], res[i + 1])
+        # local_max[0] = fmax(local_max[0], local_max[1])
+        # return local_max[0] if const_expr(init_val is None) else fmax(local_max[0], init_val)
+        local_max = [res[0], res[1], res[2], res[3]]
+        for i in cutlass.range_constexpr(4, cute.size(x.shape), 4):
+            local_max[0] = fmax(local_max[0], res[i + 0])
+            local_max[1] = fmax(local_max[1], res[i + 1])
+            local_max[2] = fmax(local_max[2], res[i + 2])
+            local_max[3] = fmax(local_max[3], res[i + 3])
+        local_max[0] = fmax(local_max[0], local_max[1])
+        local_max[2] = fmax(local_max[2], local_max[3])
+        local_max[0] = fmax(local_max[0], local_max[2])
+        return local_max[0] if const_expr(init_val is None) else fmax(local_max[0], init_val)
+    else:
+        # [2025-06-15] x.reduce only seems to use 50% 3-input max and 50% 2-input max
+        # We instead force the 3-input max.
+        res = cute.make_fragment(x.shape, Float32)
+        res.store(x)
+        local_max_0 = (
+            fmax(init_val, res[0], res[1])
+            if const_expr(init_val is not None)
+            else fmax(res[0], res[1])
+        )
+        local_max = [
+            local_max_0,
+            fmax(res[2], res[3]),
+            fmax(res[4], res[5]),
+            fmax(res[6], res[7]),
+        ]
+        for i in cutlass.range_constexpr(8, cute.size(x.shape), 8):
+            local_max[0] = fmax(local_max[0], res[i], res[i + 1])
+            local_max[1] = fmax(local_max[1], res[i + 2], res[i + 3])
+            local_max[2] = fmax(local_max[2], res[i + 4], res[i + 5])
+            local_max[3] = fmax(local_max[3], res[i + 6], res[i + 7])
+        local_max[0] = fmax(local_max[0], local_max[1])
+        return fmax(local_max[0], local_max[2], local_max[3])
+
+
+@cute.jit
+def fadd_reduce(
+    x: cute.TensorSSA, init_val: float | Float32 | None = None, arch: cutlass.Constexpr[int] = 80
+) -> Float32:
+    if const_expr(arch < 100 or cute.size(x.shape) % 8 != 0):
+        if const_expr(init_val is None):
+            init_val = Float32.zero
+        return x.reduce(cute.ReductionOp.ADD, init_val, 0)
+        # res = cute.make_fragment(x.shape, Float32)
+        # res.store(x)
+        # local_sum = [res[0], res[1], res[2], res[3]]
+        # for i in cutlass.range_constexpr(4, cute.size(x.shape), 4):
+        #     local_sum[0] += res[i + 0]
+        #     local_sum[1] += res[i + 1]
+        #     local_sum[2] += res[i + 2]
+        #     local_sum[3] += res[i + 3]
+        # local_sum[0] += local_sum[1]
+        # local_sum[2] += local_sum[3]
+        # local_sum[0] += local_sum[2]
+        # return local_sum[0] if const_expr(init_val is None) else local_sum[0] + init_val
+    else:
+        res = cute.make_fragment(x.shape, Float32)
+        res.store(x)
+        local_sum_0 = (
+            cute.arch.add_packed_f32x2((init_val, 0.0), (res[0], res[1]))
+            # cute.arch.add_packed_f32x2((init_val / 2, init_val / 2), (res[0], res[1]))
+            if const_expr(init_val is not None)
+            else (res[0], res[1])
+        )
+        local_sum = [local_sum_0, (res[2], res[3]), (res[4], res[5]), (res[6], res[7])]
+        for i in cutlass.range_constexpr(8, cute.size(x.shape), 8):
+            local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], (res[i + 0], res[i + 1]))
+            local_sum[1] = cute.arch.add_packed_f32x2(local_sum[1], (res[i + 2], res[i + 3]))
+            local_sum[2] = cute.arch.add_packed_f32x2(local_sum[2], (res[i + 4], res[i + 5]))
+            local_sum[3] = cute.arch.add_packed_f32x2(local_sum[3], (res[i + 6], res[i + 7]))
+        local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], local_sum[1])
+        local_sum[2] = cute.arch.add_packed_f32x2(local_sum[2], local_sum[3])
+        local_sum[0] = cute.arch.add_packed_f32x2(local_sum[0], local_sum[2])
+        return local_sum[0][0] + local_sum[0][1]
+
+
+@dsl_user_op
+def atomic_add_fp32(a: float | Float32, gmem_ptr: cute.Pointer, *, loc=None, ip=None) -> None:
+    # gmem_ptr_i64 = gmem_ptr.toint(loc=loc, ip=ip).ir_value()
+    # # cache_hint = cutlass.Int64(0x12F0000000000000)
+    # llvm.inline_asm(
+    #     None,
+    #     [gmem_ptr_i64, Float32(a).ir_value(loc=loc, ip=ip)],
+    #     # [gmem_ptr_i64, Float32(a).ir_value(loc=loc, ip=ip), cache_hint.ir_value()],
+    #     "red.global.add.f32 [$0], $1;",
+    #     # "red.global.add.L2::cache_hint.f32 [$0], $1, 0x12F0000000000000;",
+    #     # "red.global.add.L2::cache_hint.f32 [$0], $1, $2;",
+    #     "l,f",
+    #     # "l,f,l",
+    #     has_side_effects=True,
+    #     is_align_stack=False,
+    #     asm_dialect=llvm.AsmDialect.AD_ATT,
+    # )
+    nvvm.atomicrmw(
+        res=T.f32(), op=nvvm.AtomicOpKind.FADD, ptr=gmem_ptr.llvm_ptr, a=Float32(a).ir_value()
+    )
+
+
+@dsl_user_op
+def elem_pointer(x: cute.Tensor, coord: cute.Coord, *, loc=None, ip=None) -> cute.Pointer:
+    return x.iterator + cute.crd2idx(coord, x.layout, loc=loc, ip=ip)
+
+
+@cute.jit
+def predicate_k(tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
+    # Only compute predicates for the "k" dimension. For the mn dimension, we will use "if"
+    tApA = cute.make_fragment(
+        cute.make_layout(
+            (cute.size(tAcA, mode=[0, 1]), cute.size(tAcA, mode=[1]), cute.size(tAcA, mode=[2])),
+            stride=(cute.size(tAcA, mode=[2]), 0, 1),
+        ),
+        cutlass.Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(tApA.shape[0]):
+        for rest_k in cutlass.range_constexpr(tApA.shape[2]):
+            tApA[rest_v, 0, rest_k] = cute.elem_less(tAcA[(0, rest_v), 0, rest_k][1], limit)
+    return tApA
+
+
+def canonical_warp_group_idx(sync: bool = True) -> cutlass.Int32:
+    warp_group_idx = cute.arch.thread_idx()[0] // 128
+    if const_expr(sync):
+        warp_group_idx = cute.arch.make_warp_uniform(warp_group_idx)
+    return warp_group_idx
+
+
+# @dsl_user_op
+# def warp_vote_any_lt(a: float | Float32, b: float | Float32, *, loc=None, ip=None) -> cutlass.Boolean:
+#     mask = cutlass.Int32(-1)
+#     return cutlass.Boolean(
+#         llvm.inline_asm(
+#             T.i32(),
+#             [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip), mask.ir_value(loc=loc, ip=ip)],
+#             ".pred p1, p2;\n"
+#             "setp.lt.f32 p1, $1, $2;\n"
+#             "vote.sync.any.pred p2, p1, $3;\n"
+#             "selp.u32 $0, 1, 0, p2;",
+#             # "selp.u32 $0, 1, 0, p1;",
+#             "=r,f,f,r",
+#             has_side_effects=False,
+#             is_align_stack=False,
+#             asm_dialect=llvm.AsmDialect.AD_ATT,
+#         )
+#     )
+
+
+@cute.jit
+def shuffle_sync(
+    value: cute.Numeric,
+    offset: cute.typing.Int,
+    width: cutlass.Constexpr[int] = cute.arch.WARP_SIZE,
+) -> cute.Numeric:
+    assert value.width % 32 == 0, "value type must be a multiple of 32 bits"
+    # 1 -> 0b11111, 2 -> 0b11110, 4 -> 0b11100, 8 -> 0b11000, 16 -> 0b10000, 32 -> 0b00000
+    mask = cute.arch.WARP_SIZE - width
+    clamp = cute.arch.WARP_SIZE - 1
+    mask_and_clamp = mask << 8 | clamp
+    # important: need stride 1 and not 0 for recast_tensor to work
+    val = cute.make_rmem_tensor(cute.make_layout((1,), stride=(1,)), type(value))
+    val[0] = value
+    val_i32 = cute.recast_tensor(val, cutlass.Int32)
+    for i in cutlass.range_constexpr(cute.size(val_i32)):
+        val_i32[i] = cute.arch.shuffle_sync(val_i32[i], offset, mask_and_clamp=mask_and_clamp)
+    return val[0]
+
+
+@dsl_user_op
+def shl_u32(val: cutlass.Uint32, shift: cutlass.Uint32, *, loc=None, ip=None) -> cutlass.Uint32:
+    """
+    Left-shift val by shift bits using PTX shl.b32 (sign-agnostic).
+
+    Named ``shl_u32`` (not ``shl_b32``) because python type annotations
+    distinguish signed/unsigned.
+
+    PTX semantics (§9.7.8.8): "Shift amounts greater than the register width N
+    are clamped to N."  So ``shl.b32 d, a, 32`` is well-defined and yields 0.
+
+    This differs from C/C++ and LLVM IR, where shifting by >= the type width is
+    undefined behavior.  CuTeDSL compiles through MLIR -> LLVM IR, so a plain
+    Python-level ``Uint32(x) << Uint32(n)`` inherits LLVM's UB: the optimizer
+    may treat the result as poison and eliminate dependent code.  Inline PTX
+    bypasses the LLVM IR shift entirely — the instruction is emitted verbatim
+    into PTX where clamping makes it safe for all shift amounts.
+    """
+    return cutlass.Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                cutlass.Uint32(val).ir_value(loc=loc, ip=ip),
+                cutlass.Uint32(shift).ir_value(loc=loc, ip=ip),
+            ],
+            "shl.b32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def shr_u32(val: cutlass.Uint32, shift: cutlass.Uint32, *, loc=None, ip=None) -> cutlass.Uint32:
+    """
+    Unsigned right-shift val by shift bits using PTX shr.u32 (zero-fills).
+
+    See ``shl_u32`` docstring for why inline PTX is used instead of plain
+    CuTeDSL shift operators (LLVM shift-by-type-width UB).
+    """
+    return cutlass.Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                cutlass.Uint32(val).ir_value(loc=loc, ip=ip),
+                cutlass.Uint32(shift).ir_value(loc=loc, ip=ip),
+            ],
+            "shr.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def warp_prefix_sum(val: cutlass.Int32, lane: Optional[cutlass.Int32] = None) -> cutlass.Int32:
+    if const_expr(lane is None):
+        lane = cute.arch.lane_idx()
+    # if cute.arch.thread_idx()[0] >= 128 and cute.arch.thread_idx()[0] < 128 + 32 and cute.arch.block_idx()[0] == 0: cute.printf("tidx = %d, val = %d", cute.arch.thread_idx()[0] % 32, val)
+    for i in cutlass.range_constexpr(int(math.log2(cute.arch.WARP_SIZE))):
+        offset = 1 << i
+        # Very important that we set mask_and_clamp to 0
+        partial_sum = cute.arch.shuffle_sync_up(val, offset=offset, mask_and_clamp=0)
+        if lane >= offset:
+            val += partial_sum
+        # if cute.arch.thread_idx()[0] >= 128 and cute.arch.thread_idx()[0] < 128 + 32 and cute.arch.block_idx()[0] == 0: cute.printf("tidx = %d, partial_sum = %d, val = %d", cute.arch.thread_idx()[0] % 32, partial_sum, val)
+    return val
+
+
+@dsl_user_op
+def cvt_f16x2_f32(
+    a: float | Float32, b: float | Float32, to_dtype: Type, *, loc=None, ip=None
+) -> cutlass.Int32:
+    assert to_dtype in [cutlass.BFloat16, cutlass.Float16], "to_dtype must be BFloat16 or Float16"
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            f"cvt.rn.{'bf16x2' if to_dtype is cutlass.BFloat16 else 'f16x2'}.f32 $0, $2, $1;",
+            "=r,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@overload
+def cvt_f16(src: cute.Tensor, dst: cute.Tensor) -> None: ...
+
+
+@overload
+def cvt_f16(src: cute.Tensor, dtype: Type[cute.Numeric]) -> cute.Tensor: ...
+
+
+@cute.jit
+def cvt_f16(src: cute.Tensor, dst_or_dtype):
+    """Convert Float32 tensor to Float16/BFloat16.
+
+    Args:
+        src: Source tensor with Float32 element type
+        dst_or_dtype: Either a destination tensor or a dtype (Float16/BFloat16)
+
+    Returns:
+        None if dst is a tensor, or a new tensor if dtype is provided
+    """
+    if const_expr(isinstance(dst_or_dtype, type)):
+        # dtype variant: create new tensor and call the tensor variant
+        dtype = dst_or_dtype
+        dst = cute.make_fragment(src.shape, dtype)
+        cvt_f16(src, dst)
+        return dst
+    else:
+        # tensor variant: write to dst
+        dst = dst_or_dtype
+        assert cute.size(dst.shape) == cute.size(src.shape), "dst and src must have the same size"
+        assert cute.size(src.shape) % 2 == 0, "src must have an even number of elements"
+        assert dst.element_type in [cutlass.BFloat16, cutlass.Float16], (
+            "dst must be BFloat16 or Float16"
+        )
+        assert src.element_type is Float32, "src must be Float32"
+        dst_i32 = cute.recast_tensor(dst, cutlass.Int32)
+        assert cute.size(dst_i32.shape) * 2 == cute.size(src.shape)
+        for i in cutlass.range_constexpr(cute.size(dst_i32)):
+            dst_i32[i] = cvt_f16x2_f32(src[2 * i], src[2 * i + 1], dst.element_type)
+
+
+@dsl_user_op
+@cute.jit
+def evaluate_polynomial(x: Float32, poly: Tuple[Float32, ...], *, loc=None, ip=None) -> Float32:
+    deg = len(poly) - 1
+    out = poly[deg]
+    for i in cutlass.range_constexpr(deg - 1, -1, -1):
+        out = out * x + poly[i]
+    return out
+
+
+@dsl_user_op
+@cute.jit
+def evaluate_polynomial_2(
+    x: Float32, y: Float32, poly: Tuple[Float32, ...], *, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    deg = len(poly) - 1
+    out = (poly[deg], poly[deg])
+    for i in cutlass.range_constexpr(deg - 1, -1, -1):
+        out = cute.arch.fma_packed_f32x2(out, (x, y), (poly[i], poly[i]))
+    return out
+
+
+@dsl_user_op
+def add_round_down(x: float | Float32, y: float | Float32, *, loc=None, ip=None) -> Float32:
+    # There's probably a way to call llvm or nvvm to do this instead of ptx
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(x).ir_value(loc=loc, ip=ip), Float32(y).ir_value(loc=loc, ip=ip)],
+            "add.rm.ftz.f32 $0, $1, $2;",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def combine_int_frac_ex2(x_rounded: Float32, frac_ex2: Float32, *, loc=None, ip=None) -> Float32:
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Float32(x_rounded).ir_value(loc=loc, ip=ip),
+                Float32(frac_ex2).ir_value(loc=loc, ip=ip),
+            ],
+            "{\n\t"
+            ".reg .s32 x_rounded_i, frac_ex_i, x_rounded_e, out_i;\n\t"
+            "mov.b32 x_rounded_i, $1;\n\t"
+            "mov.b32 frac_ex_i, $2;\n\t"
+            "shl.b32 x_rounded_e, x_rounded_i, 23;\n\t"
+            # add.u32 generates IMAD instruction and add.s32 generates LEA instruction
+            # IMAD uses the FMA pipeline and LEA uses the ALU pipeline, afaik
+            "add.s32 out_i, x_rounded_e, frac_ex_i;\n\t"
+            "mov.b32 $0, out_i;\n\t"
+            "}\n",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def ex2_emulation(x: Float32, *, poly_degree: int = 3, loc=None, ip=None) -> Float32:
+    assert poly_degree in POLY_EX2, f"Polynomial degree {poly_degree} not supported"
+    # We assume x <= 127.0
+    fp32_round_int = float(2**23 + 2**22)
+    x_clamped = cute.arch.fmax(x, -127.0)
+    # We want to round down here, so that the fractional part is in [0, 1)
+    x_rounded = add_round_down(x_clamped, fp32_round_int, loc=loc, ip=ip)
+    # The integer floor of x is now in the last 8 bits of x_rounded
+    # We assume the next 2 ops round to nearest even. The rounding mode is important.
+    x_rounded_back = x_rounded - fp32_round_int
+    x_frac = x_clamped - x_rounded_back
+    x_frac_ex2 = evaluate_polynomial(x_frac, POLY_EX2[poly_degree], loc=loc, ip=ip)
+    return combine_int_frac_ex2(x_rounded, x_frac_ex2, loc=loc, ip=ip)
+
+
+# TODO: check that the ex2_emulation_2 produces the same SASS as the ptx version
+@dsl_user_op
+def ex2_emulation_2(
+    x: Float32, y: Float32, *, poly_degree: int = 3, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    # We assume x <= 127.0 and y <= 127.0
+    fp32_round_int = float(2**23 + 2**22)
+    xy_clamped = (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0))
+    # We want to round down here, so that the fractional part is in [0, 1)
+    xy_rounded = cute.arch.add_packed_f32x2(xy_clamped, (fp32_round_int, fp32_round_int), rnd="rm")
+    # The integer floor of x & y are now in the last 8 bits of xy_rounded
+    # We want the next 2 ops to round to nearest even. The rounding mode is important.
+    xy_rounded_back = quack.activation.sub_packed_f32x2(
+        xy_rounded, (fp32_round_int, fp32_round_int)
+    )
+    xy_frac = quack.activation.sub_packed_f32x2(xy_clamped, xy_rounded_back)
+    xy_frac_ex2 = evaluate_polynomial_2(*xy_frac, POLY_EX2[poly_degree], loc=loc, ip=ip)
+    x_out = combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0], loc=loc, ip=ip)
+    y_out = combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1], loc=loc, ip=ip)
+    return x_out, y_out
+
+
+@dsl_user_op
+def e2e_asm2(x: Float32, y: Float32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
+    out_f32x2 = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32(), T.f32()]),
+        [Float32(x).ir_value(loc=loc, ip=ip), Float32(y, loc=loc, ip=ip).ir_value()],
+        "{\n\t"
+        ".reg .f32 f1, f2, f3, f4, f5, f6, f7;\n\t"
+        ".reg .b64 l1, l2, l3, l4, l5, l6, l7, l8, l9, l10;\n\t"
+        ".reg .s32 r1, r2, r3, r4, r5, r6, r7, r8;\n\t"
+        "max.ftz.f32 f1, $2, 0fC2FE0000;\n\t"
+        "max.ftz.f32 f2, $3, 0fC2FE0000;\n\t"
+        "mov.b64 l1, {f1, f2};\n\t"
+        "mov.f32 f3, 0f4B400000;\n\t"
+        "mov.b64 l2, {f3, f3};\n\t"
+        "add.rm.ftz.f32x2 l7, l1, l2;\n\t"
+        "sub.rn.ftz.f32x2 l8, l7, l2;\n\t"
+        "sub.rn.ftz.f32x2 l9, l1, l8;\n\t"
+        "mov.f32 f7, 0f3D9DF09D;\n\t"
+        "mov.b64 l6, {f7, f7};\n\t"
+        "mov.f32 f6, 0f3E6906A4;\n\t"
+        "mov.b64 l5, {f6, f6};\n\t"
+        "mov.f32 f5, 0f3F31F519;\n\t"
+        "mov.b64 l4, {f5, f5};\n\t"
+        "mov.f32 f4, 0f3F800000;\n\t"
+        "mov.b64 l3, {f4, f4};\n\t"
+        "fma.rn.ftz.f32x2 l10, l9, l6, l5;\n\t"
+        "fma.rn.ftz.f32x2 l10, l10, l9, l4;\n\t"
+        "fma.rn.ftz.f32x2 l10, l10, l9, l3;\n\t"
+        "mov.b64 {r1, r2}, l7;\n\t"
+        "mov.b64 {r3, r4}, l10;\n\t"
+        "shl.b32 r5, r1, 23;\n\t"
+        "add.s32 r7, r5, r3;\n\t"
+        "shl.b32 r6, r2, 23;\n\t"
+        "add.s32 r8, r6, r4;\n\t"
+        "mov.b32 $0, r7;\n\t"
+        "mov.b32 $1, r8;\n\t"
+        "}\n",
+        "=r,=r,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    out0 = Float32(llvm.extractvalue(T.f32(), out_f32x2, [0], loc=loc, ip=ip))
+    out1 = Float32(llvm.extractvalue(T.f32(), out_f32x2, [1], loc=loc, ip=ip))
+    return out0, out1
+
+
+@dsl_user_op
+def domain_offset_aligned(
+    coord: cute.Coord, tensor: cute.Tensor, *, loc=None, ip=None
+) -> cute.Tensor:
+    assert isinstance(tensor.iterator, cute.Pointer)
+    # We assume that applying the offset does not change the pointer alignment
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        elem_pointer(tensor, coord).toint(),
+        tensor.memspace,
+        assumed_align=tensor.iterator.alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)
+
+
+@dsl_user_op
+def warp_reduction(
+    val: cute.Numeric, op: Callable, *, threads_in_group: int = 32, loc=None, ip=None
+) -> cute.Numeric:
+    """Warp-wide reduction helper for a custom binary op."""
+    offset = threads_in_group // 2
+    while offset > 0:
+        val = op(
+            val,
+            cute.arch.shuffle_sync_bfly(
+                val, offset=offset, mask=-1, mask_and_clamp=31, loc=loc, ip=ip
+            ),
+        )
+        offset //= 2
+    return val
+
+
+warp_reduction_max = partial(
+    warp_reduction, op=lambda x, y: fmax(x, y) if isinstance(x, Float32) else max(x, y)
+)
+warp_reduction_sum = partial(warp_reduction, op=lambda x, y: x + y)  # noqa: FURB118
+
+
+@dsl_user_op
+def make_cotiled_copy(
+    atom: cute.CopyAtom, atom_layout_tv: cute.Layout, data_layout: cute.Layout, *, loc=None, ip=None
+) -> cute.TiledCopy:
+    """Compatibility wrapper for deprecated CuTeDSL `make_cotiled_copy`."""
+    assert cute.is_static(atom_layout_tv.type), "atom_layout_tv must be static"
+    assert cute.is_static(data_layout.type), "data_layout must be static"
+
+    inv_layout_ = cute.left_inverse(data_layout, loc=loc, ip=ip)
+    inv_data_layout = cute.make_layout(
+        (inv_layout_.shape, (1)), stride=(inv_layout_.stride, (0)), loc=loc, ip=ip
+    )
+    layout_tv_data = cute.composition(inv_data_layout, atom_layout_tv, loc=loc, ip=ip)
+
+    atom_layout_v_to_check = cute.coalesce(
+        cute.make_layout(atom_layout_tv.shape[1], stride=atom_layout_tv.stride[1], loc=loc, ip=ip),
+        loc=loc,
+        ip=ip,
+    )
+    data_layout_v_to_check = cute.coalesce(
+        cute.composition(
+            data_layout,
+            cute.make_layout(
+                layout_tv_data.shape[1], stride=layout_tv_data.stride[1], loc=loc, ip=ip
+            ),
+            loc=loc,
+            ip=ip,
+        ),
+        loc=loc,
+        ip=ip,
+    )
+    assert data_layout_v_to_check == atom_layout_v_to_check, (
+        "the memory pointed to by atom_layout_tv does not exist in the data_layout."
+    )
+
+    flat_data_shape = cute.product_each(data_layout.shape, loc=loc, ip=ip)
+    tiler = tuple(
+        cute.filter(
+            cute.composition(
+                cute.make_layout(
+                    flat_data_shape,
+                    stride=tuple(0 if j != i else 1 for j in range(cute.rank(flat_data_shape))),
+                    loc=loc,
+                    ip=ip,
+                ),
+                layout_tv_data,
+                loc=loc,
+                ip=ip,
+            ),
+            loc=loc,
+            ip=ip,
+        )
+        for i in range(cute.rank(flat_data_shape))
+    )
+    tile2data = cute.composition(
+        cute.make_layout(flat_data_shape, loc=loc, ip=ip), tiler, loc=loc, ip=ip
+    )
+    layout_tv = cute.composition(
+        cute.left_inverse(tile2data, loc=loc, ip=ip), layout_tv_data, loc=loc, ip=ip
+    )
+    return cute.make_tiled_copy(atom, layout_tv, tiler, loc=loc, ip=ip)
+
+
+@cute.jit
+def scalar_to_ssa(a: cute.Numeric, dtype) -> cute.TensorSSA:
+    """Convert a scalar to a cute TensorSSA of shape (1,) and given dtype"""
+    vec = cute.make_fragment(1, dtype)
+    vec[0] = a
+    return vec.load()
+
+
+def ssa_to_scalar(val):
+    """Could inline but nice for reflecting the above api"""
+    return val[0]

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -331,6 +331,10 @@ extern "C" int cutlass_fp8_wide_bf16out(void*, void*, void*, int, int, int, floa
 extern "C" int cutlass_fp8_t1_bf16out(void*, void*, void*, int, int, int, float, float, cudaStream_t);
 #endif
 
+#ifdef ENABLE_LINGBOT
+#include "kernels/lingbot_kernels.h"   // LingBot-VLA model kernel decls (lingbot_-prefixed, Thor sm_110a)
+#endif
+
 PYBIND11_MODULE(flash_rt_kernels, m) {
     m.doc() = "FlashRT C++/CUDA inference kernels";
 
@@ -4816,5 +4820,9 @@ N must be a multiple of 32; K must be a multiple of 64.
                 to_ptr(y_fp4), to_ptr(y_sf),
                 B, C, T, H, W, eps, to_stream(stream));
         });
+#endif
+
+#ifdef ENABLE_LINGBOT
+#include "kernels/lingbot_bindings.inc"   // m.def("lingbot_...", &lingbot_...) for the LingBot-VLA model
 #endif
 }

--- a/csrc/kernels/lingbot_bindings.inc
+++ b/csrc/kernels/lingbot_bindings.inc
@@ -1,0 +1,129 @@
+    m.def("lingbot_ada_rms_residual_fp8_bf16", &lingbot_ada_rms_residual_fp8_bf16,
+          py::arg("residual"), py::arg("x"),
+          py::arg("rms_weight"), py::arg("gamma"), py::arg("beta"),
+          py::arg("out_fp8"), py::arg("act_scale"),
+          py::arg("B"), py::arg("S"), py::arg("D"),
+          py::arg("eps") = 1e-6f, py::arg("stream") = 0,
+          "Per-sample γ/β AdaRMSNorm + residual + FP8 static quant fused.");
+
+    m.def("lingbot_ada_rms_fp8_bf16", &lingbot_ada_rms_fp8_bf16,
+          py::arg("x"), py::arg("rms_weight"),
+          py::arg("gamma"), py::arg("beta"),
+          py::arg("out_fp8"), py::arg("act_scale"),
+          py::arg("B"), py::arg("S"), py::arg("D"),
+          py::arg("eps") = 1e-6f, py::arg("stream") = 0,
+          "Per-sample γ/β AdaRMSNorm + FP8 static quant fused (no residual).");
+
+    m.def("lingbot_rope_inplace_bf16", &lingbot_rope_inplace_bf16,
+          py::arg("x"), py::arg("cos_table"), py::arg("sin_table"),
+          py::arg("B"), py::arg("S"), py::arg("NH"), py::arg("HD"),
+          py::arg("stream") = 0,
+          "In-place split-half RoPE for bf16 Q or K tensors. cos/sin "
+          "are pre-built fp32 tables [B, S, HD/2].");
+
+    m.def("lingbot_rope_to_out_bf16", &lingbot_rope_to_out_bf16,
+          py::arg("x"), py::arg("out"),
+          py::arg("cos_table"), py::arg("sin_table"),
+          py::arg("B"), py::arg("S"), py::arg("NH"), py::arg("HD"),
+          py::arg("stream") = 0,
+          "Out-of-place split-half RoPE (bf16): reads x, writes out. "
+          "Graph-safe (no in-place hazard). cos/sin fp32 [B, S, HD/2].");
+
+    m.def("lingbot_qkv_bias_rope_bf16", &lingbot_qkv_bias_rope_bf16,
+          py::arg("q_raw"), py::arg("k_raw"), py::arg("v_raw"),
+          py::arg("q_bias"), py::arg("k_bias"), py::arg("v_bias"),
+          py::arg("cos_table"), py::arg("sin_table"),
+          py::arg("q_out"), py::arg("k_out"), py::arg("v_out"),
+          py::arg("M"), py::arg("NHQ"), py::arg("NHKV"), py::arg("HD"),
+          py::arg("stream") = 0,
+          "Fused QKV bias-add + RoPE (q/k roped, v bias-only). One launch "
+          "replaces 3 add_bias + 2 rope. Raw bf16 GEMM outputs in, "
+          "[M, NH*HD] bf16 out; cos/sin fp32 [M, HD/2]. Pass 0 for a null bias.");
+
+    m.def("lingbot_qkv_bias_rope_fp16out", &lingbot_qkv_bias_rope_fp16out,
+          py::arg("q_raw"), py::arg("k_raw"), py::arg("v_raw"),
+          py::arg("q_bias"), py::arg("k_bias"), py::arg("v_bias"),
+          py::arg("cos_table"), py::arg("sin_table"),
+          py::arg("q_out"), py::arg("k_out"), py::arg("v_out"),
+          py::arg("M"), py::arg("NHQ"), py::arg("NHKV"), py::arg("HD"),
+          py::arg("stream") = 0,
+          "G39: same as qkv_bias_rope_bf16 but writes fp16 outputs (feeds the "
+          "fp16 attention island — fmha consumes fp16 with no cast).");
+
+    m.def("lingbot_ada_rms_fp8_mpad_bf16", &lingbot_ada_rms_fp8_mpad_bf16,
+          py::arg("x"), py::arg("rms_weight"),
+          py::arg("gamma"), py::arg("beta"),
+          py::arg("out_fp8"), py::arg("act_scale"),
+          py::arg("B"), py::arg("S"), py::arg("PADM"), py::arg("D"),
+          py::arg("eps") = 1e-6f, py::arg("stream") = 0,
+          "M-padded ada_rms_fp8: writes [B,PADM,D] FP8 (rows [S,PADM) zeroed) "
+          "so q/k/v GEMMs read M=PADM directly (no pad copy).");
+
+    m.def("lingbot_ada_rms_residual_fp8_mpad_bf16", &lingbot_ada_rms_residual_fp8_mpad_bf16,
+          py::arg("residual"), py::arg("x"),
+          py::arg("rms_weight"), py::arg("gamma"), py::arg("beta"),
+          py::arg("out_fp8"), py::arg("act_scale"),
+          py::arg("B"), py::arg("S"), py::arg("PADM"), py::arg("D"),
+          py::arg("eps") = 1e-6f, py::arg("stream") = 0,
+          "M-padded ada_rms_residual_fp8: writes [B,PADM,D] FP8 (rows [S,PADM) "
+          "zeroed) so gate/up GEMMs read M=PADM directly (no pad copy).");
+
+    m.def("lingbot_ada_rms_residual_fp16_mpad", &lingbot_ada_rms_residual_fp16_mpad,
+          py::arg("residual"), py::arg("x"),
+          py::arg("rms_weight"), py::arg("gamma"), py::arg("beta"),
+          py::arg("out_fp16"),
+          py::arg("B"), py::arg("S"), py::arg("PADM"), py::arg("D"),
+          py::arg("eps") = 1e-6f, py::arg("stream") = 0,
+          "G53: M-padded ada_rms_residual with fp16 output (no FP8 quant) — feeds "
+          "the denoise FP4 gate_up quant directly, skipping the fp8->fp16 dequant.");
+
+    m.def("lingbot_silu_mul_fp8_mpad_bf16", &lingbot_silu_mul_fp8_mpad_bf16,
+          py::arg("gate"), py::arg("up"), py::arg("out_fp8"), py::arg("act_scale"),
+          py::arg("S"), py::arg("PADM"), py::arg("I"), py::arg("stream") = 0,
+          "Fused SwiGLU tail: silu(gate)*up + FP8 static-quant, writing a "
+          "pre-M-padded [PADM, I] FP8 buffer (rows [S,PADM) zeroed) so the "
+          "down GEMM reads M=PADM directly with no pad copy. bf16 gate/up in.");
+
+    m.def("lingbot_silu_mul_merged_fp8_mpad_bf16", &lingbot_silu_mul_merged_fp8_mpad_bf16,
+          py::arg("gu"), py::arg("out_fp8"), py::arg("act_scale"),
+          py::arg("S"), py::arg("PADM"), py::arg("I"), py::arg("stream") = 0,
+          "Merged-input SwiGLU tail: gate/up interleaved per row in one [S,2*I] "
+          "buffer (single merged gate_up GEMM output); silu(gate)*up + FP8 "
+          "static-quant -> [PADM, I]. Pairs with a merged gate_up GEMM to cut a "
+          "GEMM launch + the silu/mul/quant glue.");
+
+    m.def("lingbot_silu_mul_merged_fp8_mpad_fp16in", &lingbot_silu_mul_merged_fp8_mpad_fp16in,
+          py::arg("gu"), py::arg("out_fp8"), py::arg("act_scale"),
+          py::arg("S"), py::arg("PADM"), py::arg("I"), py::arg("stream") = 0,
+          "G54: fp16-input silu_mul_merged — reads gate_up from the FP4 GEMM "
+          "fp16 output directly (no bf16 cast).");
+
+    m.def("lingbot_qkv_bias_rope_merged_bf16", &lingbot_qkv_bias_rope_merged_bf16,
+          py::arg("qkv"), py::arg("q_bias"), py::arg("k_bias"), py::arg("v_bias"),
+          py::arg("cos_table"), py::arg("sin_table"),
+          py::arg("q_out"), py::arg("k_out"), py::arg("v_out"),
+          py::arg("M"), py::arg("NHQ"), py::arg("NHKV"), py::arg("HD"),
+          py::arg("stream") = 0,
+          "G49 merged-input qkv bias+RoPE: reads q/k/v from column offsets of "
+          "one merged [M, ROWQKV] GEMM output (no split); writes 3 separate "
+          "bf16 outputs. Pairs with a merged qkv GEMM to cut 2 GEMM launches.");
+
+    m.def("lingbot_qkv_bias_rope_merged_fp16out", &lingbot_qkv_bias_rope_merged_fp16out,
+          py::arg("qkv"), py::arg("q_bias"), py::arg("k_bias"), py::arg("v_bias"),
+          py::arg("cos_table"), py::arg("sin_table"),
+          py::arg("q_out"), py::arg("k_out"), py::arg("v_out"),
+          py::arg("M"), py::arg("NHQ"), py::arg("NHKV"), py::arg("HD"),
+          py::arg("stream") = 0,
+          "G49 merged-input qkv bias+RoPE, fp16 outputs (fp16 attention island).");
+
+    m.def("lingbot_vit_qkv_bias_rope_bf16", &lingbot_vit_qkv_bias_rope_bf16,
+          py::arg("qkv"), py::arg("qkv_bias"),
+          py::arg("cos_table"), py::arg("sin_table"),
+          py::arg("q_out"), py::arg("k_out"), py::arg("v_out"),
+          py::arg("M"), py::arg("NH"), py::arg("HD"),
+          py::arg("stream") = 0,
+          "P1 ViT: fused QKV bias-add + 2-D M-RoPE from the interleaved "
+          "[M, 3*NH*HD] ViT qkv GEMM output. q/k get bias+split-half RoPE, v "
+          "bias-only; writes 3×[M, NH*HD] bf16. cos/sin fp32 [M, HD] (first "
+          "HD/2 cols used). One launch replaces add_bias + the eager fp32 "
+          "RoPE storm. Pass 0 for a null qkv_bias.");

--- a/csrc/kernels/lingbot_common.cuh
+++ b/csrc/kernels/lingbot_common.cuh
@@ -1,0 +1,15 @@
+// LingBot-VLA model-specific kernel helpers (additive, Thor sm_110a / SM100-class).
+// Shared by lingbot_norm_fp8.cu / lingbot_rope_qkv.cu / lingbot_silu_mul_fp8.cu.
+// These kernels are compiled INTO flash_rt_kernels (gated by ENABLE_LINGBOT); the
+// pybind entries live in csrc/bindings.cpp under #ifdef ENABLE_LINGBOT, all
+// lingbot_-prefixed. No separate .so (mirrors the qwen36 model kernels in this dir).
+#pragma once
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cstdint>
+
+static inline cudaStream_t to_stream(uintptr_t s) {
+    return reinterpret_cast<cudaStream_t>(s);
+}

--- a/csrc/kernels/lingbot_kernels.h
+++ b/csrc/kernels/lingbot_kernels.h
@@ -1,0 +1,84 @@
+// Auto-extracted forward declarations for LingBot kernels (compiled into flash_rt_kernels).
+#pragma once
+#include <cstdint>
+
+void lingbot_ada_rms_residual_fp8_bf16(
+    uintptr_t residual, uintptr_t x,
+    uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int D, float eps, uintptr_t stream)
+;
+void lingbot_ada_rms_fp8_mpad_bf16(
+    uintptr_t x, uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int PADM, int D, float eps, uintptr_t stream)
+;
+void lingbot_ada_rms_residual_fp8_mpad_bf16(
+    uintptr_t residual, uintptr_t x,
+    uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int PADM, int D, float eps, uintptr_t stream)
+;
+void lingbot_ada_rms_residual_fp16_mpad(
+    uintptr_t residual, uintptr_t x,
+    uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp16, int B, int S, int PADM, int D, float eps, uintptr_t stream)
+;
+void lingbot_ada_rms_fp8_bf16(
+    uintptr_t x, uintptr_t rms_weight,
+    uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int D, float eps, uintptr_t stream)
+;
+void lingbot_rope_inplace_bf16(
+    uintptr_t x, uintptr_t cos_table, uintptr_t sin_table,
+    int B, int S, int NH, int HD, uintptr_t stream)
+;
+void lingbot_rope_to_out_bf16(
+    uintptr_t x, uintptr_t out, uintptr_t cos_table, uintptr_t sin_table,
+    int B, int S, int NH, int HD, uintptr_t stream)
+;
+void lingbot_qkv_bias_rope_bf16(
+    uintptr_t q_raw, uintptr_t k_raw, uintptr_t v_raw,
+    uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+;
+void lingbot_qkv_bias_rope_merged_fp16out(
+    uintptr_t qkv, uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+;
+void lingbot_qkv_bias_rope_merged_bf16(
+    uintptr_t qkv, uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+;
+void lingbot_qkv_bias_rope_fp16out(
+    uintptr_t q_raw, uintptr_t k_raw, uintptr_t v_raw,
+    uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+;
+void lingbot_vit_qkv_bias_rope_bf16(
+    uintptr_t qkv, uintptr_t qkv_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NH, int HD, uintptr_t stream)
+;
+void lingbot_silu_mul_fp8_mpad_bf16(
+    uintptr_t gate, uintptr_t up, uintptr_t out_fp8, uintptr_t act_scale,
+    int S, int PADM, int I, uintptr_t stream)
+;
+void lingbot_silu_mul_merged_fp8_mpad_bf16(
+    uintptr_t gu, uintptr_t out_fp8, uintptr_t act_scale,
+    int S, int PADM, int I, uintptr_t stream)
+;
+void lingbot_silu_mul_merged_fp8_mpad_fp16in(
+    uintptr_t gu, uintptr_t out_fp8, uintptr_t act_scale,
+    int S, int PADM, int I, uintptr_t stream)
+;

--- a/csrc/kernels/lingbot_norm_fp8.cu
+++ b/csrc/kernels/lingbot_norm_fp8.cu
@@ -1,0 +1,391 @@
+#include "lingbot_common.cuh"
+
+__device__ __forceinline__ float lingbot_block_reduce_sum(float val, float* smem) {
+    int tid = threadIdx.x;
+    smem[tid] = val;
+    __syncthreads();
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) smem[tid] += smem[tid + stride];
+        __syncthreads();
+    }
+    return smem[0];
+}
+
+__global__ void lingbot_ada_rms_residual_fp8_bf16_kernel(
+    __nv_bfloat16* __restrict__ residual,    // [B, S, D] — mutated to residual+x
+    const __nv_bfloat16* __restrict__ x,     // [B, S, D]
+    const __nv_bfloat16* __restrict__ rms_weight,  // [D]
+    const __nv_bfloat16* __restrict__ gamma, // [B, D]
+    const __nv_bfloat16* __restrict__ beta,  // [B, D]
+    __nv_fp8_e4m3* __restrict__ out_fp8,     // [B, S, D]
+    const float* __restrict__ act_scale,     // [1] scalar
+    int B, int S, int D, float eps)
+{
+    int s = blockIdx.x;
+    int b = blockIdx.y;
+    int tid = threadIdx.x;
+    int row_offset = (b * S + s) * D;
+    int bd_offset = b * D;
+
+    extern __shared__ float smem[];
+
+    // Pass 1: y = residual + x, accumulate sum of squares.
+    float local_sum_sq = 0.0f;
+    for (int d = tid; d < D; d += blockDim.x) {
+        float r = __bfloat162float(residual[row_offset + d]);
+        float xv = __bfloat162float(x[row_offset + d]);
+        float y = r + xv;
+        residual[row_offset + d] = __float2bfloat16_rn(y);
+        local_sum_sq += y * y;
+    }
+
+    float total_sum_sq = lingbot_block_reduce_sum(local_sum_sq, smem);
+    float rsqrt_var = rsqrtf(total_sum_sq / (float)D + eps);
+    float inv_scale = 1.0f / __ldg(act_scale);
+
+    // Pass 2: norm + FiLM + FP8 quantize. residual now holds y.
+    // Round through bf16 between the FiLM result and the FP8 quantize
+    // to MATCH the eager `ada_rms_norm` → `linear_fp8`-internal-quantize
+    // pipeline exactly. Without this intermediate cast our output is
+    // slightly fresher (fewer rounding steps) but drifts from the
+    // bf16-trained baseline by ~0.005 cos.
+    for (int d = tid; d < D; d += blockDim.x) {
+        float y = __bfloat162float(residual[row_offset + d]);
+        float w = __bfloat162float(rms_weight[d]);
+        float g = __bfloat162float(gamma[bd_offset + d]);
+        float bt = __bfloat162float(beta[bd_offset + d]);
+        float norm_v = y * rsqrt_var * w;
+        float film_v = (1.0f + g) * norm_v + bt;
+        float film_bf16 = __bfloat162float(__float2bfloat16_rn(film_v));
+        float fp8_v = film_bf16 * inv_scale;
+        fp8_v = fmaxf(-448.0f, fminf(448.0f, fp8_v));
+        out_fp8[row_offset + d] = __nv_fp8_e4m3(fp8_v);
+    }
+}
+
+// =============================================================================
+//  Pybind wrappers (raw pointer entry; LingBot kernel_ops.py owns lifetime)
+// =============================================================================
+
+void lingbot_ada_rms_residual_fp8_bf16(
+    uintptr_t residual, uintptr_t x,
+    uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int D, float eps, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    dim3 grid(S, B);
+    dim3 block(BLOCK_THREADS);
+    size_t smem_bytes = BLOCK_THREADS * sizeof(float);
+    lingbot_ada_rms_residual_fp8_bf16_kernel<<<grid, block, smem_bytes, to_stream(stream)>>>(
+        reinterpret_cast<__nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(rms_weight),
+        reinterpret_cast<const __nv_bfloat16*>(gamma),
+        reinterpret_cast<const __nv_bfloat16*>(beta),
+        reinterpret_cast<__nv_fp8_e4m3*>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        B, S, D, eps
+    );
+}
+
+// =============================================================================
+//  Kernel: per-sample γ/β AdaRMSNorm + FP8 (no residual)
+//  Used by the Expert ``input_layernorm`` site (the input to Q/K/V
+//  projections). Same math as ada_rms_residual_fp8 but skips the
+//  residual+x step — hidden state already holds the layer input.
+// =============================================================================
+__global__ void lingbot_ada_rms_fp8_bf16_kernel(
+    const __nv_bfloat16* __restrict__ x,     // [B, S, D] read-only
+    const __nv_bfloat16* __restrict__ rms_weight,
+    const __nv_bfloat16* __restrict__ gamma, // [B, D]
+    const __nv_bfloat16* __restrict__ beta,  // [B, D]
+    __nv_fp8_e4m3* __restrict__ out_fp8,
+    const float* __restrict__ act_scale,
+    int B, int S, int D, float eps)
+{
+    int s = blockIdx.x;
+    int b = blockIdx.y;
+    int tid = threadIdx.x;
+    int row_offset = (b * S + s) * D;
+    int bd_offset = b * D;
+
+    extern __shared__ float smem[];
+
+    float local_sum_sq = 0.0f;
+    for (int d = tid; d < D; d += blockDim.x) {
+        float v = __bfloat162float(x[row_offset + d]);
+        local_sum_sq += v * v;
+    }
+    float total_sum_sq = lingbot_block_reduce_sum(local_sum_sq, smem);
+    float rsqrt_var = rsqrtf(total_sum_sq / (float)D + eps);
+    float inv_scale = 1.0f / __ldg(act_scale);
+
+    for (int d = tid; d < D; d += blockDim.x) {
+        float v = __bfloat162float(x[row_offset + d]);
+        float w = __bfloat162float(rms_weight[d]);
+        float g = __bfloat162float(gamma[bd_offset + d]);
+        float bt = __bfloat162float(beta[bd_offset + d]);
+        float norm_v = v * rsqrt_var * w;
+        float film_v = (1.0f + g) * norm_v + bt;
+        // Round through bf16 to match eager's ada_rms_norm→linear_fp8
+        // quantize pipeline (see ada_rms_residual variant for rationale).
+        float film_bf16 = __bfloat162float(__float2bfloat16_rn(film_v));
+        float fp8_v = film_bf16 * inv_scale;
+        fp8_v = fmaxf(-448.0f, fminf(448.0f, fp8_v));
+        out_fp8[row_offset + d] = __nv_fp8_e4m3(fp8_v);
+    }
+}
+
+// =============================================================================
+//  M-padded variants: identical math but write a [B, PADM, D] FP8 output
+//  (PADM >= S) with rows [S, PADM) zero-filled, so the downstream FP8 GEMM
+//  reads M=PADM directly and skips linear_fp8_from_fp8's pad copy. The same
+//  norm output feeds q/k/v (3 GEMMs) or gate/up (2 GEMMs) — one pre-padded
+//  buffer replaces 3 (resp. 2) redundant 51->64 copies per layer.
+// =============================================================================
+__global__ void lingbot_ada_rms_fp8_mpad_bf16_kernel(
+    const __nv_bfloat16* __restrict__ x,     // [B, S, D] read-only
+    const __nv_bfloat16* __restrict__ rms_weight,
+    const __nv_bfloat16* __restrict__ gamma, // [B, D]
+    const __nv_bfloat16* __restrict__ beta,  // [B, D]
+    __nv_fp8_e4m3* __restrict__ out_fp8,     // [B, PADM, D]
+    const float* __restrict__ act_scale,
+    int B, int S, int PADM, int D, float eps)
+{
+    int s = blockIdx.x;
+    int b = blockIdx.y;
+    int tid = threadIdx.x;
+    int out_off = (b * PADM + s) * D;
+    if (s >= S) {
+        for (int d = tid; d < D; d += blockDim.x)
+            out_fp8[out_off + d] = __nv_fp8_e4m3(0.0f);
+        return;
+    }
+    int row_offset = (b * S + s) * D;
+    int bd_offset = b * D;
+    extern __shared__ float smem[];
+    float local_sum_sq = 0.0f;
+    for (int d = tid; d < D; d += blockDim.x) {
+        float v = __bfloat162float(x[row_offset + d]);
+        local_sum_sq += v * v;
+    }
+    float total_sum_sq = lingbot_block_reduce_sum(local_sum_sq, smem);
+    float rsqrt_var = rsqrtf(total_sum_sq / (float)D + eps);
+    float inv_scale = 1.0f / __ldg(act_scale);
+    for (int d = tid; d < D; d += blockDim.x) {
+        float v = __bfloat162float(x[row_offset + d]);
+        float w = __bfloat162float(rms_weight[d]);
+        float g = __bfloat162float(gamma[bd_offset + d]);
+        float bt = __bfloat162float(beta[bd_offset + d]);
+        float norm_v = v * rsqrt_var * w;
+        float film_v = (1.0f + g) * norm_v + bt;
+        float film_bf16 = __bfloat162float(__float2bfloat16_rn(film_v));
+        float fp8_v = film_bf16 * inv_scale;
+        fp8_v = fmaxf(-448.0f, fminf(448.0f, fp8_v));
+        out_fp8[out_off + d] = __nv_fp8_e4m3(fp8_v);
+    }
+}
+
+__global__ void lingbot_ada_rms_residual_fp8_mpad_bf16_kernel(
+    __nv_bfloat16* __restrict__ residual,    // [B, S, D] mutated to residual+x
+    const __nv_bfloat16* __restrict__ x,     // [B, S, D]
+    const __nv_bfloat16* __restrict__ rms_weight,
+    const __nv_bfloat16* __restrict__ gamma,
+    const __nv_bfloat16* __restrict__ beta,
+    __nv_fp8_e4m3* __restrict__ out_fp8,     // [B, PADM, D]
+    const float* __restrict__ act_scale,
+    int B, int S, int PADM, int D, float eps)
+{
+    int s = blockIdx.x;
+    int b = blockIdx.y;
+    int tid = threadIdx.x;
+    int out_off = (b * PADM + s) * D;
+    if (s >= S) {
+        for (int d = tid; d < D; d += blockDim.x)
+            out_fp8[out_off + d] = __nv_fp8_e4m3(0.0f);
+        return;
+    }
+    int row_offset = (b * S + s) * D;
+    int bd_offset = b * D;
+    extern __shared__ float smem[];
+    float local_sum_sq = 0.0f;
+    for (int d = tid; d < D; d += blockDim.x) {
+        float r = __bfloat162float(residual[row_offset + d]);
+        float xv = __bfloat162float(x[row_offset + d]);
+        float y = r + xv;
+        residual[row_offset + d] = __float2bfloat16_rn(y);
+        local_sum_sq += y * y;
+    }
+    float total_sum_sq = lingbot_block_reduce_sum(local_sum_sq, smem);
+    float rsqrt_var = rsqrtf(total_sum_sq / (float)D + eps);
+    float inv_scale = 1.0f / __ldg(act_scale);
+    for (int d = tid; d < D; d += blockDim.x) {
+        float y = __bfloat162float(residual[row_offset + d]);
+        float w = __bfloat162float(rms_weight[d]);
+        float g = __bfloat162float(gamma[bd_offset + d]);
+        float bt = __bfloat162float(beta[bd_offset + d]);
+        float norm_v = y * rsqrt_var * w;
+        float film_v = (1.0f + g) * norm_v + bt;
+        float film_bf16 = __bfloat162float(__float2bfloat16_rn(film_v));
+        float fp8_v = film_bf16 * inv_scale;
+        fp8_v = fmaxf(-448.0f, fminf(448.0f, fp8_v));
+        out_fp8[out_off + d] = __nv_fp8_e4m3(fp8_v);
+    }
+}
+
+void lingbot_ada_rms_fp8_mpad_bf16(
+    uintptr_t x, uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int PADM, int D, float eps, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    dim3 grid(PADM, B);
+    dim3 block(BLOCK_THREADS);
+    size_t smem_bytes = BLOCK_THREADS * sizeof(float);
+    lingbot_ada_rms_fp8_mpad_bf16_kernel<<<grid, block, smem_bytes, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(rms_weight),
+        reinterpret_cast<const __nv_bfloat16*>(gamma),
+        reinterpret_cast<const __nv_bfloat16*>(beta),
+        reinterpret_cast<__nv_fp8_e4m3*>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        B, S, PADM, D, eps);
+}
+
+void lingbot_ada_rms_residual_fp8_mpad_bf16(
+    uintptr_t residual, uintptr_t x,
+    uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int PADM, int D, float eps, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    dim3 grid(PADM, B);
+    dim3 block(BLOCK_THREADS);
+    size_t smem_bytes = BLOCK_THREADS * sizeof(float);
+    lingbot_ada_rms_residual_fp8_mpad_bf16_kernel<<<grid, block, smem_bytes, to_stream(stream)>>>(
+        reinterpret_cast<__nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(rms_weight),
+        reinterpret_cast<const __nv_bfloat16*>(gamma),
+        reinterpret_cast<const __nv_bfloat16*>(beta),
+        reinterpret_cast<__nv_fp8_e4m3*>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        B, S, PADM, D, eps);
+}
+
+// =============================================================================
+//  Kernel: AdaRMS + residual, fp16 OUTPUT (M-padded), no FP8 quant.
+//  For the denoise FP4 path (G53): the post-attn AdaRMS feeds the FP4 gate_up
+//  GEMM. Outputting fp16 directly lets the FP4 quant run on it WITHOUT the
+//  fp8->fp16 dequant round-trip (4 tiny launch-bound kernels, ~18us/layer).
+//  Same math as the fp8 mpad variant minus the fp8 scale/clamp.
+// =============================================================================
+__global__ void lingbot_ada_rms_residual_fp16_mpad_kernel(
+    __nv_bfloat16* __restrict__ residual,    // [B, S, D] mutated to residual+x
+    const __nv_bfloat16* __restrict__ x,     // [B, S, D]
+    const __nv_bfloat16* __restrict__ rms_weight,
+    const __nv_bfloat16* __restrict__ gamma,
+    const __nv_bfloat16* __restrict__ beta,
+    __half* __restrict__ out_fp16,           // [B, PADM, D]
+    int B, int S, int PADM, int D, float eps)
+{
+    int s = blockIdx.x;
+    int b = blockIdx.y;
+    int tid = threadIdx.x;
+    int out_off = (b * PADM + s) * D;
+    if (s >= S) {
+        for (int d = tid; d < D; d += blockDim.x)
+            out_fp16[out_off + d] = __float2half_rn(0.0f);
+        return;
+    }
+    int row_offset = (b * S + s) * D;
+    int bd_offset = b * D;
+    extern __shared__ float smem[];
+    float local_sum_sq = 0.0f;
+    for (int d = tid; d < D; d += blockDim.x) {
+        float r = __bfloat162float(residual[row_offset + d]);
+        float xv = __bfloat162float(x[row_offset + d]);
+        float y = r + xv;
+        residual[row_offset + d] = __float2bfloat16_rn(y);
+        local_sum_sq += y * y;
+    }
+    float total_sum_sq = lingbot_block_reduce_sum(local_sum_sq, smem);
+    float rsqrt_var = rsqrtf(total_sum_sq / (float)D + eps);
+    for (int d = tid; d < D; d += blockDim.x) {
+        float y = __bfloat162float(residual[row_offset + d]);
+        float w = __bfloat162float(rms_weight[d]);
+        float g = __bfloat162float(gamma[bd_offset + d]);
+        float bt = __bfloat162float(beta[bd_offset + d]);
+        float norm_v = y * rsqrt_var * w;
+        float film_v = (1.0f + g) * norm_v + bt;
+        out_fp16[out_off + d] = __float2half_rn(film_v);
+    }
+}
+
+void lingbot_ada_rms_residual_fp16_mpad(
+    uintptr_t residual, uintptr_t x,
+    uintptr_t rms_weight, uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp16, int B, int S, int PADM, int D, float eps, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    dim3 grid(PADM, B);
+    dim3 block(BLOCK_THREADS);
+    size_t smem_bytes = BLOCK_THREADS * sizeof(float);
+    lingbot_ada_rms_residual_fp16_mpad_kernel<<<grid, block, smem_bytes, to_stream(stream)>>>(
+        reinterpret_cast<__nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(rms_weight),
+        reinterpret_cast<const __nv_bfloat16*>(gamma),
+        reinterpret_cast<const __nv_bfloat16*>(beta),
+        reinterpret_cast<__half*>(out_fp16),
+        B, S, PADM, D, eps);
+}
+
+// =============================================================================
+//  Kernel: bf16 in-place RoPE (LingBot split-half variant)
+// =============================================================================
+//   For each (b, s, h):
+//     x1, x2 = x[..., :half], x[..., half:]
+//     x[..., :half] = x1 * cos - x2 * sin
+//     x[..., half:] = x2 * cos + x1 * sin
+//   cos, sin have shape [B, S, half] (per-(b,s) shared across heads).
+//
+// Replaces 5 launches per call (x.to(fp32) + apply + .to(bf16) + repeat for K)
+// with one in-place pass that does the math in fp32 internally.
+void lingbot_ada_rms_fp8_bf16(
+    uintptr_t x, uintptr_t rms_weight,
+    uintptr_t gamma, uintptr_t beta,
+    uintptr_t out_fp8, uintptr_t act_scale,
+    int B, int S, int D, float eps, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    dim3 grid(S, B);
+    dim3 block(BLOCK_THREADS);
+    size_t smem_bytes = BLOCK_THREADS * sizeof(float);
+    lingbot_ada_rms_fp8_bf16_kernel<<<grid, block, smem_bytes, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(rms_weight),
+        reinterpret_cast<const __nv_bfloat16*>(gamma),
+        reinterpret_cast<const __nv_bfloat16*>(beta),
+        reinterpret_cast<__nv_fp8_e4m3*>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        B, S, D, eps
+    );
+}
+
+
+// =============================================================================
+//  Kernel: fused QKV bias-add + RoPE (Expert denoise QKV post-processing)
+// =============================================================================
+// Replaces, per Expert layer, the 5 separate launches
+//   add_bias(q) + add_bias(k) + add_bias(v) + rope(q) + rope(k)
+// with ONE kernel. q/k get (bias add → split-half RoPE); v gets bias only.
+// q has NHQ heads, k/v have NHKV heads, all head_dim HD. Inputs are the raw
+// (bias-free) bf16 GEMM outputs [M, NH*HD]; cos/sin are [M, HD/2] fp32.
+//
+// Grid:  (NHQ + 2*NHKV, M)   — one block per (head-slot, token)
+// Block: min(HD/2, 128) threads
+//   slot < NHQ            -> q head (slot)
+//   NHQ <= slot < NHQ+NHKV-> k head (slot-NHQ)
+//   else                 -> v head (slot-NHQ-NHKV)

--- a/csrc/kernels/lingbot_rope_qkv.cu
+++ b/csrc/kernels/lingbot_rope_qkv.cu
@@ -1,0 +1,418 @@
+#include "lingbot_common.cuh"
+
+__global__ void lingbot_rope_inplace_bf16_kernel(
+    __nv_bfloat16* __restrict__ x,            // [B, S, NH, HD]
+    const float* __restrict__ cos_table,      // [B, S, HD/2] fp32
+    const float* __restrict__ sin_table,      // [B, S, HD/2] fp32
+    int B, int S, int NH, int HD)
+{
+    // Block: one (b, s, h). Threads cover HD/2 paired elements.
+    int b = blockIdx.z;
+    int s = blockIdx.y;
+    int h = blockIdx.x;
+    int tid = threadIdx.x;
+    int half = HD / 2;
+
+    int x_offset = ((b * S + s) * NH + h) * HD;
+    int cs_offset = (b * S + s) * half;
+
+    for (int d = tid; d < half; d += blockDim.x) {
+        float c = cos_table[cs_offset + d];
+        float sn = sin_table[cs_offset + d];
+        float x1 = __bfloat162float(x[x_offset + d]);
+        float x2 = __bfloat162float(x[x_offset + d + half]);
+        x[x_offset + d]        = __float2bfloat16_rn(x1 * c - x2 * sn);
+        x[x_offset + d + half] = __float2bfloat16_rn(x2 * c + x1 * sn);
+    }
+}
+
+void lingbot_rope_inplace_bf16(
+    uintptr_t x, uintptr_t cos_table, uintptr_t sin_table,
+    int B, int S, int NH, int HD, uintptr_t stream)
+{
+    int half = HD / 2;
+    int block_threads = (half < 128) ? half : 128;
+    dim3 grid(NH, S, B);
+    dim3 block(block_threads);
+    lingbot_rope_inplace_bf16_kernel<<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<__nv_bfloat16*>(x),
+        reinterpret_cast<const float*>(cos_table),
+        reinterpret_cast<const float*>(sin_table),
+        B, S, NH, HD
+    );
+}
+
+// G33-fix: out-of-place split-half RoPE. Reads ``x`` (source), writes a
+// distinct ``out`` buffer. Out-of-place avoids any read-after-write hazard
+// between source and destination across CUDA-graph replays, and lets the
+// caller keep ``x`` (e.g. for a residual) — fixes the non-determinism that
+// disabled the in-place variant.
+__global__ void lingbot_rope_to_out_bf16_kernel(
+    const __nv_bfloat16* __restrict__ x,      // [B, S, NH, HD]
+    __nv_bfloat16* __restrict__ out,          // [B, S, NH, HD]
+    const float* __restrict__ cos_table,      // [B, S, HD/2] fp32
+    const float* __restrict__ sin_table,      // [B, S, HD/2] fp32
+    int B, int S, int NH, int HD)
+{
+    int b = blockIdx.z;
+    int s = blockIdx.y;
+    int h = blockIdx.x;
+    int tid = threadIdx.x;
+    int half = HD / 2;
+
+    int x_offset = ((b * S + s) * NH + h) * HD;
+    int cs_offset = (b * S + s) * half;
+
+    for (int d = tid; d < half; d += blockDim.x) {
+        float c = cos_table[cs_offset + d];
+        float sn = sin_table[cs_offset + d];
+        float x1 = __bfloat162float(x[x_offset + d]);
+        float x2 = __bfloat162float(x[x_offset + d + half]);
+        out[x_offset + d]        = __float2bfloat16_rn(x1 * c - x2 * sn);
+        out[x_offset + d + half] = __float2bfloat16_rn(x2 * c + x1 * sn);
+    }
+}
+
+void lingbot_rope_to_out_bf16(
+    uintptr_t x, uintptr_t out, uintptr_t cos_table, uintptr_t sin_table,
+    int B, int S, int NH, int HD, uintptr_t stream)
+{
+    int half = HD / 2;
+    int block_threads = (half < 128) ? half : 128;
+    dim3 grid(NH, S, B);
+    dim3 block(block_threads);
+    lingbot_rope_to_out_bf16_kernel<<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<__nv_bfloat16*>(out),
+        reinterpret_cast<const float*>(cos_table),
+        reinterpret_cast<const float*>(sin_table),
+        B, S, NH, HD
+    );
+}
+
+__device__ __forceinline__ __nv_bfloat16 to_out_t(float v, __nv_bfloat16) {
+    return __float2bfloat16_rn(v);
+}
+__device__ __forceinline__ __half to_out_t(float v, __half) {
+    return __float2half_rn(v);
+}
+
+template <typename OutT>
+__global__ void lingbot_qkv_bias_rope_kernel(
+    const __nv_bfloat16* __restrict__ q_raw,  // [M, NHQ*HD]
+    const __nv_bfloat16* __restrict__ k_raw,  // [M, NHKV*HD]
+    const __nv_bfloat16* __restrict__ v_raw,  // [M, NHKV*HD]
+    const __nv_bfloat16* __restrict__ q_bias, // [NHQ*HD] or null
+    const __nv_bfloat16* __restrict__ k_bias, // [NHKV*HD] or null
+    const __nv_bfloat16* __restrict__ v_bias, // [NHKV*HD] or null
+    const float* __restrict__ cos_table,      // [M, HD/2]
+    const float* __restrict__ sin_table,      // [M, HD/2]
+    OutT* __restrict__ q_out,                  // [M, NHQ*HD]
+    OutT* __restrict__ k_out,                  // [M, NHKV*HD]
+    OutT* __restrict__ v_out,                  // [M, NHKV*HD]
+    int M, int NHQ, int NHKV, int HD)
+{
+    int slot = blockIdx.x;
+    int m = blockIdx.y;
+    int tid = threadIdx.x;
+    int half = HD / 2;
+    int cs_off = m * half;
+
+    const __nv_bfloat16* src;
+    const __nv_bfloat16* bias;
+    OutT* dst;
+    int head, do_rope;
+    if (slot < NHQ) {
+        head = slot; src = q_raw; bias = q_bias; dst = q_out; do_rope = 1;
+        src += m * NHQ * HD + head * HD;  dst += m * NHQ * HD + head * HD;
+    } else if (slot < NHQ + NHKV) {
+        head = slot - NHQ; src = k_raw; bias = k_bias; dst = k_out; do_rope = 1;
+        src += m * NHKV * HD + head * HD; dst += m * NHKV * HD + head * HD;
+    } else {
+        head = slot - NHQ - NHKV; src = v_raw; bias = v_bias; dst = v_out; do_rope = 0;
+        src += m * NHKV * HD + head * HD; dst += m * NHKV * HD + head * HD;
+    }
+    int bias_off = head * HD;
+    OutT tag{};
+
+    if (do_rope) {
+        for (int d = tid; d < half; d += blockDim.x) {
+            float c = cos_table[cs_off + d];
+            float sn = sin_table[cs_off + d];
+            float x1 = __bfloat162float(src[d]);
+            float x2 = __bfloat162float(src[d + half]);
+            if (bias) {
+                x1 += __bfloat162float(bias[bias_off + d]);
+                x2 += __bfloat162float(bias[bias_off + d + half]);
+            }
+            dst[d]        = to_out_t(x1 * c - x2 * sn, tag);
+            dst[d + half] = to_out_t(x2 * c + x1 * sn, tag);
+        }
+    } else {
+        for (int d = tid; d < HD; d += blockDim.x) {
+            float x = __bfloat162float(src[d]);
+            if (bias) x += __bfloat162float(bias[bias_off + d]);
+            dst[d] = to_out_t(x, tag);
+        }
+    }
+}
+
+void lingbot_qkv_bias_rope_bf16(
+    uintptr_t q_raw, uintptr_t k_raw, uintptr_t v_raw,
+    uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+{
+    int half = HD / 2;
+    int block_threads = (half < 128) ? half : 128;
+    dim3 grid(NHQ + 2 * NHKV, M);
+    dim3 block(block_threads);
+    lingbot_qkv_bias_rope_kernel<__nv_bfloat16><<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(q_raw),
+        reinterpret_cast<const __nv_bfloat16*>(k_raw),
+        reinterpret_cast<const __nv_bfloat16*>(v_raw),
+        reinterpret_cast<const __nv_bfloat16*>(q_bias),
+        reinterpret_cast<const __nv_bfloat16*>(k_bias),
+        reinterpret_cast<const __nv_bfloat16*>(v_bias),
+        reinterpret_cast<const float*>(cos_table),
+        reinterpret_cast<const float*>(sin_table),
+        reinterpret_cast<__nv_bfloat16*>(q_out),
+        reinterpret_cast<__nv_bfloat16*>(k_out),
+        reinterpret_cast<__nv_bfloat16*>(v_out),
+        M, NHQ, NHKV, HD);
+}
+
+// G49 merged-input variant: q/k/v come from ONE merged GEMM output
+// ``qkv`` [M, ROWQKV] where ROWQKV = NHQ*HD + 2*NHKV*HD and each row is
+// [q(NHQ*HD) | k(NHKV*HD) | v(NHKV*HD)]. Reads via column offsets (no split
+// copy). Writes the three SEPARATE outputs the attention needs. bias stays
+// per-section (the merged GEMM is bias-free).
+template <typename OutT>
+__global__ void lingbot_qkv_bias_rope_merged_kernel(
+    const __nv_bfloat16* __restrict__ qkv,    // [M, ROWQKV]
+    const __nv_bfloat16* __restrict__ q_bias, // [NHQ*HD] or null
+    const __nv_bfloat16* __restrict__ k_bias, // [NHKV*HD] or null
+    const __nv_bfloat16* __restrict__ v_bias, // [NHKV*HD] or null
+    const float* __restrict__ cos_table,      // [M, HD/2]
+    const float* __restrict__ sin_table,      // [M, HD/2]
+    OutT* __restrict__ q_out, OutT* __restrict__ k_out, OutT* __restrict__ v_out,
+    int M, int NHQ, int NHKV, int HD)
+{
+    int slot = blockIdx.x;
+    int m = blockIdx.y;
+    int tid = threadIdx.x;
+    int half = HD / 2;
+    int cs_off = m * half;
+    int ROWQKV = (NHQ + 2 * NHKV) * HD;
+    int row_base = m * ROWQKV;
+    const __nv_bfloat16* src;
+    const __nv_bfloat16* bias;
+    OutT* dst;
+    int head, do_rope;
+    if (slot < NHQ) {
+        head = slot; bias = q_bias; dst = q_out; do_rope = 1;
+        src = qkv + row_base + head * HD;
+        dst += m * NHQ * HD + head * HD;
+    } else if (slot < NHQ + NHKV) {
+        head = slot - NHQ; bias = k_bias; dst = k_out; do_rope = 1;
+        src = qkv + row_base + NHQ * HD + head * HD;
+        dst += m * NHKV * HD + head * HD;
+    } else {
+        head = slot - NHQ - NHKV; bias = v_bias; dst = v_out; do_rope = 0;
+        src = qkv + row_base + (NHQ + NHKV) * HD + head * HD;
+        dst += m * NHKV * HD + head * HD;
+    }
+    int bias_off = head * HD;
+    OutT tag{};
+    if (do_rope) {
+        for (int d = tid; d < half; d += blockDim.x) {
+            float c = cos_table[cs_off + d];
+            float sn = sin_table[cs_off + d];
+            float x1 = __bfloat162float(src[d]);
+            float x2 = __bfloat162float(src[d + half]);
+            if (bias) {
+                x1 += __bfloat162float(bias[bias_off + d]);
+                x2 += __bfloat162float(bias[bias_off + d + half]);
+            }
+            dst[d]        = to_out_t(x1 * c - x2 * sn, tag);
+            dst[d + half] = to_out_t(x2 * c + x1 * sn, tag);
+        }
+    } else {
+        for (int d = tid; d < HD; d += blockDim.x) {
+            float x = __bfloat162float(src[d]);
+            if (bias) x += __bfloat162float(bias[bias_off + d]);
+            dst[d] = to_out_t(x, tag);
+        }
+    }
+}
+
+void lingbot_qkv_bias_rope_merged_fp16out(
+    uintptr_t qkv, uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+{
+    int half = HD / 2;
+    int block_threads = (half < 128) ? half : 128;
+    dim3 grid(NHQ + 2 * NHKV, M);
+    dim3 block(block_threads);
+    lingbot_qkv_bias_rope_merged_kernel<__half><<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv),
+        reinterpret_cast<const __nv_bfloat16*>(q_bias),
+        reinterpret_cast<const __nv_bfloat16*>(k_bias),
+        reinterpret_cast<const __nv_bfloat16*>(v_bias),
+        reinterpret_cast<const float*>(cos_table),
+        reinterpret_cast<const float*>(sin_table),
+        reinterpret_cast<__half*>(q_out),
+        reinterpret_cast<__half*>(k_out),
+        reinterpret_cast<__half*>(v_out),
+        M, NHQ, NHKV, HD);
+}
+
+void lingbot_qkv_bias_rope_merged_bf16(
+    uintptr_t qkv, uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+{
+    int half = HD / 2;
+    int block_threads = (half < 128) ? half : 128;
+    dim3 grid(NHQ + 2 * NHKV, M);
+    dim3 block(block_threads);
+    lingbot_qkv_bias_rope_merged_kernel<__nv_bfloat16><<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv),
+        reinterpret_cast<const __nv_bfloat16*>(q_bias),
+        reinterpret_cast<const __nv_bfloat16*>(k_bias),
+        reinterpret_cast<const __nv_bfloat16*>(v_bias),
+        reinterpret_cast<const float*>(cos_table),
+        reinterpret_cast<const float*>(sin_table),
+        reinterpret_cast<__nv_bfloat16*>(q_out),
+        reinterpret_cast<__nv_bfloat16*>(k_out),
+        reinterpret_cast<__nv_bfloat16*>(v_out),
+        M, NHQ, NHKV, HD);
+}
+
+// G39: fp16-output variant — feeds the fp16 attention island (fmha consumes
+// fp16 with no cast). Reads the same bf16 GEMM outputs, writes __half.
+void lingbot_qkv_bias_rope_fp16out(
+    uintptr_t q_raw, uintptr_t k_raw, uintptr_t v_raw,
+    uintptr_t q_bias, uintptr_t k_bias, uintptr_t v_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NHQ, int NHKV, int HD, uintptr_t stream)
+{
+    int half = HD / 2;
+    int block_threads = (half < 128) ? half : 128;
+    dim3 grid(NHQ + 2 * NHKV, M);
+    dim3 block(block_threads);
+    lingbot_qkv_bias_rope_kernel<__half><<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(q_raw),
+        reinterpret_cast<const __nv_bfloat16*>(k_raw),
+        reinterpret_cast<const __nv_bfloat16*>(v_raw),
+        reinterpret_cast<const __nv_bfloat16*>(q_bias),
+        reinterpret_cast<const __nv_bfloat16*>(k_bias),
+        reinterpret_cast<const __nv_bfloat16*>(v_bias),
+        reinterpret_cast<const float*>(cos_table),
+        reinterpret_cast<const float*>(sin_table),
+        reinterpret_cast<__half*>(q_out),
+        reinterpret_cast<__half*>(k_out),
+        reinterpret_cast<__half*>(v_out),
+        M, NHQ, NHKV, HD);
+}
+
+
+// =============================================================================
+//  Kernel: ViT fused QKV bias-add + 2-D M-RoPE (per-view ViT attention prep)
+// =============================================================================
+// The Qwen2.5-VL ViT qkv GEMM output is ONE interleaved buffer
+// [M, 3*NH*HD] (type-major: type 0=q, 1=k, 2=v; NH heads each, head_dim HD).
+// q/k get (bias add → split-half RoPE); v gets bias only. Writes three
+// contiguous [M, NH*HD] outputs ready for the per-view fmha. Replaces, per
+// ViT block, the add_bias(qkv) launch + the eager fp32 RoPE storm
+// (q.float/k.float, rotate_half cat ×2, mul, add, cast back). The RoPE
+// formula is identical to the LLM split-half kernel: with emb=cat([f,f]) the
+// two cos/sin halves are equal, so we index the first HD/2 columns of the
+// [M, HD] cos/sin tables (row stride HD).
+__global__ void lingbot_vit_qkv_bias_rope_kernel(
+    const __nv_bfloat16* __restrict__ qkv,      // [M, 3*NH*HD] raw GEMM out
+    const __nv_bfloat16* __restrict__ qkv_bias, // [3*NH*HD] or null
+    const float* __restrict__ cos_table,        // [M, HD] (uses cols [0,HD/2))
+    const float* __restrict__ sin_table,        // [M, HD]
+    __nv_bfloat16* __restrict__ q_out,          // [M, NH*HD]
+    __nv_bfloat16* __restrict__ k_out,          // [M, NH*HD]
+    __nv_bfloat16* __restrict__ v_out,          // [M, NH*HD]
+    int M, int NH, int HD)
+{
+    int slot = blockIdx.x;                      // [0, 3*NH)
+    int m = blockIdx.y;
+    int tid = threadIdx.x;
+    int half = HD / 2;
+    int type = slot / NH;                       // 0=q, 1=k, 2=v
+    int head = slot - type * NH;
+    const __nv_bfloat16* src =
+        qkv + ((long)m * 3 * NH + (long)type * NH + head) * HD;
+    __nv_bfloat16* dst =
+        (type == 0 ? q_out : (type == 1 ? k_out : v_out))
+        + ((long)m * NH + head) * HD;
+    int bias_off = (type * NH + head) * HD;
+    int cs_off = m * HD;
+    if (type < 2) {                             // q, k: bias + split-half RoPE
+        for (int d = tid; d < half; d += blockDim.x) {
+            float c = cos_table[cs_off + d];
+            float sn = sin_table[cs_off + d];
+            float x1 = __bfloat162float(src[d]);
+            float x2 = __bfloat162float(src[d + half]);
+            if (qkv_bias) {
+                x1 += __bfloat162float(qkv_bias[bias_off + d]);
+                x2 += __bfloat162float(qkv_bias[bias_off + d + half]);
+            }
+            dst[d]        = __float2bfloat16_rn(x1 * c - x2 * sn);
+            dst[d + half] = __float2bfloat16_rn(x2 * c + x1 * sn);
+        }
+    } else {                                    // v: bias only
+        for (int d = tid; d < HD; d += blockDim.x) {
+            float x = __bfloat162float(src[d]);
+            if (qkv_bias) x += __bfloat162float(qkv_bias[bias_off + d]);
+            dst[d] = __float2bfloat16_rn(x);
+        }
+    }
+}
+
+void lingbot_vit_qkv_bias_rope_bf16(
+    uintptr_t qkv, uintptr_t qkv_bias,
+    uintptr_t cos_table, uintptr_t sin_table,
+    uintptr_t q_out, uintptr_t k_out, uintptr_t v_out,
+    int M, int NH, int HD, uintptr_t stream)
+{
+    int half = HD / 2;
+    int block_threads = (half < 128) ? half : 128;
+    dim3 grid(3 * NH, M);
+    dim3 block(block_threads);
+    lingbot_vit_qkv_bias_rope_kernel<<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv),
+        reinterpret_cast<const __nv_bfloat16*>(qkv_bias),
+        reinterpret_cast<const float*>(cos_table),
+        reinterpret_cast<const float*>(sin_table),
+        reinterpret_cast<__nv_bfloat16*>(q_out),
+        reinterpret_cast<__nv_bfloat16*>(k_out),
+        reinterpret_cast<__nv_bfloat16*>(v_out),
+        M, NH, HD);
+}
+
+
+// =============================================================================
+//  Kernel: fused SwiGLU tail — silu(gate)*up + FP8 static-quant + M-pad
+// =============================================================================
+//   For the Expert down_proj input. Replaces the eager chain
+//   ``F.silu(gate) * up`` (bf16 elementwise, 2 kernels) + ``quantize_fp8``
+//   + the linear_fp8 M-pad copy (51->64) with ONE pass that writes a
+//   pre-M-padded FP8 buffer the down GEMM reads directly (M=PADM, no copy).
+//   Rows [S, PADM) are zero-filled so the sliced-off GEMM output is clean.
+//
+//   Math matches eager: silu/mul computed in fp32 with a bf16 round on the
+//   product (the eager F.silu*up is bf16) before the FP8 quant — same
+//   rounding chain as linear_fp8's internal quantize.
+//
+// Grid:  (PADM,)   one block per output row
+// Block: 256 threads, strided over I (intermediate dim)

--- a/csrc/kernels/lingbot_silu_mul_fp8.cu
+++ b/csrc/kernels/lingbot_silu_mul_fp8.cu
@@ -1,0 +1,132 @@
+#include "lingbot_common.cuh"
+
+__global__ void lingbot_silu_mul_fp8_mpad_bf16_kernel(
+    const __nv_bfloat16* __restrict__ gate,  // [S, I]
+    const __nv_bfloat16* __restrict__ up,     // [S, I]
+    __nv_fp8_e4m3* __restrict__ out_fp8,      // [PADM, I]
+    const float* __restrict__ act_scale,      // [1]
+    int S, int PADM, int I)
+{
+    int row = blockIdx.x;
+    int tid = threadIdx.x;
+    int off = row * I;
+    if (row >= S) {
+        for (int d = tid; d < I; d += blockDim.x)
+            out_fp8[off + d] = __nv_fp8_e4m3(0.0f);
+        return;
+    }
+    float inv_scale = 1.0f / __ldg(act_scale);
+    for (int d = tid; d < I; d += blockDim.x) {
+        float gv = __bfloat162float(gate[off + d]);
+        float uv = __bfloat162float(up[off + d]);
+        float silu = gv / (1.0f + __expf(-gv));
+        float h = silu * uv;
+        // round product through bf16 to match the eager bf16 silu*up tensor
+        float h_bf16 = __bfloat162float(__float2bfloat16_rn(h));
+        float fp8_v = h_bf16 * inv_scale;
+        fp8_v = fmaxf(-448.0f, fminf(448.0f, fp8_v));
+        out_fp8[off + d] = __nv_fp8_e4m3(fp8_v);
+    }
+}
+
+void lingbot_silu_mul_fp8_mpad_bf16(
+    uintptr_t gate, uintptr_t up, uintptr_t out_fp8, uintptr_t act_scale,
+    int S, int PADM, int I, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    dim3 grid(PADM);
+    dim3 block(BLOCK_THREADS);
+    lingbot_silu_mul_fp8_mpad_bf16_kernel<<<grid, block, 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gate),
+        reinterpret_cast<const __nv_bfloat16*>(up),
+        reinterpret_cast<__nv_fp8_e4m3*>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        S, PADM, I);
+}
+
+// Merged-input variant: gate/up come INTERLEAVED per row in one [S, 2*I] buffer
+// (a single merged gate_up GEMM output): row r = [gate(I) | up(I)]. Reads with
+// offsets (no split copy) so one GEMM + this kernel replace 2 GEMMs + silu/mul.
+__global__ void lingbot_silu_mul_merged_fp8_mpad_bf16_kernel(
+    const __nv_bfloat16* __restrict__ gu,    // [S, 2*I] (gate|up per row)
+    __nv_fp8_e4m3* __restrict__ out_fp8,      // [PADM, I]
+    const float* __restrict__ act_scale,
+    int S, int PADM, int I)
+{
+    int row = blockIdx.x;
+    int tid = threadIdx.x;
+    int oo = row * I;
+    if (row >= S) {
+        for (int d = tid; d < I; d += blockDim.x)
+            out_fp8[oo + d] = __nv_fp8_e4m3(0.0f);
+        return;
+    }
+    int go = row * 2 * I;        // gate base
+    int uo = go + I;             // up base
+    float inv_scale = 1.0f / __ldg(act_scale);
+    for (int d = tid; d < I; d += blockDim.x) {
+        float gv = __bfloat162float(gu[go + d]);
+        float uv = __bfloat162float(gu[uo + d]);
+        float silu = gv / (1.0f + __expf(-gv));
+        float h = silu * uv;
+        float h_bf16 = __bfloat162float(__float2bfloat16_rn(h));
+        float fp8_v = h_bf16 * inv_scale;
+        fp8_v = fmaxf(-448.0f, fminf(448.0f, fp8_v));
+        out_fp8[oo + d] = __nv_fp8_e4m3(fp8_v);
+    }
+}
+
+void lingbot_silu_mul_merged_fp8_mpad_bf16(
+    uintptr_t gu, uintptr_t out_fp8, uintptr_t act_scale,
+    int S, int PADM, int I, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    lingbot_silu_mul_merged_fp8_mpad_bf16_kernel<<<dim3(PADM), dim3(BLOCK_THREADS), 0, to_stream(stream)>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gu),
+        reinterpret_cast<__nv_fp8_e4m3*>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        S, PADM, I);
+}
+
+// G54: fp16-INPUT variant — reads the merged gate_up directly from the FP4 GEMM's
+// fp16 output (no bf16 cast). Same silu(gate)*up + FP8 static-quant + M-pad.
+__global__ void lingbot_silu_mul_merged_fp8_mpad_fp16in_kernel(
+    const __half* __restrict__ gu,            // [S, 2*I] fp16 (gate|up per row)
+    __nv_fp8_e4m3* __restrict__ out_fp8,      // [PADM, I]
+    const float* __restrict__ act_scale,
+    int S, int PADM, int I)
+{
+    int row = blockIdx.x;
+    int tid = threadIdx.x;
+    int oo = row * I;
+    if (row >= S) {
+        for (int d = tid; d < I; d += blockDim.x)
+            out_fp8[oo + d] = __nv_fp8_e4m3(0.0f);
+        return;
+    }
+    int go = row * 2 * I;
+    int uo = go + I;
+    float inv_scale = 1.0f / __ldg(act_scale);
+    for (int d = tid; d < I; d += blockDim.x) {
+        float gv = __half2float(gu[go + d]);
+        float uv = __half2float(gu[uo + d]);
+        float silu = gv / (1.0f + __expf(-gv));
+        float h = silu * uv;
+        float h_bf16 = __bfloat162float(__float2bfloat16_rn(h));
+        float fp8_v = h_bf16 * inv_scale;
+        fp8_v = fmaxf(-448.0f, fminf(448.0f, fp8_v));
+        out_fp8[oo + d] = __nv_fp8_e4m3(fp8_v);
+    }
+}
+
+void lingbot_silu_mul_merged_fp8_mpad_fp16in(
+    uintptr_t gu, uintptr_t out_fp8, uintptr_t act_scale,
+    int S, int PADM, int I, uintptr_t stream)
+{
+    constexpr int BLOCK_THREADS = 256;
+    lingbot_silu_mul_merged_fp8_mpad_fp16in_kernel<<<dim3(PADM), dim3(BLOCK_THREADS), 0, to_stream(stream)>>>(
+        reinterpret_cast<const __half*>(gu),
+        reinterpret_cast<__nv_fp8_e4m3*>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        S, PADM, I);
+}

--- a/docs/lingbot_usage.md
+++ b/docs/lingbot_usage.md
@@ -1,0 +1,143 @@
+# LingBot-VLA on Thor (sm_110)
+
+LingBot-VLA is a Qwen2.5-VL backbone + flow-matching action expert. This doc
+covers building, the FA4 fast path, accuracy/latency, and running it on Jetson
+AGX Thor (sm_110).
+
+> **Status — low-level path only.** LingBot runs through the **low-level
+> `graph_runner` path** (`graph_runner.sample_actions_graph`: weight spec +
+> CUDA-graph capture). It is **not** registered in `_PIPELINE_MAP` and
+> `flash_rt.load_model` does **not** dispatch a `lingbot` config; this is **not**
+> the stable `load_model()` API. `LingbotTorchFrontendThor`
+> (`flash_rt/frontends/torch/lingbot_thor.py`) is a **G1 scaffold** whose methods
+> raise `NotImplementedError`. Use `examples/lingbot_quickstart.py` /
+> `benchmarks/lingbot_thor_latency.py`, not `flash_rt.load_model("lingbot")`.
+
+## 1. Architecture / shapes
+
+| stage | layers | notes |
+|-------|--------|-------|
+| ViT (SigLIP-style) | 32 | 3 camera views, 224² |
+| VLM prefix (Qwen2.5-VL) | 36 | FP8; FA4 for the prefix self-attention |
+| Action expert (flow-matching) | 36 | per-step denoise loop, FP8 + FP4 gate_up; FA4 denoise attention |
+
+Action chunk: `[1, 50, 75]` (horizon 50, action dim 75). Denoise step count is
+configurable (10 / 25 / 50).
+
+## 2. Build (one shared module)
+
+LingBot's model-specific kernels (fused AdaRMSNorm, SwiGLU tail, QKV+RoPE) are
+compiled **into `flash_rt_kernels`** — same pattern as the qwen36 kernels in
+`csrc/kernels/`. There is **no separate `flash_rt_lingbot.so`**. The kernels are
+`lingbot_`-prefixed and gated behind `ENABLE_LINGBOT`, built only when
+`FLASHRT_ENABLE_LINGBOT=ON` (default) **and** `GPU_ARCH=110` (Thor). RTX
+(sm_120) / Orin / L40 builds compile neither the sources nor the bindings.
+
+```bash
+git clone --depth 1 --branch v4.4.2 \
+    https://github.com/NVIDIA/cutlass.git third_party/cutlass
+cmake -B build -S . -DGPU_ARCH=110            # -DFLASHRT_ENABLE_LINGBOT=OFF to skip
+cmake --build build -j --target flash_rt_kernels flash_rt_fp4 fmha_fp16_strided
+pip install -e ".[torch,thor-fa4]"
+```
+
+Sanity-check that the LingBot kernels and FA4 are present:
+
+```bash
+python - <<'PY'
+import flash_rt.flash_rt_kernels as k
+print("lingbot kernels:", sum(x.startswith("lingbot_") for x in dir(k)))   # 15
+from flash_rt.hardware.thor import fa4_backend
+print("FA4:", fa4_backend.is_available(), "-", fa4_backend.status())        # True - active
+PY
+```
+
+## 3. FlashAttention-4 (the Thor fast path)
+
+FA4 (CuTe-DSL) gives the denoise + prefix attention ~17% over the fmha path
+(`pack_gqa`, cosine preserved). On Thor it must be compiled for **sm_101a** (the
+sm_110 Blackwell alias; `fa4_backend` sets `CUTE_DSL_ARCH=sm_101a` for you).
+
+- The FA4 forward source is **vendored, trimmed, and privately namespaced** at
+  `csrc/attention/flash_attn_4_src/` (package `flashrt_fa4`, a forward /
+  SM100-only subset of `flash_attn/cute`; see its `VENDOR.md`). No `flash-attn`
+  wheel is needed, and it never shadows a pip-installed `flash_attn`.
+  > **Install note:** the vendor lives under `csrc/` and is loaded from the
+  > source tree, so it is **not** bundled into a built wheel. Use an editable /
+  > source-tree install (`pip install -e .`); a plain `pip install .` wheel
+  > would not ship it (FA4 would silently fall back to fmha). If wheel
+  > packaging is needed later, move the vendor under `flash_rt/` or add it to
+  > `package-data`.
+- The import is isolated in `flash_rt/hardware/thor/fa4_backend.py` — the only
+  place that touches FA4. It returns `None` (→ fmha fallback) if unavailable.
+- Its runtime deps (`nvidia-cutlass-dsl`, `quack-kernels`) come from the
+  **`thor-fa4`** extra: `pip install ".[thor-fa4]"`. They are **not** in `all`.
+- FA4 is an **optional fast path**: if its deps are missing it silently falls
+  back to the fmha kernel (correct, ~+18 ms@25).
+
+**A/B the attention path:**
+
+```bash
+FLASHRT_THOR_FA4=1 python benchmarks/lingbot_thor_latency.py ...   # FA4
+FLASHRT_THOR_FA4=0 python benchmarks/lingbot_thor_latency.py ...   # force fmha
+```
+
+The benchmark prints `FA4 status: active` or the failure reason. To debug an
+unexpected fallback, set `LINGBOT_FA4_DEBUG=1` to print the import traceback,
+and check (1) `pip install .[thor-fa4]`, (2) the vendored
+`csrc/attention/flash_attn_4_src` exists, (3) `FLASHRT_THOR_FA4` is not `0`.
+
+## 4. Run
+
+```bash
+python examples/lingbot_quickstart.py \
+    --checkpoint /path/to/lingbot-vla-4b \
+    --calibration /path/to/lingbot_thor_static.json \
+    --inputs /path/to/baseline_artifacts_10/inputs \
+    --steps 50 25 10
+```
+
+`--checkpoint` is the `lingbot-vla-4b/` dir (`model.safetensors` + `config.json`;
+`modelscope download --model Robbyant/lingbot-vla-4b`). `--inputs` is a dir of
+`images/img_masks/lang_tokens/lang_masks/state/noise` `.pt` tensors.
+
+## 5. Accuracy + latency (Thor sm_110, CUDA-graph replay)
+
+Measured back-to-back A/B (fixed `noise` from `baseline_artifacts_10`). Cosine is
+the action chunk `[1,50,75]` vs the upstream LingBot BF16 PyTorch reference
+(`baseline_artifacts_10/outputs/actions.pt`, available for the 10-step run):
+
+| attention path | steps | cosine vs 10-step ref | P50 |
+|----------------|------:|----------------------:|----:|
+| upstream LingBot BF16 (reference) | 10 | 1.000000 | — |
+| FlashRT (FA4)           | 10 | 0.996245 |  64.1 ms |
+| FlashRT (fmha fallback) | 10 | 0.996067 |  73.0 ms |
+| FlashRT (FA4)           | 25 | 0.995721 |  97.5 ms |
+| FlashRT (fmha fallback) | 25 | 0.994890 | 118.1 ms |
+| FlashRT (FA4)           | 50 | 0.995455 | 155.8 ms |
+| FlashRT (fmha fallback) | 50 | 0.994928 | 193.8 ms |
+
+- Reference: upstream LingBot BF16, fixed-noise action chunk, 10 denoise steps
+  (`baseline_artifacts_10/outputs/actions.pt`). The 25/50-step rows are compared
+  against the same 10-step reference, hence the slightly lower cosine — they are
+  not a step-matched comparison.
+- Acceptance: cosine ≥ 0.995 vs the step-matched BF16 reference (FP8 bring-up
+  threshold) — met by both paths at 10 steps.
+- FA4 vs fmha are numerically equivalent paths (the FP8/FP4 GEMMs are identical;
+  only the attention kernel differs); FA4 is ~15–20% faster (e.g. 155.8 vs
+  193.8 ms @50, 97.5 vs 118.1 ms @25), measured back-to-back with
+  `FLASHRT_THOR_FA4=1` vs `=0`.
+
+Thor has CUDA-graph tactic jitter (±2–3 ms); always A/B back-to-back and don't
+compare runs taken at different times.
+
+## 6. Notes / known limitations
+
+- **Thor (sm_110) only.** The kernels and FA4 are **additive** — other hardware
+  builds neither compile the `lingbot_*` sources (gated) nor inherit the FA4
+  deps. There is no RTX / JAX LingBot path.
+- All intermediate buffers are pre-allocated; the denoise loop is captured into
+  a CUDA Graph (no dynamic allocation on the hot path). Shapes (action dim 75,
+  horizon 50) and step counts are fixed per captured graph.
+- FP8 static scales come from the calibration JSON (`docs/calibration.md`
+  contract); calibration is required.

--- a/examples/lingbot_quickstart.py
+++ b/examples/lingbot_quickstart.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""LingBot-VLA (Thor sm_110a) quickstart.
+
+Runs the LingBot-VLA flow-matching action expert end-to-end on Thor and
+reports per-step-count latency. LingBot is wired through the low-level
+``graph_runner.sample_actions_graph`` path (the ``LingbotTorchFrontendThor``
+class is a G1 scaffold and is NOT used here; LingBot is not yet registered in
+``load_model`` / ``_PIPELINE_MAP``).
+
+Build first (one shared module — LingBot kernels live inside flash_rt_kernels):
+
+    cmake -B build -S . -DGPU_ARCH=110
+    cmake --build build -j --target flash_rt_kernels flash_rt_fp4 fmha_fp16_strided
+    pip install ".[torch,thor-fa4]"      # thor-fa4 = FA4 deps (cutlass-dsl + quack)
+
+Run (FA4 source is vendored at csrc/attention/flash_attn_4_src; the loader sets
+the Thor arch alias CUTE_DSL_ARCH=sm_101a for you):
+
+    python examples/lingbot_quickstart.py \
+        --checkpoint /path/to/lingbot-vla-4b \
+        --calibration /path/to/lingbot_thor_static.json \
+        --inputs /path/to/baseline_artifacts_10/inputs \
+        --steps 50 25 10
+
+Expected on Thor (FA4 active): ~158ms@50 / ~100ms@25 / ~64ms@10. If you see
+~176/120/73ms, FA4 fell back to fmha — check `pip install .[thor-fa4]` and the
+printed FA4 status (``flash_rt.hardware.thor.fa4_backend.status()``).
+"""
+import argparse
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from flash_rt.executors.torch_weights import SafetensorsSource
+from flash_rt.executors.weight_loader import WeightLoader
+from flash_rt.frontends.torch._lingbot_thor_spec import build_spec
+from flash_rt.models.lingbot.buffer_binder import bind_target_to_device
+from flash_rt.models.lingbot.kernel_ops import clear_fp8_weight_cache
+from flash_rt.models.lingbot.graph_runner import sample_actions_graph
+from flash_rt.models.lingbot import calibration as calib
+from flash_rt.hardware.thor import fa4_backend
+
+_INPUT_KEYS = ["images", "img_masks", "lang_tokens", "lang_masks", "state", "noise"]
+
+
+def _load_inputs(inputs_dir: Path) -> dict:
+    return {k: torch.load(inputs_dir / f"{k}.pt").cuda() for k in _INPUT_KEYS}
+
+
+def main():
+    ap = argparse.ArgumentParser(description="LingBot-VLA Thor quickstart")
+    ap.add_argument("--checkpoint", required=True,
+                    help="lingbot-vla-4b dir (contains model.safetensors)")
+    ap.add_argument("--calibration", required=True,
+                    help="FP8 static-scale calibration JSON")
+    ap.add_argument("--inputs", required=True,
+                    help="dir with images/img_masks/lang_tokens/lang_masks/state/noise .pt")
+    ap.add_argument("--steps", type=int, nargs="+", default=[50, 25, 10],
+                    help="denoising step counts to benchmark")
+    ap.add_argument("--iters", type=int, default=20, help="timed replays per step count")
+    args = ap.parse_args()
+
+    fa4 = fa4_backend.is_available()
+    print(f"[lingbot] FA4 (denoise/prefix attention) active: {fa4} ({fa4_backend.status()})"
+          f"{'' if fa4 else '  <-- falling back to fmha (+~18ms@25); pip install .[thor-fa4]'}")
+
+    ckpt = Path(args.checkpoint) / "model.safetensors"
+    clear_fp8_weight_cache()
+    src = SafetensorsSource(str(ckpt), device="cpu", strip_prefix="")
+    target = SimpleNamespace()
+    WeightLoader(src, target=target, spec=build_spec()).run()
+    bind_target_to_device(target, dtype=torch.bfloat16, device="cuda")
+    calib.set_static_scales(calib.load_calibration(
+        args.calibration, device=torch.device("cuda")))
+    inp = _load_inputs(Path(args.inputs))
+
+    for ns in args.steps:
+        replay, out, g = sample_actions_graph(
+            target=target, num_steps=ns, warmup_iters=3, **inp)
+        replay(); torch.cuda.synchronize()
+        if ns == args.steps[0]:
+            print(f"[lingbot] action chunk shape={tuple(out.shape)} "
+                  f"finite={bool(torch.isfinite(out).all())}")
+        ts = []
+        for _ in range(args.iters):
+            torch.cuda.synchronize(); t0 = time.perf_counter()
+            replay(); torch.cuda.synchronize(); ts.append(time.perf_counter() - t0)
+        p50 = sorted(ts)[len(ts) // 2] * 1000
+        print(f"[lingbot] num_denoising_steps={ns:3d}  P50={p50:6.1f} ms (CUDA-graph replay)")
+        del replay, out, g
+        torch.cuda.empty_cache(); clear_fp8_weight_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_rt/frontends/torch/_lingbot_thor_spec.py
+++ b/flash_rt/frontends/torch/_lingbot_thor_spec.py
@@ -1,0 +1,321 @@
+"""FlashRT — LingBot-VLA weight spec (Thor, torch) — declarative spec.
+
+Source checkpoint: ``robbyant/lingbot-vla-4b`` (HuggingFace + ModelScope).
+1555 fp32 tensors in a single ``model.safetensors`` (~16.7 GB).
+
+This spec is BF16 round-trip — no Quant transforms (FP8 calibration lands
+later). The on-device pipeline casts to bf16 + .contiguous() at load time;
+weights themselves stay in their safetensors-native fp32 storage in the
+target attributes until then.
+
+Verified against the upstream LingBot weight inventory (1555 tensors):
+
+  Top-level singletons                                      19
+    action heads (state/in/out, time_mlp in+out, 5x{w,b})   10
+    qwenvl top-level (embed_tokens, norm, vit specials,      9
+                      visual.merger.ln_q + mlp.{0,2},
+                      visual.patch_embed.proj,
+                      qwen_expert.model.norm)
+  VLM 36 layers  × 12 items                                 432
+  Expert 36 layers × 20 items                               720
+  ViT 32 blocks  × 12 items                                 384
+                                                          ─────
+                                                           1555  ✓
+"""
+
+from __future__ import annotations
+
+from flash_rt.executors.torch_weights import Attr, TensorList
+from flash_rt.executors.weight_loader import Item, LayerBlock, ModelWeightSpec
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Top-level singletons
+# ════════════════════════════════════════════════════════════════════
+
+def _action_head_items() -> list[Item]:
+    """Action-head singletons living directly under ``model.``.
+
+    All 5 are nn.Linear, so each contributes (weight, bias):
+
+      state_proj             75 → 768
+      action_in_proj         75 → 768
+      action_out_proj       768 → 75       velocity head
+      action_time_mlp_in   1536 → 768      (1536 = sin+cos of timestep)
+      action_time_mlp_out   768 → 768
+    """
+    items: list[Item] = []
+    for name in (
+        "state_proj", "action_in_proj", "action_out_proj",
+        "action_time_mlp_in", "action_time_mlp_out",
+    ):
+        items.append(Item(
+            name=f"{name}.weight",
+            key=f"model.{name}.weight",
+            sink=Attr(f"{name}_weight"),
+        ))
+        items.append(Item(
+            name=f"{name}.bias",
+            key=f"model.{name}.bias",
+            sink=Attr(f"{name}_bias"),
+        ))
+    return items
+
+
+def _qwenvl_top_singletons() -> list[Item]:
+    """Top-level qwenvl + qwen_expert singletons (9 items)."""
+    base = "model.qwenvl_with_expert"
+    return [
+        # VLM embed + final norm
+        Item("vlm.embed_tokens",
+             key=f"{base}.qwenvl.model.embed_tokens.weight",
+             sink=Attr("vlm_embed_tokens_weight")),
+        Item("vlm.norm",
+             key=f"{base}.qwenvl.model.norm.weight",
+             sink=Attr("vlm_norm_weight")),
+
+        # Expert final norm (no embed_tokens — expert has no language head)
+        Item("expert.norm",
+             key=f"{base}.qwen_expert.model.norm.weight",
+             sink=Attr("expert_norm_weight")),
+
+        # ViT specials
+        Item("vit.patch_embed.proj",
+             key=f"{base}.qwenvl.visual.patch_embed.proj.weight",
+             sink=Attr("vit_patch_embed_proj_weight")),
+        Item("vit.merger.ln_q",
+             key=f"{base}.qwenvl.visual.merger.ln_q.weight",
+             sink=Attr("vit_merger_ln_q_weight")),
+        Item("vit.merger.mlp.0.weight",
+             key=f"{base}.qwenvl.visual.merger.mlp.0.weight",
+             sink=Attr("vit_merger_mlp_0_weight")),
+        Item("vit.merger.mlp.0.bias",
+             key=f"{base}.qwenvl.visual.merger.mlp.0.bias",
+             sink=Attr("vit_merger_mlp_0_bias")),
+        Item("vit.merger.mlp.2.weight",
+             key=f"{base}.qwenvl.visual.merger.mlp.2.weight",
+             sink=Attr("vit_merger_mlp_2_weight")),
+        Item("vit.merger.mlp.2.bias",
+             key=f"{base}.qwenvl.visual.merger.mlp.2.bias",
+             sink=Attr("vit_merger_mlp_2_bias")),
+    ]
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Layer blocks
+# ════════════════════════════════════════════════════════════════════
+
+# VLM (Qwen2.5-VL LLM backbone, 36 layers, hidden=2048)
+#   GQA 16Q/2KV, head_dim=128
+#   q/k/v_proj have bias; o_proj no bias
+#   FFN gate/up/down no bias
+#   Pre-LN: input_layernorm (RMS), post_attention_layernorm (RMS)
+_VLM_LAYER_ITEMS: list[Item] = [
+    Item("input_layernorm",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.input_layernorm.weight",
+         sink=TensorList("vlm_layer_input_layernorm_weights")),
+    Item("post_attention_layernorm",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.post_attention_layernorm.weight",
+         sink=TensorList("vlm_layer_post_attn_layernorm_weights")),
+    Item("q_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.self_attn.q_proj.weight",
+         sink=TensorList("vlm_layer_q_proj_weights")),
+    Item("q_proj.bias",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.self_attn.q_proj.bias",
+         sink=TensorList("vlm_layer_q_proj_biases")),
+    Item("k_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.self_attn.k_proj.weight",
+         sink=TensorList("vlm_layer_k_proj_weights")),
+    Item("k_proj.bias",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.self_attn.k_proj.bias",
+         sink=TensorList("vlm_layer_k_proj_biases")),
+    Item("v_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.self_attn.v_proj.weight",
+         sink=TensorList("vlm_layer_v_proj_weights")),
+    Item("v_proj.bias",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.self_attn.v_proj.bias",
+         sink=TensorList("vlm_layer_v_proj_biases")),
+    Item("o_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.self_attn.o_proj.weight",
+         sink=TensorList("vlm_layer_o_proj_weights")),
+    Item("mlp.gate_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.mlp.gate_proj.weight",
+         sink=TensorList("vlm_layer_mlp_gate_proj_weights")),
+    Item("mlp.up_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.mlp.up_proj.weight",
+         sink=TensorList("vlm_layer_mlp_up_proj_weights")),
+    Item("mlp.down_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.model.layers.{i}.mlp.down_proj.weight",
+         sink=TensorList("vlm_layer_mlp_down_proj_weights")),
+]
+
+# Action Expert (Qwen2-768, 36 layers, hidden=768, Mixed-Head Q→2048)
+#   Pre-LN is AdaRMSNorm: weight (RMS gain) + Linear beta (shift) +
+#     Linear gamma (scale). Each Linear contributes weight+bias.
+#   Attention shape: q_proj [2048, 768], k/v_proj [256, 768] (GQA),
+#     o_proj [768, 2048] (Mixed-Head: head-space → expert hidden)
+_EXPERT_LAYER_ITEMS: list[Item] = [
+    # AdaRMSNorm input
+    Item("input_layernorm.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.input_layernorm.weight",
+         sink=TensorList("expert_layer_input_layernorm_weights")),
+    Item("input_layernorm.beta.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.input_layernorm.beta.weight",
+         sink=TensorList("expert_layer_input_layernorm_beta_weights")),
+    Item("input_layernorm.beta.bias",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.input_layernorm.beta.bias",
+         sink=TensorList("expert_layer_input_layernorm_beta_biases")),
+    Item("input_layernorm.gamma.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.input_layernorm.gamma.weight",
+         sink=TensorList("expert_layer_input_layernorm_gamma_weights")),
+    Item("input_layernorm.gamma.bias",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.input_layernorm.gamma.bias",
+         sink=TensorList("expert_layer_input_layernorm_gamma_biases")),
+    # AdaRMSNorm post
+    Item("post_attention_layernorm.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.post_attention_layernorm.weight",
+         sink=TensorList("expert_layer_post_attn_layernorm_weights")),
+    Item("post_attention_layernorm.beta.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.post_attention_layernorm.beta.weight",
+         sink=TensorList("expert_layer_post_attn_layernorm_beta_weights")),
+    Item("post_attention_layernorm.beta.bias",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.post_attention_layernorm.beta.bias",
+         sink=TensorList("expert_layer_post_attn_layernorm_beta_biases")),
+    Item("post_attention_layernorm.gamma.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.post_attention_layernorm.gamma.weight",
+         sink=TensorList("expert_layer_post_attn_layernorm_gamma_weights")),
+    Item("post_attention_layernorm.gamma.bias",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.post_attention_layernorm.gamma.bias",
+         sink=TensorList("expert_layer_post_attn_layernorm_gamma_biases")),
+    # Attention
+    Item("q_proj.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.self_attn.q_proj.weight",
+         sink=TensorList("expert_layer_q_proj_weights")),
+    Item("q_proj.bias",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.self_attn.q_proj.bias",
+         sink=TensorList("expert_layer_q_proj_biases")),
+    Item("k_proj.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.self_attn.k_proj.weight",
+         sink=TensorList("expert_layer_k_proj_weights")),
+    Item("k_proj.bias",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.self_attn.k_proj.bias",
+         sink=TensorList("expert_layer_k_proj_biases")),
+    Item("v_proj.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.self_attn.v_proj.weight",
+         sink=TensorList("expert_layer_v_proj_weights")),
+    Item("v_proj.bias",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.self_attn.v_proj.bias",
+         sink=TensorList("expert_layer_v_proj_biases")),
+    Item("o_proj.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.self_attn.o_proj.weight",
+         sink=TensorList("expert_layer_o_proj_weights")),
+    # FFN
+    Item("mlp.gate_proj.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.mlp.gate_proj.weight",
+         sink=TensorList("expert_layer_mlp_gate_proj_weights")),
+    Item("mlp.up_proj.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.mlp.up_proj.weight",
+         sink=TensorList("expert_layer_mlp_up_proj_weights")),
+    Item("mlp.down_proj.weight",
+         key="model.qwenvl_with_expert.qwen_expert.model.layers.{i}.mlp.down_proj.weight",
+         sink=TensorList("expert_layer_mlp_down_proj_weights")),
+]
+
+# Qwen2.5-VL ViT (32 blocks, hidden=1280, 16 heads, head_dim=80, MHA)
+#   QKV fused: single Linear [3840, 1280] with bias
+#   All MLP / proj linears have bias
+#   norm1/norm2 are RMSNorm (no bias)
+_VIT_BLOCK_ITEMS: list[Item] = [
+    Item("attn.qkv.weight",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.attn.qkv.weight",
+         sink=TensorList("vit_block_attn_qkv_weights")),
+    Item("attn.qkv.bias",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.attn.qkv.bias",
+         sink=TensorList("vit_block_attn_qkv_biases")),
+    Item("attn.proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.attn.proj.weight",
+         sink=TensorList("vit_block_attn_proj_weights")),
+    Item("attn.proj.bias",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.attn.proj.bias",
+         sink=TensorList("vit_block_attn_proj_biases")),
+    Item("mlp.gate_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.mlp.gate_proj.weight",
+         sink=TensorList("vit_block_mlp_gate_proj_weights")),
+    Item("mlp.gate_proj.bias",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.mlp.gate_proj.bias",
+         sink=TensorList("vit_block_mlp_gate_proj_biases")),
+    Item("mlp.up_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.mlp.up_proj.weight",
+         sink=TensorList("vit_block_mlp_up_proj_weights")),
+    Item("mlp.up_proj.bias",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.mlp.up_proj.bias",
+         sink=TensorList("vit_block_mlp_up_proj_biases")),
+    Item("mlp.down_proj.weight",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.mlp.down_proj.weight",
+         sink=TensorList("vit_block_mlp_down_proj_weights")),
+    Item("mlp.down_proj.bias",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.mlp.down_proj.bias",
+         sink=TensorList("vit_block_mlp_down_proj_biases")),
+    Item("norm1.weight",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.norm1.weight",
+         sink=TensorList("vit_block_norm1_weights")),
+    Item("norm2.weight",
+         key="model.qwenvl_with_expert.qwenvl.visual.blocks.{i}.norm2.weight",
+         sink=TensorList("vit_block_norm2_weights")),
+]
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Top-level spec builder
+# ════════════════════════════════════════════════════════════════════
+
+def build_spec(*, num_vlm_layers: int = 36,
+               num_expert_layers: int = 36,
+               num_vit_blocks: int = 32) -> ModelWeightSpec:
+    """Build the LingBot-VLA weight-spec for the Thor torch frontend.
+
+    Returns a ``ModelWeightSpec`` whose enumerated keys match the 1555
+    tensors of ``robbyant/lingbot-vla-4b`` exactly (verified against the
+    upstream weight inventory).
+    """
+    return ModelWeightSpec(
+        framework="torch",
+        singletons=_action_head_items() + _qwenvl_top_singletons(),
+        blocks=[
+            LayerBlock(
+                name="vlm",
+                prefix_fmt="",  # full keys in each Item; runner only needs {i}
+                num_layers=num_vlm_layers,
+                items=_VLM_LAYER_ITEMS,
+            ),
+            LayerBlock(
+                name="expert",
+                prefix_fmt="",
+                num_layers=num_expert_layers,
+                items=_EXPERT_LAYER_ITEMS,
+            ),
+            LayerBlock(
+                name="vit",
+                prefix_fmt="",
+                num_layers=num_vit_blocks,
+                items=_VIT_BLOCK_ITEMS,
+            ),
+        ],
+    )
+
+
+def enumerate_keys(spec: ModelWeightSpec) -> list[str]:
+    """Enumerate every checkpoint key this spec will request.
+
+    Mirrors the iteration order of ``WeightLoader.run``: singletons
+    first, then each block in order, then each layer in each block,
+    then each item per layer.
+    """
+    keys: list[str] = []
+    for item in spec.singletons:
+        keys.append(item.key)
+    for block in spec.blocks:
+        for i in range(block.num_layers):
+            for item in block.items:
+                keys.append(item.key.format(i=i))
+    return keys

--- a/flash_rt/frontends/torch/lingbot_thor.py
+++ b/flash_rt/frontends/torch/lingbot_thor.py
@@ -1,0 +1,116 @@
+"""FlashRT — LingBot-VLA torch frontend for Thor (SM110) — scaffold.
+
+Class: ``LingbotTorchFrontendThor``. Intended owner of:
+    * the loaded LingBot-VLA model (~4B params, ~16.7 GB BF16)
+    * the AttentionBackend (declared here; not yet wired into kernels)
+    * the LingBotPipelineThor (orchestrates ViT → VLM prefix → 50 × Expert
+      denoise steps → action_out_proj)
+    * lifecycle: __init__ → set_prompt(prompt, ...) → infer(obs) [...]
+
+Hardware target: Jetson AGX Thor SM110. A Thor-enabled PyTorch build is
+required — standard cu128 wheels do NOT include sm_110 kernels. Validated in
+the Thor development container.
+
+Reference baseline (upstream LingBot, PyTorch BF16 eager): P50 ~2480 ms for
+50 Euler steps (prefix encode + 50 denoise steps); cos_determinism = 1.0.
+
+────────────────────────────────────────────────────────────────────
+Status
+────────────────────────────────────────────────────────────────────
+**Scaffold only — not used by the current runner.** ``__init__`` validates
+the checkpoint path layout and builds an empty weight spec; ``set_prompt`` /
+``infer`` / ``predict`` raise ``NotImplementedError``. LingBot is not yet
+registered in ``load_model`` / ``_PIPELINE_MAP``. The working inference path
+is the low-level ``flash_rt.models.lingbot.graph_runner.sample_actions_graph``
+(see ``examples/lingbot_quickstart.py`` and ``docs/lingbot_usage.md``); this
+class is a placeholder for the eventual stable-frontend integration.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from flash_rt.frontends.torch._lingbot_thor_spec import build_spec
+from flash_rt.models.lingbot.pipeline_thor import LingBotPipelineDims
+
+logger = logging.getLogger(__name__)
+
+
+class LingbotTorchFrontendThor:
+    """LingBot-VLA torch frontend for Thor SM110."""
+
+    # Static shape constants — source of truth (yaml is metadata only).
+    # Verified against the upstream LingBot weight inventory.
+    NUM_VIT_BLOCKS = 32
+    NUM_VLM_LAYERS = 36
+    NUM_EXPERT_LAYERS = 36
+    NUM_INFERENCE_STEPS = 50
+    ACTION_DIM = 75
+    STATE_DIM = 75
+    PROJ_WIDTH = 768
+    NUM_CAMS = 3
+    IMG_SIZE = 224
+    TOKENIZER_MAX_LENGTH = 72
+
+    def __init__(self, checkpoint_dir, num_views=3, autotune=3, **kwargs):
+        self.checkpoint_dir = pathlib.Path(checkpoint_dir)
+        self.num_views = num_views
+        self.autotune = autotune
+
+        # Required path layout (mirrors the upstream LingBot ckpt):
+        # ``checkpoint_dir`` points at the lingbot-vla-4b/ directory
+        # containing ``model.safetensors`` and ``config.json``. Tokenizer
+        # / processor files come from QWEN25_PATH (env var or kwarg).
+        safetensors_file = self.checkpoint_dir / "model.safetensors"
+        if not safetensors_file.exists():
+            raise FileNotFoundError(
+                f"LingBot-VLA checkpoint not found: {safetensors_file}. "
+                f"Expected HuggingFace layout (model.safetensors). "
+                f"Download via `modelscope download --model "
+                f"Robbyant/lingbot-vla-4b --local_dir lingbot-vla-4b`."
+            )
+        config_file = self.checkpoint_dir / "config.json"
+        if not config_file.exists():
+            raise FileNotFoundError(
+                f"LingBot-VLA config.json not found: {config_file}."
+            )
+        logger.info(f"[lingbot_vla] checkpoint resolved: {safetensors_file}")
+
+        self.dims = LingBotPipelineDims()
+
+        # Build the (empty) spec to confirm the import path resolves.
+        self._spec = build_spec()
+        logger.info(
+            f"[lingbot_vla] scaffold loaded; spec has "
+            f"{len(self._spec.blocks)} block(s), "
+            f"{len(self._spec.singletons)} singleton(s); "
+            f"dims: VLM={self.dims.vlm_num_layers}L h={self.dims.vlm_hidden_dim}, "
+            f"Expert={self.dims.expert_num_layers}L h={self.dims.expert_hidden_dim}, "
+            f"ViT={self.dims.vit_num_blocks}L h={self.dims.vit_hidden_dim}"
+        )
+
+        # Make the NotImplementedError explicit upfront so callers don't
+        # reach infer() before realizing this frontend is a scaffold.
+        raise NotImplementedError(
+            "LingbotTorchFrontendThor is a scaffold and is not used by the "
+            "current runner. Use the low-level "
+            "flash_rt.models.lingbot.graph_runner.sample_actions_graph path "
+            "(see examples/lingbot_quickstart.py and docs/lingbot_usage.md)."
+        )
+
+    # ──────────────────────────────────────────────────────────────
+    # Public API stubs (not implemented — use the graph_runner path)
+    # ──────────────────────────────────────────────────────────────
+
+    def set_prompt(self, prompt, state=None, images=None, **kwargs):
+        """Would tokenize + ViT encode + VLM prefix → fill KV cache + capture."""
+        raise NotImplementedError("set_prompt — scaffold; use graph_runner")
+
+    def infer(self, observation):
+        """Would replay the denoise CUDA Graph → return the action chunk."""
+        raise NotImplementedError("infer — scaffold; use graph_runner")
+
+    def predict(self, images, prompt=None, state=None):
+        """``api.VLAModel.predict`` ABI — delegates to set_prompt + infer."""
+        raise NotImplementedError("predict — scaffold; use graph_runner")

--- a/flash_rt/hardware/thor/fa4_backend.py
+++ b/flash_rt/hardware/thor/fa4_backend.py
@@ -1,0 +1,114 @@
+"""Isolated FlashAttention-4 (CuTe-DSL) backend for Thor (sm_110).
+
+FA4's SM100 Blackwell forward kernel runs on Thor when compiled for ``sm_101a``
+(the legacy alias of sm_110; the ``sm_110a`` path hits a cutlass-dsl chip bug).
+At the LingBot denoise shape (Sq=51, Skv~891, GQA 16/2, HD=128) with
+``pack_gqa`` it is ~17% faster than the vendored fmha kernel, cos=1.0, and is
+CUDA-graph capture-safe.
+
+This module is the **only** place that imports FA4. It exists to keep the FA4
+import isolated from the rest of FlashRT:
+
+- FA4 is vendored under the **private** package name ``flashrt_fa4`` (a trimmed
+  ``flash_attn/cute`` forward-only subset, see
+  ``csrc/attention/flash_attn_4_src/VENDOR.md``). It is loaded by transiently
+  adding the vendor dir to ``sys.path`` and importing ``flashrt_fa4.cute`` —
+  the vendor path is removed from ``sys.path`` again right after import, and the
+  private name guarantees it never shadows a pip-installed ``flash_attn`` (the
+  RTX backends use ``from flash_attn import flash_attn_func``).
+- It is an **optional fast path**. If the FA4 runtime deps
+  (``nvidia-cutlass-dsl`` + ``quack-kernels``, the ``thor-fa4`` pip extra) are
+  missing, every accessor returns ``None`` and the caller falls back to the
+  fmha kernel. Set ``LINGBOT_FA4_DEBUG=1`` to print the import error.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# csrc/attention/flash_attn_4_src holds the vendored `flashrt_fa4` package.
+# parents: [0]=thor [1]=hardware [2]=flash_rt [3]=<repo root>
+_VENDOR_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "csrc" / "attention" / "flash_attn_4_src"
+)
+
+_FUNC = None          # flashrt_fa4.cute.flash_attn_func (autograd wrapper)
+_FWD = None           # flashrt_fa4.cute.interface_fwd_sm100._flash_attn_fwd
+_TRIED = False
+_REASON = "not attempted"
+
+
+def _load() -> None:
+    """Import the vendored FA4 once; cache the entry points and the reason."""
+    global _FUNC, _FWD, _TRIED, _REASON
+    if _TRIED:
+        return
+    _TRIED = True
+
+    # Explicit A/B / opt-out switch: FLASHRT_THOR_FA4=0 forces the fmha path.
+    if os.environ.get("FLASHRT_THOR_FA4", "1") == "0":
+        _REASON = "disabled (FLASHRT_THOR_FA4=0)"
+        return
+
+    # Thor target: sm_101a (sm_110's Blackwell alias). Don't clobber a user value.
+    os.environ.setdefault("CUTE_DSL_ARCH", "sm_101a")
+    os.environ.setdefault("FLASH_ATTENTION_ARCH", "sm_100a")
+
+    # Allow an override dir (e.g. for local FA4 development), else the vendor.
+    src = os.environ.get("LINGBOT_FA4_SRC") or (
+        str(_VENDOR_DIR) if _VENDOR_DIR.is_dir() else None
+    )
+    if src is None:
+        _REASON = f"FA4 vendor dir not found at {_VENDOR_DIR}"
+        return
+
+    added = src not in sys.path
+    if added:
+        sys.path.insert(0, src)
+    try:
+        from flashrt_fa4.cute import flash_attn_func
+        from flashrt_fa4.cute.interface_fwd_sm100 import _flash_attn_fwd
+        _FUNC = flash_attn_func
+        _FWD = _flash_attn_fwd
+        _REASON = "active"
+    except Exception as exc:  # missing deps / arch issue -> fmha fallback
+        if os.environ.get("LINGBOT_FA4_DEBUG"):
+            import traceback
+            traceback.print_exc()
+        _REASON = f"{type(exc).__name__}: {exc}"
+        _FUNC = None
+        _FWD = None
+    finally:
+        # Do NOT leave the vendor path lingering at sys.path[0]; the module is
+        # already cached in sys.modules under `flashrt_fa4`.
+        if added:
+            try:
+                sys.path.remove(src)
+            except ValueError:
+                pass
+
+
+def is_available() -> bool:
+    """True if the FA4 fast path loaded (deps present, import succeeded)."""
+    _load()
+    return _FUNC is not None
+
+
+def status() -> str:
+    """One-line human-readable status (``active`` or the failure reason)."""
+    _load()
+    return _REASON
+
+
+def fa4_func():
+    """The autograd ``flash_attn_func`` (forward inference), or ``None``."""
+    _load()
+    return _FUNC
+
+
+def fa4_fwd():
+    """The internal ``_flash_attn_fwd`` (exposes ``seqused_k``), or ``None``."""
+    _load()
+    return _FWD

--- a/flash_rt/models/lingbot/__init__.py
+++ b/flash_rt/models/lingbot/__init__.py
@@ -1,0 +1,17 @@
+"""FlashRT — LingBot-VLA model package (Thor / sm_110).
+
+Pipeline / weight-loading / kernel-orchestration code for LingBot-VLA
+(Qwen2.5-VL-3B + Action Expert Qwen2-768, Mixed-Head joint attention,
+flow-matching denoise). FP8 backbone + FP4 gate_up; FA4 (optional) for the
+prefix / denoise attention via ``flash_rt.hardware.thor.fa4_backend``.
+
+Status: LingBot runs through the **low-level graph_runner path** —
+``graph_runner.sample_actions_graph`` (weight spec + CUDA-graph capture). See
+``examples/lingbot_quickstart.py`` and ``docs/lingbot_usage.md``.
+
+It is **not** registered in ``_PIPELINE_MAP`` and ``flash_rt.load_model`` does
+**not** dispatch a ``lingbot`` config yet; ``LingbotTorchFrontendThor``
+(``flash_rt.frontends.torch.lingbot_thor``) is a scaffold whose methods
+raise ``NotImplementedError``. Use the graph_runner entry point above, not
+``flash_rt.load_model``.
+"""

--- a/flash_rt/models/lingbot/_csrc_loader.py
+++ b/flash_rt/models/lingbot/_csrc_loader.py
@@ -1,0 +1,70 @@
+"""Access the LingBot-VLA model-specific CUDA kernels.
+
+The LingBot pipeline uses a handful of model-specific kernels (fused
+AdaRMSNorm, SwiGLU tail, QKV+RoPE). They are compiled INTO the shared
+``flash_rt_kernels`` module (``csrc/kernels/lingbot_*.cu``, gated by
+``ENABLE_LINGBOT`` for SM100-class GPUs) with ``lingbot_``-prefixed pybind
+names — there is no separate ``flash_rt_lingbot`` .so anymore. This matches
+how the qwen36 model kernels live inside ``flash_rt_kernels``.
+
+``get_lingbot_ext()`` returns a thin view over ``flash_rt_kernels`` that maps
+the un-prefixed call names used by ``kernel_ops.py`` (e.g.
+``silu_mul_merged_fp8_mpad_fp16in``) onto the prefixed symbols
+(``lingbot_silu_mul_merged_fp8_mpad_fp16in``), so callers need no changes.
+"""
+
+from __future__ import annotations
+
+import threading
+
+_EXT = None
+_LOCK = threading.Lock()
+
+
+class _LingbotKernels:
+    """Maps ``ext.<name>`` -> ``flash_rt_kernels.lingbot_<name>``."""
+
+    def __init__(self, module):
+        self._m = module
+
+    def __getattr__(self, name):
+        try:
+            return getattr(self._m, "lingbot_" + name)
+        except AttributeError as e:
+            raise AttributeError(
+                f"flash_rt_kernels has no LingBot symbol 'lingbot_{name}'. "
+                "Rebuild flash_rt_kernels for an SM100-class GPU (Thor sm_110a):\n"
+                "    cmake -B build -S . -DGPU_ARCH=110\n"
+                "    cmake --build build -j --target flash_rt_kernels\n"
+                "(LingBot kernels are gated behind ENABLE_LINGBOT.)"
+            ) from e
+
+
+def get_lingbot_ext():
+    """Return a view over ``flash_rt_kernels`` exposing the LingBot kernels."""
+    global _EXT
+    if _EXT is not None:
+        return _EXT
+    with _LOCK:
+        if _EXT is not None:
+            return _EXT
+        try:
+            import flash_rt.flash_rt_kernels as k
+        except ImportError as e:
+            raise ImportError(
+                "flash_rt_kernels is not built. Build it for an SM100-class GPU "
+                "(Thor sm_110a):\n"
+                "    cmake -B build -S . -DGPU_ARCH=110\n"
+                "    cmake --build build -j --target flash_rt_kernels"
+            ) from e
+        if not hasattr(k, "lingbot_silu_mul_merged_fp8_mpad_fp16in"):
+            raise ImportError(
+                "flash_rt_kernels was built without the LingBot kernels "
+                "(ENABLE_LINGBOT). Configure with -DGPU_ARCH=110 (SM100-class) "
+                "and rebuild the flash_rt_kernels target."
+            )
+        _EXT = _LingbotKernels(k)
+    return _EXT
+
+
+__all__ = ["get_lingbot_ext"]

--- a/flash_rt/models/lingbot/buffer_binder.py
+++ b/flash_rt/models/lingbot/buffer_binder.py
@@ -1,0 +1,156 @@
+"""Cast/bind LingBot-VLA loaded weights to a target dtype + device.
+
+The WeightLoader leaves tensors in their on-disk fp32 layout (CPU
+mmap from safetensors). is the "bridge" step: walk every attribute the
+spec wrote and move it to ``(device, dtype)`` for kernel handoff. The
+upstream LingBot baseline inference runs in bf16+cuda
+(``policy.eval().cuda().to(torch.bfloat16)``), so that is the default.
+
+Why a separate step (not a Transform on the spec):
+  * The spec stays "lossless round-trip" — no quant decisions baked into
+    declarative form. Quant decisions live in calibration.
+  * The same loaded target can be cast to different dtypes (bf16 for
+    inference, fp32 for a precision-debug build) without rebuilding the
+    spec.
+  * Frontend lifecycle is clearer: ``load_weights → bind_to_device →
+    set_prompt``. Each step has one job.
+
+Usage:
+
+    from flash_rt.executors.torch_weights import SafetensorsSource
+    from flash_rt.executors.weight_loader import WeightLoader
+    from flash_rt.frontends.torch._lingbot_thor_spec import build_spec
+    from flash_rt.models.lingbot.buffer_binder import bind_target_to_device
+
+    source = SafetensorsSource("lingbot-vla-4b/model.safetensors",
+                               device="cpu", strip_prefix="")
+    target = SomeFrontend()  # any object with attribute slots
+    WeightLoader(source, target=target, spec=build_spec()).run()
+
+    bind_target_to_device(target, dtype=torch.bfloat16, device="cuda")
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BindStats:
+    """Diagnostic counters returned by ``bind_target_to_device``."""
+
+    num_singletons: int = 0
+    num_layered: int = 0
+    num_tensors_total: int = 0
+    bytes_before: int = 0          # sum of nbytes BEFORE the cast/move
+    bytes_after: int = 0           # sum of nbytes AFTER the cast/move
+    skipped_attrs: list[str] = None  # attrs that were not tensors/lists of tensors
+
+    def __post_init__(self):
+        if self.skipped_attrs is None:
+            self.skipped_attrs = []
+
+
+def _is_loaded_tensor(obj) -> bool:
+    return isinstance(obj, torch.Tensor)
+
+
+def _is_loaded_list(obj) -> bool:
+    """A list whose entries are all tensors (i.e. ``TensorList`` sink output)."""
+    return (isinstance(obj, list)
+            and len(obj) > 0
+            and all(isinstance(x, torch.Tensor) for x in obj))
+
+
+def _attrs_to_bind(target) -> Iterable[str]:
+    """Yield public attribute names; skip dunders + callables + descriptors."""
+    for name in sorted(vars(target)):
+        if name.startswith("_"):
+            continue
+        yield name
+
+
+def bind_target_to_device(
+    target,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    device: str | torch.device = "cuda",
+    non_blocking: bool = True,
+) -> BindStats:
+    """Cast every loaded tensor on ``target`` to ``(device, dtype)`` in place.
+
+    ``target`` should be the object that received the WeightLoader output
+    (i.e. has attributes set by the spec — both ``Attr`` singletons
+    and ``TensorList`` lists). Non-tensor attributes are left untouched
+    and counted in ``BindStats.skipped_attrs``.
+
+    Args:
+        target: object loaded by ``WeightLoader``.
+        dtype: target dtype. Default ``bfloat16`` (matches LingBot baseline).
+        device: target device. Default ``"cuda"``.
+        non_blocking: passed through to ``Tensor.to``.
+
+    Returns:
+        ``BindStats`` with counts of moved tensors and pre/post byte sizes
+        for memory-budget verification.
+
+    Notes:
+        Each tensor moves to GPU then casts; the original CPU tensor is
+        garbage-collected by the caller releasing the reference (we
+        overwrite the attribute slot with the new device tensor). The
+        SafetensorsSource itself may still hold mmap views but those are
+        not in resident RAM.
+
+        Layered attributes (``TensorList``) are rebuilt as fresh lists
+        with the moved tensors; the original list object is replaced so
+        the previous CPU tensors lose all references and can be GC'd.
+    """
+    device = torch.device(device) if isinstance(device, str) else device
+    stats = BindStats()
+
+    for name in list(_attrs_to_bind(target)):
+        obj = getattr(target, name)
+
+        if _is_loaded_tensor(obj):
+            stats.bytes_before += obj.element_size() * obj.numel()
+            new_t = obj.to(device=device, dtype=dtype, non_blocking=non_blocking)
+            setattr(target, name, new_t)
+            stats.num_singletons += 1
+            stats.num_tensors_total += 1
+            stats.bytes_after += new_t.element_size() * new_t.numel()
+
+        elif _is_loaded_list(obj):
+            new_list: list[torch.Tensor] = []
+            for t in obj:
+                stats.bytes_before += t.element_size() * t.numel()
+                new_t = t.to(device=device, dtype=dtype, non_blocking=non_blocking)
+                new_list.append(new_t)
+                stats.num_tensors_total += 1
+                stats.bytes_after += new_t.element_size() * new_t.numel()
+            setattr(target, name, new_list)
+            stats.num_layered += len(new_list)
+
+        else:
+            stats.skipped_attrs.append(name)
+
+    if device.type == "cuda":
+        # Ensure the H2D copies have actually committed before the caller
+        # touches the tensors. Without this, .data_ptr() reads on a fresh
+        # graph capture can race the async copy.
+        torch.cuda.synchronize(device)
+
+    logger.info(
+        "[lingbot] bound %d tensors to %s/%s (%.2f GB -> %.2f GB)",
+        stats.num_tensors_total, device, dtype,
+        stats.bytes_before / (1 << 30), stats.bytes_after / (1 << 30),
+    )
+    return stats
+
+
+__all__ = ["bind_target_to_device", "BindStats"]

--- a/flash_rt/models/lingbot/calibration.py
+++ b/flash_rt/models/lingbot/calibration.py
@@ -1,0 +1,163 @@
+"""LingBot-VLA — static FP8 activation calibration.
+
+Replaces the per-call dynamic max-reduce in ``linear_fp8`` with a
+pre-computed scale read from a JSON table. Two effects:
+
+1. **Determinism** — the per-call ``quantize_fp8_device`` writes a
+   device-side ``act_scale`` whose value can drift slightly between
+   runs depending on cuBLAS state at warm-up time. The Thor SM110
+   FP8 GEMM heuristic is sensitive to that drift, occasionally
+   picking a tactic that produces NaN. Static scale removes the
+   freedom.
+2. **Latency** — skipping the per-call absmax reduce saves ~5-10 μs
+   × thousands of GEMMs per inference.
+
+Usage::
+
+    from flash_rt.models.lingbot import calibration as calib
+
+    # Offline: record activation max(abs) per site.
+    with calib.calibration_recorder() as stats:
+        sample_actions(...)
+    calib.save_calibration(stats, "lingbot_thor_static.json")
+
+    # Production: load scales (one-time at startup), enable, run.
+    scales = calib.load_calibration("lingbot_thor_static.json",
+                                    device=torch.device("cuda"))
+    calib.set_static_scales(scales)
+    actions = sample_actions(...)
+    calib.set_static_scales(None)      # clear when done
+
+The state is held in module-level singletons (``_CALIB_STATS`` and
+``_STATIC_SCALES``); ``linear_fp8`` consults them via ``is_calibrating()``,
+``record_max_abs()``, and ``get_static_scale()``. When a ``site_id`` is
+``None`` (legacy callers / sites not yet wired) both paths are no-ops
+and ``linear_fp8`` falls back to dynamic quantize.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+import torch
+
+# FP8 E4M3 max representable magnitude. scale = max_abs / FP8_E4M3_MAX.
+FP8_E4M3_MAX = 448.0
+
+# Floor to avoid div-by-zero when a site never sees activation (e.g.,
+# masked-out cond) — pick a tiny scale so the descale path is still finite.
+DEFAULT_SCALE_FLOOR = 1e-7
+
+# Module-level singletons. None means feature off.
+_CALIB_STATS: "dict[str, float] | None" = None
+_STATIC_SCALES: "dict[str, torch.Tensor] | None" = None
+_LOCK = threading.Lock()
+
+
+def is_calibrating() -> bool:
+    """linear_fp8 calls this once per invocation to decide whether to record."""
+    return _CALIB_STATS is not None
+
+
+def record_max_abs(site_id: "str | None", x: torch.Tensor) -> None:
+    """Update running ``max(abs(x))`` for ``site_id`` while calibrating.
+
+    Synchronizes (``.item()``) — this path is only taken during the
+    offline calibration run, never during production inference.
+    """
+    if _CALIB_STATS is None or site_id is None:
+        return
+    v = float(x.detach().abs().max().item())
+    prev = _CALIB_STATS.get(site_id, 0.0)
+    if v > prev:
+        _CALIB_STATS[site_id] = v
+
+
+@contextmanager
+def calibration_recorder() -> "Iterator[dict[str, float]]":
+    """Enable per-site activation max(abs) recording for the duration of
+    the with-block. Yields the stats dict (mutated live; also returned
+    after the block for save_calibration)."""
+    global _CALIB_STATS
+    with _LOCK:
+        if _CALIB_STATS is not None:
+            raise RuntimeError("calibration_recorder already active")
+        stats: "dict[str, float]" = {}
+        _CALIB_STATS = stats
+    try:
+        yield stats
+    finally:
+        with _LOCK:
+            _CALIB_STATS = None
+
+
+def save_calibration(stats: "dict[str, float]", path) -> None:
+    """Dump max(abs) per site to JSON. The scale conversion is deferred
+    to load time so the JSON stays human-inspectable."""
+    payload = {
+        "version": 1,
+        "format": "max_abs_per_site",
+        "fp8_max": FP8_E4M3_MAX,
+        "stats": {k: float(v) for k, v in sorted(stats.items())},
+    }
+    Path(path).write_text(json.dumps(payload, indent=2))
+
+
+def load_calibration(path, device: torch.device) -> "dict[str, torch.Tensor]":
+    """Read JSON, return dict of ``site_id`` → 1-element fp32 device
+    tensor holding ``max_abs / 448``. Tensors are persistent (caller
+    holds them for the process lifetime, typically via ``set_static_scales``).
+    """
+    payload = json.loads(Path(path).read_text())
+    if payload.get("version") != 1:
+        raise ValueError(f"unsupported calibration version: {payload.get('version')}")
+    if payload.get("format") != "max_abs_per_site":
+        raise ValueError(
+            f"unsupported calibration format: {payload.get('format')}")
+    fp8_max = float(payload.get("fp8_max", FP8_E4M3_MAX))
+    out: "dict[str, torch.Tensor]" = {}
+    for sid, max_abs in payload["stats"].items():
+        max_abs = max(float(max_abs), DEFAULT_SCALE_FLOOR)
+        scale = max_abs / fp8_max
+        out[sid] = torch.tensor([scale], dtype=torch.float32, device=device)
+    return out
+
+
+def set_static_scales(scales: "dict[str, torch.Tensor] | None") -> None:
+    """Install (or clear) the static-scale registry consulted by
+    linear_fp8. Pass ``None`` to revert to dynamic per-call quantize.
+    """
+    global _STATIC_SCALES
+    with _LOCK:
+        _STATIC_SCALES = scales
+
+
+def get_static_scale(site_id: "str | None") -> "torch.Tensor | None":
+    """Look up the static scale for ``site_id``. Returns ``None`` when
+    no calibration is loaded OR when ``site_id`` is unknown — in either
+    case ``linear_fp8`` reverts to the dynamic quantize path."""
+    if _STATIC_SCALES is None or site_id is None:
+        return None
+    return _STATIC_SCALES.get(site_id)
+
+
+def has_static_scales() -> bool:
+    """Quick check used by tests."""
+    return _STATIC_SCALES is not None
+
+
+__all__ = [
+    "FP8_E4M3_MAX",
+    "calibration_recorder",
+    "get_static_scale",
+    "has_static_scales",
+    "is_calibrating",
+    "load_calibration",
+    "record_max_abs",
+    "save_calibration",
+    "set_static_scales",
+]

--- a/flash_rt/models/lingbot/forward.py
+++ b/flash_rt/models/lingbot/forward.py
@@ -1,0 +1,784 @@
+"""LingBot-VLA layer-loop forward paths — prefix encode + denoise step.
+
+Two asymmetric forward paths from upstream
+``QwenvlWithExpertModel.forward``:
+
+1. **Prefix encode** (set_prompt, one-time per task):
+       inputs_embeds = [prefix_embs, None]    # only VLM is computed
+       fill_kv_cache = True                   # K/V STORED to past_key_values
+   Iterates 36 layers. Output = encoded VLM hidden + per-layer KV cache.
+
+2. **Denoise step** (called 50 times per inference):
+       inputs_embeds = [None, suffix_embs]    # only Expert is computed
+       fill_kv_cache = False                  # K/V APPENDED to cached prefix
+   Iterates 36 layers. Output = post-decoder Expert hidden (used by
+   velocity head).
+
+Both reuse the per-layer building blocks from ``mixed_attention``
+(``compute_kqv_vlm``, ``compute_kqv_expert``, ``_eager_attention``,
+``swiglu_mlp``) and ``norms.rms_norm`` / ``ada_rms_norm``.
+
+Reference: upstream ``QwenvlWithExpertModel.forward`` (modeling_lingbot
+_vla.py L1240-1349) — the same loop body but with our device-bound target
+attrs and our RoPE adapter (both bit-exact verified).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from flash_rt.models.lingbot.kernel_ops import (
+    ada_rms_residual_fp8_fused, ada_rms_residual_fp16_mpad_fused,
+    linear_bf16, linear_fp8, residual_rms_quant_fp8_inplace,
+    rope_inplace_bf16_fused, rope_to_out_bf16_fused,
+    _FP8_MIN_M, _FP8_PAD_MIN_M,
+)
+
+# use the out-of-place fused RoPE kernel (graph-safe) instead of the
+# eager cast→rotate→cast chain. Set False to fall back to eager.
+_USE_ROPE_KERNEL = True
+
+# PROBE ONLY: skip the denoise KV-cache suffix copy (wrong output) to measure
+# whether it's serial (reducible by baking the KV write into the rope kernel).
+_PROBE_SKIP_KV_COPY = False
+
+# route the prefix VLM attention (M=840 self-attention, HD=128) through FA4
+# instead of eager softmax. The bidirectional (vlm_causal=False) mask only drops
+# the contiguous lang-pad tail ([img | lang-valid | lang-pad]), so FA4 with
+# seqused_k = the valid prefix length reproduces it EXACTLY (cos preserved). FA4
+# fills the GPU at M=840 (~54 tiles) → ~2ms faster than eager softmax (prefix-
+# once, all step counts). The pad K/V rows are also zeroed so the denoise's own
+# unmasked FA4 sees V=0 from them (replaces mask_kv_cache_pad_rows).
+_USE_PREFIX_FA4 = True
+
+# merged gate_up GEMM (one [H→2*I] GEMM + offset-read silu_mul instead of
+# two GEMMs). gate/up weight scales are within ~1.36× → common-scale cos-free.
+_USE_MERGED_GATE_UP = True
+
+# NVFP4 on the VLM-prefix FFN gate/up GEMMs (the biggest prefix GEMMs, FP4
+# 1.6-1.9× faster than fp8 at M~840). pi05 recipe: FP4 on FFN only; QKV/attn/O
+# + the down GEMM stay FP8. RMS weight is folded into the gate/up FP4 weights so
+# the (weightless) fused FP4 norm applies. fp16 I/O on the FFN island.
+_USE_VLM_FP4 = True
+_VLM_FP4_DONE = "_vlm_fp4_done"
+
+# NVFP4 on the denoise merged gate_up GEMM. The fp8 AdaRMS output is dequant'd
+# to fp16 then FP4-quant'd (a separate quant), then the FP4 merged gate_up GEMM. Even
+# with the extra quant this is a net win at M=64: the FP4 weight is HALF the DRAM bytes
+# (4.2->2.1 MB) so the in-pipeline weight read drops, and it scales with denoise steps
+# (-~5ms@25, -~10ms@50). cos held (0.99622). A fused AdaRMS->FP4 kernel (skip the
+# dequant+quant) would add a bit more but isn't needed for the win.
+_USE_DENOISE_FP4 = True
+
+# fold the denoise 2nd residual (mlp_out + afr) into the NEXT layer's input
+# AdaRMS (which already reads that tensor and must write the sum for its own
+# post-attn residual). Reuses ada_rms_residual_fp8_fused; removes the standalone
+# add (one launch + buffer per layer, ~1.3ms@25 — measured serial via probe).
+_USE_2ND_RES_FUSION = True
+
+
+def prepare_vlm_fp4_weights(target, num_layers: int = 36) -> None:
+    """: fold post-attn RMS weight into VLM gate/up, FP4-quant (offline,
+    idempotent, eager warmup). The folded weight lets the weightless fused FP4
+    norm produce the correct (rms·w) activation. down stays FP8."""
+    if getattr(target, _VLM_FP4_DONE, False):
+        return
+    from flash_rt.models.lingbot import fp4_ops
+    if not fp4_ops.HAS_FP4:
+        setattr(target, _VLM_FP4_DONE, True)
+        return
+    gate = target.vlm_layer_mlp_gate_proj_weights
+    up = target.vlm_layer_mlp_up_proj_weights
+    rw = target.vlm_layer_post_attn_layernorm_weights
+    down = target.vlm_layer_mlp_down_proj_weights
+    gq, uq, dq = [], [], []
+    for i in range(num_layers):
+        rwi = rw[i].float()[None, :]
+        gq.append(fp4_ops.quant_weight((gate[i].float() * rwi).half().contiguous()))
+        uq.append(fp4_ops.quant_weight((up[i].float() * rwi).half().contiguous()))
+        dq.append(fp4_ops.quant_weight(down[i].half().contiguous()))
+    target.vlm_mlp_gate_fp4 = gq
+    target.vlm_mlp_up_fp4 = uq
+    target.vlm_mlp_down_fp4 = dq
+    setattr(target, _VLM_FP4_DONE, True)
+
+
+def _vlm_fp4_scratch(target, M: int, D: int, H: int):
+    """Lazily allocate (in eager warmup) the per-layer FP4 FFN scratch reused
+    across all 36 VLM layers: norm FP4 buffer [M,D] + gate/up fp16 [M,H]."""
+    s = getattr(target, "_vlm_fp4_scratch_buf", None)
+    if s is not None and s["M"] >= M:
+        return s
+    from flash_rt.models.lingbot import fp4_ops
+    s = {"norm": fp4_ops.FP4ActScratch(M, D),
+         "gate": torch.empty(M, H, dtype=torch.float16, device="cuda"),
+         "up": torch.empty(M, H, dtype=torch.float16, device="cuda"),
+         "hid": fp4_ops.FP4ActScratch(M, H),   # silu(gate)*up FP4 (down input)
+         "down": torch.empty(M, D, dtype=torch.float16, device="cuda"),
+         "M": M}
+    target._vlm_fp4_scratch_buf = s
+    return s
+
+
+def _has_static_scales() -> bool:
+    from flash_rt.models.lingbot import calibration as _calib
+    return _calib.has_static_scales()
+
+
+_EXPERT_MERGED_DONE = "_expert_gate_up_merged"
+
+
+def prepare_expert_merged_weights(target, num_layers: int = 36) -> None:
+    """: build per-layer merged gate_up weights cat([gate, up], dim=0)
+    → [2*I, H] bf16 so the SwiGLU runs ONE GEMM ([H→2*I]) instead of two.
+    The merged FP8 weight uses a common per-tensor scale (gate/up absmax are
+    within ~1.36× across layers → negligible cos cost). Idempotent; the cat
+    runs once in eager warmup, before CUDA-graph capture."""
+    if getattr(target, _EXPERT_MERGED_DONE, False):
+        return
+    gate = target.expert_layer_mlp_gate_proj_weights
+    up = target.expert_layer_mlp_up_proj_weights
+    target.expert_layer_mlp_gate_up_merged_weights = [
+        torch.cat([gate[i], up[i]], dim=0).contiguous() for i in range(num_layers)]
+    # merged q/k/v weight cat([q, k, v], dim=0) → [NHQ*HD + 2*NHKV*HD, H].
+    # The 3 q/k/v GEMMs are serial (NOT overlapped) so one merged GEMM cuts 2
+    # launches. Common per-tensor scale (q/k/v absmax within ~3× → cos ~0.995).
+    q = target.expert_layer_q_proj_weights
+    k = target.expert_layer_k_proj_weights
+    v = target.expert_layer_v_proj_weights
+    target.expert_layer_qkv_merged_weights = [
+        torch.cat([q[i], k[i], v[i]], dim=0).contiguous() for i in range(num_layers)]
+    # FP4-quant the merged gate_up weight (the post-attn AdaRMS output is
+    # already fully normed+FiLM'd, so no rms-fold needed).
+    if _USE_DENOISE_FP4:
+        from flash_rt.models.lingbot import fp4_ops
+        if fp4_ops.HAS_FP4:
+            target.expert_mlp_gate_up_fp4 = [
+                fp4_ops.quant_weight(w.half().contiguous())
+                for w in target.expert_layer_mlp_gate_up_merged_weights]
+    setattr(target, _EXPERT_MERGED_DONE, True)
+
+
+def _kv_cache_dtype() -> torch.dtype:
+    """: fp16 KV cache when the fp16 attention island is active (the QKV
+    megakernel emits fp16 q/k/v, so cache+new must be fp16 for the cat and
+    for the fmha to consume them cast-free). Else bf16. Gated on calibration
+    (the megakernel only runs on the fused FP8 path)."""
+    from flash_rt.models.lingbot import mixed_attention as _m
+    if (_m._USE_FP16_ATTN_ISLAND and _USE_ROPE_KERNEL
+            and _has_static_scales()):
+        return _m.ATTN_ISLAND_DTYPE
+    return torch.bfloat16
+
+
+def _rope(x, cos, sin):
+    """RoPE on [B,S,NH,HD] bf16 with fp32 cos/sin. Fused kernel when enabled,
+    else the eager fp32-cast reference (bit-equivalent split-half math)."""
+    if _USE_ROPE_KERNEL and x.dtype == torch.bfloat16:
+        try:
+            return rope_to_out_bf16_fused(x, cos, sin)
+        except Exception:
+            pass
+    return apply_rope_with_tables(x.to(torch.float32), cos, sin).to(x.dtype)
+
+from flash_rt.models.lingbot.mixed_attention import (
+    AttentionDims, DEFAULT_ATTN_DIMS,
+    _eager_attention,
+    compute_kqv_expert,
+    compute_kqv_vlm,
+    swiglu_mlp,
+    swiglu_mlp_from_fp8,
+)
+from flash_rt.models.lingbot.kernel_ops import attention_fa4_fused
+from flash_rt.models.lingbot.norms import ada_rms_norm, rms_norm
+from flash_rt.models.lingbot.rope_adapter import (
+    LINGBOT_ROPE_CONFIG, apply_rope_with_tables, build_cos_sin_table,
+)
+
+
+# ════════════════════════════════════════════════════════════════════
+#  PREFIX ENCODE PATH (VLM-only, fill_kv_cache=True)
+# ════════════════════════════════════════════════════════════════════
+
+def prefix_encode_layer(
+    vlm_hidden: torch.Tensor,
+    *,
+    position_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    target,
+    layer_idx: int,
+    kv_cache_out: dict,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+    rope_cos: torch.Tensor | None = None,    # hoisted RoPE tables
+    rope_sin: torch.Tensor | None = None,
+    pad_mask: torch.Tensor | None = None,    # [B, L] bool (True = valid)
+) -> torch.Tensor:
+    """One layer of prefix encode — VLM-only forward, fills KV cache.
+
+    Args:
+        vlm_hidden: ``[B, L_prefix, 2048]`` pre-norm hidden.
+        position_ids: ``[B, L_prefix]`` long.
+        attention_mask: ``[B, L_prefix, L_prefix]`` bool (True = keep).
+        target: device-bound weight namespace.
+        layer_idx: which of 36 layers.
+        kv_cache_out: dict to write {"key_states", "value_states"} into
+                      under key ``layer_idx``. Caller initializes as
+                      empty dict before the 36-layer loop.
+        dims: AttentionDims.
+
+    Returns:
+        ``[B, L_prefix, 2048]`` post-layer hidden.
+    """
+    B, L, _ = vlm_hidden.shape
+    # 1. Pre-norm + Q/K/V proj.
+    q, k, v = compute_kqv_vlm(vlm_hidden, target, layer_idx, dims)
+
+    # 2. RoPE. fused in-place would go here when (rope_cos, rope_sin)
+    # are provided, but the in-place kernel introduced cross-replay
+    # non-determinism in the captured graph (replay outputs drift by
+    # ~0.1 between calls). Falling back to the eager fp32 cast path
+    # until that's understood. The hoist still saves redundant
+    # build_cos_sin_table calls.
+    cos, sin = (rope_cos, rope_sin) if rope_cos is not None else \
+        build_cos_sin_table(
+            position_ids, LINGBOT_ROPE_CONFIG, compute_dtype=torch.float32)
+    q = _rope(q, cos, sin)   # fused out-of-place RoPE
+    k = _rope(k, cos, sin)
+
+    # zero the pad K/V rows so the unmasked FA4 path is valid (pad keys
+    # contribute V=0; the softmax-denominator distortion is the same one the
+    # denoise already uses and calibrated). This also pre-applies what
+    # mask_kv_cache_pad_rows does to the cache, so the bidirectional
+    # (vlm_causal=False) attention mask becomes a no-op → mask=None → FA4.
+    use_prefix_fa4 = _USE_PREFIX_FA4 and pad_mask is not None
+    if use_prefix_fa4:
+        keep = pad_mask.view(B, L, 1, 1).to(k.dtype)
+        k = k * keep
+        v = v * keep
+
+    # 3. Fill KV cache (BEFORE attention — matches upstream handle_kv_cache).
+    # store in the denoise consume-dtype (fp16 for the attention island).
+    # The pad K/V rows are zeroed (above) so the denoise's unmasked FA4 sees
+    # V=0 from them (replaces mask_kv_cache_pad_rows).
+    cd = _kv_cache_dtype()
+    kv_cache_out[layer_idx] = {
+        "key_states": k.to(cd), "value_states": v.to(cd)}
+
+    # 4. Attention (self-attention on prefix). : FA4 with seqused_k = the
+    # valid prefix length skips the contiguous lang-pad keys EXACTLY (the pad is
+    # at the end: [img | lang-valid | lang-pad]) — no softmax-denominator
+    # distortion, so cos is preserved AND ~68 keys are skipped. Falls back to
+    # eager softmax with the full bool mask if FA4 is unavailable.
+    A = None
+    if use_prefix_fa4:
+        valid_len = pad_mask.sum(dim=1).to(torch.int32)        # [B]
+        A = attention_fa4_fused(
+            q, k, v, num_q_heads=dims.num_q_heads,
+            num_kv_heads=dims.num_kv_heads, head_dim=dims.head_dim,
+            seqused_k=valid_len)
+    if A is None:
+        A = _eager_attention(
+            q, k, v, attention_mask,
+            num_q_heads=dims.num_q_heads, num_kv_heads=dims.num_kv_heads,
+            head_dim=dims.head_dim,
+        )                                     # [B, L, num_q*head_dim]
+
+    # 5. o_proj. : the FA4 prefix path returns fp16 (attention island), so
+    # pin the o_proj output to the weight dtype (bf16) — matches the residual
+    # stream (vlm_hidden) for the in-place residual add below (cf. denoise).
+    o_w = target.vlm_layer_o_proj_weights[layer_idx]
+    attn_out = linear_fp8(A, o_w, out_dtype=o_w.dtype,
+                          site_id=f"vlm.layer.{layer_idx}.o_proj")
+
+    # 6+7+8a. fused path (taken when static scales for the
+    # gate_proj site are loaded):  ``residual_add_rms_norm_fp8`` writes
+    # ``vlm_hidden + attn_out`` back into ``vlm_hidden`` (acting as the
+    # ``afr`` for the second residual below) and emits an FP8 tensor
+    # ready for the gate/up GEMMs of SwiGLU, skipping their own quant.
+    site_prefix = f"vlm.layer.{layer_idx}.mlp"
+    # NVFP4 FFN gate/up. afr = vlm_hidden+attn_out (bf16, in place); the
+    # weightless FP4 norm on its fp16 copy + 2 FP4 GEMMs (rms-folded weights)
+    # replace the fp8 gate/up; silu_mul (fp16) then the FP8 down (unchanged).
+    if (_USE_VLM_FP4 and _has_static_scales()
+            and getattr(target, "vlm_mlp_gate_fp4", None) is not None):
+        from flash_rt.models.lingbot import fp4_ops
+        B, L, D = vlm_hidden.shape
+        M = B * L
+        H = target.vlm_mlp_gate_fp4[layer_idx]["N"]
+        vlm_hidden.add_(attn_out)                       # afr (bf16), in place
+        sc = _vlm_fp4_scratch(target, M, D, H)
+        x16 = vlm_hidden.reshape(M, D).to(torch.float16).contiguous()
+        fp4_ops.rms_norm_to_fp4(x16, sc["norm"], M)
+        fp4_ops.fp4_gemm(sc["norm"], target.vlm_mlp_gate_fp4[layer_idx], sc["gate"], M, H, D)
+        fp4_ops.fp4_gemm(sc["norm"], target.vlm_mlp_up_fp4[layer_idx], sc["up"], M, H, D)
+        hid = (F.silu(sc["gate"][:M]) * sc["up"][:M]).to(torch.float16).contiguous()
+        # FP4 down too (down input is silu output; the fp8 path also quants,
+        # so FP4 quant-for-quant + the 1.85× FP4 GEMM is a net win at M~840).
+        fp4_ops.quant_act(hid, sc["hid"], M)
+        fp4_ops.fp4_gemm(sc["hid"], target.vlm_mlp_down_fp4[layer_idx], sc["down"], M, D, H)
+        mlp_out = sc["down"][:M].to(torch.bfloat16).reshape(B, L, D)
+        return mlp_out + vlm_hidden
+    fused = residual_rms_quant_fp8_inplace(
+        vlm_hidden, attn_out,
+        target.vlm_layer_post_attn_layernorm_weights[layer_idx],
+        eps=dims.rms_eps,
+        site_id=f"{site_prefix}.gate_proj",
+    )
+    if fused is not None:
+        # NOTE: vlm_hidden has been mutated in place to (vlm_hidden + attn_out).
+        out_fp8, act_scale = fused
+        mlp_out = swiglu_mlp_from_fp8(
+            out_fp8, act_scale,
+            gate_weight=target.vlm_layer_mlp_gate_proj_weights[layer_idx],
+            up_weight=target.vlm_layer_mlp_up_proj_weights[layer_idx],
+            down_weight=target.vlm_layer_mlp_down_proj_weights[layer_idx],
+            site_prefix=site_prefix,
+        )
+        afr = vlm_hidden  # bf16 (residual + attn_out), already in place
+    else:
+        # Fallback (no calibration loaded): the unfused eager path.
+        afr = attn_out + vlm_hidden
+        h_post = rms_norm(
+            afr, weight=target.vlm_layer_post_attn_layernorm_weights[layer_idx],
+            eps=dims.rms_eps,
+        )
+        mlp_out = swiglu_mlp(
+            h_post,
+            gate_weight=target.vlm_layer_mlp_gate_proj_weights[layer_idx],
+            up_weight=target.vlm_layer_mlp_up_proj_weights[layer_idx],
+            down_weight=target.vlm_layer_mlp_down_proj_weights[layer_idx],
+            site_prefix=site_prefix,
+        )
+
+    # 9. 2nd residual.
+    return mlp_out + afr
+
+
+def prefix_encode_36L(
+    prefix_hidden: torch.Tensor,
+    *,
+    position_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    target,
+    num_layers: int = 36,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+    pad_mask: torch.Tensor | None = None,    # [B, L] bool (True = valid)
+) -> tuple[torch.Tensor, dict]:
+    """Full prefix encode: 36 layers + final RMSNorm.
+
+    Returns:
+        out:      ``[B, L_prefix, 2048]`` final hidden.
+        kv_cache: dict ``{layer_idx: {"key_states": ..., "value_states": ...}}``
+                  one entry per layer.
+    """
+    h = prefix_hidden
+    kv_cache: dict = {}
+    # build the FP4 VLM gate/up weights once (idempotent, eager warmup).
+    if _USE_VLM_FP4 and _has_static_scales():
+        prepare_vlm_fp4_weights(target, num_layers)
+    # build cos/sin once per inference, reuse across all 36 layers.
+    rope_cos, rope_sin = build_cos_sin_table(
+        position_ids, LINGBOT_ROPE_CONFIG, compute_dtype=torch.float32)
+    for layer_idx in range(num_layers):
+        h = prefix_encode_layer(
+            h,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            target=target, layer_idx=layer_idx,
+            kv_cache_out=kv_cache, dims=dims,
+            rope_cos=rope_cos, rope_sin=rope_sin,
+            pad_mask=pad_mask,
+        )
+    # Final norm (final_norm_adanorm=False in our config → plain RMSNorm).
+    out = rms_norm(h, weight=target.vlm_norm_weight, eps=dims.rms_eps)
+    return out, kv_cache
+
+
+# ════════════════════════════════════════════════════════════════════
+# — batched FiLM (γ/β) precompute across all denoise steps
+# ════════════════════════════════════════════════════════════════════
+#
+# Each Expert layer has 4 per-sample FiLM linears (input_ln.{γ,β},
+# post_attn_ln.{γ,β}), all reading the timestep embedding ``ada_cond``.
+# Computed per-layer-per-step they are 4·36·N tiny M=1 GEMMs (1440 @10-step)
+# that the profiler shows cost ~9 ms — dominated by per-launch fixed cost,
+# not bandwidth (M=1). Since the Euler timestep schedule is deterministic,
+# every step's ``ada_cond`` is known up front, so we stack all 144 FiLM
+# weights into one [144·H, H] matrix and run ONE batched GEMM
+# ``[N, H] × [H, 144·H] → [N, 144·H]`` for the whole inference, then slice
+# γ/β per (step, layer). 1440 launches → 1.  Order per layer: γ_in, β_in,
+# γ_post, β_post (slots 0..3).
+
+_FILM_STACK_CACHE: dict = {}
+_FILM_SLOTS = 4   # γ_in, β_in, γ_post, β_post
+
+
+def _get_film_stack(target, num_layers: int):
+    """Return cached ``(W [slots·L·H, H], b [slots·L·H])`` stacking every
+    Expert FiLM linear's weight/bias in (layer, slot) order. Holds a strong
+    ref to source weights via the cache value ."""
+    key = (id(target), num_layers)
+    cached = _FILM_STACK_CACHE.get(key)
+    if cached is not None:
+        return cached
+    ws, bs = [], []
+    for l in range(num_layers):
+        ws.append(target.expert_layer_input_layernorm_gamma_weights[l])
+        ws.append(target.expert_layer_input_layernorm_beta_weights[l])
+        ws.append(target.expert_layer_post_attn_layernorm_gamma_weights[l])
+        ws.append(target.expert_layer_post_attn_layernorm_beta_weights[l])
+        bs.append(target.expert_layer_input_layernorm_gamma_biases[l])
+        bs.append(target.expert_layer_input_layernorm_beta_biases[l])
+        bs.append(target.expert_layer_post_attn_layernorm_gamma_biases[l])
+        bs.append(target.expert_layer_post_attn_layernorm_beta_biases[l])
+    W = torch.cat(ws, dim=0).contiguous()   # [slots·L·H, H]
+    b = torch.cat(bs, dim=0).contiguous()   # [slots·L·H]
+    _FILM_STACK_CACHE[key] = (W, b)
+    return W, b
+
+
+def precompute_expert_film(
+    ada_cond_all: torch.Tensor,   # [N_steps, H] timestep embeddings
+    target,
+    num_layers: int = 36,
+) -> torch.Tensor:
+    """One batched bf16 GEMM for every (step, layer, slot) FiLM vector.
+
+    Returns ``[N_steps, num_layers, 4, H]`` (slots γ_in, β_in, γ_post,
+    β_post). Matches the per-site ``linear_fp8`` math: those fall back to
+    bf16 at M=1, so a bf16 batched GEMM is numerically equivalent."""
+    W, b = _get_film_stack(target, num_layers)
+    H = ada_cond_all.shape[-1]
+    flat = linear_bf16(ada_cond_all, W, b)        # [N, slots·L·H]
+    N = ada_cond_all.shape[0]
+    return flat.view(N, num_layers, _FILM_SLOTS, H)
+
+
+# ════════════════════════════════════════════════════════════════════
+#  DENOISE STEP PATH (Expert-only with prefix KV cache)
+# ════════════════════════════════════════════════════════════════════
+
+def denoise_step_layer(
+    expert_hidden: torch.Tensor,
+    *,
+    position_ids: torch.Tensor,
+    ada_cond: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    target,
+    layer_idx: int,
+    kv_cache: dict,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+    use_fused_attn: bool = True,
+    rope_cos: torch.Tensor | None = None,
+    rope_sin: torch.Tensor | None = None,
+    layer_film: torch.Tensor | None = None,   # [4, H] precomputed γ/β
+    prev_mlp_out: torch.Tensor | None = None,  # prev-layer FFN out (2nd resid)
+) -> torch.Tensor:
+    """One layer of denoise step — Expert-only forward, uses prefix KV cache.
+
+    Args:
+        expert_hidden: ``[B, L_suffix, 768]`` pre-norm hidden.
+        position_ids:  ``[B, L_suffix]`` long. Offset by prefix length per
+                       upstream ``prefix_offsets + cumsum(suffix) - 1``.
+        ada_cond:      ``[B, 768]`` timestep embedding.
+        attention_mask: ``[B, L_suffix, L_prefix + L_suffix]`` bool.
+        target: device-bound weight namespace.
+        layer_idx: which of 36 layers.
+        kv_cache: dict from ``prefix_encode_36L`` — read-only here.
+        dims: AttentionDims.
+
+    Returns:
+        ``[B, L_suffix, 768]`` post-layer Expert hidden.
+    """
+    # cos/sin  — needed by the fused QKV path below.
+    cos, sin = (rope_cos, rope_sin) if rope_cos is not None else \
+        build_cos_sin_table(
+            position_ids, LINGBOT_ROPE_CONFIG, compute_dtype=torch.float32)
+
+    # 1. Pre-AdaRMSNorm + Q/K/V proj. : feed precomputed input-LN γ/β
+    # (slots 0,1) when available. : when the fused FP8 path is active
+    # (static scales), pass cos/sin so compute_kqv_expert does q/k/v bias+RoPE
+    # in ONE kernel (5 launches → 1); else RoPE here eagerly.
+    g_in = layer_film[0:1] if layer_film is not None else None
+    b_in = layer_film[1:2] if layer_film is not None else None
+    use_fused_qkv = _USE_ROPE_KERNEL and _has_static_scales()
+
+    # preallocated KV buffer [B, Lp+Ls, NKV, HD] (prefix copied once);
+    # set it up BEFORE the QKV proj so the fused qkv_bias_rope kernel can write
+    # k/v DIRECTLY into the suffix region  — no per-step copy.
+    entry = kv_cache[layer_idx]
+    kbuf = entry.get("key_buf")
+    B_e, Ls, _ = expert_hidden.shape
+    if kbuf is None:
+        Lp = entry["key_states"].shape[1]
+        kbuf = torch.empty(
+            B_e, Lp + Ls, *entry["key_states"].shape[2:],
+            dtype=entry["key_states"].dtype, device=entry["key_states"].device)
+        vbuf = torch.empty_like(kbuf)
+        kbuf[:, :Lp].copy_(entry["key_states"])
+        vbuf[:, :Lp].copy_(entry["value_states"])
+        entry["key_buf"] = kbuf
+        entry["value_buf"] = vbuf
+        entry["prefix_len"] = Lp
+    else:
+        Lp = entry["prefix_len"]
+        vbuf = entry["value_buf"]
+
+    # write k/v straight into the cache suffix (only on the fused merged
+    # qkv path, which supports k_out/v_out targets). Saves the per-step copy.
+    nkv_hd = dims.num_kv_heads * dims.head_dim
+    bake = use_fused_qkv and not _PROBE_SKIP_KV_COPY
+    k_suffix = kbuf[:, Lp:].reshape(B_e * Ls, nkv_hd) if bake else None
+    v_suffix = vbuf[:, Lp:].reshape(B_e * Ls, nkv_hd) if bake else None
+    # when the previous layer handed its FFN output forward (instead of
+    # adding it to afr itself), fold that 2nd-residual add into this input norm.
+    residual_add = (prev_mlp_out.view(B_e, Ls, -1)
+                    if prev_mlp_out is not None else None)
+    q, k_new, v_new = compute_kqv_expert(
+        expert_hidden, ada_cond, target, layer_idx, dims,
+        gamma_in=g_in, beta_in=b_in,
+        qk_rope=(cos, sin) if use_fused_qkv else None,
+        k_out_buf=k_suffix, v_out_buf=v_suffix,
+        residual_add=residual_add)
+    if not use_fused_qkv:
+        q = _rope(q, cos, sin)         # fused out-of-place RoPE
+        k_new = _rope(k_new, cos, sin)
+    if not bake and not _PROBE_SKIP_KV_COPY:
+        kbuf[:, Lp:].copy_(k_new)
+        vbuf[:, Lp:].copy_(v_new)
+    k_full = kbuf
+    v_full = vbuf
+
+    # 4. Attention — : when ``use_fused_attn`` is True AND caller
+    # already zeroed prefix-pad rows in the KV cache, pass mask=None
+    # to take the fused cuBLAS MHA path. Padding K/V rows are zero so
+    # their attention contribution is V[pad]=0; softmax denominator
+    # has small distortion (~26% pad fraction in our baseline → outputs
+    # scaled ~0.74×, but the entire downstream path was calibrated under
+    # this regime later so cos stays ≥0.999). The Pi0-style state-
+    # token suffix-self mask is also dropped here — measured cos hit
+    # is ~0.001 absolute (well within the ≥0.99 floor).
+    if use_fused_attn:
+        A = _eager_attention(
+            q, k_full, v_full, None,
+            num_q_heads=dims.num_q_heads, num_kv_heads=dims.num_kv_heads,
+            head_dim=dims.head_dim,
+        )
+    else:
+        A = _eager_attention(
+            q, k_full, v_full, attention_mask,
+            num_q_heads=dims.num_q_heads, num_kv_heads=dims.num_kv_heads,
+            head_dim=dims.head_dim,
+        )                                     # [B, L_suffix, num_q*head_dim]
+
+    # 5. o_proj (Expert: 2048 → 768). : the fp16 island can leave A in
+    # fp16 (fmha returns bf16, but the masked eager path returns fp16); the
+    # o_proj weight is bf16, so match it (no-op when A is already bf16).
+    # NOTE: a bf16 o_proj (skip the FP8 quant) was tried — isolated it
+    # looked ~5µs faster, but e2e it was +0.4ms@25 SLOWER: in-pipeline the bf16
+    # weight streams 2× the bytes from DRAM, offsetting the quant savings. Kept
+    # FP8 (the static quant ~4.7µs is cheaper than the extra weight-BW).
+    o_w = target.expert_layer_o_proj_weights[layer_idx]
+    # A is fp16 (FA4 island) or bf16 (eager fallback). linear_fp8 quantizes
+    # either to fp8 and emits bf16 (out_dtype) — no fp16->bf16 cast on A.
+    attn_out = linear_fp8(A, o_w, out_dtype=o_w.dtype,
+                          site_id=f"expert.layer.{layer_idx}.o_proj")
+
+    # 6+7+8a. fused path: when a static scale exists for the
+    # gate_proj site, fuse (residual + AdaRMS + FP8 quant) into ONE
+    # custom CUDA pass via ``ada_rms_residual_fp8_fused``. The kernel
+    # mutates expert_hidden in place to (expert_hidden + attn_out) and
+    # emits the FP8 tensor that the SwiGLU's gate/up GEMMs consume —
+    # the same input-quant chaining pattern as on the VLM side.
+    #
+    # γ/β are pre-computed here via the per-sample FiLM linears (M=1,
+    # which falls back to bf16 cuBLAS — no FP8 to recover at this size).
+    # post-attn γ/β are slots 2,3 of the precomputed FiLM when available.
+    site_prefix = f"expert.layer.{layer_idx}.mlp"
+    if layer_film is not None:
+        gamma = layer_film[2:3]
+        beta = layer_film[3:4]
+    else:
+        gamma = linear_fp8(
+            ada_cond,
+            target.expert_layer_post_attn_layernorm_gamma_weights[layer_idx],
+            target.expert_layer_post_attn_layernorm_gamma_biases[layer_idx],
+            site_id=f"expert.layer.{layer_idx}.post_attn_ln.gamma",
+        )
+        beta = linear_fp8(
+            ada_cond,
+            target.expert_layer_post_attn_layernorm_beta_weights[layer_idx],
+            target.expert_layer_post_attn_layernorm_beta_biases[layer_idx],
+            site_id=f"expert.layer.{layer_idx}.post_attn_ln.beta",
+        )
+    B_e, S_e, _ = expert_hidden.shape
+    m_real = B_e * S_e
+    # M-pad the post-attn norm FP8 output so the gate/up GEMMs read M=64
+    # directly (no pad copy); the down output slices back to m_real.
+    _pad = _FP8_MIN_M if _FP8_PAD_MIN_M <= m_real < _FP8_MIN_M else None
+    gate_up_merged = getattr(
+        target, "expert_layer_mlp_gate_up_merged_weights", None)
+    gate_up_fp4 = getattr(target, "expert_mlp_gate_up_fp4", None)
+    _fp4_path = (gate_up_fp4 is not None and _pad is not None
+                 and _has_static_scales())
+    if _fp4_path:
+        # FP4 gate_up path uses an fp16 AdaRMS output (no FP8 quant) so the
+        # FP4 quant runs on it directly — skips the fp8→fp16 dequant (~18us/layer
+        # of tiny launch-bound kernels). expert_hidden is mutated to afr.
+        out_fp16 = ada_rms_residual_fp16_mpad_fused(
+            expert_hidden, attn_out,
+            target.expert_layer_post_attn_layernorm_weights[layer_idx],
+            gamma, beta, eps=dims.rms_eps, pad_to=_pad)
+        mlp_out = swiglu_mlp_from_fp8(
+            None, None,
+            gate_weight=target.expert_layer_mlp_gate_proj_weights[layer_idx],
+            up_weight=target.expert_layer_mlp_up_proj_weights[layer_idx],
+            down_weight=target.expert_layer_mlp_down_proj_weights[layer_idx],
+            site_prefix=site_prefix, m_real=m_real,
+            gate_up_merged_weight=gate_up_merged[layer_idx],
+            gate_up_fp4=gate_up_fp4[layer_idx], x_fp16=out_fp16)
+        if _USE_2ND_RES_FUSION:
+            return mlp_out, expert_hidden       # next input norm sums these
+        return mlp_out + expert_hidden
+    fused = ada_rms_residual_fp8_fused(
+        expert_hidden, attn_out,
+        target.expert_layer_post_attn_layernorm_weights[layer_idx],
+        gamma, beta, eps=dims.rms_eps,
+        site_id=f"{site_prefix}.gate_proj", pad_to=_pad,
+    )
+    if fused is not None:
+        # expert_hidden has been mutated in place to (afr = attn + hidden).
+        out_fp8, act_scale = fused
+        mlp_out = swiglu_mlp_from_fp8(
+            out_fp8, act_scale,
+            gate_weight=target.expert_layer_mlp_gate_proj_weights[layer_idx],
+            up_weight=target.expert_layer_mlp_up_proj_weights[layer_idx],
+            down_weight=target.expert_layer_mlp_down_proj_weights[layer_idx],
+            site_prefix=site_prefix,
+            m_real=m_real,
+            gate_up_merged_weight=(gate_up_merged[layer_idx]
+                                   if gate_up_merged is not None else None),
+            gate_up_fp4=None,
+        )
+        afr = expert_hidden       # bf16, in-place mutated
+    else:
+        # Eager fallback (no calibration loaded).
+        afr = attn_out + expert_hidden
+        h_post = ada_rms_norm(
+            afr, ada_cond,
+            weight=target.expert_layer_post_attn_layernorm_weights[layer_idx],
+            gamma_weight=target.expert_layer_post_attn_layernorm_gamma_weights[layer_idx],
+            gamma_bias=target.expert_layer_post_attn_layernorm_gamma_biases[layer_idx],
+            beta_weight=target.expert_layer_post_attn_layernorm_beta_weights[layer_idx],
+            beta_bias=target.expert_layer_post_attn_layernorm_beta_biases[layer_idx],
+            eps=dims.rms_eps,
+            site_prefix=f"expert.layer.{layer_idx}.post_attn_ln",
+        )
+        mlp_out = swiglu_mlp(
+            h_post,
+            gate_weight=target.expert_layer_mlp_gate_proj_weights[layer_idx],
+            up_weight=target.expert_layer_mlp_up_proj_weights[layer_idx],
+            down_weight=target.expert_layer_mlp_down_proj_weights[layer_idx],
+            site_prefix=site_prefix,
+        )
+
+    # 9. 2nd residual. : on the fused (calibrated) path, hand mlp_out + afr
+    # forward unsummed so the next layer's input norm does the add; the eager
+    # fallback (no static scales — its input norm can't fuse a residual) sums here.
+    if _USE_2ND_RES_FUSION and fused is not None:
+        return mlp_out, afr
+    return mlp_out + afr
+
+
+def denoise_step_36L(
+    suffix_hidden: torch.Tensor,
+    *,
+    position_ids: torch.Tensor,
+    ada_cond: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    target,
+    kv_cache: dict,
+    num_layers: int = 36,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+    use_fused_attn: bool = True,
+    film: torch.Tensor | None = None,    # [N_steps, L, 4, H] precomputed
+    step_idx: int | None = None,         # which step's slice to use
+    rope_cos: torch.Tensor | None = None,  # precomputed (constant across steps)
+    rope_sin: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Full denoise step: 36 layers + final RMSNorm (Expert tower).
+
+    Returns:
+        ``[B, L_suffix, 768]`` Expert hidden after final norm — ready for
+        the velocity head ``action_out_proj`` (selects last n_action_steps
+        tokens).
+    """
+    h = suffix_hidden
+    # build merged gate_up weights once (idempotent, eager warmup).
+    if _USE_MERGED_GATE_UP and _has_static_scales():
+        prepare_expert_merged_weights(target, num_layers)
+    # cos/sin are constant across denoise steps (position_ids depend only
+    # on the constant suffix/prefix masks), so the caller precomputes them once
+    # per inference. Fall back to per-step build only when not provided.
+    if rope_cos is None:
+        rope_cos, rope_sin = build_cos_sin_table(
+            position_ids, LINGBOT_ROPE_CONFIG, compute_dtype=torch.float32)
+    # slice this step's precomputed FiLM γ/β [L, 4, H] once.
+    step_film = film[step_idx] if (film is not None and step_idx is not None) \
+        else None
+    # with the 2nd-residual fusion, each layer returns (mlp_out, afr)
+    # unsummed; the next layer's input norm adds them. ``prev_mlp_out`` carries
+    # the previous FFN output forward (None for layer 0, where h is the input).
+    prev_mlp_out = None
+    for layer_idx in range(num_layers):
+        out = denoise_step_layer(
+            h,
+            position_ids=position_ids,
+            ada_cond=ada_cond,
+            attention_mask=attention_mask,
+            target=target, layer_idx=layer_idx,
+            kv_cache=kv_cache, dims=dims,
+            use_fused_attn=use_fused_attn,
+            rope_cos=rope_cos, rope_sin=rope_sin,
+            layer_film=step_film[layer_idx] if step_film is not None else None,
+            prev_mlp_out=prev_mlp_out,
+        )
+        if isinstance(out, tuple):
+            prev_mlp_out, h = out          # (mlp_out, afr): defer the add
+        else:
+            h, prev_mlp_out = out, None
+    # Settle the final layer's deferred 2nd residual before the final norm.
+    if prev_mlp_out is not None:
+        h = prev_mlp_out.view_as(h) + h
+    # Final norm (plain RMSNorm — final_norm_adanorm=False).
+    return rms_norm(h, weight=target.expert_norm_weight, eps=dims.rms_eps)
+
+
+def mask_kv_cache_pad_rows(
+    kv_cache: dict,
+    pad_mask: torch.Tensor,                 # [B, L_prefix] bool: True = valid
+) -> None:
+    """: zero out K/V at padding positions for every layer of the
+    cache. Called once after ``prefix_encode_36L`` so the downstream
+    denoise step can use unmasked fused attention safely (pad K/V → 0
+    contribution; softmax denominator has small known distortion that
+    the calibration absorbed into its scales).
+
+    Mutates ``kv_cache`` in place.
+    """
+    # pad_mask: [B, L] bool → cast to value-dtype, reshape to [B, L, 1, 1]
+    # so it broadcasts over (num_kv_heads, head_dim).
+    multiplier = pad_mask.unsqueeze(-1).unsqueeze(-1)
+    for layer_idx in kv_cache:
+        entry = kv_cache[layer_idx]
+        entry["key_states"] = entry["key_states"] * multiplier
+        entry["value_states"] = entry["value_states"] * multiplier
+
+
+__all__ = [
+    "prefix_encode_layer",
+    "prefix_encode_36L",
+    "denoise_step_layer",
+    "denoise_step_36L",
+    "mask_kv_cache_pad_rows",
+]

--- a/flash_rt/models/lingbot/fp4_ops.py
+++ b/flash_rt/models/lingbot/fp4_ops.py
@@ -1,0 +1,90 @@
+"""LingBot NVFP4 helper — thin wrapper over the pi05 FP4 kernels
+(``flash_rt.flash_rt_fp4``, sm_110a block-scaled NVFP4 GEMM).
+
+Mirrors ``flash_rt/executors/fp4_utils.py`` but binds the module name present in
+this build (``flash_rt.flash_rt_fp4``). FP4 = W4A8-style NVFP4 (e2m1 4-bit
+weights + acts, per-16-element UE4M3 block scales). fp16 I/O.
+
+pi05's proven recipe: apply FP4 to the FFN (gate/up/down) only — those large-N
+GEMMs get 1.6–1.9× (M≥768) / 1.34× (M=64 gate_up); QKV/attn/O stay FP8. Measured
+FP4 GEMM cos ≈ 0.991/GEMM, so validate e2e cos≥0.99 before widening.
+"""
+from __future__ import annotations
+import torch
+
+try:
+    import flash_rt.flash_rt_fp4 as _fp4
+    HAS_FP4 = bool(_fp4.has_nvfp4())
+except Exception:
+    _fp4 = None
+    HAS_FP4 = False
+
+
+def pick_variant(N: int, K: int) -> int:
+    """Shape→tile-variant default (calibrated by tests/fp4_vs_fp8_gemm.py at the
+    LingBot shapes). The benchmark there sweeps all 10 variants per shape."""
+    if N >= 8192:          # wide-N FFN gate/up (VLM 11008)
+        return 4
+    if K >= 8192:          # wide-K FFN down (VLM 11008)
+        return 6
+    if N >= 4096:          # mid FFN
+        return 5
+    return 1
+
+
+def quant_weight(w_fp16: torch.Tensor) -> dict:
+    """Offline: fp16 weight [N,K] → NVFP4 packed int4 + tile-interleaved SFB.
+    K must be divisible by 16."""
+    assert _fp4 is not None
+    assert w_fp16.dtype == torch.float16 and w_fp16.is_contiguous()
+    N, K = w_fp16.shape
+    assert K % 16 == 0, f"K={K} must be %16 for NVFP4"
+    packed = torch.empty(N, K // 2, dtype=torch.uint8, device=w_fp16.device)
+    sfb = torch.empty(_fp4.sfa_size_bytes(N, K, True), dtype=torch.uint8, device=w_fp16.device)
+    rc = _fp4.quantize_fp4_dynamic_sfa_fp16(
+        w_fp16.data_ptr(), packed.data_ptr(), sfb.data_ptr(), N, K, True, 0)
+    if rc != 0:
+        raise RuntimeError(f"quant_weight fp4 rc={rc}")
+    torch.cuda.synchronize(w_fp16.device)
+    return {"packed": packed, "sfb": sfb, "N": N, "K": K}
+
+
+class FP4ActScratch:
+    """Preallocated per-call activation FP4 buffers (packed + SFA)."""
+    def __init__(self, max_M: int, K: int, device="cuda"):
+        assert K % 16 == 0
+        self.max_M, self.K = max_M, K
+        self.packed = torch.empty(max_M, K // 2, dtype=torch.uint8, device=device)
+        self.sfa = torch.empty(_fp4.sfa_size_bytes(max_M, K, False), dtype=torch.uint8, device=device)
+
+
+def quant_act(x_fp16: torch.Tensor, scratch: "FP4ActScratch", M: int, stream: int = 0) -> None:
+    """Runtime: fp16 act [M,K] → scratch.packed + scratch.sfa (fused quant+layout)."""
+    rc = _fp4.quantize_fp4_dynamic_sfa_fp16(
+        x_fp16.data_ptr(), scratch.packed.data_ptr(), scratch.sfa.data_ptr(),
+        M, scratch.K, False, stream)
+    if rc != 0:
+        raise RuntimeError(f"quant_act fp4 rc={rc}")
+
+
+def fp4_gemm(scratch: "FP4ActScratch", w_quant: dict, out_fp16: torch.Tensor,
+             M: int, N: int, K: int, variant: int = -1, stream: int = 0) -> None:
+    """out[M,N] fp16 = A[M,K] (fp4) @ B[N,K]^T (fp4). out must be fp16."""
+    if variant < 0:
+        variant = pick_variant(N, K)
+    rc = _fp4.cutlass_fp4_gemm_variant(
+        variant, scratch.packed.data_ptr(), scratch.sfa.data_ptr(),
+        w_quant["packed"].data_ptr(), w_quant["sfb"].data_ptr(),
+        out_fp16.data_ptr(), M, N, K, 1.0, 0.0, stream)
+    if rc != 0:
+        raise RuntimeError(f"fp4_gemm rc=0x{rc:x}")
+
+
+def rms_norm_to_fp4(x_fp16: torch.Tensor, scratch: "FP4ActScratch",
+                    seq_len: int, stream: int = 0) -> None:
+    """Fused (noweight) RMSNorm of fp16 [seq,dim] → FP4 packed+SFA in scratch.
+    The RMS weight is folded into the downstream GEMM weight (see
+    prepare_vlm_fp4_weights), so this norm is weightless."""
+    _fp4.rms_norm_fp4_sfa_fp16(
+        x_fp16.data_ptr(), scratch.packed.data_ptr(), scratch.sfa.data_ptr(),
+        seq_len, scratch.K, stream)

--- a/flash_rt/models/lingbot/graph_runner.py
+++ b/flash_rt/models/lingbot/graph_runner.py
@@ -1,0 +1,265 @@
+"""LingBot-VLA — CUDA Graph capture + replay for ``sample_actions``.
+
+Captures the full inference (prefix encode + 50× denoise) into a single
+``torch.cuda.CUDAGraph``. Every replay reuses the recorded kernels with
+no Python overhead and no allocator traffic for intermediate buffers
+(they come from the graph's private mempool).
+
+Prerequisites baked in (don't have to be re-established by the caller):
+    * static FP8 calibration must be installed before capture so
+      every ``linear_fp8`` takes the static path (the dynamic path's
+      per-call ``torch.empty(1, fp32)`` for ``act_scale`` would also
+      capture fine, but the static scales are persistent device tensors
+      that PyTorch can address-stably across replays).
+    * fused ``residual_add_rms_norm_fp8`` is gated on scales and
+      activates automatically inside the captured region.
+    * 's ViT capture cache (``_GRID_CACHE`` in :mod:`vit`) is
+      populated by the warmup runs — they materialize the ``attn_mask``,
+      ``cos``, ``sin``, and ``split_sizes`` for the input shape.
+    * Every fvk binding called on the hot path now routes through
+      ``torch.cuda.current_stream().cuda_stream`` (see ``kernel_ops.
+      _current_stream``); without this, fvk launches fall onto the
+      default stream which is NOT inside the captured graph and the
+      replay produces NaN.
+
+Usage::
+
+    from flash_rt.models.lingbot import calibration as calib
+    from flash_rt.models.lingbot.graph_runner import sample_actions_graph
+
+    calib.set_static_scales(
+        calib.load_calibration(JSON_PATH, device=torch.device("cuda")))
+    replay = sample_actions_graph(
+        target=target,
+        images=images, img_masks=img_masks,
+        lang_tokens=lang_tokens, lang_masks=lang_masks,
+        state=state, noise=noise, num_steps=50,
+    )
+    actions = replay()       # repeatable, ~3× faster than eager
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+
+from flash_rt.models.lingbot.sample_actions import sample_actions
+
+
+def sample_actions_graph(
+    *,
+    target,
+    images: torch.Tensor,
+    img_masks: torch.Tensor,
+    lang_tokens: torch.Tensor,
+    lang_masks: torch.Tensor,
+    state: torch.Tensor,
+    noise: torch.Tensor,
+    num_steps: int = 50,
+    n_action_steps: int = 50,
+    action_dim: int = 75,
+    warmup_iters: int = 3,
+) -> "tuple[Callable[[], torch.Tensor], torch.Tensor, torch.cuda.CUDAGraph]":
+    """Capture a CUDAGraph of one full ``sample_actions`` and return
+    a ``(replay_fn, captured_output, graph_handle)`` triple.
+
+    Args:
+        target: device-bound weight namespace (bf16, cuda).
+        images, img_masks, lang_tokens, lang_masks, state, noise:
+            fixed inputs. Their memory addresses are baked into the
+            captured graph; mutate-in-place if you want to change the
+            actual values across replays (the input tensor lives on,
+            but the values it holds at replay time are what the graph
+            reads).
+        num_steps: number of Euler denoise steps.
+
+    Returns:
+        replay_fn: zero-arg callable that re-runs the graph and
+            returns the same ``captured_output`` tensor (whose
+            contents will be the latest inference result).
+        captured_output: handle to the FINAL ``x_t`` tensor produced
+            by the captured pipeline. After each ``replay_fn()`` call
+            this tensor's contents are the new actions chunk.
+        graph_handle: the underlying ``torch.cuda.CUDAGraph`` (in case
+            the caller wants to inspect it).
+    """
+    # ── Warmup. Populates: FP8 weight cache + transpose cache,
+    # cuBLAS heuristic state, ViT _GRID_CACHE (attn_mask/cos/sin),
+    # static FP8 scale lookups. All allocations from warmup live in
+    # the default mempool — they're STABLE addresses that the captured
+    # graph will reference as external read-only state.
+    for _ in range(warmup_iters):
+        _ = sample_actions(
+            images, img_masks, lang_tokens, lang_masks, state,
+            target=target, noise=noise, num_steps=num_steps,
+            n_action_steps=n_action_steps, action_dim=action_dim,
+        )
+    torch.cuda.synchronize()
+
+    # ── Capture.
+    pool = torch.cuda.graph_pool_handle()
+    g = torch.cuda.CUDAGraph()
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(capture_stream):
+        with torch.cuda.graph(g, pool=pool):
+            captured_output = sample_actions(
+                images, img_masks, lang_tokens, lang_masks, state,
+                target=target, noise=noise, num_steps=num_steps,
+                n_action_steps=n_action_steps, action_dim=action_dim,
+            )
+    torch.cuda.current_stream().wait_stream(capture_stream)
+    torch.cuda.synchronize()
+
+    def replay_fn() -> torch.Tensor:
+        # Closure must hold a reference to ``pool`` so the CUDA mempool
+        # that owns the captured tensors stays alive between replays.
+        # Without this pin, ``graph_pool_handle()`` is GC'd at return
+        # and PyTorch reclaims the mempool buffers — the next replay
+        # then asserts on device-side. ``_pin`` is read at call time to
+        # keep the Python ref alive (closure capture is by name, not
+        # value, so dropping ``del pool`` would still defeat this).
+        _pin = pool  # noqa: F841
+        g.replay()
+        return captured_output
+
+    # Also attach to the graph object so callers who keep ``g`` but
+    # accidentally drop ``replay_fn`` still keep the pool alive.
+    g._lingbot_pool = pool  # noqa: SLF001
+    return replay_fn, captured_output, g
+
+
+def sample_actions_split_graph(
+    *,
+    target,
+    images: torch.Tensor,
+    img_masks: torch.Tensor,
+    lang_tokens: torch.Tensor,
+    lang_masks: torch.Tensor,
+    state: torch.Tensor,
+    noise: torch.Tensor,
+    num_steps: int = 10,
+    n_action_steps: int = 50,
+    action_dim: int = 75,
+    vlm_causal: bool = False,
+    warmup_iters: int = 3,
+):
+    """: capture prefix and decoder as TWO separate CUDAGraphs sharing
+    one mempool. Returns ``(prefix_replay, decoder_replay,
+    captured_output, kv_cache, _pin)``.
+
+    Both graphs share a single ``graph_pool_handle`` so the KV-cache
+    tensors allocated inside the prefix-graph capture region remain at
+    stable addresses and are read by the decoder graph. Lifetime is
+    pinned by the closures + ``_pin`` tuple — drop ``_pin`` only when
+    you no longer need either graph.
+
+    Usage on a stable prompt::
+
+        prefix_replay, decoder_replay, out, kv, _ = sample_actions_split_graph(...)
+        prefix_replay()              # once per prompt
+        decoder_replay()             # once per inference; out is reused
+        # mutate state/noise IN PLACE between replays, NOT reassign
+
+    Compared to :func:`sample_actions_graph` (single big capture), this
+    avoids re-running the 32-block ViT + 36-layer VLM prefix encode on
+    every inference. At deploy-realistic 10-step, the prefix portion is
+    ~22% of total time (~50 ms in the graph); skipping it on calls 2..N
+    drops the per-inference cost by ~50 ms.
+    """
+    from flash_rt.models.lingbot.sample_actions import (
+        embed_prefix, predict_velocity, make_att_2d_masks, precompute_film,
+    )
+    from flash_rt.models.lingbot.forward import prefix_encode_36L
+    from flash_rt.models.lingbot.mixed_attention import DEFAULT_ATTN_DIMS
+
+    # Warmup populates every cache (FP8 weights, transpose, ViT capture
+    # cache, cuBLAS heuristics, static FP8 scales).
+    for _ in range(warmup_iters):
+        _ = sample_actions(
+            images, img_masks, lang_tokens, lang_masks, state,
+            target=target, noise=noise, num_steps=num_steps,
+            n_action_steps=n_action_steps, action_dim=action_dim,
+            vlm_causal=vlm_causal,
+        )
+    torch.cuda.synchronize()
+
+    # Single shared mempool — KV-cache tensors allocated in the prefix
+    # capture region get the same addresses the decoder graph records.
+    pool = torch.cuda.graph_pool_handle()
+
+    # --- 1. Prefix-encode graph ---
+    prefix_graph = torch.cuda.CUDAGraph()
+    cap1 = torch.cuda.Stream()
+    cap1.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(cap1):
+        with torch.cuda.graph(prefix_graph, pool=pool):
+            prefix_embs, prefix_pad_masks, prefix_att_masks = embed_prefix(
+                images, img_masks, lang_tokens, lang_masks,
+                target=target, vlm_causal=vlm_causal,
+            )
+            prefix_att_2d = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+            prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+            _, kv_cache = prefix_encode_36L(
+                prefix_embs,
+                position_ids=prefix_position_ids,
+                attention_mask=prefix_att_2d,
+                target=target, dims=DEFAULT_ATTN_DIMS,
+                pad_mask=prefix_pad_masks,    # unmasked FA4 prefix attn
+            )
+    torch.cuda.current_stream().wait_stream(cap1)
+    torch.cuda.synchronize()
+
+    # --- 2. Decoder graph: Euler loop + velocity head ---
+    decoder_graph = torch.cuda.CUDAGraph()
+    cap2 = torch.cuda.Stream()
+    cap2.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(cap2):
+        with torch.cuda.graph(decoder_graph, pool=pool):
+            dt_f = -1.0 / num_steps
+            x_t = noise
+            time_f = 1.0
+            # batched FiLM precompute (graph mode is calibrated).
+            film = precompute_film(
+                num_steps, target, DEFAULT_ATTN_DIMS,
+                noise.device, noise.dtype)
+            for i in range(num_steps):
+                expanded_time = torch.full(
+                    (noise.shape[0],), time_f,
+                    dtype=noise.dtype, device=noise.device,
+                )
+                v_t = predict_velocity(
+                    state, prefix_pad_masks, kv_cache,
+                    x_t, expanded_time,
+                    target=target, n_action_steps=n_action_steps,
+                    dims=DEFAULT_ATTN_DIMS,
+                    film=film, step_idx=i,
+                    use_fused_attn=True,    # FA4 denoise (matches sample_actions;
+                )                           # pad K/V zeroed in prefix → cuBLAS-free capture
+                x_t = x_t + dt_f * v_t
+                time_f += dt_f
+            captured_output = x_t
+    torch.cuda.current_stream().wait_stream(cap2)
+    torch.cuda.synchronize()
+
+    # Pin the pool + the kv_cache + prefix_pad_masks tensors so the
+    # mempool isn't reclaimed at function return. ``_pin`` keeps them
+    # alive for the lifetime of the returned closures.
+    _pin = (pool, kv_cache, prefix_pad_masks, prefix_embs)
+    prefix_graph._lingbot_pin = _pin       # noqa: SLF001
+    decoder_graph._lingbot_pin = _pin      # noqa: SLF001
+
+    def prefix_replay():
+        _pin_ref = _pin                    # keep closure alive
+        prefix_graph.replay()
+
+    def decoder_replay() -> torch.Tensor:
+        _pin_ref = _pin
+        decoder_graph.replay()
+        return captured_output
+
+    return prefix_replay, decoder_replay, captured_output, kv_cache, _pin
+
+
+__all__ = ["sample_actions_graph", "sample_actions_split_graph"]

--- a/flash_rt/models/lingbot/kernel_ops.py
+++ b/flash_rt/models/lingbot/kernel_ops.py
@@ -1,0 +1,1487 @@
+"""LingBot-VLA kernel wrappers around the shared ``flash_rt_kernels`` symbols.
+
+Provides drop-in replacements for the eager-PyTorch ops used by
+``sample_actions.py`` / ``forward.py`` / ``mixed_attention.py`` /
+``vit.py``. Each wrapper:
+
+    * has a torch-natural call signature (tensors in, tensor out)
+    * extracts ``.data_ptr()`` and passes it to the C++ kernel
+    * allocates the output tensor on the same device + dtype as the input
+    * is bit-exact (or cos >= 0.997 for FP8) vs the PyTorch op it replaces
+
+This module owns a process-singleton ``GemmRunner`` for cuBLASLt heuristic
+caching (different weight shapes pick different algorithms; the cache stays
+warm across many linear sites).
+
+For ``bf16_nn`` / ``bf16_nn_bias`` cuBLAS expects the weight as ``[K, N]``
+(row-major) while HuggingFace stores ``[N, K]``. Both a per-call transposing
+helper (for first-light validation) and a ``preload_transposed_weights``
+helper (production path — transposes once at bind time) are provided.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import flash_rt.flash_rt_kernels as fvk
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Singleton resources (cuBLAS handle + GEMM autotune cache)
+# ════════════════════════════════════════════════════════════════════
+
+_FVK_CTX: fvk.FvkContext | None = None
+_GEMM_RUNNER: fvk.GemmRunner | None = None
+
+# Transpose cache: data_ptr → .T.contiguous(). Amortizes the per-call
+# transpose across all GEMM calls (one transpose per unique weight).
+_WT_CACHE: dict[int, "torch.Tensor"] = {}
+
+
+def _get_or_transpose(w: "torch.Tensor") -> "torch.Tensor":
+    key = w.data_ptr()
+    cached = _WT_CACHE.get(key)
+    if cached is None:
+        cached = w.T.contiguous()
+        _WT_CACHE[key] = cached
+    return cached
+
+
+def get_fvk_context() -> fvk.FvkContext:
+    """Get/create the process-wide FvkContext (owns cuBLAS handle)."""
+    global _FVK_CTX
+    if _FVK_CTX is None:
+        _FVK_CTX = fvk.FvkContext()
+    return _FVK_CTX
+
+
+def get_gemm_runner() -> fvk.GemmRunner:
+    """Get/create the process-wide GemmRunner."""
+    global _GEMM_RUNNER
+    if _GEMM_RUNNER is None:
+        _GEMM_RUNNER = fvk.GemmRunner()
+    return _GEMM_RUNNER
+
+
+# ════════════════════════════════════════════════════════════════════
+#  BF16 GEMM (F.linear replacement)
+# ════════════════════════════════════════════════════════════════════
+
+def _current_stream() -> int:
+    """Return the integer cudaStream of the current torch stream.
+
+    : fvk binding defaults route to stream 0 which is NOT in the
+    captured graph. Always pass this on the hot path so the kernel
+    launches end up recorded into the active capture.
+    """
+    return torch.cuda.current_stream().cuda_stream
+
+
+# dtype dispatch. The fvk bindings come in bf16 and fp16 flavors.
+# All wrappers route by ``input.dtype`` so the same model code can run
+# in either mode by switching ``bind_target_to_device(target, dtype=...)``.
+def _gemm_nn(runner, x_ptr, w_T_ptr, out_ptr, M, N, K, dtype, stream):
+    if dtype == torch.bfloat16:
+        runner.bf16_nn(x_ptr, w_T_ptr, out_ptr, M, N, K, stream)
+    elif dtype == torch.float16:
+        runner.fp16_nn(x_ptr, w_T_ptr, out_ptr, M, N, K, stream)
+    else:
+        raise NotImplementedError(f"_gemm_nn dtype {dtype}")
+
+
+def _add_bias(out_ptr, bias_ptr, M, N, dtype, stream):
+    if dtype == torch.bfloat16:
+        fvk.add_bias_bf16(out_ptr, bias_ptr, M, N, stream)
+    elif dtype == torch.float16:
+        fvk.add_bias_fp16(out_ptr, bias_ptr, M, N, stream)
+    else:
+        raise NotImplementedError(f"_add_bias dtype {dtype}")
+
+
+def _quantize_fp8_static(x_ptr, out_fp8_ptr, scale_ptr, n, dtype, stream):
+    if dtype == torch.bfloat16:
+        fvk.quantize_fp8_static(x_ptr, out_fp8_ptr, scale_ptr, n, stream)
+    elif dtype == torch.float16:
+        fvk.quantize_fp8_static_fp16(x_ptr, out_fp8_ptr, scale_ptr, n, stream)
+    else:
+        raise NotImplementedError(f"_quantize_fp8_static dtype {dtype}")
+
+
+def _quantize_fp8_device(x_ptr, out_fp8_ptr, scale_ptr, n, dtype, stream):
+    if dtype == torch.bfloat16:
+        fvk.quantize_fp8_device(x_ptr, out_fp8_ptr, scale_ptr, n, stream)
+    elif dtype == torch.float16:
+        fvk.quantize_fp8_device_fp16(x_ptr, out_fp8_ptr, scale_ptr, n, stream)
+    else:
+        raise NotImplementedError(f"_quantize_fp8_device dtype {dtype}")
+
+
+def _fp8_gemm_descale(x_fp8_ptr, w_fp8_T_ptr, out_ptr,
+                      M, N, K, act_scale_ptr, w_descale_ptr, dtype, stream):
+    """Dispatch FP8 GEMM by output dtype."""
+    if dtype == torch.bfloat16:
+        fvk.fp8_gemm_descale_bf16out(
+            x_fp8_ptr, w_fp8_T_ptr, out_ptr,
+            M, N, K, act_scale_ptr, w_descale_ptr, stream)
+    elif dtype == torch.float16:
+        fvk.fp8_gemm_descale_fp16(
+            x_fp8_ptr, w_fp8_T_ptr, out_ptr,
+            M, N, K, act_scale_ptr, w_descale_ptr, stream)
+    else:
+        raise NotImplementedError(f"_fp8_gemm_descale dtype {dtype}")
+
+
+def linear_bf16(
+    x: torch.Tensor,                    # [..., K] bf16 or fp16
+    weight: torch.Tensor,               # [N, K] same dtype as x
+    bias: torch.Tensor | None = None,   # [N] same dtype as x
+    *,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """Drop-in replacement for ``F.linear(x, weight, bias)`` using
+    ``fvk.GemmRunner.bf16_nn`` (or ``fp16_nn`` when dtype is fp16).
+
+    Auto-detects whether ``weight`` is the HuggingFace ``[N, K]``
+    storage or already a pre-transposed ``[K, N]`` (from
+    ``preload_transposed_weights``). The pre-T fast path saves a
+    per-call ``.T.contiguous()`` (~few microseconds × 14 GEMMs per
+    layer × 36 layers × 50 steps).
+
+    Name kept as ``linear_bf16`` for backward compat; works for both
+    bf16 and fp16 paths via dtype dispatch.
+    """
+    assert x.dtype in (torch.bfloat16, torch.float16), (
+        f"x dtype {x.dtype}, expected bf16 or fp16")
+    assert weight.dtype == x.dtype, (
+        f"weight dtype {weight.dtype} != x dtype {x.dtype}")
+    K_in = x.shape[-1]
+    N_out = weight.shape[0]
+    assert weight.shape == (N_out, K_in), (
+        f"weight shape {weight.shape} != ({N_out}, {K_in})")
+    if stream is None:
+        stream = _current_stream()
+    # Cached transpose — one .T.contiguous() per unique weight tensor.
+    # Avoids the per-call ~50 μs transpose for every GEMM in the hot loop.
+    w_T = _get_or_transpose(weight)
+
+    # Flatten leading dims to M.
+    # math.prod for capture-safety (torch.tensor + .item() crosses
+    # to host which is not permitted during CUDA-Graph capture).
+    M = 1
+    for d in x.shape[:-1]:
+        M *= d
+    x_2d = x.contiguous().view(M, K_in)
+    out_shape = (*x.shape[:-1], N_out)
+    out = torch.empty(out_shape, dtype=x.dtype, device=x.device)
+    out_2d = out.view(M, N_out)
+
+    runner = get_gemm_runner()
+    _gemm_nn(runner,
+             int(x_2d.data_ptr()), int(w_T.data_ptr()),
+             int(out_2d.data_ptr()), M, N_out, K_in, x.dtype, stream)
+    if bias is not None:
+        assert bias.dtype == x.dtype
+        assert bias.shape == (N_out,)
+        # Thor SM110: ``bf16_nn_bias`` returns CUBLAS_NOT_SUPPORTED, so
+        # we use bf16_nn + a separate broadcast add (the same pattern
+        # the GROOT/Pi0.5 Thor pipelines use). Same applies for fp16.
+        _add_bias(int(out_2d.data_ptr()),
+                  int(bias.contiguous().data_ptr()),
+                  M, N_out, x.dtype, stream)
+    return out
+
+
+def linear_bf16_preT(
+    x: torch.Tensor,                    # [..., K]
+    weight_T: torch.Tensor,             # [K, N] — already transposed
+    bias: torch.Tensor | None = None,
+    *,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """Fast path: caller has already transposed weight to [K, N]
+    row-major (e.g., via ``preload_transposed_weights``).
+
+    Dtype-aware (bf16 or fp16) — same dispatch logic as ``linear_bf16``.
+    """
+    assert x.dtype in (torch.bfloat16, torch.float16)
+    K_in = x.shape[-1]
+    N_out = weight_T.shape[1]
+    assert weight_T.shape == (K_in, N_out)
+    if stream is None:
+        stream = _current_stream()
+
+    # math.prod for capture-safety (torch.tensor + .item() crosses
+    # to host which is not permitted during CUDA-Graph capture).
+    M = 1
+    for d in x.shape[:-1]:
+        M *= d
+    x_2d = x.contiguous().view(M, K_in)
+    out = torch.empty((*x.shape[:-1], N_out), dtype=x.dtype, device=x.device)
+    out_2d = out.view(M, N_out)
+
+    runner = get_gemm_runner()
+    if x.dtype == torch.float16:
+        runner.fp16_nn(
+            int(x_2d.data_ptr()), int(weight_T.data_ptr()),
+            int(out_2d.data_ptr()), M, N_out, K_in, stream)
+        if bias is not None:
+            _add_bias(int(out_2d.data_ptr()),
+                      int(bias.contiguous().data_ptr()),
+                      M, N_out, torch.float16, stream)
+        return out
+    runner.bf16_nn(
+        int(x_2d.data_ptr()),
+        int(weight_T.data_ptr()),
+        int(out_2d.data_ptr()),
+        M, N_out, K_in, stream,
+    )
+    if bias is not None:
+        fvk.add_bias_bf16(
+            int(out_2d.data_ptr()),
+            int(bias.contiguous().data_ptr()),
+            M, N_out, stream,
+        )
+    return out
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Pre-transposed weight cache (production fast path)
+# ════════════════════════════════════════════════════════════════════
+
+_TRANSPOSED_ATTR_NAMES = [
+    # Action heads (singletons)
+    "state_proj_weight",
+    "action_in_proj_weight",
+    "action_out_proj_weight",
+    "action_time_mlp_in_weight",
+    "action_time_mlp_out_weight",
+    # qwenvl singletons
+    "vlm_embed_tokens_weight",       # NOT a GEMM weight, skip transpose
+    "vit_patch_embed_proj_weight",   # Conv3d, skip
+    "vit_merger_mlp_0_weight",
+    "vit_merger_mlp_2_weight",
+]
+_TRANSPOSED_LIST_NAMES = [
+    "vlm_layer_q_proj_weights",
+    "vlm_layer_k_proj_weights",
+    "vlm_layer_v_proj_weights",
+    "vlm_layer_o_proj_weights",
+    "vlm_layer_mlp_gate_proj_weights",
+    "vlm_layer_mlp_up_proj_weights",
+    "vlm_layer_mlp_down_proj_weights",
+    "expert_layer_q_proj_weights",
+    "expert_layer_k_proj_weights",
+    "expert_layer_v_proj_weights",
+    "expert_layer_o_proj_weights",
+    "expert_layer_mlp_gate_proj_weights",
+    "expert_layer_mlp_up_proj_weights",
+    "expert_layer_mlp_down_proj_weights",
+    # Expert AdaRMSNorm gamma/beta linears
+    "expert_layer_input_layernorm_gamma_weights",
+    "expert_layer_input_layernorm_beta_weights",
+    "expert_layer_post_attn_layernorm_gamma_weights",
+    "expert_layer_post_attn_layernorm_beta_weights",
+    # ViT block weights
+    "vit_block_attn_qkv_weights",
+    "vit_block_attn_proj_weights",
+    "vit_block_mlp_gate_proj_weights",
+    "vit_block_mlp_up_proj_weights",
+    "vit_block_mlp_down_proj_weights",
+]
+
+
+def preload_transposed_weights(target) -> None:
+    """Add ``<name>_T`` attributes to target with pre-transposed weights
+    for every GEMM-feeding tensor. Call once after ``bind_target_to_device``.
+
+    The original ``<name>`` attributes are kept (still useful for
+    pure-eager paths). Memory cost: +8.4 GB transient (one extra copy of
+    every weight). Acceptable on Thor 24 GB GPU.
+
+    NOTE: This is the simple "double-store" version. A future
+    optimization would replace the original tensor in-place via
+    ``data.set_(...)`` so we don't pay 2× the memory.
+    """
+    skip_singletons = {
+        "vlm_embed_tokens_weight",       # embedding table — no transpose
+        "vit_patch_embed_proj_weight",   # Conv3d weight [1280, 3, 2, 14, 14]
+    }
+    for name in _TRANSPOSED_ATTR_NAMES:
+        if name in skip_singletons:
+            continue
+        if not hasattr(target, name):
+            continue
+        w = getattr(target, name)
+        setattr(target, name + "_T", w.T.contiguous())
+
+    for name in _TRANSPOSED_LIST_NAMES:
+        if not hasattr(target, name):
+            continue
+        original = getattr(target, name)
+        setattr(target, name + "_T", [w.T.contiguous() for w in original])
+
+
+# ════════════════════════════════════════════════════════════════════
+#  FP8 GEMM (linear_fp8)
+# ════════════════════════════════════════════════════════════════════
+#
+# Two-step quantize-then-FP8-GEMM with bf16 input + bf16 output. The
+# weight is FP8 E4M3 (quantized once at first call and cached by id);
+# the activation is quantized dynamically per call via
+# ``quantize_fp8_device`` (computes absmax + scale + quant in one
+# device pass). Output flows back to bf16 via the descale parameters.
+#
+# Per-call work (sized M×K input, M×N output):
+#   1. ``quantize_fp8_device`` (bf16 → fp8)                 — 1 read + 1 write of input
+#   2. ``fp8_gemm_descale_bf16out`` (fp8 GEMM, bf16 out)    — ~2× faster than bf16 GEMM
+#   3. ``add_bias_bf16`` (if bias)                          — 1 read + 1 write of output
+#
+# Constants:
+#   FP8 E4M3 max = 448 → scale = absmax / 448
+#   weight_scale × act_scale = descale (multiplied into GEMM accumulator)
+
+import threading
+
+# Cache: weight_id -> (w_fp8 [K, N] tensor, w_descale [1] fp32 device tensor).
+_W_FP8_CACHE: dict[int, tuple] = {}
+_W_FP8_LOCK = threading.Lock()
+
+
+def _quantize_weight_fp8(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """One-time weight quantization. Pre-transposes for cuBLASLt nn layout.
+
+    Returns (w_fp8 [K_in, N_out] contiguous, w_descale [1] fp32 device).
+    """
+    # PyTorch-side quantization (one-time, off the hot path).
+    w_fp32 = w_bf16.float()
+    max_abs = w_fp32.abs().max().clamp(min=1e-12).item()
+    w_scale = max_abs / 448.0
+    # w_fp8 = clip(w / w_scale, [-448, 448]) cast to FP8 E4M3.
+    w_div = (w_fp32 / w_scale).clamp(-448.0, 448.0)
+    w_fp8 = w_div.to(torch.float8_e4m3fn)
+    # Pre-transpose to [K, N] for the cuBLASLt nn-layout FP8 GEMM.
+    w_fp8_T = w_fp8.T.contiguous()
+    w_descale = torch.tensor([w_scale], dtype=torch.float32, device=w_bf16.device)
+    return w_fp8_T, w_descale
+
+
+def _get_or_quantize_fp8_weight(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Returns (w_fp8_T, w_descale). Holds a strong reference to the
+    source bf16 weight in the cache to prevent its underlying storage
+    from being recycled by the PyTorch caching allocator (which would
+    otherwise let a new tensor occupy the same data_ptr → cache key
+    collision → wrong FP8 weight returned).
+    """
+    key = w_bf16.data_ptr()
+    with _W_FP8_LOCK:
+        cached = _W_FP8_CACHE.get(key)
+        if cached is not None:
+            # Cache entry survives as long as source bf16 lives (we hold
+            # the ref). If the source got swapped (impossible since we
+            # held ref), the storage check would catch it.
+            w_fp8_T, w_descale, _src = cached
+            return w_fp8_T, w_descale
+        w_fp8_T, w_descale = _quantize_weight_fp8(w_bf16)
+        _W_FP8_CACHE[key] = (w_fp8_T, w_descale, w_bf16)
+    return w_fp8_T, w_descale
+
+
+def clear_fp8_weight_cache() -> None:
+    """Drop the cached FP8 weights (frees VRAM, forces re-quantization)."""
+    with _W_FP8_LOCK:
+        _W_FP8_CACHE.clear()
+
+
+# cuBLASLt FP8 heuristic on Thor SM110 requires M ≥ 64. Below this,
+# we have two regimes:
+#   * M in [_FP8_PAD_MIN_M, _FP8_MIN_M): pad to _FP8_MIN_M then slice
+#     output. The pad alloc costs ~5 μs inside a graph mempool (was
+#     ~50 μs with vanilla torch.zeros before ); the FP8 GEMM at
+#     M=64 still beats bf16 at M=51 on the Expert hot path. ~10 μs
+#     net savings per call × 252 Expert sites × 10 denoise steps
+#     ≈ 25 ms / inference.
+#   * M below _FP8_PAD_MIN_M: stay on the bf16 path (the FiLM γ/β
+#     projections have M=1 and aren't worth padding).
+_FP8_MIN_M = 64
+_FP8_PAD_MIN_M = 32        # pad-and-FP8 floor (M=51 Expert qualifies)
+# Also: N < FP8_MIN_N triggers the same heuristic issue (e.g.,
+# action_out_proj N=75). Fall back unconditionally for tiny outputs.
+_FP8_MIN_N = 128
+
+
+def linear_fp8(
+    x: torch.Tensor,                    # [..., K] bf16 or fp16
+    weight: torch.Tensor,               # [N, K] bf16 (HF layout — gets quantized + cached)
+    bias: torch.Tensor | None = None,   # [N] bf16
+    *,
+    stream: int | None = None,
+    site_id: "str | None" = None,
+    out_dtype: torch.dtype | None = None,  # decouple output dtype from x.dtype
+) -> torch.Tensor:
+    """Drop-in for ``F.linear`` / ``linear_bf16`` using FP8 GEMM where
+    profitable, otherwise falls back to bf16 GEMM.
+
+    Auto-falls-back to ``linear_bf16`` when M < ``_FP8_MIN_M`` or
+    N < ``_FP8_MIN_N`` — the cuBLASLt FP8 heuristic returns FAILED on
+    those tile geometries on Thor SM110, producing garbage output. The
+    fallback is silent: the test contract (cos ≥ 0.999) holds either way.
+
+    Per-FP8-call: quantize x bf16→fp8 (device absmax or pre-loaded
+    static scale), call FP8 GEMM with bf16 output, then add bias
+    separately if provided.
+
+    Weight is FP8-quantized ONCE per ``id(weight)`` and cached. First
+    call on a new weight pays ~10ms for quant; subsequent calls only
+    pay the activation quant + GEMM.
+
+    ``site_id``: stable per-call name like ``"vlm.layer.12.q_proj"``.
+    When given:
+      * during ``calibration_recorder``: records ``max(abs(x))`` into the
+        running stats so the JSON dump covers this site.
+      * with ``set_static_scales(scales)`` active: looks up the static
+        ``act_scale`` from the registry and uses ``quantize_fp8_static``
+        (skips the per-call device absmax-reduce).
+    ``site_id=None`` keeps the old dynamic behavior (legacy callers).
+    """
+    assert x.dtype in (torch.bfloat16, torch.float16), (
+        f"x dtype {x.dtype}, expected bf16 or fp16")
+    # x.dtype may differ from weight.dtype (e.g. fp16 attn output feeding a
+    # bf16 o_proj weight). The FP8 GEMM quantizes both to fp8 so the input dtype
+    # only selects the quant kernel; out_dtype controls the GEMM output. The
+    # bf16 fallback (below) still needs matching dtype — handled there.
+    od = out_dtype if out_dtype is not None else x.dtype
+    K_in = x.shape[-1]
+    N_out = weight.shape[0]
+    assert weight.shape == (N_out, K_in)
+    if stream is None:
+        stream = _current_stream()
+
+    # hook: record activation max for THIS site (always, even when
+    # the bf16 fallback would be taken — so the JSON covers everything).
+    # No-op outside a calibration_recorder context.
+    if site_id is not None:
+        from flash_rt.models.lingbot import calibration as _calib
+        if _calib.is_calibrating():
+            _calib.record_max_abs(site_id, x)
+
+    # math.prod for capture-safety (torch.tensor + .item() crosses
+    # to host which is not permitted during CUDA-Graph capture).
+    M = 1
+    for d in x.shape[:-1]:
+        M *= d
+
+    # bf16 fallback when N/K can't hit the FP8 heuristic. cuBLAS needs matching
+    # dtype, so cast x to the weight dtype here (rare path).
+    if N_out < _FP8_MIN_N or K_in < _FP8_MIN_N:
+        xb = x if x.dtype == weight.dtype else x.to(weight.dtype)
+        return linear_bf16(xb, weight, bias, stream=stream)
+
+    # pad-and-FP8 path applies only when M ∈ [_FP8_PAD_MIN_M,
+    # _FP8_MIN_M) AND a static activation scale is loaded for this
+    # site_id. The dynamic absmax-reduce reads the entire padded
+    # buffer including pad rows — their uninitialized values
+    # pollute the scale and produce wrong output. Static scale
+    # bypasses the absmax entirely, so pad rows are harmless.
+    enable_pad = False
+    if site_id is not None and _FP8_PAD_MIN_M <= M < _FP8_MIN_M:
+        from flash_rt.models.lingbot import calibration as _calib
+        if _calib.get_static_scale(site_id) is not None:
+            enable_pad = True
+
+    if M < _FP8_MIN_M and not enable_pad:
+        xb = x if x.dtype == weight.dtype else x.to(weight.dtype)
+        return linear_bf16(xb, weight, bias, stream=stream)
+
+    if enable_pad:
+        pad_to = _FP8_MIN_M
+        x_2d_raw = x.contiguous().view(M, K_in)
+        x_2d = torch.empty(pad_to, K_in, dtype=x.dtype, device=x.device)
+        x_2d[:M].copy_(x_2d_raw)
+        # Pad rows [M:pad_to] left uninitialized — safe because the
+        # static quantize_fp8_static reads a precomputed scale (no
+        # absmax-reduce over the padded region) and the corresponding
+        # FP8 GEMM output rows are sliced off below.
+        out_padded = torch.empty(
+            pad_to, N_out, dtype=od, device=x.device)
+        out_2d = out_padded
+        slice_back = True
+    else:
+        pad_to = M
+        x_2d = x.contiguous().view(M, K_in)
+        out = torch.empty(
+            (*x.shape[:-1], N_out), dtype=od, device=x.device)
+        out_2d = out.view(M, N_out)
+        slice_back = False
+
+    # 1. Get cached FP8 weight + descale.
+    w_fp8_T, w_descale = _get_or_quantize_fp8_weight(weight)
+
+    # 2. Look up static activation scale. When present, reuse it
+    # in place of a per-call allocation — kernel reads it as input.
+    static_scale = None
+    if site_id is not None:
+        from flash_rt.models.lingbot import calibration as _calib
+        static_scale = _calib.get_static_scale(site_id)
+
+    # 3. Allocate per-call FP8 input. Allocate act-scale buffer only
+    # when we don't have a static scale.
+    x_fp8 = torch.empty(pad_to, K_in, dtype=torch.float8_e4m3fn, device=x.device)
+    if static_scale is None:
+        act_scale = torch.empty(1, dtype=torch.float32, device=x.device)
+    else:
+        act_scale = static_scale  # process-lifetime tensor from load_calibration
+
+    # 4. Quantize x to FP8. Dispatch by dtype: bf16 → quantize_fp8_*,
+    # fp16 → quantize_fp8_*_fp16. Static path reads scale; dynamic
+    # writes it (device absmax+scale+quantize in one fused pass).
+    if static_scale is None:
+        _quantize_fp8_device(
+            int(x_2d.data_ptr()), int(x_fp8.data_ptr()),
+            int(act_scale.data_ptr()), pad_to * K_in, x.dtype, stream)
+    else:
+        _quantize_fp8_static(
+            int(x_2d.data_ptr()), int(x_fp8.data_ptr()),
+            int(act_scale.data_ptr()), pad_to * K_in, x.dtype, stream)
+
+    # 5. FP8 GEMM with bf16/fp16 output and device-side descale. The quant
+    # above used x.dtype (input); the GEMM output uses ``od``.
+    _fp8_gemm_descale(
+        int(x_fp8.data_ptr()), int(w_fp8_T.data_ptr()),
+        int(out_2d.data_ptr()),
+        pad_to, N_out, K_in,
+        int(act_scale.data_ptr()), int(w_descale.data_ptr()),
+        od, stream)
+
+    # 6. Bias if any. Apply over ``pad_to`` rows; the unused tail is sliced
+    # off in the next step.
+    if bias is not None:
+        _add_bias(
+            int(out_2d.data_ptr()),
+            int(bias.contiguous().data_ptr()),
+            pad_to, N_out, od, stream)
+
+    # 7. : slice the pad rows off and reshape to the caller's
+    # leading dims. ``out_padded[:M]`` is contiguous (stride=[N,1],
+    # offset=0) so ``.view`` succeeds; the returned tensor references
+    # the same mempool storage as ``out_padded``. Caller treats it
+    # read-only (next op is a downstream GEMM input).
+    if slice_back:
+        return out_padded[:M].view(*x.shape[:-1], N_out)
+    return out
+
+
+# ════════════════════════════════════════════════════════════════════
+# — Fused MHA attention via fvk.attention_mha_bf16
+# ════════════════════════════════════════════════════════════════════
+#
+# Replaces the 4-einsum-plus-softmax eager attention in mixed_attention
+# with a single cuBLAS-decomposed call. Same kernel Pi0.5 / GROOT use
+# (Pi0.5: ``attention_qkv_fp16``; we use the bf16 variant to avoid an
+# fp16↔bf16 conversion).
+#
+# Layout contract (matches Pi0.5 pipeline_thor.py:134):
+#     Q  : [S_q,  NH, HD]   bf16, contiguous
+#     K  : [S_kv, NH, HD]   bf16, contiguous   (GQA expanded by caller)
+#     V  : same as K
+#     out: [S_q,  NH, HD]   bf16, written
+#     logits scratch: [S_q, NH, S_kv] bf16 — caller-owned
+#
+# The kernel does NOT take an attention mask; it computes
+# ``softmax(QK^T / sqrt(HD)) @ V`` unmasked. For LingBot:
+#   * Prefix encode (vlm_causal=False) is unmasked → drop-in.
+#   * Denoise suffix mask: state-token-block + full-rest. Cos delta
+#     measured below; we keep this kernel unmasked and accept the
+#     small precision drift (state token attending to actions too,
+#     which doesn't change the ODE flow direction).
+
+
+def silu_mul_to_fp8_fp16_fused(
+    gate: torch.Tensor,                 # [..., H] fp16
+    up: torch.Tensor,                   # [..., H] fp16, same shape
+    down_act_scale: torch.Tensor,       # [1] fp32 — pre-loaded static scale for down_proj
+    *,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """(fp16-only): fuses ``silu(gate) * up`` and FP8 quant into ONE
+    launch via ``fvk.silu_mul_split_fp8_fp16``. Returns the FP8 tensor
+    ready to feed into ``linear_fp8_from_fp8`` for the down-proj.
+
+    Replaces three eager ops (silu, mul, quantize) with one fused
+    kernel. Available ONLY in fp16 mode — the kernel has no bf16 sibling
+    in the installed wheel.
+    """
+    assert gate.dtype == torch.float16, f"gate dtype {gate.dtype}, need fp16"
+    assert up.dtype == torch.float16
+    assert gate.shape == up.shape
+    assert down_act_scale.dtype == torch.float32 and down_act_scale.numel() == 1
+    if stream is None:
+        stream = _current_stream()
+
+    n = gate.numel()
+    out_fp8 = torch.empty(
+        gate.shape, dtype=torch.float8_e4m3fn, device=gate.device)
+    fvk.silu_mul_split_fp8_fp16(
+        int(gate.contiguous().data_ptr()),
+        int(up.contiguous().data_ptr()),
+        int(out_fp8.data_ptr()),
+        n, int(down_act_scale.data_ptr()), stream,
+    )
+    return out_fp8
+
+
+def attention_mha_bf16_fused(
+    Q: torch.Tensor,                   # [B, S_q, NH, HD] bf16
+    K: torch.Tensor,                   # [B, S_kv, NH, HD] bf16, post-GQA-expansion
+    V: torch.Tensor,                   # [B, S_kv, NH, HD] bf16
+    *,
+    attn_scale: float | None = None,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """Wrapper around ``fvk.attention_mha_bf16`` returning a tensor
+    shaped ``[B, S_q, NH*HD]`` (matches eager attention's output).
+
+    Assumes ``B==1`` (the LingBot baseline). For larger B the pointer
+    math would need adjustment.
+    """
+    assert Q.dtype in (torch.bfloat16, torch.float16)
+    assert K.dtype == Q.dtype and V.dtype == Q.dtype, (
+        f"K/V dtype mismatch: Q={Q.dtype}, K={K.dtype}, V={V.dtype}")
+    B, S_q, NH, HD = Q.shape
+    S_kv = K.shape[1]
+    assert K.shape == (B, S_kv, NH, HD) and V.shape == (B, S_kv, NH, HD), (
+        f"K/V shape mismatch: K={K.shape}, V={V.shape}, expected (B, S_kv, NH, HD)")
+    assert B == 1, f"attention_mha wrapper currently assumes B=1, got {B}"
+    if attn_scale is None:
+        attn_scale = HD ** -0.5
+    if stream is None:
+        stream = _current_stream()
+
+    Q_c = Q.contiguous()
+    K_c = K.contiguous()
+    V_c = V.contiguous()
+
+    out = torch.empty(S_q, NH, HD, dtype=Q.dtype, device=Q.device)
+    logits = torch.empty(S_q, NH, S_kv, dtype=Q.dtype, device=Q.device)
+
+    ctx = get_fvk_context()
+    if Q.dtype == torch.bfloat16:
+        fvk.attention_mha_bf16(
+            ctx,
+            int(Q_c.data_ptr()), int(K_c.data_ptr()), int(V_c.data_ptr()),
+            int(logits.data_ptr()), int(out.data_ptr()),
+            S_q, S_kv, NH, HD,
+            float(attn_scale), 0, stream)
+    else:  # fp16
+        # attention_mha_fp16 signature differs slightly — no
+        # logits_kv_stride parameter (fp16 variant predates that).
+        fvk.attention_mha_fp16(
+            ctx,
+            int(Q_c.data_ptr()), int(K_c.data_ptr()), int(V_c.data_ptr()),
+            int(logits.data_ptr()), int(out.data_ptr()),
+            S_q, S_kv, NH, HD,
+            float(attn_scale), stream)
+    return out.view(B, S_q, NH * HD)
+
+
+# ════════════════════════════════════════════════════════════════════
+# — GQA-native fp16 CUTLASS FMHA (fmha_strided_full, sm_110a)
+# ════════════════════════════════════════════════════════════════════
+#
+# The strided CUTLASS Sm100 FMHA ships in ``libfmha_fp16_strided.so``,
+# confirmed sm_110a-built (cuobjdump). Micro-bench at LingBot's denoise
+# shape (Sq=51, Skv≈891, NHQ=16, NHKV=2, HD=128) under CUDA-Graph replay:
+# bf16 cuBLAS attention_mha 88us → fp16 fmha 47us (kernel) / 65us
+# (with bf16↔fp16 casts). It is GQA-native (takes NHKV directly) so it
+# also SKIPS the 8× KV head-expand the cuBLAS path needs. cos vs eager
+# fp32 reference = 1.0000 at this shape (fp16 has more mantissa than bf16).
+
+_FMHA_STRIDED_LOADED = None
+
+
+def _ensure_fmha_strided() -> bool:
+    """Load libfmha_fp16_strided.so once. Returns True if available."""
+    global _FMHA_STRIDED_LOADED
+    if _FMHA_STRIDED_LOADED is None:
+        import pathlib
+        so = pathlib.Path(fvk.__file__).parent / "libfmha_fp16_strided.so"
+        try:
+            if so.exists():
+                fvk.load_fmha_strided_library(str(so))
+                _FMHA_STRIDED_LOADED = True
+            else:
+                _FMHA_STRIDED_LOADED = False
+        except Exception:
+            _FMHA_STRIDED_LOADED = False
+    return _FMHA_STRIDED_LOADED
+
+
+def attention_fmha_strided_fused(
+    Q: torch.Tensor,            # [B, S_q, NHQ, HD]  bf16, NOT GQA-expanded
+    K: torch.Tensor,            # [B, S_kv, NHKV, HD] bf16
+    V: torch.Tensor,            # [B, S_kv, NHKV, HD] bf16
+    *,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """Unmasked GQA-native FMHA via ``fvk.fmha_strided_full`` (fp16).
+
+    Casts Q/K/V bf16→fp16, runs the strided CUTLASS FMHA (scale 1/sqrt(HD)
+    baked in), and returns a bf16 ``[B, S_q, NHQ*HD]`` tensor matching
+    ``attention_mha_bf16_fused``'s output layout. K/V are passed with their
+    native NHKV heads (no replication).
+    """
+    B, S_q, NHQ, HD = Q.shape
+    S_kv = K.shape[1]
+    assert B == 1, f"fmha_strided wrapper assumes B=1, got {B}"
+    assert HD == head_dim and NHQ == num_q_heads
+    assert K.shape == (B, S_kv, num_kv_heads, HD)
+    if stream is None:
+        stream = _current_stream()
+
+    Qf = Q.to(torch.float16).contiguous()
+    Kf = K.to(torch.float16).contiguous()
+    Vf = V.to(torch.float16).contiguous()
+    out = torch.empty(B, S_q, NHQ, HD, dtype=torch.float16, device=Q.device)
+
+    fvk.fmha_strided_full(
+        int(Qf.data_ptr()), int(Kf.data_ptr()), int(Vf.data_ptr()),
+        int(out.data_ptr()),
+        B, S_q, S_kv, num_q_heads, num_kv_heads, HD,
+        num_q_heads * HD, num_kv_heads * HD, stream)
+    return out.to(torch.bfloat16).view(B, S_q, NHQ * HD)
+
+
+# ════════════════════════════════════════════════════════════════════
+#  FA4 (FlashAttention-4, CuTe-DSL) denoise attention — Thor sm_101a
+# ════════════════════════════════════════════════════════════════════
+#
+# FA4 (FlashAttention-4, CuTe-DSL) is the optional Thor fast path for the
+# denoise + prefix attention (~17% over fmha, cos=1.0, CUDA-graph safe). The
+# import is fully isolated in flash_rt.hardware.thor.fa4_backend — it loads the
+# trimmed, privately-named `flashrt_fa4` vendor (no global `flash_attn`
+# pollution) and returns None when the `thor-fa4` deps are missing so the
+# caller falls back to fmha. These thin wrappers preserve the existing
+# kernel_ops call sites.
+def _get_fa4():
+    """The FA4 ``flash_attn_func`` (forward), or None → caller uses fmha."""
+    from flash_rt.hardware.thor import fa4_backend
+    return fa4_backend.fa4_func()
+
+
+def _get_fa4_fwd():
+    """FA4's internal ``_flash_attn_fwd`` (exposes ``seqused_k`` so the prefix
+    attention can skip the contiguous lang-pad keys EXACTLY, which the dense
+    ``flash_attn_func`` wrapper can't express), or None → caller uses fmha."""
+    from flash_rt.hardware.thor import fa4_backend
+    return fa4_backend.fa4_fwd()
+
+
+def attention_fa4_fused(
+    Q: torch.Tensor,            # [B, S_q, NHQ, HD] fp16/bf16, GQA-native
+    K: torch.Tensor,            # [B, S_kv, NHKV, HD]
+    V: torch.Tensor,
+    *,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    seqused_k: torch.Tensor | None = None,   # [B] int32 valid KV length
+    stream: int | None = None,
+) -> "torch.Tensor | None":
+    """FA4 GQA attention (pack_gqa). Returns [B, S_q, NHQ*HD] in the FA4 output
+    dtype (fp16 — the attention island), or None if FA4 is unavailable so the
+    caller can fall back to fmha. : NO bf16 cast here — the o_proj quantizes
+    the fp16 directly (linear_fp8 with out_dtype=bf16), removing ~900 casts.
+
+    : when ``seqused_k`` is given, only the first ``seqused_k`` KV rows are
+    attended (the rest are pad, contiguous at the end) — EXACT, via the internal
+    ``_flash_attn_fwd``. Falls back to the dense path if that entry is missing."""
+    B, S_q = Q.shape[0], Q.shape[1]
+    qf = Q if Q.dtype == torch.float16 else Q.to(torch.float16)
+    kf = K if K.dtype == torch.float16 else K.to(torch.float16)
+    vf = V if V.dtype == torch.float16 else V.to(torch.float16)
+    if seqused_k is not None:
+        fwd = _get_fa4_fwd()
+        if fwd is not None:
+            o = fwd(qf.contiguous(), kf.contiguous(), vf.contiguous(),
+                    causal=False, pack_gqa=True, seqused_k=seqused_k)
+            if isinstance(o, tuple):
+                o = o[0]
+            return o.reshape(B, S_q, num_q_heads * head_dim)
+    fa4 = _get_fa4()
+    if fa4 is None:
+        return None
+    o = fa4(qf.contiguous(), kf.contiguous(), vf.contiguous(),
+            causal=False, pack_gqa=True)
+    if isinstance(o, tuple):
+        o = o[0]
+    return o.reshape(B, S_q, num_q_heads * head_dim)
+
+
+# ════════════════════════════════════════════════════════════════════
+# — LingBot custom fused AdaRMS + residual + FP8 quant (csrc)
+# ════════════════════════════════════════════════════════════════════
+#
+# A custom CUDA kernel that fuses, in one pass per token,
+#   y          = residual + x
+#   y_norm     = rms_weight * (y / sqrt(mean(y^2) + eps))
+#   y_film     = (1 + γ) * y_norm + β     (per-sample γ, β)
+#   y_fp8      = static-scale FP8 quantize
+# and writes ``residual`` back to ``residual + x`` in place (so the
+# caller has the bf16 sum available for the SECOND residual that
+# follows the MLP).
+#
+# Replaces what eager LingBot does as 6-9 separate launches:
+#   residual + x → afr            (torch op)
+#   rms_norm(afr) (5 internal ops: pow, mean, rsqrt, mul, cast)
+#   (1+γ)*norm + β                (2 torch ops)
+#   quantize_fp8_static(...)      (1 launch)
+#
+# Per Expert layer this kernel fires 2× (input_ln + post_attn_ln). At
+# 36 layers × N denoise steps it dominates the per-step graph cost
+# after . Estimated bandwidth savings: residual+x written once
+# (one DRAM write) vs old path that read it multiple times.
+
+
+_LINGBOT_EXT = None
+
+
+def _get_lingbot_ext():
+    """Lazy-load the JIT-compiled LingBot CUDA extension."""
+    global _LINGBOT_EXT
+    if _LINGBOT_EXT is None:
+        from flash_rt.models.lingbot._csrc_loader import get_lingbot_ext
+        _LINGBOT_EXT = get_lingbot_ext()
+    return _LINGBOT_EXT
+
+
+def rope_inplace_bf16_fused(
+    x: torch.Tensor,                 # [B, S, NH, HD] bf16 — mutated in place
+    cos_table: torch.Tensor,         # [B, S, HD/2] fp32
+    sin_table: torch.Tensor,         # [B, S, HD/2] fp32
+    *,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """: in-place split-half RoPE in bf16 with fp32 internal accumulate.
+
+    Replaces ``apply_rope_with_tables(x.to(fp32), cos, sin).to(bf16)``
+    (3 launches: cast + apply + cast back) with one fused kernel pass.
+    Mutates ``x`` in place; returns the same tensor for chaining.
+
+    Used by both prefix_encode_layer and denoise_step_layer once cos/sin
+    have been hoisted out of the layer loop .
+    """
+    assert x.dtype == torch.bfloat16, f"x dtype {x.dtype}"
+    assert cos_table.dtype == torch.float32
+    assert sin_table.dtype == torch.float32
+    B, S, NH, HD = x.shape
+    if stream is None:
+        stream = _current_stream()
+    ext = _get_lingbot_ext()
+    ext.rope_inplace_bf16(
+        int(x.contiguous().data_ptr()),
+        int(cos_table.contiguous().data_ptr()),
+        int(sin_table.contiguous().data_ptr()),
+        B, S, NH, HD, stream,
+    )
+    return x
+
+
+def rope_to_out_bf16_fused(
+    x: torch.Tensor,                 # [B, S, NH, HD] bf16 (read-only)
+    cos_table: torch.Tensor,         # [B, S, HD/2] fp32
+    sin_table: torch.Tensor,         # [B, S, HD/2] fp32
+    *,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """out-of-place split-half RoPE in bf16, fp32 internal accumulate.
+
+    Replaces ``apply_rope_with_tables(x.to(fp32), cos, sin).to(bf16)``
+    (cast + rotate-half + cast back, ~5 elementwise launches) with one
+    fused kernel that reads ``x`` and writes a fresh output buffer — no
+    in-place hazard, so it's CUDA-Graph-replay deterministic (unlike the
+    in-place variant). Returns the new [B, S, NH, HD] bf16 tensor.
+    """
+    assert x.dtype == torch.bfloat16, f"x dtype {x.dtype}"
+    assert cos_table.dtype == torch.float32
+    assert sin_table.dtype == torch.float32
+    B, S, NH, HD = x.shape
+    if stream is None:
+        stream = _current_stream()
+    xc = x.contiguous()
+    out = torch.empty_like(xc)
+    ext = _get_lingbot_ext()
+    ext.rope_to_out_bf16(
+        int(xc.data_ptr()), int(out.data_ptr()),
+        int(cos_table.contiguous().data_ptr()),
+        int(sin_table.contiguous().data_ptr()),
+        B, S, NH, HD, stream,
+    )
+    return out
+
+
+def qkv_bias_rope_fused(
+    q_raw: torch.Tensor,             # [M, NHQ*HD] bf16 (bias-free GEMM out)
+    k_raw: torch.Tensor,             # [M, NHKV*HD] bf16
+    v_raw: torch.Tensor,             # [M, NHKV*HD] bf16
+    q_bias, k_bias, v_bias,          # [NHx*HD] bf16 or None
+    cos_table: torch.Tensor,         # [M, HD/2] fp32
+    sin_table: torch.Tensor,         # [M, HD/2] fp32
+    *,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    out_dtype: torch.dtype = torch.bfloat16,
+    stream: int | None = None,
+) -> "tuple[torch.Tensor, torch.Tensor, torch.Tensor]":
+    """: one kernel for q/k/v bias-add + RoPE (q/k roped, v bias-only).
+    Replaces 3 add_bias + 2 rope launches per Expert layer. Returns
+    (q [M,NHQ*HD], k [M,NHKV*HD], v [M,NHKV*HD]) in ``out_dtype``.
+
+    ``out_dtype=torch.float16`` feeds the fp16 attention island so the
+    fmha wrapper consumes q/k/v with no bf16→fp16 cast launches."""
+    M = q_raw.shape[0]
+    if stream is None:
+        stream = _current_stream()
+    q_out = torch.empty(q_raw.shape, dtype=out_dtype, device=q_raw.device)
+    k_out = torch.empty(k_raw.shape, dtype=out_dtype, device=k_raw.device)
+    v_out = torch.empty(v_raw.shape, dtype=out_dtype, device=v_raw.device)
+
+    def _p(t):
+        return int(t.contiguous().data_ptr()) if t is not None else 0
+
+    ext = _get_lingbot_ext()
+    fn = ext.qkv_bias_rope_fp16out if out_dtype == torch.float16 \
+        else ext.qkv_bias_rope_bf16
+    fn(
+        int(q_raw.contiguous().data_ptr()),
+        int(k_raw.contiguous().data_ptr()),
+        int(v_raw.contiguous().data_ptr()),
+        _p(q_bias), _p(k_bias), _p(v_bias),
+        int(cos_table.contiguous().data_ptr()),
+        int(sin_table.contiguous().data_ptr()),
+        int(q_out.data_ptr()), int(k_out.data_ptr()), int(v_out.data_ptr()),
+        M, num_q_heads, num_kv_heads, head_dim, stream,
+    )
+    return q_out, k_out, v_out
+
+
+def qkv_bias_rope_merged_fused(
+    qkv: torch.Tensor,               # [M, NHQ*HD + 2*NHKV*HD] bf16 (merged GEMM out)
+    q_bias, k_bias, v_bias,          # [NHx*HD] bf16 or None
+    cos_table: torch.Tensor,         # [M, HD/2] fp32
+    sin_table: torch.Tensor,         # [M, HD/2] fp32
+    *,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    out_dtype: torch.dtype = torch.bfloat16,
+    k_out: torch.Tensor | None = None,   # write k/v into these (e.g. the KV
+    v_out: torch.Tensor | None = None,   # cache suffix) directly — no copy after.
+    stream: int | None = None,
+) -> "tuple[torch.Tensor, torch.Tensor, torch.Tensor]":
+    """: merged-input variant of :func:`qkv_bias_rope_fused`. Reads q/k/v
+    from column offsets of one merged ``[M, ROWQKV]`` GEMM output (no split
+    copy); writes 3 separate outputs. Pairs with a merged qkv GEMM.
+
+    : if ``k_out``/``v_out`` are given (e.g. views into the preallocated KV
+    cache suffix), the kernel writes k/v there directly — the denoise step then
+    skips the per-layer ``kbuf[:,Lp:].copy_(k_new)`` memcpy."""
+    M = qkv.shape[0]
+    if stream is None:
+        stream = _current_stream()
+    q_out = torch.empty(M, num_q_heads * head_dim, dtype=out_dtype, device=qkv.device)
+    if k_out is None:
+        k_out = torch.empty(M, num_kv_heads * head_dim, dtype=out_dtype, device=qkv.device)
+    if v_out is None:
+        v_out = torch.empty(M, num_kv_heads * head_dim, dtype=out_dtype, device=qkv.device)
+
+    def _p(t):
+        return int(t.contiguous().data_ptr()) if t is not None else 0
+
+    ext = _get_lingbot_ext()
+    fn = ext.qkv_bias_rope_merged_fp16out if out_dtype == torch.float16 \
+        else ext.qkv_bias_rope_merged_bf16
+    fn(
+        int(qkv.contiguous().data_ptr()),
+        _p(q_bias), _p(k_bias), _p(v_bias),
+        int(cos_table.contiguous().data_ptr()),
+        int(sin_table.contiguous().data_ptr()),
+        int(q_out.data_ptr()), int(k_out.data_ptr()), int(v_out.data_ptr()),
+        M, num_q_heads, num_kv_heads, head_dim, stream,
+    )
+    return q_out, k_out, v_out
+
+
+def vit_qkv_bias_rope_fused(
+    qkv: torch.Tensor,               # [M, 3*NH*HD] bf16 (bias-free GEMM out)
+    qkv_bias,                        # [3*NH*HD] bf16 or None
+    cos_table: torch.Tensor,         # [M, HD] fp32 (first HD/2 cols used)
+    sin_table: torch.Tensor,         # [M, HD] fp32
+    *,
+    num_heads: int,
+    head_dim: int,
+    stream: int | None = None,
+) -> "tuple[torch.Tensor, torch.Tensor, torch.Tensor]":
+    """P1 ViT: one kernel for the interleaved ViT qkv bias-add + 2-D M-RoPE.
+    Replaces, per ViT block, the add_bias(qkv) launch + the eager fp32 RoPE
+    storm (cast/rotate_half/mul/add/cast). Returns (q, k, v) each
+    [M, NH*HD] bf16, ready to view as [num_views, view_len, NH, HD] for the
+    per-view fmha."""
+    M = qkv.shape[0]
+    if stream is None:
+        stream = _current_stream()
+    nk = num_heads * head_dim
+    q_out = torch.empty(M, nk, dtype=torch.bfloat16, device=qkv.device)
+    k_out = torch.empty(M, nk, dtype=torch.bfloat16, device=qkv.device)
+    v_out = torch.empty(M, nk, dtype=torch.bfloat16, device=qkv.device)
+    ext = _get_lingbot_ext()
+    ext.vit_qkv_bias_rope_bf16(
+        int(qkv.contiguous().data_ptr()),
+        int(qkv_bias.contiguous().data_ptr()) if qkv_bias is not None else 0,
+        int(cos_table.contiguous().data_ptr()),
+        int(sin_table.contiguous().data_ptr()),
+        int(q_out.data_ptr()), int(k_out.data_ptr()), int(v_out.data_ptr()),
+        M, num_heads, head_dim, stream,
+    )
+    return q_out, k_out, v_out
+
+
+def ada_rms_fp8_fused(
+    x: torch.Tensor,                       # [B, S, D] bf16 (read-only)
+    rms_weight: torch.Tensor,              # [D] bf16
+    gamma: torch.Tensor,                   # [B, D] bf16 — pre-computed FiLM γ
+    beta: torch.Tensor,                    # [B, D] bf16 — pre-computed FiLM β
+    *,
+    eps: float = 1e-6,
+    site_id: "str | None" = None,
+    pad_to: int | None = None,
+    stream: int | None = None,
+) -> "tuple[torch.Tensor, torch.Tensor] | None":
+    """: one-pass AdaRMSNorm + FP8 quant (NO residual). Same kernel
+    family as :func:`ada_rms_residual_fp8_fused` but for the
+    ``input_layernorm`` site where there is no residual upstream.
+
+    Returns ``(out_fp8 [B*S or B*pad_to, D], act_scale [1])`` or ``None``
+    when no static scale is available for ``site_id``. When ``pad_to``
+    is given (and > S), the FP8 output is M-padded to ``B*pad_to`` rows
+    (rows ``[S, pad_to)`` zeroed) so the downstream FP8 GEMM reads M=pad_to
+    directly and skips the per-call pad copy — the same buffer feeds all of
+    q/k/v. The static scale is unchanged (zero pad rows don't affect it).
+    """
+    assert x.dtype == torch.bfloat16
+    assert rms_weight.dtype == torch.bfloat16
+    assert gamma.dtype == torch.bfloat16 and beta.dtype == torch.bfloat16
+    B, S, D = x.shape
+    assert rms_weight.shape == (D,)
+    assert gamma.shape == (B, D) and beta.shape == (B, D)
+
+    if site_id is None:
+        return None
+    from flash_rt.models.lingbot import calibration as _calib
+    act_scale = _calib.get_static_scale(site_id)
+    if act_scale is None:
+        return None
+    if stream is None:
+        stream = _current_stream()
+
+    ext = _get_lingbot_ext()
+    if pad_to is not None and pad_to > S:
+        out_fp8 = torch.empty(
+            B * pad_to, D, dtype=torch.float8_e4m3fn, device=x.device)
+        ext.ada_rms_fp8_mpad_bf16(
+            int(x.contiguous().data_ptr()),
+            int(rms_weight.contiguous().data_ptr()),
+            int(gamma.contiguous().data_ptr()),
+            int(beta.contiguous().data_ptr()),
+            int(out_fp8.data_ptr()),
+            int(act_scale.data_ptr()),
+            B, S, pad_to, D, float(eps), stream,
+        )
+        return out_fp8, act_scale
+
+    out_fp8 = torch.empty(
+        B * S, D, dtype=torch.float8_e4m3fn, device=x.device)
+    ext.ada_rms_fp8_bf16(
+        int(x.contiguous().data_ptr()),
+        int(rms_weight.contiguous().data_ptr()),
+        int(gamma.contiguous().data_ptr()),
+        int(beta.contiguous().data_ptr()),
+        int(out_fp8.data_ptr()),
+        int(act_scale.data_ptr()),
+        B, S, D, float(eps), stream,
+    )
+    return out_fp8, act_scale
+
+
+def silu_mul_fp8_mpad_bf16_fused(
+    gate: torch.Tensor,                    # [M, I] bf16
+    up: torch.Tensor,                      # [M, I] bf16
+    down_act_scale: torch.Tensor,          # [1] fp32 — static down_proj scale
+    *,
+    pad_to: int = _FP8_MIN_M,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """Fused SwiGLU tail (bf16): ``silu(gate)*up`` + FP8 static-quant into a
+    pre-M-padded ``[pad_to, I]`` FP8 buffer (rows ``[M, pad_to)`` zeroed).
+
+    Replaces eager ``F.silu(gate)*up`` (2 elementwise launches) + a separate
+    ``quantize_fp8`` + the ``linear_fp8`` M-pad copy with ONE launch. The
+    returned buffer feeds ``linear_fp8_from_fp8`` at M=pad_to directly (no copy);
+    the caller slices the GEMM output back to M.
+    """
+    assert gate.dtype == torch.bfloat16 and up.dtype == torch.bfloat16
+    assert gate.shape == up.shape
+    M, I = gate.shape
+    assert M <= pad_to
+    if stream is None:
+        stream = _current_stream()
+    out_fp8 = torch.empty(pad_to, I, dtype=torch.float8_e4m3fn, device=gate.device)
+    ext = _get_lingbot_ext()
+    ext.silu_mul_fp8_mpad_bf16(
+        int(gate.contiguous().data_ptr()),
+        int(up.contiguous().data_ptr()),
+        int(out_fp8.data_ptr()),
+        int(down_act_scale.data_ptr()),
+        M, pad_to, I, stream,
+    )
+    return out_fp8
+
+
+def ada_rms_residual_fp16_mpad_fused(
+    residual: torch.Tensor,                # [B, S, D] bf16 — MUTATED to residual+x
+    x: torch.Tensor,                       # [B, S, D] bf16
+    rms_weight: torch.Tensor,              # [D] bf16
+    gamma: torch.Tensor,                   # [B, D] bf16
+    beta: torch.Tensor,                    # [B, D] bf16
+    *,
+    pad_to: int,
+    eps: float = 1e-6,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """: AdaRMSNorm+residual with fp16 output (M-padded to ``pad_to``), no FP8
+    quant. SIDE EFFECT: ``residual`` updated to residual+x. Returns ``[B*pad_to, D]``
+    fp16. Feeds the denoise FP4 gate_up quant directly (skips the fp8→fp16 dequant)."""
+    assert residual.dtype == torch.bfloat16 and x.dtype == torch.bfloat16
+    B, S, D = residual.shape
+    if stream is None:
+        stream = _current_stream()
+    out = torch.empty(B * pad_to, D, dtype=torch.float16, device=residual.device)
+    ext = _get_lingbot_ext()
+    ext.ada_rms_residual_fp16_mpad(
+        int(residual.contiguous().data_ptr()), int(x.contiguous().data_ptr()),
+        int(rms_weight.contiguous().data_ptr()),
+        int(gamma.contiguous().data_ptr()), int(beta.contiguous().data_ptr()),
+        int(out.data_ptr()), B, S, pad_to, D, float(eps), stream)
+    return out
+
+
+def silu_mul_merged_fp8_mpad_bf16_fused(
+    gu: torch.Tensor,                      # [M, 2*I] bf16 — merged gate|up GEMM output
+    down_act_scale: torch.Tensor,          # [1] fp32 — static down_proj scale
+    *,
+    pad_to: int = _FP8_MIN_M,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """Merged-input fused SwiGLU tail: gate/up interleaved per row in one
+    ``[M, 2*I]`` buffer (the output of a single merged gate_up GEMM). Computes
+    ``silu(gate)*up`` + FP8 static-quant into a pre-M-padded ``[pad_to, I]``
+    FP8 buffer. Pairs with the merged gate_up GEMM to cut a GEMM launch."""
+    assert gu.dtype == torch.bfloat16
+    M, twoI = gu.shape
+    assert twoI % 2 == 0
+    I = twoI // 2
+    assert M <= pad_to
+    if stream is None:
+        stream = _current_stream()
+    out_fp8 = torch.empty(pad_to, I, dtype=torch.float8_e4m3fn, device=gu.device)
+    ext = _get_lingbot_ext()
+    ext.silu_mul_merged_fp8_mpad_bf16(
+        int(gu.contiguous().data_ptr()), int(out_fp8.data_ptr()),
+        int(down_act_scale.data_ptr()), M, pad_to, I, stream)
+    return out_fp8
+
+
+def silu_mul_merged_fp8_mpad_fp16in_fused(
+    gu: torch.Tensor,                      # [M, 2*I] fp16 — merged gate|up FP4-GEMM out
+    down_act_scale: torch.Tensor,
+    *,
+    pad_to: int = _FP8_MIN_M,
+    stream: int | None = None,
+) -> torch.Tensor:
+    """: fp16-input variant of :func:`silu_mul_merged_fp8_mpad_bf16_fused` —
+    reads the merged gate_up straight from the FP4 GEMM's fp16 output (no bf16
+    cast)."""
+    assert gu.dtype == torch.float16
+    M, twoI = gu.shape
+    I = twoI // 2
+    assert M <= pad_to
+    if stream is None:
+        stream = _current_stream()
+    out_fp8 = torch.empty(pad_to, I, dtype=torch.float8_e4m3fn, device=gu.device)
+    ext = _get_lingbot_ext()
+    ext.silu_mul_merged_fp8_mpad_fp16in(
+        int(gu.contiguous().data_ptr()), int(out_fp8.data_ptr()),
+        int(down_act_scale.data_ptr()), M, pad_to, I, stream)
+    return out_fp8
+
+
+def ada_rms_residual_fp8_fused(
+    residual: torch.Tensor,                # [B, S, D] bf16 — MUTATED to residual+x
+    x: torch.Tensor,                       # [B, S, D] bf16
+    rms_weight: torch.Tensor,              # [D] bf16
+    gamma: torch.Tensor,                   # [B, D] bf16 — pre-computed FiLM γ
+    beta: torch.Tensor,                    # [B, D] bf16 — pre-computed FiLM β
+    *,
+    eps: float = 1e-6,
+    site_id: "str | None" = None,
+    pad_to: int | None = None,
+    stream: int | None = None,
+) -> "tuple[torch.Tensor, torch.Tensor] | None":
+    """One-pass fused AdaRMSNorm + residual + FP8 static-quant.
+
+    SIDE EFFECT: ``residual`` is updated to ``residual + x``.
+
+    Returns ``(out_fp8 [B*S or B*pad_to, D] fp8, act_scale [1] fp32)`` or
+    ``None`` when no static scale is available for ``site_id``. When
+    ``pad_to`` is given (and > S), the FP8 output is M-padded (rows
+    ``[S, pad_to)`` zeroed) so the gate/up GEMMs read M=pad_to directly
+    (no pad copy). ``residual`` stays ``[B, S, D]``. The static scale is
+    unchanged (zero pad rows don't affect it).
+
+    Currently bf16-only. The custom kernel uses fp32 internal accumulation
+    for the variance reduction; the output FP8 matches eager quantize
+    within FP8 noise (cos > 0.9999 in unit tests).
+    """
+    assert residual.dtype == torch.bfloat16
+    assert x.dtype == torch.bfloat16
+    assert rms_weight.dtype == torch.bfloat16
+    assert gamma.dtype == torch.bfloat16 and beta.dtype == torch.bfloat16
+    assert residual.shape == x.shape
+    B, S, D = residual.shape
+    assert rms_weight.shape == (D,)
+    assert gamma.shape == (B, D) and beta.shape == (B, D)
+
+    if site_id is None:
+        return None
+    from flash_rt.models.lingbot import calibration as _calib
+    act_scale = _calib.get_static_scale(site_id)
+    if act_scale is None:
+        return None
+    if stream is None:
+        stream = _current_stream()
+
+    ext = _get_lingbot_ext()
+    if pad_to is not None and pad_to > S:
+        out_fp8 = torch.empty(
+            B * pad_to, D, dtype=torch.float8_e4m3fn, device=residual.device)
+        ext.ada_rms_residual_fp8_mpad_bf16(
+            int(residual.contiguous().data_ptr()),
+            int(x.contiguous().data_ptr()),
+            int(rms_weight.contiguous().data_ptr()),
+            int(gamma.contiguous().data_ptr()),
+            int(beta.contiguous().data_ptr()),
+            int(out_fp8.data_ptr()),
+            int(act_scale.data_ptr()),
+            B, S, pad_to, D, float(eps), stream,
+        )
+        return out_fp8, act_scale
+
+    out_fp8 = torch.empty(
+        B * S, D, dtype=torch.float8_e4m3fn, device=residual.device)
+    ext.ada_rms_residual_fp8_bf16(
+        int(residual.contiguous().data_ptr()),
+        int(x.contiguous().data_ptr()),
+        int(rms_weight.contiguous().data_ptr()),
+        int(gamma.contiguous().data_ptr()),
+        int(beta.contiguous().data_ptr()),
+        int(out_fp8.data_ptr()),
+        int(act_scale.data_ptr()),
+        B, S, D, float(eps), stream,
+    )
+    return out_fp8, act_scale
+
+
+# ════════════════════════════════════════════════════════════════════
+# — Fused residual + RMS + quant + FP8-input GEMM
+# ════════════════════════════════════════════════════════════════════
+#
+# ``residual_add_rms_norm_fp8`` from fvk fuses four ops that the eager
+# path emits as four separate launches::
+#
+#     1. ``residual + x``     (bf16 element-wise add)
+#     2. ``rms_norm(., weight)``
+#     3. ``quantize_fp8``     (the absmax-reduce inside linear_fp8)
+#
+# Verified behavior :
+#   - cos vs PyTorch eager reference: 0.9999
+#   - The ``residual`` buffer is MUTATED IN PLACE to ``residual + x``.
+#     This matches LingBot's pattern exactly: the post-attention residual
+#     buffer (``vlm_hidden`` in ``prefix_encode_layer``) is needed again
+#     as bf16 for the second residual, so writing it back is desirable.
+#   - The output FP8 tensor + the (static) act_scale are ready to feed
+#     directly into the next FP8 GEMM via ``linear_fp8_from_fp8`` (no
+#     re-quantize).
+#
+# Requires a static activation scale (the kernel takes ``d_scale`` as
+# an input, not an output — there is no per-call absmax-reduce). When
+# ``calibration.set_static_scales`` has been installed and a scale
+# exists for the given ``site_id``, the fused path is taken; otherwise
+# the wrapper returns ``None`` and the caller falls back to the
+# unfused path.
+
+
+def residual_rms_quant_fp8_inplace(
+    residual: torch.Tensor,             # [..., D] bf16 — MUTATED to residual+x
+    x: torch.Tensor,                    # [..., D] bf16
+    weight: torch.Tensor,               # [D] bf16 (RMS gain)
+    *,
+    eps: float = 1e-6,
+    site_id: "str | None" = None,
+    stream: int | None = None,
+) -> "tuple[torch.Tensor, torch.Tensor] | None":
+    """Fused ``out_fp8 = quantize(rms_norm(residual + x, weight))``.
+
+    SIDE EFFECT: ``residual`` is updated to ``residual + x`` (bf16, in place).
+
+    Returns ``(out_fp8 [..., D] fp8, act_scale [1] fp32)`` on success,
+    or ``None`` if a static scale is not available for ``site_id`` —
+    in which case the caller should fall back to the unfused path.
+
+    The returned ``act_scale`` is the SAME persistent device tensor
+    held by ``calibration._STATIC_SCALES`` — caller MUST NOT mutate it.
+    """
+    assert residual.dtype in (torch.bfloat16, torch.float16)
+    assert x.dtype == residual.dtype
+    assert weight.dtype == residual.dtype
+    assert residual.shape == x.shape
+    D = residual.shape[-1]
+    assert weight.shape == (D,)
+
+    if site_id is None:
+        return None
+    from flash_rt.models.lingbot import calibration as _calib
+    act_scale = _calib.get_static_scale(site_id)
+    if act_scale is None:
+        return None
+    if stream is None:
+        stream = _current_stream()
+
+    M = 1
+    for d in residual.shape[:-1]:
+        M *= d
+    res_2d = residual.contiguous().view(M, D)
+    x_2d = x.contiguous().view(M, D)
+
+    out_fp8 = torch.empty(
+        M, D, dtype=torch.float8_e4m3fn, device=residual.device)
+
+    if residual.dtype == torch.bfloat16:
+        fvk.residual_add_rms_norm_fp8(
+            int(res_2d.data_ptr()), int(x_2d.data_ptr()),
+            int(weight.contiguous().data_ptr()),
+            int(out_fp8.data_ptr()),
+            M, D, eps, int(act_scale.data_ptr()), stream)
+    else:  # fp16
+        fvk.residual_add_rms_norm_fp8_fp16(
+            int(res_2d.data_ptr()), int(x_2d.data_ptr()),
+            int(weight.contiguous().data_ptr()),
+            int(out_fp8.data_ptr()),
+            M, D, eps, int(act_scale.data_ptr()), stream)
+    return out_fp8, act_scale
+
+
+def linear_fp8_from_fp8(
+    x_fp8: torch.Tensor,                # [M, K] fp8_e4m3 — already quantized
+    act_scale: torch.Tensor,            # [1] fp32 device — the scale used to quant x_fp8
+    weight: torch.Tensor,               # [N, K] bf16 (HF layout — quantized + cached)
+    bias: torch.Tensor | None = None,   # [N] bf16
+    *,
+    out_shape: "tuple[int, ...] | None" = None,
+    stream: int | None = None,
+    site_id: "str | None" = None,       # unused, kept for symmetry / future calib
+) -> torch.Tensor:
+    """FP8 GEMM whose input is ALREADY a quantized FP8 tensor.
+
+    Used downstream of :func:`residual_rms_quant_fp8_inplace` so the
+    next GEMM doesn't re-quantize the same activation. Same weight
+    cache as :func:`linear_fp8`. Falls back to a runtime error rather
+    than bf16 here — if you hit the FP8 heuristic floor, you shouldn't
+    be on this code path.
+    """
+    del site_id  # currently unused (no per-call recording — pre-quantized)
+    assert x_fp8.dtype == torch.float8_e4m3fn, f"x_fp8 dtype {x_fp8.dtype}"
+    assert weight.dtype in (torch.bfloat16, torch.float16)
+    M, K_in = x_fp8.shape
+    N_out = weight.shape[0]
+    assert weight.shape == (N_out, K_in)
+    assert N_out >= _FP8_MIN_N and K_in >= _FP8_MIN_N, (
+        f"linear_fp8_from_fp8 needs N>={_FP8_MIN_N}, K>={_FP8_MIN_N}; "
+        f"got N={N_out} K={K_in}")
+    if stream is None:
+        stream = _current_stream()
+
+    out_dtype = weight.dtype     # output matches weight dtype
+
+    # pad path: when M < _FP8_MIN_M (Expert M=51) but ≥
+    # _FP8_PAD_MIN_M, pad to M=_FP8_MIN_M so the FP8 GEMM heuristic
+    # fires. Pad rows are uninitialized; their output rows are sliced
+    # off below.
+    if _FP8_PAD_MIN_M <= M < _FP8_MIN_M:
+        pad_to = _FP8_MIN_M
+        x_padded = torch.empty(
+            pad_to, K_in, dtype=torch.float8_e4m3fn, device=x_fp8.device)
+        x_padded[:M].copy_(x_fp8)
+        out_padded = torch.empty(
+            pad_to, N_out, dtype=out_dtype, device=x_fp8.device)
+        w_fp8_T, w_descale = _get_or_quantize_fp8_weight(weight)
+        _fp8_gemm_descale(
+            int(x_padded.data_ptr()), int(w_fp8_T.data_ptr()),
+            int(out_padded.data_ptr()), pad_to, N_out, K_in,
+            int(act_scale.data_ptr()), int(w_descale.data_ptr()),
+            out_dtype, stream)
+        if bias is not None:
+            _add_bias(int(out_padded.data_ptr()),
+                      int(bias.contiguous().data_ptr()),
+                      pad_to, N_out, out_dtype, stream)
+        return out_padded[:M].view(*((M,) if out_shape is None else out_shape[:-1]), N_out)
+
+    assert M >= _FP8_MIN_M, (
+        f"linear_fp8_from_fp8 needs M>={_FP8_PAD_MIN_M}; got M={M}")
+    if out_shape is None:
+        out_shape = (M, N_out)
+    out = torch.empty(out_shape, dtype=out_dtype, device=x_fp8.device)
+    out_2d = out.view(M, N_out)
+
+    w_fp8_T, w_descale = _get_or_quantize_fp8_weight(weight)
+    _fp8_gemm_descale(
+        int(x_fp8.data_ptr()), int(w_fp8_T.data_ptr()),
+        int(out_2d.data_ptr()), M, N_out, K_in,
+        int(act_scale.data_ptr()), int(w_descale.data_ptr()),
+        out_dtype, stream)
+    if bias is not None:
+        _add_bias(int(out_2d.data_ptr()),
+                  int(bias.contiguous().data_ptr()),
+                  M, N_out, out_dtype, stream)
+    return out
+
+
+__all__ = [
+    "get_fvk_context",
+    "get_gemm_runner",
+    "linear_bf16",
+    "linear_bf16_preT",
+    "linear_fp8",
+    "linear_fp8_from_fp8",
+    "residual_rms_quant_fp8_inplace",
+    "attention_mha_bf16_fused",
+    "silu_mul_to_fp8_fp16_fused",
+    "silu_mul_fp8_mpad_bf16_fused",
+    "silu_mul_merged_fp8_mpad_bf16_fused",
+    "ada_rms_residual_fp8_fused",
+    "ada_rms_fp8_fused",
+    "rope_inplace_bf16_fused",
+    "clear_fp8_weight_cache",
+    "preload_transposed_weights",
+]

--- a/flash_rt/models/lingbot/mixed_attention.py
+++ b/flash_rt/models/lingbot/mixed_attention.py
@@ -1,0 +1,793 @@
+"""LingBot-VLA Mixed-Head joint attention — one-layer forward (reference path).
+
+Replicates the per-layer attention block of
+``QwenvlWithExpertModel.forward`` in ``lingbotvla/models/vla/pi0/
+modeling_lingbot_vla.py`` (L1240-1314), starting from raw hiddens and
+ending at the per-tower o_proj output (i.e. before residual + post-LN +
+MLP). The full layer = this function + residual + post-LN(+ada_cond) +
+MLP + residual; FFN/residual land later.
+
+Math (per layer):
+
+    # 1. Pre-norm
+    h_vlm  = rms_norm(vlm_hidden,    weight=vlm.input_layernorm)
+    h_exp  = ada_rms_norm(expert_hidden, ada_cond,
+                            weight, gamma, beta from expert.input_layernorm.*)
+
+    # 2. Q/K/V projections — Mixed-Head asymmetry: Expert hidden=768
+    #    but Q_exp out = 16 × 128 = 2048 (matches VLM head space).
+    Q_vlm = q_proj_vlm(h_vlm).view(B, L_vlm, 16, 128)
+    K_vlm = k_proj_vlm(h_vlm).view(B, L_vlm,  2, 128)        # GQA n_rep=8
+    V_vlm = v_proj_vlm(h_vlm).view(B, L_vlm,  2, 128)
+    Q_exp = q_proj_exp(h_exp).view(B, L_exp, 16, 128)
+    K_exp = k_proj_exp(h_exp).view(B, L_exp,  2, 128)
+    V_exp = v_proj_exp(h_exp).view(B, L_exp,  2, 128)
+
+    # 3. Joint sequence (concat on token axis)
+    Q = cat([Q_vlm, Q_exp], dim=1)
+    K = cat([K_vlm, K_exp], dim=1)
+    V = cat([V_vlm, V_exp], dim=1)
+
+    # 4. 1-D RoPE θ=10000 (via the adapter, bit-exact to upstream apply_rope)
+    Q = apply_rope(Q, position_ids)
+    K = apply_rope(K, position_ids)
+
+    # 5. GQA: replicate KV from 2 heads → 16 heads
+    K = K.repeat_interleave(8, dim=2)
+    V = V.repeat_interleave(8, dim=2)
+
+    # 6. Scaled dot-product attention with attention_mask
+    A = scaled_dot_product_attention(Q.T, K.T, V.T, attn_mask=mask)
+    A = A.T.reshape(B, L_total, 16*128)              # [B, L_total, 2048]
+
+    # 7. Per-tower output projection
+    out_vlm    = o_proj_vlm(A[:, :L_vlm])             # 2048 → 2048
+    out_expert = o_proj_exp(A[:, L_vlm:])             # 2048 → 768  (Mixed-Head asym)
+
+This function does NOT touch the KV cache; adds cache integration
+for the denoise step where prefix-KV is reused. For now ``position_ids``
+must cover both VLM and Expert tokens in one flat vector.
+
+Reference for bit-exact tests: ``Qwen2DecoderLayer.forward`` with
+``compute_kqv=True`` + manual concat + ``utils.apply_rope`` + sdpa +
+``Qwen2DecoderLayer.forward`` with ``output_atten=True`` (start/end
+slicing).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from flash_rt.models.lingbot.kernel_ops import (
+    ada_rms_fp8_fused,
+    ada_rms_residual_fp8_fused,
+    attention_fmha_strided_fused,
+    attention_mha_bf16_fused,
+    linear_bf16, linear_fp8, linear_fp8_from_fp8,
+    qkv_bias_rope_fused,
+    qkv_bias_rope_merged_fused,
+    silu_mul_to_fp8_fp16_fused,
+    silu_mul_fp8_mpad_bf16_fused,
+    silu_mul_merged_fp8_mpad_bf16_fused,
+    silu_mul_merged_fp8_mpad_fp16in_fused,
+    attention_fa4_fused,
+    _ensure_fmha_strided,
+)
+from flash_rt.models.lingbot.kernel_ops import _FP8_MIN_M, _FP8_PAD_MIN_M
+
+# fusion-budget probe (denoise FFN megakernel): skip the silu_mul kernel (gu-read +
+# silu-compute + h-write + launch) and feed down a dummy h_fp8 so down still runs.
+# Lower bound on the megakernel's serial DRAM-elimination budget. NOT for production.
+_PROBE_SKIP_SILU = False
+_PROBE_DUMMY_H = {}
+
+# FA4 (FlashAttention-4 CuTe-DSL) denoise attention. Measured ~17% faster than
+# the vendored fmha at the denoise shape (Sq=51) via pack_gqa, cos=1.0,
+# CUDA-graph safe. Runs on Thor compiled for sm_101a. Opt-in; falls back to
+# fmha if FA4 (cutlass-dsl/quack) isn't available.
+_USE_FA4_ATTN = True
+
+# prefer the GQA-native fp16 CUTLASS FMHA on the unmasked fused path.
+# Set False to fall back to the cuBLAS bf16 attention_mha path.
+_USE_FMHA_STRIDED = True
+
+# fp16 attention island. The QKV megakernel emits fp16 q/k/v (and the
+# KV cache is fp16), so the fmha wrapper consumes them with NO bf16→fp16 cast
+# (eliminates ~1080 cast launches/inference @10-step). Output returns to bf16
+# at the o_proj boundary. Set False to keep the bf16 attention path.
+_USE_FP16_ATTN_ISLAND = True
+ATTN_ISLAND_DTYPE = torch.float16
+
+from flash_rt.models.lingbot.norms import rms_norm, ada_rms_norm
+from flash_rt.models.lingbot.rope_adapter import (
+    LINGBOT_ROPE_CONFIG,
+    apply_rope_with_tables,
+    build_cos_sin_table,
+)
+
+
+def _eager_attention(
+    Q: torch.Tensor,     # [B, L, num_q_heads, head_dim]
+    K: torch.Tensor,     # [B, L, num_kv_heads, head_dim]
+    V: torch.Tensor,     # [B, L, num_kv_heads, head_dim]
+    attention_mask: torch.Tensor | None,
+    *,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    use_fused: bool = True,
+) -> torch.Tensor:
+    """Per-layer multi-head attention.
+
+    fast path (``use_fused=True``, mask=None or near-trivial): one
+    ``fvk.attention_mha_bf16`` call replaces the einsum chain. Reduces
+    36 layers × 4 launches (Q*scale, QK^T, softmax, P@V) to 36 × 1.
+
+    Eager fallback: bit-exact replica of ``lingbotvla.models.vla.pi0.
+    utils.our_eager_attention_forward`` — explicit einsum chain in the
+    input dtype (bf16), softmax in-dtype, bool mask via
+    ``torch.where(big_neg)``. Used when the caller passes a non-trivial
+    bool mask.
+
+    Args:
+        Q/K/V: ``[B, L, *_heads, head_dim]``.
+        attention_mask: bool mask ``[B, L_q, L_kv]`` (True = keep). When
+            ``None`` and ``use_fused`` is True, takes the fused path.
+        num_q_heads, num_kv_heads, head_dim: shape constants.
+        use_fused: opt-in (default) into the fused kernel. Set False
+            from tests that need bit-exact eager .
+
+    Returns:
+        ``[B, L, num_q_heads * head_dim]`` attention output.
+    """
+    B, L_q, _, D = Q.shape
+    L_kv = K.shape[1]
+    n_groups = num_q_heads // num_kv_heads
+
+    # Fused unmasked path. LingBot's prefix attention is non-causal full
+    # (``vlm_causal=False`` upstream); denoise suffix attention drops the
+    # Pi0-style state-token mask (cos delta ≤1e-4/layer — softmax is
+    # dominated by the prefix keys, not the 1 state key).
+    if use_fused and attention_mask is None:
+        # FA4: ~17% faster than fmha at the denoise shape (pack_gqa). Returns
+        # None if unavailable → fall through to fmha.
+        if _USE_FA4_ATTN:
+            _o = attention_fa4_fused(
+                Q, K, V, num_q_heads=num_q_heads,
+                num_kv_heads=num_kv_heads, head_dim=head_dim)
+            if _o is not None:
+                return _o
+        # GQA-native fp16 CUTLASS FMHA — skips the 8× KV head-expand
+        # and runs ~1.3-1.9× faster than the cuBLAS path (see kernel_ops).
+        if _USE_FMHA_STRIDED and _ensure_fmha_strided():
+            return attention_fmha_strided_fused(
+                Q, K, V, num_q_heads=num_q_heads,
+                num_kv_heads=num_kv_heads, head_dim=head_dim)
+        # Fallback: GQA-expand + cuBLAS bf16 attention_mha.
+        Ke = K.unsqueeze(3).expand(B, L_kv, num_kv_heads, n_groups, D).reshape(
+            B, L_kv, num_kv_heads * n_groups, D)
+        Ve = V.unsqueeze(3).expand(B, L_kv, num_kv_heads, n_groups, D).reshape(
+            B, L_kv, num_kv_heads * n_groups, D)
+        return attention_mha_bf16_fused(
+            Q, Ke, Ve, attn_scale=head_dim ** -0.5)
+
+    # Masked / non-fused path needs KV expanded to NHQ heads.
+    # "b l h d -> b l (h g) d" is index-identical to repeat_interleave(g, dim=2).
+    K = K.unsqueeze(3).expand(B, L_kv, num_kv_heads, n_groups, D).reshape(
+        B, L_kv, num_kv_heads * n_groups, D)
+    V = V.unsqueeze(3).expand(B, L_kv, num_kv_heads, n_groups, D).reshape(
+        B, L_kv, num_kv_heads * n_groups, D)
+
+    # Permute to [B, H, L, D] via the same einsum upstream uses (matters
+    # for bit-exactness of contiguous-mem ordering).
+    Q_p = torch.einsum("blhd->bhld", Q)
+    K_p = torch.einsum("blhd->bhld", K)
+    V_p = torch.einsum("blhd->bhld", V)
+
+    # QK^T overflows in fp16 (Q~150 × K~30 × 128 ≈ 5e5, exceeds 65504).
+    # Bf16 is fine because of its wider exponent. Promote to fp32 for the
+    # matmul when running on fp16; bf16 path stays in-dtype.
+    if Q.dtype == torch.float16:
+        att_weights = torch.einsum(
+            "bhqd,bhkd->bhqk", Q_p.float(), K_p.float())
+    else:
+        att_weights = torch.einsum("bhqd,bhkd->bhqk", Q_p, K_p)
+    att_weights = att_weights * (head_dim ** -0.5)
+
+    if attention_mask is None:
+        # Synthesize an all-True bool mask — upstream always passes one.
+        attention_mask = torch.ones(
+            (B, L_q, L_kv), dtype=torch.bool, device=Q.device)
+
+    # Dtype-safe negative infinity for the mask fill. fp16 max is
+    # 65504 so the bf16-tuned -2.38e38 overflows on the fp16 path.
+    big_neg = float(torch.finfo(att_weights.dtype).min)
+    masked = torch.where(
+        attention_mask[:, None, :, :], att_weights, big_neg)
+    probs = F.softmax(masked, dim=-1)
+    probs = probs.to(dtype=V.dtype)
+
+    att_out = torch.einsum("bhqk,bhkv->bhqv", probs, V_p)
+    att_out = torch.einsum("bhld->blhd", att_out)
+    return att_out.reshape(B, L_q, num_q_heads * head_dim)
+
+
+@dataclass(frozen=True)
+class AttentionDims:
+    """Mixed-Head joint attention shape constants."""
+
+    num_q_heads: int = 16
+    num_kv_heads: int = 2          # GQA n_rep = 8
+    head_dim: int = 128            # Q_out = 16*128 = 2048
+    vlm_hidden: int = 2048
+    expert_hidden: int = 768
+    rms_eps: float = 1e-6
+
+
+DEFAULT_ATTN_DIMS = AttentionDims()
+
+
+def compute_kqv_vlm(
+    hidden_states: torch.Tensor,
+    target,
+    layer_idx: int,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pre-norm + Q/K/V projections for one VLM layer.
+
+    Mirrors ``Qwen2DecoderLayer.forward(compute_kqv=True)`` with no ada
+    conditioning. Returns Q, K, V in shape ``(B, L, num_*_heads, head_dim)``.
+    """
+    h = rms_norm(
+        hidden_states,
+        weight=target.vlm_layer_input_layernorm_weights[layer_idx],
+        eps=dims.rms_eps,
+    )
+    B, L, _ = h.shape
+    prefix = f"vlm.layer.{layer_idx}"
+    q = linear_fp8(h,
+                 target.vlm_layer_q_proj_weights[layer_idx],
+                 target.vlm_layer_q_proj_biases[layer_idx],
+                 site_id=f"{prefix}.q_proj").view(
+        B, L, dims.num_q_heads, dims.head_dim)
+    k = linear_fp8(h,
+                 target.vlm_layer_k_proj_weights[layer_idx],
+                 target.vlm_layer_k_proj_biases[layer_idx],
+                 site_id=f"{prefix}.k_proj").view(
+        B, L, dims.num_kv_heads, dims.head_dim)
+    v = linear_fp8(h,
+                 target.vlm_layer_v_proj_weights[layer_idx],
+                 target.vlm_layer_v_proj_biases[layer_idx],
+                 site_id=f"{prefix}.v_proj").view(
+        B, L, dims.num_kv_heads, dims.head_dim)
+    return q, k, v
+
+
+def compute_kqv_expert(
+    hidden_states: torch.Tensor,
+    ada_cond: torch.Tensor,
+    target,
+    layer_idx: int,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+    gamma_in: torch.Tensor | None = None,    # precomputed FiLM γ
+    beta_in: torch.Tensor | None = None,     # precomputed FiLM β
+    qk_rope: "tuple[torch.Tensor, torch.Tensor] | None" = None,  # (cos,sin)
+    k_out_buf: torch.Tensor | None = None,   # write k/v here (KV cache suffix)
+    v_out_buf: torch.Tensor | None = None,   # [M, NHKV*HD] views — no copy after
+    residual_add: torch.Tensor | None = None,  # prev-layer mlp_out (2nd resid)
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pre-AdaRMSNorm + Q/K/V projections for one Action Expert layer.
+
+    Mirrors ``Qwen2DecoderLayer.forward(compute_kqv=True, ada_cond=...)``.
+    The expert Q projection is Mixed-Head asymmetric: in=768, out=2048
+    (matches VLM head space so the towers can share attention).
+    """
+    # try the fused AdaRMS+FP8 path. When static scale exists
+    # for the Q-proj site, pre-compute γ/β then call our custom kernel
+    # that produces FP8 input directly for the Q/K/V GEMMs. Saves the
+    # 6-9 launches that eager ada_rms_norm + linear_fp8 internal quantize
+    # would emit per layer.
+    # γ_in/β_in may be precomputed (batched across all denoise steps);
+    # only fall back to the per-site linear_fp8 when not provided.
+    prefix = f"expert.layer.{layer_idx}"
+    q_site = f"{prefix}.q_proj"
+    if gamma_in is None:
+        gamma_in = linear_fp8(
+            ada_cond,
+            target.expert_layer_input_layernorm_gamma_weights[layer_idx],
+            target.expert_layer_input_layernorm_gamma_biases[layer_idx],
+            site_id=f"{prefix}.input_ln.gamma",
+        )
+    if beta_in is None:
+        beta_in = linear_fp8(
+            ada_cond,
+            target.expert_layer_input_layernorm_beta_weights[layer_idx],
+            target.expert_layer_input_layernorm_beta_biases[layer_idx],
+            site_id=f"{prefix}.input_ln.beta",
+        )
+    B, L, _ = hidden_states.shape
+    NHQ, NHKV, HD = dims.num_q_heads, dims.num_kv_heads, dims.head_dim
+    # M-pad the norm's FP8 output to 64 ONCE (the same buffer feeds q/k/v),
+    # so the three q/k/v GEMMs read M=64 directly and skip three redundant
+    # 51->64 pad copies. Only when the M=51 pad regime applies.
+    M_real = B * L
+    _pad = _FP8_MIN_M if _FP8_PAD_MIN_M <= M_real < _FP8_MIN_M else None
+    if residual_add is not None:
+        # fuse the previous layer's 2nd residual (mlp_out + afr) into this
+        # input norm. ``hidden_states`` (= prev afr) is mutated in place to
+        # ``hidden_states + residual_add`` (= the real layer input h), which the
+        # caller then reuses as the post-attn residual — so the standalone
+        # ``mlp_out + afr`` add (one launch + buffer per layer) is removed.
+        fused = ada_rms_residual_fp8_fused(
+            hidden_states, residual_add,
+            target.expert_layer_input_layernorm_weights[layer_idx],
+            gamma_in, beta_in,
+            eps=dims.rms_eps, site_id=q_site, pad_to=_pad,
+        )
+    else:
+        fused = ada_rms_fp8_fused(
+            hidden_states,
+            target.expert_layer_input_layernorm_weights[layer_idx],
+            gamma_in, beta_in,
+            eps=dims.rms_eps, site_id=q_site, pad_to=_pad,
+        )
+    if fused is not None:
+        h_fp8, act_scale = fused
+        qkv_merged = getattr(target, "expert_layer_qkv_merged_weights", None)
+        if qk_rope is not None:
+            cos, sin = qk_rope
+            half = HD // 2
+            M = B * L
+            out_dtype = ATTN_ISLAND_DTYPE if _USE_FP16_ATTN_ISLAND \
+                else torch.bfloat16
+            if qkv_merged is not None:
+                # ONE merged q/k/v GEMM ([H -> NHQ*HD+2*NHKV*HD]) instead of
+                # three; the merged-input rope kernel reads q/k/v from column
+                # offsets (no split). h_fp8 may be M-padded -> slice to M_real.
+                qkv_raw = linear_fp8_from_fp8(
+                    h_fp8, act_scale, qkv_merged[layer_idx], None,
+                    site_id=q_site)
+                if _pad is not None:
+                    qkv_raw = qkv_raw[:M_real]
+                q, k, v = qkv_bias_rope_merged_fused(
+                    qkv_raw,
+                    target.expert_layer_q_proj_biases[layer_idx],
+                    target.expert_layer_k_proj_biases[layer_idx],
+                    target.expert_layer_v_proj_biases[layer_idx],
+                    cos.reshape(M, half), sin.reshape(M, half),
+                    num_q_heads=NHQ, num_kv_heads=NHKV, head_dim=HD,
+                    out_dtype=out_dtype,
+                    k_out=k_out_buf, v_out=v_out_buf)  # k/v→cache suffix
+                return (q.view(B, L, NHQ, HD), k.view(B, L, NHKV, HD),
+                        v.view(B, L, NHKV, HD))
+            # bias-free q/k/v GEMMs, then ONE fused kernel does
+            # bias-add + RoPE (q/k) + bias (v) — replaces 3 add_bias + 2 rope.
+            # When h_fp8 is M-padded ([64,K]), the GEMMs return [64,N]; slice
+            # the raw outputs back to M_real (free view) before the RoPE kernel.
+            q_raw = linear_fp8_from_fp8(
+                h_fp8, act_scale, target.expert_layer_q_proj_weights[layer_idx],
+                None, site_id=q_site)
+            k_raw = linear_fp8_from_fp8(
+                h_fp8, act_scale, target.expert_layer_k_proj_weights[layer_idx],
+                None, site_id=f"{prefix}.k_proj")
+            v_raw = linear_fp8_from_fp8(
+                h_fp8, act_scale, target.expert_layer_v_proj_weights[layer_idx],
+                None, site_id=f"{prefix}.v_proj")
+            if _pad is not None:
+                q_raw = q_raw[:M_real]; k_raw = k_raw[:M_real]; v_raw = v_raw[:M_real]
+            q, k, v = qkv_bias_rope_fused(
+                q_raw, k_raw, v_raw,
+                target.expert_layer_q_proj_biases[layer_idx],
+                target.expert_layer_k_proj_biases[layer_idx],
+                target.expert_layer_v_proj_biases[layer_idx],
+                cos.reshape(M, half), sin.reshape(M, half),
+                num_q_heads=NHQ, num_kv_heads=NHKV, head_dim=HD,
+                out_dtype=out_dtype)
+            return (q.view(B, L, NHQ, HD), k.view(B, L, NHKV, HD),
+                    v.view(B, L, NHKV, HD))
+        q = linear_fp8_from_fp8(
+            h_fp8, act_scale, target.expert_layer_q_proj_weights[layer_idx],
+            target.expert_layer_q_proj_biases[layer_idx],
+            site_id=q_site,
+        )[:M_real].view(B, L, dims.num_q_heads, dims.head_dim)
+        k = linear_fp8_from_fp8(
+            h_fp8, act_scale, target.expert_layer_k_proj_weights[layer_idx],
+            target.expert_layer_k_proj_biases[layer_idx],
+            site_id=f"{prefix}.k_proj",
+        )[:M_real].view(B, L, dims.num_kv_heads, dims.head_dim)
+        v = linear_fp8_from_fp8(
+            h_fp8, act_scale, target.expert_layer_v_proj_weights[layer_idx],
+            target.expert_layer_v_proj_biases[layer_idx],
+            site_id=f"{prefix}.v_proj",
+        )[:M_real].view(B, L, dims.num_kv_heads, dims.head_dim)
+        return q, k, v
+
+    # Eager fallback when no calibration is loaded.
+    h = ada_rms_norm(
+        hidden_states, ada_cond,
+        weight=target.expert_layer_input_layernorm_weights[layer_idx],
+        gamma_weight=target.expert_layer_input_layernorm_gamma_weights[layer_idx],
+        gamma_bias=target.expert_layer_input_layernorm_gamma_biases[layer_idx],
+        beta_weight=target.expert_layer_input_layernorm_beta_weights[layer_idx],
+        beta_bias=target.expert_layer_input_layernorm_beta_biases[layer_idx],
+        eps=dims.rms_eps,
+        site_prefix=f"{prefix}.input_ln",
+    )
+    q = linear_fp8(h,
+                 target.expert_layer_q_proj_weights[layer_idx],
+                 target.expert_layer_q_proj_biases[layer_idx],
+                 site_id=f"{prefix}.q_proj").view(
+        B, L, dims.num_q_heads, dims.head_dim)
+    k = linear_fp8(h,
+                 target.expert_layer_k_proj_weights[layer_idx],
+                 target.expert_layer_k_proj_biases[layer_idx],
+                 site_id=f"{prefix}.k_proj").view(
+        B, L, dims.num_kv_heads, dims.head_dim)
+    v = linear_fp8(h,
+                 target.expert_layer_v_proj_weights[layer_idx],
+                 target.expert_layer_v_proj_biases[layer_idx],
+                 site_id=f"{prefix}.v_proj").view(
+        B, L, dims.num_kv_heads, dims.head_dim)
+    return q, k, v
+
+
+def mixed_head_attention_layer(
+    *,
+    vlm_hidden: torch.Tensor,
+    expert_hidden: torch.Tensor,
+    position_ids: torch.Tensor,
+    ada_cond: torch.Tensor,
+    target,
+    layer_idx: int,
+    attention_mask: torch.Tensor | None = None,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """One layer of LingBot-VLA Mixed-Head joint attention (no FFN/residual).
+
+    Args:
+        vlm_hidden:      ``[B, L_vlm, 2048]`` pre-norm hidden state.
+        expert_hidden:   ``[B, L_exp, 768]`` pre-norm hidden state.
+        position_ids:    ``[B, L_total]`` long, where L_total = L_vlm + L_exp.
+        ada_cond:        ``[B, 768]`` timestep embedding for AdaRMSNorm.
+        target:          object loaded by the + bound by the — must have all
+                         weight attributes from the lingbot WEIGHT_SPEC.
+        layer_idx:       which of the 36 layers to run.
+        attention_mask:  optional ``[B, 1, L_total, L_total]`` mask
+                         (float fill_value, additive). None = unmasked.
+        dims:            ``AttentionDims`` overrides.
+
+    Returns:
+        ``(out_vlm, out_expert)`` —
+          ``out_vlm:    [B, L_vlm, 2048]``
+          ``out_expert: [B, L_exp,  768]``    (Mixed-Head asymmetric o_proj)
+    """
+    # 1+2. Pre-norm + Q/K/V projections per tower.
+    q_v, k_v, v_v = compute_kqv_vlm(vlm_hidden, target, layer_idx, dims)
+    q_e, k_e, v_e = compute_kqv_expert(expert_hidden, ada_cond,
+                                       target, layer_idx, dims)
+
+    B, L_vlm = vlm_hidden.shape[:2]
+    _, L_exp = expert_hidden.shape[:2]
+
+    # 3. Concat on token axis.
+    Q = torch.cat([q_v, q_e], dim=1)
+    K = torch.cat([k_v, k_e], dim=1)
+    V = torch.cat([v_v, v_e], dim=1)
+
+    # 4. 1-D RoPE .
+    cos, sin = build_cos_sin_table(
+        position_ids, LINGBOT_ROPE_CONFIG,
+        compute_dtype=torch.float32,
+    )
+    Q = apply_rope_with_tables(Q.to(torch.float32), cos, sin).to(Q.dtype)
+    K = apply_rope_with_tables(K.to(torch.float32), cos, sin).to(K.dtype)
+
+    # 5+6. Eager attention (matches upstream our_eager_attention_forward
+    # bit-exact: explicit einsum + softmax in input-dtype + bool mask).
+    A = _eager_attention(
+        Q, K, V, attention_mask,
+        num_q_heads=dims.num_q_heads,
+        num_kv_heads=dims.num_kv_heads,
+        head_dim=dims.head_dim,
+    )
+    assert A.shape == (B, L_vlm + L_exp, dims.num_q_heads * dims.head_dim)
+
+    # 7. Per-tower o_proj.
+    a_v, a_e = A.split([L_vlm, L_exp], dim=1)
+    out_v = linear_fp8(a_v.contiguous(),
+                     target.vlm_layer_o_proj_weights[layer_idx],
+                     site_id=f"vlm.layer.{layer_idx}.o_proj")
+    out_e = linear_fp8(a_e.contiguous(),
+                     target.expert_layer_o_proj_weights[layer_idx],
+                     site_id=f"expert.layer.{layer_idx}.o_proj")
+    return out_v, out_e
+
+
+def swiglu_mlp(
+    x: torch.Tensor,
+    *,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    site_prefix: "str | None" = None,
+) -> torch.Tensor:
+    """Qwen2MLP: ``down(silu(gate(x)) * up(x))``.
+
+    All linears have ``bias=False`` in Qwen2.5-VL & Qwen2-768.
+
+    ``site_prefix``: when given, the three internal linears are
+    tagged ``f"{site_prefix}.gate_proj"`` / ``up_proj`` / ``down_proj``
+    so they can be calibrated and routed through ``quantize_fp8_static``.
+    """
+    if site_prefix is None:
+        sid_g = sid_u = sid_d = None
+    else:
+        sid_g = f"{site_prefix}.gate_proj"
+        sid_u = f"{site_prefix}.up_proj"
+        sid_d = f"{site_prefix}.down_proj"
+    gate = linear_fp8(x, gate_weight, site_id=sid_g)
+    up = linear_fp8(x, up_weight, site_id=sid_u)
+
+    # (fp16-only): fuse silu+mul+fp8-quant when gate/up are fp16
+    # AND the down_proj has a static scale. Used by Expert hot loop.
+    if gate.dtype == torch.float16 and sid_d is not None:
+        from flash_rt.models.lingbot import calibration as _calib
+        down_scale = _calib.get_static_scale(sid_d)
+        if down_scale is not None:
+            h_fp8 = silu_mul_to_fp8_fp16_fused(gate, up, down_scale)
+            # linear_fp8_from_fp8 expects [M, K] 2D shape; the fused
+            # output keeps the input shape so reshape and restore.
+            orig_shape = gate.shape
+            H = orig_shape[-1]
+            M = 1
+            for d in orig_shape[:-1]:
+                M *= d
+            out_2d = linear_fp8_from_fp8(
+                h_fp8.view(M, H), down_scale, down_weight, site_id=sid_d)
+            return out_2d.view(*orig_shape[:-1], down_weight.shape[0])
+    return linear_fp8(F.silu(gate) * up, down_weight, site_id=sid_d)
+
+
+_DENOISE_FP4_SCRATCH: dict = {}
+
+
+def _denoise_fp4_scratch(M: int, K: int, twoI: int, device):
+    """Lazy (eager-warmup) FP4 scratch for the denoise gate_up probe, reused
+    across all denoise layers/steps: act FP4 [M,K] + gate_up fp16 out [M,2I]."""
+    from flash_rt.models.lingbot import fp4_ops
+    key = (M, K, twoI)
+    s = _DENOISE_FP4_SCRATCH.get(key)
+    if s is None:
+        s = {"a": fp4_ops.FP4ActScratch(M, K),
+             "gu": torch.empty(M, twoI, dtype=torch.float16, device=device)}
+        _DENOISE_FP4_SCRATCH[key] = s
+    return s
+
+
+def swiglu_mlp_from_fp8(
+    x_fp8: torch.Tensor,                # [M, K] fp8 — pre-quantized (M may be padded)
+    act_scale: torch.Tensor,            # [1] fp32 — scale used to quant x_fp8
+    *,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+    site_prefix: str,
+    m_real: int | None = None,          # real token count when x_fp8 is M-padded
+    gate_up_merged_weight: torch.Tensor | None = None,  # cat([gate,up])
+    gate_up_fp4: dict | None = None,    # FP4 merged gate_up weight
+    x_fp16: torch.Tensor | None = None,  # fp16 norm output (skip fp8 dequant)
+) -> torch.Tensor:
+    """FP8-input variant of :func:`swiglu_mlp`.
+
+    The input has already been quantized to FP8 by a fused
+    ``residual_add_rms_norm_fp8`` upstream; this function reuses that
+    quantization for the ``gate_proj`` and ``up_proj`` GEMMs (no
+    re-quantize). The ``down_proj`` input is the bf16 product
+    ``silu(gate) * up`` and goes through the normal
+    :func:`linear_fp8` (dynamic or static, whichever is active).
+
+    ``m_real``: when ``x_fp8`` is M-padded upstream (rows ``[m_real, M)`` are
+    zero), the gate/up GEMMs run at M directly (no pad copy); the down output
+    is sliced back to ``m_real``. Pad rows of gate/up are zero (zero input, no
+    bias) so ``silu(0)*0 = 0`` — processing them is harmless.
+    """
+    # merged gate_up fast path. ONE GEMM ([H→2*I]) + a merged-input
+    # silu_mul (reads gate/up from row offsets, no split) replaces two GEMMs +
+    # the silu/mul/quant glue. Gated on a merged weight + static down scale +
+    # the M=51 pad regime.
+    if gate_up_merged_weight is not None:
+        from flash_rt.models.lingbot import calibration as _calib
+        down_sid = f"{site_prefix}.down_proj"
+        down_scale = _calib.get_static_scale(down_sid)
+        M_in = (x_fp16 if x_fp16 is not None else x_fp8).shape[0]
+        mr_g = M_in if m_real is None else m_real
+        if down_scale is not None and _FP8_PAD_MIN_M <= mr_g < _FP8_MIN_M:
+            if gate_up_fp4 is not None:
+                # FP4 merged gate_up. Dequant the fp8 norm output to fp16,
+                # FP4-quant, FP4 GEMM → fp16, cast bf16 for the existing silu_mul.
+                # Net win at M=64 (FP4 weight = half the DRAM bytes); cos held.
+                from flash_rt.models.lingbot import fp4_ops
+                twoI = gate_up_fp4["N"]
+                if x_fp16 is not None:
+                    # norm already produced fp16 — FP4-quant directly (no
+                    # fp8->fp16 dequant, which was ~18us/layer of tiny kernels).
+                    K_in = x_fp16.shape[1]
+                    sc = _denoise_fp4_scratch(M_in, K_in, twoI, x_fp16.device)
+                    fp4_ops.quant_act(x_fp16, sc["a"], M_in)
+                else:
+                    K_in = x_fp8.shape[1]
+                    sc = _denoise_fp4_scratch(M_in, K_in, twoI, x_fp8.device)
+                    x16 = (x_fp8.float() * act_scale).to(torch.float16).contiguous()
+                    fp4_ops.quant_act(x16, sc["a"], M_in)
+                fp4_ops.fp4_gemm(sc["a"], gate_up_fp4, sc["gu"], M_in, twoI, K_in)
+                # feed the FP4 GEMM fp16 output to the fp16-input silu_mul
+                # directly (no bf16 cast — that cast was ~360 calls/inference).
+                if _PROBE_SKIP_SILU:
+                    # fusion-budget probe: skip silu (gu-read+silu+h-write+launch);
+                    # feed down a persistent dummy h_fp8 so down still runs.
+                    _I = twoI // 2; _key = (_FP8_MIN_M, _I)
+                    h_fp8 = _PROBE_DUMMY_H.get(_key)
+                    if h_fp8 is None:
+                        h_fp8 = torch.zeros(_FP8_MIN_M, _I, dtype=torch.float8_e4m3fn, device=sc["gu"].device)
+                        _PROBE_DUMMY_H[_key] = h_fp8
+                else:
+                    h_fp8 = silu_mul_merged_fp8_mpad_fp16in_fused(
+                        sc["gu"], down_scale, pad_to=_FP8_MIN_M)
+            else:
+                gu = linear_fp8_from_fp8(
+                    x_fp8, act_scale, gate_up_merged_weight,
+                    site_id=f"{site_prefix}.gate_up")            # [M_in, 2*I]
+                h_fp8 = silu_mul_merged_fp8_mpad_bf16_fused(
+                    gu, down_scale, pad_to=_FP8_MIN_M)
+            out_pad = linear_fp8_from_fp8(
+                h_fp8, down_scale, down_weight, site_id=down_sid)
+            return out_pad[:mr_g].reshape(mr_g, down_weight.shape[0])
+
+    gate = linear_fp8_from_fp8(
+        x_fp8, act_scale, gate_weight,
+        site_id=f"{site_prefix}.gate_proj")
+    up = linear_fp8_from_fp8(
+        x_fp8, act_scale, up_weight,
+        site_id=f"{site_prefix}.up_proj")
+
+    # (fp16-only): when gate/up are fp16 AND the down_proj has a
+    # static scale, fuse silu+mul+fp8-quant into one launch via
+    # ``silu_mul_split_fp8_fp16``. Saves 3 launches per MLP × 36 Expert
+    # layers × N denoise steps + 36 VLM (prefix-once).
+    if gate.dtype == torch.float16:
+        from flash_rt.models.lingbot import calibration as _calib
+        down_sid = f"{site_prefix}.down_proj"
+        down_scale = _calib.get_static_scale(down_sid)
+        if down_scale is not None:
+            h_fp8 = silu_mul_to_fp8_fp16_fused(gate, up, down_scale)
+            orig_shape = gate.shape
+            H = orig_shape[-1]
+            M = 1
+            for d in orig_shape[:-1]:
+                M *= d
+            out_2d = linear_fp8_from_fp8(
+                h_fp8.view(M, H), down_scale, down_weight, site_id=down_sid)
+            return out_2d.view(*orig_shape[:-1], down_weight.shape[0])
+
+    # bf16 path: fuse silu(gate)*up + FP8 quant + M-pad into ONE kernel that
+    # writes a pre-padded [pad_to, I] FP8 buffer the down GEMM reads directly
+    # (skips the eager silu/mul/quant + linear_fp8's pad copy). Gated on a
+    # static down_proj scale (the FP8 quant needs it) and the M-pad regime.
+    from flash_rt.models.lingbot import calibration as _calib
+    down_sid = f"{site_prefix}.down_proj"
+    down_scale = _calib.get_static_scale(down_sid)
+    orig_shape = gate.shape
+    H = orig_shape[-1]
+    M = 1
+    for d in orig_shape[:-1]:
+        M *= d
+    mr = M if m_real is None else m_real
+    # Fuse when down has a static scale and the real token count is in the
+    # M=51 pad regime. gate/up may already be M-padded ([64,I]); their pad
+    # rows are zero so silu_mul over all M rows is exact. down reads M=pad_to
+    # directly; slice the output to the real token count.
+    if down_scale is not None and _FP8_PAD_MIN_M <= mr < _FP8_MIN_M:
+        h_fp8 = silu_mul_fp8_mpad_bf16_fused(
+            gate.view(M, H), up.view(M, H), down_scale, pad_to=_FP8_MIN_M)
+        out_pad = linear_fp8_from_fp8(
+            h_fp8, down_scale, down_weight, site_id=down_sid)  # [pad_to, N]
+        return out_pad[:mr].view(*orig_shape[:-1], down_weight.shape[0]) \
+            if M == mr else out_pad[:mr].reshape(mr, down_weight.shape[0])
+    return linear_fp8(
+        F.silu(gate) * up,
+        down_weight, site_id=f"{site_prefix}.down_proj",
+    )
+
+
+def mixed_head_layer_full(
+    *,
+    vlm_hidden: torch.Tensor,
+    expert_hidden: torch.Tensor,
+    position_ids: torch.Tensor,
+    ada_cond: torch.Tensor,
+    target,
+    layer_idx: int,
+    attention_mask: torch.Tensor | None = None,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """One **full** transformer layer of LingBot-VLA Mixed-Head joint forward.
+
+    Replicates the layer-loop body of ``QwenvlWithExpertModel.forward``:
+
+        1. Joint Mixed-Head attention
+        2. Residual:     out += hidden    (first residual)
+        3. Post-LN:      RMSNorm (VLM)   or  AdaRMSNorm(out, ada_cond) (Expert)
+        4. SwiGLU MLP:   down(silu(gate(h)) * up(h))
+        5. Residual:     out += after_first_residual
+
+    Args:
+        vlm_hidden / expert_hidden: pre-norm hidden states.
+        position_ids: joint sequence positions.
+        ada_cond:     timestep embedding for AdaRMSNorm.
+        target:       device-bound weight namespace.
+        layer_idx:    which of 36 layers.
+        attention_mask: optional bool ``[B, L_q, L_kv]``.
+        dims:         AttentionDims override.
+
+    Returns:
+        ``(out_vlm, out_expert)`` post-layer hiddens (after both residuals).
+        Same shapes as inputs.
+    """
+    # 1. Attention.
+    attn_v, attn_e = mixed_head_attention_layer(
+        vlm_hidden=vlm_hidden, expert_hidden=expert_hidden,
+        position_ids=position_ids, ada_cond=ada_cond,
+        target=target, layer_idx=layer_idx,
+        attention_mask=attention_mask, dims=dims,
+    )
+
+    # 2. First residual.
+    afr_v = attn_v + vlm_hidden
+    afr_e = attn_e + expert_hidden
+
+    # 3. Post-LN (VLM: RMS, Expert: AdaRMS with ada_cond).
+    h_v = rms_norm(afr_v,
+                   weight=target.vlm_layer_post_attn_layernorm_weights[layer_idx],
+                   eps=dims.rms_eps)
+    h_e = ada_rms_norm(
+        afr_e, ada_cond,
+        weight=target.expert_layer_post_attn_layernorm_weights[layer_idx],
+        gamma_weight=target.expert_layer_post_attn_layernorm_gamma_weights[layer_idx],
+        gamma_bias=target.expert_layer_post_attn_layernorm_gamma_biases[layer_idx],
+        beta_weight=target.expert_layer_post_attn_layernorm_beta_weights[layer_idx],
+        beta_bias=target.expert_layer_post_attn_layernorm_beta_biases[layer_idx],
+        eps=dims.rms_eps,
+        site_prefix=f"expert.layer.{layer_idx}.post_attn_ln",
+    )
+
+    # 4. SwiGLU MLP (no bias).
+    mlp_v = swiglu_mlp(h_v,
+        gate_weight=target.vlm_layer_mlp_gate_proj_weights[layer_idx],
+        up_weight=target.vlm_layer_mlp_up_proj_weights[layer_idx],
+        down_weight=target.vlm_layer_mlp_down_proj_weights[layer_idx],
+        site_prefix=f"vlm.layer.{layer_idx}.mlp")
+    mlp_e = swiglu_mlp(h_e,
+        gate_weight=target.expert_layer_mlp_gate_proj_weights[layer_idx],
+        up_weight=target.expert_layer_mlp_up_proj_weights[layer_idx],
+        down_weight=target.expert_layer_mlp_down_proj_weights[layer_idx],
+        site_prefix=f"expert.layer.{layer_idx}.mlp")
+
+    # 5. Second residual.
+    out_v = mlp_v + afr_v
+    out_e = mlp_e + afr_e
+
+    return out_v, out_e
+
+
+__all__ = [
+    "AttentionDims",
+    "DEFAULT_ATTN_DIMS",
+    "compute_kqv_vlm",
+    "compute_kqv_expert",
+    "mixed_head_attention_layer",
+    "mixed_head_layer_full",
+    "swiglu_mlp",
+    "swiglu_mlp_from_fp8",
+]

--- a/flash_rt/models/lingbot/norms.py
+++ b/flash_rt/models/lingbot/norms.py
@@ -1,0 +1,113 @@
+"""LingBot-VLA normalization helpers.
+
+Pure-PyTorch reference implementations of:
+    * ``Qwen2RMSNorm``    used by the VLM tower (input/post-attn LN)
+    * ``AdaRMSNorm``      used by the Action Expert (input/post-attn LN
+                           with FiLM scale+shift conditioned on the
+                           timestep embedding)
+
+Math copied from ``lingbotvla/models/vla/pi0/modeling_lingbot_vla.py``
+(Qwen2RMSNorm @ L227, AdaRMSNorm @ L1043). Both compute the variance and
+normalization in fp32 and cast the final result back to the input dtype
+— matching this is required for bit-exact cosine vs upstream.
+
+These functions are stateless (take raw weight tensors instead of an
+nn.Module); they exist to make + forward paths composable from the
+device-bound weight target without needing to instantiate upstream modules.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from flash_rt.models.lingbot.kernel_ops import linear_bf16, linear_fp8
+
+
+def rms_norm(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """Functional Qwen2RMSNorm: ``weight * (x / sqrt(mean(x^2) + eps))``.
+
+    Math is identical to upstream ``Qwen2RMSNorm.forward``:
+        1. Cast to fp32.
+        2. variance = mean(x^2, dim=-1, keepdim=True).
+        3. x = x * rsqrt(variance + eps).
+        4. y = weight * x.to(input_dtype).
+
+    Args:
+        hidden_states: ``[..., hidden]``.
+        weight:        ``[hidden]`` RMS gain (no bias).
+        eps:           variance epsilon (default 1e-6 matches Qwen2.5-VL).
+
+    Returns:
+        Same shape/dtype as ``hidden_states``.
+    """
+    input_dtype = hidden_states.dtype
+    x = hidden_states.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    return weight * x.to(input_dtype)
+
+
+def ada_rms_norm(
+    hidden_states: torch.Tensor,
+    cond: torch.Tensor,
+    *,
+    weight: torch.Tensor,
+    gamma_weight: torch.Tensor,
+    gamma_bias: torch.Tensor,
+    beta_weight: torch.Tensor,
+    beta_bias: torch.Tensor,
+    eps: float = 1e-6,
+    site_prefix: "str | None" = None,
+) -> torch.Tensor:
+    """Functional AdaRMSNorm: RMSNorm + FiLM ``(1 + γ(cond)) * x + β(cond)``.
+
+    Math is identical to upstream ``AdaRMSNorm.forward``:
+        x_norm = weight * (x / sqrt(mean(x^2) + eps))    in fp32
+        γ      = Linear(gamma_w, gamma_b)(cond)          [B, hidden]
+        β      = Linear(beta_w,  beta_b )(cond)          [B, hidden]
+        y      = (1 + γ.unsqueeze(1)) * x_norm + β.unsqueeze(1)
+        return y.to(input_dtype)
+
+    Note the FiLM linears use ``(weight @ cond.T + bias).T`` semantics;
+    we call ``F.linear`` which is the same matmul. The result is
+    broadcast over the token axis via ``unsqueeze(1)``.
+
+    Args:
+        hidden_states: ``[B, L, hidden]``.
+        cond:          ``[B, cond_dim]`` (timestep embedding).
+        weight:        ``[hidden]`` RMS gain.
+        gamma_weight:  ``[hidden, cond_dim]``.
+        gamma_bias:    ``[hidden]``.
+        beta_weight:   ``[hidden, cond_dim]``.
+        beta_bias:     ``[hidden]``.
+        eps:           variance epsilon.
+
+    Returns:
+        ``[B, L, hidden]`` same dtype as ``hidden_states``.
+    """
+    input_dtype = hidden_states.dtype
+    x = hidden_states.to(torch.float32)
+    variance = x.pow(2).mean(-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    x = weight * x                                   # still fp32
+
+    if site_prefix is None:
+        sid_g = sid_b = None
+    else:
+        sid_g = f"{site_prefix}.gamma"
+        sid_b = f"{site_prefix}.beta"
+    gamma = linear_fp8(cond, gamma_weight, gamma_bias,
+                       site_id=sid_g).unsqueeze(1)  # [B, 1, hidden]
+    beta = linear_fp8(cond, beta_weight, beta_bias,
+                      site_id=sid_b).unsqueeze(1)
+    out = (1 + gamma.to(torch.float32)) * x + beta.to(torch.float32)
+    return out.to(input_dtype)
+
+
+__all__ = ["rms_norm", "ada_rms_norm"]

--- a/flash_rt/models/lingbot/pipeline_thor.py
+++ b/flash_rt/models/lingbot/pipeline_thor.py
@@ -1,0 +1,169 @@
+"""LingBot-VLA pipeline dimensions for Thor SM110.
+
+Holds ``LingBotPipelineDims`` — the static shape constants (layer counts,
+hidden/head dims, FFN widths) shared by the compute functions in
+``forward.py`` / ``sample_actions.py`` and by the torch frontend. The
+actual forward functions live in ``forward.py`` (prefix encode) and
+``sample_actions.py`` / ``graph_runner.py`` (denoise loop + CUDA Graph
+capture); they operate on raw device pointers via ``fvk.*`` and the
+LingBot kernel wrappers in ``kernel_ops.py``.
+
+Architecture summary: SigLIP-style ViT vision tower, a 36-layer
+Qwen2.5-VL backbone (VLM prefix), and a 36-layer flow-matching action
+expert that runs a multi-step Euler ODE captured into a CUDA Graph.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LingBotPipelineDims:
+    """Static shape constants for LingBot-VLA on Thor.
+
+    These are the source of truth (yaml is metadata). Verified against
+    the baseline weight inventory (1555 tensors, 36L VLM + 36L expert +
+    32L ViT) on 2026-05-19.
+    """
+    # ── Vision Tower (Qwen2.5-VL ViT) ─────────────────────────────
+    vit_num_blocks: int = 32
+    vit_hidden_dim: int = 1280
+    vit_num_heads: int = 16
+    vit_head_dim: int = 80                    # 1280 / 16
+    vit_patch_size: int = 14
+    vit_temporal_patch_size: int = 2
+    vit_spatial_merge_size: int = 2
+    vit_intermediate: int = 3420
+    vit_out_hidden_size: int = 2048
+    vit_num_patches_per_img: int = 256        # (224/14)^2
+    vit_num_tokens_per_img: int = 64          # after spatial_merge=2
+
+    # ── Prefix LLM (Qwen2.5-VL 3B) ────────────────────────────────
+    vlm_num_layers: int = 36
+    vlm_hidden_dim: int = 2048
+    vlm_num_heads: int = 16
+    vlm_num_kv_heads: int = 2                 # GQA n_rep=8
+    vlm_head_dim: int = 128
+    vlm_intermediate: int = 11008
+    vlm_rope_theta: float = 1_000_000.0
+    vlm_mrope_section: tuple[int, int, int] = (16, 24, 24)
+    vlm_rms_norm_eps: float = 1e-6
+    vlm_vocab_size: int = 151936
+
+    # ── Action Expert (Qwen2-768, Mixed-Head) ─────────────────────
+    expert_num_layers: int = 36
+    expert_hidden_dim: int = 768
+    expert_num_heads: int = 16
+    expert_num_kv_heads: int = 2
+    expert_head_dim: int = 128
+    expert_q_proj_out_dim: int = 2048         # 16 * 128 — Mixed-Head asymmetry
+    expert_intermediate: int = 2752
+    expert_adanorm_cond_dim: int = 768
+
+    # ── Action head / Flow Matching ───────────────────────────────
+    state_dim: int = 75
+    action_dim: int = 75
+    proj_width: int = 768                     # state_proj/action_in_proj out
+    action_time_mlp_in: int = 1536            # sin/cos timestep emb (2*768)
+
+    # ── Inference ─────────────────────────────────────────────────
+    num_steps: int = 50
+    num_cams: int = 3
+    img_size: int = 224
+    tokenizer_max_length: int = 72
+
+    # ── Sequence length budgets (max, for site allocation) ────────
+    # Prefix tokens = num_cams * num_tokens_per_img + tokenizer_max_length
+    #               = 3 * 64 + 72 = 264; round up to 384 for headroom.
+    max_prefix_seq: int = 384
+    # Suffix tokens = 1 state + n_action_steps actions = 51; round to 64.
+    max_suffix_seq: int = 64
+
+
+def make_attention_spec(dims: LingBotPipelineDims):
+    """Build an AttentionSpec for LingBot-VLA's three attention sites.
+
+    Sites:
+      * ``vit``   — Qwen2.5-VL ViT, 32 blocks, full MHA (16Q/16KV, HD=80),
+                    Q seq = 3 cams × 256 patches = 768.
+      * ``vlm_prefix`` — Mixed-Head joint attention during *prefix encode*,
+                    Q seq = prefix tokens only (img+lang), 36 layers,
+                    GQA 16Q/2KV, HD=128. Even though Expert also computes
+                    Q/K/V here, embed_prefix only feeds prefix embeddings;
+                    the expert path stays empty until denoise.
+      * ``vlm_suffix`` — Mixed-Head joint attention during *denoise step*,
+                    Q seq = suffix only (state + 50 actions = 51), KV =
+                    prefix + suffix concatenated. Same 36 layers,
+                    GQA 16Q/2KV, HD=128.
+
+    : spec is declared but the backend is a stub that does not run
+    kernels yet.
+    """
+    from flash_rt.hardware.backend import SiteSpec, AttentionSpec
+
+    return AttentionSpec(sites={
+        "vit": SiteSpec(
+            num_layers=dims.vit_num_blocks,
+            num_q_heads=dims.vit_num_heads,
+            num_kv_heads=dims.vit_num_heads,        # MHA
+            head_dim=dims.vit_head_dim,
+            max_q_seq=dims.num_cams * dims.vit_num_patches_per_img,
+            batch_axis=1,
+        ),
+        "vlm_prefix": SiteSpec(
+            num_layers=dims.vlm_num_layers,
+            num_q_heads=dims.vlm_num_heads,
+            num_kv_heads=dims.vlm_num_kv_heads,     # GQA
+            head_dim=dims.vlm_head_dim,
+            max_q_seq=dims.max_prefix_seq,
+        ),
+        "vlm_suffix": SiteSpec(
+            num_layers=dims.vlm_num_layers,
+            num_q_heads=dims.vlm_num_heads,
+            num_kv_heads=dims.vlm_num_kv_heads,
+            head_dim=dims.vlm_head_dim,
+            max_q_seq=dims.max_suffix_seq,
+            max_kv_seq=dims.max_prefix_seq + dims.max_suffix_seq,
+        ),
+    })
+
+
+class LingBotPipelineThor:
+    """LingBot-VLA pipeline on Thor SM110.
+
+    : constructor stub — accepts dims + an attention backend, validates
+    geometry, then any compute method raises NotImplementedError.
+    """
+
+    def __init__(self, gemm, fvk, attn_backend, weights, dims: LingBotPipelineDims):
+        self._gemm = gemm
+        self._fvk = fvk
+        self._attn = attn_backend
+        self._weights = weights
+        self.dims = dims
+
+    def encode_prefix(self, *, stream: int = 0) -> int:
+        """Run ViT + VLM 36L (prefix-only attention, fill KV cache).
+
+        Returns: int ptr to prefix KV cache base.
+        """
+        raise NotImplementedError("encode_prefix — implemented later+")
+
+    def denoise_step(self, *, t_emb_ptr: int, x_t_ptr: int, stream: int = 0) -> int:
+        """One Euler ODE step: 36L expert + Mixed-Head attention into KV.
+
+        Returns: int ptr to velocity v_t [B, 50, 75].
+        """
+        raise NotImplementedError("denoise_step — implemented later+")
+
+    def run_pipeline(self, *, stream: int = 0):
+        """Full forward: prefix → 50 × denoise_step → action_out_proj."""
+        raise NotImplementedError("run_pipeline — implemented later+")
+
+    def forward(self):
+        """Replay captured CUDA graph or fall back to run_pipeline."""
+        raise NotImplementedError("forward — CUDA graph wired later+")

--- a/flash_rt/models/lingbot/rope_adapter.py
+++ b/flash_rt/models/lingbot/rope_adapter.py
@@ -1,0 +1,156 @@
+"""Host-side RoPE cos/sin table construction for LingBot-VLA.
+
+LingBot's Mixed-Head LLM (the hot 36 layers × 50 Euler steps path) does NOT
+use the Qwen2.5-VL multimodal M-RoPE despite the ckpt config exposing one.
+Instead, ``lingbotvla/models/vla/pi0/utils.py::apply_rope`` is called with
+flat 1D ``position_ids`` (constructed in modeling_lingbot_vla.py via
+``cumsum(pad_masks) - 1`` and ``prefix_offsets + cumsum(suffix_pad_masks) - 1``).
+
+That apply_rope is plain 1-D RoPE in **split-half** layout:
+
+    inv_freq[i] = 1.0 / 10000 ** (2 i / head_dim)     for i in [0, head_dim/2)
+    radians[b, l, i] = positions[b, l] * inv_freq[i]
+    cos = cos(radians), sin = sin(radians)           shape (B, L, head_dim/2)
+    x1, x2 = x.split(head_dim/2, dim=-1)
+    out = concat([x1*cos - x2*sin, x2*cos + x1*sin], dim=-1)
+
+This is **NOT** the HF ``rotate_half`` form (which interleaves dims by 1)
+and **NOT** M-RoPE (which selects axis frequencies per chunk). For the
+ViT path (which DOES use a different 2-D M-RoPE over image patches),
+see ``flash_rt.models.lingbot.rope_adapter_vit`` (added later).
+
+Built once per ``set_prompt`` (when the prefix layout is fixed) and
+once per denoise step (when the suffix position_ids extend). Stored as
+device tensors and reused as inputs to the existing flash_rt RoPE
+kernels during every graph replay.
+
+Math source: ``lingbotvla/models/vla/pi0/utils.py::apply_rope`` —
+validated bit-exact against the upstream reference.
+
+This module is pure-PyTorch (CPU/GPU agnostic). It does NOT call any
+flash_rt_kernels symbol — the kernel consumes the tensors produced here
+unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class LingbotRopeConfig:
+    """LingBot-VLA Mixed-Head LLM 1-D RoPE constants.
+
+    Locked by ``utils.apply_rope`` defaults + the QwenvlWithExpertConfig
+    head_dim. NOT to be confused with Qwen2.5-VL's M-RoPE config on the
+    ViT side (which has rope_theta=1e6 and mrope_section=[16,24,24]) — the
+    Mixed-Head LLM forward overrides the HF path and uses these constants.
+    """
+
+    head_dim: int = 128
+    max_wavelength: float = 10_000.0
+
+
+def compute_inv_freq(
+    cfg: LingbotRopeConfig,
+    *,
+    device=None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """``1 / max_wavelength ** (2 i / head_dim)`` for ``i ∈ [0, head_dim/2)``.
+
+    Returns: tensor of shape ``(head_dim/2,)``, dtype as requested.
+    """
+    half = cfg.head_dim // 2
+    freq_exponents = (2.0 / cfg.head_dim) * torch.arange(
+        half, dtype=dtype, device=device
+    )
+    timescale = cfg.max_wavelength ** freq_exponents
+    return 1.0 / timescale
+
+
+def build_cos_sin_table(
+    positions: torch.Tensor,
+    cfg: LingbotRopeConfig,
+    *,
+    compute_dtype: torch.dtype = torch.float32,
+    out_dtype: torch.dtype | None = None,
+    device=None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build ``(cos, sin)`` of shape ``(B, L, head_dim/2)`` from position ids.
+
+    Args:
+        positions: ``(B, L)`` integer or float positions. Will be cast to
+            ``compute_dtype`` internally to match the upstream apply_rope
+            arithmetic exactly.
+        cfg: ``LingbotRopeConfig``.
+        compute_dtype: dtype used for the sin/cos compute. Default fp32
+            (matches lingbot apply_rope's default ``dtype=torch.float32``).
+        out_dtype: dtype of returned tensors. ``None`` means same as
+            ``compute_dtype``. Set to fp16 for kernel handoff.
+        device: device for the output. Defaults to positions' device.
+
+    Returns:
+        ``cos``, ``sin`` of shape ``(B, L, head_dim/2)``.
+
+    Notes:
+        The returned tables are **split-half** — they cover the first
+        ``head_dim/2`` slots only. The downstream apply step treats the
+        head_dim as ``[x1 | x2]`` where ``x1, x2`` each have ``head_dim/2``
+        elements and uses the SAME cos/sin for both halves. (This is the
+        layout used by ``utils.apply_rope`` — NOT HF's rotate_half form.)
+    """
+    if device is None:
+        device = positions.device
+    inv_freq = compute_inv_freq(cfg, device=device, dtype=compute_dtype)
+    pos_cast = positions.to(compute_dtype)
+    # radians: (B, L, head_dim/2)
+    radians = torch.einsum("bl,h->blh", pos_cast, inv_freq)
+    cos = torch.cos(radians)
+    sin = torch.sin(radians)
+    if out_dtype is not None and out_dtype != compute_dtype:
+        cos = cos.to(out_dtype)
+        sin = sin.to(out_dtype)
+    return cos, sin
+
+
+def apply_rope_with_tables(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> torch.Tensor:
+    """Apply pre-built cos/sin to ``x: (B, L, H, D)`` — pure-PyTorch reference.
+
+    Used by the bit-exact test to verify our cos/sin path matches the
+    upstream apply_rope. The flash_rt kernel will do the same math
+    on-device.
+
+    cos, sin should have shape ``(B, L, head_dim/2)``; we add a head
+    broadcast axis automatically (the original ``utils.apply_rope`` does
+    the same via ``radians[..., None, :]``).
+    """
+    d = x.shape[-1]
+    d_half = d // 2
+    cos = cos[..., None, :]  # (B, L, 1, head_dim/2)
+    sin = sin[..., None, :]
+    x1, x2 = x.split(d_half, dim=-1)
+    return torch.cat(
+        [x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1
+    )
+
+
+# Default config instance for the LingBot-VLA Mixed-Head LLM path.
+# Importers should use this constant rather than re-instantiating, so
+# that the values stay in lock-step with the model file.
+LINGBOT_ROPE_CONFIG = LingbotRopeConfig(head_dim=128, max_wavelength=10_000.0)
+
+
+__all__ = [
+    "LingbotRopeConfig",
+    "LINGBOT_ROPE_CONFIG",
+    "compute_inv_freq",
+    "build_cos_sin_table",
+    "apply_rope_with_tables",
+]

--- a/flash_rt/models/lingbot/sample_actions.py
+++ b/flash_rt/models/lingbot/sample_actions.py
@@ -1,0 +1,394 @@
+"""LingBot-VLA end-to-end ``sample_actions`` — full inference pipeline.
+
+Glues together every component to produce action chunks from raw
+inputs (images + state + prompt + noise), matching the upstream
+``LingbotVlaPolicy.model.sample_actions`` API.
+
+Pipeline:
+
+    embed_prefix(images, img_masks, lang_tokens, lang_masks)
+        ↓ prefix_embs, prefix_pad_masks, prefix_att_masks
+    make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+    prefix_position_ids = cumsum(prefix_pad_masks) - 1
+    prefix_encode_36L(prefix_embs, ...)
+        ↓ _, kv_cache (one entry per layer)
+
+    x_t = noise  (or randn)
+    time = 1.0
+    while time >= -dt / 2:
+        embed_suffix(state, x_t, time)
+            ↓ time_emb (ada_cond), suffix_embs, suffix_pad_masks, suffix_att_masks
+        full attention mask = [prefix_pad_2d | suffix_att_2d]
+        position_ids = prefix_offsets + cumsum(suffix_pad_masks) - 1
+        denoise_step_36L(suffix_embs, ..., ada_cond=time_emb, kv_cache)
+            ↓ out [B, suffix_len, 768]
+        v_t = action_out_proj(out[:, -50:])
+        x_t += dt * v_t
+        time += dt
+    return x_t
+
+Reference: upstream
+``lingbotvla/models/vla/pi0/modeling_lingbot_vla.py::FlowMatching::sample_actions``
+(L1744) + ``embed_prefix`` (L1551) + ``embed_suffix`` (L1616) +
+``predict_velocity`` (L1796).
+"""
+
+from __future__ import annotations
+
+import math
+
+import einops
+import torch
+import torch.nn.functional as F
+from flash_rt.models.lingbot.kernel_ops import linear_bf16, linear_fp8
+
+from flash_rt.models.lingbot.forward import (
+    denoise_step_36L, prefix_encode_36L, mask_kv_cache_pad_rows,
+    precompute_expert_film,
+)
+from flash_rt.models.lingbot.mixed_attention import (
+    AttentionDims, DEFAULT_ATTN_DIMS,
+)
+from flash_rt.models.lingbot.rope_adapter import (
+    LINGBOT_ROPE_CONFIG, build_cos_sin_table,
+)
+from flash_rt.models.lingbot.vit import embed_image
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Helpers ported from lingbotvla/models/vla/pi0/utils.py
+# ════════════════════════════════════════════════════════════════════
+
+def _create_sinusoidal_pos_embedding(
+    time: torch.Tensor, dimension: int,
+    min_period: float, max_period: float, device,
+) -> torch.Tensor:
+    """Bit-exact replica of ``utils.create_sinusoidal_pos_embedding``."""
+    if dimension % 2 != 0:
+        raise ValueError(f"dimension ({dimension}) must be divisible by 2")
+    fraction = torch.linspace(
+        0.0, 1.0, dimension // 2, dtype=torch.float32, device=device)
+    period = min_period * (max_period / min_period) ** fraction
+    scaling_factor = 1.0 / period * 2 * math.pi
+    sin_input = scaling_factor[None, :] * time[:, None]
+    return torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=1)
+
+
+def precompute_film(
+    num_steps: int, target, dims, device, dtype,
+) -> torch.Tensor:
+    """: the Euler timestep schedule (time 1.0 → 0, step dt=-1/N) is
+    deterministic, so build every step's ``ada_cond`` (the timestep
+    sinusoidal embedding) up front, [N, H], and run one batched GEMM for
+    all Expert FiLM γ/β. Returns ``[N, num_layers, 4, H]``."""
+    dt = -1.0 / num_steps
+    # Build on-device with arange (capture-safe); torch.tensor([...]) would
+    # do an illegal host->device copy inside a CUDA-graph capture.
+    times = 1.0 + dt * torch.arange(num_steps, device=device, dtype=dtype)
+    ada_all = _create_sinusoidal_pos_embedding(
+        times, dims.expert_hidden, min_period=4e-3, max_period=4.0,
+        device=device).to(dtype)                       # [N, H]
+    return precompute_expert_film(ada_all, target, num_layers=36)
+
+
+def make_att_2d_masks(
+    pad_masks: torch.Tensor, att_masks: torch.Tensor,
+) -> torch.Tensor:
+    """Bit-exact replica of ``utils.make_att_2d_masks``.
+
+    pad_masks: ``[B, N]`` bool.
+    att_masks: ``[B, N]`` int — cumulative-segment block-causal coding.
+    """
+    cumsum = torch.cumsum(att_masks, dim=1)
+    att_2d_masks = cumsum[:, None, :] <= cumsum[:, :, None]
+    pad_2d_masks = pad_masks[:, None, :] * pad_masks[:, :, None]
+    return att_2d_masks & pad_2d_masks
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Embed prefix (vision + language)
+# ════════════════════════════════════════════════════════════════════
+
+def embed_prefix(
+    images: torch.Tensor,         # [B, N, 256, 1176] (pre-patchified)
+    img_masks: torch.Tensor,      # [B, N] bool
+    lang_tokens: torch.Tensor,    # [B, L_lang] long
+    lang_masks: torch.Tensor,     # [B, L_lang] bool
+    *,
+    target,
+    vlm_causal: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return ``(prefix_embs, pad_masks, att_masks)`` matching upstream
+    ``FlowMatching.embed_prefix`` for the inference path (no depth).
+    """
+    B = images.shape[0]
+    if images.ndim == 5:
+        images = einops.rearrange(images, "b n c h w -> (b n) c h w")
+    elif images.ndim == 4:
+        images = einops.rearrange(images, "b n l d -> (b n) l d")
+
+    img_emb = embed_image(images, target=target)              # [B*N, 64, 2048]
+    num_patch = img_emb.shape[1]
+    img_emb = einops.rearrange(img_emb, "(b n) l d -> b (n l) d", b=B)
+    num_img_embs = img_emb.shape[1]
+    if img_masks.ndim == 1:
+        img_masks = img_masks.unsqueeze(0)
+    img_masks = einops.repeat(img_masks, "b n -> b (n l)", l=num_patch)
+
+    # Language embedding — F.embedding using vlm_embed_tokens_weight.
+    lang_emb = F.embedding(lang_tokens, target.vlm_embed_tokens_weight)
+    num_lang_embs = lang_emb.shape[1]
+
+    embs = torch.cat([img_emb, lang_emb], dim=1)
+    pad_masks = torch.cat([img_masks, lang_masks], dim=1)
+    if vlm_causal:
+        att_masks = torch.ones(
+            (img_emb.size(0), num_img_embs + num_lang_embs),
+            device=images.device, dtype=torch.bool,
+        )
+    else:
+        att_masks = torch.zeros(
+            (img_emb.size(0), num_img_embs + num_lang_embs),
+            device=images.device, dtype=torch.bool,
+        )
+    return embs, pad_masks, att_masks
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Embed suffix (state + action + timestep)
+# ════════════════════════════════════════════════════════════════════
+
+def embed_suffix(
+    state: torch.Tensor,                # [B, state_dim=75]
+    noisy_actions: torch.Tensor,        # [B, n_steps=50, action_dim=75]
+    timestep: torch.Tensor,             # [B]
+    *,
+    target,
+    proj_width: int = 768,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return ``(time_emb_for_ada, embs, pad_masks, att_masks)`` matching
+    upstream ``FlowMatching.embed_suffix`` for the inference path
+    (no ``separate_time_proj``)."""
+    B = state.shape[0]
+    device = state.device
+    dtype = state.dtype
+
+    # state projection
+    state_emb = linear_fp8(state, target.state_proj_weight,
+                         target.state_proj_bias,
+                         site_id="action.state_proj")          # [B, 768]
+
+    # sinusoidal timestep embedding (fp32 internal, then cast)
+    time_emb = _create_sinusoidal_pos_embedding(
+        timestep, proj_width, min_period=4e-3, max_period=4.0, device=device,
+    ).to(dtype)                                              # [B, 768]
+    time_emb_ori = time_emb
+
+    # action proj
+    action_emb = linear_fp8(
+        noisy_actions, target.action_in_proj_weight,
+        target.action_in_proj_bias,
+        site_id="action.in_proj",
+    )                                                        # [B, n_steps, 768]
+
+    # broadcast time across n_steps and fuse via action_time_mlp
+    time_emb_exp = einops.repeat(
+        time_emb, "b d -> b n d", n=action_emb.shape[1])
+    action_time_emb = torch.cat([action_emb, time_emb_exp], dim=-1)   # [B, n_steps, 1536]
+    action_time_emb = linear_fp8(
+        action_time_emb, target.action_time_mlp_in_weight,
+        target.action_time_mlp_in_bias,
+        site_id="action.time_mlp.in",
+    )
+    action_time_emb = F.silu(action_time_emb)
+    action_time_emb = linear_fp8(
+        action_time_emb, target.action_time_mlp_out_weight,
+        target.action_time_mlp_out_bias,
+        site_id="action.time_mlp.out",
+    )                                                        # [B, n_steps, 768]
+
+    n_action = action_time_emb.shape[1]
+    embs = torch.cat([state_emb[:, None], action_time_emb], dim=1)   # [B, 1+n_steps, 768]
+    pad_masks = torch.ones((B, n_action + 1), device=device, dtype=torch.bool)
+    att_masks = torch.zeros((B, n_action + 1), device=device, dtype=torch.bool)
+    att_masks[:, :2] = True                                  # state + first action are anchors
+
+    return time_emb_ori, embs, pad_masks, att_masks
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Velocity head + full sample_actions
+# ════════════════════════════════════════════════════════════════════
+
+def predict_velocity(
+    state: torch.Tensor,
+    prefix_pad_masks: torch.Tensor,
+    kv_cache: dict,
+    x_t: torch.Tensor,
+    timestep: torch.Tensor,
+    *,
+    target,
+    n_action_steps: int = 50,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+    use_fused_attn: bool = False,
+    film: torch.Tensor | None = None,    # precomputed FiLM [N, L, 4, H]
+    step_idx: int | None = None,         # which step
+    rope_cos: torch.Tensor | None = None,  # precomputed (constant across steps)
+    rope_sin: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """One denoise step — Expert-only forward + velocity head."""
+    time_emb, suffix_embs, suffix_pad_masks, suffix_att_masks = embed_suffix(
+        state, x_t, timestep, target=target, proj_width=dims.expert_hidden,
+    )
+
+    B, suffix_len = suffix_pad_masks.shape
+    prefix_len = prefix_pad_masks.shape[1]
+
+    # Full attention mask: [B, suffix_len, prefix_len + suffix_len]. The fused
+    # denoise attention ignores the mask , so building it
+    # is dead per-step work — skip it entirely when fused.
+    if use_fused_attn:
+        full_mask = None
+    else:
+        prefix_pad_2d = prefix_pad_masks[:, None, :].expand(B, suffix_len, prefix_len)
+        suffix_att_2d = make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
+        full_mask = torch.cat([prefix_pad_2d, suffix_att_2d], dim=2)
+
+    # position_ids only feeds build_cos_sin_table, which is skipped when
+    # rope_cos/sin are precomputed . So the
+    # per-step sum+cumsum is dead work on the graph path; compute it only on the
+    # fallback path that actually builds the RoPE table per step.
+    if rope_cos is None:
+        prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
+        position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
+    else:
+        position_ids = None
+
+    # Denoise step (Expert-only, reads prefix KV from cache).
+    out = denoise_step_36L(
+        suffix_embs,
+        position_ids=position_ids,
+        ada_cond=time_emb,
+        attention_mask=full_mask,
+        target=target, kv_cache=kv_cache, dims=dims,
+        use_fused_attn=use_fused_attn,
+        film=film, step_idx=step_idx,
+        rope_cos=rope_cos, rope_sin=rope_sin,
+    )
+
+    # Take last n_action_steps tokens → velocity head (768 → 75).
+    suffix_out = out[:, -n_action_steps:]
+    v_t = linear_fp8(
+        suffix_out, target.action_out_proj_weight,
+        target.action_out_proj_bias,
+        site_id="action.out_proj",
+    )
+    return v_t
+
+
+def sample_actions(
+    images: torch.Tensor,
+    img_masks: torch.Tensor,
+    lang_tokens: torch.Tensor,
+    lang_masks: torch.Tensor,
+    state: torch.Tensor,
+    *,
+    target,
+    noise: torch.Tensor | None = None,
+    num_steps: int = 50,
+    n_action_steps: int = 50,
+    action_dim: int = 75,
+    vlm_causal: bool = False,
+    dims: AttentionDims = DEFAULT_ATTN_DIMS,
+    use_fused_denoise_attn: "bool | None" = None,
+) -> torch.Tensor:
+    """Full inference. Returns ``[B, n_action_steps, action_dim]`` action chunk.
+
+    Match the upstream ABI of ``FlowMatching.sample_actions``.
+    """
+    # auto-enable fused denoise attention when static scales
+    # are loaded. The dynamic-FP8 path's per-call absmax-reduce is
+    # unstable on the slightly-shifted activation distribution that the
+    # unmasked attention produces (the prior calibration captured
+    # the masked-attention distribution; static scales absorb the shift,
+    # dynamic scales don't). Without static scales, fall back to eager.
+    if use_fused_denoise_attn is None:
+        from flash_rt.models.lingbot import calibration as _calib
+        use_fused_denoise_attn = _calib.has_static_scales()
+
+    B = state.shape[0]
+    device = state.device
+    dtype = state.dtype
+
+    if noise is None:
+        noise = torch.randn(
+            (B, n_action_steps, action_dim), device=device, dtype=dtype,
+        )
+
+    # ─── Prefix encode (one-time per task) ────────────────────────
+    prefix_embs, prefix_pad_masks, prefix_att_masks = embed_prefix(
+        images, img_masks, lang_tokens, lang_masks,
+        target=target, vlm_causal=vlm_causal,
+    )
+    prefix_att_2d = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+    prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+
+    _, kv_cache = prefix_encode_36L(
+        prefix_embs,
+        position_ids=prefix_position_ids,
+        attention_mask=prefix_att_2d,
+        target=target, dims=dims,
+        pad_mask=prefix_pad_masks,           # enable unmasked FA4 prefix attn
+    )
+
+    # zero out KV cache rows for padding positions in prefix so the
+    # denoise step can use unmasked fused attention (pad K/V → 0
+    # contribution). Saves the eager 4-einsum + softmax + bool-where
+    # chain per Expert layer × num_steps.
+    if use_fused_denoise_attn:
+        mask_kv_cache_pad_rows(kv_cache, prefix_pad_masks)
+
+    # ─── Euler ODE: time 1.0 → 0.0 over num_steps ────────────────
+    # Use Python-side scalars for dt/time so loop control doesn't cross
+    # to device (CUDA-Graph-capture-safe). expanded_time tensor created
+    # per step via torch.full from a Python float.
+    dt_f = -1.0 / num_steps
+    x_t = noise
+    time_f = 1.0
+    # the Euler schedule is deterministic, so precompute every step's
+    # FiLM γ/β in ONE batched GEMM (1440 tiny M=1 launches → 1) when the
+    # fused Expert path is active.
+    film = precompute_film(num_steps, target, dims, device, dtype) \
+        if use_fused_denoise_attn else None
+    # position_ids (hence cos/sin) are constant across denoise steps —
+    # the suffix pad/att masks are structural constants. Precompute the RoPE
+    # tables ONCE here instead of rebuilding them every step in denoise_step_36L.
+    n_action = noise.shape[1]
+    suffix_pad_const = torch.ones((B, n_action + 1), device=device, dtype=torch.bool)
+    prefix_offsets_c = torch.sum(prefix_pad_masks, dim=-1)[:, None]
+    position_ids_c = prefix_offsets_c + torch.cumsum(suffix_pad_const, dim=1) - 1
+    rope_cos_c, rope_sin_c = build_cos_sin_table(
+        position_ids_c, LINGBOT_ROPE_CONFIG, compute_dtype=torch.float32)
+    for i in range(num_steps):
+        expanded_time = torch.full(
+            (B,), time_f, dtype=dtype, device=device,
+        )
+        v_t = predict_velocity(
+            state, prefix_pad_masks, kv_cache, x_t, expanded_time,
+            target=target, n_action_steps=n_action_steps, dims=dims,
+            use_fused_attn=use_fused_denoise_attn,
+            film=film, step_idx=i,
+            rope_cos=rope_cos_c, rope_sin=rope_sin_c,
+        )
+        x_t = x_t + dt_f * v_t
+        time_f += dt_f
+    return x_t
+
+
+__all__ = [
+    "embed_prefix",
+    "embed_suffix",
+    "predict_velocity",
+    "sample_actions",
+    "make_att_2d_masks",
+]

--- a/flash_rt/models/lingbot/vit.py
+++ b/flash_rt/models/lingbot/vit.py
@@ -1,0 +1,486 @@
+"""LingBot-VLA Qwen2.5-VL Vision Tower forward.
+
+ViT path that turns the pre-patchified image tensor produced by the
+upstream image-processor into per-image token embeddings ready for the
+joint prefix sequence (concatenated with the language token embeddings).
+
+Pipeline:
+
+    images [B, N, num_patches=256, patch_dim=1176]
+        │ einops.rearrange "b n l d -> (b n) l d"
+        ▼ [B*N, 256, 1176]
+    patch_embed (Conv3d as kernel=(2,14,14) stride=same)
+        │ proj.weight [1280, 3, 2, 14, 14] applied to view(-1, 3, 2, 14, 14)
+        ▼ [B*N*256, 1280]
+    32 × VitBlock
+        │ each block:
+        │   x + attn(RMSNorm(x))     (varlen mask via cu_seqlens, ViT M-RoPE)
+        │   x + mlp(RMSNorm(x))      (SwiGLU with bias, GELU NOT used here)
+        ▼ [B*N*256, 1280]
+    merger
+        │ RMSNorm → view(-1, 4*1280=5120) → Linear(5120,5120) → GELU → Linear(5120,2048)
+        ▼ [B*N*64, 2048]                (spatial_merge_size=2: 4 tokens → 1)
+    split by image, stack
+        ▼ [B*N, 64, 2048]
+    embed_image returns this; embed_prefix then does
+    einops.rearrange "(b n) l d -> b (n l) d" → [B, N*64, 2048].
+
+Reference upstream implementations (bit-exact targets):
+    Qwen2_5_VisionPatchEmbed.forward    @ qwenvl_in_vla.py L75
+    Qwen2_5_VLVisionAttention.forward   @ L148  (eager, fp32 softmax)
+    Qwen2_5_VLMLP.forward               @ L46   (SwiGLU)
+    Qwen2_5_VLVisionBlock.forward       @ L264
+    Qwen2_5_VLPatchMerger.forward       @ L114-127
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from flash_rt.models.lingbot.kernel_ops import (
+    attention_mha_bf16_fused, linear_bf16, linear_fp8,
+    vit_qkv_bias_rope_fused,
+)
+
+# P1: fuse the per-block ViT qkv bias-add + 2-D M-RoPE into one custom
+# kernel (replaces add_bias + the eager fp32 RoPE storm). Opt-in; the
+# eager path stays the bit-exact test reference.
+_USE_VIT_FUSED_QKV_ROPE = True
+
+from flash_rt.models.lingbot.norms import rms_norm
+from flash_rt.models.lingbot.vit_rope_adapter import (
+    LINGBOT_VIT_ROPE_CONFIG, build_cos_sin_table,
+)
+
+# Capture-safe cache for ``image_grid_thw`` and ``split_sizes`` (which
+# get re-constructed each call in the upstream API). Populated once
+# during warmup, reused during CUDA-Graph capture+replay.
+_GRID_CACHE: dict = {}
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Building blocks
+# ════════════════════════════════════════════════════════════════════
+
+def vit_patch_embed(
+    images: torch.Tensor,
+    *,
+    proj_weight: torch.Tensor,
+    temporal_patch_size: int = 2,
+    patch_size: int = 14,
+    in_channels: int = 3,
+    embed_dim: int = 1280,
+) -> torch.Tensor:
+    """Conv3d patch projection. Input is the pre-patchified tensor from
+    the image processor: ``[N_total, num_patches, patch_dim]`` where
+    ``patch_dim = in_channels * temporal_patch_size * patch_size**2``.
+
+    Matches ``Qwen2_5_VisionPatchEmbed.forward``:
+        view(-1, in_ch, t, p, p) → Conv3d(k=stride=(t,p,p)) → view(-1, embed_dim).
+    """
+    target_dtype = proj_weight.dtype
+    x = images.view(
+        -1, in_channels, temporal_patch_size, patch_size, patch_size
+    ).to(target_dtype)
+    x = F.conv3d(x, proj_weight, bias=None,
+                 stride=(temporal_patch_size, patch_size, patch_size))
+    return x.view(-1, embed_dim)
+
+
+_VIT_MLP_PAD_DONE = "_vit_mlp_intermediate_padded"
+
+
+def pad_vit_mlp_weights(target, *, align: int = 16) -> None:
+    """Zero-pad the ViT MLP intermediate dim up to a 16-multiple, in place.
+
+    Qwen2.5-VL ViT has intermediate=3420, which is NOT 16-aligned, so the
+    gate/up/down FP8 GEMMs fall off the aligned cutlass fast path and run at
+    ~15% efficiency (~6× slower). Padding gate/up output rows (N) and the
+    down input cols (K) to 3424 with zeros recovers the fast path. The pad is
+    mathematically exact: gate_pad = 0·x + 0 = 0 → silu(0) = 0, up_pad = 0,
+    so h_pad = silu(0)·0 = 0, and the down GEMM's extra zero-input cols
+    contribute nothing. absmax is unchanged → static calibration scales stay
+    valid (no recalibration). Idempotent; runs once in eager warmup.
+    """
+    if getattr(target, _VIT_MLP_PAD_DONE, False):
+        return
+    gate_w = target.vit_block_mlp_gate_proj_weights
+    inter = gate_w[0].shape[0]
+    padded = ((inter + align - 1) // align) * align
+    if padded == inter:
+        setattr(target, _VIT_MLP_PAD_DONE, True)
+        return
+    n_pad = padded - inter
+
+    def pad_rows(t):  # [N, K] -> [N+n_pad, K]
+        return F.pad(t, (0, 0, 0, n_pad))
+
+    def pad_vec(t):   # [N] -> [N+n_pad]
+        return F.pad(t, (0, n_pad))
+
+    def pad_cols(t):  # [N, K] -> [N, K+n_pad]
+        return F.pad(t, (0, n_pad))
+
+    target.vit_block_mlp_gate_proj_weights = [pad_rows(w) for w in gate_w]
+    target.vit_block_mlp_up_proj_weights = [
+        pad_rows(w) for w in target.vit_block_mlp_up_proj_weights]
+    target.vit_block_mlp_gate_proj_biases = [
+        pad_vec(b) for b in target.vit_block_mlp_gate_proj_biases]
+    target.vit_block_mlp_up_proj_biases = [
+        pad_vec(b) for b in target.vit_block_mlp_up_proj_biases]
+    target.vit_block_mlp_down_proj_weights = [
+        pad_cols(w) for w in target.vit_block_mlp_down_proj_weights]
+    setattr(target, _VIT_MLP_PAD_DONE, True)
+
+
+def vit_swiglu_mlp(
+    x: torch.Tensor,
+    target,
+    block_idx: int,
+) -> torch.Tensor:
+    """ViT FFN: SwiGLU **with bias** (Qwen2_5_VLMLP, bias=True path)."""
+    prefix = f"vit.block.{block_idx}.mlp"
+    gate = linear_fp8(x,
+        target.vit_block_mlp_gate_proj_weights[block_idx],
+        target.vit_block_mlp_gate_proj_biases[block_idx],
+        site_id=f"{prefix}.gate_proj")
+    up = linear_fp8(x,
+        target.vit_block_mlp_up_proj_weights[block_idx],
+        target.vit_block_mlp_up_proj_biases[block_idx],
+        site_id=f"{prefix}.up_proj")
+    h = F.silu(gate) * up
+    return linear_fp8(h,
+        target.vit_block_mlp_down_proj_weights[block_idx],
+        target.vit_block_mlp_down_proj_biases[block_idx],
+        site_id=f"{prefix}.down_proj")
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """HF rotate_half: ``cat([-x[..., D/2:], x[..., :D/2]], dim=-1)``."""
+    half = x.shape[-1] // 2
+    return torch.cat([-x[..., half:], x[..., :half]], dim=-1)
+
+
+def _apply_rotary_pos_emb_vision(
+    q: torch.Tensor, k: torch.Tensor,
+    cos: torch.Tensor, sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Bit-exact replica of ``apply_rotary_pos_emb_vision`` from
+    transformers.qwen2_5_vl:
+
+        q, k → fp32, cos/sin → fp32 with unsqueeze(-2)
+        q_embed = q * cos + rotate_half(q) * sin
+        cast back to input dtype.
+    """
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q = q.float()
+    k = k.float()
+    cos = cos.unsqueeze(-2).float()
+    sin = sin.unsqueeze(-2).float()
+    q_emb = q * cos + _rotate_half(q) * sin
+    k_emb = k * cos + _rotate_half(k) * sin
+    return q_emb.to(orig_q_dtype), k_emb.to(orig_k_dtype)
+
+
+def vit_attention(
+    hidden_states: torch.Tensor,        # [seq, 1280]
+    *,
+    attn_mask: torch.Tensor,            # ignored when use_per_view_fused=True;
+                                         # kept in API for the eager fallback path
+    cos: torch.Tensor,                  # [seq, 80] ViT 2-D M-RoPE
+    sin: torch.Tensor,
+    target,
+    block_idx: int,
+    num_heads: int = 16,
+    head_dim: int = 80,
+    num_views: int = 3,
+    view_len: int = 256,
+    use_per_view_fused: bool = True,
+) -> torch.Tensor:
+    """One ViT attention block.
+
+    fast path (``use_per_view_fused=True``, default): the upstream
+    ViT mask is block-diagonal — each image's 256 tokens only attend
+    within their own image. We exploit this directly by reshaping
+    Q/K/V to per-view tensors and running ``attention_mha_bf16_fused``
+    once per image (3 unmasked attentions @ S=256 each, vs one large
+    eager softmax @ S=768 that wastes 2/3 of compute on masked-out
+    cross-image terms). cuBLAS-decomposed MHA replaces the 4-einsum
+    + softmax chain. Same primitive Pi0.5 uses; cos-equivalent to the
+    eager + mask path (verified ≤1e-4 absolute).
+
+    Eager fallback (``use_per_view_fused=False``): the original
+    explicit-mask path. Kept for tests that need bit-exact reference.
+    """
+    seq_len = hidden_states.shape[0]
+    use_fused = (use_per_view_fused and _USE_VIT_FUSED_QKV_ROPE
+                 and seq_len == num_views * view_len)
+    qkv_bias = target.vit_block_attn_qkv_biases[block_idx]
+    qkv = linear_fp8(hidden_states,
+        target.vit_block_attn_qkv_weights[block_idx],
+        None if use_fused else qkv_bias,
+        site_id=f"vit.block.{block_idx}.attn.qkv")
+
+    if use_fused:
+        # P1: fused bias-add + 2-D M-RoPE from the raw interleaved
+        # [seq, 3*NH*HD] GEMM output → q/k/v [seq, NH*HD] (q/k roped).
+        q, k, v = vit_qkv_bias_rope_fused(
+            qkv, qkv_bias, cos, sin,
+            num_heads=num_heads, head_dim=head_dim)
+        q_v = q.view(num_views, view_len, num_heads, head_dim)
+        k_v = k.view(num_views, view_len, num_heads, head_dim)
+        v_v = v.view(num_views, view_len, num_heads, head_dim)
+        outs = []
+        for i in range(num_views):
+            outs.append(attention_mha_bf16_fused(
+                q_v[i:i + 1], k_v[i:i + 1], v_v[i:i + 1]))
+        attn = torch.cat(outs, dim=1).view(seq_len, num_heads * head_dim)
+        return linear_fp8(attn,
+            target.vit_block_attn_proj_weights[block_idx],
+            target.vit_block_attn_proj_biases[block_idx],
+            site_id=f"vit.block.{block_idx}.attn.proj")
+
+    qkv = qkv.reshape(seq_len, 3, num_heads, head_dim).permute(1, 0, 2, 3)
+    q, k, v = qkv.unbind(0)             # each [seq, num_heads, head_dim]
+    q, k = _apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+    if use_per_view_fused and seq_len == num_views * view_len:
+        # per-view fused attention. q/k/v reshape from
+        # [N*L, NH, HD] to [N, L, NH, HD] and call the unmasked fused
+        # kernel once per view (L=256 each). The block-diagonal mask
+        # is encoded structurally by the per-view dispatch.
+        q_v = q.view(num_views, view_len, num_heads, head_dim)
+        k_v = k.view(num_views, view_len, num_heads, head_dim)
+        v_v = v.view(num_views, view_len, num_heads, head_dim)
+        outs = []
+        for i in range(num_views):
+            outs.append(attention_mha_bf16_fused(
+                q_v[i:i + 1], k_v[i:i + 1], v_v[i:i + 1]))
+        # outs: list of [1, L, NH*HD] → cat to [1, N*L, NH*HD] → [seq, NH*HD]
+        attn = torch.cat(outs, dim=1).view(seq_len, num_heads * head_dim)
+        return linear_fp8(attn,
+            target.vit_block_attn_proj_weights[block_idx],
+            target.vit_block_attn_proj_biases[block_idx],
+            site_id=f"vit.block.{block_idx}.attn.proj")
+
+    # Eager fallback (used by per-block tests; matches upstream bit-exact).
+    q = q.transpose(0, 1)
+    k = k.transpose(0, 1)
+    v = v.transpose(0, 1)
+    attn_w = torch.matmul(q, k.transpose(1, 2)) / math.sqrt(head_dim)
+    attn_w = attn_w + attn_mask
+    attn_w = F.softmax(attn_w, dim=-1, dtype=torch.float32).to(q.dtype)
+    attn = torch.matmul(attn_w, v).transpose(0, 1).reshape(
+        seq_len, num_heads * head_dim,
+    )
+    return linear_fp8(attn,
+        target.vit_block_attn_proj_weights[block_idx],
+        target.vit_block_attn_proj_biases[block_idx],
+        site_id=f"vit.block.{block_idx}.attn.proj")
+
+
+def vit_block(
+    hidden_states: torch.Tensor,
+    *,
+    attn_mask: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    target,
+    block_idx: int,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """One ViT transformer block (norm1+attn+residual, norm2+mlp+residual)."""
+    h = hidden_states + vit_attention(
+        rms_norm(hidden_states,
+                 weight=target.vit_block_norm1_weights[block_idx], eps=eps),
+        attn_mask=attn_mask, cos=cos, sin=sin,
+        target=target, block_idx=block_idx,
+    )
+    h = h + vit_swiglu_mlp(
+        rms_norm(h, weight=target.vit_block_norm2_weights[block_idx], eps=eps),
+        target=target, block_idx=block_idx,
+    )
+    return h
+
+
+def vit_merger(
+    hidden_states: torch.Tensor,        # [seq, 1280]
+    *,
+    target,
+    spatial_merge_size: int = 2,
+    context_dim: int = 1280,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """``Qwen2_5_VLPatchMerger``: RMSNorm → view → MLP (Linear+GELU+Linear).
+
+    Output: ``[seq / merge_size**2, 2048]`` — 4 tokens collapsed into 1 LLM
+    token via the view (NOT a learned reduction; the merge happens by
+    flattening 4 adjacent feature vectors).
+    """
+    h = rms_norm(hidden_states, weight=target.vit_merger_ln_q_weight, eps=eps)
+    merged_dim = context_dim * (spatial_merge_size ** 2)
+    h = h.view(-1, merged_dim)          # [seq/4, 5120]
+    h = linear_fp8(h,
+        target.vit_merger_mlp_0_weight, target.vit_merger_mlp_0_bias,
+        site_id="vit.merger.mlp_0")
+    h = F.gelu(h)                       # default approx="none" matches nn.GELU()
+    h = linear_fp8(h,
+        target.vit_merger_mlp_2_weight, target.vit_merger_mlp_2_bias,
+        site_id="vit.merger.mlp_2")
+    return h
+
+
+# ════════════════════════════════════════════════════════════════════
+#  Full ViT forward
+# ════════════════════════════════════════════════════════════════════
+
+def vit_forward(
+    images: torch.Tensor,               # [B*N, 256, 1176]
+    *,
+    attn_mask: torch.Tensor,            # pre-built block-diag mask [1, seq, seq]
+    cos: torch.Tensor,                  # pre-built ViT M-RoPE [seq, 80]
+    sin: torch.Tensor,
+    target,
+    num_blocks: int = 32,
+) -> torch.Tensor:
+    """Full Qwen2.5-VL ViT tower forward.
+
+    Returns ``[total_merged_tokens, 2048]`` where
+    ``total_merged_tokens = sum(t*h*w/4 for each image) = N * 64`` for
+    the LingBot baseline.
+
+    capture-prep: ``attn_mask`` / ``cos`` / ``sin`` are now caller-
+    provided (built once per shape in :func:`embed_image` via the
+    shape-keyed ``_GRID_CACHE``). The previous in-function
+    ``torch.repeat_interleave`` + ``.item()`` mask loop were capture-
+    unsafe and have moved to that warmup path.
+    """
+    # Pad MLP intermediate to a 16-multiple (3420->3424) so gate/up/down FP8
+    # GEMMs hit the aligned cutlass fast path. Idempotent; the alloc happens
+    # once in eager warmup, before CUDA-Graph capture.
+    pad_vit_mlp_weights(target)
+
+    # 1. Patch embed.
+    x = vit_patch_embed(images,
+        proj_weight=target.vit_patch_embed_proj_weight)              # [seq, 1280]
+
+    # 2. 32 blocks.
+    for block_idx in range(num_blocks):
+        x = vit_block(x,
+            attn_mask=attn_mask, cos=cos, sin=sin,
+            target=target, block_idx=block_idx,
+        )
+
+    # 3. Merger collapses 4 tokens into 1.
+    return vit_merger(x, target=target)
+
+
+def _build_vit_capture_cache(
+    image_grid_thw: torch.Tensor,        # [BN, 3] long
+    seq_len: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.bfloat16,
+):
+    """Pre-build the capture-unsafe constants once per shape.
+
+    Returns ``(attn_mask [1, seq, seq] dtype, cos [seq, 80], sin [seq, 80])``.
+    Called from :func:`embed_image` outside any CUDA-Graph capture.
+    """
+    # cu_seqlens: torch.repeat_interleave with tensor `repeats` produces a
+    # variable-length output that CUDA-Graph capture cannot record. Run it
+    # here, outside capture, and discard once the mask is built.
+    cu = torch.repeat_interleave(
+        image_grid_thw[:, 1] * image_grid_thw[:, 2],
+        image_grid_thw[:, 0],
+    ).cumsum(dim=0, dtype=torch.int32)
+    cu_seqlens = F.pad(cu, (1, 0), value=0)
+
+    # Block-diagonal attention mask: filled with -inf, then zero per image
+    # block. ``.item()`` is fine here (outside capture) — the mask becomes
+    # a captured constant.
+    attn_mask = torch.full(
+        (1, seq_len, seq_len), torch.finfo(dtype).min,
+        device=device, dtype=dtype,
+    )
+    for i in range(1, int(cu_seqlens.shape[0])):
+        s = int(cu_seqlens[i - 1].item())
+        e = int(cu_seqlens[i].item())
+        attn_mask[..., s:e, s:e] = 0
+
+    # ViT 2-D M-RoPE table .
+    cos, sin = build_cos_sin_table(
+        image_grid_thw, LINGBOT_VIT_ROPE_CONFIG,
+        compute_dtype=torch.float32,
+    )
+    return attn_mask, cos, sin
+
+
+def embed_image(
+    images: torch.Tensor,               # [B, N, 256, 1176]  OR  [B*N, 256, 1176]
+    *,
+    target,
+    image_grid_thw: torch.Tensor | None = None,
+    patch_size: int = 14,
+    temporal_patch_size: int = 2,
+) -> torch.Tensor:
+    """Wrap ``vit_forward`` to match the upstream ``embed_image`` ABI
+    (modeling_lingbot_vla.py:1203):
+
+        Input: ``images`` with optional batch dim.
+            If 5-D ``[B, N, C, H, W]``: NOT supported here — caller must
+            pre-patchify (matches the lingbot baseline harness).
+            If 4-D ``[B, N, L, D]``: rearranged to ``[B*N, L, D]``.
+            If 3-D ``[(B*N), L, D]``: used directly.
+        ``image_grid_thw`` defaults to ``[[1, sqrt(L), sqrt(L)]] *
+        images.shape[0]`` — matches upstream's default.
+
+    Returns: ``[B*N, L/4, 2048]`` (4 patches collapsed into 1 LLM token).
+    """
+    import einops
+
+    if images.ndim == 4:
+        images = einops.rearrange(images, "b n l d -> (b n) l d")
+    BN, L, _ = images.shape
+
+    # Capture-safe cache: pre-compute everything that crosses to host
+    # (grid_thw, split_sizes, cu_seqlens, attn_mask, cos, sin) once per
+    # shape during the first call (warmup). Subsequent calls reuse the
+    # cached tensors and never re-enter the capture-unsafe construction
+    # path — required for CUDA-Graph capture.
+    key = (BN, L, images.device.index)
+    cached = _GRID_CACHE.get(key)
+    if cached is None:
+        h = w = int(L ** 0.5)
+        igtw = torch.tensor(
+            [[1, h, w]] * BN, device=images.device, dtype=torch.long,
+        )
+        split_sizes = [int((1 * h * w) // 4)] * BN
+        seq_len = BN * L  # patch_embed flattens to this seq length
+        attn_mask, cos, sin = _build_vit_capture_cache(
+            igtw, seq_len, images.device,
+            dtype=torch.bfloat16,
+        )
+        cached = (igtw, split_sizes, attn_mask, cos, sin)
+        _GRID_CACHE[key] = cached
+    igtw, split_sizes, attn_mask, cos, sin = cached
+    if image_grid_thw is None:
+        image_grid_thw = igtw
+
+    flat = vit_forward(
+        images, attn_mask=attn_mask, cos=cos, sin=sin, target=target)
+    parts = torch.split(flat, split_sizes)
+    return torch.stack(parts, dim=0)    # [B*N, num_tokens_per_img, 2048]
+
+
+__all__ = [
+    "vit_patch_embed",
+    "vit_swiglu_mlp",
+    "pad_vit_mlp_weights",
+    "vit_attention",
+    "vit_block",
+    "vit_merger",
+    "vit_forward",
+    "embed_image",
+]

--- a/flash_rt/models/lingbot/vit_rope_adapter.py
+++ b/flash_rt/models/lingbot/vit_rope_adapter.py
@@ -1,0 +1,247 @@
+"""Host-side ViT 2-D M-RoPE cos/sin table construction for LingBot-VLA.
+
+LingBot's Qwen2.5-VL ViT (32 blocks, hidden=1280, 16 heads, head_dim=80)
+uses a 2-D M-RoPE over the (h, w) patch grid — NOT the 3-axis text M-RoPE
+(``mrope_section=[16,24,24]``) and NOT the 1-D LLM RoPE
+(``flash_rt.models.lingbot.rope_adapter`` — that's for Mixed-Head LLM).
+
+Upstream reference (replicated bit-exact, validated against the upstream model):
+
+    ``lingbotvla/models/vla/pi0/qwenvl_in_vla.py::Qwen2_5_VisionRotaryEmbedding``
+    ``lingbotvla/models/vla/pi0/qwenvl_in_vla.py::Qwen2_5_VLVisionTransformer.rot_pos_emb``
+
+Math:
+    half_dim = head_dim // 2  (= 40 for Qwen2.5-VL ViT)
+    inv_freq[i] = 1 / theta ** (2 i / half_dim)   for i ∈ [0, half_dim/2 = 20)
+
+For each token at patch position (h_pos, w_pos):
+    freqs_h = h_pos * inv_freq                    shape (half_dim/2,)
+    freqs_w = w_pos * inv_freq                    shape (half_dim/2,)
+    freqs   = concat([freqs_h, freqs_w], dim=-1)  shape (half_dim,) = 40
+
+Then for the attention apply step (HF rotate_half form):
+    emb = concat([freqs, freqs], dim=-1)          shape (head_dim=80)
+    cos = emb.cos(),  sin = emb.sin()
+    q_emb = apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+Position-ID construction (matches upstream's spatial-merge-aware layout):
+    For each image with grid (t, h, w):
+        hpos = arange(h).unsqueeze(1).expand(-1, w)
+              .reshape(h/sm, sm, w/sm, sm).permute(0,2,1,3).flatten()
+        wpos = arange(w).unsqueeze(0).expand(h, -1).
+              .reshape(h/sm, sm, w/sm, sm).permute(0,2,1,3).flatten()
+        pos_per_image = stack([hpos, wpos], dim=-1).repeat(t, 1)
+    pos_ids = cat([pos_per_image_i for i], dim=0)
+
+The permute(0,2,1,3) is what implements the spatial_merge_size=2 layout
+where each 2×2 block of patches (which the merger collapses into one LLM
+token) is kept adjacent in the flattened sequence.
+
+This module is pure-PyTorch (CPU/GPU agnostic). It does NOT call any
+flash_rt_kernels symbol. Built once per ``set_prompt`` (image layout is
+fixed at that point) and reused as input to the on-device ViT attention
+RoPE kernel during every graph replay.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class LingbotVitRopeConfig:
+    """LingBot-VLA Qwen2.5-VL ViT 2-D M-RoPE constants.
+
+    Locked by the ViT submodule of Qwen2.5-VL-3B-Instruct:
+        hidden_size=1280, num_heads=16 → head_dim=80,  half_dim=40
+        theta=10000 (default of Qwen2_5_VisionRotaryEmbedding)
+        spatial_merge_size=2
+
+    Note ``half_dim`` is the dim passed to ``Qwen2_5_VisionRotaryEmbedding``,
+    which then computes inv_freq over ``[0, half_dim/2)`` — so the actual
+    inv_freq length is ``half_dim // 2 = 20``.
+    """
+
+    head_dim: int = 80                    # 1280 // 16
+    half_dim: int = 40                    # head_dim // 2 (what upstream Embedding sees)
+    theta: float = 10_000.0
+    spatial_merge_size: int = 2
+
+
+def compute_inv_freq(
+    cfg: LingbotVitRopeConfig,
+    *,
+    device=None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """``1 / theta ** (2 i / half_dim)`` for ``i ∈ [0, half_dim/2)``.
+
+    Returns: tensor of shape ``(half_dim // 2,) = (20,)``.
+
+    Note we follow the upstream ``Qwen2_5_VisionRotaryEmbedding.__init__``
+    which does ``arange(0, dim, 2)`` for ``dim = half_dim`` — so the result
+    has length ``half_dim // 2``, NOT ``half_dim``.
+    """
+    return 1.0 / (
+        cfg.theta ** (torch.arange(0, cfg.half_dim, 2, dtype=dtype, device=device) / cfg.half_dim)
+    )
+
+
+def build_position_ids_from_grid(
+    grid_thw: torch.Tensor,
+    cfg: LingbotVitRopeConfig,
+    *,
+    device=None,
+) -> torch.Tensor:
+    """Replicate upstream ``rot_pos_emb`` position-id construction.
+
+    Args:
+        grid_thw: tensor of shape ``(num_images, 3)`` with (t, h, w) per
+            image. For LingBot baseline this is ``[[1, 16, 16], [1, 16, 16],
+            [1, 16, 16]]`` (3 cameras × 224/14 = 16 patches per side).
+        cfg: ``LingbotVitRopeConfig``.
+
+    Returns:
+        ``pos_ids`` of shape ``(sum_seqlen, 2)`` long — column 0 is h_pos,
+        column 1 is w_pos. ``sum_seqlen = sum(t * h * w for each image)``.
+    """
+    if device is None:
+        device = grid_thw.device
+
+    sm = cfg.spatial_merge_size
+    pieces: list[torch.Tensor] = []
+    for t, h, w in grid_thw.tolist():
+        hpos = (
+            torch.arange(h, dtype=torch.long, device=device)
+            .unsqueeze(1)
+            .expand(-1, w)
+            .reshape(h // sm, sm, w // sm, sm)
+            .permute(0, 2, 1, 3)
+            .flatten()
+        )
+        wpos = (
+            torch.arange(w, dtype=torch.long, device=device)
+            .unsqueeze(0)
+            .expand(h, -1)
+            .reshape(h // sm, sm, w // sm, sm)
+            .permute(0, 2, 1, 3)
+            .flatten()
+        )
+        # Stack to (h*w, 2), repeat t times for video frames (T=1 for images).
+        pieces.append(torch.stack([hpos, wpos], dim=-1).repeat(t, 1))
+    return torch.cat(pieces, dim=0)
+
+
+def build_rotary_pos_emb_full(
+    max_grid_size: int,
+    cfg: LingbotVitRopeConfig,
+    *,
+    device=None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Build the full ``(max_grid_size, half_dim/2)`` freq lookup table.
+
+    This is what the upstream ``Qwen2_5_VisionRotaryEmbedding.forward``
+    produces: ``outer(arange(seqlen), inv_freq)``.
+    """
+    inv_freq = compute_inv_freq(cfg, device=device, dtype=dtype)
+    seq = torch.arange(max_grid_size, dtype=dtype, device=device)
+    return torch.outer(seq, inv_freq)
+
+
+def build_freqs_from_positions(
+    pos_ids: torch.Tensor,
+    cfg: LingbotVitRopeConfig,
+    *,
+    max_grid_size: int | None = None,
+    device=None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Compose the full per-token freq tensor used by the ViT attention.
+
+    Replicates the last lines of upstream ``rot_pos_emb``::
+
+        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
+        rotary_pos_emb      = rotary_pos_emb_full[pos_ids].flatten(1)
+
+    Args:
+        pos_ids: ``(seq, 2)`` from ``build_position_ids_from_grid``.
+        cfg: ``LingbotVitRopeConfig``.
+        max_grid_size: defaults to ``pos_ids.max() + 1`` — pass an explicit
+            value when you want to share the lookup table across multiple
+            calls of differing image sizes.
+
+    Returns:
+        ``freqs`` of shape ``(seq, half_dim)`` — the 2-D-composed M-RoPE
+        freq vector per token. Each token's vector is
+        ``[inv_freq * h_pos | inv_freq * w_pos]``.
+    """
+    if device is None:
+        device = pos_ids.device
+    if max_grid_size is None:
+        max_grid_size = int(pos_ids.max().item()) + 1
+    full = build_rotary_pos_emb_full(max_grid_size, cfg, device=device, dtype=dtype)
+    # full[pos_ids] -> (seq, 2, half_dim/2); flatten(1) -> (seq, half_dim).
+    return full[pos_ids].flatten(1)
+
+
+def build_cos_sin_table(
+    grid_thw: torch.Tensor,
+    cfg: LingbotVitRopeConfig,
+    *,
+    compute_dtype: torch.dtype = torch.float32,
+    out_dtype: torch.dtype | None = None,
+    device=None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """End-to-end host-side cos/sin builder for the ViT attention kernel.
+
+    Args:
+        grid_thw: ``(num_images, 3)`` with (t, h, w) per image.
+        cfg: ``LingbotVitRopeConfig``.
+        compute_dtype: dtype used inside (default fp32 — matches upstream).
+        out_dtype: dtype of returned tensors. ``None`` → same as
+            compute_dtype. Set to fp16 for kernel handoff.
+
+    Returns:
+        ``cos``, ``sin`` of shape ``(seq, head_dim)``.
+
+    The returned tensors match the upstream attention path::
+
+        emb = cat((rotary_pos_emb, rotary_pos_emb), dim=-1)   # (seq, head_dim)
+        cos = emb.cos(); sin = emb.sin()
+    """
+    if device is None:
+        device = grid_thw.device
+
+    pos_ids = build_position_ids_from_grid(grid_thw, cfg, device=device)
+    max_grid_size = int(grid_thw[:, 1:].max().item())
+    freqs = build_freqs_from_positions(
+        pos_ids, cfg, max_grid_size=max_grid_size,
+        device=device, dtype=compute_dtype,
+    )
+    emb = torch.cat([freqs, freqs], dim=-1)
+    cos = torch.cos(emb)
+    sin = torch.sin(emb)
+    if out_dtype is not None and out_dtype != compute_dtype:
+        cos = cos.to(out_dtype)
+        sin = sin.to(out_dtype)
+    return cos, sin
+
+
+# Default config instance for the LingBot-VLA Qwen2.5-VL ViT path.
+LINGBOT_VIT_ROPE_CONFIG = LingbotVitRopeConfig(
+    head_dim=80, half_dim=40, theta=10_000.0, spatial_merge_size=2,
+)
+
+
+__all__ = [
+    "LingbotVitRopeConfig",
+    "LINGBOT_VIT_ROPE_CONFIG",
+    "compute_inv_freq",
+    "build_position_ids_from_grid",
+    "build_rotary_pos_emb_full",
+    "build_freqs_from_positions",
+    "build_cos_sin_table",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,14 @@ eval = ["opencv-python", "tqdm"]
 # https://github.com/Dao-AILab/flash-attention/releases — building
 # the sdist takes 30+ minutes on cold cloud images.
 flash-attn = ["flash-attn"]
+# Thor-only optional fast path: FlashAttention-4 (CuTe-DSL) denoise/prefix
+# attention for LingBot-VLA on Thor (sm_110). The forward / SM100-only source
+# is vendored (privately, as `flashrt_fa4`) at csrc/attention/flash_attn_4_src
+# (no flash-attn wheel needed); these are its runtime deps. Without them,
+# LingBot silently falls back to the fmha path (correct, ~+18ms@25). The loader
+# (flash_rt/hardware/thor/fa4_backend.py) sets CUTE_DSL_ARCH=sm_101a.
+# Requires an editable / source-tree install (pip install -e). pip install ".[thor-fa4]".
+thor-fa4 = ["nvidia-cutlass-dsl==4.5.1", "quack-kernels==0.4.1"]
 all = ["flash-rt[torch,jax,server,eval]"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
… + trimmed FA4 vendor

Add the LingBot-VLA (Qwen2.5-VL + flow-matching action expert) Thor (sm_110) inference path, run through the low-level graph_runner (not yet registered in load_model / _PIPELINE_MAP; LingbotTorchFrontendThor is a scaffold).

Kernels (one shared module):
- LingBot model kernels (fused AdaRMSNorm / SwiGLU tail / QKV+RoPE) compiled INTO flash_rt_kernels as lingbot_-prefixed sources + #ifdef ENABLE_LINGBOT bindings, same pattern as the qwen36 kernels. No separate .so.
- Gated additively: FLASHRT_ENABLE_LINGBOT (default ON) AND GPU_ARCH==110. RTX (sm_120) / Orin / L40 builds compile neither the sources nor the bindings (configure prints "LingBot-VLA kernels: DISABLED").

FlashAttention-4 (optional Thor fast path):
- Forward / SM100-only trimmed vendor at csrc/attention/flash_attn_4_src/ (103 -> 28 files): backward, SM80/SM90/SM120, MLA, hd256 2CTA, Triton, and the non-cute wheel packages removed. SM100 forward control flow is byte- identical to upstream (verified bit-exact, cosine=1.0). See VENDOR.md.
- Vendored under a private package name (flashrt_fa4) so it never shadows a pip-installed flash_attn (the RTX backends use `from flash_attn import ...`).
- Import isolated in flash_rt/hardware/thor/fa4_backend.py: transient sys.path, arch alias CUTE_DSL_ARCH=sm_101a, optional (returns None -> fmha fallback). Deps via the thor-fa4 pip extra (not in `all`). A/B with FLASHRT_THOR_FA4=0|1.

Validation (Thor sm_110, CUDA-graph replay, fixed noise):
- Build green; flash_rt_kernels exposes 15 lingbot_ symbols; imports clean.
- Action chunk vs upstream LingBot BF16 reference (10-step): FA4 cos=0.996245, fmha cos=0.996067 (>= 0.995 bring-up threshold).
- Latency 50/25/10 steps: FA4 155.8/97.5/64.1 ms, fmha 193.8/118.1/73.0 ms (FA4 ~15-20% faster).
- RTX(120) configure: LingBot gated off (additive).

Docs: docs/lingbot_usage.md (build flags, FA4 vendor, fallback, accuracy + latency table, limitations); examples/lingbot_quickstart.py and a parameterized benchmarks/lingbot_thor_latency.py (argparse + clean skip).