### PR TITLE
Add state handling to public VLA API

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ actions = model.predict(
 )
 # Pi0.5: actions shape (10, 7) — 10 future steps, 7 DOF
 
+# State is part of the VLA observation. Pi0/GROOT N1.6 consume it during
+# inference; token-based variants encode it in the prompt prefix.
+
 # Pi0 (continuous state input):
 model = flash_rt.load_model(
     checkpoint="/path/to/pi0_checkpoint",
@@ -420,16 +423,20 @@ model = flash_rt.load_model(
 actions = model.predict(
     images=[base_img, wrist_img],
     prompt="pick up the red block",
+    state=state,
 )
 # Pi0: actions shape (10, 7)
-# Note: Pi0 also accepts 'state' in observation dict for continuous state input
 
 # GROOT N1.6:
 model = flash_rt.load_model(
     checkpoint="/path/to/groot_checkpoint",
     config="groot",
 )
-actions = model.predict(images=[base_img, wrist_img], prompt="pick up the red block")
+actions = model.predict(
+    images=[base_img, wrist_img],
+    prompt="pick up the red block",
+    state=state,
+)
 # GROOT: actions shape (50, 128) — 50 steps, 128-dim padded
 
 # Pi0-FAST (autoregressive — discrete token generation, not diffusion):

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -118,8 +118,25 @@ class VLAModel:
   `images`: list of `(224,224,3)` uint8 numpy arrays, or a dict with
   `"image"` / `"wrist_image"` / `"wrist_image_right"` keys.
   `prompt`: required on first call, reused on subsequent calls if `None`.
-  `state`: robot state array (Pi0/Pi0-FAST only).
+  `state`: optional robot state array. `predict()` attaches it to the
+  observation as `"state"` when the caller passes image lists, while preserving
+  an explicit `"state"` already present in a dict observation.
+  For frontends whose `set_prompt()` accepts `state`, `predict()` refreshes the
+  prompt prefix when either the prompt text or that prompt-state value changes.
   Returns `np.ndarray` of shape `(action_horizon, action_dim)`.
+
+  `state` is part of the VLA observation schema; each model encodes it through
+  its own reference contract:
+  - Pi0 uses a continuous state token in the action-expert suffix.
+  - Pi0.5's openpi reference encodes state as discretized prompt tokens. The
+    current FlashRT Pi0.5 frontend still tokenizes prompts without that state
+    argument, so this is the remaining Pi0.5 API gap.
+  - Pi0-FAST encodes state in the FAST token prefix.
+  - GROOT N1.6 consumes proprioceptive state from `obs["state"]`; if omitted,
+    the backend uses zeros.
+  - GROOT N1.7 currently uses the lower-level
+    `normalize_state(...)` + `infer(state_normalized, initial_noise=...)`
+    contract rather than the image-list `predict()` contract.
 
 - `recalibrate()` — clear FP8 calibration cache and force re-calibration
   on the next `predict()` call.

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -38,6 +38,7 @@ class VLAModel:
         self._pipe = pipe
         self._framework = framework
         self._current_prompt = None
+        self._current_prompt_state = None
         # rtx Pi0.5 (RtxTorchPi05) requires an explicit
         # ``calibrate_with_real_data([obs])`` call before the first
         # ``infer()``; Thor / rtx GROOT lazy-calibrate inside ``infer()``.
@@ -47,6 +48,24 @@ class VLAModel:
             pipe, "calibrate_with_real_data"
         )
 
+    @staticmethod
+    def _snapshot_prompt_state(state):
+        if state is None:
+            return None
+        try:
+            return np.asarray(state).copy()
+        except Exception:
+            return state
+
+    @staticmethod
+    def _prompt_state_equal(a, b) -> bool:
+        if a is None or b is None:
+            return a is b
+        try:
+            return np.array_equal(np.asarray(a), np.asarray(b))
+        except Exception:
+            return a is b
+
     def predict(self, images, prompt=None, state=None):
         """Run inference.
 
@@ -55,26 +74,43 @@ class VLAModel:
                     Or a dict with 'image'/'wrist_image' keys.
             prompt: text prompt. Only needed on first call or when changing prompt.
                     If None, reuses the last prompt.
-            state: robot state array (Pi0/Pi0-FAST only). Passed to set_prompt().
-                   Pi0 uses continuous state projection; Pi0-FAST discretizes to text.
+            state: optional robot state array. It is forwarded to
+                   set_prompt() for frontends that encode state in prompt
+                   tokens, and attached to the observation for frontends that
+                   consume state during infer().
 
         Returns:
             np.ndarray: actions
         """
-        if prompt is not None and prompt != self._current_prompt:
-            if hasattr(self._pipe, 'set_prompt'):
-                import inspect
-                sig = inspect.signature(self._pipe.set_prompt)
-                if 'state' in sig.parameters:
-                    self._pipe.set_prompt(prompt, state=state)
-                else:
-                    self._pipe.set_prompt(prompt)
-            self._current_prompt = prompt
-        elif self._current_prompt is None:
+        if prompt is None and self._current_prompt is None:
             raise ValueError("prompt is required on first call")
 
+        prompt_for_call = self._current_prompt if prompt is None else prompt
+        prompt_changed = prompt is not None and prompt != self._current_prompt
+        prompt_state_changed = False
+
+        if hasattr(self._pipe, 'set_prompt'):
+            import inspect
+            sig = inspect.signature(self._pipe.set_prompt)
+            prompt_accepts_state = 'state' in sig.parameters
+            if prompt_accepts_state and state is not None:
+                prompt_state_changed = not self._prompt_state_equal(
+                    self._current_prompt_state, state)
+        else:
+            sig = None
+            prompt_accepts_state = False
+
+        if prompt_changed or prompt_state_changed:
+            if hasattr(self._pipe, 'set_prompt'):
+                if prompt_accepts_state:
+                    self._pipe.set_prompt(prompt_for_call, state=state)
+                else:
+                    self._pipe.set_prompt(prompt_for_call)
+            self._current_prompt = prompt_for_call
+            self._current_prompt_state = self._snapshot_prompt_state(state)
+
         if isinstance(images, dict):
-            obs = images
+            obs = dict(images)
         elif isinstance(images, (list, tuple)):
             if len(images) == 0:
                 raise ValueError("images list must have at least one frame")
@@ -90,6 +126,9 @@ class VLAModel:
                 obs['wrist_image_right'] = images[2]
         else:
             raise ValueError("images must be a list of numpy arrays or a dict")
+
+        if state is not None and "state" not in obs:
+            obs["state"] = state
 
         # rtx Pi0.5 expects an explicit calibration bootstrap before the
         # first infer(); fire it lazily here so user code stays "3 lines".

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -5,6 +5,92 @@ from pathlib import Path
 import pytest
 
 
+def test_predict_forwards_state_to_prompt_and_observation():
+    from flash_rt.api import VLAModel
+
+    image0 = object()
+    image1 = object()
+    state = object()
+    actions = object()
+
+    class StateFrontend:
+        prompt_state = None
+        seen_obs = None
+
+        def set_prompt(self, prompt, state=None):
+            type(self).prompt_state = state
+
+        def infer(self, obs):
+            type(self).seen_obs = obs
+            return {"actions": actions}
+
+    model = VLAModel(StateFrontend(), framework="torch")
+    result = model.predict(
+        images=[image0, image1],
+        prompt="pick up the red block",
+        state=state,
+    )
+
+    assert result is actions
+    assert StateFrontend.prompt_state is state
+    assert StateFrontend.seen_obs["state"] is state
+    assert StateFrontend.seen_obs["image"] is image0
+    assert StateFrontend.seen_obs["wrist_image"] is image1
+
+
+def test_predict_refreshes_prompt_when_prompt_state_changes():
+    from flash_rt.api import VLAModel
+
+    image = object()
+    state0 = [0.0, 1.0]
+    state1 = [1.0, 2.0]
+
+    class TokenStateFrontend:
+        prompt_states = []
+
+        def set_prompt(self, prompt, state=None):
+            type(self).prompt_states.append(list(state))
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    TokenStateFrontend.prompt_states = []
+    model = VLAModel(TokenStateFrontend(), framework="torch")
+    model.predict(images=[image], prompt="pick", state=state0)
+    model.predict(images=[image], state=state0)
+    model.predict(images=[image], state=state1)
+
+    assert TokenStateFrontend.prompt_states == [state0, state1]
+
+
+def test_predict_preserves_state_from_observation_dict():
+    from flash_rt.api import VLAModel
+
+    image = object()
+    dict_state = object()
+    kwarg_state = object()
+
+    class ObservationFrontend:
+        seen_obs = None
+
+        def set_prompt(self, prompt):
+            return None
+
+        def infer(self, obs):
+            type(self).seen_obs = obs
+            return {"actions": None}
+
+    model = VLAModel(ObservationFrontend(), framework="torch")
+    model.predict(
+        images={"image": image, "state": dict_state},
+        prompt="pick up the red block",
+        state=kwarg_state,
+    )
+
+    assert ObservationFrontend.seen_obs["state"] is dict_state
+    assert ObservationFrontend.seen_obs["image"] is image
+
+
 def test_load_model_only_passes_use_fp8_when_frontend_accepts_it():
     from flash_rt.api import load_model
 


### PR DESCRIPTION
## Summary
- attach `state` from `VLAModel.predict()` to observation dicts without overwriting explicit observation state
- refresh prompt prefixes when `set_prompt(..., state=...)` frontends receive a changed state value
- document the state contract for Pi0, Pi0.5, Pi0-FAST, GROOT N1.6, and GROOT N1.7

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_load_model_use_fp8_kwarg.py -q` (18 passed)
- StableHLO: Pi0 RTX vs official PyTorch FP32 ref cosine 0.997490
- StableHLO: Pi0.5 RTX vs official PyTorch FP32 ref cosine 0.999705
- StableHLO: GROOT N1.6 RTX DiT/action path vs `rtx_groot_ref.npz` cosine 0.999248
- StableHLO: Pi0-FAST JAX vs JAX bf16 ref worst segment cosine 0.993657
- `git diff --check`
