### PR TITLE
Add Wan2.2 TI2V RTX official API

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pi0.5: 44 ms / 23 Hz on Jetson AGX Thor (2v, FP8) · 39.78 ms / 25 Hz (2v, NVFP4
 
 - [2026/05] **Qwen3.6-27B NVFP4** is supported with 256 K context on a single RTX 5090, OpenAI-compatible serving, and **~100 tok/s typical / 129 tok/s peak** decode. See [Qwen3.6 NVFP4](docs/qwen36_nvfp4.md) and [Performance](#qwen36-performance).
 - [2026/05] **Qwen3-8B NVFP4** text-only serving is supported on RTX 5090, with **9.1 ms TTFT at P=64** and **150 tok/s** warm decode. See [Qwen3-8B NVFP4](docs/qwen3_8b_nvfp4.md) and [Performance](#qwen3-8b-performance).
-- [2026/05] **Wan2.2 TI2V-5B** official-pipeline baseline is available on RTX SM120. See [Wan2.2 usage](docs/wan22_usage.md).
+- [2026/05] **Wan2.2 TI2V-5B** official-pipeline baseline is available on RTX SM120, with opt-in TeaCache acceleration. See [Wan2.2 usage](docs/wan22_usage.md).
 - [2026/05] **Lingbot-VLA** is supported. See [Lingbot usage](https://github.com/LiangSu8899/FlashRT/blob/main/docs/lingbot_usage.md).
 - [2026/05] Community Pi0.5 hardware benchmarks: thanks to [@cuihengrui35](https://github.com/cuihengrui35) for **RTX 5060 Ti** results (**41.4 ms / ~24 Hz**, plus LIBERO Spatial **344/350 = 98.3%**) and [@wangerforcs](https://github.com/wangerforcs) for **NVIDIA L40** results (**26.6 ms / 38 Hz**) on 2-view FP8. See [community benchmarks](#community-benchmarks).
 - [2026/05] Special thanks to [@gugudeshubao](https://github.com/gugudeshubao) for the **Pi0.5 Jetson AGX Orin (SM87) port**: INT8 W8A8 kernels, Orin tile dispatch, frame-cache inference, deployment docs, and benchmark results. Thanks also to [@strayberry](https://github.com/strayberry) for Orin BF16 Pi0.5 testing. See [Orin deployment](docs/deployment_orin.md) and [community benchmarks](#community-benchmarks).
@@ -119,6 +119,7 @@ First call: ~3 s (calibration + CUDA Graph capture). Every subsequent call: 44 m
 | **Pi0-FAST** | **Jetson AGX Thor** (SM110) | **8.1 ms/token** (28 ms prefill + 8.1 × N decode) | **123 tok/s** |
 | **Pi0-FAST** | **RTX 5090** (SM120) | **2.39 ms/token** (11 ms prefill + 2.39 × N decode) | **418 tok/s** |
 | **Motus Stage3** | **RTX 5090** (SM120) | **~167 ms** (fast) / **~100 ms** (+TeaCache) | RTC-lite **50 Hz** action streaming |
+| **Wan2.2 TI2V-5B** | **RTX 5090** (SM120) | **178.6 s** 720p/121f/20-step official path; **114.2 s** with TeaCache `0.3` | see [Wan2.2](#wan22-performance) |
 
 <a name="qwen36-performance"></a>
 
@@ -199,6 +200,26 @@ Text-only OpenAI-compatible serving path for
 
 See [`docs/qwen3_8b_nvfp4.md`](docs/qwen3_8b_nvfp4.md) for the
 quickstart, server command, architecture notes, and caveats.
+
+<a name="wan22-performance"></a>
+
+### Wan2.2 TI2V-5B official pipeline (RTX 5090)
+
+Official 720p T2V configuration: `1280x704`, `frames=121`, `steps=20`,
+`shift=5.0`, `guide_scale=5.0`, `sample_solver=unipc`. Timings exclude
+checkpoint load and include text encoding, DiT sampling, and VAE decode.
+
+| Path | TeaCache threshold | DiT calls | Time | Note |
+|---|---:|---:|---:|---|
+| FlashRT official pipeline | off | 20/20 | **178.6 s** | baseline |
+| FlashRT official pipeline | 0.3 | 8/20 | **114.2 s** | 1.56x faster; visible prompt-dependent quality drift |
+| Upstream public reference | off | n/a | under 9 min | Wan2.2 TI2V-5B model-card 720p single consumer GPU reference |
+
+TeaCache is opt-in through `model.infer(teacache=True,
+teacache_threshold=...)`. Use the no-TeaCache output as the quality
+reference; Wan2.2 5B currently uses coefficient-free TeaCache. Upstream
+reference: [Wan2.2-TI2V-5B model card](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B).
+Full usage and caveats are in [`docs/wan22_usage.md`](docs/wan22_usage.md).
 
 <a name="motus-performance"></a>
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Pi0.5: 44 ms / 23 Hz on Jetson AGX Thor (2v, FP8) · 39.78 ms / 25 Hz (2v, NVFP4
 
 - [2026/05] **Qwen3.6-27B NVFP4** is supported with 256 K context on a single RTX 5090, OpenAI-compatible serving, and **~100 tok/s typical / 129 tok/s peak** decode. See [Qwen3.6 NVFP4](docs/qwen36_nvfp4.md) and [Performance](#qwen36-performance).
 - [2026/05] **Qwen3-8B NVFP4** text-only serving is supported on RTX 5090, with **9.1 ms TTFT at P=64** and **150 tok/s** warm decode. See [Qwen3-8B NVFP4](docs/qwen3_8b_nvfp4.md) and [Performance](#qwen3-8b-performance).
+- [2026/05] **Wan2.2 TI2V-5B** official-pipeline baseline is available on RTX SM120. See [Wan2.2 usage](docs/wan22_usage.md).
 - [2026/05] **Lingbot-VLA** is supported. See [Lingbot usage](https://github.com/LiangSu8899/FlashRT/blob/main/docs/lingbot_usage.md).
 - [2026/05] Community Pi0.5 hardware benchmarks: thanks to [@cuihengrui35](https://github.com/cuihengrui35) for **RTX 5060 Ti** results (**41.4 ms / ~24 Hz**, plus LIBERO Spatial **344/350 = 98.3%**) and [@wangerforcs](https://github.com/wangerforcs) for **NVIDIA L40** results (**26.6 ms / 38 Hz**) on 2-view FP8. See [community benchmarks](#community-benchmarks).
 - [2026/05] Special thanks to [@gugudeshubao](https://github.com/gugudeshubao) for the **Pi0.5 Jetson AGX Orin (SM87) port**: INT8 W8A8 kernels, Orin tile dispatch, frame-cache inference, deployment docs, and benchmark results. Thanks also to [@strayberry](https://github.com/strayberry) for Orin BF16 Pi0.5 testing. See [Orin deployment](docs/deployment_orin.md) and [community benchmarks](#community-benchmarks).
@@ -83,6 +84,7 @@ First call: ~3 s (calibration + CUDA Graph capture). Every subsequent call: 44 m
 | **Run Qwen3.6-27B NVFP4 (LLM, ~100 tok/s typical / 129 tok/s peak on RTX 5090)** | [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) — quickstart, K selection, measured throughput · [`docs/qwen36_usage.md`](docs/qwen36_usage.md) — full parameter reference · [`examples/qwen36_openai_server.py`](examples/qwen36_openai_server.py) — OpenAI-compatible HTTP server |
 | **Run Qwen3-8B NVFP4 text serving** | [`docs/qwen3_8b_nvfp4.md`](docs/qwen3_8b_nvfp4.md) · [`examples/qwen3_openai_server.py`](examples/qwen3_openai_server.py) |
 | **Run Motus RTX beta, TeaCache, or RTC-lite** | [`docs/motus_usage_beta.md`](docs/motus_usage_beta.md) · [`docs/rtc_lite_design.md`](docs/rtc_lite_design.md) |
+| **Run Wan2.2 TI2V-5B official-pipeline baseline** | [`docs/wan22_usage.md`](docs/wan22_usage.md) |
 | **Look up the stable Python API surface** | [`docs/stable_api.md`](docs/stable_api.md) |
 | **Integrate a new model into FlashRT** | [`docs/adding_new_model.md`](docs/adding_new_model.md) — end-to-end walkthrough; external plugin pattern in [`docs/plugin_model_template.md`](docs/plugin_model_template.md) |
 | **Contribute a bug fix, benchmark, or model path** | [`CONTRIBUTING.md`](CONTRIBUTING.md) — development rules, validation expectations, and PR checklist |

--- a/USAGE.md
+++ b/USAGE.md
@@ -150,7 +150,7 @@ model = flash_rt.load_model(
 | `autotune` | `int\|bool` | `3` | CUDA Graph autotune intensity. See [Autotune](#autotune). |
 | `recalibrate` | `bool` | `False` | Force fresh FP8 calibration (and weight cache for JAX), ignoring cache. See [Calibration](#calibration). |
 | `weight_cache` | `bool` | `True` | Cache FP8-quantized weights to disk. **JAX only** — reduces cold start from ~42s to ~6s. Torch loads in ~3s and ignores this. See [Weight Cache](#weight-cache-jax-only). |
-| `config` | `str` | `"pi05"` | Model architecture config: `"pi05"`, `"pi0"`, `"groot"`, `"groot_n17"`, `"pi0fast"`, `"motus"`. |
+| `config` | `str` | `"pi05"` | Model architecture config: `"pi05"`, `"pi0"`, `"groot"`, `"groot_n17"`, `"pi0fast"`, `"motus"`, `"wan22_ti2v_5b"`. |
 | `decode_cuda_graph` | `bool` | `False` | **Pi0-FAST only.** Capture action-phase decode as CUDA Graph. Trades startup time for per-token speed. See [Pi0-FAST](#pi0-fast). |
 | `decode_graph_steps` | `int` | `80` | **Pi0-FAST only.** Number of action tokens to capture in the decode graph. Should cover your longest expected action sequence. |
 | `use_fp4` | `bool` | `False` | **Pi0.5 torch + jax on Thor.** Enable NVFP4 quantization on the encoder FFN stack. When `True`, resolves to the production preset (`fp4_layers=tuple(range(18))` + `use_awq=True` + `use_p1_split_gu=True`). Requires SM100+ GPU. Other configs emit a warning and fall back to FP8. See [NVFP4](#nvfp4-pi05-only). |
@@ -279,6 +279,38 @@ RTX 5090 validation against the N1.7 reference fixture:
 
 This path does not change CMake targets, C++ bindings, or existing
 Pi0/Pi0.5/GROOT N1.6 runtime dispatch.
+
+### Wan2.2 TI2V-5B
+
+Wan2.2 TI2V-5B is exposed as an RTX SM120 official-pipeline baseline:
+
+```python
+import flash_rt
+
+model = flash_rt.load_model(
+    "/path/to/Wan2.2-TI2V-5B",
+    framework="torch",
+    config="wan22_ti2v_5b",
+    hardware="rtx_sm120",
+)
+
+model.set_prompt("A blue sphere rolls across a wooden table")
+video = model.infer(
+    mode="t2v",
+    width=832,
+    height=480,
+    frames=81,
+    steps=20,
+    shift=5.0,
+    guide_scale=5.0,
+    seed=1234,
+)
+```
+
+This route uses the official Wan Python pipeline and original ModelScope
+checkpoint layout. It is separate from ComfyUI; ComfyUI integration should
+be provided by an external custom-node package. See
+[`docs/wan22_usage.md`](docs/wan22_usage.md).
 
 ### `model.predict()`
 

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -81,8 +81,10 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
 - `config="wan22_ti2v_5b"` is an RTX SM120 official-pipeline Wan2.2
   baseline. It exposes `set_prompt(prompt, negative_prompt=...)` and
   `infer(mode="t2v"|"i2v", width=..., height=..., frames=..., steps=...,
-  shift=..., guide_scale=..., seed=...)`; `predict()` is not part of this
-  video-generation API. See `docs/wan22_usage.md`.
+  shift=..., guide_scale=..., seed=..., teacache=False,
+  teacache_threshold=..., teacache_start_step=...,
+  teacache_end_step=..., teacache_cache_device=...)`; `predict()` is not
+  part of this video-generation API. See `docs/wan22_usage.md`.
 - `config="groot_n17"` is registered for `framework="torch"` and
   `hardware="rtx_sm120"`. This route validates the N1.7 DiT
   self/cross-attention path on the vendored FA2 backend.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -29,7 +29,7 @@ def load_model(
     autotune: int = 3,              # 0=off, 3=default, 5+=thorough
     recalibrate: bool = False,
     weight_cache: bool = True,      # JAX only
-    config: str = "pi05",           # "pi05" | "pi0" | "groot" | "groot_n17" | "pi0fast" | "motus"
+    config: str = "pi05",           # "pi05" | "pi0" | "groot" | "groot_n17" | "pi0fast" | "motus" | "wan22_ti2v_5b"
     device=None,                    # reserved
     # Pi0-FAST-specific:
     decode_cuda_graph: bool = False,
@@ -78,6 +78,11 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
 - `config="motus"` is a beta RTX SM120 frontend. It expects a Motus
   checkpoint plus Wan and VLM checkpoint paths supplied to the Motus
   quickstart/frontend; see `docs/motus_usage_beta.md`.
+- `config="wan22_ti2v_5b"` is an RTX SM120 official-pipeline Wan2.2
+  baseline. It exposes `set_prompt(prompt, negative_prompt=...)` and
+  `infer(mode="t2v"|"i2v", width=..., height=..., frames=..., steps=...,
+  shift=..., guide_scale=..., seed=...)`; `predict()` is not part of this
+  video-generation API. See `docs/wan22_usage.md`.
 - `config="groot_n17"` is registered for `framework="torch"` and
   `hardware="rtx_sm120"`. This route validates the N1.7 DiT
   self/cross-attention path on the vendored FA2 backend.
@@ -138,6 +143,8 @@ Lazily imports and returns the concrete frontend class for the given
 Motus beta is registered for `(config="motus", framework="torch",
 arch="rtx_sm120")`.
 GROOT N1.7 RTX is registered for `(config="groot_n17",
+framework="torch", arch="rtx_sm120")`.
+Wan2.2 TI2V-5B is registered for `(config="wan22_ti2v_5b",
 framework="torch", arch="rtx_sm120")`.
 
 ### `_PIPELINE_MAP`

--- a/docs/wan22_usage.md
+++ b/docs/wan22_usage.md
@@ -62,6 +62,34 @@ video = out["video"]       # torch.Tensor [C, F, H, W]
 metadata = out["metadata"]
 ```
 
+TeaCache is available as an explicit experimental acceleration option:
+
+```python
+out = model.infer(
+    mode="t2v",
+    width=1280,
+    height=704,
+    frames=121,
+    steps=20,
+    shift=5.0,
+    guide_scale=5.0,
+    teacache=True,
+    teacache_threshold=0.3,
+    teacache_start_step=1,
+    teacache_end_step=-1,
+    teacache_cache_device="cuda",
+    return_metadata=True,
+)
+
+print(out["metadata"]["teacache"])
+```
+
+`teacache_threshold` controls the speed/quality trade-off. Larger values
+skip more DiT steps and may change composition or motion. The Wan2.2 5B
+route uses training-free relative-L1 TeaCache without model-specific
+coefficients, so treat it as a validation tool until the threshold is
+qualified for your prompt class.
+
 For image-to-video:
 
 ```python
@@ -106,6 +134,26 @@ shift=5.0
 guide_scale=5.0
 sample_solver=unipc
 ```
+
+## Benchmarks
+
+RTX 5090, official Wan2.2-TI2V-5B checkpoint, T2V, `1280x704`,
+`frames=121`, `steps=20`, `shift=5.0`, `guide_scale=5.0`,
+`sample_solver=unipc`. Timings are `infer_seconds`, which includes text
+encoding, DiT sampling, and VAE decode but excludes checkpoint load.
+
+| Path | TeaCache threshold | DiT calls | Time | Peak VRAM | Note |
+|---|---:|---:|---:|---:|---|
+| FlashRT official pipeline | off | 20/20 | **178.6 s** | 24.37 GiB | baseline |
+| FlashRT official pipeline | 0.3 | 8/20 | **114.2 s** | 24.37 GiB | 1.56x faster; visible quality drift on the test prompt |
+| Upstream public reference | off | n/a | under 9 min | n/a | Wan2.2 TI2V-5B model-card 720p single consumer GPU reference |
+
+Use `teacache_threshold=0.15`-`0.30` as a starting search range. In local
+testing `0.03` did not skip steps on a small smoke run, while `0.3`
+skipped aggressively and changed the result. Keep the no-TeaCache output
+as the quality reference for each prompt class.
+
+Upstream reference: [Wan2.2-TI2V-5B model card](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B).
 
 Keep ComfyUI wall time separate from this official-pipeline timing. ComfyUI
 adds graph-node scheduling, model-file repackaging, optional FP8/GGUF/Sage

--- a/docs/wan22_usage.md
+++ b/docs/wan22_usage.md
@@ -1,0 +1,112 @@
+# Wan2.2 TI2V-5B Usage
+
+This page documents the FlashRT official-pipeline route for
+Wan2.2-TI2V-5B on RTX SM120.
+
+FlashRT exposes a stable `set_prompt()` / `infer()` API around the official
+Wan Python pipeline. ComfyUI support is handled outside the core repository
+through custom nodes that call FlashRT public APIs.
+
+## Requirements
+
+Use the original Wan2.2-TI2V-5B checkpoint layout:
+
+```text
+Wan2.2-TI2V-5B/
+  diffusion_pytorch_model-00001-of-00003.safetensors
+  diffusion_pytorch_model-00002-of-00003.safetensors
+  diffusion_pytorch_model-00003-of-00003.safetensors
+  diffusion_pytorch_model.safetensors.index.json
+  Wan2.2_VAE.pth
+  models_t5_umt5-xxl-enc-bf16.pth
+  google/umt5-xxl/
+```
+
+The official Wan Python package must be importable. Either install the Wan
+source package, add it to `PYTHONPATH`, or set one of:
+
+```bash
+export FLASH_RT_WAN22_ROOT=/path/to/Wan2.2/source
+export MOTUS_ROOT=/path/to/Motus        # works when Wan is vendored in bak/wan
+```
+
+## API
+
+```python
+import flash_rt
+
+model = flash_rt.load_model(
+    "/path/to/Wan2.2-TI2V-5B",
+    framework="torch",
+    config="wan22_ti2v_5b",
+    hardware="rtx_sm120",
+)
+
+model.set_prompt(
+    "A cinematic shot of a blue sphere rolling across a wooden table",
+)
+
+out = model.infer(
+    mode="t2v",
+    width=832,
+    height=480,
+    frames=81,
+    steps=20,
+    shift=5.0,
+    guide_scale=5.0,
+    seed=1234,
+    return_metadata=True,
+)
+
+video = out["video"]       # torch.Tensor [C, F, H, W]
+metadata = out["metadata"]
+```
+
+For image-to-video:
+
+```python
+model.set_prompt("A handheld camera shot, smooth motion")
+video = model.infer(
+    mode="i2v",
+    image=start_image,     # PIL.Image.Image
+    width=832,
+    height=480,
+    frames=81,
+    steps=20,
+    shift=5.0,
+    guide_scale=5.0,
+)
+```
+
+`model.predict()` is not part of the Wan API because `predict()` is the VLA
+action-output convenience wrapper.
+
+## Recommended Baselines
+
+Community 480p performance baseline:
+
+```text
+width=832
+height=480
+frames=81
+steps=20
+shift=5.0
+guide_scale=5.0
+sample_solver=unipc
+```
+
+Official quality baseline:
+
+```text
+width=1280
+height=704
+frames=121
+steps=20 or 50
+shift=5.0
+guide_scale=5.0
+sample_solver=unipc
+```
+
+Keep ComfyUI wall time separate from this official-pipeline timing. ComfyUI
+adds graph-node scheduling, model-file repackaging, optional FP8/GGUF/Sage
+attention paths, and video-output overhead.

--- a/examples/wan22_quickstart.py
+++ b/examples/wan22_quickstart.py
@@ -32,6 +32,14 @@ def main() -> None:
     parser.add_argument("--shift", type=float, default=5.0)
     parser.add_argument("--guide-scale", type=float, default=5.0)
     parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--teacache", action="store_true",
+                        help="Enable Wan2.2 TeaCache acceleration")
+    parser.add_argument("--teacache-threshold", type=float, default=0.0)
+    parser.add_argument("--teacache-start-step", type=int, default=1)
+    parser.add_argument("--teacache-end-step", type=int, default=-1)
+    parser.add_argument("--teacache-cache-device", default="cuda",
+                        choices=("cuda", "cpu", "main_device",
+                                 "offload_device"))
     parser.add_argument("--out", default="wan22_out.mp4")
     args = parser.parse_args()
 
@@ -62,12 +70,23 @@ def main() -> None:
         shift=args.shift,
         guide_scale=args.guide_scale,
         seed=args.seed,
+        teacache=args.teacache,
+        teacache_threshold=args.teacache_threshold,
+        teacache_start_step=args.teacache_start_step,
+        teacache_end_step=args.teacache_end_step,
+        teacache_cache_device=args.teacache_cache_device,
         save_path=args.out,
         return_metadata=True,
     )
     meta = result["metadata"]
     print(f"[wan22] infer={meta['infer_seconds']:.2f}s "
           f"peak={meta['peak_allocated_gib']:.2f} GiB")
+    if meta["teacache"]["enabled"]:
+        tc = meta["teacache"]
+        print("[wan22] teacache "
+              f"threshold={tc['threshold']} "
+              f"cond_skipped={len(tc['cond_skipped'])} "
+              f"uncond_skipped={len(tc['uncond_skipped'])}")
     print(f"[wan22] saved {pathlib.Path(args.out)}")
 
 

--- a/examples/wan22_quickstart.py
+++ b/examples/wan22_quickstart.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Wan2.2 TI2V-5B official-pipeline quickstart."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import flash_rt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", required=True,
+                        help="Path to Wan2.2-TI2V-5B checkpoint directory")
+    parser.add_argument("--prompt", default=(
+        "A cinematic shot of a blue sphere rolling across a wooden table"))
+    parser.add_argument("--negative-prompt", default=None)
+    parser.add_argument("--mode", choices=("t2v", "i2v"), default="t2v")
+    parser.add_argument("--image", default=None,
+                        help="Input image for i2v mode")
+    parser.add_argument("--width", type=int, default=832)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--frames", type=int, default=81)
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--shift", type=float, default=5.0)
+    parser.add_argument("--guide-scale", type=float, default=5.0)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--out", default="wan22_out.mp4")
+    args = parser.parse_args()
+
+    image = None
+    if args.mode == "i2v":
+        if args.image is None:
+            raise SystemExit("--image is required for --mode i2v")
+        from PIL import Image
+        image = Image.open(args.image).convert("RGB")
+
+    t0 = time.perf_counter()
+    model = flash_rt.load_model(
+        args.checkpoint,
+        framework="torch",
+        config="wan22_ti2v_5b",
+        hardware="rtx_sm120",
+    )
+    print(f"[wan22] load_model wall={time.perf_counter() - t0:.2f}s")
+
+    model.set_prompt(args.prompt, negative_prompt=args.negative_prompt)
+    result = model.infer(
+        mode=args.mode,
+        image=image,
+        width=args.width,
+        height=args.height,
+        frames=args.frames,
+        steps=args.steps,
+        shift=args.shift,
+        guide_scale=args.guide_scale,
+        seed=args.seed,
+        save_path=args.out,
+        return_metadata=True,
+    )
+    meta = result["metadata"]
+    print(f"[wan22] infer={meta['infer_seconds']:.2f}s "
+          f"peak={meta['peak_allocated_gib']:.2f} GiB")
+    print(f"[wan22] saved {pathlib.Path(args.out)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -223,7 +223,7 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         weight_cache: if True (default), cache FP8-quantized weights to disk
             after first load. Only affects JAX.
         config: model config name: "pi05", "pi0", "groot", "groot_n17",
-            "pi0fast", "motus"
+            "pi0fast", "motus", "wan22_ti2v_5b"
         device: ignored (auto-detects GPU). Reserved for future multi-GPU.
         decode_cuda_graph: Pi0-FAST only. Capture action-phase decode as CUDA
             Graph for max throughput (trades startup time for per-token speed).
@@ -285,10 +285,12 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
     Returns:
         VLAModel instance with .predict() method.
     """
-    if config not in ("pi05", "groot", "groot_n17", "pi0", "pi0fast", "motus"):
+    if config not in ("pi05", "groot", "groot_n17", "pi0", "pi0fast",
+                      "motus", "wan22_ti2v_5b"):
         raise ValueError(
             f"Unknown config: {config}. "
-            f"Supported: pi05, groot, groot_n17, pi0, pi0fast, motus")
+            f"Supported: pi05, groot, groot_n17, pi0, pi0fast, motus, "
+            f"wan22_ti2v_5b")
     if framework not in ("torch", "jax"):
         raise ValueError(
             f"Unknown framework: {framework}. Supported: torch, jax")
@@ -413,6 +415,9 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             kwargs["embodiment_tag"] = embodiment_tag
         if "action_horizon" in sig.parameters and action_horizon is not None:
             kwargs["action_horizon"] = action_horizon
+    elif config == "wan22_ti2v_5b":
+        if "autotune" in sig.parameters:
+            kwargs["autotune"] = autotune
     else:
         # pi05, pi0 — both Thor and rtx variants take (checkpoint, num_views, autotune)
         # or (checkpoint, num_views). Feature-detect.

--- a/flash_rt/configs/wan22_ti2v_5b.yaml
+++ b/flash_rt/configs/wan22_ti2v_5b.yaml
@@ -1,0 +1,24 @@
+name: wan22_ti2v_5b
+family: wan
+frameworks: ["torch"]
+hardware: ["rtx_sm120"]
+
+model:
+  backbone: Wan2.2-TI2V-5B
+  source: official_wan
+  latent_channels: 48
+  num_layers: 30
+  hidden_size: 3072
+  num_heads: 24
+  head_dim: 128
+  text_len: 512
+  vae_stride: [4, 16, 16]
+
+defaults:
+  width: 832
+  height: 480
+  frames: 81
+  steps: 20
+  shift: 5.0
+  guide_scale: 5.0
+  sample_solver: unipc

--- a/flash_rt/frontends/torch/wan22_rtx.py
+++ b/flash_rt/frontends/torch/wan22_rtx.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import sys
 import time
+import types
 from copy import deepcopy
 from typing import Any, Optional
 
@@ -60,6 +61,7 @@ class Wan22TorchFrontendRtx:
         self.negative_prompt: Optional[str] = None
         self._pipe = None
         self._load_seconds: Optional[float] = None
+        self._teacache_installed = False
 
     @staticmethod
     def _candidate_wan_roots() -> list[pathlib.Path]:
@@ -149,6 +151,11 @@ class Wan22TorchFrontendRtx:
         seed: int = 1234,
         sample_solver: str = DEFAULT_SOLVER,
         offload_model: bool = True,
+        teacache: bool = False,
+        teacache_threshold: float = 0.0,
+        teacache_start_step: int = 1,
+        teacache_end_step: int = -1,
+        teacache_cache_device: str = "cuda",
         save_path: Optional[str] = None,
         return_metadata: bool = False,
     ):
@@ -170,8 +177,19 @@ class Wan22TorchFrontendRtx:
             raise ValueError("width and height must be multiples of 32")
         if steps <= 0:
             raise ValueError("steps must be positive")
+        if teacache and teacache_threshold <= 0:
+            raise ValueError(
+                "teacache_threshold must be positive when teacache=True")
 
         pipe = self._load_pipe()
+        teacache_meta = self._configure_teacache(
+            pipe.model,
+            enabled=bool(teacache),
+            threshold=float(teacache_threshold),
+            start_step=int(teacache_start_step),
+            end_step=int(teacache_end_step),
+            cache_device=teacache_cache_device,
+        )
         torch.cuda.reset_peak_memory_stats()
         t0 = time.perf_counter()
         with torch.no_grad():
@@ -190,6 +208,8 @@ class Wan22TorchFrontendRtx:
                 offload_model=bool(offload_model),
             )
         infer_seconds = time.perf_counter() - t0
+        teacache_meta = self._teacache_metadata(pipe.model, teacache_meta)
+        self._release_teacache_cache(pipe.model)
 
         if save_path is not None:
             self._save_video(video, save_path)
@@ -213,8 +233,227 @@ class Wan22TorchFrontendRtx:
                 "guide_scale": float(guide_scale),
                 "sample_solver": sample_solver,
                 "seed": int(seed),
+                "teacache": teacache_meta,
             },
         }
+
+    def _configure_teacache(
+        self,
+        model,
+        *,
+        enabled: bool,
+        threshold: float,
+        start_step: int,
+        end_step: int,
+        cache_device: str,
+    ) -> dict[str, Any]:
+        if not enabled:
+            state = getattr(model, "_flashrt_teacache", None)
+            if state is not None:
+                state["enabled"] = False
+            return {"enabled": False}
+
+        if not self._teacache_installed:
+            self._install_teacache(model)
+            self._teacache_installed = True
+
+        if cache_device in ("cuda", "gpu", "main_device"):
+            resolved_device = self.device
+            device_name = "cuda"
+        elif cache_device in ("cpu", "offload_device"):
+            resolved_device = torch.device("cpu")
+            device_name = "cpu"
+        else:
+            raise ValueError(
+                "teacache_cache_device must be 'cuda'/'main_device' or "
+                "'cpu'/'offload_device'")
+
+        model._flashrt_teacache = self._new_teacache_state(
+            enabled=True,
+            threshold=threshold,
+            start_step=start_step,
+            end_step=end_step,
+            cache_device=resolved_device,
+        )
+        return {
+            "enabled": True,
+            "threshold": threshold,
+            "start_step": start_step,
+            "end_step": end_step,
+            "cache_device": device_name,
+        }
+
+    @staticmethod
+    def _new_teacache_state(
+        *,
+        enabled: bool,
+        threshold: float,
+        start_step: int,
+        end_step: int,
+        cache_device: torch.device,
+    ) -> dict[str, Any]:
+        def slot() -> dict[str, Any]:
+            return {
+                "previous_modulated_input": None,
+                "previous_residual": None,
+                "accumulated": torch.tensor(0.0, device=cache_device),
+                "calculated": 0,
+                "skipped": [],
+            }
+
+        return {
+            "enabled": enabled,
+            "threshold": threshold,
+            "start_step": start_step,
+            "end_step": end_step,
+            "cache_device": cache_device,
+            "last_t": None,
+            "step": -1,
+            "call_index": 0,
+            "states": {0: slot(), 1: slot()},
+        }
+
+    @staticmethod
+    def _relative_l1(cur: torch.Tensor, prev: torch.Tensor) -> torch.Tensor:
+        denom = prev.abs().mean().clamp_min(1e-6)
+        return (cur - prev).abs().mean() / denom
+
+    @classmethod
+    def _install_teacache(cls, model) -> None:
+        cls._ensure_wan_importable()
+        from wan.modules.model import sinusoidal_embedding_1d
+
+        original_forward = model.forward
+
+        def teacache_forward(self, x, t, context, seq_len, y=None):
+            tc = getattr(self, "_flashrt_teacache", None)
+            if tc is None or not tc.get("enabled", False):
+                return original_forward(x, t, context, seq_len, y=y)
+
+            if self.model_type == "i2v":
+                assert y is not None
+
+            device = self.patch_embedding.weight.device
+            if self.freqs.device != device:
+                self.freqs = self.freqs.to(device)
+
+            if y is not None:
+                x = [torch.cat([u, v], dim=0) for u, v in zip(x, y)]
+
+            x = [self.patch_embedding(u.unsqueeze(0)) for u in x]
+            grid_sizes = torch.stack([
+                torch.tensor(u.shape[2:], dtype=torch.long) for u in x
+            ])
+            x = [u.flatten(2).transpose(1, 2) for u in x]
+            seq_lens = torch.tensor([u.size(1) for u in x], dtype=torch.long)
+            assert seq_lens.max() <= seq_len
+            x = torch.cat([
+                torch.cat(
+                    [u, u.new_zeros(1, seq_len - u.size(1), u.size(2))],
+                    dim=1)
+                for u in x
+            ])
+
+            if t.dim() == 1:
+                t = t.expand(t.size(0), seq_len)
+            with torch.amp.autocast("cuda", dtype=torch.float32):
+                bt = t.size(0)
+                t_flat = t.flatten()
+                e = self.time_embedding(
+                    sinusoidal_embedding_1d(self.freq_dim, t_flat)
+                    .unflatten(0, (bt, seq_len))
+                    .float())
+                e0 = self.time_projection(e).unflatten(2, (6, self.dim))
+                assert e.dtype == torch.float32 and e0.dtype == torch.float32
+
+            context_lens = None
+            context = self.text_embedding(
+                torch.stack([
+                    torch.cat([
+                        u,
+                        u.new_zeros(self.text_len - u.size(0), u.size(1))
+                    ])
+                    for u in context
+                ]))
+
+            kwargs = dict(
+                e=e0,
+                seq_lens=seq_lens,
+                grid_sizes=grid_sizes,
+                freqs=self.freqs,
+                context=context,
+                context_lens=context_lens,
+            )
+
+            t_key = float(t_flat[0].detach().cpu())
+            if tc["last_t"] != t_key:
+                tc["last_t"] = t_key
+                tc["step"] += 1
+                tc["call_index"] = 0
+            pred_id = tc["call_index"] % 2
+            tc["call_index"] += 1
+            state = tc["states"][pred_id]
+
+            active = tc["start_step"] <= tc["step"]
+            if tc["end_step"] >= 0:
+                active = active and tc["step"] <= tc["end_step"]
+
+            cache_device = tc["cache_device"]
+            modulated = e.detach().to(cache_device)
+            should_calc = True
+            if active and state["previous_modulated_input"] is not None:
+                state["accumulated"] = (
+                    state["accumulated"] + cls._relative_l1(
+                        modulated, state["previous_modulated_input"]))
+                if (state["accumulated"] < tc["threshold"]
+                        and state["previous_residual"] is not None):
+                    should_calc = False
+                else:
+                    state["accumulated"] = torch.tensor(
+                        0.0, device=cache_device)
+            state["previous_modulated_input"] = modulated.clone()
+
+            if should_calc:
+                x_before = x.detach().to(cache_device).clone()
+                for block in self.blocks:
+                    x = block(x, **kwargs)
+                state["previous_residual"] = (
+                    x.detach().to(cache_device) - x_before)
+                state["calculated"] += 1
+            else:
+                x = x + state["previous_residual"].to(x.device)
+                state["skipped"].append(tc["step"])
+
+            x = self.head(x, e)
+            x = self.unpatchify(x, grid_sizes)
+            return [u.float() for u in x]
+
+        model._flashrt_teacache_original_forward = original_forward
+        model.forward = types.MethodType(teacache_forward, model)
+
+    @staticmethod
+    def _teacache_metadata(model, base: dict[str, Any]) -> dict[str, Any]:
+        state = getattr(model, "_flashrt_teacache", None)
+        if state is None or not base.get("enabled", False):
+            return {"enabled": False}
+        meta = dict(base)
+        meta.update({
+            "cond_calculated": state["states"][0]["calculated"],
+            "cond_skipped": list(state["states"][0]["skipped"]),
+            "uncond_calculated": state["states"][1]["calculated"],
+            "uncond_skipped": list(state["states"][1]["skipped"]),
+        })
+        return meta
+
+    @staticmethod
+    def _release_teacache_cache(model) -> None:
+        state = getattr(model, "_flashrt_teacache", None)
+        if state is None:
+            return
+        state["enabled"] = False
+        for slot in state.get("states", {}).values():
+            slot["previous_modulated_input"] = None
+            slot["previous_residual"] = None
 
     @classmethod
     def _save_video(cls, video: torch.Tensor, path: str) -> None:

--- a/flash_rt/frontends/torch/wan22_rtx.py
+++ b/flash_rt/frontends/torch/wan22_rtx.py
@@ -1,0 +1,238 @@
+"""FlashRT -- Wan2.2 TI2V-5B official torch frontend for RTX SM120.
+
+This frontend exposes the official Wan text/image-to-video pipeline through
+FlashRT's stable ``set_prompt`` / ``infer`` wrapper. ComfyUI integrations
+can use this API from an external custom-node package.
+
+Scope:
+    * Official Wan pipeline baseline for T2V/I2V.
+    * RTX SM120 registration only.
+    * No CMake or pybind changes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import time
+from copy import deepcopy
+from typing import Any, Optional
+
+import torch
+
+
+class Wan22TorchFrontendRtx:
+    """Wan2.2 TI2V-5B official pipeline frontend for RTX."""
+
+    DEFAULT_WIDTH = 832
+    DEFAULT_HEIGHT = 480
+    DEFAULT_FRAMES = 81
+    DEFAULT_STEPS = 20
+    DEFAULT_SHIFT = 5.0
+    DEFAULT_GUIDE_SCALE = 5.0
+    DEFAULT_SOLVER = "unipc"
+
+    def __init__(
+        self,
+        checkpoint_dir: str,
+        num_views: int = 1,
+        autotune: int = 3,
+        dtype: torch.dtype = torch.bfloat16,
+        t5_cpu: bool = True,
+        init_on_cpu: bool = True,
+        convert_model_dtype: bool = True,
+        **_: Any,
+    ) -> None:
+        self.checkpoint_dir = pathlib.Path(checkpoint_dir).expanduser()
+        if not self.checkpoint_dir.exists():
+            raise FileNotFoundError(
+                f"Wan2.2 checkpoint not found: {self.checkpoint_dir}")
+        self.num_views = num_views
+        self.autotune = autotune
+        self.dtype = dtype
+        self.t5_cpu = bool(t5_cpu)
+        self.init_on_cpu = bool(init_on_cpu)
+        self.convert_model_dtype = bool(convert_model_dtype)
+        self.device = torch.device("cuda")
+        self.prompt: Optional[str] = None
+        self.negative_prompt: Optional[str] = None
+        self._pipe = None
+        self._load_seconds: Optional[float] = None
+
+    @staticmethod
+    def _candidate_wan_roots() -> list[pathlib.Path]:
+        roots: list[pathlib.Path] = []
+        for key in ("FLASH_RT_WAN22_ROOT", "WAN22_ROOT", "MOTUS_ROOT",
+                    "FLASH_RT_MOTUS_ROOT"):
+            value = os.environ.get(key)
+            if value:
+                p = pathlib.Path(value).expanduser()
+                roots.extend([p, p / "bak"])
+        return roots
+
+    @classmethod
+    def _ensure_wan_importable(cls) -> None:
+        try:
+            import wan.textimage2video  # noqa: F401
+            return
+        except ModuleNotFoundError as exc:
+            if exc.name != "wan":
+                raise
+            pass
+
+        for root in cls._candidate_wan_roots():
+            if (root / "wan").is_dir():
+                root_s = str(root)
+                if root_s not in sys.path:
+                    sys.path.insert(0, root_s)
+                try:
+                    import wan.textimage2video  # noqa: F401
+                    return
+                except ModuleNotFoundError as exc:
+                    if exc.name != "wan":
+                        raise
+                    continue
+
+        raise ModuleNotFoundError(
+            "Cannot import official Wan modules. Install the Wan2.2 source "
+            "package, add it to PYTHONPATH, or set FLASH_RT_WAN22_ROOT to a "
+            "directory containing the 'wan' package. A Motus checkout also "
+            "works via FLASH_RT_MOTUS_ROOT/MOTUS_ROOT because it vendors "
+            "Wan under bak/wan.")
+
+    def _load_pipe(self):
+        if self._pipe is not None:
+            return self._pipe
+
+        self._ensure_wan_importable()
+        from wan.configs.wan_ti2v_5B import ti2v_5B
+        from wan.textimage2video import WanTI2V
+
+        cfg = deepcopy(ti2v_5B)
+        cfg.param_dtype = self.dtype
+        t0 = time.perf_counter()
+        self._pipe = WanTI2V(
+            config=cfg,
+            checkpoint_dir=str(self.checkpoint_dir),
+            device_id=torch.cuda.current_device(),
+            t5_cpu=self.t5_cpu,
+            init_on_cpu=self.init_on_cpu,
+            convert_model_dtype=self.convert_model_dtype,
+        )
+        self._load_seconds = time.perf_counter() - t0
+        return self._pipe
+
+    def set_prompt(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: Optional[str] = None,
+    ) -> None:
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+        self.prompt = prompt
+        self.negative_prompt = negative_prompt
+
+    def infer(
+        self,
+        *,
+        mode: str = "t2v",
+        image=None,
+        width: int = DEFAULT_WIDTH,
+        height: int = DEFAULT_HEIGHT,
+        frames: int = DEFAULT_FRAMES,
+        steps: int = DEFAULT_STEPS,
+        shift: float = DEFAULT_SHIFT,
+        guide_scale: float = DEFAULT_GUIDE_SCALE,
+        seed: int = 1234,
+        sample_solver: str = DEFAULT_SOLVER,
+        offload_model: bool = True,
+        save_path: Optional[str] = None,
+        return_metadata: bool = False,
+    ):
+        """Generate video frames with the official Wan pipeline.
+
+        Returns a ``torch.Tensor`` in ``[C, F, H, W]`` format by default. If
+        ``return_metadata=True``, returns a dict with the tensor plus timing and
+        generation settings.
+        """
+        if self.prompt is None:
+            raise ValueError("set_prompt(prompt=...) must be called first")
+        if mode not in ("t2v", "i2v"):
+            raise ValueError("mode must be 't2v' or 'i2v'")
+        if mode == "i2v" and image is None:
+            raise ValueError("mode='i2v' requires image=")
+        if frames < 1 or (frames - 1) % 4 != 0:
+            raise ValueError("frames must be 4n+1 for Wan2.2")
+        if width % 32 != 0 or height % 32 != 0:
+            raise ValueError("width and height must be multiples of 32")
+        if steps <= 0:
+            raise ValueError("steps must be positive")
+
+        pipe = self._load_pipe()
+        torch.cuda.reset_peak_memory_stats()
+        t0 = time.perf_counter()
+        with torch.no_grad():
+            video = pipe.generate(
+                self.prompt,
+                img=image if mode == "i2v" else None,
+                size=(int(width), int(height)),
+                max_area=int(width) * int(height),
+                frame_num=int(frames),
+                shift=float(shift),
+                sample_solver=sample_solver,
+                sampling_steps=int(steps),
+                guide_scale=float(guide_scale),
+                n_prompt=self.negative_prompt or "",
+                seed=int(seed),
+                offload_model=bool(offload_model),
+            )
+        infer_seconds = time.perf_counter() - t0
+
+        if save_path is not None:
+            self._save_video(video, save_path)
+
+        if not return_metadata:
+            return video
+
+        return {
+            "video": video,
+            "metadata": {
+                "load_seconds": self._load_seconds,
+                "infer_seconds": infer_seconds,
+                "peak_allocated_gib": (
+                    torch.cuda.max_memory_allocated() / 1024 ** 3),
+                "mode": mode,
+                "width": int(width),
+                "height": int(height),
+                "frames": int(frames),
+                "steps": int(steps),
+                "shift": float(shift),
+                "guide_scale": float(guide_scale),
+                "sample_solver": sample_solver,
+                "seed": int(seed),
+            },
+        }
+
+    @classmethod
+    def _save_video(cls, video: torch.Tensor, path: str) -> None:
+        cls._ensure_wan_importable()
+        from wan.utils.utils import save_video
+
+        out = pathlib.Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        save_video(
+            tensor=video[None],
+            save_file=str(out),
+            fps=24,
+            nrow=1,
+            normalize=True,
+            value_range=(-1, 1),
+        )
+
+    @staticmethod
+    def write_summary(result: dict[str, Any], path: str) -> None:
+        payload = dict(result.get("metadata", result))
+        pathlib.Path(path).write_text(json.dumps(payload, indent=2))

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -119,6 +119,10 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     ("motus", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.motus_rtx", "MotusTorchFrontendRtx"),
 
+    # ── Wan2.2 TI2V-5B official pipeline baseline ──
+    ("wan22_ti2v_5b", "torch", "rtx_sm120"):
+        ("flash_rt.frontends.torch.wan22_rtx", "Wan22TorchFrontendRtx"),
+
     # ── Pi0-FAST ── (SM120 runtime fork inside pipeline, no AttentionBackend protocol.)
     ("pi0fast", "torch", "thor"):
         ("flash_rt.frontends.torch.pi0fast", "Pi0FastTorchFrontend"),

--- a/flash_rt/models/wan22/__init__.py
+++ b/flash_rt/models/wan22/__init__.py
@@ -1,0 +1,1 @@
+"""Wan2.2 official pipeline integration."""

--- a/flash_rt/models/wan22/pipeline_rtx.py
+++ b/flash_rt/models/wan22/pipeline_rtx.py
@@ -1,0 +1,28 @@
+"""Wan2.2 RTX shape constants.
+
+The official Wan2.2 route exposes the upstream Python pipeline through
+``Wan22TorchFrontendRtx``. These constants document the DiT attention
+surface used by the RTX frontend:
+
+* ``wan_self``: 30 layers, MHA, 24 heads, head_dim 128.
+* ``wan_cross``: 30 layers, MHA, 24 heads, head_dim 128, KV text length 512.
+"""
+
+WAN22_NUM_LAYERS = 30
+WAN22_NUM_HEADS = 24
+WAN22_HEAD_DIM = 128
+WAN22_TEXT_LEN = 512
+WAN22_VAE_STRIDE = (4, 16, 16)
+WAN22_PATCH_SIZE = (1, 2, 2)
+
+
+def latent_token_count(width: int, height: int, frames: int) -> int:
+    """Return Wan2.2 DiT token count for a generated video shape."""
+    latent_t = (int(frames) - 1) // WAN22_VAE_STRIDE[0] + 1
+    latent_h = int(height) // WAN22_VAE_STRIDE[1]
+    latent_w = int(width) // WAN22_VAE_STRIDE[2]
+    return (
+        latent_t
+        * (latent_h // WAN22_PATCH_SIZE[1])
+        * (latent_w // WAN22_PATCH_SIZE[2])
+    )

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -184,6 +184,21 @@ def test_load_model_accepts_wan22_ti2v_5b_config():
     }
 
 
+def test_wan22_infer_exposes_teacache_parameters():
+    import inspect
+    from flash_rt.frontends.torch.wan22_rtx import Wan22TorchFrontendRtx
+
+    sig = inspect.signature(Wan22TorchFrontendRtx.infer)
+    for name in (
+        "teacache",
+        "teacache_threshold",
+        "teacache_start_step",
+        "teacache_end_step",
+        "teacache_cache_device",
+    ):
+        assert name in sig.parameters
+
+
 def test_load_model_accepts_groot_n17_config():
     from flash_rt.api import load_model
 

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -132,6 +132,58 @@ def test_groot_n17_sm89_is_not_registered_without_validation():
         resolve_pipeline_class("groot_n17", "torch", "rtx_sm89")
 
 
+def test_wan22_ti2v_5b_rtx_sm120_is_registered():
+    from flash_rt.hardware import resolve_pipeline_class
+
+    cls = resolve_pipeline_class("wan22_ti2v_5b", "torch", "rtx_sm120")
+    assert cls.__name__ == "Wan22TorchFrontendRtx"
+
+
+def test_wan22_ti2v_5b_sm89_is_not_registered_without_validation():
+    from flash_rt.hardware import resolve_pipeline_class
+
+    with pytest.raises(RuntimeError, match="rtx_sm120"):
+        resolve_pipeline_class("wan22_ti2v_5b", "torch", "rtx_sm89")
+
+
+def test_load_model_accepts_wan22_ti2v_5b_config():
+    from flash_rt.api import load_model
+
+    class Wan22Frontend:
+        seen = None
+
+        def __init__(self, checkpoint, num_views=1, autotune=3):
+            type(self).seen = {
+                "checkpoint": checkpoint,
+                "num_views": num_views,
+                "autotune": autotune,
+            }
+
+        def set_prompt(self, *args, **kwargs):
+            return None
+
+        def infer(self, *args, **kwargs):
+            return None
+
+    with patch("flash_rt.hardware.resolve_pipeline_class",
+              return_value=Wan22Frontend):
+        model = load_model(
+            "unused-checkpoint",
+            config="wan22_ti2v_5b",
+            framework="torch",
+            hardware="rtx_sm120",
+            num_views=1,
+            autotune=0,
+        )
+
+    assert isinstance(model._pipe, Wan22Frontend)
+    assert Wan22Frontend.seen == {
+        "checkpoint": "unused-checkpoint",
+        "num_views": 1,
+        "autotune": 0,
+    }
+
+
 def test_load_model_accepts_groot_n17_config():
     from flash_rt.api import load_model
 


### PR DESCRIPTION
## Summary
- Add the Wan2.2 TI2V-5B official-pipeline RTX SM120 route.
- Expose the public FlashRT API via config="wan22_ti2v_5b".
- Add opt-in TeaCache parameters for Wan2.2 inference.
- Add quickstart, usage docs, stable API docs, and README benchmark notes.

## Scope
- Official Wan2.2 TI2V-5B pipeline path only.
- RTX SM120 only.
- No CMake or binding changes.
- ComfyUI integration is not included in this PR.

## Validation
- Wan2.2 dispatch/API tests pass.
- Syntax checks pass.
- 256x256 Wan2.2 smoke test passes.
- 256x256 TeaCache smoke test passes with cond/uncond skipped steps reported.
- Full light pytest has one unrelated existing environment failure: missing ml_dtypes for Pi0.5 RTX import.
