### PR TITLE
Optimize Qwen3.6 NVFP4 long-context serving

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,14 +641,22 @@ if(ENABLE_FA2)
   # against any subset of the matrix.
   list(APPEND FA2_SRCS csrc/attention/fa2_wrapper.cu)
 
-  # P1-a (Qwen3-8B prefill): causal FA2 forward — built only for
-  # hdim=128 + bf16 to keep the public .so size in check.
+  # Causal FA2 forward. hdim=128 serves Qwen3-8B prefill; hdim=256
+  # serves Qwen3.6 full-attention prefill/verify chunks.
   if("128" IN_LIST FA2_HDIMS AND "bf16" IN_LIST FA2_DTYPES)
     list(APPEND FA2_SRCS
       csrc/attention/fa2_causal_inst/flash_fwd_hdim128_bf16_sm80_causal.cu
       csrc/attention/fa2_causal_inst/flash_fwd_split_hdim128_bf16_sm80_causal.cu
-      csrc/attention/fa2_wrapper_causal.cu
     )
+  endif()
+  if("256" IN_LIST FA2_HDIMS AND "bf16" IN_LIST FA2_DTYPES)
+    list(APPEND FA2_SRCS
+      csrc/attention/fa2_causal_inst/flash_fwd_hdim256_bf16_sm80_causal.cu
+      csrc/attention/fa2_causal_inst/flash_fwd_split_hdim256_bf16_sm80_causal.cu
+    )
+  endif()
+  if("bf16" IN_LIST FA2_DTYPES AND ("128" IN_LIST FA2_HDIMS OR "256" IN_LIST FA2_HDIMS))
+    list(APPEND FA2_SRCS csrc/attention/fa2_wrapper_causal.cu)
   endif()
 
   add_library(fa2_vendor_obj OBJECT ${FA2_SRCS})
@@ -775,6 +783,43 @@ if(ENABLE_FA2)
   message(STATUS "FA2 pybind module: flash_rt_fa2 (separate .so)")
 endif()
 
+# ── Qwen3.6 SM120 FlashInfer XQA FP8-KV probe ──
+if(GPU_ARCH STREQUAL "120")
+  add_library(qwen36_flashinfer_xqa_obj OBJECT
+    csrc/attention/flashinfer_xqa_src/mha.cu
+    csrc/kernels/qwen36_flashinfer_xqa.cu)
+  set_target_properties(qwen36_flashinfer_xqa_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(qwen36_flashinfer_xqa_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/attention/flashinfer_xqa_src)
+  target_compile_definitions(qwen36_flashinfer_xqa_obj PRIVATE
+    NDEBUG=1
+    BEAM_WIDTH=1
+    USE_INPUT_KV=0
+    USE_CUSTOM_BARRIER=1
+    MLA_WRAPPER=0
+    USE_SM90_MHA=0
+    INPUT_FP16=0
+    DTYPE=__nv_bfloat16
+    CACHE_ELEM_ENUM=2
+    TOKENS_PER_PAGE=128
+    HEAD_ELEMS=256
+    HEAD_GRP_SIZE=6
+    SLIDING_WINDOW=0
+    LOW_PREC_OUTPUT=0
+    SPEC_DEC=1)
+  target_compile_options(qwen36_flashinfer_xqa_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3
+      --ftz=true --prec-div=false --prec-sqrt=false
+      -U__CUDA_NO_BFLOAT16_OPERATORS__
+      -U__CUDA_NO_BFLOAT162_OPERATORS__
+      ${GPU_GENCODE}
+    >)
+endif()
+
 # ── Main module ──
 pybind11_add_module(flash_rt_kernels
   csrc/gemm/gemm_runner.cu
@@ -815,6 +860,7 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/rms_norm_gated_silu_qwen36.cu
   csrc/kernels/silu_mul_qwen36.cu
   csrc/kernels/silu_mul_to_nvfp4_swizzled.cu
+  csrc/kernels/qwen36_misc.cu
   csrc/kernels/qwen3_qkv_post_proc.cu
   csrc/kernels/fp4_w4a4_matvec_sm120.cu
   csrc/kernels/fp4_w4a4_mma_sm120.cu
@@ -873,6 +919,13 @@ if(GPU_ARCH STREQUAL "120")
     csrc/quantize/nvfp4_sf_reshape_sm120.cu)
   target_compile_definitions(flash_rt_kernels PRIVATE
     ENABLE_CUTLASS_SM120_NVFP4_W4A16=1)
+endif()
+
+if(GPU_ARCH STREQUAL "120")
+  target_sources(flash_rt_kernels PRIVATE
+    $<TARGET_OBJECTS:qwen36_flashinfer_xqa_obj>)
+  target_compile_definitions(flash_rt_kernels PRIVATE
+    ENABLE_QWEN36_FLASHINFER_XQA=1)
 endif()
 
 if(FLASHRT_ENABLE_MOTUS AND GPU_ARCH STREQUAL "120")

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A general kernel library composed into static graphs — no ONNX export, no engine compilation, no per-driver rebuild. Hand-written kernels (norm / activation / fusion / RoPE / FP8 / NVFP4 GEMM / attention) cover standard transformer, DiT, and SigLIP primitives. The composition pattern itself is hardware-agnostic; today the codebase ships with NVIDIA implementations spanning edge to server (Jetson AGX Thor through A100 / RTX 4090 / 5090).
 
-The flagship integration today is **VLA control** — production frontends for Pi0, Pi0.5, GROOT N1.6, GROOT N1.7, and Pi0-FAST, validated on LIBERO where applicable. The same kernel set also powers the BAGEL world-model image-generation pipeline (research preview) and audio / video generation (4× over PyTorch). FlashRT now also serves **single-stream LLM inference** — the v1 release ships **Qwen3.6-27B (NVFP4)** with **256 K context on a single RTX 5090**, an OpenAI-compatible HTTP server, and decode throughput of **~100 tok/s typical / 129 tok/s peak** (real warm-state range across mixed chat / reasoning / code prompts; see [Performance](#performance) for the breakdown). The pattern is workload-shaped (small-batch realtime), not model-class-shaped.
+The flagship integration today is **VLA control** — production frontends for Pi0, Pi0.5, GROOT N1.6, GROOT N1.7, and Pi0-FAST, validated on LIBERO where applicable. The same kernel set also powers the BAGEL world-model image-generation pipeline (research preview) and audio / video generation (4× over PyTorch). FlashRT now also serves **single-stream LLM inference** — the v1 release ships **Qwen3.6-27B (NVFP4)** with **256 K context on a single RTX 5090**, an OpenAI-compatible HTTP server, and warm decode throughput from **~120 tok/s at 512-token prompts to ~130 tok/s at 256 K** (peak measured bucket: **176 tok/s at 64 K**; see [Performance](#performance)). The pattern is workload-shaped (small-batch realtime), not model-class-shaped.
 
 Existing inference tooling is shaped for different workloads — TensorRT for tactic-search compile to frozen engines, vLLM / SGLang for high-batch LLM serving. FlashRT targets the small-batch realtime cell with hand-tuned kernels and no compile step.
 
@@ -27,7 +27,7 @@ Existing inference tooling is shaped for different workloads — TensorRT for ta
 ## FlashRT supports:
 
 - **VLA models**: Pi0, Pi0.5, GROOT N1.6, GROOT N1.7, Pi0-FAST. Pi0/Pi0.5/GROOT N1.6/Pi0-FAST are production-validated on LIBERO; GROOT N1.7 currently exposes an RTX SM120 DiT FA2 path. Motus RTX beta — Wan2.2-based robot policy path at ~167 ms / ~100 ms with TeaCache. BAGEL world-model (research preview) — image-gen pipeline at ~4× vs PyTorch.
-- **LLM**: **Qwen3.6-27B NVFP4 — ~100 tok/s typical / 129 tok/s peak decode, 256 K context, single RTX 5090** — speculative decoding via the FP8 ckpt's MTP head, OpenAI-compatible HTTP server. **Qwen3-8B NVFP4** text-only serving reaches **150 tok/s** warm decode.
+- **LLM**: **Qwen3.6-27B NVFP4 — FP8-KV long-context decode to 256 K on one RTX 5090** — speculative decoding via the FP8 ckpt's MTP head, OpenAI-compatible HTTP server, **130 tok/s at 256 K** and **176 tok/s at 64 K** in the warm 64-token table. **Qwen3-8B NVFP4** text-only serving reaches **150 tok/s** warm decode.
 - **Hardware (today)**: NVIDIA Jetson AGX Thor (SM110), RTX 5090 (SM120), RTX 4090 (SM89), and SM80 / SM86 / SM89 cards (A100, RTX 3090, 4060 Ti, etc.). The kernel composition pattern is portable to other accelerators.
 - **Frameworks**: PyTorch (safetensors) + JAX (Orbax) — same compiled kernels
 
@@ -35,7 +35,7 @@ Pi0.5: 44 ms / 23 Hz on Jetson AGX Thor (2v, FP8) · 39.78 ms / 25 Hz (2v, NVFP4
 
 ## News
 
-- [2026/05] **Qwen3.6-27B NVFP4** is supported with 256 K context on a single RTX 5090, OpenAI-compatible serving, and **~100 tok/s typical / 129 tok/s peak** decode. See [Qwen3.6 NVFP4](docs/qwen36_nvfp4.md) and [Performance](#qwen36-performance).
+- [2026/05] **Qwen3.6-27B NVFP4** is supported with 256 K context on a single RTX 5090, OpenAI-compatible serving, FP8-KV long-context verify, and **130 tok/s warm decode at 256 K**. See [Qwen3.6 NVFP4](docs/qwen36_nvfp4.md) and [Performance](#qwen36-performance).
 - [2026/05] **Qwen3-8B NVFP4** text-only serving is supported on RTX 5090, with **9.1 ms TTFT at P=64** and **150 tok/s** warm decode. See [Qwen3-8B NVFP4](docs/qwen3_8b_nvfp4.md) and [Performance](#qwen3-8b-performance).
 - [2026/05] **Wan2.2 TI2V-5B** official-pipeline baseline is available on RTX SM120, with opt-in TeaCache acceleration. See [Wan2.2 usage](docs/wan22_usage.md).
 - [2026/05] **Lingbot-VLA** is supported. See [Lingbot usage](https://github.com/LiangSu8899/FlashRT/blob/main/docs/lingbot_usage.md).
@@ -81,7 +81,7 @@ First call: ~3 s (calibration + CUDA Graph capture). Every subsequent call: 44 m
 |---|---|
 | **Run your first inference** | [Build & install](#build--install) — Docker and native Linux paths |
 | **See API examples for all 4 VLA models + the Qwen3.6 LLM** | [API snippets](#api-snippets) |
-| **Run Qwen3.6-27B NVFP4 (LLM, ~100 tok/s typical / 129 tok/s peak on RTX 5090)** | [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) — quickstart, K selection, measured throughput · [`docs/qwen36_usage.md`](docs/qwen36_usage.md) — full parameter reference · [`examples/qwen36_openai_server.py`](examples/qwen36_openai_server.py) — OpenAI-compatible HTTP server |
+| **Run Qwen3.6-27B NVFP4 (LLM, 256 K on RTX 5090)** | [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) — quickstart, K selection, measured throughput · [`docs/qwen36_usage.md`](docs/qwen36_usage.md) — full parameter reference · [`examples/qwen36_openai_server.py`](examples/qwen36_openai_server.py) — OpenAI-compatible HTTP server |
 | **Run Qwen3-8B NVFP4 text serving** | [`docs/qwen3_8b_nvfp4.md`](docs/qwen3_8b_nvfp4.md) · [`examples/qwen3_openai_server.py`](examples/qwen3_openai_server.py) |
 | **Run Motus RTX beta, TeaCache, or RTC-lite** | [`docs/motus_usage_beta.md`](docs/motus_usage_beta.md) · [`docs/rtc_lite_design.md`](docs/rtc_lite_design.md) |
 | **Run Wan2.2 TI2V-5B official-pipeline baseline** | [`docs/wan22_usage.md`](docs/wan22_usage.md) |
@@ -127,59 +127,37 @@ First call: ~3 s (calibration + CUDA Graph capture). Every subsequent call: 44 m
 
 Single-stream chat-completion latency. NVFP4 W4A16 main weights +
 FP8→NVFP4-converted MTP head for K-step speculative decoding. All
-numbers are decode-only tok/s (excluding prefill); same metric vLLM
-and TensorRT-LLM report.
+numbers below use warm-state decode after startup graph warmup. TTFT is
+the measured prefill-to-first-token window. The table uses the measured
+best configuration per bucket.
 
-**Peak (single prompt, NTOK=128, no chat template)** — `"Explain
-quantum entanglement in one short paragraph."`, 11 prompt tokens:
+**Warm context sweep** — repeated text prompt, `max_new_tokens=64`,
+single RTX 5090:
 
-| Configuration | Decode latency | Throughput |
-|---|---|---|
-| **Qwen3.6-27B NVFP4** + spec K=3 | **8.49 ms/token** | **117.8 tok/s** |
-| **Qwen3.6-27B NVFP4** + spec K=6 | **7.74 ms/token** | **128.9 tok/s** |
+| prompt ctx | K | MTP tail | TTFT / prefill | prefill tok/s | decode tok/s |
+|---:|---:|---:|---:|---:|---:|
+| 128 | 6 | full | 2.72 s | 47 | 141.0 |
+| 512 | 4 | 512 | 66.6 ms | 7,683 | 119.7 |
+| 1 K | 5 | 2048 | 122.9 ms | 8,334 | 115.3 |
+| 2 K | 6 | 2048 | 238.9 ms | 8,572 | 149.6 |
+| 4 K | 3 | 512 | 333.4 ms | 12,285 | 113.9 |
+| 8 K | 5 | 2048 | 749.7 ms | 10,926 | 157.5 |
+| 16 K | 7 | 2048 | 1.55 s | 10,587 | 170.6 |
+| 32 K | 6 | 2048 | 3.54 s | 9,262 | 157.5 |
+| 64 K | 7 | 2048 | 9.11 s | 7,195 | 176.1 |
+| 128 K | 7 | 2048 | 26.64 s | 4,920 | 153.9 |
+| 200 K | 6 | 2048 | 56.81 s | 3,605 | 114.7 |
+| 256 K | 6 | 2048 | 87.71 s | 2,989 | 129.7 |
 
-**Real-world warm-state (chat-template + NTOK=256, mixed-task workload)**
-— measured across 6 prompts (EN chat / EN reasoning / CN chat / CN
-factual / CN poetry / Code) at K=6:
+The decode column excludes TTFT, matching the usual TPOT-derived LLM
+metric. The table above keeps the fastest measured decode configuration
+for each bucket.
 
-| Stat | tok/s |
-|---|---:|
-| **mean** | **~93** |
-| min (Code prompt) | 75 |
-| max (CN factual prompt) | 101 |
-
-So users can expect roughly **~100 tok/s typical** in production with
-peak around **129 tok/s** on the easiest prompt class. The cliff is
-content-dependent (drafter alignment with the input distribution):
-
-* **Instruction-following / factual / chat** prompts hit the headline
-  rate — drafter aligns well with the prompt distribution.
-* **Code generation** drops to ~75 tok/s — drafter has lower acceptance
-  on punctuation / indentation / bracket tokens. Same trade-off seen
-  in vLLM and SGLang spec decode.
-* **Long generations** (NTOK ≥ 256) shave ~5-10 tok/s vs short outputs
-  — drafter quality decays past the prompt's local distribution.
-* **First call** at a new (prompt_len, max_tokens) shape pays a
-  ~5-25 s CUDA-Graph capture cost. The bundled OpenAI server
-  ([`examples/qwen36_openai_server.py`](examples/qwen36_openai_server.py))
-  pre-captures common shapes at startup via `--warmup`.
-
-Long-context decode at fixed context length (TurboQuant packed KV
-cache, single-token forward, AL=3.17 amortization):
-
-| ctx | forward latency | est. tok/s with spec |
-|---|---|---|
-| 8 K | 26.6 ms | 119 |
-| 32 K | 38.7 ms | 81 |
-| 128 K | 87.7 ms | 36 |
-| **256 K** | **153 ms** | **21** ← single-card |
-
-CUDA Graph capture+replay at 32 K / 64 K / 128 K / 256 K passes the
-cosine = 1.000000 gate (bit-identical token output across replays).
-TTFT scales linearly at ~22 ms / prompt-token.
-
-The full per-prompt variance breakdown (5 prompts × NTOK 128/256 ×
-K=3/6) is in [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) §3.
+First live request at a new `(prompt_len, max_tokens)` shape can pay
+CUDA Graph capture cost. The bundled OpenAI server
+([`examples/qwen36_openai_server.py`](examples/qwen36_openai_server.py))
+pre-captures bucketed short/long shapes at startup via
+`--warmup-preset auto` and optional explicit `--warmup` buckets.
 
 <a name="qwen3-8b-performance"></a>
 
@@ -830,6 +808,10 @@ pip install pybind11 cmake "numpy>=1.24" safetensors
 #    path broke in 4.56+; drop the upper bound once we verify the new
 #    tokenizer API.
 pip install "transformers<4.56" pandas pillow pyarrow
+
+# 3b. Qwen3.6 long-context runtime deps. These are also installed by
+#     `pip install -e ".[torch]"` below.
+pip install einops "triton>=3.2" packaging
 
 # 4. JAX-side (optional — only if you will load Orbax checkpoints).
 #    Versions are pinned because the Orbax/jaxlib/PJRT plugin ABI is

--- a/csrc/attention/fa2_causal_inst/flash_fwd_hdim256_bf16_sm80_causal.cu
+++ b/csrc/attention/fa2_causal_inst/flash_fwd_hdim256_bf16_sm80_causal.cu
@@ -1,0 +1,18 @@
+// FlashRT — FA2 causal instantiation for (bf16, head_dim=256).
+//
+// Add-only sibling of flash_attn_2_src/flash_attn/
+// flash_fwd_hdim256_bf16_sm80.cu. Qwen3.6 full-attention prefill uses
+// head_dim=256; exposing Is_causal=true lets one S-token prefill chunk
+// run as a single FA2 call instead of S serial q_seq=1 calls.
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 256, true>(
+    Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim256<cutlass::bfloat16_t, true>(params, stream);
+}
+
+}  // namespace FLASH_NAMESPACE

--- a/csrc/attention/fa2_causal_inst/flash_fwd_split_hdim256_bf16_sm80_causal.cu
+++ b/csrc/attention/fa2_causal_inst/flash_fwd_split_hdim256_bf16_sm80_causal.cu
@@ -1,0 +1,14 @@
+// FlashRT — FA2 causal splitkv instantiation for (bf16, head_dim=256).
+//
+// Add-only sibling of flash_attn_2_src/flash_attn/
+// flash_fwd_split_hdim256_bf16_sm80.cu.
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template void run_mha_fwd_splitkv_dispatch<
+    cutlass::bfloat16_t, 256, true>(
+        Flash_fwd_params &params, cudaStream_t stream);
+
+}  // namespace FLASH_NAMESPACE

--- a/csrc/attention/fa2_wrapper_causal.cu
+++ b/csrc/attention/fa2_wrapper_causal.cu
@@ -7,11 +7,8 @@
 // and is exposed to Python as `flash_rt_fa2.fwd_bf16_causal`
 // (binding added in csrc/fa2_bindings.cpp).
 //
-// Build set is intentionally minimal — only (bf16, head_dim=128)
-// — because that is the only shape Qwen3-8B prefill needs. Other
-// hdims / dtypes can be added later by adding new instantiation
-// files under csrc/attention/fa2_causal_inst/ and extending the
-// dispatch below.
+// Build set is intentionally small: bf16 hdim=128 for Qwen3-8B and
+// bf16 hdim=256 for Qwen3.6 full-attention chunked prefill.
 //
 // The non-causal wrapper's helpers (fill_params, splitkv heuristic)
 // are duplicated here intentionally to keep this file standalone
@@ -183,10 +180,10 @@ extern "C" void fvk_attention_fa2_fwd_bf16_causal(
     int o_batch_stride, int o_row_stride, int o_head_stride,
     float softmax_scale, int num_sms, cudaStream_t stream)
 {
-    if (head_dim != 128) {
+    if (head_dim != 128 && head_dim != 256) {
         fprintf(stderr,
             "fvk_attention_fa2_fwd_bf16_causal: head_dim=%d not built. "
-            "Only head_dim=128 is currently instantiated for the causal "
+            "Only head_dim=128 and 256 are currently instantiated for the causal "
             "path. Add a new file under csrc/attention/fa2_causal_inst/ "
             "and extend the dispatch in fa2_wrapper_causal.cu to support "
             "additional shapes.\n", head_dim);
@@ -207,9 +204,13 @@ extern "C" void fvk_attention_fa2_fwd_bf16_causal(
     int num_splits = setup_splitkv_causal(params, softmax_lse_accum_ptr, o_accum_ptr,
                                           num_sms, seqlen_q, seqlen_k,
                                           head_dim, batch, num_heads_q);
-    if (num_splits > 1) {
+    if (head_dim == 128 && num_splits > 1) {
         FLASH_NAMESPACE::run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 128, true>(params, stream);
-    } else {
+    } else if (head_dim == 128) {
         FLASH_NAMESPACE::run_mha_fwd_<cutlass::bfloat16_t, 128, true>(params, stream);
+    } else if (num_splits > 1) {
+        FLASH_NAMESPACE::run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 256, true>(params, stream);
+    } else {
+        FLASH_NAMESPACE::run_mha_fwd_<cutlass::bfloat16_t, 256, true>(params, stream);
     }
 }

--- a/csrc/attention/flashinfer_xqa_src/LICENSE
+++ b/csrc/attention/flashinfer_xqa_src/LICENSE
@@ -1,0 +1,229 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-------------------------------------------------------------------------------------------------
+Some of the code in this project are adapted from other open-source projects with different
+licenses. This product also bundles some third-party components under other open source licenses.
+This section summarizes those components and their licenses.
+See licenses/ for text of these licenses.
+
+BSD 3-Clause License
+--------------------
+
+include/flashinfer/attention/hopper/epilogue.cuh
+include/flashinfer/attention/hopper/mainloop.cuh
+include/flashinfer/attention/hopper/kernel_traits.cuh
+include/flashinfer/attention/hopper/named_barrier.cuh
+include/flashinfer/attention/hopper/tile_scheduler.cuh
+include/flashinfer/attention/hopper/utils.cuh
+
+BSD 3-Clause "New" License
+--------------------------
+
+3rdparty/cutlass
+include/flashinfer/attention/hopper/block_sparse_gather.cuh
+
+MIT License
+-----------
+
+3rdparty/spdlog
+3rdparty/spdlog/include/spdlog/fmt/bundled (fmt library)

--- a/csrc/attention/flashinfer_xqa_src/VENDOR.md
+++ b/csrc/attention/flashinfer_xqa_src/VENDOR.md
@@ -1,0 +1,18 @@
+FlashInfer XQA subset
+=====================
+
+Source: https://github.com/flashinfer-ai/flashinfer
+Imported commit: bff85f3
+
+This directory vendors only the XQA files needed by the Qwen3.6 SM120
+BF16-query / FP8-KV speculative attention probe. The build instantiates a
+single fixed shape in CMake:
+
+- head_dim = 256
+- Q heads / KV heads = 24 / 4
+- page size = 128
+- BF16 Q/O, FP8 e4m3 KV
+- speculative decode enabled
+
+Do not add the full FlashInfer runtime here. New files should be imported
+only when a benchmark proves they are needed by the production Qwen path.

--- a/csrc/attention/flashinfer_xqa_src/barriers.cuh
+++ b/csrc/attention/flashinfer_xqa_src/barriers.cuh
@@ -1,0 +1,424 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cassert>
+
+#include "cuda_hint.cuh"
+#include "defines.h"
+#if !USE_CUSTOM_BARRIER
+#include <cuda/std/barrier>
+using CtaBarrier = cuda::barrier<cuda::thread_scope_block>;
+#else
+
+#ifndef __CUDACC__
+#include <cuda_runtime_api.h>
+#endif
+
+#if __CUDACC_VER_MAJOR__ < 12
+#define STR_REL_CTA ""
+#define STR_ACQ_CTA ""
+#else
+#define STR_REL_CTA ".release.cta"
+#define STR_ACQ_CTA ".acquire.cta"
+#endif
+
+enum class Scope : uint32_t {
+  CTA = 0,
+  CGA = 1,
+};
+
+enum class ArriveOrder : uint32_t {
+  RELEASE = 0,
+  RELAXED = 1,
+};
+
+enum class ArrivalToken : uint64_t {};
+
+template <Scope defaultScope_ = Scope::CTA>
+class MBarrier  // rename this to MBarrier
+{
+ public:
+  using ArrivalToken = ::ArrivalToken;
+  static constexpr Scope defaultScope = defaultScope_;
+  using arrival_token = ArrivalToken;
+
+  __device__ inline MBarrier(uint32_t count) {
+    assert(count > 0);
+    asm volatile("mbarrier.init.b64 [%0], %1;\n" ::"l"(addr()), "r"(count) : "memory");
+  }
+
+  __device__ ~MBarrier() { asm volatile("mbarrier.inval.b64 [%0];\n" ::"l"(addr()) : "memory"); }
+
+  template <Scope scope = defaultScope, ArriveOrder order = ArriveOrder::RELEASE>
+  __device__ inline mha::conditional_t<scope == Scope::CTA, ArrivalToken, void> arrive(
+      uint32_t update = 1) {
+    ArrivalToken token{};
+#if __CUDA_ARCH__ >= 900
+    if constexpr (scope == Scope::CTA) {
+      switch (order) {
+        case ArriveOrder::RELEASE:
+          asm volatile("mbarrier.arrive.release.cta.b64 %0, [%1], %2;\n"
+                       : "=l"(token)
+                       : "l"(addr()), "r"(update)
+                       : "memory");
+          break;
+        case ArriveOrder::RELAXED:
+          asm volatile("mbarrier.arrive.relaxed.cta.b64 %0, [%1], %2;\n"
+                       : "=l"(token)
+                       : "l"(addr()), "r"(update)
+                       : "memory");
+          break;
+      }
+      return token;
+    } else {
+      static_assert(scope == Scope::CGA);
+      switch (order) {
+        case ArriveOrder::RELEASE:
+          asm volatile("mbarrier.arrive.release.cluster.b64 _, [%0], %1;\n" ::"l"(addr()),
+                       "r"(update)
+                       : "memory");
+          break;
+        case ArriveOrder::RELAXED:
+          asm volatile("mbarrier.arrive.relaxed.cluster.b64 _, [%0], %1;\n" ::"l"(addr()),
+                       "r"(update)
+                       : "memory");
+          break;
+      }
+      return;
+    }
+#else
+    static_assert(scope == Scope::CTA && order == ArriveOrder::RELEASE);
+    if (update > 1) {
+      asm volatile("mbarrier.arrive.noComplete" STR_REL_CTA ".b64 %0, [%1], %2;\n"
+                   : "=l"(token)
+                   : "l"(addr()), "r"(update - 1U)
+                   : "memory");
+      ArrivalToken refToken;
+      asm volatile("mbarrier.arrive" STR_REL_CTA ".b64 %0, [%1];\n"
+                   : "=l"(refToken)
+                   : "l"(addr())
+                   : "memory");
+      assert(token == refToken);
+      return token;
+    } else {
+      asm volatile("mbarrier.arrive" STR_REL_CTA ".b64 %0, [%1];\n"
+                   : "=l"(token)
+                   : "l"(addr())
+                   : "memory");
+      return token;
+    }
+#endif
+  }
+
+  __device__ inline bool isLocal() const {
+    uint32_t addrCtaRank{};
+    asm("getctarank.u64 %0, %1;\n" : "=r"(addrCtaRank) : "l"(addr()));
+    uint32_t ctaRank{};
+    asm("mov.u32 %0, %%cluster_ctarank;\n" : "=r"(ctaRank));
+    return addrCtaRank == ctaRank;
+  }
+
+  __device__ inline void remoteArrive(uint32_t update = 1) {
+#if __CUDA_ARCH__ >= 900
+    assert(!isLocal());
+    asm volatile("mbarrier.arrive.release.cluster.shared::cluster.b64 _, [%0], %1;\n"
+                 :
+                 : "l"(__cvta_generic_to_shared(&mBar)), "r"(update)
+                 : "memory");
+#else
+    asm volatile("trap;\n");
+#endif
+  }
+
+  template <Scope scope = defaultScope, ArriveOrder order = ArriveOrder::RELEASE>
+  __device__ inline mha::conditional_t<scope == Scope::CTA, ArrivalToken, void> arrive_tx_relaxed(
+      uint32_t txCount) {
+#if __CUDA_ARCH__ >= 900
+    if constexpr (scope == Scope::CTA) {
+      ArrivalToken token{};
+      asm volatile("mbarrier.arrive.expect_tx.relaxed.cta.b64 %0, [%1], %2;\n"
+                   : "=l"(token)
+                   : "l"(addr()), "r"(txCount)
+                   : "memory");
+      return token;
+    } else {
+      asm volatile("mbarrier.arrive.expect_tx.relaxed.cluster.b64 _, [%0], %1;\n" ::"l"(addr()),
+                   "r"(txCount)
+                   : "memory");
+      return;
+    }
+#else
+    asm volatile("trap;\n");
+#endif
+  }
+
+  template <Scope scope = defaultScope, ArriveOrder order = ArriveOrder::RELEASE>
+  __device__ inline mha::conditional_t<scope == Scope::CTA, ArrivalToken, void> arrive_tx(
+      uint32_t txCount, uint32_t arriveCount = 1) {
+#if __CUDA_ARCH__ >= 900
+    if (arriveCount == 1) {
+      if constexpr (scope == Scope::CTA) {
+        ArrivalToken token{};
+        switch (order) {
+          case ArriveOrder::RELEASE:
+            asm volatile("mbarrier.arrive.expect_tx.release.cta.b64 %0, [%1], %2;\n"
+                         : "=l"(token)
+                         : "l"(addr()), "r"(txCount)
+                         : "memory");
+            break;
+          case ArriveOrder::RELAXED:
+            asm volatile("mbarrier.arrive.expect_tx.relaxed.cta.b64 %0, [%1], %2;\n"
+                         : "=l"(token)
+                         : "l"(addr()), "r"(txCount)
+                         : "memory");
+            break;
+        }
+        return token;
+      } else {
+        static_assert(scope == Scope::CGA);
+        switch (order) {
+          case ArriveOrder::RELEASE:
+            asm volatile(
+                "mbarrier.arrive.expect_tx.release.cluster.b64 _, [%0], %1;\n" ::"l"(addr()),
+                "r"(txCount)
+                : "memory");
+            break;
+          case ArriveOrder::RELAXED:
+            asm volatile(
+                "mbarrier.arrive.expect_tx.relaxed.cluster.b64 _, [%0], %1;\n" ::"l"(addr()),
+                "r"(txCount)
+                : "memory");
+            break;
+        }
+        return;
+      }
+    } else {
+      if constexpr (scope == Scope::CTA) {
+        asm volatile("mbarrier.expect_tx.relaxed.cta.b64 [%0], %1;\n" ::"l"(addr()), "r"(txCount)
+                     : "memory");
+      } else {
+        asm volatile("mbarrier.expect_tx.relaxed.cluster.b64 [%0], %1;\n" ::"l"(addr()),
+                     "r"(txCount)
+                     : "memory");
+      }
+      return arrive<scope, order>(arriveCount);
+    }
+#else
+    asm volatile("trap;\n");
+#endif
+  }
+
+  template <Scope scope = defaultScope>
+  __device__ inline bool test_wait(ArrivalToken&& token) {
+    uint32_t ready{};
+    if constexpr (scope == Scope::CGA) {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.test_wait.acquire.cluster.b64 ready, [%1], %2;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "l"(token)
+          : "memory");
+    } else {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.test_wait" STR_ACQ_CTA
+          ".b64 ready, [%1], %2;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "l"(token)
+          : "memory");
+    }
+    return ready != 0;
+  }
+
+  template <Scope scope = defaultScope>
+  __device__ inline bool test_wait_parity(bool parity) {
+    uint32_t ready{};
+    if constexpr (scope == Scope::CGA) {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.test_wait.parity.acquire.cluster.b64 ready, [%1], %2;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "r"(uint32_t{parity})
+          : "memory");
+    } else {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.test_wait.parity" STR_ACQ_CTA
+          ".b64 ready, [%1], %2;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "r"(uint32_t{parity})
+          : "memory");
+    }
+    return ready != 0;
+  }
+#if __CUDA_ARCH__ >= 900
+  template <Scope scope = defaultScope>
+  __device__ inline bool try_wait(ArrivalToken&& token) {
+    uint32_t ready{};
+    if constexpr (scope == Scope::CGA) {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.try_wait.acquire.cluster.b64 ready, [%1], %2, %3;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "l"(token), "n"(kSUSPEND_TIME_HINT)
+          : "memory");
+    } else {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.try_wait.acquire.cta.b64 ready, [%1], %2, %3;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "l"(token), "n"(kSUSPEND_TIME_HINT)
+          : "memory");
+    }
+    return ready != 0;
+  }
+
+  template <Scope scope = defaultScope>
+  __device__ inline bool try_wait_parity(bool parity) {
+    uint32_t ready{};
+    if constexpr (scope == Scope::CGA) {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.try_wait.parity.acquire.cluster.b64 ready, [%1], %2, %3;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "r"(uint32_t{parity}), "n"(kSUSPEND_TIME_HINT)
+          : "memory");
+    } else {
+      asm volatile(
+          "{\n"
+          ".reg .pred ready;\n"
+          "mbarrier.try_wait.parity.acquire.cta.b64 ready, [%1], %2, %3;\n"
+          "selp.b32 %0, 1, 0, ready;\n"
+          "}\n"
+          : "=r"(ready)
+          : "l"(addr()), "r"(uint32_t{parity}), "n"(kSUSPEND_TIME_HINT)
+          : "memory");
+    }
+    return ready != 0;
+  }
+#endif
+  template <Scope scope = defaultScope>
+  __device__ inline void wait(ArrivalToken&& token) {
+#if __CUDA_ARCH__ >= 900
+    poll<true>([&]() { return try_wait<scope>(ArrivalToken{token}); });
+#else
+    poll<false>([&]() { return test_wait<scope>(ArrivalToken{token}); });
+#endif
+  }
+
+  // starting from `parity = false`.
+  template <Scope scope = defaultScope>
+  __device__ inline void wait_parity(bool parity) {
+#if __CUDA_ARCH__ >= 900
+    poll<true>([&]() { return try_wait_parity<scope>(parity); });
+#else
+    poll<false>([&]() { return test_wait_parity<scope>(parity); });
+#endif
+  }
+
+  template <Scope scope = defaultScope, ArriveOrder order = ArriveOrder::RELEASE>
+  __device__ inline mha::enable_if_t<scope == Scope::CTA, void> arrive_and_wait(
+      uint32_t update = 1) {
+    wait<scope>(arrive<scope, order>(update));
+  }
+
+ private:
+  __device__ inline uint64_t addr() const { return reinterpret_cast<uint64_t>(&mBar); }
+
+  template <bool funcSupportsBlocking, typename F>
+  __device__ inline static void poll(F&& func) {
+    if constexpr (funcSupportsBlocking) {
+      while (!func()) {
+      }
+    } else {
+      float sleepDuration = 0.125F;
+      while (!func()) {
+        // if (sleepDuration > 1) {
+        __nanosleep(uint32_t(sleepDuration));
+        // }
+        sleepDuration = sleepDuration * 1.25F + 0.F;
+      }
+    }
+  }
+
+ public:
+  static constexpr uint32_t kSUSPEND_TIME_HINT = 0xFFFFFFFFU;
+
+ private:
+  uint64_t mBar;
+};
+
+template <Scope defaultScope>
+__device__ inline void init(MBarrier<defaultScope>* bar, uint32_t count) {
+  new (bar) MBarrier<defaultScope>{count};
+}
+
+using CtaBarrier = MBarrier<Scope::CTA>;
+using CgaBarrier = MBarrier<Scope::CGA>;
+
+template <uint32_t nbBars>
+__device__ inline constexpr bool toParity(uint32_t i) {
+  return i % (nbBars * 2) / nbBars;
+}
+
+class NamedBarrier {
+ public:
+  __device__ inline NamedBarrier(uint32_t idxBar, uint32_t arriveCount)
+      : mName{idxBar}, mArriveCount{arriveCount} {
+    assert(idxBar < 16 && arriveCount % 32 == 0);
+  }
+
+  __device__ inline void arrive() const {
+    asm volatile("barrier.cta.arrive %0, %1;\n" ::"r"(mName), "r"(mArriveCount) : "memory");
+  }
+
+  __device__ inline void arrive_and_wait() const {
+    asm volatile("barrier.cta.sync %0, %1;\n" ::"r"(mName), "r"(mArriveCount) : "memory");
+  }
+
+ private:
+  uint32_t const mName;
+  uint32_t const mArriveCount;
+};
+
+__device__ inline void namedBarSync(uint32_t idxBar, uint32_t arriveCount) {
+  NamedBarrier bar{idxBar, arriveCount};
+  bar.arrive_and_wait();
+}
+#endif

--- a/csrc/attention/flashinfer_xqa_src/cuda_hint.cuh
+++ b/csrc/attention/flashinfer_xqa_src/cuda_hint.cuh
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "platform.h"
+
+#if IS_IN_IDE_PARSER
+
+#ifndef __CUDACC__
+#define __CUDACC__ 1
+#endif
+
+#ifndef __CUDA_ARCH__
+#define __CUDA_ARCH__ 900
+#endif
+
+#ifndef __CUDACC_VER_MAJOR__
+#define __CUDACC_VER_MAJOR__ 12
+#endif
+#ifndef __CUDACC_VER_MINOR__
+#define __CUDACC_VER_MINOR__ 9
+#endif
+
+#if __CUDA_ARCH__ == 900
+#ifndef __CUDA_ARCH_FEAT_SM90_ALL
+#define __CUDA_ARCH_FEAT_SM90_ALL
+#endif
+#endif
+
+#endif

--- a/csrc/attention/flashinfer_xqa_src/defines.h
+++ b/csrc/attention/flashinfer_xqa_src/defines.h
@@ -1,0 +1,242 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "mha_stdheaders.cuh"
+
+#define STATIC_NB_K_HEADS 0
+#if STATIC_NB_K_HEADS
+#define NB_K_HEADS 2
+#endif
+
+// allowed values are multiples of 16 in range [16, 256]
+#ifndef HEAD_ELEMS
+#define HEAD_ELEMS 128
+#endif
+
+// nbQHeads / nbKHeads for MQA/GQA
+#ifndef HEAD_GRP_SIZE
+#define HEAD_GRP_SIZE 8
+#endif
+
+#define IS_MLA (HEAD_GRP_SIZE == 128 && HEAD_ELEMS == 576)
+
+#if IS_MLA
+#if defined(MLA_BF16) && MLA_BF16
+#define INPUT_ELEM __nv_bfloat16
+#define INPUT_ELEM2 __nv_bfloat162
+#else
+#define INPUT_ELEM __nv_fp8_e4m3
+#define INPUT_ELEM2 __nv_fp8x2_e4m3
+#endif
+#define HEAD_ELEMS_V 512
+#else
+// 1 means fp16 and 0 means bf16 input/output
+#ifndef INPUT_FP16
+#define INPUT_FP16 1
+#endif
+
+// Don't modify
+#if INPUT_FP16
+#define INPUT_ELEM half
+#define INPUT_ELEM2 half2
+#else
+#define INPUT_ELEM __nv_bfloat16
+#define INPUT_ELEM2 __nv_bfloat162
+#endif
+#endif
+
+// For beam search. Allowed values: 1, 4
+#ifndef BEAM_WIDTH
+#define BEAM_WIDTH 1
+#endif
+
+#ifndef SPEC_DEC
+#define SPEC_DEC 0
+#endif
+
+#if SPEC_DEC
+using MaskType = uint32_t;
+
+#ifndef M_TILESIZE
+#define M_TILESIZE 32
+#endif
+#endif
+
+// Enables SWAP AB optimization for speculative decoding when using a small, fixed Q_SEQ_LEN.
+// NOTE: Requires a uniform input sequence length for the entire batch.
+#ifdef SPEC_Q_SEQ_LEN
+static_assert(SPEC_DEC, "SPEC_Q_SEQ_LEN should only be used when SPEC_DEC is enabled.");
+#endif
+
+// 0: half/bf16 based on INPUT_FP16; 1: int8_t; 2: __nv_fp8_e4m3
+#ifndef CACHE_ELEM_ENUM
+#define CACHE_ELEM_ENUM 2
+#endif
+
+#if CACHE_ELEM_ENUM == 3
+#define ENABLE_4BIT_KV_CACHE 1
+#else
+#define ENABLE_4BIT_KV_CACHE 0
+#endif
+
+// don't modify
+#define USE_KV_CACHE true
+
+// don't modify
+#ifndef ALLOW_MULTI_BLOCK_MODE
+#define ALLOW_MULTI_BLOCK_MODE true
+#endif
+
+// For paged KV cache. Allowed values: 0, 16, 32, 64, 128
+// 0 means contiguous KV cache (non-paged).
+#ifndef TOKENS_PER_PAGE
+#define TOKENS_PER_PAGE 32
+#endif
+
+// don't modify
+#define USE_BEAM_SEARCH (BEAM_WIDTH > 1)
+
+#if CACHE_ELEM_ENUM == 0
+#define PRAGMA_UNROLL_FP16_ONLY _Pragma("unroll")
+#else
+#define PRAGMA_UNROLL_FP16_ONLY _Pragma("unroll(1)")
+#endif
+
+// good for short sequence length but bad for long sequence length. Only for mha.cu.
+#ifndef SHORT_SEQ_OPT
+#define SHORT_SEQ_OPT 1
+#endif
+
+#ifndef SLIDING_WINDOW
+#define SLIDING_WINDOW 0
+#endif
+
+// 0 - no PDL
+// 1 - naive PDL
+// 2 - aggressive PDL (implemented only in mha_sm90.cu for now)
+#ifndef ENABLE_PDL
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#if __CUDA_ARCH__ == 900
+#define ENABLE_PDL 2
+#else
+#define ENABLE_PDL 1
+#endif
+#else
+/* default for host or older architectures */
+#define ENABLE_PDL 0
+#endif
+#endif
+
+#ifndef USE_INPUT_KV
+#define USE_INPUT_KV 0
+#endif
+
+#if USE_INPUT_KV
+// 0 - no RoPE
+// 1 - NEOX style
+// 2 - GPTJ style
+#ifndef ROPE_STYLE
+#define ROPE_STYLE 0
+#endif
+
+#if SPEC_DEC
+#error "SPEC_DEC is not supported for USE_INPUT_KV"
+#endif
+#endif
+
+// Output element type:
+//   0 - input element type
+//   1 - KV cache element type
+#ifndef LOW_PREC_OUTPUT
+#define LOW_PREC_OUTPUT 0
+#endif
+
+#if LOW_PREC_OUTPUT
+static_assert(CACHE_ELEM_ENUM != 0);
+#endif
+
+// true should be better if warpTile.x * cacheElemSize < 128. otherwise use false.
+#define GRP_LOAD_V (CACHE_ELEM_ENUM != 0) || (HEAD_ELEMS == 256 && BEAM_WIDTH > 1)
+
+// use custom barrier for NVRTC to avoid pulling in many headers
+#ifndef USE_CUSTOM_BARRIER
+#define USE_CUSTOM_BARRIER 1
+#endif
+
+#ifndef OPTIMIZE_FOR_LATENCY
+#define OPTIMIZE_FOR_LATENCY 1
+#endif
+
+#ifndef IS_SPEC_DEC_TREE
+#define IS_SPEC_DEC_TREE 1  // by default SPEC_DEC expect tree-based draft token structure
+#endif
+
+#define DBG_BATCH_SIZE 2
+#define DBG_SEQ_LEN 256 * 4 + 3
+#define DBG_NB_CTAS_PER_SEQ 8
+
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#if ENABLE_4BIT_KV_CACHE
+#include <cuda_fp4.h>
+#endif
+
+template <int32_t elemTypeEnum>
+struct ElemTypeConverter;
+// Specialization for elemTypeEnum = 0 (half/bf16)
+template <>
+struct ElemTypeConverter<0> {
+  using Type = INPUT_ELEM;
+  using ContainerType = INPUT_ELEM;
+  static constexpr int ElemsPerContainer = 1;
+  using ScalingFactorType = void;
+  static constexpr int QuantVectorSize = 1;
+};
+
+// Specialization for elemTypeEnum = 1 (int8)
+template <>
+struct ElemTypeConverter<1> {
+  using Type = int8_t;
+  using ContainerType = int8_t;
+  static constexpr int ElemsPerContainer = 1;
+  using ScalingFactorType = void;
+  static constexpr int QuantVectorSize = 1;
+};
+
+// Specialization for elemTypeEnum = 2 (fp8)
+template <>
+struct ElemTypeConverter<2> {
+  using Type = __nv_fp8_e4m3;
+  using ContainerType = __nv_fp8_e4m3;
+  static constexpr int ElemsPerContainer = 1;
+  using ScalingFactorType = void;
+  static constexpr int QuantVectorSize = 1;
+};
+
+#if ENABLE_4BIT_KV_CACHE
+// Specialization for elemTypeEnum = 3 (NVFP4)
+template <>
+struct ElemTypeConverter<3> {
+  using Type = __nv_fp4_e2m1;
+  using ContainerType = __nv_fp4x2_e2m1;
+  static constexpr int ElemsPerContainer = 2;
+  using ScalingFactorType = __nv_fp8_e4m3;
+  static constexpr int QuantVectorSize = 16;
+};
+#endif

--- a/csrc/attention/flashinfer_xqa_src/hostUtils.h
+++ b/csrc/attention/flashinfer_xqa_src/hostUtils.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cuda_runtime.h>
+
+inline cudaLaunchConfig_t makeLaunchConfig(dim3 const& gridDim, dim3 const& ctaDim,
+                                           size_t dynShmBytes, cudaStream_t stream, bool usePDL) {
+  static cudaLaunchAttribute pdlAttr;
+  pdlAttr.id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  pdlAttr.val.programmaticStreamSerializationAllowed = (usePDL ? 1 : 0);
+
+  cudaLaunchConfig_t cfg{gridDim, ctaDim, dynShmBytes, stream, &pdlAttr, 1};
+  return cfg;
+}

--- a/csrc/attention/flashinfer_xqa_src/ldgsts.cuh
+++ b/csrc/attention/flashinfer_xqa_src/ldgsts.cuh
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cuda_hint.cuh"
+#ifndef __CUDACC__
+#include <cuda_runtime.h>
+#endif
+#include "barriers.cuh"
+
+namespace ldgsts {
+// @fixme: prefetch makes it slower on sm_86. Try on other platforms.
+template <uint32_t size>
+__device__ inline void copyAsync(void* dst, void const* src,
+                                 uint32_t srcSize = size)  // srcSize == 0 means filling with zeros.
+{
+  static_assert(size == 4 || size == 8 || size == 16);
+  if constexpr (size == 16) {
+    // asm volatile("cp.async.ca.shared.global.L2::128B [%0], [%1], 16, %2;\n" ::
+    // "l"(__cvta_generic_to_shared(dst)), "l"(src), "r"(srcSize));
+    asm volatile(
+        "cp.async.cg.shared.global [%0], [%1], 16, %2;\n" ::"l"(__cvta_generic_to_shared(dst)),
+        "l"(src), "r"(srcSize));
+  } else {
+    asm volatile(
+        "cp.async.ca.shared.global [%0], [%1], %2, %3;\n" ::"l"(__cvta_generic_to_shared(dst)),
+        "l"(src), "n"(size), "r"(srcSize));
+  }
+}
+
+__device__ inline void commitGroup() { asm volatile("cp.async.commit_group;\n"); }
+
+// wait until only targetNbInFlightGroups groups are still in-flight.
+template <uint32_t targetNbInFlightGroups>
+__device__ inline void waitGroup() {
+  asm volatile("cp.async.wait_group %0;\n" ::"n"(targetNbInFlightGroups));
+}
+
+// noInc = false:  increase expected arrive count, in additional to increasing arrive count
+// noInc = true: increases arrive count but does not modify expected arrive count
+__device__ inline void barArrive(CtaBarrier& bar, bool noInc = false) {
+  if (noInc) {
+    asm volatile(
+        "cp.async.mbarrier.arrive.noinc.shared.b64 [%0];\n" ::"l"(__cvta_generic_to_shared(&bar)));
+  } else {
+    asm volatile(
+        "cp.async.mbarrier.arrive.shared.b64 [%0];\n" ::"l"(__cvta_generic_to_shared(&bar)));
+  }
+}
+
+}  // namespace ldgsts

--- a/csrc/attention/flashinfer_xqa_src/mha.cu
+++ b/csrc/attention/flashinfer_xqa_src/mha.cu
@@ -1,0 +1,3009 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuda_hint.cuh"
+#include "defines.h"
+#if !(IS_MLA)
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#include "ldgsts.cuh"
+#include "mha.h"
+#include "mhaUtils.cuh"
+#include "mha_components.cuh"
+#include "mma.cuh"
+#include "utils.cuh"
+#ifndef GENERATE_CUBIN
+#include <cuda_runtime.h>
+
+#include "hostUtils.h"
+#ifndef NDEBUG
+#include <cstdio>
+#endif
+#endif
+
+// There are 4 ways to pass ctaRowMax backward from gemm1 warps to gemm0 warps:
+//  1. Protect with xFwdBarriers+xBwdBarriers. This way, ctaRowMax is available to gemm0 warps
+//  together with x tiles and warpRowMax/warpRowSum. But ctaRowMax is required before warp tile
+//  online softmax, while the other buffers is needed only after online softmax. So xBwdBarriers
+//  wait will need to be moved before online softmax.
+//  2. Similar to approach 1, but we add an additional register copy of ctaRowMax in gemm0 warps.
+//  It's loaded from smem ctaRowMax after warp tile online softmax, so the current warp tile can't
+//  use it. But we can pass it to next iteration so softmax of next tile can use it. The update will
+//  be delayed by 1 more iteration and we need one or two more registers. Alternatively, put the
+//  extra copy in shared memory, so we have double buffer for ctaRowMax.
+//  3. Protected with dedicated backward barriers (xFwdBarriers + ctaRowmaxBwdBarriers). Then we
+//  don't have drawbacks of 1 or 2, but we need extra smem barriers and extra arrive/wait
+//  instructions.
+//  4. No protection, just use volatile read/write. This approach gives most timely update and has
+//  lowest cost, but the result is non-deterministic up to an small numeric error.
+// #define CTA_ROW_MAX_BACKWARD_METHOD 4
+// 1 is 8% slower than 4. 2/3 are 10% slower than 4.
+#define CTA_ROW_MAX_BACKWARD_METHOD 1
+
+static_assert(inputElemSize >= cacheElemSize);
+
+constexpr uint32_t cacheElemsPerGrain = exactDiv(grainBytes, cacheElemSize);
+constexpr uint32_t inputElemsPerGrain = exactDiv(grainBytes, inputElemSize);
+
+// If cache is 4-bit, in GMEM the elements are packed, but after loading to SMEM they are padded.
+// Each 16 elements (64b) are padded with 64b to match 128b smem grains. Therefore,
+// the grainBytes of GMEM is half of the grainBytes of SMEM.
+constexpr uint32_t grainBytesGmemCache = grainBytes / CacheElemConverter::ElemsPerContainer;
+#if ENABLE_4BIT_KV_CACHE
+constexpr uint32_t grainBytesSf = 4;
+#endif
+
+constexpr bool enableMicroFastPath = false;
+
+// x: horizontal stacking for cta horizontal tile size
+// y: vertical stacking for cta vertical tile size
+// z: must be 2 for warp specialization.
+constexpr uint3 ctaShapeInWarps = {4, 1, 2};
+
+static_assert(ctaShapeInWarps.z == 2);  // for warp specialization
+constexpr uint32_t nbWarpsPerCta = ctaShapeInWarps.x * ctaShapeInWarps.y * ctaShapeInWarps.z;
+constexpr uint32_t ctaSize = warp_size * nbWarpsPerCta;
+
+#if SPEC_DEC
+// Use 32 row size
+constexpr uint32_t nbValidRows = rowsPerBlock;
+static_assert(nbValidRows <= 32u);
+#else
+constexpr uint32_t nbValidRows = headGrpSize * beamWidth;
+#endif
+constexpr uint2 warpTile = {64, roundUp(nbValidRows, 16U)};
+static_assert(nbValidRows <= warpTile.y);
+
+constexpr uint32_t gemm1WarpsPerGrp = exactDiv(headElems, warpTile.x);
+constexpr uint32_t gemm1NbWarpGrps =
+    exactDiv(ctaShapeInWarps.x, gemm1WarpsPerGrp);  // warp groups split along seqLen dim.
+
+constexpr uint2 ctaTile = {
+    warpTile.x * ctaShapeInWarps.x,  // if .x is greater than headSize, then gemm1 uses split-K
+    warpTile.y* ctaShapeInWarps.y};
+
+constexpr uint32_t cvtExpansion = exactDiv(inputElemSize, cacheElemSize);
+
+#ifndef __CUDA_ARCH__
+constexpr uint32_t preferedKHeadPartBytes = 64;
+__constant__ constexpr uint32_t cacheVTileSeqLen = 32;
+#else
+#if __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200 || __CUDA_ARCH__ == 1210
+constexpr uint32_t preferedKHeadPartBytes = 64;
+__constant__ constexpr uint32_t cacheVTileSeqLen = 32;
+#elif __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 870 || __CUDA_ARCH__ == 900 || \
+    __CUDA_ARCH__ == 1000 || __CUDA_ARCH__ == 1030 || __CUDA_ARCH__ == 1100
+constexpr uint32_t preferedKHeadPartBytes = 128;
+__constant__ constexpr uint32_t cacheVTileSeqLen = 64;
+#else
+#error "perferedKHeadPartBytes not defined"
+#endif
+#endif
+constexpr uint32_t kHeadPartBytes = mha::min(preferedKHeadPartBytes, paddedCacheHeadBytes);
+// constexpr uint32_t cacheElemsPerKHeadPart = exactDiv(kHeadPartBytes, cacheElemSize);
+
+constexpr bool persistentQ = paddedInputHeadBytes * ctaTile.y <= (16u << 10);
+static_assert(persistentQ);
+constexpr uint32_t qHeadPartBytes = persistentQ ? paddedInputHeadBytes : kHeadPartBytes;
+constexpr uint32_t qHeadPartElems = exactDiv(qHeadPartBytes, inputElemSize);
+
+constexpr uint32_t nbPartsPerCacheKHead = exactDiv(paddedCacheHeadBytes, kHeadPartBytes);
+constexpr uint32_t nbPartsPerInputKHead = exactDiv(paddedInputHeadBytes, kHeadPartBytes);
+constexpr uint32_t nbPartsPerInputQHead = exactDiv(paddedInputHeadBytes, qHeadPartBytes);
+
+// false - each warp load V tiles independent of each other; true - all warps in a warp group load V
+// tiles together.
+// @fixme: when true, and nbVBuffers is only 2, we need to sync all warps in a group after finishing
+// using a buffer and before refill it with prefetch data. We may need at least 3.
+constexpr bool grpLoadV = GRP_LOAD_V;
+
+// number of shared memory buffers for latency hiding
+constexpr uint32_t nbQBuffers = mha::min(nbPartsPerInputQHead, 2u);  // for latency hiding
+constexpr uint32_t nbKBuffers = 2;                                   // for latency hiding
+constexpr uint32_t nbVBuffers =
+    2;  // @fixme: H100 SXM need more in-flight requests. may need to increase this.
+constexpr uint32_t nbXBuffers = 1;
+
+__device__ inline uint3 getWarpIdx(Warp const& warp = this_warp()) {
+  return uint3{ctaShapeInWarps.x == 1 ? 0 : makeWarpUniform(warp, threadIdx.x / warp_size),
+               ctaShapeInWarps.y == 1 ? 0 : makeWarpUniform(warp, threadIdx.y),
+               ctaShapeInWarps.z == 1 ? 0 : makeWarpUniform(warp, threadIdx.z)};
+}
+
+__device__ inline uint32_t gemm1WarpGrpIdx(uint32_t warpIdxX) {
+  return gemm1NbWarpGrps == 1 ? 0 : warpIdxX / gemm1WarpsPerGrp;
+}
+
+__device__ inline uint32_t gemm1WarpIdxInGrp(uint32_t warpIdxX) {
+  return gemm1WarpsPerGrp == 1 ? 0
+                               : (gemm1NbWarpGrps == 1 ? warpIdxX : warpIdxX % gemm1WarpsPerGrp);
+}
+
+constexpr uint32_t instM = 16;
+constexpr uint32_t instN = 8;
+// constexpr uint32_t instK = 16;
+
+using QuadRegRowMax =
+    QuadRegRowMaxT<warpTile.y>;  // data is replicated across 4 threads in a MMA quad.
+using ThrdRegRowMax = ThrdRegRowMaxT<warpTile.y>;  // unlike QuadRegRowMax, not replicated.
+using UniformRescaleMask = UniformRescaleMaskT<warpTile.y>;  // uniform and stored in UR
+
+__device__ inline bool any(UniformRescaleMask const& x) {
+  uint32_t val = 0U;
+#pragma unroll
+  for (uint32_t i = 0; i < x.size; i++) {
+    uint32_t word = x[i];
+    constexpr uint32_t wordBits = 32;
+    if (warpTile.y % wordBits != 0 && i + 1 == x.size) {
+      constexpr uint32_t validBits = warpTile.y % wordBits;
+      word &= ((1U << validBits) - 1);
+    }
+    val |= word;
+  }
+  return val != 0;
+}
+
+#ifndef NDEBUG
+__device__ inline void printRowMax(ThrdRegRowMax const& src) {
+  for (uint32_t i = 0; i < warp_size * src.size; i++) {
+    if (laneId() == i % warp_size) {
+      printf("%f%s", src[i / warp_size], i == 31 ? "\n" : " ");
+    }
+    __syncwarp();
+  }
+}
+
+__device__ inline void printRowMax(QuadRegRowMax const& src) {
+  for (uint32_t i = 0; i < src.size / 4; i++) {
+    for (uint32_t j = 0; j < 8; j++) {
+      if (laneId() == 4 * j) {
+        for (uint32_t k = 0; k < 4; k++) {
+          printf("%f%s", src[i * 4 + k], i == 31 ? "\n" : " ");
+        }
+      }
+      __syncwarp();
+    }
+  }
+}
+#endif
+
+struct alignas(16) SMemWarpRowMax {
+  __device__ inline float const& operator[](uint32_t idxRow) const {
+    assert(idxRow < ThrdRegRowMax::size * warp_size);
+    uint32_t const idxInstM8 = idxRow / quadPerWarp;
+    return data[ThrdRegRowMax::size == 1 ? 0 : idxInstM8 / 4][idxRow % quadPerWarp][idxInstM8 % 4];
+  }
+
+  __device__ inline float& operator[](uint32_t idxRow) {
+    return const_cast<float&>(static_cast<SMemWarpRowMax const&>(*this)[idxRow]);
+  }
+
+  // When data is register, data is replicate across 4 threads in a quad.
+  template <bool asVolatile>
+  __device__ inline QuadRegRowMax const loadToRegForQuad(Warp const& warp) const {
+    uint32_t const idxQuad = laneId() / 4;
+    QuadRegRowMax result;
+#pragma unroll
+    for (uint32_t i = 0; i < divUp(warpTile.y, quadPerWarp * 4); i++) {
+      auto const& src = data[i][idxQuad];
+      auto& dst = reinterpret_cast<float(&)[4]>(result[4 * i]);
+      if constexpr (asVolatile) {
+        asm volatile("ld.volatile.shared.v4.f32 {%0, %1, %2, %3}, [%4];\n"
+                     : "=f"(dst[0]), "=f"(dst[1]), "=f"(dst[2]), "=f"(dst[3])
+                     : "l"(__cvta_generic_to_shared(&src)));
+      } else {
+        reinterpret_cast<float4&>(dst) = reinterpret_cast<float4 const&>(src);
+      }
+    }
+    return result;
+  }
+
+  template <bool asVolatile>
+  __device__ inline ThrdRegRowMax const loadToReg(Warp const& warp) const {
+    ThrdRegRowMax result;
+#pragma unroll
+    for (uint32_t i = 0; i < result.size; i++) {
+      auto const& src = this->operator[](warp_size * i + laneId());
+      float& dst = result[i];
+      if constexpr (asVolatile) {
+        dst = static_cast<float const volatile&>(src);
+        // asm volatile("ld.volatile.shared.f32 %0, [%1];\n"
+        //     : "=f"(dst) : "l"(__cvta_generic_to_shared(&src)));
+      } else {
+        dst = src;
+      }
+    }
+    return result;
+  }
+
+  template <bool asVolatile>
+  __device__ inline void storeFromReg(Warp const& warp, QuadRegRowMax const& regData) {
+    for (uint32_t i = 0; i < regData.size; i++) {
+      assert(regData[i] == __shfl_sync(0xFU << (laneId() / 4 * 4), regData[i], 0, 4));
+    }
+    if (laneId() % 4 != 0) {
+      return;
+    }
+    uint32_t const idxQuad = laneId() / 4;
+#pragma unroll
+    for (uint32_t i = 0; i < ThrdRegRowMax::size; i++) {
+      auto& dst = data[i][idxQuad];
+      auto const& src = reinterpret_cast<float const(&)[4]>(regData[4 * i]);
+      if constexpr (asVolatile) {
+        asm volatile("st.volatile.shared.v4.f32 [%0], {%1, %2, %3, %4};\n" ::"l"(
+                         __cvta_generic_to_shared(&dst)),
+                     "f"(src[0]), "f"(src[1]), "f"(src[2]), "f"(src[3]));
+      } else {
+        reinterpret_cast<float4&>(dst) = reinterpret_cast<float4 const&>(src);
+      }
+    }
+  }
+
+  template <bool asVolatile>
+  __device__ inline void storeFromReg(Warp const& warp, ThrdRegRowMax const& regData) {
+#pragma unroll
+    for (uint32_t i = 0; i < ThrdRegRowMax::size; i++) {
+      auto& dst = this->operator[](warp_size * i + laneId());
+      assert(!hasBankConflict(&dst));
+      float const src = regData[i];
+      if constexpr (asVolatile) {
+        static_cast<float volatile&>(dst) = src;
+      } else {
+        dst = src;
+      }
+    }
+  }
+
+  __device__ inline void atomicMaxUpdate(Warp const& warp, ThrdRegRowMax const& regData) {
+#pragma unroll
+    for (uint32_t i = 0; i < ThrdRegRowMax::size; i++) {
+      auto& dst = this->operator[](warp_size * i + laneId());
+      assert(!hasBankConflict(&dst));
+      float const src = regData[i];
+      atomicMax(&dst, src);
+    }
+  }
+
+  float data[ThrdRegRowMax::size][quadPerWarp][4];
+};
+
+// cacheVTileSeqLen may be smaller than x cols, so we need multiple v tiles per X tile.
+constexpr uint32_t nbCacheVTilesPerXTile = exactDiv(warpTile.x, cacheVTileSeqLen);
+
+constexpr uint32_t nbWarpGrpsPerXTile = mha::min(nbCacheVTilesPerXTile, gemm1NbWarpGrps);
+
+constexpr uint32_t nbPagesPerWarpTile =
+    (warpTile.x <= tokensPerPage ? 1U : exactDiv(warpTile.x, tokensPerPage));
+using KCachePageIndices = Vec<KVCachePageIndex, nbPagesPerWarpTile>;
+constexpr uint32_t nbPagesPerVTile =
+    (cacheVTileSeqLen <= tokensPerPage ? 1 : exactDiv(cacheVTileSeqLen, tokensPerPage));
+using VCachePageIndices = Vec<KVCachePageIndex, nbPagesPerVTile>;
+
+static_assert(ctaShapeInWarps.y == 1);
+
+struct alignas(128) SharedMem {
+  using QSmemBuffer = Array2D<LdGrain, warpTile.y, exactDiv(qHeadPartBytes, grainBytes)>;
+  using KSmemBuffer = Array2D<LdGrain, warpTile.x, exactDiv(kHeadPartBytes, grainBytes)>;
+  using XSmemBuffer = Array2D<LdGrain, warpTile.y, exactDiv(inputElemSize* warpTile.x, grainBytes)>;
+  using VSmemBuffer = Array2D<LdGrain, cacheVTileSeqLen,
+                              exactDiv(grpLoadV ? headElems : warpTile.x, cacheElemsPerGrain)>;
+
+#if ENABLE_4BIT_KV_CACHE
+  using KSfSmemBuffer =
+      Array2D<uint32_t, warpTile.x,
+              exactDiv(kHeadPartBytes / CacheElemConverter::QuantVectorSize, grainBytesSf)>;
+  using VSfSmemBuffer =
+      Array2D<uint32_t, cacheVTileSeqLen,
+              exactDiv((grpLoadV ? headElems : warpTile.x) / CacheElemConverter::QuantVectorSize,
+                       grainBytesSf)>;
+  using KSfSmemBufferPlain =
+      Array2D<__nv_fp8_e4m3, warpTile.x, kHeadPartBytes / CacheElemConverter::QuantVectorSize>;
+  using VSfSmemBufferPlain =
+      Array2D<__nv_fp8_e4m3, cacheVTileSeqLen,
+              (grpLoadV ? headElems : warpTile.x) / CacheElemConverter::QuantVectorSize>;
+#endif
+
+  QSmemBuffer q[ctaShapeInWarps.y][nbQBuffers];
+  KSmemBuffer k[ctaShapeInWarps.x][nbKBuffers];
+  XSmemBuffer x[ctaShapeInWarps.y][ctaShapeInWarps.x];
+  static_assert(nbXBuffers == 1);
+  VSmemBuffer v[gemm1NbWarpGrps][grpLoadV ? 1 : gemm1WarpsPerGrp][nbVBuffers];
+
+#if ENABLE_4BIT_KV_CACHE
+  KSfSmemBuffer kSf[ctaShapeInWarps.x][nbKBuffers];
+  VSfSmemBuffer vSf[gemm1NbWarpGrps][grpLoadV ? 1 : gemm1WarpsPerGrp][nbVBuffers];
+#endif
+
+  SMemWarpRowMax warpRowMax[ctaShapeInWarps.y]
+                           [ctaShapeInWarps.x];  // the max used when computing this->x
+  SMemWarpRowMax warpRowSum[ctaShapeInWarps.y][ctaShapeInWarps.x];  // the row sum of gemm0 output
+
+#if CTA_ROW_MAX_BACKWARD_METHOD == 1 || CTA_ROW_MAX_BACKWARD_METHOD == 2 || \
+    CTA_ROW_MAX_BACKWARD_METHOD == 3
+  // protected with xFwdBarriers+xBwdBarriers for CTA_ROW_MAX_BACKWARD_METHOD 1 or 2, and with
+  // xFwdBarriers+ctaRowMaxBwdBarriers for 3. Cannot reuse warpRowMax because a gemm1 warp is not
+  // sure whether other gemm1 warps have finished using it, unless we want to pay extra sync.
+  SMemWarpRowMax ctaRowMax[ctaShapeInWarps.y][ctaShapeInWarps.x];
+#elif CTA_ROW_MAX_BACKWARD_METHOD == 4
+  SMemWarpRowMax
+      ctaRowMax[ctaShapeInWarps.y];  // just a hint, no strict protection required if you don't care
+                                     // about non-deterministic output (up to a small numeric error)
+#endif
+
+#if BEAM_WIDTH > 1
+  Vec<uint32_t, warpTile.x> gemm0CacheIndir[ctaShapeInWarps.x];
+  Vec<uint32_t, cacheVTileSeqLen> gemm1CacheIndir[grpLoadV ? gemm1NbWarpGrps : ctaShapeInWarps.x];
+  Vec<KCachePageIndices, beamWidth> kCachePages[ctaShapeInWarps.x];
+  Vec<VCachePageIndices, beamWidth> vCachePages[grpLoadV ? gemm1NbWarpGrps : ctaShapeInWarps.x];
+#endif
+
+  using Barrier = CtaBarrier;
+
+  Barrier qBarrier[ctaShapeInWarps.y];
+  // Beside X buffers, also protects warpRowMax and warpRowSum. For CTA_ROW_MAX_BACKWARD_METHOD==1
+  // or 2, also ctaRowMax.
+  CtaBarrierPair xBarriers[ctaShapeInWarps.y][ctaShapeInWarps.x];
+#if CTA_ROW_MAX_BACKWARD_METHOD == 3
+  Barrier ctaRowMaxBwdBarriers[ctaShapeInWarps.y]
+                              [ctaShapeInWarps.x];  // xFwdBarriers+ctaRowMaxBwdBarriers
+                                                    // protects ctaRowMax
+#endif
+
+#if GRP_LOAD_V
+  static constexpr uint32_t nbOtherBarriers = nbVBuffers * gemm1NbWarpGrps + gemm1NbWarpGrps;
+  Barrier otherBarriers[nbOtherBarriers];
+#endif
+  __device__ inline Barrier* vBarrier(uint32_t warpGrpIdx, uint32_t idxBuf) {
+#if GRP_LOAD_V
+    return &reinterpret_cast<Barrier(&)[gemm1NbWarpGrps][nbVBuffers]>(
+        otherBarriers)[warpGrpIdx][idxBuf];
+#else
+    return nullptr;
+#endif
+  }
+
+  __device__ inline Barrier* warpGrpBar(uint32_t warpGrpIdx) {
+#if GRP_LOAD_V
+    return &otherBarriers[nbVBuffers * gemm1NbWarpGrps + warpGrpIdx];
+#else
+    return nullptr;
+#endif
+  }
+};
+
+CUBIN_EXPORT __device__ constexpr uint32_t smemSize = sizeof(SharedMem);
+#ifdef __CUDA_ARCH__
+static_assert(smemSize < kMAX_SMEM_SIZE);
+#endif
+
+#if 0
+template <bool swizzled, uint32_t rows, uint32_t cols>
+__device__ inline void smemRotateInplace(Warp const& Warp, Array2D<LdGrain, rows, cols>& data, uint32_t idxPart, uint32_t idxToken) {
+    static_assert(inputSeqLen == 1);
+    constexpr uint32_t rowElems = inputElemsPerGrain * cols;
+    constexpr uint32_t nbParts = exactDiv(headElems, idxPart);
+    static_assert(nbParts % 2 == 0);
+    bool const isFirstHalf = (idxPart < nbParts / 2);
+    static_assert(mha::is_same_v<InputElem, half>, "not implemented");
+    if constexpr (cols <= warp_size) {
+        static_assert(warp_size % cols == 0);
+        constexpr uint32_t thrdGrpSize = LdGrain::size * cols;
+        uint32_t const idxThrdGrp = laneId() / thrdGrpSize;
+        uint32_t const thrdGrpLane = laneId() % thrdGrpSize;
+        constexpr uint32_t nbThrdGrps = warp_size / thrdGrpSize;
+        static_assert(warp_size % thrdGrpSize == 0);
+        constexpr uint32_t nbElemsPerWord = exactDiv(sizeof(LdGrain::Elem), inputElemSize);
+        Vec<float, nbElemsPerWord> cosAngles;
+        Vec<float, nbElemsPerWord> sinAngles;
+#pragma unroll
+        for (uint32_t i = 0; i < angles.size; i++) {
+            uint32_t const n = rowElems * (idxPart % (nbParts / 2)) + angles.size * thrdGrpLane + i;
+            float const angle = powf(1E-4f, n * (2.f / headElems)) * idxToken;
+            sincosf(angle, &sinAngles[i], &cosAngles[i]);
+        }
+
+        constexpr uint32_t nbIters = exactDiv(rows, nbThrdGrps);
+#pragma unroll
+        for (uint32_t i = 0; i < nbIters; i++) {
+            auto const word = data.template at<swizzled>(nbThrdGrps * i + idxThrdGrp, thrdGrpLane / LdGrain::size)[thrdGrpLane % LdGrain::size];
+            float2 const val = __half22float2(reinterpret_cast<InputElem2 const&>(word));
+            Vec<float, nbElemsPerWord> result;
+#pragma unroll
+            for (uint32_t j = 0; j < nbElemsPerWord; j++) {
+                if (isFirstHalf) {
+                    result[j] = cosAngles[j] * ;
+                }
+            }
+        }
+    }
+    else {
+        static_assert(cols <= warp_size, "not implemented");
+    }
+}
+#endif
+
+using WarpAcc = WarpAccT<warpTile.y, warpTile.x>;
+
+#if SPEC_DEC
+#define MMAS_N_PER_MASK 2
+
+__device__ inline void applyMaskFromInput(Warp const& warp, WarpAcc& acc, MaskType const* mask,
+                                          uint32_t rowOffset, uint32_t nbValidCols,
+                                          uint32_t qSeqLen, uint32_t actualQSeqLen,
+                                          uint32_t headGrpSize) {
+  uint32_t const idxInQuad = laneId() % 4;
+  uint32_t const idxQuad = laneId() / 4;
+  // Packed mask is aligned with 32 bits (2 uint16_t).
+  uint32_t const nbPackedMasksPerRow = divUp(qSeqLen, 32u) * 2u;
+  uint16_t const* uint16Mask = reinterpret_cast<uint16_t const*>(mask);
+#pragma unroll
+  for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+    for (uint32_t i = 0; i < InstAcc::rows; i++) {
+      uint32_t const tokenRow =
+          min((rowOffset + instM * m + idxQuad + i * 8) / headGrpSize, actualQSeqLen - 1);
+#pragma unroll
+      for (uint32_t mask_n = 0; mask_n < acc.cols / MMAS_N_PER_MASK; mask_n++) {
+        uint32_t const firstCol = instN * mask_n * MMAS_N_PER_MASK + InstAcc::cols * idxInQuad;
+        uint32_t const lastCol = firstCol + instN * (MMAS_N_PER_MASK - 1) + InstAcc::cols - 1;
+        uint32_t const maskPos0 =
+            firstCol + actualQSeqLen < nbValidCols
+                ? 0u
+                : min(firstCol + actualQSeqLen - nbValidCols, actualQSeqLen - 1);
+        uint32_t const maskPos1 =
+            lastCol + actualQSeqLen < nbValidCols
+                ? 0u
+                : min(lastCol + actualQSeqLen - nbValidCols, actualQSeqLen - 1);
+        uint32_t packedMask = 0u;
+        uint32_t const maskPosStart = (maskPos0 / 16) * 16;
+        reinterpret_cast<uint16_t*>(&packedMask)[0] =
+            uint16Mask[tokenRow * nbPackedMasksPerRow + (maskPos0 / 16)];
+        reinterpret_cast<uint16_t*>(&packedMask)[1] =
+            uint16Mask[tokenRow * nbPackedMasksPerRow + (maskPos1 / 16)];
+#pragma unroll
+        for (uint32_t nj = 0; nj < MMAS_N_PER_MASK; nj++) {
+#pragma unroll
+          for (uint32_t j = 0; j < InstAcc::cols; j++) {
+            uint32_t const n = (mask_n * MMAS_N_PER_MASK + nj);
+            uint32_t const col = instN * n + InstAcc::cols * idxInQuad + j;
+            // bool const maskFlag = col + qSeqLen < nbValidCols ? true : mask[tokenRow * qSeqLen +
+            // (col + qSeqLen - nbValidCols)];
+            bool const maskFlag =
+                col + actualQSeqLen < nbValidCols
+                    ? true
+                    : packedMask & (1u << ((col + actualQSeqLen - nbValidCols) - maskPosStart));
+            acc(m, n)(i, j) = maskFlag && col < nbValidCols ? acc(m, n)(i, j) : safeInitRowMax;
+          }
+        }
+      }
+    }
+  }
+}
+#endif
+
+__device__ inline QuadRegRowMax warpTileOnlineSoftmax(Warp const& warp,
+                                                      QuadRegRowMax const& rowMaxHint,
+                                                      WarpAcc& acc) {
+  QuadRegRowMax rowMax = rowMaxHint;
+// compute per-thread row max
+#pragma unroll
+  for (uint32_t n = 0; n < acc.cols; n++) {
+#pragma unroll
+    for (uint32_t j = 0; j < InstAcc::cols; j++) {
+#pragma unroll
+      for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+        for (uint32_t i = 0; i < InstAcc::rows; i++) {
+          rowMax[m * InstAcc::rows + i] = fmaxf(rowMax[m * InstAcc::rows + i], acc(m, n)(i, j));
+        }
+      }
+    }
+  }
+// compute warp row max
+#pragma unroll
+  for (uint32_t xorMask = 2; xorMask != 0; xorMask /= 2) {
+#pragma unroll
+    for (uint32_t i = 0; i < rowMax.size; i++) {
+      rowMax[i] = fmaxf(rowMax[i], __shfl_xor_sync(~0U, rowMax[i], xorMask));
+    }
+  }
+// update acc and rowMax
+#pragma unroll
+  for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+    for (uint32_t i = 0; i < InstAcc::rows; i++) {
+      float const maxVal = rowMax[m * InstAcc::rows + i];
+      float const bias = maxVal * log2e;
+#pragma unroll
+      for (uint32_t n = 0; n < acc.cols; n++) {
+#pragma unroll
+        for (uint32_t j = 0; j < InstAcc::cols; j++) {
+          float& elem = acc(m, n)(i, j);
+          assert(maxVal >= elem);
+          elem = exp2f(elem * log2e - bias);
+        }
+      }
+    }
+  }
+  return rowMax;
+}
+
+using GemmOutRegTile =
+    Array2D<InputElem2, WarpAcc::rows * InstAcc::rows, WarpAcc::cols * exactDiv(InstAcc::cols, 2)>;
+
+__device__ inline GemmOutRegTile toFp16(WarpAcc const& acc) {
+  GemmOutRegTile dst;
+#pragma unroll
+  for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+    for (uint32_t i = 0; i < InstAcc::rows; i++) {
+#pragma unroll
+      for (uint32_t n = 0; n < acc.cols; n++) {
+#pragma unroll
+        for (uint32_t j = 0; j < InstAcc::cols; j += 2) {
+#if INPUT_FP16
+          dst(m * InstAcc::rows + i, (n * InstAcc::cols + j) / 2) =
+              __floats2half2_rn(acc(m, n)(i, j), acc(m, n)(i, j + 1));
+#else
+          dst(m * InstAcc::rows + i, (n * InstAcc::cols + j) / 2) =
+              __floats2bfloat162_rn(acc(m, n)(i, j), acc(m, n)(i, j + 1));
+#endif
+        }
+      }
+    }
+  }
+  return dst;
+}
+
+__device__ inline WarpAcc toWarpAcc(GemmOutRegTile const& outTile) {
+  WarpAcc acc;
+#pragma unroll
+  for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+    for (uint32_t i = 0; i < InstAcc::rows; i++) {
+#pragma unroll
+      for (uint32_t n = 0; n < acc.cols; n++) {
+#pragma unroll
+        for (uint32_t j = 0; j < InstAcc::cols; j += 2) {
+#if INPUT_FP16
+          float2 const fp32Vals =
+              __half22float2(outTile(m * InstAcc::rows + i, (n * InstAcc::cols + j) / 2));
+#else
+          float2 const fp32Vals =
+              __bfloat1622float2(outTile(m * InstAcc::rows + i, (n * InstAcc::cols + j) / 2));
+#endif
+          acc(m, n)(i, j) = fp32Vals.x;
+          acc(m, n)(i, j + 1) = fp32Vals.y;
+        }
+      }
+    }
+  }
+  return acc;
+}
+
+__device__ inline QuadRegRowMax computeRowSum(Warp const& warp, GemmOutRegTile const& src) {
+  Vec<InstAcc, exactDiv(GemmOutRegTile::rows, InstAcc::rows)> acc{};
+#if INPUT_FP16
+  InputElem2 const b[2][1] = {__floats2half2_rn(1, 1), __floats2half2_rn(1, 1)};
+#else
+  InputElem2 const b[2][1] = {__floats2bfloat162_rn(1, 1), __floats2bfloat162_rn(1, 1)};
+#endif
+#pragma unroll
+  for (uint32_t n = 0; n < exactDiv(GemmOutRegTile::cols, 2); n++) {
+#pragma unroll
+    for (uint32_t m = 0; m < exactDiv(GemmOutRegTile::rows, 2); m++) {
+      InputElem2 const a[2 /*kEx*/][2 /*mEx*/] = {src(m * 2, n * 2), src(m * 2 + 1, n * 2),
+                                                  src(m * 2, n * 2 + 1), src(m * 2 + 1, n * 2 + 1)};
+      mma<InputElem>(acc[m].data, reinterpret_cast<uint32_t const(&)[2][2]>(a),
+                     reinterpret_cast<uint32_t const(&)[2][1]>(b));
+    }
+  }
+  QuadRegRowMax rowSum;
+#pragma unroll
+  for (uint32_t i = 0; i < acc.size; i++) {
+#pragma unroll
+    for (uint32_t j = 0; j < InstAcc::rows; j++) {
+      rowSum[i * InstAcc::rows + j] = acc[i](j, 0);
+#pragma unroll
+      for (uint32_t k = 0; k < InstAcc::cols; k++) {
+        assert(acc[i](j, k) == acc[i](j, 0));
+      }
+    }
+    rowSum[i * 2] = acc[i](0, 0);
+    rowSum[i * 2 + 1] = acc[i](1, 0);
+  }
+// Sometimes there are errors in sum and they mismatch inside a quad. Force broadcast from lane 0 of
+// each quad to eliminate mismatch. This has no visible impact on final result and can be removed.
+#pragma unroll
+  for (uint32_t i = 0; i < QuadRegRowMax::size; i++) {
+    auto const lane0Val = __shfl_sync(0xFU << (laneId() / 4 * 4), rowSum[i], 0, 4);
+    // Disable the assert, sometimes it triggers because of different orders of accumulation.
+    // assert(fabs(rowSum[i] - lane0Val) < 1E-4f);
+    rowSum[i] = lane0Val;
+  }
+  return rowSum;
+}
+
+__device__ inline void storeOrderedGemmOutTile(Warp const& warp, SharedMem::XSmemBuffer& dst,
+                                               GemmOutRegTile const& src) {
+  static_assert(sizeof(dst) == sizeof(src) * warp_size);
+  uint32_t const lane = laneId();
+#if __CUDA_ARCH__ >= 900
+  constexpr uint2 storeUnits = {4, 1};  // in 8x8 b16 matrices.
+  static_assert(storeUnits.x * storeUnits.y == 4);
+#pragma unroll
+  for (uint32_t m = 0; m < exactDiv(dst.rows, 8 * storeUnits.y); m++) {
+#pragma unroll
+    for (uint32_t n = 0; n < exactDiv(dst.cols * grainBytes / inputElemSize, 8 * storeUnits.x);
+         n++) {
+      uint32_t const idxRowLocal = lane % 8;
+      uint32_t const flatIdxMatLocal = lane / 8;
+      uint2 const idxMatLocal = {flatIdxMatLocal % storeUnits.x, flatIdxMatLocal / storeUnits.x};
+      LdGrain* const p = &dst.template at<true>(
+          8 * (storeUnits.y * m + idxMatLocal.y) + idxRowLocal, storeUnits.x * n + idxMatLocal.x);
+
+      LdGrain data;
+#pragma unroll
+      for (uint32_t i = 0; i < storeUnits.y; i++) {
+#pragma unroll
+        for (uint32_t j = 0; j < storeUnits.x; j++) {
+          data[i * storeUnits.x + j] =
+              reinterpret_cast<uint32_t const&>(src(m * storeUnits.y + i, n * storeUnits.x + j));
+        }
+      }
+      stmatrix_4x<false>(warp, p, data);
+    }
+  }
+#else
+#pragma unroll
+  for (uint32_t m = 0; m < exactDiv(dst.rows, 8); m++) {
+#pragma unroll
+    for (uint32_t n = 0; n < exactDiv(dst.cols * grainBytes / inputElemSize, 8); n++) {
+      uint32_t const idxRowLocal = laneId() / 4;
+      uint32_t const idxWordLocal = laneId() % 4;
+      dst.template at<true>(8 * m + idxRowLocal, n)[idxWordLocal] =
+          reinterpret_cast<uint32_t const&>(src(m, n));
+    }
+  }
+#endif
+}
+
+__device__ inline void storeReorderedXTile(Warp const& warp, SharedMem::XSmemBuffer& dst,
+                                           GemmOutRegTile const& src) {
+  static_assert(sizeof(dst) == sizeof(src) * warp_size);
+  uint32_t const lane = laneId();
+
+#pragma unroll
+  for (uint32_t m = 0; m < exactDiv(dst.rows, 8); m++) {
+#pragma unroll
+    for (uint32_t n = 0; n < exactDiv(dst.cols * grainBytes / inputElemSize, 16); n++) {
+      uint32_t const idxRowLocal = laneId() / 4;
+      // Reorder from e0, e1, e2, e3, e4, e5, e6, e7   | e8, e9, e10, e11, e12, e13, e14, e15
+      // to ========> e0, e1, e4, e5, e8, e9, e12, e13 | e2, e3, e6,  e7,  e10, e11, e14, e15
+
+      ////  Tid: dst reg idx, ldGrain idx, idx word
+      //     T0: 0, 2            0          (0, 2)
+      //     T1: 4, 6            1          (0, 2)
+      //     T2: 1, 3            0          (1, 3)
+      //     T3: 5, 7            1          (1, 3)
+      uint32_t const idxColLdGrain = n * 2 + laneId() % 2;
+      uint32_t const idxWordLocal = (laneId() % 4) / 2;
+      dst.template at<true>(8 * m + idxRowLocal, idxColLdGrain)[idxWordLocal] =
+          reinterpret_cast<uint32_t const&>(src(m, 2 * n));
+      dst.template at<true>(8 * m + idxRowLocal, idxColLdGrain)[idxWordLocal + 2] =
+          reinterpret_cast<uint32_t const&>(src(m, 2 * n + 1));
+    }
+  }
+}
+
+// Reorder to compensate the reorder caused by V cache load+conversion.
+__device__ inline void reorderAndStoreGemmOutTile(Warp const& warp, SharedMem::XSmemBuffer& dst,
+                                                  GemmOutRegTile const& src) {
+  static_assert(sizeof(dst) == sizeof(src) * warp_size);
+  uint32_t const lane = laneId();
+#pragma unroll
+  for (uint32_t m = 0; m < exactDiv(dst.rows, 8); m++) {
+#pragma unroll
+    for (uint32_t n = 0; n < exactDiv(dst.cols * grainBytes / inputElemSize, 8 * 2); n++) {
+      uint32_t const idxRowLocal = laneId() / 4;
+      uint32_t const idxSegLocal = laneId() % 4;
+      Vec<InputElem2, cvtExpansion> seg;
+#pragma unroll
+      for (uint32_t e = 0; e < cvtExpansion; e++) {
+        seg[e] = src(m, n * cvtExpansion + e);
+      }
+      // reorder
+      // Ideally compiler should be able to fuse this into toFp16() and just reorder input registers
+      // of F2FP instructions.
+      Vec<InputElem, cvtExpansion * 2> reorderedSeg;
+#pragma unroll
+      for (uint32_t e = 0; e < cvtExpansion; e++) {
+        reorderedSeg[e] = seg[e].x;
+        reorderedSeg[cvtExpansion + e] = seg[e].y;
+      }
+      static_assert(cvtExpansion <= LdGrain::size);
+      constexpr uint32_t nbSegPerGrain = exactDiv(grainBytes, sizeof(seg));
+      reinterpret_cast<Vec<uint32_t, cvtExpansion>&>(dst.template at<true>(
+          8 * m + idxRowLocal,
+          n * cvtExpansion +
+              idxSegLocal / nbSegPerGrain)[idxSegLocal % nbSegPerGrain * cvtExpansion]) =
+          reinterpret_cast<Vec<uint32_t, cvtExpansion>&>(reorderedSeg);
+    }
+  }
+}
+
+__device__ inline void storeGemmOutTile(Warp const& warp, SharedMem::XSmemBuffer& dst,
+                                        GemmOutRegTile const& src, bool reorder) {
+  if (reorder) {
+    reorderAndStoreGemmOutTile(warp, dst, src);
+  } else {
+    storeOrderedGemmOutTile(warp, dst, src);
+  }
+}
+
+__device__ inline GemmOutRegTile loadGemmOutTile(Warp const& warp,
+                                                 SharedMem::XSmemBuffer const& src) {
+  uint32_t const lane = laneId();
+  GemmOutRegTile dst;
+  static_assert(sizeof(src) == sizeof(dst) * warp_size);
+#if __CUDA_ARCH__ >= 900
+  constexpr uint2 storeUnits = {4, 1};  // in 8x8 b16 matrices.
+  static_assert(storeUnits.x * storeUnits.y == 4);
+#pragma unroll
+  for (uint32_t m = 0; m < exactDiv(SharedMem::XSmemBuffer::rows, 8 * storeUnits.y); m++) {
+#pragma unroll
+    for (uint32_t n = 0;
+         n < exactDiv(SharedMem::XSmemBuffer::cols * grainBytes / inputElemSize, 8 * storeUnits.x);
+         n++) {
+      uint32_t const idxRowLocal = lane % 8;
+      uint32_t const flatIdxMatLocal = lane / 8;
+      uint2 const idxMatLocal = {flatIdxMatLocal % storeUnits.x, flatIdxMatLocal / storeUnits.x};
+      LdGrain const* const p = &src.template at<true>(
+          8 * (storeUnits.y * m + idxMatLocal.y) + idxRowLocal, storeUnits.x * n + idxMatLocal.x);
+
+      LdGrain data = ldmatrix_4x<false>(warp, p);
+#pragma unroll
+      for (uint32_t i = 0; i < storeUnits.y; i++) {
+#pragma unroll
+        for (uint32_t j = 0; j < storeUnits.x; j++) {
+          reinterpret_cast<uint32_t&>(dst(m * storeUnits.y + i, n * storeUnits.x + j)) =
+              data[i * storeUnits.x + j];
+        }
+      }
+    }
+  }
+#else
+#pragma unroll
+  for (uint32_t m = 0; m < exactDiv(SharedMem::XSmemBuffer::rows, 8); m++) {
+#pragma unroll
+    for (uint32_t n = 0; n < exactDiv(SharedMem::XSmemBuffer::cols * grainBytes / inputElemSize, 8);
+         n++) {
+      uint32_t const idxRowLocal = laneId() / 4;
+      uint32_t const idxWordLocal = laneId() % 4;
+      reinterpret_cast<uint32_t&>(dst(m, n)) =
+          src.template at<true>(8 * m + idxRowLocal, n)[idxWordLocal];
+    }
+  }
+#endif
+  return dst;
+}
+// only the first nbValidRows rows are copied, to allow padding.
+__device__ inline void copyOutputToGlobalMem(Warp const& warp, OutputHead* dst, uint32_t nbQHeads,
+#if SPEC_DEC
+                                             uint32_t headGrpSize, uint32_t idxHeadGrpOffset,
+                                             uint32_t nbValidHeadTokens,
+#else
+                                             uint32_t idxHeadGrp,
+#endif
+                                             uint2 dstOffset, SharedMem::XSmemBuffer const& src) {
+  static_assert(sizeof(PaddedInputHead) ==
+                grainBytes * SharedMem::XSmemBuffer::cols * gemm1WarpsPerGrp);
+#if SPEC_DEC
+  static_assert(warpTile.y <= SharedMem::XSmemBuffer::rows);
+#else
+  static_assert(nbValidRows <= SharedMem::XSmemBuffer::rows);
+#endif
+  constexpr uint32_t nbIters = divUp(nbValidRows * SharedMem::XSmemBuffer::cols, warp_size);
+#pragma unroll
+  for (uint32_t i = 0; i < nbIters; i++) {
+    uint32_t const flatIdx = warp_size * i + laneId();
+    uint32_t const r = flatIdx / SharedMem::XSmemBuffer::cols;
+    uint32_t const c = flatIdx % SharedMem::XSmemBuffer::cols;
+    assert(r < SharedMem::XSmemBuffer::rows);
+    LdGrain const data = src.template at<true>(r, c);
+
+    uint32_t const m = dstOffset.y + r;
+    uint32_t const n = exactDiv(dstOffset.x, grainBytes / inputElemSize) + c;
+#if SPEC_DEC
+    if (r >= nbValidHeadTokens) {
+#else
+    if (nbValidRows * SharedMem::XSmemBuffer::cols % warp_size != 0 && m >= nbValidRows) {
+#endif
+      break;
+    }
+    assert(m < nbValidRows);
+#if SPEC_DEC
+    uint32_t const idxBeam = 0;
+    uint32_t const idxInGrp = m;
+    uint32_t const tokenIdx = idxInGrp / headGrpSize;
+    uint32_t const headIdx = idxInGrp % headGrpSize;
+    assert(idxBeam < beamWidth);
+    uint32_t const idxHead = idxHeadGrpOffset + tokenIdx * nbQHeads + headIdx;
+    assert(idxHead < nbValidHeadTokens * nbQHeads);
+#else
+    uint32_t const idxBeam = m / headGrpSize;
+    uint32_t const idxInGrp = m % headGrpSize;
+    assert(idxBeam < beamWidth);
+    uint32_t const idxHead = headGrpSize * idxHeadGrp + idxInGrp;
+    assert(idxHead < nbQHeads);
+#endif
+    assert(n < paddedInputHeadBytes / grainBytes);
+    if (!isHeadPadded || n < ioHeadBytes / grainBytes) {
+      auto const outVec = convert<OutputHead::Elem>(
+          reinterpret_cast<Vec<InputElem, inputElemsPerGrain> const&>(data));
+      reinterpret_cast<Vec<mha::decay_t<decltype(outVec)>, exactDiv(ioHeadBytes, grainBytes)>&>(
+          dst[nbQHeads * idxBeam + idxHead])[n] = outVec;
+    }
+  }
+}
+
+// MMA instruction expansion in GEMM k-dim and m/n-dim, with b16 8x8 as baseline
+template <uint32_t kEx_, uint32_t mnEx_>
+struct InstInMat {
+  static constexpr uint32_t kEx = kEx_;
+  static constexpr uint32_t mnEx = mnEx_;
+  uint32_t data[kEx][mnEx];
+};
+
+template <uint32_t kEx, uint32_t mnEx, bool transOuter>
+using InstInMatWTrans = InstInMat<transOuter ? mnEx : kEx, transOuter ? kEx : mnEx>;
+
+//@fixme: for B-mat, use InstInMat<2, 1>[2] instead.
+
+// kEx is for srcCol and mnEx is for srcRow, before transpose.
+// rowBeg/colBeg are in src indices
+// note that grainBytes-byte swizzling per 128-byte or per row(>=128byte) is applied when loading to
+// avoid bank conflict. transOuter: transpose InstInMat with 8x8 b16 matrices as elements unchanged.
+// transInner: transpose the elements, i.e. the 8x8 b16 matrices. transOuter=true and
+// transInner=false is for B matrix of 16816. It actually loads two 8x16 B matrices for two
+// instructions. transOuter=false and transInner=false is for A matrix of 16816.
+template <uint32_t kEx, uint32_t mnEx, bool transOuter, bool transInner, bool is4BitElem,
+          uint32_t srcRows, uint32_t srcCols>
+__device__ inline InstInMatWTrans<kEx, mnEx, transOuter> loadInstInMat(
+    Warp const& warp, Array2D<LdGrain, srcRows, srcCols> const& src, uint32_t rowOffset,
+    uint32_t colOffset) {
+  static_assert(kEx * mnEx == 4, "implemented only for ldmatrix.x4 for now");
+  using Dst = InstInMatWTrans<kEx, mnEx, transOuter>;
+  assert(rowOffset % (8 * mnEx) == 0 && colOffset % kEx == 0);
+  uint32_t const idx = laneId() / 8;
+  uint32_t const idxKEx = idx / Dst::mnEx;
+  uint32_t const idxMNEx = idx % Dst::mnEx;
+  uint32_t const srcIdxKEx = (transOuter ? idxMNEx : idxKEx);
+  uint32_t const srcIdxMNEx = (transOuter ? idxKEx : idxMNEx);
+
+  LdGrain const* const ptr =
+      &src.template at<true>(rowOffset + 8 * srcIdxMNEx + laneId() % 8, colOffset + srcIdxKEx);
+
+  Vec<uint32_t, 4> data;
+#if ENABLE_4BIT_KV_CACHE
+  if constexpr (is4BitElem) {
+    data = ldmatrix_4x_unpack_4b<transInner>(warp, ptr);
+  } else {
+    data = ldmatrix_4x<transInner>(warp, ptr);
+  }
+#else
+  data = ldmatrix_4x<transInner>(warp, ptr);
+#endif
+  static_assert(sizeof(Dst) == sizeof(data));
+  Dst dst;
+#pragma unroll
+  for (int i = 0; i < data.size; i++) {
+    (&dst.data[0][0])[i] = data[i];
+  }
+  return dst;
+}
+
+template <typename T, uint32_t rows, uint32_t cols, bool transpose>
+using Array2DWTrans = Array2D<T, transpose ? cols : rows, transpose ? rows : cols>;
+
+// src rows/cols are in src indices
+// dst rows/cols are in InstInMatWTrans
+// row is contiguous and gemm-K dim.
+// kEx combines with dstCols and mnEx combines with dstRows.
+template <uint32_t kEx, uint32_t mnEx, uint32_t dstRows, uint32_t dstCols, bool transArr2D,
+          bool transInstInMatOuter, bool transInstInMatInner, bool is4BitElem, uint32_t srcRows,
+          uint32_t srcCols /*in LdGrain*/>
+__device__ inline Array2DWTrans<InstInMatWTrans<kEx, mnEx, transInstInMatOuter>, dstRows, dstCols,
+                                transArr2D>
+loadMatrix(Warp const& warp, Array2D<LdGrain, srcRows, srcCols> const& src, uint32_t rowBeg,
+           uint32_t colBeg) {
+  assert(rowBeg % (8 * mnEx * dstRows) == 0 && colBeg % (kEx * dstCols) == 0);
+  Array2DWTrans<InstInMatWTrans<kEx, mnEx, transInstInMatOuter>, dstRows, dstCols, transArr2D> dst;
+#pragma unroll
+  for (uint32_t i = 0; i < dstRows; i++) {
+#pragma unroll
+    for (uint32_t j = 0; j < dstCols; j++) {
+      (transArr2D ? dst(j, i) : dst(i, j)) =
+          loadInstInMat<kEx, mnEx, transInstInMatOuter, transInstInMatInner, is4BitElem>(
+              warp, src, rowBeg + (mnEx * 8) * i, colBeg + kEx * j);
+    }
+  }
+  return dst;
+}
+
+// acc is used as both input and output
+// qColBeg is in the unit of LdGrain
+// using KElemType = int8_t;
+template <typename KElemType>
+__device__ inline void smemQKPartGemm(Warp const& warp, WarpAcc& acc,
+                                      SharedMem::QSmemBuffer const& q, uint32_t qColBeg,
+                                      SharedMem::KSmemBuffer const& k
+#if ENABLE_4BIT_KV_CACHE
+                                      ,
+                                      SharedMem::KSfSmemBuffer const& kSf
+#endif
+) {
+  assert(qColBeg % (SharedMem::KSmemBuffer::cols) == 0);
+  constexpr uint32_t kEx = 2;
+  constexpr uint32_t mnEx = 2;
+  static_assert(mha::is_same_v<InputElem, half> || mha::is_same_v<InputElem, __nv_bfloat16>,
+                "not implemented");
+#if !ENABLE_4BIT_KV_CACHE
+  static_assert((mha::is_same_v<KElemType, half> || mha::is_same_v<KElemType, __nv_bfloat16> ||
+                 mha::is_same_v<KElemType, int8_t> || mha::is_same_v<KElemType, __nv_fp8_e4m3>),
+                "not implemented");
+#else
+  static_assert(mha::is_same_v<KElemType, __nv_fp4_e2m1>, "not implemented");
+#endif
+  constexpr uint32_t nbInstInMatPerSliceInGemmKDim = 1;
+  constexpr uint32_t kElemSize = sizeof(KElemType);
+  constexpr uint32_t elemsPerKHeadPart = exactDiv(kHeadPartBytes, kElemSize);
+  constexpr uint32_t gemmKSplit =
+      exactDiv(elemsPerKHeadPart, 8 * kEx * nbInstInMatPerSliceInGemmKDim);
+
+#if ENABLE_4BIT_KV_CACHE
+  constexpr uint32_t cvtExp = exactDiv(inputElemSize, kElemSize);
+  constexpr uint32_t mnExK = mnEx * cvtExp;
+  constexpr uint32_t kExK = exactDiv(kEx, cvtExp);
+  constexpr uint32_t kSliceRows = exactDiv(warpTile.x, 8 * mnExK);  // in InstInMat
+  constexpr uint32_t kSliceCols = nbInstInMatPerSliceInGemmKDim;
+  // The FP16/BF16 SF for K tile. Each InputElem2 element holds 2 SFs for 2 mnExK.
+  uint32_t kSfSlice[gemmKSplit][kSliceRows][kSliceCols][exactDiv(mnExK, 2)][kExK];
+  // This simplifies the loop.
+  static_assert(kExK == 1, "not implemented");
+  // We want to load 4 SFs in K dimension to utilize 32b LDS.
+  static_assert(gemmKSplit % 4 == 0, "not implemented");
+#pragma unroll
+  for (uint32_t m = 0; m < kSliceRows; m++) {
+#pragma unroll
+    for (uint32_t n = 0; n < kSliceCols; n++) {
+#pragma unroll
+      for (uint32_t i = 0; i < exactDiv(mnExK, 2); i++) {
+        // The corresponding SF row index.
+        uint32_t const sfRowIdx = (m * mnExK + i * 2) * 8 + laneId() / 4;
+#pragma unroll
+        for (uint32_t s = 0; s < exactDiv(gemmKSplit, 4); s++) {
+          // Load the SF from 2 rows.
+          uint32_t const sfOrigRow0 = kSf(sfRowIdx, s);
+          uint32_t const sfOrigRow1 = kSf(sfRowIdx + 8, s);
+          // Permute the elements.
+          // SFRow0: [(0,0) (0,1) (0,2) (0,3)]
+          // SFRow1: [(1,0) (1,1) (1,2) (1,3)]
+          // After permutation:
+          // tmpReg0: [(0,0) (1,0) (0,2) (1,2)]
+          // tmpReg1: [(0,1) (1,1) (0,3) (1,3)]
+          uint32_t tmpReg0 = prmt(sfOrigRow0, sfOrigRow1, {0, 4, 2, 6});
+          uint32_t tmpReg1 = prmt(sfOrigRow0, sfOrigRow1, {1, 5, 3, 7});
+          // Result after conversion:
+          // sfVal0[0]: [(0,0) (1,0)]; sfVal0[1]: [(0,2) (1,2)]
+          // sfVal1[0]: [(0,1) (1,1)]; sfVal1[1]: [(0,3) (1,3)]
+          auto sfVal0 = convertKCacheWordToF16<InputElem, __nv_fp8_e4m3>(tmpReg0);
+          auto sfVal1 = convertKCacheWordToF16<InputElem, __nv_fp8_e4m3>(tmpReg1);
+          // Store to kSfSlice.
+          kSfSlice[s * 4 + 0][m][n][i][0] = sfVal0[0];
+          kSfSlice[s * 4 + 2][m][n][i][0] = sfVal0[1];
+          kSfSlice[s * 4 + 1][m][n][i][0] = sfVal1[0];
+          kSfSlice[s * 4 + 3][m][n][i][0] = sfVal1[1];
+        }
+      }
+    }
+  }
+#endif
+
+  // @fixme: check if compiler mixes LDS+HMMA and does prefetch properly. We are not doing prefetch
+  // explicitly. But we do fully unroll and expect compiler to do that for us.
+  constexpr uint32_t nbUnroll = cacheElemSize == 2 ? gemmKSplit : 2;
+#pragma unroll(nbUnroll)
+  for (uint32_t s = 0; s < gemmKSplit; s++) {
+    // load q
+    constexpr uint32_t qSliceRows = exactDiv(warpTile.y, 8 * mnEx);  // in InstInMat
+    constexpr uint32_t qSliceCols = nbInstInMatPerSliceInGemmKDim;
+    Array2D<InstInMat<kEx, mnEx>, qSliceRows, qSliceCols> const qSlice =
+        loadMatrix<kEx, mnEx, qSliceRows, qSliceCols, false, false, false, false>(
+            warp, q, 0, qColBeg + kEx * qSliceCols * s);
+    // load k
+    constexpr uint32_t cvtExp = exactDiv(inputElemSize, kElemSize);
+    constexpr uint32_t mnExK = mnEx * cvtExp;
+    constexpr uint32_t kExK = exactDiv(kEx, cvtExp);
+    constexpr uint32_t kSliceRows = exactDiv(warpTile.x, 8 * mnExK);  // in InstInMat
+    constexpr uint32_t kSliceCols = nbInstInMatPerSliceInGemmKDim;
+    Array2D<InstInMat<mnExK, kExK>, kSliceRows, kSliceCols> const kSliceOrig =
+        loadMatrix<kExK, mnExK, kSliceRows, kSliceCols, false, true, false, true>(
+            warp, k, 0, kExK * kSliceCols * s);
+    auto const kSlice = [&]() -> Array2D<InstInMat<mnExK, kEx>, kSliceRows, kSliceCols> {
+      if constexpr (mha::is_same_v<InputElem, KElemType>) {
+        return kSliceOrig;
+      } else {
+        Array2D<InstInMat<mnExK, kEx>, kSliceRows, kSliceCols> ret;
+#pragma unroll
+        for (uint32_t m = 0; m < kSliceRows; m++) {
+#pragma unroll
+          for (uint32_t n = 0; n < kSliceCols; n++) {
+#pragma unroll
+            for (uint32_t i = 0; i < mnExK; i++) {
+#pragma unroll
+              for (uint32_t j = 0; j < kExK; j++) {
+                auto data =
+                    convertKCacheWordToF16<InputElem, KElemType>(kSliceOrig(m, n).data[i][j]);
+#if ENABLE_4BIT_KV_CACHE
+                uint32_t const sfPacked = kSfSlice[s][m][n][i / 2][0];
+                uint16_t const sf = reinterpret_cast<uint16_t const*>(&sfPacked)[i % 2];
+                data[0] = applyF16ScalingFactor<InputElem>(data[0], sf);
+                data[1] = applyF16ScalingFactor<InputElem>(data[1], sf);
+#endif
+
+                ret(m, n).data[i][j * cvtExp] = data[0];
+                ret(m, n).data[i][j * cvtExp + 1] = data[1];
+              }
+            }
+          }
+        }
+        return ret;
+      }
+    }();
+// compute
+#pragma unroll
+    for (uint32_t i = 0; i < qSliceRows; i++) {
+#pragma unroll
+      for (uint32_t j = 0; j < kSliceRows; j++) {
+        InstInMat<kEx, mnEx> const matrixA = qSlice(i, 0);
+        InstInMat<mnExK, kEx> const matrixB = kSlice(j, 0);
+#pragma unroll
+        for (uint32_t n = 0; n < mnExK; n++) {
+          uint32_t const b[2][1] = {matrixB.data[n][0], matrixB.data[n][1]};
+          mma<InputElem>(acc(i, j * mnExK + n).data, matrixA.data, b);
+        }
+      }
+    }
+  }
+}
+
+// acc is used as both input and output
+// v needs transpose
+template <typename VElemType>
+__device__ inline void smemXVPartGemm(Warp const& warp, WarpAcc& acc, bool skipXRowRescale,
+                                      UniformRescaleMask xRowNeedRescaleMask,
+                                      ThrdRegRowMax xRowScales, SharedMem::XSmemBuffer const& x,
+                                      uint32_t idxVTilePerXTile, SharedMem::VSmemBuffer const& vt,
+#if ENABLE_4BIT_KV_CACHE
+                                      SharedMem::VSfSmemBuffer const& vSf,
+#endif
+                                      uint32_t idxNSplit) {
+  static_assert(mha::is_same_v<InputElem, half> || mha::is_same_v<InputElem, __nv_bfloat16>,
+                "not implemented");
+#if !ENABLE_4BIT_KV_CACHE
+  static_assert((mha::is_same_v<VElemType, half> || mha::is_same_v<VElemType, __nv_bfloat16> ||
+                 mha::is_same_v<VElemType, int8_t> || mha::is_same_v<VElemType, __nv_fp8_e4m3>),
+                "not implemented");
+#else
+  static_assert(mha::is_same_v<VElemType, __nv_fp4_e2m1>, "not implemented");
+#endif
+
+  constexpr uint32_t kEx = 2;
+  constexpr uint32_t mnEx = 2;
+  constexpr uint32_t nbInstInMatPerSliceInGemmKDim = 1;
+  static_assert(SharedMem::XSmemBuffer::rows == 8 * InstAcc::rows * WarpAcc::rows);
+  static_assert(grpLoadV || sizeof(SharedMem::VSmemBuffer::Elem) / cacheElemSize *
+                                    SharedMem::VSmemBuffer::cols ==
+                                warpTile.x);
+  static_assert(!grpLoadV || sizeof(SharedMem::VSmemBuffer::Elem) / cacheElemSize *
+                                     SharedMem::VSmemBuffer::cols ==
+                                 headElems);
+  if (grpLoadV) {
+    assert(idxNSplit < gemm1WarpsPerGrp);
+  } else {
+    assert(idxNSplit == 0);
+  }
+  constexpr uint32_t gemmKSplit =
+      exactDiv(SharedMem::VSmemBuffer::rows, 8 * kEx * nbInstInMatPerSliceInGemmKDim);
+
+  Vec<InputElem2, QuadRegRowMax::size> xRowScalesQuad;
+  if (!enableMicroFastPath || !skipXRowRescale) {
+    assertWarpConverged();
+#if INPUT_FP16
+    Vec<InputElem2, ThrdRegRowMax::size> const xRowScalesF16 = __float2half2_rn(xRowScales);
+#else
+    Vec<InputElem2, ThrdRegRowMax::size> const xRowScalesF16 = __float2bfloat162_rn(xRowScales);
+#endif
+    static_assert(sizeof(xRowScalesF16) == sizeof(ThrdRegRowMax));
+    reinterpret_cast<QuadRegRowMax&>(xRowScalesQuad) =
+        replicateForQuad(warp, reinterpret_cast<ThrdRegRowMax const&>(xRowScalesF16));
+  }
+
+#if ENABLE_4BIT_KV_CACHE
+  // Prefetch buffer for SF
+  constexpr uint32_t nbSfPrefetchBuffers = exactDiv(warpTile.x, 16 * sizeof(uint32_t));
+  Array2D<uint32_t, exactDiv(cacheVTileSeqLen, 4), nbSfPrefetchBuffers> vSfPrefetch;
+#pragma unroll
+  for (uint32_t i = 0; i < vSfPrefetch.rows; i += 4) {
+#pragma unroll
+    for (uint32_t j = 0; j < nbSfPrefetchBuffers; j++) {
+      // T0 reads 0-3, 16-19
+      // T1 reads 4-7, 20-23
+      // T2 reads 8-11, 24-27
+      // T3 reads 12-15, 28-31
+      uint32_t const sfRowIdxInSlice = (laneId() % 4) * 4;
+      uint32_t const sfRowIdx = (i / 4) * 16 + i % 4 + sfRowIdxInSlice;
+      vSfPrefetch(i, j) = reinterpret_cast<const uint32_t&>(vSf.template at(sfRowIdx, j));
+    }
+  }
+#endif
+
+// @fixme: check if compiler mixes LDS+HMMA and does prefetch properly. We are not doing prefetch
+// explicitly. But we do fully unroll and expect compiler to do that for us.
+#pragma unroll
+  for (uint32_t s = 0; s < gemmKSplit; s++) {
+    // load x
+    constexpr uint32_t xSliceRows = exactDiv(warpTile.y, 8 * mnEx);  // in InstInMat
+    constexpr uint32_t xSliceCols = nbInstInMatPerSliceInGemmKDim;
+    uint32_t const colBeg =
+        SharedMem::XSmemBuffer::cols / nbCacheVTilesPerXTile * idxVTilePerXTile +
+        exactDiv(inputElemSize * 8 * kEx * nbInstInMatPerSliceInGemmKDim, grainBytes) * s;
+    Array2D<InstInMat<kEx, mnEx>, xSliceRows, xSliceCols> xSlice =
+        loadMatrix<kEx, mnEx, xSliceRows, xSliceCols, false, false, false, false>(warp, x, 0u,
+                                                                                  colBeg);
+    if (!enableMicroFastPath || !skipXRowRescale) {
+#pragma unroll
+      for (uint32_t m = 0; m < xSliceRows; m++) {
+#pragma unroll
+        for (uint32_t i = 0; i < mnEx; i++) {
+          uint32_t const r = m * mnEx + i;
+#pragma unroll
+          for (uint32_t n = 0; n < xSliceCols; n++) {
+#pragma unroll
+            for (uint32_t j = 0; j < kEx; j++) {
+              InputElem2& elem = reinterpret_cast<InputElem2&>(xSlice(m, n).data[j][i]);
+              elem = skipXRowRescale ? elem : elem * xRowScalesQuad[r];
+            }
+          }
+        }
+      }
+    }
+    // load v slice. rows and cols here are before transpose
+    constexpr uint32_t mnExV = mnEx * cvtExpansion;
+    constexpr uint32_t vSliceCols = exactDiv(warpTile.x, 8 * mnExV);  // in InstInMat
+    constexpr uint32_t vSliceRows = nbInstInMatPerSliceInGemmKDim;
+    uint32_t const rowBeg = 8 * kEx * nbInstInMatPerSliceInGemmKDim * s;
+    Array2D<InstInMat<mnEx, kEx>, vSliceCols, vSliceRows> const vSliceOrig =
+        loadMatrix<mnEx, kEx, vSliceRows, vSliceCols, true, false, true, true>(
+            warp, vt, rowBeg, mnEx * vSliceCols * idxNSplit);
+
+    // Load and convert SFs for V.
+#if ENABLE_4BIT_KV_CACHE
+    // The FP16/BF16 SF for V tile.
+    uint32_t vSfSlice[vSliceCols][vSliceRows][mnEx][kEx];
+    // We want to load 4 SFs in head dimension to utilize 32b LDS.
+    static_assert(vSliceCols % 2 == 0, "not implemented");
+    static_assert(mnEx == 2, "not implemented");
+    // Assert kEx is 2
+    static_assert(kEx == 2, "not implemented");
+    for (uint32_t m = 0; m < exactDiv(vSliceCols, 2); m++) {
+#pragma unroll
+      for (uint32_t n = 0; n < vSliceRows; n++) {
+        // Load the SF from 4 rows.
+        uint32_t sfOrig[4];
+#pragma unroll
+        for (uint32_t j = 0; j < 4; j++) {
+          uint32_t const rowIdx = rowBeg + (laneId() % 4) * 4 + j;
+          // The column index is in 32b load unit.
+          uint32_t const colIdx = idxNSplit * (vSliceCols / 2) + m;
+          sfOrig[j] = vSf(rowIdx, colIdx);
+        }
+        // Permute the elements.
+        // SFRow0: [(0,0) (0,1) (0,2) (0,3)]
+        // SFRow1: [(1,0) (1,1) (1,2) (1,3)]
+        // SFRow2: [(2,0) (2,1) (2,2) (2,3)]
+        // SFRow3: [(3,0) (3,1) (3,2) (3,3)]
+        // After permutation:
+        // tmpReg0: [(0,0) (1,0) (0,2) (1,2)]
+        // tmpReg1: [(0,1) (1,1) (0,3) (1,3)]
+        // tmpReg2: [(2,0) (3,0) (2,2) (3,2)]
+        // tmpReg3: [(2,1) (3,1) (2,3) (3,3)]
+        uint32_t tmpReg[4];
+        tmpReg[0] = prmt(sfOrig[0], sfOrig[1], {0, 4, 2, 6});
+        tmpReg[1] = prmt(sfOrig[0], sfOrig[1], {1, 5, 3, 7});
+        tmpReg[2] = prmt(sfOrig[2], sfOrig[3], {0, 4, 2, 6});
+        tmpReg[3] = prmt(sfOrig[2], sfOrig[3], {1, 5, 3, 7});
+        // Result after conversion:
+        // sfVal0[0]: [(0,0) (1,0)]; sfVal0[1]: [(0,2) (1,2)]
+        // sfVal1[0]: [(0,1) (1,1)]; sfVal1[1]: [(0,3) (1,3)]
+        // sfVal2[0]: [(2,0) (3,0)]; sfVal2[1]: [(2,2) (3,2)]
+        // sfVal3[0]: [(2,1) (3,1)]; sfVal3[1]: [(2,3) (3,3)]
+        auto sfVal0 = convertKCacheWordToF16<InputElem, __nv_fp8_e4m3>(tmpReg[0]);
+        auto sfVal1 = convertKCacheWordToF16<InputElem, __nv_fp8_e4m3>(tmpReg[1]);
+        auto sfVal2 = convertKCacheWordToF16<InputElem, __nv_fp8_e4m3>(tmpReg[2]);
+        auto sfVal3 = convertKCacheWordToF16<InputElem, __nv_fp8_e4m3>(tmpReg[3]);
+        // Store to kSfSlice.
+        vSfSlice[m * 2 + 0][n][0][0] = sfVal0[0];
+        vSfSlice[m * 2 + 0][n][0][1] = sfVal2[0];
+        vSfSlice[m * 2 + 0][n][1][0] = sfVal1[0];
+        vSfSlice[m * 2 + 0][n][1][1] = sfVal3[0];
+        vSfSlice[m * 2 + 1][n][0][0] = sfVal0[1];
+        vSfSlice[m * 2 + 1][n][0][1] = sfVal2[1];
+        vSfSlice[m * 2 + 1][n][1][0] = sfVal1[1];
+        vSfSlice[m * 2 + 1][n][1][1] = sfVal3[1];
+      }
+    }
+#endif
+
+    Array2D<InstInMat<mnExV, kEx>, vSliceCols, vSliceRows> const vSlice = [&]() {
+      if constexpr (mha::is_same_v<InputElem, VElemType>) {
+        return vSliceOrig;
+      } else {
+        Array2D<InstInMat<mnExV, kEx>, vSliceCols, vSliceRows> ret;
+#pragma unroll
+        for (uint32_t m = 0; m < ret.rows; m++) {
+#pragma unroll
+          for (uint32_t n = 0; n < ret.cols; n++) {
+            auto const& src = vSliceOrig(m, n);
+            auto& dst = ret(m, n);
+#if ENABLE_4BIT_KV_CACHE
+#pragma unroll
+            for (uint32_t i = 0; i < mnEx; i++) {
+#pragma unroll
+              for (uint32_t j = 0; j < kEx; j++) {
+                // Does not need PRMT, so use convertKCacheWordToF16 instead of
+                // convertVCacheWordToF16
+                auto data = convertKCacheWordToF16<InputElem, VElemType>(src.data[i][j]);
+                // Apply scaling factor to the data
+                InputElem2 scaledData0 = reinterpret_cast<InputElem2 const&>(data[0]) *
+                                         reinterpret_cast<InputElem2&>(vSfSlice[m][n][i][0]);
+                InputElem2 scaledData1 = reinterpret_cast<InputElem2 const&>(data[1]) *
+                                         reinterpret_cast<InputElem2&>(vSfSlice[m][n][i][1]);
+                data[0] = reinterpret_cast<uint32_t&>(scaledData0);
+                data[1] = reinterpret_cast<uint32_t&>(scaledData1);
+#pragma unroll
+                for (uint32_t e = 0; e < cvtExpansion; e++) {
+                  dst.data[i * cvtExpansion + j][e] = data[e];
+                }
+              }
+            }
+#else
+#pragma unroll
+            for (uint32_t i = 0; i < mnEx; i++) {
+#pragma unroll
+              for (uint32_t j = 0; j < kEx; j++) {
+                auto const data = convertVCacheWordToF16<InputElem, VElemType>(src.data[i][j]);
+#pragma unroll
+                for (uint32_t e = 0; e < cvtExpansion; e++) {
+                  dst.data[i * cvtExpansion + e][j] = data[e];
+                }
+              }
+            }
+#endif
+          }
+        }
+        return ret;
+      }
+    }();
+// compute
+#pragma unroll
+    for (uint32_t i = 0; i < xSliceRows; i++) {
+#pragma unroll
+      for (uint32_t j = 0; j < vSliceCols; j++) {
+        auto const& vInMat = vSlice(j, 0);
+#pragma unroll
+        for (uint32_t n = 0; n < mnExV; n++) {
+          mma<InputElem>(acc(i, j * mnExV + n).data, xSlice(i, 0).data,
+                         reinterpret_cast<uint32_t const(&)[2][1]>(vInMat.data[n]));
+        }
+      }
+    }
+  }
+}
+
+__device__ inline void pickAccRowsForBeamSearch(Warp const& warp, WarpAcc& dst, WarpAcc const& src,
+                                                bool isCtxTile, uint32_t idxBeam,
+                                                void (*func)(float& d, float s)) {
+  uint32_t const idxQuad = laneId() / 4;
+  constexpr uint32_t nbQuads = warp_size / 4;
+#pragma unroll
+  for (uint32_t m = 0; m < WarpAcc::rows; m++) {
+#pragma unroll
+    for (uint32_t i = 0; i < InstAcc::rows; i++) {
+#pragma unroll
+      for (uint32_t n = 0; n < WarpAcc::cols; n++) {
+#pragma unroll
+        for (uint32_t j = 0; j < InstAcc::cols; j++) {
+          uint32_t const idxRow = instM * m + nbQuads * i + idxQuad;
+          if (isCtxTile ||
+              (idxRow >= headGrpSize * idxBeam && idxRow < headGrpSize * idxBeam + headGrpSize)) {
+            func(dst(m, n)(i, j), src(m, n)(i, j));
+          }
+        }
+      }
+    }
+  }
+}
+
+__device__ inline void rescaleAcc(Warp const& warp, WarpAcc& acc,
+                                  UniformRescaleMask const& rescaleMask,
+                                  ThrdRegRowMax const& rowScales) {
+  static_assert(WarpAcc::rows * InstAcc::rows * 8 <= ThrdRegRowMax::size * warp_size);
+// QuadRegRowMax const quadRowScales = replicateForQuad(warp, rowScales);
+#pragma unroll
+  for (uint32_t m = 0; m < WarpAcc::rows; m++) {
+#pragma unroll
+    for (uint32_t i = 0; i < InstAcc::rows; i++) {
+      uint32_t const r = m * InstAcc::rows + i;  // in 8-row unit.
+      bool const skip = enableMicroFastPath && ((rescaleMask[r / 4] & (0xFFU << 8 * r)) == 0);
+      if (skip) {  // @fixme: do we need this?
+        continue;
+      }
+      // float const scale = quadRowScales[r]; // @fixme: see if this is faster than the line below.
+      float const scale = replicateValForQuad(warp, rowScales, r);
+#pragma unroll
+      for (uint32_t n = 0; n < WarpAcc::cols; n++) {
+#pragma unroll
+        for (uint32_t j = 0; j < InstAcc::cols; j++) {
+          acc(m, n)(i, j) *= scale;
+        }
+      }
+    }
+  }
+}
+
+__device__ inline void rescaleAcc(Warp const& warp, WarpAcc& acc, float scale) {
+#pragma unroll
+  for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+    for (uint32_t i = 0; i < InstAcc::rows; i++) {
+#pragma unroll
+      for (uint32_t n = 0; n < acc.cols; n++) {
+#pragma unroll
+        for (uint32_t j = 0; j < InstAcc::cols; j++) {
+          acc(m, n)(i, j) *= scale;
+        }
+      }
+    }
+  }
+}
+
+template <bool useFp32Acc, uint32_t nbWarps, uint32_t nbTiles, uint32_t rows, uint32_t cols>
+__device__ inline void smemFp16ArraySum(uint32_t idxWarp, Array2D<LdGrain, rows, cols>& dst,
+                                        Array2D<LdGrain, rows, cols> const tiles[nbTiles]) {
+  constexpr uint32_t nbThrds = warp_size * nbWarps;
+  uint32_t const tid = warp_size * idxWarp + laneId();
+  constexpr uint32_t nbGrains = SharedMem::XSmemBuffer::rows * SharedMem::XSmemBuffer::cols;
+  constexpr uint32_t nbGrainsPerThrd = exactDiv(nbGrains, nbThrds);
+  using AccType = mha::conditional_t<useFp32Acc, float2, InputElem2>;
+
+#pragma unroll
+  for (uint32_t i = 0; i < nbGrainsPerThrd; i++) {
+    Vec<AccType, LdGrain::size> result;
+    result.fill(AccType{0, 0});
+    uint32_t const idx = nbThrds * i + tid;
+#pragma unroll
+    for (uint32_t j = 0; j < nbTiles; j++) {
+      auto const data =
+          reinterpret_cast<Vec<InputElem2, LdGrain::size> const(&)[nbGrains]>(tiles[j])[idx];
+      if constexpr (useFp32Acc) {
+#if INPUT_FP16
+        result = addFloat2(result, __half22float2(data));
+#else
+        result = addFloat2(result, __bfloat1622float2(data));
+#endif
+      } else {
+        result = __hadd2_rn(result, data);
+      }
+    }
+    auto& dstGrain = reinterpret_cast<Vec<InputElem2, LdGrain::size>(&)[nbGrains]>(dst)[idx];
+    if constexpr (useFp32Acc) {
+#if INPUT_FP16
+      dstGrain = __float22half2_rn(result);
+#else
+      dstGrain = __floats2bfloat162_rn(result);
+#endif
+    } else {
+      dstGrain = result;
+    }
+  }
+}
+
+template <uint32_t nbBuffers>
+__device__ inline ThrdRegRowMax mergeRowMax(Warp const& warp,
+                                            TinyPtr<SMemWarpRowMax> const rowMaxBuffers,
+                                            uint32_t nbSubSeqPerSeq) {
+  ThrdRegRowMax regBuffers[nbBuffers];
+  auto load = [&](uint32_t n) {
+    assert(n < nbSubSeqPerSeq);
+    regBuffers[n % nbBuffers] = rowMaxBuffers[n].loadToReg<false>(warp);
+  };
+#pragma unroll
+  for (uint32_t i = 0; i < nbBuffers; i++) {
+    if (i >= nbSubSeqPerSeq) {
+      break;
+    }
+    load(i);
+  }
+  ThrdRegRowMax mergedRowMax = regBuffers[0];
+  for (uint32_t n = 0; n < divUp(nbSubSeqPerSeq, nbBuffers); n++) {
+#pragma unroll
+    for (uint32_t i = 0; i < nbBuffers; i++) {
+      uint32_t const idx = nbBuffers * n + i;
+      if (idx >= nbSubSeqPerSeq) {
+        break;
+      }
+      mergedRowMax = fmaxf(mergedRowMax, regBuffers[i]);
+      uint32_t const idxNext = idx + nbBuffers;
+      if (idxNext < nbSubSeqPerSeq) {
+        load(idxNext);
+      }
+    }
+  }
+  return mergedRowMax;
+}
+
+__device__ inline void addAttentionSinks(ThrdRegRowMax& globalRowSum,
+                                         ThrdRegRowMax const globalRowMax,
+                                         float const* attentionSinks) {
+  for (uint32_t i = 0; i < globalRowSum.size; i++) {
+    uint32_t srcOffset = warp_size * i + laneId();
+    if (srcOffset < headGrpSize) {
+      globalRowSum[i] += expf(attentionSinks[srcOffset] - globalRowMax[i]);
+    }
+  }
+}
+
+#if SPEC_DEC
+// SPEC_DEC version: handles head-token mixed layout
+__device__ inline void addAttentionSinksSpecDec(ThrdRegRowMax& globalRowSum,
+                                                ThrdRegRowMax const globalRowMax,
+                                                float const* attentionSinks, uint32_t headGrpSize) {
+  for (uint32_t i = 0; i < globalRowSum.size; i++) {
+    uint32_t idxHeadToken = warp_size * i + laneId();
+    // In SPEC_DEC, layout is [token0_head0, token0_head1, ..., token1_head0, ...]
+    // Extract head index from head-token index
+    uint32_t headIdx = idxHeadToken % headGrpSize;
+    if (headIdx < headGrpSize && idxHeadToken < rowsPerBlock) {
+      globalRowSum[i] += expf(attentionSinks[headIdx] - globalRowMax[i]);
+    }
+  }
+}
+#endif
+
+#ifdef NDEBUG
+__device__ __forceinline__
+#else
+CUBIN_EXPORT __global__
+#endif
+    void
+    kernel_mha_impl(
+#if SPEC_DEC
+        uint32_t const qSeqLen, uint32_t const nbKHeads, uint32_t const headGrpSize,
+        SeqLenDataType const* __restrict__ qCuSeqLens,  // [nbReq + 1]
+#else
+        uint32_t const nbKHeads,
+#endif
+#if SLIDING_WINDOW
+        uint32_t slidingWinSize,
+#endif
+        float qScale, float const* qScalePtr,
+        OutputHead* __restrict__ const output,  // [nbReq][beamWidth][nbQHeads]
+#if LOW_PREC_OUTPUT
+        float rcpOutScale,
+#endif
+        // NOTE: the input is actually Q buffer when integrated to TRT-LLM.
+        IOHead const* __restrict__ const q,  // [nbReq][beamWidth][nbQHeads],
+#if SPEC_DEC
+        MaskType const* __restrict__ mask,  // [qSeqLen, divUp(qSeqLen, 32)].
+#endif
+        float const* attentionSinks,  // [headGrpSize]
+#ifdef NDEBUG
+        KVCacheList<usePagedKVCache> const& cacheList,
+#if BEAM_WIDTH > 1
+        BeamSearchParams const& beamSearchParams,
+#endif
+#else
+        KVCacheList<usePagedKVCache> const cacheList,
+#if BEAM_WIDTH > 1
+        BeamSearchParams const beamSearchParams,
+#endif
+#endif
+        uint32_t const batchSize, float kvCacheScale,
+        float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
+        uint32_t kv_stride_page, uint32_t kv_stride_token, uint32_t kv_stride_head,
+        uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
+
+  float const qScaleValue = qScalePtr != nullptr ? qScalePtr[0] : qScale;
+  float const kvCacheScaleValue = kvScalePtr != nullptr ? kvScalePtr[0] : kvCacheScale;
+  assert(allowMultiBlockMode || gridDim.x == 1);
+  bool const isMultiBlock = allowMultiBlockMode && (gridDim.x != 1);
+  uint32_t const nbSubSeqPerSeq = allowMultiBlockMode ? gridDim.x : 1;
+  uint32_t const idxSubSeqInSeq = allowMultiBlockMode ? blockIdx.x : 0;
+  assert(!isMultiBlock || (semaphores != nullptr && scratch != nullptr));
+
+  // gridDim: x - K/V sequence-dim split; y - number of K or V heads per token; z - number of
+  // requests
+  assert(gridDim.z == batchSize && gridDim.y == nbKHeads);
+  extern __shared__ char smemByteBuf[];
+  SharedMem& smem = *reinterpret_cast<SharedMem*>(&smemByteBuf[0]);
+
+  uint32_t const idxReq = blockIdx.z;
+#if SPEC_DEC
+  // Variable query sequence length support.
+  bool const variableQSeqLen = qCuSeqLens != nullptr;
+  uint32_t const actualQSeqLen =
+      variableQSeqLen ? uint32_t(qCuSeqLens[idxReq + 1] - qCuSeqLens[idxReq]) : qSeqLen;
+  // Same as idxReq * qSeqLen if all sequences all the same.
+  // Take different beams as different requests/sequences currently.
+  uint32_t const reqSeqOffset = variableQSeqLen ? uint32_t(qCuSeqLens[idxReq]) : (qSeqLen * idxReq);
+
+  uint32_t const nbVHeads = nbKHeads;
+  uint32_t const nbQHeads = nbKHeads * headGrpSize;
+  uint32_t const nbQHeadTokens = nbQHeads * actualQSeqLen;
+  uint32_t const nbQKVHeads = nbQHeads + nbKHeads + nbVHeads;
+
+  uint32_t const nbTokenBlocksPerGrp = gridDim.y / nbKHeads;
+  uint32_t const idxHeadGrp = blockIdx.y / nbTokenBlocksPerGrp;  // inside one request
+  uint32_t const idxHeadTokenInGrp = (blockIdx.y % nbTokenBlocksPerGrp) * warpTile.y;
+  uint32_t const totalNbHeadTokensInGrp = actualQSeqLen * headGrpSize;
+  uint32_t const nbValidHeadTokens =
+      idxHeadTokenInGrp > totalNbHeadTokensInGrp
+          ? 0u
+          : mha::min(totalNbHeadTokensInGrp - idxHeadTokenInGrp, rowsPerBlock);
+  // Shift the mask ptr by batch_idx.
+  mask += reqSeqOffset * divUp(qSeqLen, 32u);
+#else
+  uint32_t const nbQHeads = nbKHeads * headGrpSize;
+
+  uint32_t const idxHeadGrp = blockIdx.y;  // inside one request
+#endif
+
+  auto const ctaThrdId =
+      threadIdx.x + warp_size * ctaShapeInWarps.x * (threadIdx.y + ctaShapeInWarps.y * threadIdx.z);
+  assert(blockDim.x == ctaShapeInWarps.x * warp_size && blockDim.y == ctaShapeInWarps.y &&
+         blockDim.z == ctaShapeInWarps.z);
+  auto const warp = this_warp();
+  uint3 const warpIdx = getWarpIdx(warp);  // @fixme: use BoundedVal
+  assert(warpIdx.x < ctaShapeInWarps.x && warpIdx.y < ctaShapeInWarps.y &&
+         warpIdx.z < ctaShapeInWarps.z);
+  uint32_t const flatWarpIdPerRow =
+      warpIdx.z * ctaShapeInWarps.x + warpIdx.x;  // per ctaShapeInWarps.y value
+
+  // initialize shared memory
+  static_assert(persistentQ && ctaShapeInWarps.y == 1);
+  if (ctaThrdId < ctaShapeInWarps.y) {
+    init(&smem.qBarrier[ctaThrdId], warp_size * ctaShapeInWarps.x);  // be sure to use .noinc
+  }
+  constexpr uint32_t cacheVTileSeqStride = cacheVTileSeqLen * gemm1NbWarpGrps;
+  constexpr uint32_t nbXTilesPerXIter =
+      cacheVTileSeqStride < warpTile.x ? 1 : exactDiv(cacheVTileSeqStride, warpTile.x);
+  constexpr uint32_t nbXItersPerCtaTile = exactDiv(ctaShapeInWarps.x, nbXTilesPerXIter);
+  constexpr uint32_t nbVItersPerXIter =
+      exactDiv(warpTile.x * nbXTilesPerXIter, cacheVTileSeqStride);
+  constexpr uint32_t nbWarpGrpsPerXTile = mha::min(nbCacheVTilesPerXTile, gemm1NbWarpGrps);
+  static_assert(warpTile.x >= cacheVTileSeqLen, "not implemented yet");
+  static_assert(ctaSize >= uint32_t(sizeof(smem.xBarriers) / sizeof(CtaBarrierPair)));
+  if (ctaThrdId < uint32_t(sizeof(smem.xBarriers) / sizeof(CtaBarrierPair))) {
+    (&smem.xBarriers[0][0])[ctaThrdId].initialize(
+        warp_size, warp_size * gemm1WarpsPerGrp * nbWarpGrpsPerXTile);
+  }
+#if CTA_ROW_MAX_BACKWARD_METHOD == 3
+  static_assert(ctaSize >= sizeof(smem.ctaRowMaxBwdBarriers) / sizeof(SharedMem::Barrier));
+  if (ctaThrdId < sizeof(smem.ctaRowMaxBwdBarriers) / sizeof(SharedMem::Barrier)) {
+    init(&smem.ctaRowMaxBwdBarriers[0][0] + ctaThrdId, warp_size);
+  }
+#endif
+#if CTA_ROW_MAX_BACKWARD_METHOD != 0
+  static_assert(ctaSize >= sizeof(smem.ctaRowMax) / sizeof(float));
+  if (ctaThrdId < sizeof(smem.ctaRowMax) / sizeof(float)) {
+    reinterpret_cast<float*>(&smem.ctaRowMax[0])[ctaThrdId] = safeInitRowMax;
+  }
+#endif
+#if GRP_LOAD_V
+  static_assert(ctaSize >= gemm1NbWarpGrps * nbVBuffers);
+  if (ctaThrdId < gemm1NbWarpGrps * nbVBuffers) {
+    init(smem.vBarrier(0, 0) + ctaThrdId, warp_size * gemm1WarpsPerGrp);
+  }
+  if (ctaThrdId < gemm1NbWarpGrps) {
+    init(smem.warpGrpBar(ctaThrdId), warp_size * gemm1WarpsPerGrp);
+  }
+#endif
+  __syncthreads();
+
+#if ENABLE_PDL
+  preExit();
+  acqBulk();
+#endif
+
+  constexpr bool qkSwizzle = true;
+  // load whole Q heads into shared memory
+#if SPEC_DEC
+  if (warpIdx.z == 0) {
+    // map from idxQHead to idxHead in q input.
+    auto const localQHeadTokenIdxMap = [nbQHeads, headGrpSize, reqSeqOffset, idxReq,
+                                        idxHeadTokenInGrp](uint32_t idxHeadTokenLocal) -> uint32_t {
+      assert(idxHeadTokenLocal <
+             warpTile.y);  // may be larger than nbValidRows, then the output does not matter.
+      if constexpr (beamWidth == 1) {
+        idxHeadTokenLocal += idxHeadTokenInGrp;
+        uint32_t const tokenIdx = (idxHeadTokenLocal / headGrpSize);
+        uint32_t const headIdx = idxHeadTokenLocal % headGrpSize;
+        return tokenIdx * nbQHeads + headIdx;
+      }
+    };
+    static_assert(nbValidRows <= warpTile.y);
+    auto const srcBase = q;
+    uint32_t const idxHeadTokenBeg = nbQHeads * reqSeqOffset + (idxHeadGrp * headGrpSize);
+    TinyPtr<IOHead const> const src{srcBase, idxHeadTokenBeg};
+
+    bool const isFullTile = (nbValidHeadTokens == warpTile.y);
+    static_assert(nbQBuffers == 1);
+    if (isFullTile) {
+      copyHeadsAsync<PaddedInputHead, warpTile.y, ctaShapeInWarps.x, grainBytes, grainBytes,
+                     qkSwizzle, true, warpTile.y>(warpIdx.x, smem.q[warpIdx.y][0], src,
+                                                  nbValidHeadTokens, localQHeadTokenIdxMap);
+    } else {
+      copyHeadsAsync<PaddedInputHead, warpTile.y, ctaShapeInWarps.x, grainBytes, grainBytes,
+                     qkSwizzle, false, warpTile.y>(warpIdx.x, smem.q[warpIdx.y][0], src,
+                                                   nbValidHeadTokens, localQHeadTokenIdxMap);
+    }
+
+    ldgsts::barArrive(smem.qBarrier[warpIdx.y], true);
+  }
+#else
+  if (warpIdx.z == 0) {
+    // map from idxQHead to idxHead in q input.
+    auto const localQHeadIdxMap = [nbQHeads, idxReq,
+                                   idxHeadGrp](uint32_t idxHeadLocal) -> uint32_t {
+      assert(idxHeadLocal <
+             warpTile.y);  // may be larger than nbValidRows, then the output does not matter.
+      if constexpr (beamWidth == 1) {
+        return idxHeadLocal;
+      }
+      uint32_t const idxBeam = idxHeadLocal / headGrpSize;
+      uint32_t const result = idxHeadLocal + idxBeam * (nbQHeads - headGrpSize);
+      uint32_t const idxQHeadInGrp = idxHeadLocal % headGrpSize;
+      uint32_t const ref = nbQHeads * idxBeam + idxQHeadInGrp;
+      assert(result == ref);
+      unused(ref);
+      return result;
+    };
+    static_assert(nbValidRows <= warpTile.y);
+    auto const srcBase = q;
+    // NOTE: read from Q buffer directly.
+    uint32_t const idxHeadBeg = nbQHeads * beamWidth * idxReq + headGrpSize * idxHeadGrp;
+    TinyPtr<IOHead const> const src{srcBase, idxHeadBeg};
+
+    constexpr bool isFullTile = (nbValidRows == warpTile.y);
+    static_assert(nbQBuffers == 1);
+    copyHeadsAsync<PaddedInputHead, warpTile.y, ctaShapeInWarps.x, grainBytes, grainBytes,
+                   qkSwizzle, isFullTile, warpTile.y>(warpIdx.x, smem.q[warpIdx.y][0], src,
+                                                      nbValidRows, localQHeadIdxMap);
+    ldgsts::barArrive(smem.qBarrier[warpIdx.y], true);
+  }
+#endif
+
+  uint32_t const cacheSeqLen = getCacheSeqLen<usePagedKVCache>(cacheList, idxReq);
+#if SLIDING_WINDOW
+  bool const rtIsReallySliding = (cacheSeqLen > slidingWinSize);
+  uint32_t const nbTotalSkipTokens = rtIsReallySliding ? cacheSeqLen - slidingWinSize : 0;
+#else
+  constexpr bool rtIsReallySliding = false;
+  constexpr uint32_t nbTotalSkipTokens = 0;
+#endif
+  uint32_t const nbSkipLeadingTiles = nbTotalSkipTokens / ctaTile.x;
+  uint32_t const tile0NbSkipTokens = nbTotalSkipTokens % ctaTile.x;
+  uint32_t const nbPages = divUp(cacheSeqLen, tokensPerPage);
+  constexpr uint32_t nbPagesPerCtaTile = exactDiv(ctaTile.x, tokensPerPage);
+
+  uint32_t const nbSeqIters = useKVCache ? divUp(cacheSeqLen, ctaTile.x) : 0;
+#if SPEC_DEC
+  uint32_t const nbSeqItersWithoutMask = (cacheSeqLen - actualQSeqLen) / ctaTile.x;
+#endif
+
+  uint32_t const seqStrideIters = nbSubSeqPerSeq;
+  constexpr bool isKVCacheQuantized = (cacheElemSize < 2);
+  uint32_t const seqIterInit = nbSkipLeadingTiles + idxSubSeqInSeq;
+#if BEAM_WIDTH > 1
+  uint32_t const nbCtxCtaTiles = beamSearchParams.ctxLenList[idxReq * beamWidth] / ctaTile.x;
+#endif
+  auto isConvergedTile = [&](uint32_t seqIter) {
+#if BEAM_WIDTH == 1
+    return true;
+#else
+    return seqIter < nbCtxCtaTiles;
+#endif
+  };
+  if (warpIdx.z == 0) {
+    float const qkScale =
+        qScaleValue * (isKVCacheQuantized ? kvCacheScaleValue : 1.f) *
+        rsqrtf(validElemsPerHead);  // qkScale is applied onto Q*K.T before softmax.
+    CircIdx<nbKBuffers> idxCurrSMemKBuf{nbKBuffers - 1};
+    auto const getSMemKTile = [&](uint32_t idx) -> SharedMem::KSmemBuffer& {
+      return smem.k[warpIdx.x][idx];
+    };
+#if ENABLE_4BIT_KV_CACHE
+    auto const getSMemKSfTile = [&](uint32_t idx) -> SharedMem::KSfSmemBuffer& {
+      return smem.kSf[warpIdx.x][idx];
+    };
+#endif
+#if BEAM_WIDTH > 1
+    auto loadCacheIndir = [&](uint32_t seqIter, uint32_t idxBeam) mutable {
+      auto& dst = smem.gemm0CacheIndir[warpIdx.x];
+      uint32_t const offset = ctaTile.x * seqIter + warpTile.x * warpIdx.x;
+      loadIndicesForBeamSearchAsync<1, warpTile.x>(0, dst, beamSearchParams, idxReq, idxBeam,
+                                                   offset, cacheSeqLen);
+    };
+    loadCacheIndir(seqIterInit, 0U);
+#endif
+#if BEAM_WIDTH == 1
+    KCachePageIndices pageIdx = KCachePageIndices::filled(kBAD_PAGE_INDEX);
+#endif
+    auto loadPages = [&](uint32_t idxPage) mutable {
+#if BEAM_WIDTH == 1
+      uint32_t const idxBeam = 0;
+      pageIdx =
+          getPage<KCachePageIndices::size>(cacheList, true, idxReq, idxBeam, idxPage, nbPages);
+#else
+      auto& dst = smem.kCachePages[warpIdx.x];
+      loadPagesForBeamSearchAsync<1>(0U, dst, cacheList, true, idxReq, idxPage, nbPages);
+#endif
+    };
+    uint32_t idxPageBeg = nbPagesPerCtaTile * seqIterInit + warpIdx.x * warpTile.x / tokensPerPage;
+    loadPages(idxPageBeg);
+    auto loadKTilePart = [&](uint32_t seqIter, uint32_t idxBeam, uint32_t idxPart) mutable {
+      assert(idxBeam < beamWidth);
+      assert(seqIter % nbSubSeqPerSeq == seqIterInit % nbSubSeqPerSeq);
+      auto const idxNextSMemKBuf = idxCurrSMemKBuf.next();
+      auto& dst = getSMemKTile(idxNextSMemKBuf);
+#if ENABLE_4BIT_KV_CACHE
+      auto& dstSf = getSMemKSfTile(idxNextSMemKBuf);
+#endif
+
+      uint32_t const dstHeadOffset = 0;
+      uint32_t const seqOffset = ctaTile.x * seqIter + warpTile.x * warpIdx.x;
+      uint32_t const tokenOffset = seqOffset % tokensPerPage;
+
+#if BEAM_WIDTH == 1
+      HeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerWarpTile> const src{
+          cacheList.kCacheVLLM, pageIdx,         tokenOffset,   idxHeadGrp,
+          kv_stride_page,       kv_stride_token, kv_stride_head};
+#if ENABLE_4BIT_KV_CACHE
+      HeadPtr<GMemCacheHeadSf const, tokensPerPage, nbPagesPerWarpTile> const srcSf{
+          cacheList.kSfCacheVLLM, pageIdx,         tokenOffset,   idxHeadGrp,
+          kv_stride_page,         kv_stride_token, kv_stride_head};
+#endif
+
+#else
+      IndexedHeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerWarpTile> const src{
+          /*indices=*/smem.gemm0CacheIndir[warpIdx.x].data,
+          /*pool=*/cacheList.kCacheVLLM,
+          /*pageIndices=*/smem.kCachePages[warpIdx.x].data,
+          /*tokenOffset=*/tokenOffset,
+          /*headIdx=*/idxHeadGrp,
+          /*stride_page=*/kv_stride_page,
+          /*stride_token=*/kv_stride_token,
+          /*stride_head=*/kv_stride_head};
+      if constexpr (ENABLE_4BIT_KV_CACHE) {
+        // Not supported yet.
+        assert(!"not implemented");
+        trap();
+      }
+#endif
+      // if (threadIdx.x == dbgPrintTid) {
+      //     printf("K: seqIter=%u, idxBeam=%u, idxPart=%u: pointers={%p, %p}, indices={", seqIter,
+      //     idxBeam, idxPart, src.pointers[0], src.pointers[1]); uint32_t const nbHeadsAvail =
+      //     mha::min((seqOffset < cacheSeqLen ? cacheSeqLen - seqOffset : 0U), warpTile.x); for
+      //     (int i = 0; i < nbHeadsAvail; i++) {
+      //         printf("%u, ", src.indices[i]);
+      //     }
+      //     printf("}\n");
+      // }
+      bool const isFullTile = (seqIter + 1 < nbSeqIters);
+      if (isFullTile) {
+        copyPartialHeadsAsync<PaddedCacheHead, warpTile.x, nbPartsPerCacheKHead, grainBytes,
+                              grainBytesGmemCache, qkSwizzle, true>(warp, dst, dstHeadOffset, src,
+                                                                    idxPart);
+      } else {
+        uint32_t const nbHeadsAvail =
+            (seqOffset < cacheSeqLen
+                 ? cacheSeqLen - seqOffset
+                 : 0U);  // may also be full but it can be handled correctly anyway
+        copyPartialHeadsAsync<PaddedCacheHead, warpTile.x, nbPartsPerCacheKHead, grainBytes,
+                              grainBytesGmemCache, qkSwizzle, false>(warp, dst, dstHeadOffset, src,
+                                                                     idxPart, nbHeadsAvail);
+      }
+#if ENABLE_4BIT_KV_CACHE
+      copyPartialHeadsAsync<PaddedCacheHeadSf, warpTile.x, nbPartsPerCacheKHead, grainBytesSf,
+                            grainBytesSf, false, true>(warp, dstSf, dstHeadOffset, srcSf, idxPart);
+#endif
+
+#if BEAM_WIDTH > 1
+      // to make sure all threads has finished usage of cache indir and pages
+      __syncwarp();
+#endif
+      if (idxPart + 1 == nbPartsPerCacheKHead) {
+        bool const isForNextSeqIter = isConvergedTile(seqIter) || idxBeam == beamWidth - 1;
+        if (isForNextSeqIter) {
+          idxPageBeg += nbPagesPerCtaTile * nbSubSeqPerSeq;
+          loadPages(idxPageBeg);
+        }
+#if BEAM_WIDTH > 1
+        uint32_t idxBeamNext, seqIterDelta;
+        mha::tie(idxBeamNext, seqIterDelta) =
+            isConvergedTile(seqIter)
+                ? mha::tuple<uint32_t, uint32_t>(0U, 1U)
+                : carryLE<beamWidth>(idxBeam + 1, 0);  // optimize for context cache
+        loadCacheIndir(seqIter + seqStrideIters * seqIterDelta, idxBeamNext);
+#endif
+      }
+    };
+
+#if BEAM_WIDTH > 1
+    ldgsts::commitGroup();
+    ldgsts::waitGroup<0>();
+    __syncwarp();
+#endif
+    loadKTilePart(seqIterInit, 0, 0);
+    ldgsts::commitGroup();  // @fixme: do prefetch for next iter tile if last part
+    idxCurrSMemKBuf++;
+
+    auto& xBar = smem.xBarriers[warpIdx.y][warpIdx.x];
+    bool xBarConsumedParityNext = false;
+
+    bool qBarParityNext = false;
+    auto& qBar = smem.qBarrier[warpIdx.y];
+    qBar.wait_parity(qBarParityNext);
+    qBarParityNext = !qBarParityNext;
+    constexpr bool reorderForKCache = (useKVCache && inputElemSize == 2 && cacheElemSize == 1);
+    if constexpr (reorderForKCache) {
+      reorder16bQHeadsToMatch8bKCache<ctaShapeInWarps.x, qkSwizzle, true>(warpIdx.x,
+                                                                          smem.q[warpIdx.y][0]);
+      unused(qBar.arrive());
+      qBar.wait_parity(qBarParityNext);
+      qBarParityNext = !qBarParityNext;
+      assertWarpConverged();
+    }
+#if CTA_ROW_MAX_BACKWARD_METHOD == 2
+    ThrdRegRowMax initRowMax;
+    initRowMax.fill(safeInitRowMax);
+#endif
+    for (uint32_t seqIter = seqIterInit; seqIter < nbSeqIters; seqIter += seqStrideIters) {
+#if SHORT_SEQ_OPT
+      if (ctaTile.x * seqIter + warpTile.x * warpIdx.x >= cacheSeqLen) {
+        break;
+      }
+#endif
+      auto runGemm0 = [&](auto elemK, uint32_t idxBeam) {
+        assert(idxBeam < (isConvergedTile(seqIter) ? 1U : beamWidth));
+        using KElemType = mha::decay_t<decltype(elemK)>;
+        constexpr uint32_t elemsPerKHeadPart = exactDiv(kHeadPartBytes, sizeof(KElemType));
+        constexpr uint32_t nbPartsPerKHead = exactDiv(headElems, elemsPerKHeadPart);
+        // the accumulator
+        WarpAcc acc{};
+        constexpr uint32_t nbUnroll = (cacheElemSize == 2 ? nbPartsPerKHead : 1);
+#pragma unroll(nbUnroll)
+        for (uint32_t p = 0; p < nbPartsPerKHead; p++) {
+          constexpr bool syncKTileEarly =
+              (beamWidth > 1);  // alternative is to use double buffer for cacheIndir and pages
+          if constexpr (syncKTileEarly) {
+            // synchronize gemm0CacheIndir for the next loadKTilePart. the last loaded K tile is
+            // also sync'ed at the same time.
+            ldgsts::waitGroup<0>();
+            __syncwarp();
+          }
+          // prefetch next part into shared memory
+          uint32_t idxPartNext, idxBeamNext, nNextBias;
+          mha::tie(idxPartNext, idxBeamNext, nNextBias) =
+              isConvergedTile(seqIter) ? carryLE<nbPartsPerKHead, 1U>(p + 1, idxBeam, 0U)
+                                       : carryLE<nbPartsPerKHead, beamWidth>(p + 1, idxBeam, 0U);
+
+          loadKTilePart(seqIter + seqStrideIters * nNextBias, idxBeamNext, idxPartNext);
+          ldgsts::commitGroup();
+          // @fixme: do L2 cache prefetch for next iter tile if last part
+
+          // q is already synchronized
+          if constexpr (!syncKTileEarly) {
+            // synchronize k
+            ldgsts::waitGroup<1>();
+          }
+          SharedMem::QSmemBuffer const& smemQ = smem.q[warpIdx.y][0];
+          constexpr uint32_t qOffsetPerPart = exactDiv(elemsPerKHeadPart, inputElemsPerGrain);
+          uint32_t const smemQOffset = qOffsetPerPart * p;
+          SharedMem::KSmemBuffer const& smemKPart = getSMemKTile(idxCurrSMemKBuf);
+#if ENABLE_4BIT_KV_CACHE
+          SharedMem::KSfSmemBuffer const& smemKSfPart = getSMemKSfTile(idxCurrSMemKBuf);
+#endif
+
+          // #ifndef NDEGBUG
+          //                     for (uint32_t i = 0; i < exactDiv(smemKPart.rows * smemKPart.cols,
+          //                     warp_size); i++) {
+          //                         uint32_t const idx = warp_size * i + laneId();
+          //                         uint32_t const r = idx / smemKPart.cols;
+          //                         uint32_t const c = idx % smemKPart.cols;
+
+          //                         assert(smemKPart(r, c) == );
+          //                     }
+          // #endif
+          // do computation.
+          smemQKPartGemm<KElemType>(warp, acc, smemQ, smemQOffset, smemKPart
+#if ENABLE_4BIT_KV_CACHE
+                                    ,
+                                    smemKSfPart
+#endif
+          );
+          idxCurrSMemKBuf++;
+        }
+        return acc;
+      };
+      WarpAcc acc;
+      //@fixme: alternative is to use separate inner loop, which results in larger but maybe faster
+      // code.
+      for (uint32_t idxBeam = 0; idxBeam < (isConvergedTile(seqIter) ? 1U : beamWidth); idxBeam++) {
+        WarpAcc tmp;
+        if constexpr (mha::is_same_v<CacheElem, InputElem>) {
+          tmp = runGemm0(CacheElem{}, idxBeam);
+        } else {
+          tmp = runGemm0(CacheElem{}, idxBeam);
+        }
+        pickAccRowsForBeamSearch(warp, acc, tmp, isConvergedTile(seqIter), idxBeam,
+                                 [](float& d, float s) { d = s; });
+      }
+      // apply qkScale
+      rescaleAcc(warp, acc, qkScale);
+#if CTA_ROW_MAX_BACKWARD_METHOD == 0
+      QuadRegRowMax initRowMaxQuad;
+      initRowMaxQuad.fill(safeInitRowMax);
+#elif CTA_ROW_MAX_BACKWARD_METHOD == 1
+      // load hint
+      xBar.consumed.wait_parity(getAndFlip(xBarConsumedParityNext));
+      QuadRegRowMax initRowMaxQuad =
+          smem.ctaRowMax[warpIdx.y][warpIdx.x].loadToRegForQuad<false>(warp);
+#elif CTA_ROW_MAX_BACKWARD_METHOD == 2
+      QuadRegRowMax initRowMaxQuad = replicateForQuad(warp, initRowMax);
+#elif CTA_ROW_MAX_BACKWARD_METHOD == 3
+      // load hint
+      smem.ctaRowMaxBwdBarriers[warpIdx.y][warpIdx.x].wait_parity(xBarConsumedParityNext);
+      QuadRegRowMax initRowMaxQuad =
+          smem.ctaRowMax[warpIdx.y][warpIdx.x].loadToRegForQuad<false>(warp);
+#elif CTA_ROW_MAX_BACKWARD_METHOD == 4
+      // load hint
+      QuadRegRowMax initRowMaxQuad = smem.ctaRowMax[warpIdx.y].loadToRegForQuad<true>(warp);
+#endif
+      // masking
+      uint32_t const warpTileTokenBeg = ctaTile.x * seqIter + warpTile.x * warpIdx.x;
+#if SPEC_DEC
+      if (seqIter >= nbSeqItersWithoutMask) {
+        uint32_t const nbValidCols =
+            (warpTileTokenBeg < cacheSeqLen ? cacheSeqLen - warpTileTokenBeg : 0U);
+        applyMaskFromInput(warp, acc, mask, idxHeadTokenInGrp, nbValidCols, qSeqLen, actualQSeqLen,
+                           headGrpSize);
+      }
+#else
+      bool const isFirstIter = (seqIter == nbSkipLeadingTiles);
+      bool const needMaskLeading = (rtIsReallySliding && isFirstIter);
+      bool const isLastIter = (seqIter + 1 == nbSeqIters);
+      bool const needMaskTrailing = isLastIter && cacheSeqLen % ctaTile.x != 0;
+      if (needMaskLeading || needMaskTrailing) {
+        uint32_t const validTokenBeg = (!needMaskLeading || nbTotalSkipTokens < warpTileTokenBeg)
+                                           ? 0
+                                           : nbTotalSkipTokens - warpTileTokenBeg;
+        uint32_t const validTokenEnd =
+            (warpTileTokenBeg < cacheSeqLen ? cacheSeqLen - warpTileTokenBeg : 0U);
+        if (validTokenBeg > 0 || validTokenEnd < warpTile.x) {
+          applyMask(warp, acc, validTokenBeg, validTokenEnd);
+        }
+      }
+#endif
+
+      // find max and update acc into exp(acc-max).
+      QuadRegRowMax const regRowMax = warpTileOnlineSoftmax(warp, initRowMaxQuad, acc);
+
+      // store result and max to shared memory.
+      GemmOutRegTile const fp16Acc = toFp16(acc);
+      QuadRegRowMax const regRowSum = computeRowSum(warp, fp16Acc);
+#if CTA_ROW_MAX_BACKWARD_METHOD != 1
+      xBar.consumed.wait_parity(getAndFlip(xBarConsumedParityNext));
+#if CTA_ROW_MAX_BACKWARD_METHOD == 2
+      initRowMax = smem.ctaRowMax[warpIdx.y][warpIdx.x].loadToReg<false>(warp);
+#endif
+#endif
+
+#if ENABLE_4BIT_KV_CACHE
+      storeReorderedXTile(warp, smem.x[warpIdx.y][warpIdx.x], fp16Acc);
+#else
+      storeOrderedGemmOutTile(warp, smem.x[warpIdx.y][warpIdx.x], fp16Acc);
+#endif
+      smem.warpRowMax[warpIdx.y][warpIdx.x].storeFromReg<false>(warp, regRowMax);
+      smem.warpRowSum[warpIdx.y][warpIdx.x].storeFromReg<false>(warp, regRowSum);
+      unused(xBar.produced.arrive());
+    }
+  } else {
+    assert(warpIdx.z == 1);
+#if CTA_ROW_MAX_BACKWARD_METHOD == 3
+    unused(smem.ctaRowMaxBwdBarriers[warpIdx.y][warpIdx.x].arrive());
+#endif
+    uint32_t const warpIdxInGrp = gemm1WarpIdxInGrp(warpIdx.x);  // @fixme: use BoundedVal
+    uint32_t const warpGrpIdx = gemm1WarpGrpIdx(warpIdx.x);      // @fixme: use BoundedVal
+    auto* const pWarpGrpBar = smem.warpGrpBar(warpGrpIdx);
+    ParityOrNone<grpLoadV> warpGrpBarParityNext{};
+#if BEAM_WIDTH > 1
+    auto loadCacheIndir = [&](uint32_t seqIter, uint32_t xIter, uint32_t vIter,
+                              uint32_t idxBeam) mutable {
+      uint32_t const seqOffset = ctaTile.x * seqIter + warpTile.x * nbXTilesPerXIter * xIter +
+                                 cacheVTileSeqStride * vIter + cacheVTileSeqLen * warpGrpIdx;
+      auto& dst = smem.gemm1CacheIndir[grpLoadV ? warpGrpIdx : warpIdx.x];
+      loadIndicesForBeamSearchAsync<grpLoadV ? gemm1WarpsPerGrp : 1U, cacheVTileSeqLen>(
+          grpLoadV ? warpIdxInGrp : 0U, dst, beamSearchParams, idxReq, idxBeam, seqOffset,
+          cacheSeqLen);
+    };
+    loadCacheIndir(seqIterInit, 0, 0, 0);
+#endif
+    unused(smem.xBarriers[warpIdx.y][warpIdx.x].consumed.arrive(gemm1WarpsPerGrp *
+                                                                nbWarpGrpsPerXTile));
+    CircIdx<nbVBuffers> idxCurrSMemVBuf{nbVBuffers - 1};
+    auto const getSmemVTile = [&](uint32_t idx) -> SharedMem::VSmemBuffer& {
+      return smem.v[warpGrpIdx][grpLoadV ? 0 : warpIdxInGrp][idx];
+    };
+#if ENABLE_4BIT_KV_CACHE
+    auto const getSmemVSfTile = [&](uint32_t idx) -> SharedMem::VSfSmemBuffer& {
+      return smem.vSf[warpGrpIdx][grpLoadV ? 0 : warpIdxInGrp][idx];
+    };
+#endif
+
+    auto const getSmemVBar = [&](uint32_t idx) -> SharedMem::Barrier* {
+      return smem.vBarrier(warpGrpIdx, idx);
+    };
+#if BEAM_WIDTH == 1
+    VCachePageIndices pageIdx = VCachePageIndices::filled(kBAD_PAGE_INDEX);
+#endif
+    auto loadPages = [&](uint32_t idxPageBeg) mutable {
+#if BEAM_WIDTH == 1
+      uint32_t const idxBeam = 0;
+      pageIdx =
+          getPage<VCachePageIndices::size>(cacheList, false, idxReq, idxBeam, idxPageBeg, nbPages);
+#else
+      auto& dst = smem.vCachePages[grpLoadV ? warpGrpIdx : warpIdx.x];
+#if ENABLE_4BIT_KV_CACHE
+      static_assert(false, "4bit kv cache + beam search is not implemented");
+#endif
+
+      loadPagesForBeamSearchAsync<grpLoadV ? gemm1WarpsPerGrp : 1U>(
+          grpLoadV ? warpIdxInGrp : 0U, dst, cacheList, false, idxReq, idxPageBeg, nbPages);
+#endif
+    };
+    uint32_t idxPageBeg =
+        nbPagesPerCtaTile * seqIterInit + cacheVTileSeqLen * warpGrpIdx / tokensPerPage;
+    loadPages(idxPageBeg);
+    auto nextStep = [&](uint32_t seqIter, uint32_t xIter, uint32_t vIter, uint32_t idxBeam) {
+      uint32_t vIterNext, isNextBeam;
+      mha::tie(vIterNext, isNextBeam) = carryLE<nbVItersPerXIter>(vIter + 1, 0);
+
+      uint32_t idxBeamNext, xIterNext, nNextBias;
+      mha::tie(idxBeamNext, xIterNext, nNextBias) =
+          isConvergedTile(seqIter)
+              ? carryLE<1, nbXItersPerCtaTile>(idxBeam + isNextBeam, xIter, 0)
+              : carryLE<beamWidth, nbXItersPerCtaTile>(idxBeam + isNextBeam, xIter, 0);
+
+      uint32_t const seqIterNext = seqIter + seqStrideIters * nNextBias;
+      return mha::tuple<uint32_t, uint32_t, uint32_t, uint32_t>(seqIterNext, xIterNext, vIterNext,
+                                                                idxBeamNext);
+    };
+    auto loadVTilePart = [&](uint32_t seqIter, uint32_t xIter, uint32_t vIter,
+                             uint32_t idxBeam) mutable {  // @fixme: merge three iteration
+                                                          // parameters into idxVTileGlb.
+      assert(idxBeam < beamWidth);
+      assert(seqIter % nbSubSeqPerSeq == seqIterInit % nbSubSeqPerSeq);
+      auto const idxNextSMemVBuf = idxCurrSMemVBuf.next();
+      auto& dst = getSmemVTile(idxNextSMemVBuf);
+#if ENABLE_4BIT_KV_CACHE
+      auto& dstSf = getSmemVSfTile(idxNextSMemVBuf);
+#endif
+      uint32_t const dstHeadOffset = 0;
+      constexpr bool vSwizzle = true;
+
+      uint32_t const seqOffset = ctaTile.x * seqIter + warpTile.x * nbXTilesPerXIter * xIter +
+                                 cacheVTileSeqStride * vIter + cacheVTileSeqLen * warpGrpIdx;
+      uint32_t const tokenOffset = seqOffset % tokensPerPage;
+
+#if BEAM_WIDTH == 1
+      HeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerVTile> const src{
+          cacheList.vCacheVLLM, pageIdx,         tokenOffset,   idxHeadGrp,
+          kv_stride_page,       kv_stride_token, kv_stride_head};
+#if ENABLE_4BIT_KV_CACHE
+      HeadPtr<GMemCacheHeadSf const, tokensPerPage, nbPagesPerVTile> const srcSf{
+          cacheList.vSfCacheVLLM, pageIdx,         tokenOffset,   idxHeadGrp,
+          kv_stride_page,         kv_stride_token, kv_stride_head};
+#endif
+#else
+      IndexedHeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerVTile> const src{
+          /*indices=*/smem.gemm1CacheIndir[grpLoadV ? warpGrpIdx : warpIdx.x].data,
+          /*pool=*/cacheList.vCacheVLLM,
+          /*pageIndices=*/smem.vCachePages[grpLoadV ? warpGrpIdx : warpIdx.x].data,
+          /*tokenOffset=*/tokenOffset,
+          /*headIdx=*/idxHeadGrp,
+          /*stride_page=*/kv_stride_page,
+          /*stride_token=*/kv_stride_token,
+          /*stride_head=*/kv_stride_head};
+      if constexpr (ENABLE_4BIT_KV_CACHE) {
+        // Not supported yet.
+        assert(!"not implemented");
+        trap();
+      }
+#endif
+      // if (threadIdx.x == dbgPrintTid) {
+      //     printf("V: seqIter=%u, xIter=%u, idxBeam=%u, vIter=%u: pointers={%p, %p}, indices={",
+      //     seqIter, xIter, idxBeam, vIter, src.pointers[0], src.pointers[1]); uint32_t const
+      //     nbHeadsAvail = mha::min((seqOffset < cacheSeqLen ? cacheSeqLen - seqOffset : 0U),
+      //     cacheVTileSeqLen); for (int i = 0; i < nbHeadsAvail; i++) {
+      //         printf("%u, ", src.indices[i]);
+      //     }
+      //     printf("}\n");
+      // }
+
+#if GRP_LOAD_V
+      uint32_t const nbHeadsAvail =
+          (seqIter + 1 < nbSeqIters)
+              ? cacheVTileSeqLen
+              : (seqOffset < cacheSeqLen
+                     ? cacheSeqLen - seqOffset
+                     : 0U);  // may also be full but it can be handled correctly anyway
+      copyHeadsAsync<PaddedCacheHead, cacheVTileSeqLen, gemm1WarpsPerGrp, grainBytes,
+                     grainBytesGmemCache, vSwizzle, false>(warpIdxInGrp, dst, src, nbHeadsAvail);
+#if ENABLE_4BIT_KV_CACHE
+      copyHeadsAsync<PaddedCacheHeadSf, cacheVTileSeqLen, gemm1WarpsPerGrp, grainBytesSf,
+                     grainBytesSf, false, false>(warpIdxInGrp, dstSf, srcSf, nbHeadsAvail);
+#endif
+
+#else
+      uint32_t const nbHeadsAvail =
+          (seqOffset < cacheSeqLen
+               ? cacheSeqLen - seqOffset
+               : 0U);  // may also be full but it can be handled correctly anyway
+      bool const isFullTile = (seqIter + 1 < nbSeqIters);
+      if (isFullTile) {
+        copyPartialHeadsAsync<PaddedCacheHead, cacheVTileSeqLen, gemm1WarpsPerGrp, grainBytes,
+                              grainBytesGmemCache, vSwizzle, true>(warp, dst, dstHeadOffset, src,
+                                                                   warpIdxInGrp);
+      } else {
+        uint32_t const nbHeadsAvail =
+            (seqOffset < cacheSeqLen
+                 ? cacheSeqLen - seqOffset
+                 : 0U);  // may also be full but it can be handled correctly anyway
+        copyPartialHeadsAsync<PaddedCacheHead, cacheVTileSeqLen, gemm1WarpsPerGrp, grainBytes,
+                              grainBytesGmemCache, vSwizzle, false>(
+            warp, dst, dstHeadOffset, src, warpIdxInGrp, mha::min(nbHeadsAvail, cacheVTileSeqLen));
+      }
+#if ENABLE_4BIT_KV_CACHE
+      copyPartialHeadsAsync<PaddedCacheHeadSf, cacheVTileSeqLen, gemm1WarpsPerGrp, grainBytesSf,
+                            grainBytesSf, false, true>(warp, dstSf, dstHeadOffset, srcSf,
+                                                       warpIdxInGrp);
+#endif
+#endif
+
+#if BEAM_WIDTH > 1
+      // to make sure all threads has finished usage of cache indir and pages
+      unused(arrive<grpLoadV>(pWarpGrpBar));
+      wait_parity<grpLoadV>(pWarpGrpBar, getAndFlip<grpLoadV>(warpGrpBarParityNext));
+#endif
+      constexpr uint32_t xIterSeqStride = cacheVTileSeqStride * nbVItersPerXIter;
+      if constexpr (xIterSeqStride <= tokensPerPage) {
+        uint32_t const nbXItersPerPage = exactDiv(tokensPerPage, xIterSeqStride);
+        assert(nbXItersPerPage <= nbXItersPerCtaTile);
+        if (xIter % nbXItersPerPage == nbXItersPerPage - 1 && vIter == nbVItersPerXIter - 1 &&
+            (idxBeam == beamWidth - 1 || isConvergedTile(seqIter))) {
+          auto const step = 1;  // cacheVTileSeqLen * gemm1NbWarpGrps / tokensPerPage;
+          idxPageBeg += (idxPageBeg % nbPagesPerCtaTile == nbPagesPerCtaTile - 1
+                             ? nbPagesPerCtaTile * (nbSubSeqPerSeq - 1) + step
+                             : step);
+          assert(beamWidth == 1 ||
+                 cacheVTileSeqStride <= tokensPerPage &&
+                     "todo: need to substrate from idxPageBeg for beam switching");
+          loadPages(idxPageBeg);
+        }
+      } else {
+        constexpr auto step_per_viter = exactDiv(cacheVTileSeqStride, tokensPerPage);
+        bool const isLastVIter = (vIter == nbVItersPerXIter - 1);
+        bool const isLastBeam = (idxBeam == beamWidth - 1 || isConvergedTile(seqIter));
+        if (isLastVIter && isLastBeam) {
+          idxPageBeg += (idxPageBeg % nbPagesPerCtaTile + step_per_viter >= nbPagesPerCtaTile
+                             ? nbPagesPerCtaTile * (nbSubSeqPerSeq - 1) + step_per_viter
+                             : step_per_viter);
+          loadPages(idxPageBeg);
+        } else if (isLastVIter) {
+          idxPageBeg -= step_per_viter * (nbVItersPerXIter - 1);
+          loadPages(idxPageBeg);
+        } else {
+          idxPageBeg += step_per_viter;
+          loadPages(idxPageBeg);
+        }
+      }
+#if BEAM_WIDTH > 1
+      uint32_t seqIterNext, xIterNext, vIterNext, idxBeamNext;
+      mha::tie(seqIterNext, xIterNext, vIterNext, idxBeamNext) =
+          nextStep(seqIter, xIter, vIter, idxBeam);
+      loadCacheIndir(seqIterNext, xIterNext, vIterNext, idxBeamNext);
+#endif
+    };
+    auto commitVTileLoad = [&](uint32_t idxVBar) {
+#if GRP_LOAD_V
+      auto& bar = *getSmemVBar(idxVBar);
+      ldgsts::barArrive(bar, true);
+#else
+      ldgsts::commitGroup();
+#endif
+    };
+    auto syncVTileLoad = [&](uint32_t idxVBar, ParityOrNone<grpLoadV> parity,
+                             bool alreadyComplete) {
+#if GRP_LOAD_V
+      if (alreadyComplete) {
+        return;
+      }
+      SharedMem::Barrier& bar = *getSmemVBar(idxVBar);
+      bar.wait_parity(parity);
+#else
+      assert(!alreadyComplete);
+      ldgsts::waitGroup<nbVBuffers - 1>();
+#endif
+    };
+    auto testVTileLoad = [&](uint32_t idxVBar, ParityOrNone<grpLoadV> parity) {
+      return test_wait_parity<grpLoadV>(getSmemVBar(idxVBar), parity);
+    };
+
+#if BEAM_WIDTH > 1
+    // synchronize first page/cacheIndir loading to shared memory
+    ldgsts::commitGroup();
+    ldgsts::waitGroup<0>();
+    unused(arrive<grpLoadV>(pWarpGrpBar));
+    wait_parity<grpLoadV>(pWarpGrpBar, getAndFlip<grpLoadV>(warpGrpBarParityNext));
+#endif
+
+    loadVTilePart(seqIterInit, 0, 0, 0);
+    commitVTileLoad(idxCurrSMemVBuf.next());
+    idxCurrSMemVBuf++;
+    ParityOrNone<grpLoadV> vBarParity{};
+    // @fixme: do prefetch for next iter tile if last part
+
+    ThrdRegRowMax globalRowMax;
+    globalRowMax.fill(safeInitRowMax);
+    ThrdRegRowMax globalRowSum;
+    globalRowSum.fill(0);
+    // the accumulator
+    WarpAcc acc{};
+    if (grpLoadV) {
+      unused(pWarpGrpBar->arrive());
+    }
+    bool xBarProducedParityNext = false;
+    for (uint32_t seqIter = seqIterInit; seqIter < nbSeqIters; seqIter += seqStrideIters) {
+#pragma unroll
+      for (uint32_t xIter = 0; xIter < nbXItersPerCtaTile; xIter++) {
+        uint32_t const idxXTile = xIter * nbXTilesPerXIter + warpGrpIdx / nbCacheVTilesPerXTile;
+        assert(idxXTile < ctaShapeInWarps.x);
+#if SHORT_SEQ_OPT
+        if (ctaTile.x * seqIter + warpTile.x * idxXTile >= cacheSeqLen) {
+          break;
+        }
+#endif
+        auto const& smemXTile = smem.x[warpIdx.y][idxXTile];
+        auto& xBar = smem.xBarriers[warpIdx.y][idxXTile];
+        ThrdRegRowMax xRowScales;
+        UniformRescaleMask xRowNeedRescaleMask;  // expect storage in UR
+        bool skipXRowRescale;
+        for (uint32_t idxBeam = 0; idxBeam < (isConvergedTile(seqIter) ? 1U : beamWidth);
+             idxBeam++) {
+#pragma unroll
+          for (uint32_t vIter = 0; vIter < nbVItersPerXIter; vIter++) {
+            bool const vTestConsumed =
+                test_wait_parity<grpLoadV>(pWarpGrpBar, warpGrpBarParityNext);
+            constexpr bool syncVTileEarly =
+                (beamWidth > 1);  // alternative is to use double buffer for cacheIndir and pages
+            bool vTestProduced = syncVTileEarly && testVTileLoad(idxCurrSMemVBuf, vBarParity);
+            auto isLastVBuf = [&] { return (idxCurrSMemVBuf == idxCurrSMemVBuf.nbBuffers - 1); };
+            uint32_t const idxVTileInsideXIter = gemm1NbWarpGrps * vIter + warpGrpIdx;
+            uint32_t const idxVTile = idxVTileInsideXIter % nbCacheVTilesPerXTile;  // inside XTile.
+            assert(idxVTile < nbCacheVTilesPerXTile);
+            uint32_t nNext, xIterNext, vIterNext, idxBeamNext;
+            mha::tie(nNext, xIterNext, vIterNext, idxBeamNext) =
+                nextStep(seqIter, xIter, vIter, idxBeam);
+            if constexpr (syncVTileEarly) {
+              // sync early to make sure that cacheIndir and pages has been loaded. The last loaded
+              // V tile is also sync'ed at the same time.
+              syncVTileLoad(idxCurrSMemVBuf, vBarParity, vTestProduced);
+              if (idxCurrSMemVBuf == idxCurrSMemVBuf.nbBuffers - 1) {
+                flip<grpLoadV>(vBarParity);
+              }
+            }
+            if (!vTestConsumed) {
+              wait_parity<grpLoadV>(pWarpGrpBar, warpGrpBarParityNext);
+            }
+            flip<grpLoadV>(warpGrpBarParityNext);
+            loadVTilePart(nNext, xIterNext, vIterNext, idxBeamNext);
+            commitVTileLoad(idxCurrSMemVBuf.next());
+            // @fixme: do L2 cache prefetch for next iter tile
+
+            if constexpr (!syncVTileEarly) {
+              vTestProduced = testVTileLoad(idxCurrSMemVBuf, vBarParity);
+            }
+
+            if (idxBeam == 0 && vIter == 0) {
+              xBar.produced.wait_parity(xBarProducedParityNext);
+              auto const& smemRowMax = smem.warpRowMax[warpIdx.y][idxXTile];
+              auto const& smemRowSum = smem.warpRowSum[warpIdx.y][idxXTile];
+              // update globalRowMax
+              ThrdRegRowMax xTileRowMax;
+              ThrdRegRowMax xTileRowSum;
+              UniformRescaleMask needRescaleMask;
+#pragma unroll
+              for (uint32_t i = 0; i < ThrdRegRowMax::size; i++) {
+                xTileRowMax[i] = smemRowMax[warp_size * i + laneId()];
+                xTileRowSum[i] = smemRowSum[warp_size * i + laneId()];
+                assert(__ballot_sync(~0U, laneId() == 0) == 1U);
+                assert(__ballot_sync(~0U, laneId() == 0) == 1U);
+                needRescaleMask[i] = __ballot_sync(~0U, xTileRowMax[i] != globalRowMax[i]);
+              }
+              bool const skipAllRescale = !any(needRescaleMask);
+              if (skipAllRescale) {
+                skipXRowRescale = true;
+#if CTA_ROW_MAX_BACKWARD_METHOD == 3
+                if (idxXTile == warpIdx.x) {
+                  unused(smem.ctaRowMaxBwdBarriers[warpIdx.y][warpIdx.x].arrive());
+                }
+#endif
+              } else {
+                ThrdRegRowMax const globalRowMaxOld = globalRowMax;
+                UniformRescaleMask accRowNeedRescaleMask;
+#pragma unroll
+                for (uint32_t i = 0; i < ThrdRegRowMax::size; i++) {
+                  accRowNeedRescaleMask[i] =
+                      __ballot_sync(~0U, xTileRowMax[i] > globalRowMaxOld[i]);
+                  xRowNeedRescaleMask[i] = (needRescaleMask[i] & ~accRowNeedRescaleMask[i]);
+                  assert(xRowNeedRescaleMask[i] ==
+                         __ballot_sync(~0U, xTileRowMax[i] < globalRowMaxOld[i]));
+                  globalRowMax[i] = fmaxf(globalRowMaxOld[i], xTileRowMax[i]);
+                }
+                skipXRowRescale = !any(xRowNeedRescaleMask);
+
+#if CTA_ROW_MAX_BACKWARD_METHOD == 1 || CTA_ROW_MAX_BACKWARD_METHOD == 2 || \
+    CTA_ROW_MAX_BACKWARD_METHOD == 3
+                // update smem.ctaRowMax.
+                if (idxXTile == warpIdx.x) {
+                  smem.ctaRowMax[warpIdx.y][warpIdx.x].storeFromReg<false>(warp, globalRowMax);
+#if CTA_ROW_MAX_BACKWARD_METHOD == 3
+                  unused(smem.ctaRowMaxBwdBarriers[warpIdx.y][warpIdx.x].arrive());
+#endif
+                }
+#elif CTA_ROW_MAX_BACKWARD_METHOD == 4
+                // update smem.ctaRowMax.
+                // smem.ctaRowMax[warpIdx.y].storeFromReg<true>(warp, globalRowMax);
+                smem.ctaRowMax[warpIdx.y].atomicMaxUpdate(warp, globalRowMax);
+#endif
+                // update row sum and acc
+                if (!enableMicroFastPath || any(accRowNeedRescaleMask)) {
+                  ThrdRegRowMax const accRowScales = expf(globalRowMaxOld - globalRowMax);
+                  globalRowSum = globalRowSum * accRowScales;
+                  // @fixme: when tmpAcc is used, this can be delayed.
+                  rescaleAcc(warp, acc, accRowNeedRescaleMask, accRowScales);
+                }
+                if (!enableMicroFastPath || !skipXRowRescale) {
+                  xRowScales = skipXRowRescale ? xRowScales : expf(xTileRowMax - globalRowMax);
+                  xTileRowSum = skipXRowRescale ? xTileRowSum : xTileRowSum * xRowScales;
+                }
+              }
+              globalRowSum = globalRowSum + xTileRowSum;
+            }
+            if constexpr (!syncVTileEarly) {
+              syncVTileLoad(idxCurrSMemVBuf, vBarParity, vTestProduced);
+              if (idxCurrSMemVBuf == idxCurrSMemVBuf.nbBuffers - 1) {
+                flip<grpLoadV>(vBarParity);
+              }
+            }
+            auto const& smemVTile = getSmemVTile(idxCurrSMemVBuf);
+#if ENABLE_4BIT_KV_CACHE
+            auto const& smemVSfPart = getSmemVSfTile(idxCurrSMemVBuf);
+#endif
+
+            // do computation from shared memory X and V tiles
+#if BEAM_WIDTH == 1
+            smemXVPartGemm<CacheElem>(warp, acc, skipXRowRescale, xRowNeedRescaleMask, xRowScales,
+                                      smemXTile, idxVTile, smemVTile,
+#if ENABLE_4BIT_KV_CACHE
+                                      smemVSfPart,
+#endif
+                                      grpLoadV ? warpIdxInGrp : 0);
+#else
+            WarpAcc tmpAcc{};
+            smemXVPartGemm<CacheElem>(warp, tmpAcc, skipXRowRescale, xRowNeedRescaleMask,
+                                      xRowScales, smemXTile, idxVTile, smemVTile,
+#if ENABLE_4BIT_KV_CACHE
+                                      smemVSfPart,
+#endif
+                                      grpLoadV ? warpIdxInGrp : 0);
+            pickAccRowsForBeamSearch(warp, acc, tmpAcc, isConvergedTile(seqIter), idxBeam,
+                                     [](float& d, float s) { d += s; });
+#endif
+            if (grpLoadV) {
+              unused(pWarpGrpBar->arrive());
+            }
+            idxCurrSMemVBuf++;
+          }
+        }  // idxBeam
+        xBar.consumed.arrive();
+      }  // xIter
+      flip(xBarProducedParityNext);
+    }  // seqIter
+
+    auto const fullRescaleMask = UniformRescaleMask::filled(~0U);
+
+    constexpr bool needMergeGlobal = (gemm1NbWarpGrps > 1 && nbXTilesPerXIter > 1);
+    if constexpr (needMergeGlobal) {
+      assert(gemm1NbWarpGrps != 1);
+      __syncthreads();
+      smem.warpRowMax[warpIdx.y][warpIdx.x].template storeFromReg<false>(warp, globalRowMax);
+      smem.warpRowSum[warpIdx.y][warpIdx.x].template storeFromReg<false>(warp, globalRowSum);
+      __syncthreads();
+      for (uint32_t i = 1; i < nbXTilesPerXIter; i++) {  // i = 0 is for self and we can skip
+        static_assert(nbXTilesPerXIter * nbWarpGrpsPerXTile == gemm1NbWarpGrps);
+        uint32_t const otherWarpGrpIdx = (warpGrpIdx + nbWarpGrpsPerXTile * i) % gemm1NbWarpGrps;
+        uint32_t const otherWarpIdx = warpIdxInGrp + gemm1WarpsPerGrp * otherWarpGrpIdx;
+        assert(
+            all(smem.warpRowMax[warpIdx.y][otherWarpIdx].template loadToReg<false>(warp) ==
+                smem.warpRowMax[warpIdx.y][otherWarpIdx - warpIdxInGrp].template loadToReg<false>(
+                    warp)));
+        auto const otherRowMax =
+            smem.warpRowMax[warpIdx.y][otherWarpIdx].template loadToReg<false>(warp);
+        auto const otherRowSum =
+            smem.warpRowSum[warpIdx.y][otherWarpIdx].template loadToReg<false>(warp);
+        auto const globalRowMaxNew = fmaxf(globalRowMax, otherRowMax);
+        auto const scaleForThis = expf(globalRowMax - globalRowMaxNew);
+        auto const scaleForOther = expf(otherRowMax - globalRowMaxNew);
+        rescaleAcc(warp, acc, fullRescaleMask, scaleForThis);
+        globalRowSum = globalRowSum * scaleForThis + otherRowSum * scaleForOther;
+        globalRowMax = globalRowMaxNew;
+      }
+    }
+
+    float voScale = (isKVCacheQuantized ? kvCacheScaleValue : 1.F);
+    if (seqIterInit < nbSeqIters) {  // otherwise rcpRowSum will be NAN.
+      // The attention sinks are moved to the multi-block reduction part if the multi-block is
+      // enabled.
+      if (!isMultiBlock && attentionSinks != nullptr) {
+        // Attention sinks are per head.
+#if SPEC_DEC
+        addAttentionSinksSpecDec(globalRowSum, globalRowMax,
+                                 attentionSinks + headGrpSize * idxHeadGrp, headGrpSize);
+#else
+        addAttentionSinks(globalRowSum, globalRowMax, attentionSinks + headGrpSize * idxHeadGrp);
+#endif
+      }
+      ThrdRegRowMax const rcpRowSum = __frcp_rn(globalRowSum);
+#if LOW_PREC_OUTPUT
+      voScale *= rcpOutScale;
+#endif
+      rescaleAcc(warp, acc, fullRescaleMask, rcpRowSum * ThrdRegRowMax::filled(voScale));
+    }
+    GemmOutRegTile const outTile = toFp16(acc);
+
+    auto mergeAndSaveOutTile = [&](GemmOutRegTile const& tile, bool reorder) {
+      if constexpr (gemm1NbWarpGrps == 1) {
+        // swizzle in shared memory and write output global memory
+        auto& outSwizzleBuffer = smem.x[warpIdx.y][warpIdx.x];
+        __syncthreads();
+        storeGemmOutTile(warp, outSwizzleBuffer, tile, reorder);
+        __syncwarp();
+        return &outSwizzleBuffer;
+      } else {
+        __syncthreads();
+        // store to shared memory, then merge groups.
+        using PostProcSMem =
+            SharedMem::XSmemBuffer[ctaShapeInWarps.y][gemm1WarpsPerGrp][gemm1NbWarpGrps];
+        static_assert(sizeof(PostProcSMem) <= smemSize);
+        SharedMem::XSmemBuffer(&postSMem)[gemm1NbWarpGrps] =
+            reinterpret_cast<PostProcSMem&>(smem)[warpIdx.y][warpIdxInGrp];
+        storeGemmOutTile(warp, postSMem[warpGrpIdx], tile, reorder);
+        __syncthreads();
+        smemFp16ArraySum<false, gemm1NbWarpGrps, gemm1NbWarpGrps>(warpGrpIdx, postSMem[0],
+                                                                  postSMem);
+        __syncthreads();
+        return &postSMem[0];
+      }
+    };
+
+    // merge results from different warp groups
+#if ENABLE_4BIT_KV_CACHE
+    bool reorderOutRows = false;
+#else
+    bool reorderOutRows = inputElemSize == 2 && cacheElemSize == 1;
+#endif
+    SharedMem::XSmemBuffer* smemOutTile = mergeAndSaveOutTile(outTile, reorderOutRows);
+    if (isMultiBlock) {
+      static_assert(ctaShapeInWarps.y == 1, "not implemented");
+#if SPEC_DEC
+      // Includes both kHeads and qTokens.
+      uint32_t const nbIndepHeadTokens = gridDim.y;
+      uint32_t const indepHeadTokenIdx = blockIdx.y;
+      uint32_t const nbSeq = nbIndepHeadTokens * batchSize;
+#else
+      uint32_t const nbSeq = nbKHeads * batchSize;
+#endif
+      uint32_t const nbSubSeq = nbSubSeqPerSeq * nbSeq;
+      MemSegmenter<false> segmenter{scratch};
+
+#if SPEC_DEC
+      uint32_t const idxSeq = nbIndepHeadTokens * idxReq + indepHeadTokenIdx;
+#else
+      uint32_t const idxSeq = nbKHeads * idxReq + idxHeadGrp;
+#endif
+      uint32_t const idxBufBase = nbSubSeqPerSeq * idxSeq;
+      uint32_t const idxBuf = idxBufBase + idxSubSeqInSeq;
+      // copy row max/sum
+      TinyPtr<SMemWarpRowMax> const rowMaxBuffers = segmenter.newSeg<SMemWarpRowMax>(nbSubSeq);
+      TinyPtr<SMemWarpRowMax> const rowSumBuffers = segmenter.newSeg<SMemWarpRowMax>(nbSubSeq);
+      if (warpGrpIdx == 0 && warpIdxInGrp == 0) {
+        rowMaxBuffers[idxBuf].storeFromReg<false>(warp, globalRowMax);
+        rowSumBuffers[idxBuf].storeFromReg<false>(warp, globalRowSum);
+      }
+      using ScratchBuf = Array2D<LdGrain, nbValidRows, SharedMem::XSmemBuffer::cols>;
+      TinyPtr<Vec<ScratchBuf, gemm1WarpsPerGrp>> const scratchBuffers =
+          segmenter.newSeg<Vec<ScratchBuf, gemm1WarpsPerGrp>>(nbSubSeq);
+      // copy output to scratch
+      copyGrains<false, nbValidRows * ScratchBuf::cols, gemm1NbWarpGrps>(
+          warpGrpIdx, &scratchBuffers[idxBuf][warpIdxInGrp](0, 0), &(*smemOutTile)(0, 0));
+      __syncthreads();
+      constexpr uint32_t nbTileBuffers = 2;
+
+      struct MultiBlockSMem {
+        bool isLastCta;
+
+        struct MBBuf {
+          SMemWarpRowMax rowMax;
+          SMemWarpRowMax rowSum;
+          SharedMem::XSmemBuffer tiles[gemm1NbWarpGrps][gemm1WarpsPerGrp][nbTileBuffers];
+          SMemWarpRowMax tileRowMax[gemm1NbWarpGrps][gemm1WarpsPerGrp][nbTileBuffers];
+          SMemWarpRowMax tileRowSums[gemm1NbWarpGrps][gemm1WarpsPerGrp][nbTileBuffers];
+          SMemWarpRowMax mergedRowSum[gemm1NbWarpGrps];
+        };
+
+        MBBuf storage[ctaShapeInWarps.y];
+      };
+
+      static_assert(sizeof(MultiBlockSMem) <= smemSize);
+      MultiBlockSMem& mbsmem = reinterpret_cast<MultiBlockSMem&>(smem);
+      // increase the semaphore by 1
+      if (warpIdx.y == 0 && warpGrpIdx == 0 && warpIdxInGrp == 0 && laneId() == 0) {
+        uint32_t old;
+        uint32_t const lastOld = nbSubSeqPerSeq - 1;
+        asm volatile("atom.acq_rel.gpu.global.inc.u32 %0, [%1], %2;\n"
+                     : "=r"(old)
+                     : "l"(&semaphores[idxSeq]), "r"(lastOld));
+        assert(old < nbSubSeqPerSeq);
+        mbsmem.isLastCta = (old == lastOld);
+      }
+      __syncthreads();
+
+      // merge if we are the last CTA.
+      bool const isLastCta = mbsmem.isLastCta;
+      if (isLastCta) {
+        MultiBlockSMem::MBBuf& mbbuf = mbsmem.storage[warpIdx.y];
+        SMemWarpRowMax& smemRowMax = reinterpret_cast<SMemWarpRowMax&>(smem);
+        // get row max.
+        if (warpIdx.x == 0) {
+          ThrdRegRowMax const mergedRowMax =
+              mergeRowMax<8>(warp, rowMaxBuffers + idxBufBase, nbSubSeqPerSeq);
+          smemRowMax.storeFromReg<false>(warp, mergedRowMax);
+        }
+        __syncthreads();
+        ThrdRegRowMax const mergedRowMax = smemRowMax.loadToReg<false>(warp);
+
+        // rescale and accumulate
+        auto getTileBuf = [&](auto& buffers, uint32_t d) -> decltype(buffers[0][0][0])& {
+          return buffers[warpGrpIdx][warpIdxInGrp][d];
+        };
+        auto loadBufAsync = [&](uint32_t n) {
+          uint32_t const d = n / gemm1NbWarpGrps % nbTileBuffers;
+          SharedMem::XSmemBuffer& dstTile = getTileBuf(mbbuf.tiles, d);
+          SMemWarpRowMax& dstRowSum = getTileBuf(mbbuf.tileRowSums, d);
+          SMemWarpRowMax& dstRowMax = getTileBuf(mbbuf.tileRowMax, d);
+          copyGrains<true, sizeof(ScratchBuf) / grainBytes, 1, true>(
+              0, &dstTile(0, 0), &scratchBuffers[idxBufBase + n][warpIdxInGrp](0, 0));
+          constexpr uint32_t nbGrainsPerRowMaxBuf = exactDiv(sizeof(SMemWarpRowMax), grainBytes);
+          copyGrains<true, roundUp(nbGrainsPerRowMaxBuf, 32u), 1, nbGrainsPerRowMaxBuf % 32 == 0>(
+              0, reinterpret_cast<LdGrain*>(&dstRowSum),
+              reinterpret_cast<LdGrain const*>(&rowSumBuffers[idxBufBase + n]),
+              nbGrainsPerRowMaxBuf);
+          copyGrains<true, roundUp(nbGrainsPerRowMaxBuf, 32u), 1, nbGrainsPerRowMaxBuf % 32 == 0>(
+              0, reinterpret_cast<LdGrain*>(&dstRowMax),
+              reinterpret_cast<LdGrain const*>(&rowMaxBuffers[idxBufBase + n]),
+              nbGrainsPerRowMaxBuf);
+        };
+        loadBufAsync(warpGrpIdx);
+        ldgsts::commitGroup();
+        WarpAcc sumAcc{};
+        ThrdRegRowMax partialMergedRowSum{};
+        for (uint32_t n = warpGrpIdx; n < nbSubSeqPerSeq; n += gemm1NbWarpGrps) {
+          if (n + gemm1NbWarpGrps < nbSubSeqPerSeq) {
+            loadBufAsync(n + gemm1NbWarpGrps);
+          }
+          ldgsts::commitGroup();
+          ldgsts::waitGroup<1>();
+          uint32_t const d = n / gemm1NbWarpGrps % nbTileBuffers;
+          WarpAcc tile = toWarpAcc(loadGemmOutTile(warp, mbbuf.tiles[warpGrpIdx][warpIdxInGrp][d]));
+          ThrdRegRowMax const tileRowMax = getTileBuf(mbbuf.tileRowMax, d).loadToReg<false>(warp);
+          ThrdRegRowMax const tileRowSum = getTileBuf(mbbuf.tileRowSums, d).loadToReg<false>(warp);
+          ThrdRegRowMax const tileRowScales = expf(tileRowMax - mergedRowMax);
+          ThrdRegRowMax const scaledTileRowSum = tileRowSum * tileRowScales;
+          partialMergedRowSum = partialMergedRowSum + scaledTileRowSum;
+          assert(std::isfinite(partialMergedRowSum[0]));
+          rescaleAcc(warp, tile, fullRescaleMask, scaledTileRowSum);
+          sumAcc = sumAcc + tile;
+        }
+
+        ThrdRegRowMax mergedRowSum{};
+        if (gemm1NbWarpGrps == 1) {
+          mergedRowSum = partialMergedRowSum;
+        } else {
+          if (warpIdxInGrp == 0) {
+            mbbuf.mergedRowSum[warpGrpIdx].storeFromReg<false>(warp, partialMergedRowSum);
+          }
+          __syncthreads();
+#ifndef NDEBUG
+          assert((mbbuf.mergedRowSum[warpGrpIdx].loadToReg<false>(warp) == partialMergedRowSum)[0]);
+          __syncthreads();
+#endif
+#pragma unroll
+          for (uint32_t i = 0; i < gemm1NbWarpGrps; i++) {
+            mergedRowSum = mergedRowSum + mbbuf.mergedRowSum[i].loadToReg<false>(warp);
+            assert(std::isfinite(mergedRowSum[0]));
+          }
+        }
+        if (attentionSinks != nullptr) {
+          // Attention sinks are per head.
+#if SPEC_DEC
+          addAttentionSinksSpecDec(mergedRowSum, mergedRowMax,
+                                   attentionSinks + headGrpSize * idxHeadGrp, headGrpSize);
+#else
+          addAttentionSinks(mergedRowSum, mergedRowMax, attentionSinks + headGrpSize * idxHeadGrp);
+#endif
+        }
+        __syncthreads();
+        rescaleAcc(warp, sumAcc, fullRescaleMask, __frcp_rn(mergedRowSum));
+        GemmOutRegTile const mergedOutTile = toFp16(sumAcc);
+        smemOutTile = mergeAndSaveOutTile(mergedOutTile, false);
+      }
+    }
+    if (warpGrpIdx == 0) {
+#if SPEC_DEC
+      copyOutputToGlobalMem(
+          warp, &output[reqSeqOffset * nbQHeads], nbQHeads, headGrpSize, (idxHeadGrp * headGrpSize),
+          nbValidHeadTokens,
+          uint2{warpTile.x * warpIdxInGrp, nbValidRows * warpIdx.y + idxHeadTokenInGrp},
+          *smemOutTile);
+#else
+      copyOutputToGlobalMem(warp, &output[nbQHeads * beamWidth * idxReq], nbQHeads, idxHeadGrp,
+                            uint2{warpTile.x * warpIdxInGrp, nbValidRows * warpIdx.y},
+                            *smemOutTile);
+#endif
+    }
+  }
+}
+
+#if SPEC_DEC
+#if __CUDA_ARCH__ == 900 && M_TILESIZE == 16
+constexpr uint32_t nbCtaPerSM = 2;
+#else
+constexpr uint32_t nbCtaPerSM = 1;
+#endif
+#else
+#if __CUDA_ARCH__ == 900
+constexpr uint32_t nbCtaPerSM = 2;
+#else
+constexpr uint32_t nbCtaPerSM = 1;
+#endif
+#endif
+
+CUBIN_EXPORT __device__ constexpr XQAKernelType kernelType =
+    XQAKernelType::kAMPERE_WARP_SPECIALIZED;
+
+#ifdef NDEBUG
+CUBIN_EXPORT __global__ __launch_bounds__(256, nbCtaPerSM) void kernel_mha(
+#if SPEC_DEC
+    uint32_t const qSeqLen, uint32_t const nbKHeads, uint32_t const headGrpSize,
+    SeqLenDataType const* qCuSeqLens,
+#else
+    uint32_t const nbKHeads,
+#endif
+#if SLIDING_WINDOW
+    uint32_t slidingWinSize,
+#endif
+    float qScale, float const* qScalePtr,
+    OutputHead* __restrict__ const output,  // [nbReq][beamWidth][nbQHeads]
+#if LOW_PREC_OUTPUT
+    float rcpOutScale,
+#endif
+    IOHead const* __restrict__ const q,  // [nbReq][beamWidth][nbQHeads],
+#if SPEC_DEC
+    MaskType const* __restrict__ mask,  // [qSeqLen, divUp(qSeqLen, 32))] uint2 (each bit represents
+                                        // mask for one col position).
+#endif
+    float const* attentionSinks,  // [headGrpSize]
+    KVCacheList<usePagedKVCache> const cacheList,
+#if BEAM_WIDTH > 1
+    BeamSearchParams const beamSearchParams,
+#endif
+    uint32_t const batchSize, float kvCacheScale,
+    float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
+    uint32_t kv_stride_page, uint32_t kv_stride_token, uint32_t kv_stride_head,
+    uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
+#if SPEC_DEC
+  kernel_mha_impl(qSeqLen, nbKHeads, headGrpSize, qCuSeqLens,
+#else
+  kernel_mha_impl(nbKHeads,
+#endif
+#if SLIDING_WINDOW
+                  slidingWinSize,
+#endif
+                  qScale, qScalePtr, output,
+#if LOW_PREC_OUTPUT
+                  rcpOutScale,
+#endif
+                  q,
+#if SPEC_DEC
+                  mask,
+#endif
+                  attentionSinks, cacheList,
+#if BEAM_WIDTH > 1
+                  beamSearchParams,
+#endif
+                  batchSize, kvCacheScale, kvScalePtr, kv_stride_page, kv_stride_token,
+                  kv_stride_head, semaphores, scratch);
+}
+#else
+static constexpr auto kernel_mha = kernel_mha_impl;
+#endif
+
+#ifndef GENERATE_CUBIN
+void launchMHA(
+    cudaDeviceProp const& prop, uint32_t nbKHeads,
+#if SLIDING_WINDOW
+    uint32_t slidingWinSize,
+#endif
+    float qScale, float const* qScalePtr, OutputHead* output,
+#if LOW_PREC_OUTPUT
+    float rcpOutScale,
+#endif
+#if USE_INPUT_KV
+    InputHead const* qkv,
+#if ROPE_STYLE != 0
+    Vec<float, validElemsPerHead> const* ropeCosSin,
+#endif
+#else
+    InputHead const* q,
+#endif
+    float const* attentionSinks,  // [headGrpSize]
+    GMemCacheHead* kCacheVLLM, GMemCacheHead* vCacheVLLM,
+#if ENABLE_4BIT_KV_CACHE
+    GMemCacheHeadSf* kSfCacheVLLM, GMemCacheHeadSf* vSfCacheVLLM,
+#endif
+    KVCachePageIndex const*
+        kvCachePageList,  // device pointer. shape:
+                          // KVCachePageIndex[batchSize][beamWidth][2][maxNbPagesPerSeq].
+    uint32_t maxSeqLen, uint32_t const* seqLen,
+#if BEAM_WIDTH > 1
+    BeamSearchParams const& beamSearchParams,
+#endif
+    uint32_t batchSize, float kvCacheScale,
+    float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
+#if SPEC_DEC
+    SpecDecParams const& specDecParams,
+#endif
+    uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
+    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream) {
+#if SPEC_DEC
+  auto const qSeqLen = specDecParams.qSeqLen;
+  auto const qCuSeqLens = specDecParams.qCuSeqLens;
+  auto const mask = specDecParams.mask;
+#endif
+#if USE_INPUT_KV
+  throw std::runtime_error("not implemented");
+#else
+  static uint32_t const hostSmemSize = [&]() {
+    uint32_t size;
+    checkCuda(cudaMemcpyFromSymbol(&size, smemSize, sizeof(smemSize)));
+    checkCuda(cudaFuncSetAttribute(kernel_mha, cudaFuncAttributeMaxDynamicSharedMemorySize, size));
+    return size;
+  }();
+  uint32_t const nbVHeads = nbKHeads;
+  uint32_t const nbQHeads = nbKHeads * headGrpSize;
+
+  // const uint32_t nbSubSeqPerSeq = allowMultiBlockMode ? DBG_NB_CTAS_PER_SEQ : 1;
+  uint32_t const nbSubSeqPerSeq = [&]() -> uint32_t {
+    if (!allowMultiBlockMode) {
+      return 1;
+    }
+    auto const env = std::getenv("XQA_NB_SUB_SEQ");
+    if (env != nullptr) {
+      int32_t const val = std::stoi(env);
+      if (val > 0) {
+        return val;
+      }
+    }
+    return std::min<uint32_t>(
+        std::max<uint32_t>(1U, prop.multiProcessorCount / (batchSize * nbKHeads)),
+        divUp(maxSeqLen, ctaTile.x));
+  }();
+  // gridDim.z == batchSize && gridDim.y == nbKHeads && gridDim.x == nbSubSeqPerSeq
+#if SPEC_DEC
+  const uint32_t nbTokenBlocksPerGrp = divUp(qSeqLen * headGrpSize, rowsPerBlock);
+  dim3 const dimGrid{nbSubSeqPerSeq, nbKHeads * nbTokenBlocksPerGrp, batchSize};
+#else
+  dim3 const dimGrid{nbSubSeqPerSeq, nbKHeads, batchSize};
+#endif
+  dim3 const dimCta{warp_size * ctaShapeInWarps.x, ctaShapeInWarps.y, ctaShapeInWarps.z};
+  auto const launchCfg = makeLaunchConfig(dimGrid, dimCta, hostSmemSize, stream, enable_pdl);
+  uint32_t const maxNbPagesPerSeq = exactDiv(maxSeqLen, tokensPerPage);
+  KVCacheList<true> const cacheList{kCacheVLLM,      vCacheVLLM,
+#if ENABLE_4BIT_KV_CACHE
+                                    kSfCacheVLLM,    vSfCacheVLLM,
+#endif
+                                    kvCachePageList, seqLen,       maxNbPagesPerSeq};
+  // Convert stride from elements to Heads
+  uint32_t const stride_page_in_heads = static_cast<uint32_t>(kv_stride_page / validElemsPerHead);
+  uint32_t const stride_token_in_heads = static_cast<uint32_t>(kv_stride_token / validElemsPerHead);
+  uint32_t const stride_head_in_heads = static_cast<uint32_t>(kv_stride_head / validElemsPerHead);
+
+  cudaLaunchKernelEx(&launchCfg, kernel_mha,
+#if SPEC_DEC
+                     qSeqLen, nbKHeads, headGrpSize, qCuSeqLens,
+#else
+                     nbKHeads,
+#endif
+#if SLIDING_WINDOW
+                     slidingWinSize,
+#endif
+                     qScale, qScalePtr, output,
+#if LOW_PREC_OUTPUT
+                     rcpOutScale,
+#endif
+                     q,
+#if SPEC_DEC
+                     mask,
+#endif
+                     attentionSinks, cacheList,
+#if BEAM_WIDTH > 1
+                     beamSearchParams,
+#endif
+                     batchSize, kvCacheScale, kvScalePtr, stride_page_in_heads,
+                     stride_token_in_heads, stride_head_in_heads, semaphores, scratch);
+  checkCuda(cudaPeekAtLastError());
+#endif  // USE_INPUT_KV
+}
+#endif
+
+static uint32_t configureKernel() {
+  uint32_t size;
+  cudaMemcpyFromSymbol(&size, smemSize, sizeof(smemSize));
+  cudaFuncSetAttribute(kernel_mha, cudaFuncAttributeMaxDynamicSharedMemorySize, size);
+  return size;
+}
+
+static uint32_t const hostSmemSize = configureKernel();
+
+void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32_t slidingWinSize,
+                         float qScale, float const* qScalePtr, OutputHead* output,
+#if LOW_PREC_OUTPUT
+                         float rcpOutScale,
+#endif
+                         InputHead const* q, float const* attentionSinks, GMemCacheHead* kCacheVLLM,
+                         GMemCacheHead* vCacheVLLM,
+#if ENABLE_4BIT_KV_CACHE
+                         GMemCacheHeadSf* kSfCacheVLLM, GMemCacheHeadSf* vSfCacheVLLM,
+#endif
+                         KVCachePageIndex const* kvCachePageList, uint32_t maxSeqLen,
+                         uint32_t const* seqLen, uint32_t batchSize, float kvCacheScale,
+                         float const* kvScalePtr,
+#if SPEC_DEC
+                         uint32_t qSeqLen, uint32_t const* qCuSeqLens, MaskType const* mask,
+#endif
+                         uint32_t* semaphores, void* scratch, bool enable_pdl,
+                         uint64_t kv_stride_page, uint64_t kv_stride_token, uint64_t kv_stride_head,
+                         cudaStream_t stream) {
+  uint32_t const nbSubSeqPerSeq = [&]() -> uint32_t {
+    if (!allowMultiBlockMode) {
+      return 1;
+    }
+    return std::min<uint32_t>(std::max<uint32_t>(1U, multiProcessorCount / (batchSize * nbKHeads)),
+                              divUp(maxSeqLen, ctaTile.x));
+  }();
+#if SPEC_DEC
+  const uint32_t nbTokenBlocksPerGrp = divUp(qSeqLen * headGrpSize, rowsPerBlock);
+  dim3 const dimGrid{nbSubSeqPerSeq, nbKHeads * nbTokenBlocksPerGrp, batchSize};
+#else
+  dim3 const dimGrid{nbSubSeqPerSeq, nbKHeads, batchSize};
+#endif
+  dim3 const dimCta{warp_size * ctaShapeInWarps.x, ctaShapeInWarps.y, ctaShapeInWarps.z};
+  auto const launchCfg = makeLaunchConfig(dimGrid, dimCta, hostSmemSize, stream, enable_pdl);
+  uint32_t const maxNbPagesPerSeq = exactDiv(maxSeqLen, tokensPerPage);
+  KVCacheList<true> const cacheList{kCacheVLLM,      vCacheVLLM,
+#if ENABLE_4BIT_KV_CACHE
+                                    kSfCacheVLLM,    vSfCacheVLLM,
+#endif
+                                    kvCachePageList, seqLen,       maxNbPagesPerSeq};
+  // Convert stride from elements to Heads
+  uint32_t const container_elems_per_head =
+      validElemsPerHead / CacheElemConverter::ElemsPerContainer;
+  uint32_t const stride_page_in_heads =
+      static_cast<uint32_t>(kv_stride_page / container_elems_per_head);
+  uint32_t const stride_token_in_heads =
+      static_cast<uint32_t>(kv_stride_token / container_elems_per_head);
+  uint32_t const stride_head_in_heads =
+      static_cast<uint32_t>(kv_stride_head / container_elems_per_head);
+
+  cudaLaunchKernelEx(&launchCfg, kernel_mha,
+#if SPEC_DEC
+                     qSeqLen, nbKHeads, headGrpSize, qCuSeqLens,
+#else
+                     nbKHeads,
+#endif
+#if SLIDING_WINDOW
+                     slidingWinSize,
+#endif
+                     qScale, qScalePtr, output,
+#if LOW_PREC_OUTPUT
+                     rcpOutScale,
+#endif
+                     q,
+#if SPEC_DEC
+                     mask,
+#endif
+                     attentionSinks, cacheList, batchSize, kvCacheScale, kvScalePtr,
+                     stride_page_in_heads, stride_token_in_heads, stride_head_in_heads, semaphores,
+                     scratch);
+  checkCuda(cudaPeekAtLastError());
+}
+#endif

--- a/csrc/attention/flashinfer_xqa_src/mha.h
+++ b/csrc/attention/flashinfer_xqa_src/mha.h
@@ -1,0 +1,270 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef __CUDACC__
+#include <cuda_runtime_api.h>
+#endif
+#include "defines.h"
+#include "utils.h"
+#if SPEC_DEC
+#include "specDec.h"
+#endif
+using CacheElemConverter = ElemTypeConverter<CACHE_ELEM_ENUM>;
+using CacheElem = CacheElemConverter::Type;
+constexpr uint32_t validElemsPerHead = HEAD_ELEMS;
+constexpr bool isMLA = IS_MLA;
+static_assert((isMLA || validElemsPerHead <= 256) &&
+              (sizeof(CacheElem) * validElemsPerHead) % 16 == 0);
+constexpr uint32_t headElems =
+    validElemsPerHead <= 64 ? 64 : (validElemsPerHead <= 128 ? 128 : (isMLA ? 576 : 256));
+static_assert(headElems == 64 || headElems == 128 || headElems == 256 || headElems == 576,
+              "not implemented");
+constexpr uint32_t beamWidth = BEAM_WIDTH;
+constexpr uint32_t headGrpSize = HEAD_GRP_SIZE;
+#if SPEC_DEC
+__device__ constexpr uint32_t rowsPerBlock = M_TILESIZE;
+#endif
+
+inline constexpr bool useSpecDec = SPEC_DEC;
+
+using InputElem = INPUT_ELEM;
+using InputElem2 = INPUT_ELEM2;
+#if !(SPEC_DEC)
+constexpr uint32_t inputSeqLen = 1;  // speculative decoding if > 1
+#endif
+
+constexpr bool useKVCache = USE_KV_CACHE;
+
+using SeqLenDataType = uint32_t;
+
+constexpr bool usePagedKVCache = true;
+constexpr uint32_t tokensPerPage = TOKENS_PER_PAGE;
+
+using IOHead = Vec<InputElem, validElemsPerHead>;
+using InputHead = IOHead;
+using GMemCacheHead = Vec<CacheElemConverter::ContainerType,
+                          exactDiv(validElemsPerHead, CacheElemConverter::ElemsPerContainer)>;
+#if ENABLE_4BIT_KV_CACHE
+using GMemCacheHeadSf = Vec<CacheElemConverter::ScalingFactorType,
+                            exactDiv(validElemsPerHead, CacheElemConverter::QuantVectorSize)>;
+#endif
+
+constexpr uint32_t validElemsPerKHead = validElemsPerHead;
+constexpr bool lowPrecOutput = LOW_PREC_OUTPUT;
+
+#if IS_MLA
+constexpr uint32_t validElemsPerVHead = 512;
+static_assert(lowPrecOutput == false);
+using OutputHead = Vec<__nv_bfloat16, validElemsPerVHead>;
+#else
+constexpr uint32_t validElemsPerVHead = validElemsPerHead;
+using OutputHead = mha::conditional_t<lowPrecOutput, GMemCacheHead, InputHead>;
+#endif
+using OutputElem = OutputHead::Elem;
+
+using PaddedInputHead = Vec<InputElem, headElems>;
+// For 4 bit KV cache, each 16 elements (64b) are padded with 64b to match 128b banks.
+using PaddedCacheHead = Vec<CacheElemConverter::ContainerType, headElems>;
+
+#if ENABLE_4BIT_KV_CACHE
+using PaddedCacheHeadSf =
+    Vec<CacheElemConverter::ScalingFactorType, headElems / CacheElemConverter::QuantVectorSize>;
+#endif
+
+// impl detail, may be moved to mha.cu/mha_sm90.cu
+constexpr bool isHeadPadded = (validElemsPerHead != headElems);
+
+constexpr bool useInputKV = USE_INPUT_KV;
+
+using GMemKVCacheHead = mha::conditional_t<useInputKV, GMemCacheHead, GMemCacheHead const>;
+
+using KVCachePageIndex =
+    int32_t;  // shape: KVCacheHead[nbKHeads][tokensPerPage]. Page index in the global pool of pages
+
+constexpr bool allowSlidingWindow = SLIDING_WINDOW;
+
+struct BeamSearchParams {
+  uint32_t const* __restrict__ indices;  // shape: [batchSize][beamWidth][capacity]
+  uint32_t capacity;
+  uint32_t const* __restrict__ ctxLenList;  // shape: [batchSize][beamWidth]. Should be [batchSize]
+                                            // but we have to match trt-llm API.
+};
+
+void launchMHA(
+    cudaDeviceProp const& prop, uint32_t const nbKHeads,
+#if SLIDING_WINDOW
+    uint32_t slidingWinSize,
+#endif
+    float qScale, float const* qScalePtr, OutputHead* output,
+#if LOW_PREC_OUTPUT
+    float rcpOutScale,
+#endif
+#if USE_INPUT_KV
+    InputHead const* qkv,
+#if ROPE_STYLE != 0
+    Vec<float, validElemsPerHead> const* ropeCosSin,
+#endif
+#else
+    InputHead const* q,
+#endif
+    float const* attentionSinks,  // [headGrpSize]
+    GMemCacheHead* kCacheVLLM, GMemCacheHead* vCacheVLLM,
+#if ENABLE_4BIT_KV_CACHE
+    GMemCacheHeadSf* kSfCacheVLLM, GMemCacheHeadSf* vSfCacheVLLM,
+#endif
+
+    KVCachePageIndex const*
+        kvCachePageList,  // device pointer. shape:
+                          // KVCachePage[batchSize][beamWidth][2][maxNbPagesPerSeq]
+    uint32_t maxSeqLen, uint32_t const* seqLen,
+#if BEAM_WIDTH > 1
+    BeamSearchParams const& beamSearchParams,
+#endif
+    uint32_t batchSize, float kvCacheScale,
+    float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
+#if SPEC_DEC
+    SpecDecParams const& specDecParams,
+#endif
+    uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
+    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream);
+
+void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32_t slidingWinSize,
+                         float qScale, float const* qScalePtr, OutputHead* output,
+#if LOW_PREC_OUTPUT
+                         float rcpOutScale,
+#endif
+                         InputHead const* q, float const* attentionSinks, GMemCacheHead* kCacheVLLM,
+                         GMemCacheHead* vCacheVLLM,
+#if ENABLE_4BIT_KV_CACHE
+                         GMemCacheHeadSf* kSfCacheVLLM, GMemCacheHeadSf* vSfCacheVLLM,
+#endif
+                         KVCachePageIndex const* kvCachePageList, uint32_t maxSeqLen,
+                         uint32_t const* seqLen, uint32_t batchSize, float kvCacheScale,
+                         float const* kvScalePtr,
+#if SPEC_DEC
+                         uint32_t qSeqLen, uint32_t const* qCuSeqLens, MaskType const* mask,
+#endif
+                         uint32_t* semaphores, void* scratch, bool enable_pdl,
+                         uint64_t kv_stride_page, uint64_t kv_stride_token, uint64_t kv_stride_head,
+                         cudaStream_t stream);
+
+void launchHopperF8MHA(
+    cudaDeviceProp const& prop, uint32_t nbKHeads,
+#if SLIDING_WINDOW
+    uint32_t slidingWinSize,
+#endif
+    float qScale, float const* qScalePtr, OutputHead* output,
+#if LOW_PREC_OUTPUT
+    float rcpOutScale,
+#endif
+#if USE_INPUT_KV
+    InputHead const* qkv,
+#if ROPE_STYLE != 0
+    Vec<float, validElemsPerHead> const* ropeCosSin,
+#endif
+#else
+    InputHead const* q,
+#endif
+    float const* attentionSinks,  // [headGrpSize]
+    GMemCacheHead* kCacheVLLM, GMemCacheHead* vCacheVLLM,
+    KVCachePageIndex const*
+        kvCachePageList,  // device pointer. shape:
+                          // KVCachePageIndex[batchSize][beamWidth][2][maxNbPagesPerSeq].
+    uint32_t maxSeqLen, uint32_t const* seqLen,
+#if BEAM_WIDTH > 1
+    BeamSearchParams const& beamSearchParams,
+#endif
+    uint32_t batchSize, float kvCacheScale,
+    float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
+#if SPEC_DEC
+    SpecDecParams const& specDecParams,
+#endif
+    uint32_t* semaphores, void* scratch, bool enable_pdl, cudaStream_t stream);
+
+void launchHopperF8MHAFlashInfer(
+    uint32_t multiProcessorCount, uint32_t nbKHeads, uint32_t slidingWinSize, float qScale,
+    float const* qScalePtr, OutputHead* output,
+#if LOW_PREC_OUTPUT
+    float rcpOutScale,
+#endif
+    InputHead const* q, float const* attentionSinks, GMemCacheHead* kCacheVLLM,
+    GMemCacheHead* vCacheVLLM, KVCachePageIndex const* kvCachePageList, uint32_t maxSeqLen,
+    uint32_t const* seqLen, uint32_t batchSize, float kvCacheScale, float const* kvScalePtr,
+#if SPEC_DEC
+    uint32_t qSeqLen, uint32_t const* qCuSeqLens, MaskType const* mask,
+#endif
+    uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
+    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream);
+
+void launchMLA(
+    cudaDeviceProp const& prop,
+    uint32_t inputSeqLen,  // uniform for all requests and causal mask is assumed
+    float qScale, float const* qScalePtr, OutputHead* output, InputHead const* q,
+    GMemCacheHead* kCacheVLLM, GMemCacheHead* vCacheVLLM,
+    KVCachePageIndex const*
+        kvCachePageList,  // device pointer. shape:
+                          // KVCachePage[batchSize][beamWidth][2][maxNbPagesPerSeq]
+                          // (Layout 0) or [batchSize][maxNbPagesPerSeq] (Layout 1)
+    uint32_t maxSeqLen, uint32_t const* seqLen, uint32_t batchSize, float kvCacheScale,
+    float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
+    uint32_t* semaphores, void* scratch, bool enable_pdl, cudaStream_t stream);
+
+void launchMLAFlashInfer(
+    uint32_t multiProcessorCount,
+    uint32_t inputSeqLen,  // uniform for all requests and causal mask is assumed
+    float qScale, float const* qScalePtr, OutputHead* output, InputHead const* q,
+    GMemCacheHead* kCacheVLLM, GMemCacheHead* vCacheVLLM,
+    KVCachePageIndex const*
+        kvCachePageList,  // device pointer. shape:
+                          // KVCachePage[batchSize][beamWidth][2][maxNbPagesPerSeq] (Layout 0) or
+                          // [batchSize][maxNbPagesPerSeq] (Layout 1)
+    uint32_t maxSeqLen, uint32_t const* seqLen, uint32_t batchSize, float kvCacheScale,
+    float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
+    uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
+    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream);
+
+#if STATIC_NB_K_HEADS
+constexpr uint32_t nbKHeads = NB_K_HEADS;
+
+constexpr uint32_t nbVHeads = nbKHeads;
+constexpr uint32_t nbQHeads = nbKHeads * headGrpSize;
+constexpr uint32_t nbQKVHeads = nbQHeads + nbKHeads + nbVHeads;
+#endif
+constexpr uint32_t cacheElemSize = sizeof(CacheElem);
+constexpr uint32_t inputElemSize = sizeof(InputElem);
+constexpr uint32_t outputElemSize = sizeof(OutputElem);
+
+constexpr uint32_t ioHeadBytes = sizeof(IOHead);
+constexpr uint32_t gmemCacheHeadBytes = sizeof(GMemCacheHead);
+
+constexpr uint32_t paddedInputHeadBytes = sizeof(PaddedInputHead);
+constexpr uint32_t paddedCacheHeadBytes = sizeof(PaddedCacheHead);
+
+constexpr bool allowMultiBlockMode = ALLOW_MULTI_BLOCK_MODE;
+
+enum class XQAKernelType : int32_t {
+  kAMPERE_WARP_SPECIALIZED = 0,
+  kHOPPER_WARP_SPECIALIZED = 1,
+  kSM120_MLA = 2
+};
+
+#ifdef GENERATE_CUBIN
+#define CUBIN_EXPORT extern "C"
+#else
+#define CUBIN_EXPORT static
+#endif

--- a/csrc/attention/flashinfer_xqa_src/mhaUtils.cuh
+++ b/csrc/attention/flashinfer_xqa_src/mhaUtils.cuh
@@ -1,0 +1,457 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "ldgsts.cuh"
+#include "mha.h"
+#include "utils.cuh"
+
+// for beam search
+template <typename Head, uint32_t tokensPerPage, uint32_t nbPages>
+struct IndexedHeadPtrImpl {
+  static_assert(tokensPerPage != 0 && nbPages != 0);
+  uint32_t const* indices;  // values are in range [0, beamWidth)
+  Head* pool;
+  Vec<KVCachePageIndex, nbPages> const* pageIndices;
+  uint32_t tokenOffset;   // token offset within the first page
+  uint32_t headIdx;       // head index
+  uint32_t stride_page;   // stride for each page (in units of Head)
+  uint32_t stride_token;  // stride for each token (in units of Head)
+  uint32_t stride_head;   // stride for each head (in units of Head)
+
+  __device__ inline Head& operator[](uint32_t i) const { return *(*this + i); }
+
+  __device__ inline Head* operator+(uint32_t i) const {
+    uint32_t const beamIdx = indices[i];
+    assert(beamIdx < beamWidth);
+    uint32_t const absoluteTokenIdx = tokenOffset + i;
+    auto const pageIdx = pageIndices[beamIdx][nbPages == 1 ? 0U : absoluteTokenIdx / tokensPerPage];
+    return pool + pageIdx * stride_page + (absoluteTokenIdx % tokensPerPage) * stride_token +
+           headIdx * stride_head;
+  }
+};
+
+template <typename Head>
+struct IndexedHeadPtrImpl<Head, 0, 0> {
+  uint32_t const* indices;  // values are in range [0, beamWidth)
+  Head* pointer;
+  uint32_t offset;
+  uint32_t beamStride;
+
+  __device__ inline Head& operator[](uint32_t i) const { return *(*this + i); }
+
+  __device__ inline Head* operator+(uint32_t i) const {
+    assert(indices[i] < beamWidth);
+    return pointer + (beamStride * indices[i] + offset + i);
+  }
+};
+
+template <typename Head, uint32_t tokensPerPage, uint32_t nbPages = 0>
+using IndexedHeadPtr = IndexedHeadPtrImpl<Head, tokensPerPage, nbPages>;
+
+// for beamWidth = 1
+template <typename Head, uint32_t tokensPerPage, uint32_t nbPages>
+struct HeadPtr {
+  static_assert(tokensPerPage != 0 && nbPages != 0);
+  Head* pool;
+  Vec<KVCachePageIndex, nbPages> pageIndices;
+  uint32_t tokenOffset;   // token offset within the first page
+  uint32_t headIdx;       // head index
+  uint32_t stride_page;   // stride for each page (in units of Head)
+  uint32_t stride_token;  // stride for each token (in units of Head)
+  uint32_t stride_head;   // stride for each head (in units of Head)
+
+  __device__ inline Head& operator[](uint32_t i) const { return *(*this + i); }
+
+  __device__ inline Head* operator+(uint32_t i) const {
+    uint32_t const absoluteTokenIdx = tokenOffset + i;
+    auto const pageIdx = pageIndices[nbPages == 1 ? 0U : absoluteTokenIdx / tokensPerPage];
+    return (pageIdx & (1U << 31))
+               ? nullptr
+               : pool + pageIdx * stride_page + (absoluteTokenIdx % tokensPerPage) * stride_token +
+                     headIdx * stride_head;
+  }
+};
+
+template <typename Head>
+struct HeadPtr<Head, 0, 0> : TinyPtr<Head> {};
+
+// template <typename Head>
+// #if BEAM_WIDTH == 1
+// using SrcHeadPtr = TinyPtr<Head const>;
+// #else
+// using SrcHeadPtr = IndexedHeadPtr<Head>;
+// #endif
+
+// @fixme: give evict first hint for last part.
+template <typename Head, uint32_t maxNbCopiedHeads, uint32_t nbPartsPerHead,
+          uint32_t grainBytesSmem, uint32_t grainBytesGmem, bool swizzle, bool isFull,
+          uint32_t dstNbHeads, typename SrcHeadPtr, typename _LdGrain,
+          typename LocalHeadIdxMap = uint32_t (*)(uint32_t)>
+__device__ inline void copyPartialHeadsAsync(
+    Warp const& warp,
+    Array2D<_LdGrain, dstNbHeads, exactDiv(exactDiv(sizeof(Head), nbPartsPerHead), grainBytesSmem)>&
+        dst,
+    uint32_t dstHeadOffset, SrcHeadPtr const& src, uint32_t idxPart,
+    uint32_t nbAvailHeads = maxNbCopiedHeads,
+    LocalHeadIdxMap&& localHeadIdxMap = [](uint32_t x) { return x; }) {
+  static_assert(maxNbCopiedHeads <= dstNbHeads);
+  assert(idxPart < nbPartsPerHead);
+  assert(dstHeadOffset + maxNbCopiedHeads <= dstNbHeads);
+  assert(sizeof(Head) * (src.offset + maxNbCopiedHeads) <= (1UL << 32));
+  assert(!isFull || nbAvailHeads >= maxNbCopiedHeads);
+  constexpr uint32_t headBytes = sizeof(Head);
+  constexpr uint32_t partBytes = exactDiv(headBytes, nbPartsPerHead);
+  constexpr uint32_t warpLdBytes = partBytes * maxNbCopiedHeads;
+  constexpr uint32_t thrdLdBytes = exactDiv(warpLdBytes, warp_size);
+  assertIsPowerOf2<thrdLdBytes>();
+  static_assert(thrdLdBytes >= grainBytesSmem);
+  // a segment is responsible for loading one partial head collaboratively
+  constexpr uint32_t thrdsPerSeg = exactDiv(partBytes, grainBytesSmem);
+  static_assert(thrdsPerSeg > 0 && thrdsPerSeg <= warp_size);
+  assertIsPowerOf2<thrdsPerSeg>();
+  assert(__shfl_sync(0xFU << (laneId() / 4 * 4), src.offset, 0, 4) == src.offset);
+  auto const warpLane = laneId();
+  uint32_t const segIdx = warpLane / thrdsPerSeg;
+  uint32_t const segLane = warpLane % thrdsPerSeg;
+  constexpr uint32_t partsPerWarpInst = exactDiv(grainBytesSmem * warp_size, partBytes);
+#pragma unroll
+  for (uint32_t i = 0; i < thrdLdBytes / grainBytesSmem; i++) {
+    uint32_t const idxHeadLocal = partsPerWarpInst * i + segIdx;
+    assert(idxHeadLocal < maxNbCopiedHeads);
+    bool const isHeadInBound = isFull || (idxHeadLocal < nbAvailHeads);
+    constexpr uint32_t grainsPerPart = exactDiv(partBytes, grainBytesSmem);
+    using SrcHead = mha::decay_t<decltype(src[0])>;
+    constexpr uint32_t nbValidGrains = exactDiv(sizeof(SrcHead), grainBytesGmem);
+    uint32_t const idxGrainInsideHead = grainsPerPart * idxPart + segLane;
+    bool const isGrainInBound = (!isHeadPadded || idxGrainInsideHead < nbValidGrains);
+    SrcHead const* const pSrcHead = src + localHeadIdxMap(idxHeadLocal);
+    bool const isValidPage = (pSrcHead != nullptr);
+    Vec<uint8_t, grainBytesGmem> const* const pSrc =
+        reinterpret_cast<Vec<uint8_t, grainBytesGmem> const*>(pSrcHead) + idxGrainInsideHead;
+    Vec<uint8_t, grainBytesSmem>* const pDst = reinterpret_cast<Vec<uint8_t, grainBytesSmem>*>(
+        &dst.template at<swizzle>(dstHeadOffset + idxHeadLocal, segLane));
+#if !ENABLE_4BIT_KV_CACHE
+    // 4-bit KV cache is not bank-conflict free now.
+    assert(!hasBankConflict(pDst));
+#endif
+    ldgsts::copyAsync<grainBytesGmem>(
+        pDst, pSrc, isValidPage && isHeadInBound && isGrainInBound ? grainBytesGmem : 0u);
+  }
+}
+
+template <typename Head, uint32_t maxNbCopiedHeads, uint32_t nbWarps, uint32_t grainBytesSmem,
+          uint32_t grainBytesGmem, bool swizzle, bool isFull, uint32_t dstNbHeads,
+          typename SrcHeadPtr, typename _LdGrain, typename LocalHeadIdxMap = uint32_t (*)(uint32_t)>
+__device__ inline void copyHeadsAsync(
+    uint32_t idxWarp, Array2D<_LdGrain, dstNbHeads, exactDiv(sizeof(Head), grainBytesSmem)>& dst,
+    SrcHeadPtr const& src, uint32_t nbAvailHeads = maxNbCopiedHeads,
+    LocalHeadIdxMap&& localHeadIdxMap = [](uint32_t x) { return x; }) {
+  assert(idxWarp < nbWarps);
+  Warp const& warp = this_warp();
+  constexpr uint32_t maxNbHeadsPerWarp = exactDiv(maxNbCopiedHeads, nbWarps);
+  uint32_t const dstHeadOffset = maxNbHeadsPerWarp * idxWarp;
+  uint32_t const warpNbAvailHeads =
+      (dstHeadOffset < nbAvailHeads ? nbAvailHeads - dstHeadOffset : 0);
+  constexpr uint32_t idxPart = 0;
+  copyPartialHeadsAsync<Head, maxNbHeadsPerWarp, 1, grainBytesSmem, grainBytesGmem, swizzle, isFull,
+                        dstNbHeads>(warp, dst, dstHeadOffset, src, idxPart, warpNbAvailHeads,
+                                    [&](uint32_t x) { return localHeadIdxMap(dstHeadOffset + x); });
+}
+
+template <bool isAsync, uint32_t maxTotalNbGrains, uint32_t nbWarps, bool isFull = true>
+__device__ inline void copyGrains(uint32_t idxWarp, LdGrain* dst, LdGrain const* src,
+                                  uint32_t totalNbGrains = maxTotalNbGrains) {
+  assert((isFull && totalNbGrains == maxTotalNbGrains) ||
+         (!isFull && totalNbGrains <= maxTotalNbGrains));
+  constexpr uint32_t nbThrds = warp_size * nbWarps;
+  uint32_t const tid = warp_size * idxWarp + laneId();
+// copy output to scratch
+#pragma unroll
+  for (uint32_t i = 0; i < divUp(maxTotalNbGrains, nbThrds); i++) {
+    uint32_t const idx = nbThrds * i + tid;
+    if (!(isFull && maxTotalNbGrains % nbThrds == 0) && idx >= totalNbGrains) {
+      break;
+    }
+    if constexpr (isAsync) {
+      ldgsts::copyAsync<grainBytes>(&dst[idx], &src[idx], grainBytes);
+    } else {
+      dst[idx] = src[idx];
+    }
+  }
+}
+
+// with ldmatrix, what we load for fp8 cache is T0:{e0,e1,e2,e3}; T1:{e4, e5, e6, e7};
+// T2:{e8,e9,e10,e11}; T3:{e12, e13, e14, e15}; When casted to fp16, it will be T0:{e0, e1}; T1{e4,
+// e5};...  | T0:{e2, e3}; T1{e6, e7}; ... We need to reorder Q to match that order. isFwd=false to
+// revert the reorder.
+template <uint32_t nbWarps, bool swizzled, bool isFwd, uint32_t cols, uint32_t rows>
+__device__ inline void reorder16bQHeadsToMatch8bKCache(uint32_t idxWarp,
+                                                       Array2D<LdGrain, rows, cols>& qHeads) {
+  assert(idxWarp < nbWarps);
+  constexpr uint32_t nbWarpIters = exactDiv(exactDiv(cols, 2) * rows, warp_size);  // warps * iters
+  constexpr uint32_t nbWorkingWarps = mha::min(nbWarps, nbWarpIters);
+  if (idxWarp >= nbWorkingWarps) {
+    return;
+  }
+  static_assert(cols % 2 == 0);
+  uint32_t const tid = warp_size * idxWarp + laneId();
+  constexpr uint32_t iterCols = exactDiv(warp_size * nbWorkingWarps, rows) * 2;
+  static_assert(cols % iterCols == 0,
+                "fix this by reducing nbWorkingWarps, or use divUp and add runtime check");
+  constexpr uint32_t nbIters = exactDiv(cols, iterCols);
+  static_assert(nbIters == exactDiv(nbWarpIters, nbWorkingWarps));
+  uint32_t const r = tid % rows;
+  uint32_t const cInit = tid / rows * 2;
+#pragma unroll
+  for (uint32_t n = 0; n < nbIters; n++) {
+    uint32_t const c = cInit + iterCols * n;
+    LdGrain const src[2] = {
+        qHeads.template at<swizzled>(r, c),
+        qHeads.template at<swizzled>(r, c + 1),
+    };
+    auto const& s = reinterpret_cast<Vec<uint32_t, LdGrain::size * 2> const&>(src);
+    if constexpr (isFwd) {
+      qHeads.template at<swizzled>(r, c) = LdGrain{s[0], s[2], s[4], s[6]};
+      qHeads.template at<swizzled>(r, c + 1) = LdGrain{s[1], s[3], s[5], s[7]};
+    } else {
+      qHeads.template at<swizzled>(r, c) = LdGrain{s[0], s[4], s[1], s[5]};
+      qHeads.template at<swizzled>(r, c + 1) = LdGrain{s[2], s[6], s[3], s[7]};
+    }
+  }
+}
+
+template <bool usePagedKVCache>
+struct KVCacheList;
+
+template <>
+struct KVCacheList<true> {
+  GMemCacheHead* kCacheVLLM;
+  GMemCacheHead* vCacheVLLM;
+#if ENABLE_4BIT_KV_CACHE
+  GMemCacheHeadSf* kSfCacheVLLM;
+  GMemCacheHeadSf* vSfCacheVLLM;
+#endif
+  KVCachePageIndex const*
+      kvCachePageList;  // shape: KVCachePageIndex[batchSize][beamWidth][2][maxNbPagesPerSeq].
+  SeqLenDataType const* seqLenList;  // shape: [batchSize][beamWidth] (for compatibility)
+  uint32_t maxNbPagesPerSeq;
+};
+
+template <>
+struct KVCacheList<false> {
+  GMemKVCacheHead* data;  // shape: KVCacheHead[batchSize][beamWidth][2][nbKHeads][capacity]
+  SeqLenDataType const* seqLenList;  // shape: [batchSize][beamWidth] (for compatibility)
+  uint32_t capacity;
+};
+
+__device__ inline uint32_t getSeqLen(uint32_t const* seqLenList, uint32_t idxReq) {
+  uint64_t cachePolicy;
+  asm("createpolicy.fractional.L2::evict_last.b64 %0;\n" : "=l"(cachePolicy));
+  uint32_t len;
+  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b32 %0, [%1], %2;\n"
+      : "=r"(len)
+      : "l"(&seqLenList[idxReq * beamWidth]), "l"(cachePolicy));
+  for (uint32_t i = 0; i < beamWidth; i++) {
+    assert(len == seqLenList[idxReq * beamWidth + i]);
+  }
+  return len;
+}
+
+template <bool isPaged>
+__device__ inline uint32_t getCacheSeqLen(KVCacheList<isPaged> const& cacheList, uint32_t idxReq) {
+  return getSeqLen(cacheList.seqLenList, idxReq);
+}
+
+__device__ inline uint32_t getCtxCacheSeqLen(BeamSearchParams const& beamSearchParams,
+                                             uint32_t idxReq) {
+  return getSeqLen(beamSearchParams.ctxLenList, idxReq);
+}
+
+template <uint32_t nbLoadedPages>
+__device__ inline Vec<KVCachePageIndex, nbLoadedPages> getPage(KVCacheList<true> const& cacheList,
+                                                               bool isK, uint32_t idxReq,
+                                                               uint32_t idxBeam,
+                                                               uint32_t idxPageBeg,
+                                                               uint32_t nbPages) {
+  auto const maxNbPagesPerSeq = cacheList.maxNbPagesPerSeq;
+  Vec<KVCachePageIndex, nbLoadedPages> ret;
+#pragma unroll
+  for (uint32_t i = 0; i < nbLoadedPages; i++) {
+    uint32_t const idxPage = idxPageBeg + i;
+    ret[i] = (idxPage < nbPages ? cacheList.kvCachePageList[maxNbPagesPerSeq * idxReq + idxPage]
+                                : kBAD_PAGE_INDEX);
+  }
+  return ret;
+}
+
+template <uint32_t nbWarps, uint32_t nbLoadedPages>
+__device__ inline void loadPagesForBeamSearchAsync(
+    uint32_t idxWarp, Vec<Vec<KVCachePageIndex, nbLoadedPages>, beamWidth>& dst,
+    KVCacheList<true> const& cacheList, bool isK, uint32_t idxReq, uint32_t idxPageBeg,
+    uint32_t nbPages) {
+  assert(idxWarp < nbWarps);
+  auto const maxNbPagesPerSeq = cacheList.maxNbPagesPerSeq;
+  static_assert(beamWidth < warp_size);
+  auto const tid = warp_size * idxWarp + laneId();
+  auto const idxBeam = tid / nbLoadedPages;
+  auto const idxLoadedPage = tid % nbLoadedPages;
+  static_assert(warp_size * nbWarps >= beamWidth * nbLoadedPages);
+  if (idxBeam < beamWidth) {
+    constexpr uint32_t nbBytes = sizeof(KVCachePageIndex);
+    uint32_t const idxPage = idxPageBeg + idxLoadedPage;
+    ldgsts::copyAsync<nbBytes>(
+        &dst[idxBeam][idxLoadedPage],
+        &cacheList.kvCachePageList[beamWidth * 2 * maxNbPagesPerSeq * idxReq +
+                                   2 * maxNbPagesPerSeq * idxBeam + (isK ? 0U : maxNbPagesPerSeq) +
+                                   idxPage],
+        idxPage < nbPages ? nbBytes : 0U);
+  }
+}
+
+template <uint32_t nbWarps, uint32_t length, bool isFullTile = false>
+__device__ inline void loadIndicesForBeamSearchAsync(uint32_t idxWarp, Vec<uint32_t, length>& dst,
+                                                     BeamSearchParams const& params,
+                                                     uint32_t idxReq, uint32_t idxBeam,
+                                                     uint32_t uniformSeqOffset, uint32_t seqLen) {
+  constexpr uint32_t nbThreads = warp_size * nbWarps;
+  // constexpr uint32_t indicesPerInst = mha::min(exactDiv(grainBytes, sizeof(uint32_t)),
+  // divUp(length, nbThreads));
+  // // @fixme: std::bit_ceil on length
+  constexpr uint32_t indicesPerInst = 1U;  // to handle unaligned case.
+  constexpr uint32_t bytesPerInst = sizeof(uint32_t) * indicesPerInst;
+  assertIsPowerOf2<indicesPerInst>();
+  uint32_t const capacity = params.capacity;
+  uint32_t const srcOffset = (idxReq * beamWidth + idxBeam) * capacity + uniformSeqOffset;
+  uint32_t const tid = warp_size * idxWarp + laneId();
+  constexpr uint32_t indicesPerIter = indicesPerInst * nbThreads;
+#pragma unroll
+  for (uint32_t i = 0; i < length / indicesPerIter; i++) {
+    uint32_t const idx = indicesPerIter * i + indicesPerInst * tid;
+    ldgsts::copyAsync<bytesPerInst>(
+        &dst[idx], &params.indices[srcOffset + idx],
+        (isFullTile || uniformSeqOffset + idx < seqLen) ? bytesPerInst : 0);
+  }
+  if constexpr (length % indicesPerIter != 0) {
+    uint32_t const idx = indicesPerIter * (length / indicesPerIter) + indicesPerInst * tid;
+    if (idx < length) {
+      ldgsts::copyAsync<bytesPerInst>(
+          &dst[idx], &params.indices[srcOffset + idx],
+          (isFullTile || uniformSeqOffset + idx < seqLen) ? bytesPerInst : 0);
+    }
+  }
+}
+
+__device__ inline InputElem2 float2ToInputElem2(float2 src) {
+  InputElem2 dst;
+  if constexpr (mha::is_same_v<InputElem2, half2>) {
+    reinterpret_cast<half2&>(dst) = __float22half2_rn(src);
+    return dst;
+  } else if constexpr (mha::is_same_v<InputElem2, nv_bfloat162>) {
+    reinterpret_cast<nv_bfloat162&>(dst) = __float22bfloat162_rn(src);
+    return dst;
+  } else if constexpr (mha::is_same_v<InputElem2, __nv_fp8x2_e4m3>) {
+    reinterpret_cast<__nv_fp8x2_e4m3&>(dst) = __nv_fp8x2_e4m3{src};
+    return dst;
+  } else {
+    trap();
+  }
+}
+
+template <bool real>
+using TokenOrNone = RealTypeOrNone<real, CtaBarrier::arrival_token>;
+
+template <bool real>
+__device__ inline TokenOrNone<real> arrive(CtaBarrier* pBarrier) {
+  if constexpr (real) {
+    return pBarrier->arrive();
+  } else {
+    assert(pBarrier == nullptr);
+    return None{};
+  }
+}
+
+template <bool real>
+__device__ inline void wait(CtaBarrier* pBarrier, TokenOrNone<real>&& token) {
+  if constexpr (real) {
+    pBarrier->wait(mha::move(token));
+  } else {
+    assert(pBarrier == nullptr);
+    __syncwarp();
+  }
+}
+
+template <bool real>
+__device__ inline bool test_wait(CtaBarrier* pBarrier, TokenOrNone<real>&& token) {
+  if constexpr (real) {
+    uint32_t complete;
+    asm volatile(
+        "{\n"
+        ".reg .pred       complete;\n"
+        "mbarrier.test_wait.acquire.cta.shared::cta.b64 complete, [%1], %2;\n"
+        "selp.b32 %0, 1, 0, complete;\n}\n"
+        : "=r"(complete)
+        : "l"(__cvta_generic_to_shared(pBarrier)), "l"(token));
+    return bool(complete);
+  } else {
+    return false;
+  }
+}
+
+template <bool real>
+using ParityOrNone = RealTypeOrNone<real, bool>;
+
+template <bool real>
+__device__ inline void wait_parity(CtaBarrier* pBarrier, ParityOrNone<real> parity) {
+  assert(real == (pBarrier != nullptr));
+  if constexpr (real) {
+    pBarrier->wait_parity(parity);
+  } else {
+    __syncwarp();
+  }
+}
+
+template <bool real>
+__device__ inline bool test_wait_parity(CtaBarrier* pBarrier, ParityOrNone<real> parity) {
+  assert(real == (pBarrier != nullptr));
+  if constexpr (real) {
+#if USE_CUSTOM_BARRIER
+    return pBarrier->test_wait_parity(parity);
+#else
+    return pBarrier->try_wait_parity_for(parity, cuda::std::chrono::nanoseconds(0));
+#endif
+  } else {
+    return false;
+  }
+}
+
+template <bool real = true>
+__device__ inline ParityOrNone<real>& flip(ParityOrNone<real>& flip) {
+  if constexpr (real) {
+    flip = !flip;
+  }
+  return flip;
+}
+
+template <bool real = true>
+__device__ inline ParityOrNone<real> getAndFlip(ParityOrNone<real>& flag) {
+  ParityOrNone<real> const ret = flag;
+  if constexpr (real) {
+    flag = !flag;
+  }
+  return ret;
+}

--- a/csrc/attention/flashinfer_xqa_src/mha_components.cuh
+++ b/csrc/attention/flashinfer_xqa_src/mha_components.cuh
@@ -1,0 +1,164 @@
+#pragma once
+#include "mma.cuh"
+#include "utils.cuh"
+
+using InstAcc = Array2D<float, 2, 2>;
+
+template <uint32_t m, uint32_t n>
+using WarpAccT = Array2D<InstAcc, exactDiv(m, 16), exactDiv(n, 8)>;
+
+template <uint32_t accRows, uint32_t accCols>
+__device__ inline void applyMask(Warp const& warp, Array2D<InstAcc, accRows, accCols>& acc,
+                                 uint32_t validColBeg, uint32_t validColEnd) {
+  uint32_t const idxInQuad = laneId() % 4;
+  uint32_t const idxQuad = laneId() / 4;
+#pragma unroll
+  for (uint32_t n = 0; n < acc.cols; n++) {
+#pragma unroll
+    for (uint32_t j = 0; j < InstAcc::cols; j++) {
+      uint32_t const col = 8 * n + InstAcc::cols * idxInQuad + j;
+      if (col >= validColBeg && col < validColEnd) {
+        continue;
+      }
+#pragma unroll
+      for (uint32_t m = 0; m < acc.rows; m++) {
+#pragma unroll
+        for (uint32_t i = 0; i < InstAcc::rows; i++) {
+          acc(m, n)(i, j) = mha::numeric_limits<float>::lowest();
+        }
+      }
+    }
+  }
+}
+
+template <uint32_t tileM>
+using QuadRegRowMaxT =
+    Vec<float, divUp(tileM, warp_size) * 4>;  // data is replicated across 4 threads in a MMA quad.
+template <uint32_t tileM>
+using ThrdRegRowMaxT =
+    Vec<float, divUp(tileM, warp_size)>;  // unlike QuadRegRowMax, not replicated.
+template <uint32_t tileM>
+using UniformRescaleMaskT = Vec<uint32_t, divUp(tileM, warp_size)>;  // uniform and stored in UR
+inline constexpr uint32_t quadPerWarp = warp_size / 4;
+
+// idxMat8 is the reduced row index in 8-row unit.
+template <uint32_t n>
+__device__ inline float replicateValForQuad(Warp const& warp, Vec<float, n> const& src,
+                                            uint32_t idxMat8) {
+  assertWarpConverged();
+  uint32_t const i = idxMat8 / 4;
+  uint32_t const j = idxMat8 % 4;
+  return __shfl_sync(~0U, src[i], quadPerWarp * j + laneId() / 4);
+}
+
+template <uint32_t n>
+__device__ inline QuadRegRowMaxT<n * warp_size> replicateForQuad(Warp const& warp,
+                                                                 Vec<float, n> const& src) {
+  assertWarpConverged();
+  QuadRegRowMaxT<n * warp_size> dst{};
+#pragma unroll
+  for (uint32_t i = 0; i < src.size; i++) {
+#pragma unroll
+    for (uint32_t j = 0; j < 4; j++) {
+      dst[i * 4 + j] = __shfl_sync(~0U, src[i], quadPerWarp * j + laneId() / 4);
+      assert(dst[i * 4 + j] == replicateValForQuad(warp, src, i * 4 + j));
+    }
+  }
+  return dst;
+}
+
+template <uint32_t n>
+__device__ inline ThrdRegRowMaxT<warp_size * exactDiv(n, 4)> dedupFromQuad(
+    Warp const& warp, Vec<float, n> const& src) {
+#ifndef NDEBUG
+  for (uint32_t i = 0; i < src.size; i++) {
+    assert(src[i] == __shfl_sync(~0U, src[i], laneId() / 4 * 4));
+  }
+#endif
+  ThrdRegRowMaxT<warp_size * exactDiv(n, 4)> dst{};
+  uint32_t const lane = laneId();
+  uint32_t const idxMat = lane / 8;
+  uint32_t const idxRow = lane % 8;
+#pragma unroll
+  for (uint32_t i = 0; i < dst.size; i++) {
+#pragma unroll
+    for (uint32_t j = 0; j < 4; j++) {
+      float const val = __shfl_sync(~0U, src[i * 4 + j], 4 * idxRow);
+      if (idxMat == j) {
+        dst[i] = val;
+      }
+    }
+  }
+#ifndef NDEBUG  // refcheck
+  QuadRegRowMaxT<warp_size * exactDiv(n, 4)> rep = replicateForQuad(warp, dst);
+#pragma unroll
+  for (uint32_t i = 0; i < n; i++) {
+    assert(src[i] == rep[i]);
+    __syncwarp();
+  }
+#endif
+  return dst;
+}
+
+template <uint32_t tileM, uint32_t tileN>
+__device__ inline ThrdRegRowMaxT<tileM> computeRowSumF8(
+    Warp const& warp,
+    Array2D<Array2D<uint32_t, 2, 1>, exactDiv(tileM, 16), exactDiv(tileN, 16)> const& src) {
+  using WarpAcc = WarpAccT<tileM, 8>;
+  WarpAcc acc{};
+  Vec<__nv_fp8x2_e4m3, 2> const bWord = {__nv_fp8x2_e4m3{float2{1, 1}},
+                                         __nv_fp8x2_e4m3{float2{1, 1}}};
+  uint32_t const b[2][1] = {reinterpret_cast<uint32_t const&>(bWord),
+                            reinterpret_cast<uint32_t const&>(bWord)};
+#pragma unroll
+  for (uint32_t i = 0; i < WarpAcc::rows; i++) {
+#pragma unroll
+    for (uint32_t k = 0; k < exactDiv(src.cols, 2); k++) {
+      mma<__nv_fp8_e4m3>(reinterpret_cast<float(&)[2][2]>(acc(i, 0)),
+                         reinterpret_cast<uint32_t const(&)[2][2]>(src(i, k * 2)), b);
+    }
+  }
+  QuadRegRowMaxT<tileM> rowSum;
+  for (uint32_t i = 0; i < WarpAcc::rows; i++) {
+    for (uint32_t m = 0; m < InstAcc::rows; m++) {
+#ifndef NDEBUG
+      assert(acc(i, 0)(m, 0) == acc(i, 0)(m, 1));
+      assert(acc(i, 0)(m, 0) == __shfl_sync(~0U, acc(i, 0)(m, 0), laneId() / 4 * 4));
+#endif
+      rowSum[i * InstAcc::rows + m] = acc(i, 0)(m, 0);
+    }
+  }
+  return dedupFromQuad(warp, rowSum);
+}
+
+template <uint32_t tileM, uint32_t tileN>
+__device__ inline ThrdRegRowMaxT<tileM> computeRowSumF32(Warp const& warp,
+                                                         WarpAccT<tileM, tileN> const& src) {
+  QuadRegRowMaxT<tileM> rowSum{};
+#pragma unroll
+  for (uint32_t n = 0; n < src.cols; n++) {
+#pragma unroll
+    for (uint32_t j = 0; j < InstAcc::cols; j++) {
+#pragma unroll
+      for (uint32_t m = 0; m < src.rows; m++) {
+#pragma unroll
+        for (uint32_t i = 0; i < InstAcc::rows; i++) {
+          if (n == 0 && j == 0) {
+            rowSum[m * InstAcc::rows + i] = src(m, n)(i, j);
+          } else {
+            rowSum[m * InstAcc::rows + i] += src(m, n)(i, j);
+          }
+        }
+      }
+    }
+  }
+  uint32_t const lane = laneId();
+#pragma unroll
+  for (uint32_t mask = 2; mask != 0; mask /= 2) {
+#pragma unroll
+    for (uint32_t i = 0; i < rowSum.size; i++) {
+      rowSum[i] += __shfl_xor_sync(~0U, rowSum[i], mask);
+    }
+  }
+  return dedupFromQuad(warp, rowSum);
+}

--- a/csrc/attention/flashinfer_xqa_src/mha_stdheaders.cuh
+++ b/csrc/attention/flashinfer_xqa_src/mha_stdheaders.cuh
@@ -1,0 +1,984 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GENERATE_CUBIN
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#endif
+
+#ifndef __CUDACC__
+#include <cuda_runtime.h>
+#endif
+
+#define HOST_DEVICE_FUNC __host__ __device__
+#define DEVICE_FUNC __device__
+
+namespace mha {
+
+#ifndef GENERATE_CUBIN
+template <typename T>
+using numeric_limits = std::numeric_limits<T>;
+using std::max;
+using std::min;
+#else
+
+using uint8_t = unsigned char;
+using int8_t = signed char;
+using uint16_t = unsigned short;
+using uint32_t = unsigned int;
+using int32_t = int;
+using uint64_t = unsigned long long;
+using uintptr_t = uint64_t;
+static_assert(sizeof(uint8_t) == 1);
+static_assert(sizeof(int8_t) == 1);
+static_assert(sizeof(uint16_t) == 2);
+static_assert(sizeof(uint32_t) == 4);
+static_assert(sizeof(int32_t) == 4);
+static_assert(sizeof(uint64_t) == 8);
+
+template <typename T>
+class numeric_limits;
+
+template <>
+class numeric_limits<int32_t> {
+ public:
+  static constexpr int32_t max() noexcept { return 0x7FFFFFFF; }
+};
+
+template <>
+class numeric_limits<float> {
+ public:
+  static constexpr float lowest() noexcept { return -3.40282347E+38F; }
+};
+
+template <typename T>
+DEVICE_FUNC constexpr T const& max(T const& a, T const& b) {
+  return a > b ? a : b;
+}
+
+template <typename T>
+DEVICE_FUNC constexpr T const& min(T const& a, T const& b) {
+  return a < b ? a : b;
+}
+
+#endif
+
+#ifndef GENERATE_CUBIN
+template <bool cond, class T, class F>
+using conditional_t = std::conditional_t<cond, T, F>;
+
+template <bool cond, class T = void>
+using enable_if_t = typename std::enable_if<cond, T>::type;
+#else
+
+// https://en.cppreference.com/w/cpp/types/conditional
+template <bool cond, class T, class F>
+struct conditional {
+  using type = T;
+};
+
+template <class T, class F>
+struct conditional<false, T, F> {
+  using type = F;
+};
+
+template <bool cond, class T, class F>
+using conditional_t = typename conditional<cond, T, F>::type;
+
+template <bool cond, class T = void>
+struct enable_if {};
+
+template <class T>
+struct enable_if<true, T> {
+  typedef T type;
+};
+
+template <bool cond, class T = void>
+using enable_if_t = typename enable_if<cond, T>::type;
+#endif
+
+#ifndef GENERATE_CUBIN
+using byte = std::byte;
+#else
+// https://en.cppreference.com/w/cpp/types/byte
+enum class byte : unsigned char {};
+#endif
+
+#ifndef GENERATE_CUBIN
+using std::declval;
+#else
+
+// https://en.cppreference.com/w/cpp/types/add_reference
+namespace detail {
+template <class T>
+struct type_identity {
+  using type = T;
+};  // or use std::type_identity (since C++20)
+
+template <class T>  // Note that `cv void&` is a substitution failure
+DEVICE_FUNC auto try_add_lvalue_reference(int) -> type_identity<T&>;
+template <class T>  // Handle T = cv void case
+DEVICE_FUNC auto try_add_lvalue_reference(...) -> type_identity<T>;
+
+template <class T>
+DEVICE_FUNC auto try_add_rvalue_reference(int) -> type_identity<T&&>;
+template <class T>
+DEVICE_FUNC auto try_add_rvalue_reference(...) -> type_identity<T>;
+}  // namespace detail
+
+template <class T>
+struct add_lvalue_reference : decltype(detail::try_add_lvalue_reference<T>(0)) {};
+
+template <class T>
+struct add_rvalue_reference : decltype(detail::try_add_rvalue_reference<T>(0)) {};
+
+// https://en.cppreference.com/w/cpp/utility/declval
+template <typename T>
+DEVICE_FUNC typename add_rvalue_reference<T>::type declval() noexcept {
+  static_assert(false, "declval not allowed in an evaluated context");
+}
+#endif
+
+#ifndef GENERATE_CUBIN
+template <class T, size_t N>
+using array = std::array<T, N>;
+#else
+// https://en.cppreference.com/w/cpp/container/array
+template <class T, size_t N>
+struct array;
+#endif
+
+#ifndef GENERATE_CUBIN
+template <typename T, typename U>
+using is_same = std::is_same<T, U>;
+using std::is_same_v;
+#else
+
+// https://en.cppreference.com/w/cpp/types/integral_constant
+template <class T, T v>
+struct integral_constant {
+  static constexpr T value = v;
+  using value_type = T;
+  using type = integral_constant;  // using injected-class-name
+
+  DEVICE_FUNC constexpr operator value_type() const noexcept { return value; }
+
+  DEVICE_FUNC constexpr value_type operator()() const noexcept { return value; }  // since c++14
+};
+
+using false_type = integral_constant<bool, false>;
+using true_type = integral_constant<bool, true>;
+
+// https://en.cppreference.com/w/cpp/types/is_same
+template <class T, class U>
+struct is_same : false_type {};
+
+template <class T>
+struct is_same<T, T> : true_type {};
+
+template <class T, class U>
+inline constexpr bool is_same_v = is_same<T, U>::value;
+
+#endif
+
+#ifndef GENERATE_CUBIN
+
+using std::forward;
+using std::is_empty;
+using std::move;
+
+#else
+
+// /usr/include/c++/11/type_traits
+template <typename _Tp>
+struct is_empty : public integral_constant<bool, __is_empty(_Tp)> {};
+
+template <class T>
+struct remove_reference {
+  typedef T type;
+};
+
+template <class T>
+struct remove_reference<T&> {
+  typedef T type;
+};
+
+template <class T>
+struct remove_reference<T&&> {
+  typedef T type;
+};
+
+template <typename T>
+constexpr typename remove_reference<T>::type&& move(T&& arg) {
+  return static_cast<typename remove_reference<T>::type&&>(arg);
+}
+
+template <typename T>
+constexpr T&& forward(typename remove_reference<T>::type& param) {
+  return static_cast<T&&>(param);
+}
+
+#endif
+
+// https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-api-4.5/a01066_source.html
+namespace libstdcpp {
+// Adds a const reference to a non-reference type.
+template <typename _Tp>
+struct __add_c_ref {
+  typedef _Tp const& type;
+};
+
+template <typename _Tp>
+struct __add_c_ref<_Tp&> {
+  typedef _Tp& type;
+};
+
+// Adds a reference to a non-reference type.
+template <typename _Tp>
+struct __add_ref {
+  typedef _Tp& type;
+};
+
+template <typename _Tp>
+struct __add_ref<_Tp&> {
+  typedef _Tp& type;
+};
+
+template <size_t _Idx, typename _Head, bool _IsEmpty>
+struct _Head_base;
+
+template <size_t _Idx, typename _Head>
+struct _Head_base<_Idx, _Head, true> : public _Head {
+  DEVICE_FUNC _Head_base() : _Head() {}
+
+  DEVICE_FUNC _Head_base(_Head const& __h) : _Head(__h) {}
+
+  template <typename _UHead>
+  DEVICE_FUNC _Head_base(_UHead&& __h) : _Head(forward<_UHead>(__h)) {}
+
+  DEVICE_FUNC _Head& _M_head() { return *this; }
+
+  DEVICE_FUNC _Head const& _M_head() const { return *this; }
+
+  DEVICE_FUNC void _M_swap_impl(_Head&) { /* no-op */ }
+};
+
+template <size_t _Idx, typename _Head>
+struct _Head_base<_Idx, _Head, false> {
+  DEVICE_FUNC _Head_base() : _M_head_impl() {}
+
+  DEVICE_FUNC _Head_base(_Head const& __h) : _M_head_impl(__h) {}
+
+  template <typename _UHead>
+  DEVICE_FUNC _Head_base(_UHead&& __h) : _M_head_impl(forward<_UHead>(__h)) {}
+
+  DEVICE_FUNC _Head& _M_head() { return _M_head_impl; }
+
+  DEVICE_FUNC _Head const& _M_head() const { return _M_head_impl; }
+
+  DEVICE_FUNC void _M_swap_impl(_Head& __h) {
+    using std::swap;
+    swap(__h, _M_head_impl);
+  }
+
+  _Head _M_head_impl;
+};
+
+/**
+ * Contains the actual implementation of the @c tuple template, stored
+ * as a recursive inheritance hierarchy from the first element (most
+ * derived class) to the last (least derived class). The @c Idx
+ * parameter gives the 0-based index of the element stored at this
+ * point in the hierarchy; we use it to implement a constant-time
+ * get() operation.
+ */
+template <size_t _Idx, typename... _Elements>
+struct _Tuple_impl;
+
+/**
+ * Zero-element tuple implementation. This is the basis case for the
+ * inheritance recursion.
+ */
+template <size_t _Idx>
+struct _Tuple_impl<_Idx> {
+ protected:
+  DEVICE_FUNC void _M_swap_impl(_Tuple_impl&) { /* no-op */ }
+};
+
+/**
+ * Recursive tuple implementation. Here we store the @c Head element
+ * and derive from a @c Tuple_impl containing the remaining elements
+ * (which contains the @c Tail).
+ */
+template <size_t _Idx, typename _Head, typename... _Tail>
+struct _Tuple_impl<_Idx, _Head, _Tail...>
+    : public _Tuple_impl<_Idx + 1, _Tail...>,
+      private _Head_base<_Idx, _Head, is_empty<_Head>::value> {
+  typedef _Tuple_impl<_Idx + 1, _Tail...> _Inherited;
+  typedef _Head_base<_Idx, _Head, is_empty<_Head>::value> _Base;
+
+  DEVICE_FUNC _Head& _M_head() { return _Base::_M_head(); }
+
+  DEVICE_FUNC _Head const& _M_head() const { return _Base::_M_head(); }
+
+  DEVICE_FUNC _Inherited& _M_tail() { return *this; }
+
+  DEVICE_FUNC _Inherited const& _M_tail() const { return *this; }
+
+  DEVICE_FUNC _Tuple_impl() : _Inherited(), _Base() {}
+
+  explicit DEVICE_FUNC _Tuple_impl(_Head const& __head, _Tail const&... __tail)
+      : _Inherited(__tail...), _Base(__head) {}
+
+  template <typename _UHead, typename... _UTail>
+  explicit DEVICE_FUNC _Tuple_impl(_UHead&& __head, _UTail&&... __tail)
+      : _Inherited(forward<_UTail>(__tail)...), _Base(forward<_UHead>(__head)) {}
+
+  DEVICE_FUNC _Tuple_impl(_Tuple_impl const& __in)
+      : _Inherited(__in._M_tail()), _Base(__in._M_head()) {}
+
+  DEVICE_FUNC _Tuple_impl(_Tuple_impl&& __in)
+      : _Inherited(move(__in._M_tail())), _Base(forward<_Head>(__in._M_head())) {}
+
+  template <typename... _UElements>
+  DEVICE_FUNC _Tuple_impl(_Tuple_impl<_Idx, _UElements...> const& __in)
+      : _Inherited(__in._M_tail()), _Base(__in._M_head()) {}
+
+  template <typename... _UElements>
+  DEVICE_FUNC _Tuple_impl(_Tuple_impl<_Idx, _UElements...>&& __in)
+      : _Inherited(move(__in._M_tail())), _Base(move(__in._M_head())) {}
+
+  DEVICE_FUNC _Tuple_impl& operator=(_Tuple_impl const& __in) {
+    _M_head() = __in._M_head();
+    _M_tail() = __in._M_tail();
+    return *this;
+  }
+
+  DEVICE_FUNC _Tuple_impl& operator=(_Tuple_impl&& __in) {
+    _M_head() = move(__in._M_head());
+    _M_tail() = move(__in._M_tail());
+    return *this;
+  }
+
+  template <typename... _UElements>
+  DEVICE_FUNC _Tuple_impl& operator=(_Tuple_impl<_Idx, _UElements...> const& __in) {
+    _M_head() = __in._M_head();
+    _M_tail() = __in._M_tail();
+    return *this;
+  }
+
+  template <typename... _UElements>
+  DEVICE_FUNC _Tuple_impl& operator=(_Tuple_impl<_Idx, _UElements...>&& __in) {
+    _M_head() = move(__in._M_head());
+    _M_tail() = move(__in._M_tail());
+    return *this;
+  }
+
+ protected:
+  DEVICE_FUNC void _M_swap_impl(_Tuple_impl& __in) {
+    _Base::_M_swap_impl(__in._M_head());
+    _Inherited::_M_swap_impl(__in._M_tail());
+  }
+};
+
+/// tuple
+template <typename... _Elements>
+class tuple : public _Tuple_impl<0, _Elements...> {
+  typedef _Tuple_impl<0, _Elements...> _Inherited;
+
+ public:
+  DEVICE_FUNC tuple() : _Inherited() {}
+
+  explicit DEVICE_FUNC tuple(_Elements const&... __elements) : _Inherited(__elements...) {}
+
+  template <typename... _UElements>
+  explicit DEVICE_FUNC tuple(_UElements&&... __elements)
+      : _Inherited(forward<_UElements>(__elements)...) {}
+
+  DEVICE_FUNC tuple(tuple const& __in) : _Inherited(static_cast<_Inherited const&>(__in)) {}
+
+  DEVICE_FUNC tuple(tuple&& __in) : _Inherited(static_cast<_Inherited&&>(__in)) {}
+
+  template <typename... _UElements>
+  DEVICE_FUNC tuple(tuple<_UElements...> const& __in)
+      : _Inherited(static_cast<_Tuple_impl<0, _UElements...> const&>(__in)) {}
+
+  template <typename... _UElements>
+  DEVICE_FUNC tuple(tuple<_UElements...>&& __in)
+      : _Inherited(static_cast<_Tuple_impl<0, _UElements...>&&>(__in)) {}
+
+  // XXX http://gcc.gnu.org/ml/libstdc++/2008-02/msg00047.html
+  template <typename... _UElements>
+  DEVICE_FUNC tuple(tuple<_UElements...>& __in)
+      : _Inherited(static_cast<_Tuple_impl<0, _UElements...> const&>(__in)) {}
+
+  DEVICE_FUNC tuple& operator=(tuple const& __in) {
+    static_cast<_Inherited&>(*this) = __in;
+    return *this;
+  }
+
+  DEVICE_FUNC tuple& operator=(tuple&& __in) {
+    static_cast<_Inherited&>(*this) = move(__in);
+    return *this;
+  }
+
+  template <typename... _UElements>
+  DEVICE_FUNC tuple& operator=(tuple<_UElements...> const& __in) {
+    static_cast<_Inherited&>(*this) = __in;
+    return *this;
+  }
+
+  template <typename... _UElements>
+  DEVICE_FUNC tuple& operator=(tuple<_UElements...>&& __in) {
+    static_cast<_Inherited&>(*this) = move(__in);
+    return *this;
+  }
+
+  void DEVICE_FUNC swap(tuple& __in) { _Inherited::_M_swap_impl(__in); }
+};
+
+template <>
+class tuple<> {
+ public:
+  DEVICE_FUNC void swap(tuple&) { /* no-op */ }
+};
+
+/// Gives the type of the ith element of a given tuple type.
+template <size_t __i, typename _Tp>
+struct tuple_element;
+
+/**
+ * Recursive case for tuple_element: strip off the first element in
+ * the tuple and retrieve the (i-1)th element of the remaining tuple.
+ */
+template <size_t __i, typename _Head, typename... _Tail>
+struct tuple_element<__i, tuple<_Head, _Tail...>> : tuple_element<__i - 1, tuple<_Tail...>> {};
+
+/**
+ * Basis case for tuple_element: The first element is the one we're seeking.
+ */
+template <typename _Head, typename... _Tail>
+struct tuple_element<0, tuple<_Head, _Tail...>> {
+  typedef _Head type;
+};
+
+/// Finds the size of a given tuple type.
+template <typename _Tp>
+struct tuple_size;
+
+/// class tuple_size
+template <typename... _Elements>
+struct tuple_size<tuple<_Elements...>> {
+  static const size_t value = sizeof...(_Elements);
+};
+
+template <typename... _Elements>
+const size_t tuple_size<tuple<_Elements...>>::value;
+
+template <size_t __i, typename _Head, typename... _Tail>
+DEVICE_FUNC inline typename __add_ref<_Head>::type __get_helper(
+    _Tuple_impl<__i, _Head, _Tail...>& __t) {
+  return __t._M_head();
+}
+
+template <size_t __i, typename _Head, typename... _Tail>
+DEVICE_FUNC inline typename __add_c_ref<_Head>::type __get_helper(
+    _Tuple_impl<__i, _Head, _Tail...> const& __t) {
+  return __t._M_head();
+}
+
+// Return a reference (const reference) to the ith element of a tuple.
+// Any const or non-const ref elements are returned with their original type.
+template <size_t __i, typename... _Elements>
+DEVICE_FUNC inline typename __add_ref<typename tuple_element<__i, tuple<_Elements...>>::type>::type
+get(tuple<_Elements...>& __t) {
+  return __get_helper<__i>(__t);
+}
+
+template <size_t __i, typename... _Elements>
+DEVICE_FUNC inline
+    typename __add_c_ref<typename tuple_element<__i, tuple<_Elements...>>::type>::type
+    get(tuple<_Elements...> const& __t) {
+  return __get_helper<__i>(__t);
+}
+
+// This class helps construct the various comparison operations on tuples
+template <size_t __check_equal_size, size_t __i, size_t __j, typename _Tp, typename _Up>
+struct __tuple_compare;
+
+template <size_t __i, size_t __j, typename _Tp, typename _Up>
+struct __tuple_compare<0, __i, __j, _Tp, _Up> {
+  DEVICE_FUNC static bool __eq(_Tp const& __t, _Up const& __u) {
+    return (get<__i>(__t) == get<__i>(__u) &&
+            __tuple_compare<0, __i + 1, __j, _Tp, _Up>::__eq(__t, __u));
+  }
+
+  DEVICE_FUNC static bool __less(_Tp const& __t, _Up const& __u) {
+    return ((get<__i>(__t) < get<__i>(__u)) ||
+            !(get<__i>(__u) < get<__i>(__t)) &&
+                __tuple_compare<0, __i + 1, __j, _Tp, _Up>::__less(__t, __u));
+  }
+};
+
+template <size_t __i, typename _Tp, typename _Up>
+struct __tuple_compare<0, __i, __i, _Tp, _Up> {
+  static bool __eq(_Tp const&, _Up const&) { return true; }
+
+  static bool __less(_Tp const&, _Up const&) { return false; }
+};
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC bool operator==(tuple<_TElements...> const& __t, tuple<_UElements...> const& __u) {
+  typedef tuple<_TElements...> _Tp;
+  typedef tuple<_UElements...> _Up;
+  return (__tuple_compare<tuple_size<_Tp>::value - tuple_size<_Up>::value, 0,
+                          tuple_size<_Tp>::value, _Tp, _Up>::__eq(__t, __u));
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC bool operator<(tuple<_TElements...> const& __t, tuple<_UElements...> const& __u) {
+  typedef tuple<_TElements...> _Tp;
+  typedef tuple<_UElements...> _Up;
+  return (__tuple_compare<tuple_size<_Tp>::value - tuple_size<_Up>::value, 0,
+                          tuple_size<_Tp>::value, _Tp, _Up>::__less(__t, __u));
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline bool operator!=(tuple<_TElements...> const& __t,
+                                   tuple<_UElements...> const& __u) {
+  return !(__t == __u);
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline bool operator>(tuple<_TElements...> const& __t,
+                                  tuple<_UElements...> const& __u) {
+  return __u < __t;
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline bool operator<=(tuple<_TElements...> const& __t,
+                                   tuple<_UElements...> const& __u) {
+  return !(__u < __t);
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline bool operator>=(tuple<_TElements...> const& __t,
+                                   tuple<_UElements...> const& __u) {
+  return !(__t < __u);
+}
+
+template <size_t...>
+struct __index_holder {};
+
+template <size_t __i, typename _IdxHolder, typename... _Elements>
+struct __index_holder_impl;
+
+template <size_t __i, size_t... _Indexes, typename _IdxHolder, typename... _Elements>
+struct __index_holder_impl<__i, __index_holder<_Indexes...>, _IdxHolder, _Elements...> {
+  typedef
+      typename __index_holder_impl<__i + 1, __index_holder<_Indexes..., __i>, _Elements...>::type
+          type;
+};
+
+template <size_t __i, size_t... _Indexes>
+struct __index_holder_impl<__i, __index_holder<_Indexes...>> {
+  typedef __index_holder<_Indexes...> type;
+};
+
+template <typename... _Elements>
+struct __make_index_holder : __index_holder_impl<0, __index_holder<>, _Elements...> {};
+
+template <typename... _TElements, size_t... _TIdx, typename... _UElements, size_t... _UIdx>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> __tuple_cat_helper(
+    tuple<_TElements...> const& __t, __index_holder<_TIdx...> const&,
+    tuple<_UElements...> const& __u, __index_holder<_UIdx...> const&) {
+  return tuple<_TElements..., _UElements...>(get<_TIdx>(__t)..., get<_UIdx>(__u)...);
+}
+
+template <typename... _TElements, size_t... _TIdx, typename... _UElements, size_t... _UIdx>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> __tuple_cat_helper(
+    tuple<_TElements...>&& __t, __index_holder<_TIdx...> const&, tuple<_UElements...> const& __u,
+    __index_holder<_UIdx...> const&) {
+  return tuple<_TElements..., _UElements...>(move(get<_TIdx>(__t))..., get<_UIdx>(__u)...);
+}
+
+template <typename... _TElements, size_t... _TIdx, typename... _UElements, size_t... _UIdx>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> __tuple_cat_helper(
+    tuple<_TElements...> const& __t, __index_holder<_TIdx...> const&, tuple<_UElements...>&& __u,
+    __index_holder<_UIdx...> const&) {
+  return tuple<_TElements..., _UElements...>(get<_TIdx>(__t)..., move(get<_UIdx>(__u))...);
+}
+
+template <typename... _TElements, size_t... _TIdx, typename... _UElements, size_t... _UIdx>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> __tuple_cat_helper(
+    tuple<_TElements...>&& __t, __index_holder<_TIdx...> const&, tuple<_UElements...>&& __u,
+    __index_holder<_UIdx...> const&) {
+  return tuple<_TElements..., _UElements...>(move(get<_TIdx>(__t))..., move(get<_UIdx>(__u))...);
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> tuple_cat(tuple<_TElements...> const& __t,
+                                                                 tuple<_UElements...> const& __u) {
+  return __tuple_cat_helper(__t, typename __make_index_holder<_TElements...>::type(), __u,
+                            typename __make_index_holder<_UElements...>::type());
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> tuple_cat(tuple<_TElements...>&& __t,
+                                                                 tuple<_UElements...> const& __u) {
+  return __tuple_cat_helper(move(__t), typename __make_index_holder<_TElements...>::type(), __u,
+                            typename __make_index_holder<_UElements...>::type());
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> tuple_cat(tuple<_TElements...> const& __t,
+                                                                 tuple<_UElements...>&& __u) {
+  return __tuple_cat_helper(__t, typename __make_index_holder<_TElements...>::type(), move(__u),
+                            typename __make_index_holder<_UElements...>::type());
+}
+
+template <typename... _TElements, typename... _UElements>
+DEVICE_FUNC inline tuple<_TElements..., _UElements...> tuple_cat(tuple<_TElements...>&& __t,
+                                                                 tuple<_UElements...>&& __u) {
+  return __tuple_cat_helper(move(__t), typename __make_index_holder<_TElements...>::type(),
+                            move(__u), typename __make_index_holder<_UElements...>::type());
+}
+
+template <typename... _Elements>
+DEVICE_FUNC inline tuple<_Elements&...> tie(_Elements&... __args) {
+  return tuple<_Elements&...>(__args...);
+}
+
+template <typename... _Elements>
+DEVICE_FUNC inline void swap(tuple<_Elements...>& __x, tuple<_Elements...>& __y) {
+  __x.swap(__y);
+}
+
+// A class (and instance) which can be used in 'tie' when an element
+// of a tuple is not required
+struct _Swallow_assign {
+  template <class _Tp>
+  DEVICE_FUNC _Swallow_assign& operator=(_Tp const&) {
+    return *this;
+  }
+};
+
+// TODO: Put this in some kind of shared file.
+namespace {
+_Swallow_assign ignore;
+};  // anonymous namespace
+}  // namespace libstdcpp
+
+template <typename... Types>
+using tuple = libstdcpp::tuple<Types...>;
+
+using libstdcpp::tie;
+using libstdcpp::tuple_cat;
+
+#ifndef GENERATE_CUBIN
+template <class T>
+using remove_cv = std::remove_cv<T>;
+template <class T>
+using remove_cv_t = typename std::remove_cv<T>::type;
+template <typename T>
+using decay = std::decay<T>;
+template <typename T>
+using decay_t = std::decay_t<T>;
+#else
+
+// https://en.cppreference.com/w/cpp/types/is_array
+template <class T>
+struct is_array : false_type {};
+
+template <class T>
+struct is_array<T[]> : true_type {};
+
+template <class T, size_t N>
+struct is_array<T[N]> : true_type {};
+
+// https://en.cppreference.com/w/cpp/types/remove_extent
+template <class T>
+struct remove_extent {
+  using type = T;
+};
+
+template <class T>
+struct remove_extent<T[]> {
+  using type = T;
+};
+
+template <class T, size_t N>
+struct remove_extent<T[N]> {
+  using type = T;
+};
+
+// https://en.cppreference.com/w/cpp/types/is_function
+template <class>
+struct is_function : false_type {};
+
+// specialization for regular functions
+template <class Ret, class... Args>
+struct is_function<Ret(Args...)> : true_type {};
+
+// specialization for variadic functions such as printf
+template <class Ret, class... Args>
+struct is_function<Ret(Args......)> : true_type {};
+
+// specialization for function types that have cv-qualifiers
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) volatile> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const volatile> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) volatile> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const volatile> : true_type {};
+
+// specialization for function types that have ref-qualifiers
+template <class Ret, class... Args>
+struct is_function<Ret(Args...)&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) volatile&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const volatile&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......)&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) volatile&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const volatile&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) &&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const&&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) volatile&&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const volatile&&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) &&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const&&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) volatile&&> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const volatile&&> : true_type {};
+
+// specializations for noexcept versions of all the above (C++17 and later)
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) volatile noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const volatile noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) volatile noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const volatile noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) volatile & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const volatile & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) volatile & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const volatile & noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) && noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const && noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) volatile && noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args...) const volatile && noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) && noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const && noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) volatile && noexcept> : true_type {};
+
+template <class Ret, class... Args>
+struct is_function<Ret(Args......) const volatile && noexcept> : true_type {};
+
+// https://en.cppreference.com/w/cpp/types/remove_cv
+template <class T>
+struct remove_cv {
+  typedef T type;
+};
+
+template <class T>
+struct remove_cv<T const> {
+  typedef T type;
+};
+
+template <class T>
+struct remove_cv<T volatile> {
+  typedef T type;
+};
+
+template <class T>
+struct remove_cv<const volatile T> {
+  typedef T type;
+};
+
+template <class T>
+struct remove_const {
+  typedef T type;
+};
+
+template <class T>
+struct remove_const<T const> {
+  typedef T type;
+};
+
+template <class T>
+struct remove_volatile {
+  typedef T type;
+};
+
+template <class T>
+struct remove_volatile<T volatile> {
+  typedef T type;
+};
+
+template <class T>
+using remove_cv_t = typename remove_cv<T>::type;
+
+// https://en.cppreference.com/w/cpp/types/add_pointer
+namespace detail {
+template <class T>
+auto try_add_pointer(int) -> type_identity<typename remove_reference<T>::type*>;  // usual case
+
+template <class T>
+auto try_add_pointer(...)
+    -> type_identity<T>;  // unusual case (cannot form std::remove_reference<T>::type*)
+}  // namespace detail
+
+template <class T>
+struct add_pointer : decltype(detail::try_add_pointer<T>(0)) {};
+
+// https://en.cppreference.com/w/cpp/types/decay
+template <class T>
+struct decay {
+ private:
+  typedef typename remove_reference<T>::type U;
+
+ public:
+  typedef typename conditional<
+      is_array<U>::value, typename add_pointer<typename remove_extent<U>::type>::type,
+      typename conditional<is_function<U>::value, typename add_pointer<U>::type,
+                           typename remove_cv<U>::type>::type>::type type;
+};
+
+template <typename T>
+using decay_t = typename decay<T>::type;
+#endif
+
+#ifndef GENERATE_CUBIN
+template <typename T>
+using is_void = std::is_void<T>;
+template <typename T>
+inline constexpr bool is_void_v = std::is_void_v<T>;
+#else
+template <typename T>
+using is_void = is_same<remove_cv_t<T>, void>;
+template <typename T>
+inline constexpr bool is_void_v = is_void<T>::value;
+#endif
+}  // namespace mha
+
+#if GENERATE_CUBIN
+using uint8_t = mha::uint8_t;
+using int8_t = mha::int8_t;
+using uint16_t = mha::uint16_t;
+using int32_t = mha::int32_t;
+using uint32_t = mha::uint32_t;
+using uint64_t = mha::uint64_t;
+using uintptr_t = mha::uintptr_t;
+#endif

--- a/csrc/attention/flashinfer_xqa_src/mma.cuh
+++ b/csrc/attention/flashinfer_xqa_src/mma.cuh
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "cuda_hint.cuh"
+#include "mha_stdheaders.cuh"
+#ifndef __CUDACC__
+#include <cuda_runtime.h>
+#endif
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+// for both a and b, outer-dim is gemm-K and inner-dim is gemm-M or gemm-N
+// acc is used as both input and output.
+template <typename InputElem>
+__device__ inline void mma(float (&acc)[2][2], uint32_t const (&a)[2][2],
+                           uint32_t const (&b)[2][1]) {
+  static_assert(mha::is_same_v<InputElem, half> || mha::is_same_v<InputElem, __nv_bfloat16> ||
+                    mha::is_same_v<InputElem, __nv_fp8_e4m3>,
+                "not implemented");
+  if constexpr (mha::is_same_v<InputElem, half>) {
+    asm("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 \n"
+        "    {%0, %1, %2, %3}, \n"
+        "    {%4, %5, %6, %7}, \n"
+        "    {%8, %9}, \n"
+        "    {%0, %1, %2, %3}; \n"
+        : "+f"(acc[0][0]), "+f"(acc[0][1]), "+f"(acc[1][0]), "+f"(acc[1][1])
+        : "r"(a[0][0]), "r"(a[0][1]), "r"(a[1][0]), "r"(a[1][1]), "r"(b[0][0]), "r"(b[1][0]));
+  } else if constexpr (mha::is_same_v<InputElem, __nv_bfloat16>) {
+    asm("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 \n"
+        "    {%0, %1, %2, %3}, \n"
+        "    {%4, %5, %6, %7}, \n"
+        "    {%8, %9}, \n"
+        "    {%0, %1, %2, %3}; \n"
+        : "+f"(acc[0][0]), "+f"(acc[0][1]), "+f"(acc[1][0]), "+f"(acc[1][1])
+        : "r"(a[0][0]), "r"(a[0][1]), "r"(a[1][0]), "r"(a[1][1]), "r"(b[0][0]), "r"(b[1][0]));
+  } else if constexpr (mha::is_same_v<InputElem, __nv_fp8_e4m3>) {
+    asm("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 \n"
+        "    {%0, %1, %2, %3}, \n"
+        "    {%4, %5, %6, %7}, \n"
+        "    {%8, %9}, \n"
+        "    {%0, %1, %2, %3}; \n"
+        : "+f"(acc[0][0]), "+f"(acc[0][1]), "+f"(acc[1][0]), "+f"(acc[1][1])
+        : "r"(a[0][0]), "r"(a[0][1]), "r"(a[1][0]), "r"(a[1][1]), "r"(b[0][0]), "r"(b[1][0]));
+  } else {
+    asm volatile("trap;");
+  }
+}
+
+__device__ inline void mmaF8_k16(float (&acc)[2][2], uint32_t const (&a)[2], uint32_t const b) {
+  asm("mma.sync.aligned.m16n8k16.row.col.f32.e4m3.e4m3.f32 \n"
+      "    {%0, %1, %2, %3}, \n"
+      "    {%4, %5}, \n"
+      "    {%6}, \n"
+      "    {%0, %1, %2, %3}; \n"
+      : "+f"(acc[0][0]), "+f"(acc[0][1]), "+f"(acc[1][0]), "+f"(acc[1][1])
+      : "r"(a[0]), "r"(a[1]), "r"(b));
+}
+
+__device__ inline void mmaF8_k32_2inst(float (&acc)[2][2], uint32_t const (&a)[2][2],
+                                       uint32_t const (&b)[2][1]) {
+  for (uint32_t i = 0; i < 2; i++) {
+    mmaF8_k16(acc, a[i], b[i][0]);
+  }
+}
+
+struct mmaShape {
+  uint32_t m;
+  uint32_t n;
+  uint32_t k;
+};
+
+inline constexpr mmaShape qmmaShape = {16, 8, 32};

--- a/csrc/attention/flashinfer_xqa_src/platform.h
+++ b/csrc/attention/flashinfer_xqa_src/platform.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// for IDE parser
+#if defined(Q_CREATOR_RUN) || defined(__CLION_IDE__) || defined(__INTELLISENSE__) || \
+    defined(IN_KDEVELOP_PARSER) || defined(__JETBRAINS_IDE__) || defined(__CLANGD__)
+#define IS_IN_IDE_PARSER 1
+#else
+#define IS_IN_IDE_PARSER 0
+#endif

--- a/csrc/attention/flashinfer_xqa_src/specDec.h
+++ b/csrc/attention/flashinfer_xqa_src/specDec.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "defines.h"
+#if SPEC_DEC
+
+struct SpecDecParams {
+  uint32_t qSeqLen;
+  uint32_t const* qCuSeqLens;  // [nbReq + 1]
+  MaskType const*
+      mask;  // [nbReq][qSeqLen][divUp(qSeqLen, 32)] or [qCuSeqLen[nbReq]][divUp(qSeqLen, 32)]
+};
+
+#endif

--- a/csrc/attention/flashinfer_xqa_src/utils.cuh
+++ b/csrc/attention/flashinfer_xqa_src/utils.cuh
@@ -1,0 +1,1042 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cuda_hint.cuh"
+#include "utils.h"
+
+#ifndef GENERATE_CUBIN
+#include <cstdint>
+#else
+#include "mha_stdheaders.cuh"
+#endif
+
+#ifndef __CUDACC__
+#include <cuda_runtime.h>
+#endif
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#include "barriers.cuh"
+
+inline constexpr float log2e = 1.4426950408889634;  // std::log2(M_E)
+// we used an optimization where exp(x-rowMax) is computed as:
+/*  bias = rowMax * log2e  // shared for the whole row
+    exp(x-rowMax) = exp2f(x * log2e - bias)
+*/
+// But this optimization is not numerically stable when (x * log2e - bias) is computed with FMA and
+// x is too large. For this reason, don't set safeInitRowMax with a huge absolute value.
+inline constexpr float safeInitRowMax = -1e+5F;
+inline constexpr int32_t kBAD_PAGE_INDEX = -1;
+__constant__ constexpr float kE4M3_MAX = 448.F;
+
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ == 860 || __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 1200 || __CUDA_ARCH__ == 1210
+constexpr uint32_t kMAX_SMEM_SIZE = (99u << 10);
+#elif __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 870
+constexpr uint32_t kMAX_SMEM_SIZE = (163u << 10);
+#elif __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1000 || __CUDA_ARCH__ == 1030 || \
+    __CUDA_ARCH__ == 1100
+constexpr uint32_t kMAX_SMEM_SIZE = (227u << 10);
+#endif
+#endif
+
+__device__ inline void assertWarpConverged() {
+  // assert(__activemask() == ~0U);
+}
+
+#define DEFINE_VEC_BINARY_FUNC(func)                                                               \
+  template <typename T, uint32_t size>                                                             \
+  __device__ __host__ inline Vec<decltype(func(mha::declval<T>(), mha::declval<T>())), size> func( \
+      Vec<T, size> const& a, Vec<T, size> const& b) {                                              \
+    Vec<decltype(func(mha::declval<T>(), mha::declval<T>())), size> result;                        \
+    _Pragma("unroll") for (uint32_t i = 0; i < size; i++) { result[i] = func(a[i], b[i]); }        \
+    return result;                                                                                 \
+  }
+DEFINE_VEC_BINARY_FUNC(max)
+DEFINE_VEC_BINARY_FUNC(fmaxf)
+DEFINE_VEC_BINARY_FUNC(__hadd2_rn)
+
+__device__ __host__ inline float2 addFloat2(float2 a, float2 b) {
+  return float2{a.x + b.x, a.y + b.y};
+}
+DEFINE_VEC_BINARY_FUNC(addFloat2)
+#undef DEFINE_VEC_BINARY_FUNC
+#define DEFINE_VEC_BINARY_OP(op)                                                         \
+  template <typename T, uint32_t size>                                                   \
+  __device__ __host__ inline Vec<decltype(mha::declval<T>() op mha::declval<T>()), size> \
+  operator op(Vec<T, size> const& a, Vec<T, size> const& b) {                            \
+    Vec<decltype(mha::declval<T>() op mha::declval<T>()), size> result;                  \
+    _Pragma("unroll") for (uint32_t i = 0; i < size; i++) { result[i] = a[i] op b[i]; }  \
+    return result;                                                                       \
+  }                                                                                      \
+  template <typename T, uint32_t size, typename Scalar>                                  \
+  __device__ __host__ inline Vec<decltype(mha::declval<T>() op mha::declval<T>()), size> \
+  operator op(Vec<T, size> const& a, Scalar const& b) {                                  \
+    Vec<decltype(mha::declval<T>() op mha::declval<Scalar>()), size> result;             \
+    _Pragma("unroll") for (uint32_t i = 0; i < size; i++) { result[i] = a[i] op b; }     \
+    return result;                                                                       \
+  }                                                                                      \
+  template <typename Scalar, typename T, uint32_t size>                                  \
+  __device__ __host__ inline Vec<decltype(mha::declval<T>() op mha::declval<T>()), size> \
+  operator op(Scalar const& a, Vec<T, size> const& b) {                                  \
+    Vec<decltype(mha::declval<Scalar>() op mha::declval<T>()), size> result;             \
+    _Pragma("unroll") for (uint32_t i = 0; i < size; i++) { result[i] = a op b[i]; }     \
+    return result;                                                                       \
+  }
+// Don't use DEFINE_VEC_BINARY_FUNC(operator+), as operator+(float, float) is undefined,
+// and float will be converted into half to perform the operation, which results in much
+// lower precision. It's a defect of C++ that operator+(1.F, 2.F) does not work!
+DEFINE_VEC_BINARY_OP(+)
+DEFINE_VEC_BINARY_OP(-)
+DEFINE_VEC_BINARY_OP(*)
+DEFINE_VEC_BINARY_OP(/)
+DEFINE_VEC_BINARY_OP(==)
+DEFINE_VEC_BINARY_OP(!=)
+DEFINE_VEC_BINARY_OP(>)
+DEFINE_VEC_BINARY_OP(<)
+DEFINE_VEC_BINARY_OP(>=)
+DEFINE_VEC_BINARY_OP(<=)
+#undef DEFINE_VEC_BINARY_OP
+
+template <uint32_t size>
+HOST_DEVICE_FUNC inline bool all(Vec<bool, size> const& src) {
+  bool ret = true;
+#pragma unroll
+  for (uint32_t i = 0; i < size; i++) {
+    ret = ret && src[i];
+  }
+  return ret;
+}
+
+template <uint32_t size>
+HOST_DEVICE_FUNC inline bool any(Vec<bool, size> const& src) {
+  bool ret = false;
+#pragma unroll
+  for (uint32_t i = 0; i < size; i++) {
+    ret = ret || src[i];
+  }
+  return ret;
+}
+
+#define DEFINE_VEC_UNARY_OP(op)                                                     \
+  template <typename T, uint32_t size>                                              \
+  __device__ __host__ inline Vec<decltype(op(mha::declval<T>())), size> op(         \
+      Vec<T, size> const& a) {                                                      \
+    Vec<decltype(op(mha::declval<T>())), size> result;                              \
+    _Pragma("unroll") for (uint32_t i = 0; i < size; i++) { result[i] = op(a[i]); } \
+    return result;                                                                  \
+  }
+DEFINE_VEC_UNARY_OP(expf)
+DEFINE_VEC_UNARY_OP(exp2f)
+DEFINE_VEC_UNARY_OP(__float2bfloat162_rn)
+DEFINE_VEC_UNARY_OP(__float2half2_rn)
+DEFINE_VEC_UNARY_OP(__float22half2_rn)
+DEFINE_VEC_UNARY_OP(__bfloat1622float2)
+DEFINE_VEC_UNARY_OP(__half22float2)
+DEFINE_VEC_UNARY_OP(__frcp_rn)
+#undef DEFINE_VEC_UNARY_OP
+
+template <typename Dst, typename Src, uint32_t size>
+__device__ __host__ inline Vec<Dst, size> convert(Vec<Src, size> const& src) {
+  if constexpr (mha::is_same_v<mha::decay_t<Dst>, mha::decay_t<Src>>) {
+    return src;
+  }
+  Vec<Dst, size> dst;
+  if constexpr (mha::is_same_v<Src, half> && mha::is_same_v<Dst, float>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<float2&>(dst[i]) = __half22float2(reinterpret_cast<half2 const&>(src[i]));
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  } else if constexpr (mha::is_same_v<Src, float> && mha::is_same_v<Dst, half>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<half2&>(dst[i]) = __float22half2_rn(reinterpret_cast<float2 const&>(src[i]));
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  }
+  if constexpr (mha::is_same_v<Src, __nv_bfloat16> && mha::is_same_v<Dst, float>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<float2&>(dst[i]) =
+          __bfloat1622float2(reinterpret_cast<__nv_bfloat162 const&>(src[i]));
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  } else if constexpr (mha::is_same_v<Src, float> && mha::is_same_v<Dst, __nv_bfloat16>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<__nv_bfloat162&>(dst[i]) =
+          __float22bfloat162_rn(reinterpret_cast<float2 const&>(src[i]));
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  } else if constexpr (mha::is_same_v<Src, __nv_fp8_e4m3> && mha::is_same_v<Dst, float>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<float2&>(dst[i]) = float2(reinterpret_cast<__nv_fp8x2_e4m3 const&>(src[i]));
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  } else if constexpr (mha::is_same_v<Src, float> && mha::is_same_v<Dst, __nv_fp8_e4m3>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<__nv_fp8x2_e4m3&>(dst[i]) = __nv_fp8x2_e4m3{float2{src[i], src[i + 1]}};
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  } else if constexpr (mha::is_same_v<Src, __nv_fp8_e4m3> && mha::is_same_v<Dst, half>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<half2&>(dst[i]) = half2(reinterpret_cast<__nv_fp8x2_e4m3 const&>(src[i]));
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  } else if constexpr (mha::is_same_v<Src, half> && mha::is_same_v<Dst, __nv_fp8_e4m3>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<__nv_fp8x2_e4m3&>(dst[i]) =
+          __nv_fp8x2_e4m3{reinterpret_cast<half2 const&>(src[i])};
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  }
+  // else if constexpr (mha::is_same_v<Src, __nv_fp8_e4m3> && mha::is_same_v<Dst, __nv_bfloat16>) {
+  //     static_assert("not implemented");
+  // }
+  else if constexpr (mha::is_same_v<Src, __nv_bfloat16> && mha::is_same_v<Dst, __nv_fp8_e4m3>) {
+    for (uint32_t i = 0; i < size - 1; i += 2) {
+      reinterpret_cast<__nv_fp8x2_e4m3&>(dst[i]) =
+          __nv_fp8x2_e4m3{reinterpret_cast<__nv_bfloat162 const&>(src[i])};
+    }
+    if constexpr (size % 2 != 0) {
+      dst[size - 1] = Dst{src[size - 1]};
+    }
+  } else {
+    for (uint32_t i = 0; i < size; i++) {
+      dst[i] = Dst{src[i]};
+    }
+  }
+  return dst;
+}
+
+__device__ inline uint32_t laneId() {
+  uint32_t id;
+  asm("mov.u32 %0, %%laneid;\n" : "=r"(id));
+  return id;
+}
+
+__device__ inline uint32_t dynamicSmemSize() {
+  uint32_t size;
+  asm("mov.u32 %0, %%dynamic_smem_size;\n" : "=r"(size));
+  return size;
+}
+
+__device__ inline void trap() { asm volatile("trap;\n"); }
+
+inline constexpr uint32_t warp_size = 32;
+
+struct Warp {};
+
+__device__ inline Warp this_warp() { return {}; }
+
+// @fixme: check asm code to make sure UR is used and SHFL is not generated.
+template <typename T>
+__device__ inline T makeWarpUniform(Warp const& warp, T const& val) {
+  T const val0 = __shfl_sync(~0U, val, 0);
+  assert(val == val0);
+  return val0;
+}
+
+__device__ inline uint3 getWarpIdx(uint3 ctaShapeInWarps, Warp const& warp = this_warp()) {
+  assert(ctaShapeInWarps.x % 128 == 0);
+  return uint3{ctaShapeInWarps.x == 1 ? 0 : makeWarpUniform(warp, threadIdx.x / warp_size),
+               ctaShapeInWarps.y == 1 ? 0 : makeWarpUniform(warp, threadIdx.y),
+               ctaShapeInWarps.z == 1 ? 0 : makeWarpUniform(warp, threadIdx.z)};
+}
+
+constexpr uint32_t cacheLineSize = 128;
+
+template <uint32_t x>
+__device__ __host__ inline void assertIsPowerOf2() {
+  static_assert((x & (x - 1)) == 0);
+}
+
+template <typename T>
+__device__ inline bool hasBankConflict(T* p) {
+  static_assert(sizeof(T) % 4 == 0 && sizeof(T) <= 16 && alignof(T) == sizeof(T));
+  constexpr uint32_t grpSize = 128 / sizeof(T);
+  const uint32_t grpMask = (((1U << grpSize) - 1U) << (laneId() / grpSize * grpSize));
+  uint32_t const x = reinterpret_cast<uintptr_t>(p) / sizeof(T) % grpSize;
+  auto const match = __match_any_sync(grpMask, x);
+  bool const conflict = __popc(match) > 1;
+  if (grpSize <= 8 && conflict) {
+    char str[grpSize * 2 + 1] = {};
+    for (uint32_t i = 0; i < grpSize; i++) {
+      str[i * 2] = __shfl_sync(grpMask, x, i, grpSize) + '0';
+      str[i * 2 + 1] = ' ';
+    }
+    if (laneId() % grpSize == 0) {
+      printf("bank conflict (%u): %s\n", match, str);
+    }
+  }
+  return conflict;
+}
+
+__device__ inline float atomicMax(float* addr, float value) {
+  float old;
+  old = (value >= 0)
+            ? __int_as_float(atomicMax(reinterpret_cast<int32_t*>(addr), __float_as_int(value)))
+            : __uint_as_float(atomicMin(reinterpret_cast<uint32_t*>(addr), __float_as_uint(value)));
+  return old;
+}
+
+__device__ inline bool isInInt32Range(uint32_t x) {
+  return x <= static_cast<uint32_t>(mha::numeric_limits<int32_t>::max());
+}
+
+// struct of arrays instead of array of structs for compact storage
+template <typename Pointer, size_t length>
+struct CompactRangeList {
+  mha::array<Pointer, length> pointerList;
+  mha::array<uint32_t, length> sizeList;
+
+  struct Range {
+    Pointer const& data;
+    uint32_t const& size;
+  };
+
+  __device__ inline Range operator[](uint32_t i) const {
+    return Range{pointerList[i], sizeList[i]};
+  }
+};
+
+// alignedForSwizzle is for case when you need to mix TMA+LDS/LDSM, or LDGSTS/STS/STSM+GMMA
+template <typename T, uint32_t rows_, uint32_t cols_, bool alignedForSwizzle = true>
+struct alignas(mha::min<uint32_t>(maxArrayAlign<T>(rows_* cols_), cacheLineSize)) Array2D {
+  using Elem = T;
+  static constexpr uint32_t rows = rows_;
+  static constexpr uint32_t cols = cols_;
+  static constexpr uint32_t size = rows * cols;
+  static constexpr uint32_t rowBytes = sizeof(T) * cols;
+
+  template <bool swizzle = false>
+  __device__ inline T const& at(uint32_t r, uint32_t c) const {
+    assert(r < rows && c < cols);
+    // two different swizzle styles
+#if 1
+    uint32_t const c_swizzled = [&] {
+      if constexpr (swizzle) {
+        static_assert(rowBytes % cacheLineSize == 0 || cacheLineSize % rowBytes == 0);
+        static constexpr uint32_t rowsPerSliding =
+            exactDiv(cacheLineSize,
+                     rowBytes % cacheLineSize == 0 ? cacheLineSize : rowBytes % cacheLineSize);
+        constexpr uint32_t swizzleRowsRepeat = exactDiv(cacheLineSize, sizeof(Elem));
+        auto const runtimeBaseOffset =
+            static_cast<uint32_t>(__cvta_generic_to_shared(this->data)) / rowBytes % rows;
+        uint32_t const baseOffset =
+            alignedForSwizzle
+                ? 0
+                : runtimeBaseOffset;  // To match TMA when array is not aligned to pattern boundary
+        uint32_t const xorMask =
+            alignedForSwizzle
+                ? BoundedVal<rows>{r}
+                      .template divBy<rowsPerSliding>()
+                      .template mod<exactDiv(swizzleRowsRepeat, rowsPerSliding)>()
+                      .get()
+                : (r + baseOffset) / rowsPerSliding % exactDiv(swizzleRowsRepeat, rowsPerSliding);
+        return c ^ xorMask;
+      }
+      return c;
+    }();
+#else
+    uint32_t const c_swizzled = swizzle ? (c + r / rowsPerSliding) % cols : c;
+#endif
+    T const& ret = (&data[0][0])[r * cols + c_swizzled];
+    assert(&data[r][c_swizzled] == &ret);
+    return ret;
+  }
+
+  template <bool swizzle = false>
+  __device__ inline T& at(uint32_t r, uint32_t c) {
+    return const_cast<T&>(static_cast<Array2D const*>(this)->at<swizzle>(r, c));
+  }
+
+  __device__ inline T const& operator()(uint32_t r, uint32_t c) const { return at<false>(r, c); }
+
+  __device__ inline T& operator()(uint32_t r, uint32_t c) { return at<false>(r, c); }
+
+  template <typename T2>
+  __device__ inline Array2D<T2, rows, exactDiv(sizeof(T) * cols, sizeof(T2))>& as() {
+    return reinterpret_cast<Array2D<T2, rows, exactDiv(sizeof(T) * cols, sizeof(T2))>&>(*this);
+  }
+
+  __device__ inline void fill(T val) {
+#pragma unroll
+    for (uint32_t i = 0; i < rows * cols; i++) {
+      (&data[0][0])[i] = val;
+    }
+  }
+
+  __device__ inline static Array2D<T, rows, cols> filled(T val) {
+    Array2D<T, rows, cols> ret;
+    ret.fill(val);
+    return ret;
+  }
+
+  T data[rows][cols];
+};
+
+#define DEFINE_ARRAY2D_BINARY_OP(op)                                                               \
+  template <typename T, uint32_t rows, uint32_t cols>                                              \
+  __device__ __host__ inline Array2D<decltype(mha::declval<T>() op mha::declval<T>()), rows, cols> \
+  operator op(Array2D<T, rows, cols> const& a, Array2D<T, rows, cols> const& b) {                  \
+    Array2D<decltype(mha::declval<T>() op mha::declval<T>()), rows, cols> result;                  \
+    _Pragma("unroll") for (uint32_t i = 0; i < rows; i++) {                                        \
+      for (uint32_t j = 0; j < cols; j++) {                                                        \
+        result(i, j) = a(i, j) op b(i, j);                                                         \
+      }                                                                                            \
+    }                                                                                              \
+    return result;                                                                                 \
+  }                                                                                                \
+  template <typename T, uint32_t rows, uint32_t cols, typename Scalar>                             \
+  __device__ __host__ inline Array2D<decltype(mha::declval<T>() op mha::declval<T>()), rows, cols> \
+  operator op(Array2D<T, rows, cols> const& a, Scalar const& b) {                                  \
+    Array2D<decltype(mha::declval<T>() op mha::declval<Scalar>()), rows, cols> result;             \
+    _Pragma("unroll") for (uint32_t i = 0; i < rows; i++) {                                        \
+      for (uint32_t j = 0; j < cols; j++) {                                                        \
+        result(i, j) = a(i, j) op b;                                                               \
+      }                                                                                            \
+    }                                                                                              \
+    return result;                                                                                 \
+  }                                                                                                \
+  template <typename Scalar, typename T, uint32_t rows, uint32_t cols>                             \
+  __device__ __host__ inline Array2D<decltype(mha::declval<T>() op mha::declval<T>()), rows, cols> \
+  operator op(Scalar const& a, Array2D<T, rows, cols> const& b) {                                  \
+    Array2D<decltype(mha::declval<Scalar>() op mha::declval<T>()), rows, cols> result;             \
+    _Pragma("unroll") for (uint32_t i = 0; i < rows; i++) {                                        \
+      for (uint32_t j = 0; j < cols; j++) {                                                        \
+        result(i, j) = a op b(i, j);                                                               \
+      }                                                                                            \
+    }                                                                                              \
+    return result;                                                                                 \
+  }
+// Don't use DEFINE_VEC_BINARY_FUNC(operator+), as operator+(float, float) is undefined,
+// and float will be converted into half to perform the operation, which results in much
+// lower precision. It's a defect of C++ that operator+(1.F, 2.F) does not work!
+DEFINE_ARRAY2D_BINARY_OP(+)
+DEFINE_ARRAY2D_BINARY_OP(-)
+DEFINE_ARRAY2D_BINARY_OP(*)
+
+using LdGrain = Vec<uint32_t, 4>;
+constexpr uint32_t grainBytes = sizeof(LdGrain);
+
+// wrapper for PTX ldmatrix
+template <bool transpose, uint32_t nbMat>
+__device__ inline Vec<uint32_t, nbMat> ldmatrix(LdGrain const* row) {
+  assertWarpConverged();
+  uint32_t a, b, c, d;
+  if constexpr (nbMat == 4) {
+    if (transpose) {
+      asm("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+          : "=r"(a), "=r"(b), "=r"(c), "=r"(d)
+          : "l"(__cvta_generic_to_shared(row))
+          : "memory");
+    } else {
+      asm("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+          : "=r"(a), "=r"(b), "=r"(c), "=r"(d)
+          : "l"(__cvta_generic_to_shared(row))
+          : "memory");
+    }
+#if 0
+        auto checkMat = [&](uint32_t val, uint32_t idxMat) -> Vec<uint16_t, 8> const& {
+            auto const v = (Vec<uint16_t, 2> const&)val;
+            uint32_t const lane = laneId();
+            auto getRow = [&](uint32_t r) {
+                assert(r<8);
+                auto const ret = __shfl_sync(~0U, reinterpret_cast<uint64_t const&>(row), 8*idxMat+r);
+                return *reinterpret_cast<Vec<uint16_t, 8> const*>(ret);
+            };
+            auto checkEq = [](uint16_t x, uint16_t y) {
+                if (!(x==y)) {
+                    printf("x=%u, y= %u\n", (unsigned)x, (unsigned)y);
+                }
+            };
+            if (transpose) {
+                checkEq(v[0], getRow(lane % 4 * 2)[lane / 4]);
+                checkEq(v[1], getRow(lane % 4 * 2 + 1)[lane / 4]);
+            }
+            else {
+                checkEq(v[0], getRow(lane / 4)[lane % 4 * 2]);
+                checkEq(v[1], getRow(lane / 4)[lane % 4 * 2 + 1]);
+            }
+        };
+        checkMat(a, 0);
+        checkMat(b, 1);
+        checkMat(c, 2);
+        checkMat(d, 3);
+#endif
+    return Vec<uint32_t, 4>{a, b, c, d};
+  } else if constexpr (nbMat == 2) {
+    if (transpose) {
+      asm("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 {%0, %1}, [%2];\n"
+          : "=r"(a), "=r"(b)
+          : "l"(__cvta_generic_to_shared(row))
+          : "memory");
+    } else {
+      asm("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+          : "=r"(a), "=r"(b)
+          : "l"(__cvta_generic_to_shared(row))
+          : "memory");
+    }
+    return Vec<uint32_t, 2>{a, b};
+  } else if constexpr (nbMat == 1) {
+    if (transpose) {
+      asm("ldmatrix.sync.aligned.m8n8.x2.trans.shared.b16 %0, [%1];\n"
+          : "=r"(a)
+          : "l"(__cvta_generic_to_shared(row))
+          : "memory");
+    } else {
+      asm("ldmatrix.sync.aligned.m8n8.x2.shared.b16 %0, [%1];\n"
+          : "=r"(a)
+          : "l"(__cvta_generic_to_shared(row))
+          : "memory");
+    }
+    return Vec<uint32_t, 1>{a};
+  } else {
+    static_assert(nbMat == 1 || nbMat == 2 || nbMat == 4);
+  }
+}
+
+template <bool transpose>
+__device__ inline Vec<uint32_t, 4> ldmatrix_4x(Warp const& warp, LdGrain const* row) {
+  return ldmatrix<transpose, 4>(row);
+}
+
+template <uint32_t nbMat>
+__device__ inline Vec<uint32_t, nbMat * 2> ldmatrix_16x16_trans(LdGrain const* row) {
+  uint32_t a, b, c, d;
+  if constexpr (nbMat == 1) {
+    asm("ldmatrix.sync.aligned.m16n16.x1.trans.shared::cta.b8 {%0, %1}, [%2];\n"
+        : "=r"(a), "=r"(b)
+        : "l"(__cvta_generic_to_shared(row))
+        : "memory");
+    return Vec<uint32_t, 2>{a, b};
+  } else if constexpr (nbMat == 2) {
+    asm("ldmatrix.sync.aligned.m16n16.x2.trans.shared::cta.b8 {%0, %1, %2, %3}, [%4];\n"
+        : "=r"(a), "=r"(b), "=r"(c), "=r"(d)
+        : "l"(__cvta_generic_to_shared(row))
+        : "memory");
+    return Vec<uint32_t, 4>{a, b, c, d};
+  } else {
+    static_assert(nbMat == 1 || nbMat == 2);
+  }
+}
+
+template <uint32_t nbMat>
+__device__ inline Vec<uint32_t, nbMat * 2> ldmatrix_16x16_trans_unpack_4b(LdGrain const* row) {
+#if __CUDA_ARCH__ >= 1000
+  uint32_t a, b, c, d;
+  if constexpr (nbMat == 1) {
+    asm("ldmatrix.sync.aligned.m16n16.x1.trans.shared::cta.b8x16.b4x16_p64 {%0, %1}, [%2];\n"
+        : "=r"(a), "=r"(b)
+        : "l"(__cvta_generic_to_shared(row))
+        : "memory");
+    return Vec<uint32_t, 2>{a, b};
+  } else if constexpr (nbMat == 2) {
+    asm("ldmatrix.sync.aligned.m16n16.x2.trans.shared::cta.b8x16.b4x16_p64 {%0, %1, %2, %3}, "
+        "[%4];\n"
+        : "=r"(a), "=r"(b), "=r"(c), "=r"(d)
+        : "l"(__cvta_generic_to_shared(row))
+        : "memory");
+    return Vec<uint32_t, 4>{a, b, c, d};
+  } else {
+    static_assert(nbMat == 1 || nbMat == 2);
+  }
+#else
+  trap();
+#endif
+}
+
+template <uint32_t nbMat>
+__device__ inline Vec<uint32_t, nbMat> ldmatrix_8x16_4x_unpack_4b(LdGrain const* row) {
+#if __CUDA_ARCH__ >= 1000
+  uint32_t a, b, c, d;
+  if constexpr (nbMat == 4) {
+    asm("ldmatrix.sync.aligned.m8n16.x4.shared.b8x16.b4x16_p64 {%0, %1, %2, %3}, [%4];\n"
+        : "=r"(a), "=r"(b), "=r"(c), "=r"(d)
+        : "l"(__cvta_generic_to_shared(row))
+        : "memory");
+    return Vec<uint32_t, 4>{a, b, c, d};
+  } else if constexpr (nbMat == 2) {
+    asm("ldmatrix.sync.aligned.m8n16.x2.shared.b8x16.b4x16_p64 {%0, %1}, [%2];\n"
+        : "=r"(a), "=r"(b)
+        : "l"(__cvta_generic_to_shared(row))
+        : "memory");
+    return Vec<uint32_t, 2>{a, b};
+  } else if constexpr (nbMat == 1) {
+    asm("ldmatrix.sync.aligned.m8n16.x1.shared.b8x16.b4x16_p64 {%0}, [%1];\n"
+        : "=r"(a)
+        : "l"(__cvta_generic_to_shared(row))
+        : "memory");
+    return Vec<uint32_t, 1>{a};
+  } else {
+    static_assert(nbMat == 1 || nbMat == 2 || nbMat == 4);
+  }
+#else
+  trap();
+#endif
+}
+
+template <bool transpose>
+__device__ inline Vec<uint32_t, 4> ldmatrix_4x_unpack_4b(Warp const& warp, LdGrain const* row) {
+  if constexpr (transpose) {
+    return ldmatrix_16x16_trans_unpack_4b<2>(row);
+  } else {
+    return ldmatrix_8x16_4x_unpack_4b<4>(row);
+  }
+}
+
+template <bool transpose, uint32_t nbMat>
+__device__ inline void stmatrix(LdGrain* row, Vec<uint32_t, nbMat> const& data) {
+#if __CUDA_ARCH__ >= 900
+  assertWarpConverged();
+  if constexpr (nbMat == 4) {
+    if constexpr (transpose) {
+      asm("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"l"(
+              __cvta_generic_to_shared(row)),
+          "r"(data[0]), "r"(data[1]), "r"(data[2]), "r"(data[3])
+          : "memory");
+    } else {
+      asm("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n" ::"l"(
+              __cvta_generic_to_shared(row)),
+          "r"(data[0]), "r"(data[1]), "r"(data[2]), "r"(data[3])
+          : "memory");
+    }
+  } else if constexpr (nbMat == 2) {
+    if constexpr (transpose) {
+      asm("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n" ::"l"(
+              __cvta_generic_to_shared(row)),
+          "r"(data[0]), "r"(data[1])
+          : "memory");
+    } else {
+      asm("stmatrix.sync.aligned.m8n8.x2.shared.b16 [%0], {%1, %2};\n" ::"l"(
+              __cvta_generic_to_shared(row)),
+          "r"(data[0]), "r"(data[1])
+          : "memory");
+    }
+  } else if constexpr (nbMat == 1) {
+    if constexpr (transpose) {
+      asm("stmatrix.sync.aligned.m8n8.x1.trans.shared.b16 [%0], {%1};\n" ::"l"(
+              __cvta_generic_to_shared(row)),
+          "r"(data[0])
+          : "memory");
+    } else {
+      asm("stmatrix.sync.aligned.m8n8.x1.shared.b16 [%0], {%1};\n" ::"l"(
+              __cvta_generic_to_shared(row)),
+          "r"(data[0])
+          : "memory");
+    }
+  } else {
+    static_assert(nbMat == 1 || nbMat == 2 || nbMat == 4);
+  }
+#else
+  trap();
+#endif
+}
+
+template <bool transpose>
+__device__ inline void stmatrix_4x(Warp const& warp, LdGrain* row, Vec<uint32_t, 4> const& data) {
+  stmatrix<transpose, 4>(row, data);
+}
+
+struct None {};
+
+template <bool real, typename T>
+using RealTypeOrNone = mha::conditional_t<real, T, None>;
+
+template <Scope producerScope = Scope::CTA, Scope consumerScope = Scope::CTA>
+struct MBarrierPair {
+  MBarrier<producerScope> produced;
+  MBarrier<consumerScope> consumed;
+
+  __device__ inline void initialize(uint32_t producedCount, uint32_t consumedCount) {
+    init(&produced, producedCount);
+    init(&consumed, consumedCount);
+  }
+};
+
+using CtaBarrierPair = MBarrierPair<Scope::CTA, Scope::CTA>;
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+template <Scope scope>
+__device__ inline auto arrive_tx(MBarrier<scope>& bar, uint32_t txCount, uint32_t arriveCount = 1) {
+#if USE_CUSTOM_BARRIER
+  return bar.arrive_tx(txCount, arriveCount);
+#else
+  return cuda::device::barrier_arrive_tx(bar, arriveCount, txCount);
+#endif
+}
+
+template <Scope scope>
+__device__ inline void arrive_tx_and_wait(MBarrier<scope>& bar, uint32_t txCount,
+                                          uint32_t arriveCount = 1) {
+  bar.wait(arrive_tx(bar, txCount, arriveCount));
+}
+#endif
+
+template <uint32_t bound0>
+__device__ inline mha::tuple<uint32_t, uint32_t> carryLE(uint32_t i0, uint32_t iLast) {
+  return mha::tuple<uint32_t, uint32_t>{i0 % bound0, iLast + i0 / bound0};
+}
+
+template <uint32_t bound0, uint32_t bound1, uint32_t... bounds>
+__device__ inline mha::tuple<uint32_t, uint32_t, decltype(bounds)..., uint32_t> carryLE(
+    uint32_t i0, uint32_t i1, decltype(bounds)... i, uint32_t iLast) {
+  return mha::tuple_cat(mha::tuple<uint32_t>(i0 % bound0),
+                        carryLE<bound1, bounds...>(i1 + i0 / bound0, i..., iLast));
+}
+
+__device__ __host__ inline void assertClose(float a, float b, float threshold = 0.01f) {
+  assert(abs(a - b) < threshold);
+}
+
+__device__ __host__ inline void assertClose(half a, half b, float threshold = 0.01f) {
+  assertClose(__half2float(a), __half2float(b), threshold);
+}
+
+template <typename InputElem, typename CacheElem>
+__device__ inline Vec<uint32_t, 2> convertKCacheWordToF16(uint32_t i8data) {
+  static_assert(mha::is_same_v<InputElem, half> || mha::is_same_v<InputElem, __nv_bfloat16>,
+                "not implemented");
+  static_assert(sizeof(CacheElem) == 1);
+  Vec<uint32_t, 2> ret;
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 890)
+  if constexpr (mha::is_same_v<InputElem, half> && mha::is_same_v<CacheElem, __nv_fp8_e4m3>) {
+    uint16_t(&src)[2] = reinterpret_cast<uint16_t(&)[2]>(i8data);
+    uint32_t(&dst)[2] = reinterpret_cast<uint32_t(&)[2]>(ret);
+    asm("{\n"
+        "cvt.rn.f16x2.e4m3x2 %0, %2;\n"
+        "cvt.rn.f16x2.e4m3x2 %1, %3;\n"
+        "}"
+        : "=r"(dst[0]), "=r"(dst[1])
+        : "h"(src[0]), "h"(src[1]));
+    return ret;
+  }
+#endif
+  CacheElem const(&src)[4] = reinterpret_cast<CacheElem(&)[4]>(i8data);
+  InputElem(&dst)[4] = reinterpret_cast<InputElem(&)[4]>(ret);
+#pragma unroll
+  for (uint32_t i = 0; i < 4; i++) {
+    dst[i] = InputElem(src[i]);
+  }
+  return ret;
+}
+
+#if ENABLE_4BIT_KV_CACHE
+template <>
+__device__ inline Vec<uint32_t, 2> convertKCacheWordToF16<half, __nv_fp4_e2m1>(uint32_t i8data) {
+  Vec<uint32_t, 2> ret;
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t src = i8data | (i8data >> 4);
+  uint32_t(&dst)[2] = reinterpret_cast<uint32_t(&)[2]>(ret);
+  asm("{\n"
+      ".reg .b8 byte0, byte2;\n"
+      "mov.b32 {byte0, _, byte2, _}, %2;\n"
+      "cvt.rn.f16x2.e2m1x2 %0, byte0;\n"
+      "cvt.rn.f16x2.e2m1x2 %1, byte2;\n"
+      "}"
+      : "=r"(dst[0]), "=r"(dst[1])
+      : "r"(src));
+#else
+  assert(!"need arch >= 1000");
+  trap();
+#endif
+  return ret;
+}
+
+template <>
+__device__ inline Vec<uint32_t, 2> convertKCacheWordToF16<__nv_bfloat16, __nv_fp4_e2m1>(
+    uint32_t i8data) {
+  Vec<uint32_t, 2> ret;
+  // This needs CUDA Toolkit version >= 13.2
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+#if (defined __CUDACC_VER_MAJOR__) && (defined __CUDACC_VER_MINOR__) && \
+    ((__CUDACC_VER_MAJOR__ > 13) || ((__CUDACC_VER_MAJOR__ == 13) && (__CUDACC_VER_MINOR__ >= 2)))
+  uint32_t src = i8data | (i8data >> 4);
+  uint32_t(&dst)[2] = reinterpret_cast<uint32_t(&)[2]>(ret);
+  asm("{\n"
+      ".reg .b8 byte0, byte2;\n"
+      "mov.b32 {byte0, _, byte2, _}, %2;\n"
+      "cvt.rn.bf16x2.e2m1x2 %0, byte0;\n"
+      "cvt.rn.bf16x2.e2m1x2 %1, byte2;\n"
+      "}"
+      : "=r"(dst[0]), "=r"(dst[1])
+      : "r"(src));
+#else
+  // Fallback: convert e2m1 -> fp16 -> bf16
+  uint32_t src = i8data | (i8data >> 4);
+  __half halfData[4];
+  uint32_t(&dst)[2] = reinterpret_cast<uint32_t(&)[2]>(halfData);
+  asm("{\n"
+      ".reg .b8 byte0, byte2;\n"
+      "mov.b32 {byte0, _, byte2, _}, %2;\n"
+      "cvt.rn.f16x2.e2m1x2 %0, byte0;\n"
+      "cvt.rn.f16x2.e2m1x2 %1, byte2;\n"
+      "}"
+      : "=r"(dst[0]), "=r"(dst[1])
+      : "r"(src));
+  auto bf16Data = reinterpret_cast<__nv_bfloat16(&)[4]>(ret);
+#pragma unroll
+  for (uint32_t ii = 0; ii < 4; ii++) {
+    bf16Data[ii] = __nv_bfloat16(halfData[ii]);
+  }
+#endif
+#else
+  assert(!"need arch >= 1000");
+  trap();
+#endif
+  return ret;
+}
+#endif
+
+template <typename InputElem, typename CacheElem>
+__device__ inline Vec<uint32_t, 2> convertVCacheWordToF16(uint32_t i8data) {
+  static_assert(mha::is_same_v<InputElem, half> || mha::is_same_v<InputElem, __nv_bfloat16>,
+                "not implemented");
+  static_assert(sizeof(CacheElem) == 1);
+  Vec<uint32_t, 2> ret;
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 890)
+  if constexpr (mha::is_same_v<InputElem, half> && mha::is_same_v<CacheElem, __nv_fp8_e4m3>) {
+    uint32_t(&dst)[2] = reinterpret_cast<uint32_t(&)[2]>(ret);
+    asm("{\n"
+        ".reg .b32 dst0;\n"
+        ".reg .b32 dst1;\n"
+        ".reg .b32 src;\n"
+        ".reg .b16 src0;\n"
+        ".reg .b16 src1;\n"
+        "prmt.b32 src, %2, 0x0, 0x3120;\n"
+        "mov.b32 {src0, src1}, src;\n"
+        "cvt.rn.f16x2.e4m3x2 %0, src0;\n"
+        "cvt.rn.f16x2.e4m3x2 %1, src1;\n"
+        "}"
+        : "=r"(dst[0]), "=r"(dst[1])
+        : "r"(i8data));
+    return ret;
+  }
+#endif
+  CacheElem const(&src)[2][2] = reinterpret_cast<CacheElem(&)[2][2]>(i8data);
+  InputElem(&dst)[2][2] = reinterpret_cast<InputElem(&)[2][2]>(ret);
+#pragma unroll
+  for (uint32_t i = 0; i < 2; i++) {
+#pragma unroll
+    for (uint32_t j = 0; j < 2; j++) {
+      dst[i][j] = InputElem(src[j][i]);
+    }
+  }
+
+  return ret;
+}
+
+template <typename InputElem>
+__device__ inline uint32_t applyF16ScalingFactor(uint32_t x, uint16_t sf) {
+  // Broadcasts sf to both lanes and multiplies:
+  // (o0, o1) = (x0, x1) * (sf, sf)
+  uint32_t ret;
+  if constexpr (mha::is_same_v<InputElem, half>) {
+    asm("{\n"
+        ".reg .b32 sf2;\n"
+        "mov.b32 sf2, {%2, %2};\n"
+        "mul.rn.f16x2 %0, %1, sf2;\n"
+        "}"
+        : "=r"(ret)
+        : "r"(x), "h"(sf));
+  } else {
+    static_assert(mha::is_same_v<InputElem, __nv_bfloat16>);
+    asm("{\n"
+        ".reg .b32 sf2;\n"
+        "mov.b32 sf2, {%2, %2};\n"
+        "mul.rn.bf16x2 %0, %1, sf2;\n"
+        "}"
+        : "=r"(ret)
+        : "r"(x), "h"(sf));
+  }
+  return ret;
+}
+
+struct PermuteOrder {
+  uint16_t x0 : 4;
+  uint16_t x1 : 4;
+  uint16_t x2 : 4;
+  uint16_t x3 : 4;
+};
+
+static_assert(sizeof(PermuteOrder) == 2);
+
+__device__ inline uint32_t prmt(uint32_t a, uint32_t b, PermuteOrder order) {
+  uint32_t d;
+  uint32_t const c = reinterpret_cast<uint16_t const&>(order);
+  asm("prmt.b32 %0, %1, %2, %3;\n" : "=r"(d) : "r"(a), "r"(b), "r"(c));
+  return d;
+}
+
+__device__ inline uint32_t movmatrix(uint32_t src) {
+  uint32_t dst;
+  asm("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n" : "=r"(dst) : "r"(src));
+  return dst;
+}
+
+__device__ inline bool warpElectSync() {
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  uint32_t pred = 0;
+  asm volatile(
+      "{\n"
+      "    .reg .b32 d;\n"
+      "    .reg .pred p;\n"
+      "    elect.sync d|p, 0xFFFFFFFF;\n"
+      "    selp.b32 %0, 1, 0, p;\n"
+      "}\n"
+      : "=r"(pred));
+  return pred != 0;
+#else
+  assert("not available");
+  return false;
+#endif
+}
+
+__device__ inline void preExit() {
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  asm volatile("griddepcontrol.launch_dependents;\n");
+#endif
+}
+
+__device__ inline void acqBulk() {
+#if (defined __CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  asm volatile("griddepcontrol.wait;\n");
+#endif
+}
+
+__device__ inline uint3 nbClusters() {
+  uint3 id;
+  asm("mov.v4.u32 {%0, %1, %2, _}, %%nclusterid;\n" : "=r"(id.x), "=r"(id.y), "=r"(id.z));
+  return id;
+}
+
+__device__ inline uint3 clusterId() {
+  uint3 id;
+  asm("mov.v4.u32 {%0, %1, %2, _}, %%clusterid;\n" : "=r"(id.x), "=r"(id.y), "=r"(id.z));
+  return id;
+}
+
+__device__ inline uint32_t clusterCtaRank() {
+  uint32_t rank;
+  asm("mov.u32 %0, %%cluster_ctarank;\n" : "=r"(rank));
+  return rank;
+}
+
+__device__ inline uint3 clusterCtaId() {
+  uint3 id;
+  asm("mov.v4.u32 {%0, %1, %2, _}, %%cluster_ctaid;\n" : "=r"(id.x), "=r"(id.y), "=r"(id.z));
+  return id;
+}
+
+// src and return are both generic address
+template <typename T>
+__device__ inline T* mapa(T* src, uint32_t clusterCtaRank) {
+  uint64_t dst;
+  asm volatile("mapa.u64 %0, %1, %2;\n"
+               : "=l"(dst)
+               : "l"(reinterpret_cast<uint64_t>(src)), "r"(clusterCtaRank));
+  return reinterpret_cast<T*>(dst);
+}
+
+template <typename T>
+__device__ inline T& mapa(T& src, uint32_t clusterCtaRank) {
+  return *mapa(&src, clusterCtaRank);
+}
+
+__device__ inline void clusterBarArrive() {
+  asm volatile("barrier.cluster.arrive.release.aligned;\n");
+}
+
+__device__ inline void clusterBarWait() { asm volatile("barrier.cluster.wait.acquire.aligned;\n"); }
+
+__device__ inline uint32_t clock32() {
+  uint32_t ret;
+  asm volatile("mov.u32 %0, %%clock;\n" : "=r"(ret)::"memory");
+  return ret;
+}
+
+template <uint32_t nbBufs, Scope producerScope = Scope::CTA, Scope consumerScope = Scope::CTA>
+struct BarWaiter {
+  MBarrierPair<producerScope, consumerScope> (*bars)[nbBufs];
+  uint32_t idx;
+  uint32_t idxBuf;
+  bool skipBarWait = false;
+
+  __device__ inline BarWaiter(MBarrierPair<producerScope, consumerScope> (&bars)[nbBufs],
+                              uint32_t idx)
+      : bars{&bars}, idx{idx}, idxBuf{idx % nbBufs} {}
+
+  __device__ inline bool testWait() {
+    bool const parity = toParity<nbBufs>(idx);
+    skipBarWait = bar().produced.test_wait_parity(parity);
+    return skipBarWait;
+  }
+
+  __device__ inline BarWaiter next(uint32_t step = 1) { return BarWaiter{*bars, idx + step}; }
+
+  __device__ inline void wait() {
+    if (!skipBarWait) {
+      bar().produced.wait_parity(toParity<nbBufs>(idx));
+    }
+  }
+
+  __device__ inline MBarrierPair<producerScope, consumerScope>& bar() { return (*bars)[idxBuf]; }
+
+  __device__ inline void consumed() { bar().consumed.arrive(); }
+};
+
+class Timer {
+ public:
+  __device__ inline Timer() { reset(); }
+
+  __device__ inline void print(char const* name = "unnamed", bool reset = false) {
+    auto const toc = clock32();
+    printf("%s: %u (block={%u, %u, %u})\n", name, toc - mTic, blockIdx.x, blockIdx.y, blockIdx.z);
+    if (reset) {
+      this->reset();
+    }
+  }
+
+  __device__ inline void reset() { mTic = clock32(); }
+
+ private:
+  uint32_t mTic;
+};
+
+// [beg, end)
+struct Range {
+  uint32_t beg, end;
+};
+
+constexpr bool overlap(Range a, Range b) { return a.beg < b.end && b.beg < a.end; }

--- a/csrc/attention/flashinfer_xqa_src/utils.h
+++ b/csrc/attention/flashinfer_xqa_src/utils.h
@@ -1,0 +1,292 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef GENERATE_CUBIN
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#endif
+#include "mha_stdheaders.cuh"
+
+template <typename T>
+HOST_DEVICE_FUNC constexpr inline void unused(T&& x) {
+  static_cast<void>(x);
+}
+
+#ifndef GENERATE_CUBIN
+inline void checkCuda(cudaError_t err) {
+  if (err != cudaSuccess) {
+    printf("%s\n", cudaGetErrorName(err));
+    throw std::runtime_error(cudaGetErrorName(err));
+  }
+}
+
+inline void checkCu(CUresult err) {
+  if (err != CUDA_SUCCESS) {
+    char const* str = nullptr;
+    if (cuGetErrorName(err, &str) != CUDA_SUCCESS) {
+      str = "A cuda driver API error happened, but we failed to query the error name\n";
+    }
+    printf("%s\n", str);
+    throw std::runtime_error(str);
+  }
+}
+#endif
+
+HOST_DEVICE_FUNC constexpr inline uint32_t greatestPowerOf2Divisor(uint32_t x) {
+  return x & ~(x - 1);
+}
+
+template <typename T>
+HOST_DEVICE_FUNC constexpr uint32_t maxArrayAlign(uint32_t size) {
+  return sizeof(T) * greatestPowerOf2Divisor(size);
+}
+
+HOST_DEVICE_FUNC constexpr inline uint32_t exactDiv(uint32_t a, uint32_t b) {
+  assert(a % b == 0);
+  return a / b;
+}
+
+template <typename T>
+HOST_DEVICE_FUNC constexpr inline T divUp(T a, T b) {
+  return (a + b - 1) / b;
+}
+
+template <typename T>
+HOST_DEVICE_FUNC constexpr inline T roundUp(T a, T b) {
+  return divUp(a, b) * b;
+}
+
+// upperBound is exclusive, i.e. range is [0, upperBound)
+template <uint32_t upperBound>
+struct BoundedVal {
+  template <uint32_t divisor>
+  HOST_DEVICE_FUNC inline BoundedVal<upperBound / divisor> divBy() const {
+    assert(value < upperBound);
+    return {upperBound <= divisor ? 0 : value / divisor};
+  }
+
+  template <uint32_t divisor>
+  HOST_DEVICE_FUNC inline BoundedVal<mha::min(divisor, upperBound)> mod() const {
+    assert(value < upperBound);
+    return {upperBound <= divisor ? value : value % divisor};
+  }
+
+  HOST_DEVICE_FUNC inline bool operator<=(uint32_t rhs) const {
+    assert(value < upperBound);
+    return upperBound <= rhs || value <= rhs;
+  }
+
+  HOST_DEVICE_FUNC inline uint32_t get() const {
+    assert(value < upperBound);
+    return upperBound == 1 ? 0 : value;
+  }
+
+  uint32_t value;
+};
+
+template <typename T, uint32_t size_>
+struct alignas(mha::max<uint32_t>(alignof(T),
+                                  mha::min<uint32_t>(maxArrayAlign<T>(size_), 16))) Vec {
+  using Elem = T;
+  static constexpr uint32_t size = size_;
+  Elem data[size];
+
+  HOST_DEVICE_FUNC inline void fill(T val) {
+#pragma unroll
+    for (uint32_t i = 0; i < size; i++) {
+      data[i] = val;
+    }
+  }
+
+  static HOST_DEVICE_FUNC inline Vec<T, size> filled(T val) {
+    Vec<T, size> ret;
+    ret.fill(val);
+    return ret;
+  }
+
+  HOST_DEVICE_FUNC inline Elem const& operator[](uint32_t i) const {
+    assert(i < size);
+    return data[BoundedVal<size>{i}.get()];
+  }
+
+  HOST_DEVICE_FUNC inline Elem& operator[](uint32_t i) {
+    assert(i < size);
+    return data[BoundedVal<size>{i}.get()];
+  }
+};
+
+template <uint32_t nbBuffers_>
+struct CircIdx {
+ public:
+  static constexpr uint32_t nbBuffers = nbBuffers_;
+  static_assert(nbBuffers >= 1);
+
+  __device__ inline CircIdx(uint32_t init) : mIndex{init % nbBuffers} {}
+
+  __device__ inline operator uint32_t() const { return mIndex; }
+
+  __device__ inline CircIdx operator+(uint32_t i) const {
+    return CircIdx{(mIndex + i) % nbBuffers};
+  }
+
+  __device__ inline CircIdx operator-(uint32_t i) const {
+    return CircIdx{(mIndex + (nbBuffers - 1) * i) % nbBuffers};
+  }
+
+  __device__ inline CircIdx next() const { return *this + 1u; }
+
+  __device__ inline CircIdx& operator++() {
+    mIndex = next();
+    return *this;
+  }
+
+  __device__ inline CircIdx operator++(int) {
+    CircIdx old = *this;
+    operator++();
+    return old;
+  }
+
+  __device__ inline CircIdx prev() const { return *this - 1u; }
+
+  __device__ inline CircIdx& operator--() {
+    mIndex = prev();
+    return *this;
+  }
+
+  __device__ inline CircIdx operator--(int) {
+    CircIdx old = *this;
+    operator--();
+    return old;
+  }
+
+ private:
+  uint32_t mIndex;
+};
+
+// base is usually in constant memory, so usually only require 1 register to store the offset.
+template <typename T>
+struct TinyPtr {
+  T* base;          // typically in constant memory or uniform registers
+  uint32_t offset;  // may be non-uniform
+
+  template <typename D>
+  __device__ __host__ inline TinyPtr<D> cast() const {
+    D* const p = reinterpret_cast<D*>(base);
+    assert(reinterpret_cast<uintptr_t>(p) % alignof(D) == 0);
+    if constexpr (mha::is_void_v<T>) {
+      assert(offset == 0);
+      return TinyPtr<D>{p, 0};
+    } else if constexpr (sizeof(T) < sizeof(D)) {
+      return TinyPtr<D>{p, exactDiv(offset, exactDiv(sizeof(D), sizeof(T)))};
+    } else {
+      return TinyPtr<D>{p, offset * exactDiv(sizeof(T), sizeof(D))};
+    }
+  }
+
+  __device__ __host__ inline T& operator*() const { return base[offset]; }
+
+  __device__ __host__ inline TinyPtr<T> operator+(uint32_t i) const {
+    return TinyPtr<T>{base, offset + i};
+  }
+
+  __device__ __host__ inline T& operator[](uint32_t i) const { return *(*this + i); }
+
+  __device__ __host__ inline operator T*() const { return base + offset; }
+};
+
+template <typename OffsetInt = uint32_t>
+class Segmenter {
+ public:
+  HOST_DEVICE_FUNC Segmenter(uint32_t offset = 0) : mNextOffset{offset} {}
+
+  // offset is in bytes
+  template <typename T>
+  HOST_DEVICE_FUNC OffsetInt newSeg(uint32_t count = 1, uint32_t alignment = alignof(T)) {
+    mMaxAlignment = mha::max<uint32_t>(mMaxAlignment, alignment);
+    OffsetInt const offset = roundUp<OffsetInt>(mNextOffset, alignment);
+    mNextOffset = offset + sizeof(T) * count;
+    return offset;
+  }
+
+  HOST_DEVICE_FUNC OffsetInt getEndOffset() const { return mNextOffset; }
+
+  HOST_DEVICE_FUNC uint32_t getMaxAlignment() const { return mMaxAlignment; }
+
+ private:
+  OffsetInt mNextOffset;
+  uint32_t mMaxAlignment = 1;
+};
+
+template <typename T, bool addConst>
+using AddConst = mha::conditional_t<addConst, T const, T>;
+
+template <bool isConst, typename OffsetInt = uint32_t>
+class MemSegmenter {
+ public:
+  HOST_DEVICE_FUNC MemSegmenter(AddConst<void, isConst>* base, uint32_t offset = 0)
+      : mBase{static_cast<AddConst<mha::byte, isConst>*>(base)}, mSegmenter{offset} {}
+
+  // to use TinyPtr, alignment must be sizeof(T)
+  template <typename T>
+  HOST_DEVICE_FUNC TinyPtr<AddConst<T, isConst>> newSeg(uint32_t count = 1,
+                                                        uint32_t alignment = sizeof(T)) {
+    assert(reinterpret_cast<uintptr_t>(mBase) % alignment == 0);
+    OffsetInt const offset = mSegmenter.template newSeg<T>(count, alignment);
+    return TinyPtr<AddConst<mha::byte, isConst>>{mBase, offset}
+        .template cast<AddConst<T, isConst>>();
+  }
+
+  HOST_DEVICE_FUNC OffsetInt getEndOffset() const { return mSegmenter.getEndOffset(); }
+
+  HOST_DEVICE_FUNC uint32_t getMaxAlignment() const { return mSegmenter.getMaxAlignment(); }
+
+ private:
+  AddConst<mha::byte, isConst>* mBase;
+  Segmenter<OffsetInt> mSegmenter;
+};
+
+// dims in little endian
+template <uint32_t nbDims_>
+struct DimsLE {
+  static constexpr uint32_t nbDims = nbDims_;
+
+  __device__ __host__ inline uint32_t& operator[](uint32_t i) { return d[i]; }
+
+  __device__ __host__ inline uint32_t const& operator[](uint32_t i) const { return d[i]; }
+
+  uint32_t d[nbDims];
+};
+
+// check if val is in range [lb, ub)
+template <typename T>
+constexpr bool inRange(T val, T lb, T ub) {
+  return val >= lb && val < ub;
+}
+
+// val is an optimized / pre-computed value, ref is the original value
+template <typename T>
+HOST_DEVICE_FUNC constexpr inline T checkedVal(T val, T ref) {
+  assert(val == ref);
+  return val;
+}

--- a/csrc/attention/sage2/sage2_attn_raw.cu
+++ b/csrc/attention/sage2/sage2_attn_raw.cu
@@ -254,4 +254,223 @@ int qk_int8_sv_f16_bf16_nhd_d128(
   return static_cast<int>(cudaGetLastError());
 }
 
+int qk_int8_sv_f16_bf16_gqa_nhd_d256(
+    const void* q_int8,
+    const void* k_int8,
+    const void* v_half,
+    void* out_bf16,
+    const void* q_scale,
+    const void* k_scale,
+    int batch,
+    int seqlen_q,
+    int seqlen_k,
+    int num_q_heads,
+    int num_kv_heads,
+    float softmax_scale,
+    cudaStream_t stream) {
+  constexpr int kHeadDim256 = 256;
+  if (!q_int8 || !k_int8 || !v_half || !out_bf16 || !q_scale || !k_scale) {
+    return -1;
+  }
+  if (batch <= 0 || seqlen_q <= 0 || seqlen_k <= 0 ||
+      num_q_heads <= 0 || num_kv_heads <= 0 ||
+      num_q_heads % num_kv_heads != 0) {
+    return -2;
+  }
+
+  const int num_kv_groups = num_q_heads / num_kv_heads;
+
+  const uint32_t stride_bz_q = static_cast<uint32_t>(seqlen_q * num_q_heads * kHeadDim256);
+  const uint32_t stride_seq_q = static_cast<uint32_t>(num_q_heads * kHeadDim256);
+  const uint32_t stride_h_q = static_cast<uint32_t>(kHeadDim256);
+
+  const uint32_t stride_bz_k = static_cast<uint32_t>(seqlen_k * num_kv_heads * kHeadDim256);
+  const uint32_t stride_seq_k = static_cast<uint32_t>(num_kv_heads * kHeadDim256);
+  const uint32_t stride_h_k = static_cast<uint32_t>(kHeadDim256);
+
+  const uint32_t stride_bz_v = static_cast<uint32_t>(seqlen_k * num_kv_heads * kHeadDim256);
+  const uint32_t stride_seq_v = static_cast<uint32_t>(num_kv_heads * kHeadDim256);
+  const uint32_t stride_h_v = static_cast<uint32_t>(kHeadDim256);
+
+  const uint32_t stride_bz_o = static_cast<uint32_t>(seqlen_q * num_q_heads * kHeadDim256);
+  const uint32_t stride_seq_o = static_cast<uint32_t>(num_q_heads * kHeadDim256);
+  const uint32_t stride_h_o = static_cast<uint32_t>(kHeadDim256);
+
+  using Kernel = decltype(&qk_int_sv_f16_attn_kernel<
+      kCtaQ, kCtaK, kWarpQ, kWarpK, kHeadDim256,
+      DataType::kInt8,
+      QuantGranularity::kPerWarp,
+      QuantGranularity::kPerWarp,
+      float,
+      false,
+      nv_bfloat16,
+      ComputeUnit::kTensorCore,
+      MaskMode::kNone,
+      false,
+      false>);
+
+  Kernel kernel = qk_int_sv_f16_attn_kernel<
+      kCtaQ, kCtaK, kWarpQ, kWarpK, kHeadDim256,
+      DataType::kInt8,
+      QuantGranularity::kPerWarp,
+      QuantGranularity::kPerWarp,
+      float,
+      false,
+      nv_bfloat16,
+      ComputeUnit::kTensorCore,
+      MaskMode::kNone,
+      false,
+      false>;
+
+  const size_t smem_qkv =
+      static_cast<size_t>(kCtaQ * kHeadDim256 * sizeof(int8_t) +
+                          kCtaK * kHeadDim256 * sizeof(int8_t) +
+                          kCtaK * kHeadDim256 * sizeof(half));
+  const size_t smem_o = static_cast<size_t>(kCtaQ * kHeadDim256 * sizeof(half));
+  const size_t smem_max = std::max(smem_qkv, smem_o);
+  static std::once_flag attr_once;
+  std::call_once(attr_once, [&]() {
+    cudaFuncSetAttribute(
+        kernel,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(smem_max));
+  });
+
+  dim3 grid(div_up_int(seqlen_q, kCtaQ), num_q_heads, batch);
+  dim3 block(32, (kCtaQ / kWarpQ) * (kCtaK / kWarpK));
+
+  kernel<<<grid, block, smem_max, stream>>>(
+      const_cast<int8_t*>(reinterpret_cast<const int8_t*>(q_int8)),
+      const_cast<int8_t*>(reinterpret_cast<const int8_t*>(k_int8)),
+      const_cast<half*>(reinterpret_cast<const half*>(v_half)),
+      reinterpret_cast<nv_bfloat16*>(out_bf16),
+      nullptr,
+      const_cast<float*>(reinterpret_cast<const float*>(q_scale)),
+      const_cast<float*>(reinterpret_cast<const float*>(k_scale)),
+      nullptr,
+      static_cast<uint32_t>(seqlen_q),
+      static_cast<uint32_t>(seqlen_k),
+      static_cast<uint32_t>(num_kv_groups),
+      stride_bz_q, stride_seq_q, stride_h_q,
+      stride_bz_k, stride_seq_k, stride_h_k,
+      stride_bz_v, stride_seq_v, stride_h_v,
+      stride_bz_o, stride_seq_o, stride_h_o,
+      softmax_scale);
+
+  return static_cast<int>(cudaGetLastError());
+}
+
+int qk_int8_sv_f8_bf16_gqa_nhd_d256(
+    const void* q_int8,
+    const void* k_int8,
+    const void* v_fp8,
+    void* out_bf16,
+    const void* q_scale,
+    const void* k_scale,
+    const void* v_scale,
+    int batch,
+    int seqlen_q,
+    int seqlen_k,
+    int num_q_heads,
+    int num_kv_heads,
+    float softmax_scale,
+    cudaStream_t stream) {
+  constexpr int kHeadDim256 = 256;
+  if (!q_int8 || !k_int8 || !v_fp8 || !out_bf16 ||
+      !q_scale || !k_scale || !v_scale) {
+    return -1;
+  }
+  if (batch <= 0 || seqlen_q <= 0 || seqlen_k <= 0 ||
+      num_q_heads <= 0 || num_kv_heads <= 0 ||
+      num_q_heads % num_kv_heads != 0) {
+    return -2;
+  }
+
+  const int num_kv_groups = num_q_heads / num_kv_heads;
+  const int padded_k = div_up_int(seqlen_k, kCtaK) * kCtaK;
+
+  const uint32_t stride_bz_q = static_cast<uint32_t>(seqlen_q * num_q_heads * kHeadDim256);
+  const uint32_t stride_seq_q = static_cast<uint32_t>(num_q_heads * kHeadDim256);
+  const uint32_t stride_h_q = static_cast<uint32_t>(kHeadDim256);
+
+  const uint32_t stride_bz_k = static_cast<uint32_t>(seqlen_k * num_kv_heads * kHeadDim256);
+  const uint32_t stride_seq_k = static_cast<uint32_t>(num_kv_heads * kHeadDim256);
+  const uint32_t stride_h_k = static_cast<uint32_t>(kHeadDim256);
+
+  // Sage per-channel FP8 V layout: [B, D, Hkv, padded_K].
+  const uint32_t stride_bz_v = static_cast<uint32_t>(kHeadDim256 * num_kv_heads * padded_k);
+  const uint32_t stride_h_v = static_cast<uint32_t>(padded_k);
+  const uint32_t stride_d_v = static_cast<uint32_t>(num_kv_heads * padded_k);
+
+  const uint32_t stride_bz_o = static_cast<uint32_t>(seqlen_q * num_q_heads * kHeadDim256);
+  const uint32_t stride_seq_o = static_cast<uint32_t>(num_q_heads * kHeadDim256);
+  const uint32_t stride_h_o = static_cast<uint32_t>(kHeadDim256);
+
+  using Kernel = decltype(&qk_int_sv_f8_attn_kernel<
+      kCtaQ, kCtaK, kWarpQ, kWarpK, kHeadDim256,
+      DataType::kInt8,
+      QuantGranularity::kPerWarp,
+      QuantGranularity::kPerWarp,
+      float,
+      false,
+      nv_bfloat16,
+      ComputeUnit::kCudaCore,
+      MaskMode::kNone,
+      false,
+      true,
+      false>);
+
+  Kernel kernel = qk_int_sv_f8_attn_kernel<
+      kCtaQ, kCtaK, kWarpQ, kWarpK, kHeadDim256,
+      DataType::kInt8,
+      QuantGranularity::kPerWarp,
+      QuantGranularity::kPerWarp,
+      float,
+      false,
+      nv_bfloat16,
+      ComputeUnit::kCudaCore,
+      MaskMode::kNone,
+      false,
+      true,
+      false>;
+
+  const size_t smem_qkv =
+      static_cast<size_t>(kCtaQ * kHeadDim256 +
+                          kCtaK * kHeadDim256 +
+                          kCtaK * kHeadDim256);
+  const size_t smem_o = static_cast<size_t>(kCtaQ * kHeadDim256 * sizeof(half));
+  const size_t smem_max = std::max(smem_qkv, smem_o);
+  static std::once_flag attr_once;
+  std::call_once(attr_once, [&]() {
+    cudaFuncSetAttribute(
+        kernel,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(smem_max));
+  });
+
+  dim3 grid(div_up_int(seqlen_q, kCtaQ), num_q_heads, batch);
+  dim3 block(32, (kCtaQ / kWarpQ) * (kCtaK / kWarpK));
+
+  kernel<<<grid, block, smem_max, stream>>>(
+      const_cast<int8_t*>(reinterpret_cast<const int8_t*>(q_int8)),
+      const_cast<int8_t*>(reinterpret_cast<const int8_t*>(k_int8)),
+      const_cast<int8_t*>(reinterpret_cast<const int8_t*>(v_fp8)),
+      reinterpret_cast<nv_bfloat16*>(out_bf16),
+      nullptr,
+      const_cast<float*>(reinterpret_cast<const float*>(q_scale)),
+      const_cast<float*>(reinterpret_cast<const float*>(k_scale)),
+      const_cast<float*>(reinterpret_cast<const float*>(v_scale)),
+      nullptr,
+      static_cast<uint32_t>(seqlen_q),
+      static_cast<uint32_t>(seqlen_k),
+      static_cast<uint32_t>(num_kv_groups),
+      stride_bz_q, stride_seq_q, stride_h_q,
+      stride_bz_k, stride_seq_k, stride_h_k,
+      stride_bz_v, stride_h_v, stride_d_v,
+      stride_bz_o, stride_seq_o, stride_h_o,
+      softmax_scale);
+
+  return static_cast<int>(cudaGetLastError());
+}
+
 }  // namespace flash_rt::attention::sage2

--- a/csrc/attention/sage2/sage2_attn_raw.cuh
+++ b/csrc/attention/sage2/sage2_attn_raw.cuh
@@ -33,4 +33,35 @@ int qk_int8_sv_f16_bf16_nhd_d128(
     float softmax_scale,
     cudaStream_t stream);
 
+int qk_int8_sv_f16_bf16_gqa_nhd_d256(
+    const void* q_int8,
+    const void* k_int8,
+    const void* v_half,
+    void* out_bf16,
+    const void* q_scale,
+    const void* k_scale,
+    int batch,
+    int seqlen_q,
+    int seqlen_k,
+    int num_q_heads,
+    int num_kv_heads,
+    float softmax_scale,
+    cudaStream_t stream);
+
+int qk_int8_sv_f8_bf16_gqa_nhd_d256(
+    const void* q_int8,
+    const void* k_int8,
+    const void* v_fp8,
+    void* out_bf16,
+    const void* q_scale,
+    const void* k_scale,
+    const void* v_scale,
+    int batch,
+    int seqlen_q,
+    int seqlen_k,
+    int num_q_heads,
+    int num_kv_heads,
+    float softmax_scale,
+    cudaStream_t stream);
+
 }  // namespace flash_rt::attention::sage2

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -32,6 +32,9 @@
 #ifdef ENABLE_TINYFP8_KERNELS
 #include "kernels/megakernel/tinyfp8_kernels_sm120.cuh"
 #endif
+#ifdef ENABLE_QWEN36_FLASHINFER_XQA
+#include "kernels/qwen36_flashinfer_xqa.cuh"
+#endif
 #ifdef ENABLE_CUTLASS_SM120_NVFP4_W4A16
 #include "quantize/nvfp4_sf_reshape_sm120.cuh"
 #endif
@@ -125,6 +128,7 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #include "kernels/silu_mul_to_nvfp4_swizzled.cuh"
 #include "kernels/rms_norm_gated_silu_qwen36.cuh"
 #include "kernels/silu_mul_qwen36.cuh"
+#include "kernels/qwen36_misc.cuh"
 #include "kernels/bf16_matvec_qwen36.cuh"
 #include "kernels/bf16_matmul_qwen36.cuh"
 #include "kernels/fp4_w4a4_matvec_sm120.cuh"
@@ -228,6 +232,38 @@ extern "C" void tq_fp32_gemm_tf32_launch(
     const void* a_fp32, const void* b_fp32,
     void* c_fp32,
     int M, int N, int K,
+    cudaStream_t stream);
+extern "C" void tq_fp32_gemm_fp32_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream);
+extern "C" void tq_fp32_gemm_fp32_bt_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream);
+extern "C" void tq_fp32_gemm_lt_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream);
+extern "C" void tq_fp32_gemm_lt_bt_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream);
+extern "C" void tq_fp32_gemm_lt_algo_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    int algo_idx,
+    cudaStream_t stream);
+extern "C" void tq_fp32_gemm_lt_bt_algo_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    int algo_idx,
     cudaStream_t stream);
 extern "C" void wmma_probe_launch(
     const void* a_bf16, const void* b_bf16, void* c_fp32,
@@ -1858,6 +1894,34 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                         nbytes, to_stream(stream));
     }, py::arg("dst"), py::arg("src"), py::arg("nbytes"), py::arg("stream") = 0);
 
+    m.def("concat2_bf16", [](uintptr_t a, uintptr_t b, uintptr_t out,
+                             int rows, int cols_a, int cols_b,
+                             uintptr_t stream) {
+        concat2_bf16(
+            reinterpret_cast<const __nv_bfloat16*>(a),
+            reinterpret_cast<const __nv_bfloat16*>(b),
+            reinterpret_cast<__nv_bfloat16*>(out),
+            rows, cols_a, cols_b, to_stream(stream));
+    }, py::arg("a"), py::arg("b"), py::arg("out"),
+       py::arg("rows"), py::arg("cols_a"), py::arg("cols_b"),
+       py::arg("stream") = 0);
+
+    m.def("cuda_read_i32_sync", [](uintptr_t src, uintptr_t stream) {
+        int host = 0;
+        cudaStream_t st = to_stream(stream);
+        cudaError_t err = cudaMemcpyAsync(
+            &host, reinterpret_cast<const void*>(src), sizeof(int),
+            cudaMemcpyDeviceToHost, st);
+        if (err != cudaSuccess) {
+            throw std::runtime_error(cudaGetErrorString(err));
+        }
+        err = cudaStreamSynchronize(st);
+        if (err != cudaSuccess) {
+            throw std::runtime_error(cudaGetErrorString(err));
+        }
+        return host;
+    }, py::arg("src"), py::arg("stream") = 0);
+
     m.def("gpu_fill_neginf_fp16", [](uintptr_t dst, int n, uintptr_t stream) {
         extern void gpu_fill_neginf_fp16(__half*, int, cudaStream_t);
         gpu_fill_neginf_fp16(reinterpret_cast<__half*>(dst), n, to_stream(stream));
@@ -2367,6 +2431,78 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("M"), py::arg("N"), py::arg("K"),
         py::arg("stream") = 0);
 
+    m.def("tq_fp32_gemm_fp32",
+        [](uintptr_t a_fp32, uintptr_t b_fp32, uintptr_t c_fp32,
+           int M, int N, int K, uintptr_t stream) {
+            tq_fp32_gemm_fp32_launch(
+                to_ptr(a_fp32), to_ptr(b_fp32),
+                reinterpret_cast<void*>(c_fp32),
+                M, N, K, to_stream(stream));
+        },
+        py::arg("a_fp32"), py::arg("b_fp32"), py::arg("c_fp32"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("stream") = 0);
+
+    m.def("tq_fp32_gemm_fp32_bt",
+        [](uintptr_t a_fp32, uintptr_t b_fp32, uintptr_t c_fp32,
+           int M, int N, int K, uintptr_t stream) {
+            tq_fp32_gemm_fp32_bt_launch(
+                to_ptr(a_fp32), to_ptr(b_fp32),
+                reinterpret_cast<void*>(c_fp32),
+                M, N, K, to_stream(stream));
+        },
+        py::arg("a_fp32"), py::arg("b_fp32"), py::arg("c_fp32"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("stream") = 0);
+
+    m.def("tq_fp32_gemm_lt",
+        [](uintptr_t a_fp32, uintptr_t b_fp32, uintptr_t c_fp32,
+           int M, int N, int K, uintptr_t stream) {
+            tq_fp32_gemm_lt_launch(
+                to_ptr(a_fp32), to_ptr(b_fp32),
+                reinterpret_cast<void*>(c_fp32),
+                M, N, K, to_stream(stream));
+        },
+        py::arg("a_fp32"), py::arg("b_fp32"), py::arg("c_fp32"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("stream") = 0);
+
+    m.def("tq_fp32_gemm_lt_bt",
+        [](uintptr_t a_fp32, uintptr_t b_fp32, uintptr_t c_fp32,
+           int M, int N, int K, uintptr_t stream) {
+            tq_fp32_gemm_lt_bt_launch(
+                to_ptr(a_fp32), to_ptr(b_fp32),
+                reinterpret_cast<void*>(c_fp32),
+                M, N, K, to_stream(stream));
+        },
+        py::arg("a_fp32"), py::arg("b_fp32"), py::arg("c_fp32"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("stream") = 0);
+
+    m.def("tq_fp32_gemm_lt_algo",
+        [](uintptr_t a_fp32, uintptr_t b_fp32, uintptr_t c_fp32,
+           int M, int N, int K, int algo_idx, uintptr_t stream) {
+            tq_fp32_gemm_lt_algo_launch(
+                to_ptr(a_fp32), to_ptr(b_fp32),
+                reinterpret_cast<void*>(c_fp32),
+                M, N, K, algo_idx, to_stream(stream));
+        },
+        py::arg("a_fp32"), py::arg("b_fp32"), py::arg("c_fp32"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("algo_idx"), py::arg("stream") = 0);
+
+    m.def("tq_fp32_gemm_lt_bt_algo",
+        [](uintptr_t a_fp32, uintptr_t b_fp32, uintptr_t c_fp32,
+           int M, int N, int K, int algo_idx, uintptr_t stream) {
+            tq_fp32_gemm_lt_bt_algo_launch(
+                to_ptr(a_fp32), to_ptr(b_fp32),
+                reinterpret_cast<void*>(c_fp32),
+                M, N, K, algo_idx, to_stream(stream));
+        },
+        py::arg("a_fp32"), py::arg("b_fp32"), py::arg("c_fp32"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("algo_idx"), py::arg("stream") = 0);
+
     m.def("tq_bf16_fp32_gemm",
         [](uintptr_t a_bf16, uintptr_t b_bf16, uintptr_t c_fp32,
            int M, int N, int K, uintptr_t stream) {
@@ -2701,6 +2837,25 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                 n, to_stream(stream));
         },
         py::arg("input"), py::arg("output"), py::arg("d_scale"),
+        py::arg("n"), py::arg("stream") = 0);
+
+    m.def("dequantize_fp8_static_bf16_2",
+        [](uintptr_t in0, uintptr_t in1,
+           uintptr_t out0, uintptr_t out1,
+           uintptr_t s0, uintptr_t s1,
+           int n, uintptr_t stream) {
+            dequantize_fp8_static_bf16_2(
+                typed_ptr<__nv_fp8_e4m3>(in0),
+                typed_ptr<__nv_fp8_e4m3>(in1),
+                typed_ptr<__nv_bfloat16>(out0),
+                typed_ptr<__nv_bfloat16>(out1),
+                reinterpret_cast<const float*>(s0),
+                reinterpret_cast<const float*>(s1),
+                n, to_stream(stream));
+        },
+        py::arg("in0"), py::arg("in1"),
+        py::arg("out0"), py::arg("out1"),
+        py::arg("s0"), py::arg("s1"),
         py::arg("n"), py::arg("stream") = 0);
 
     m.def("dequantize_fp8_static_bf16_6",
@@ -3384,6 +3539,39 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("out_bf16"), py::arg("q_scale"), py::arg("k_scale"),
         py::arg("B"), py::arg("Lq"), py::arg("Lk"), py::arg("H"),
         py::arg("softmax_scale"), py::arg("stream") = 0);
+
+    m.def("sage2_qk_int8_sv_f16_bf16_gqa_nhd_d256",
+        [](uintptr_t q_int8, uintptr_t k_int8, uintptr_t v_half,
+           uintptr_t out_bf16, uintptr_t q_scale, uintptr_t k_scale,
+           int B, int Lq, int Lk, int Hq, int Hkv, float softmax_scale,
+           uintptr_t stream) {
+            return flash_rt::attention::sage2::qk_int8_sv_f16_bf16_gqa_nhd_d256(
+                to_ptr(q_int8), to_ptr(k_int8), to_ptr(v_half),
+                to_ptr(out_bf16), to_ptr(q_scale), to_ptr(k_scale),
+                B, Lq, Lk, Hq, Hkv, softmax_scale, to_stream(stream));
+        },
+        py::arg("q_int8"), py::arg("k_int8"), py::arg("v_half"),
+        py::arg("out_bf16"), py::arg("q_scale"), py::arg("k_scale"),
+        py::arg("B"), py::arg("Lq"), py::arg("Lk"),
+        py::arg("Hq"), py::arg("Hkv"), py::arg("softmax_scale"),
+        py::arg("stream") = 0);
+
+    m.def("sage2_qk_int8_sv_f8_bf16_gqa_nhd_d256",
+        [](uintptr_t q_int8, uintptr_t k_int8, uintptr_t v_fp8,
+           uintptr_t out_bf16, uintptr_t q_scale, uintptr_t k_scale,
+           uintptr_t v_scale, int B, int Lq, int Lk, int Hq, int Hkv,
+           float softmax_scale, uintptr_t stream) {
+            return flash_rt::attention::sage2::qk_int8_sv_f8_bf16_gqa_nhd_d256(
+                to_ptr(q_int8), to_ptr(k_int8), to_ptr(v_fp8),
+                to_ptr(out_bf16), to_ptr(q_scale), to_ptr(k_scale),
+                to_ptr(v_scale), B, Lq, Lk, Hq, Hkv, softmax_scale,
+                to_stream(stream));
+        },
+        py::arg("q_int8"), py::arg("k_int8"), py::arg("v_fp8"),
+        py::arg("out_bf16"), py::arg("q_scale"), py::arg("k_scale"),
+        py::arg("v_scale"), py::arg("B"), py::arg("Lq"),
+        py::arg("Lk"), py::arg("Hq"), py::arg("Hkv"),
+        py::arg("softmax_scale"), py::arg("stream") = 0);
 #endif
 
     m.def("quant_per_block_int8_bf16_d128",
@@ -3713,6 +3901,38 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("B"), py::arg("conv_dim"), py::arg("k"),
         py::arg("apply_silu") = true, py::arg("stream") = 0);
 
+    m.def("causal_conv1d_qwen36_update_chunk_bf16",
+        [](uintptr_t x, uintptr_t w, uintptr_t bias,
+           uintptr_t out, uintptr_t state,
+           int B, int S, int conv_dim, int k, bool apply_silu,
+           uintptr_t stream) {
+            flash_rt::kernels::causal_conv1d_qwen36_update_chunk_bf16(
+                to_ptr(x), to_ptr(w),
+                bias ? to_ptr(bias) : nullptr,
+                to_ptr(out), to_ptr(state),
+                B, S, conv_dim, k, apply_silu, to_stream(stream));
+        },
+        py::arg("x"), py::arg("w"), py::arg("bias"),
+        py::arg("out"), py::arg("state"),
+        py::arg("B"), py::arg("S"), py::arg("conv_dim"), py::arg("k"),
+        py::arg("apply_silu") = true, py::arg("stream") = 0);
+
+    m.def("causal_conv1d_qwen36_update_chunk_parallel_bf16",
+        [](uintptr_t x, uintptr_t w, uintptr_t bias,
+           uintptr_t out, uintptr_t state,
+           int B, int S, int conv_dim, int k, bool apply_silu,
+           uintptr_t stream) {
+            flash_rt::kernels::causal_conv1d_qwen36_update_chunk_parallel_bf16(
+                to_ptr(x), to_ptr(w),
+                bias ? to_ptr(bias) : nullptr,
+                to_ptr(out), to_ptr(state),
+                B, S, conv_dim, k, apply_silu, to_stream(stream));
+        },
+        py::arg("x"), py::arg("w"), py::arg("bias"),
+        py::arg("out"), py::arg("state"),
+        py::arg("B"), py::arg("S"), py::arg("conv_dim"), py::arg("k"),
+        py::arg("apply_silu") = true, py::arg("stream") = 0);
+
     // Phase 4.4 — stream-invariant bf16 matvec for Qwen3.6 (replaces F.linear
     // / cuBLASLt for the small in_proj_a/b and the lm_head bf16 GEMM whose
     // per-stream / per-graph algo selection breaks CUDA Graph correctness).
@@ -3746,6 +3966,111 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("x"), py::arg("W"), py::arg("out"),
         py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
 
+    m.def("bf16_matmul_qwen36_ab96_bf16",
+        [](uintptr_t x, uintptr_t W_ab, uintptr_t out_ab,
+           int M, uintptr_t stream) {
+            flash_rt::kernels::bf16_matmul_qwen36_ab96_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const __nv_bfloat16*>(W_ab),
+                reinterpret_cast<__nv_bfloat16*>(out_ab),
+                M, to_stream(stream));
+        },
+        py::arg("x"), py::arg("W_ab"), py::arg("out_ab"),
+        py::arg("M"), py::arg("stream") = 0);
+
+    m.def("qwen36_embedding_lookup_bf16",
+        [](uintptr_t token_ids, uintptr_t embed, uintptr_t out,
+           int rows, int hidden, uintptr_t stream) {
+            flash_rt::kernels::qwen36_embedding_lookup_bf16(
+                reinterpret_cast<const int64_t*>(token_ids),
+                reinterpret_cast<const __nv_bfloat16*>(embed),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                rows, hidden, to_stream(stream));
+        },
+        py::arg("token_ids"), py::arg("embed"), py::arg("out"),
+        py::arg("rows"), py::arg("hidden"), py::arg("stream") = 0);
+
+    m.def("qwen36_partial_rope_qk_bf16",
+        [](uintptr_t q_in, uintptr_t k_in, uintptr_t cos, uintptr_t sin,
+           uintptr_t q_out, uintptr_t k_out, int rows, int q_heads,
+           int k_heads, int head_dim, int rope_dim, uintptr_t stream) {
+            flash_rt::kernels::qwen36_partial_rope_qk_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(q_in),
+                reinterpret_cast<const __nv_bfloat16*>(k_in),
+                reinterpret_cast<const __nv_bfloat16*>(cos),
+                reinterpret_cast<const __nv_bfloat16*>(sin),
+                reinterpret_cast<__nv_bfloat16*>(q_out),
+                reinterpret_cast<__nv_bfloat16*>(k_out),
+                rows, q_heads, k_heads, head_dim, rope_dim,
+                to_stream(stream));
+        },
+        py::arg("q_in"), py::arg("k_in"), py::arg("cos"), py::arg("sin"),
+        py::arg("q_out"), py::arg("k_out"), py::arg("rows"),
+        py::arg("q_heads"), py::arg("k_heads"), py::arg("head_dim"),
+        py::arg("rope_dim"), py::arg("stream") = 0);
+
+    m.def("qwen36_tq_prepare_scalars",
+        [](uintptr_t k_norm, uintptr_t k_rnorm, uintptr_t v_norm,
+           uintptr_t norm_k, uintptr_t coef_rnorm, uintptr_t norm_v,
+           int n, float coef, uintptr_t stream) {
+            flash_rt::kernels::qwen36_tq_prepare_scalars(
+                reinterpret_cast<const __half*>(k_norm),
+                reinterpret_cast<const __half*>(k_rnorm),
+                reinterpret_cast<const __half*>(v_norm),
+                reinterpret_cast<float*>(norm_k),
+                reinterpret_cast<float*>(coef_rnorm),
+                reinterpret_cast<float*>(norm_v),
+                n, coef, to_stream(stream));
+        },
+        py::arg("k_norm"), py::arg("k_rnorm"), py::arg("v_norm"),
+        py::arg("norm_k"), py::arg("coef_rnorm"), py::arg("norm_v"),
+        py::arg("n"), py::arg("coef"), py::arg("stream") = 0);
+
+    m.def("qwen36_argmax_bf16",
+        [](uintptr_t logits, uintptr_t argmax_out,
+           int rows, int vocab, uintptr_t stream) {
+            flash_rt::kernels::qwen36_argmax_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(logits),
+                reinterpret_cast<int64_t*>(argmax_out),
+                rows, vocab, to_stream(stream));
+        },
+        py::arg("logits"), py::arg("argmax_out"),
+        py::arg("rows"), py::arg("vocab"), py::arg("stream") = 0);
+
+    m.def("qwen36_spec_accept_greedy_bf16",
+        [](uintptr_t logits, uintptr_t drafts, uintptr_t argmax_out,
+           uintptr_t accept_n, int rows, int vocab, int spec_k,
+           uintptr_t stream) {
+            flash_rt::kernels::qwen36_spec_accept_greedy_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(logits),
+                reinterpret_cast<const int64_t*>(drafts),
+                reinterpret_cast<int64_t*>(argmax_out),
+                reinterpret_cast<int*>(accept_n),
+                rows, vocab, spec_k, to_stream(stream));
+        },
+        py::arg("logits"), py::arg("drafts"), py::arg("argmax_out"),
+        py::arg("accept_n"), py::arg("rows"), py::arg("vocab"),
+        py::arg("spec_k"), py::arg("stream") = 0);
+
+    m.def("qwen36_spec_accept_partitioned_bf16",
+        [](uintptr_t logits, uintptr_t drafts, uintptr_t argmax_out,
+           uintptr_t accept_n, uintptr_t partial_vals,
+           uintptr_t partial_idx, int rows, int vocab, int spec_k,
+           int parts, uintptr_t stream) {
+            flash_rt::kernels::qwen36_spec_accept_partitioned_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(logits),
+                reinterpret_cast<const int64_t*>(drafts),
+                reinterpret_cast<int64_t*>(argmax_out),
+                reinterpret_cast<int*>(accept_n),
+                reinterpret_cast<float*>(partial_vals),
+                reinterpret_cast<int*>(partial_idx),
+                rows, vocab, spec_k, parts, to_stream(stream));
+        },
+        py::arg("logits"), py::arg("drafts"), py::arg("argmax_out"),
+        py::arg("accept_n"), py::arg("partial_vals"),
+        py::arg("partial_idx"), py::arg("rows"), py::arg("vocab"),
+        py::arg("spec_k"), py::arg("parts"), py::arg("stream") = 0);
+
     // Phase 4.3 — SiLU-gate elementwise multiply for Qwen3.6 SwiGLU MLP.
     // out[i] = silu(gate[i]) * up[i], bf16 in/out, fp32 internal.
     // Replaces the F.silu(gate) * up Python composite (2 allocs/call).
@@ -3759,6 +4084,18 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                 n, to_stream(stream));
         },
         py::arg("gate"), py::arg("up"), py::arg("out"),
+        py::arg("n"), py::arg("stream") = 0);
+
+    m.def("sigmoid_mul_qwen36_bf16",
+        [](uintptr_t gate, uintptr_t x, uintptr_t out,
+           int n, uintptr_t stream) {
+            flash_rt::kernels::sigmoid_mul_qwen36_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(gate),
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                n, to_stream(stream));
+        },
+        py::arg("gate"), py::arg("x"), py::arg("out"),
         py::arg("n"), py::arg("stream") = 0);
 
     // Fused RMSNorm + weight + silu(gate) for Qwen3.6 linear-attn output.
@@ -3813,6 +4150,160 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("state_in"), py::arg("state_out"), py::arg("out"),
         py::arg("B"), py::arg("num_v_heads"),
         py::arg("head_k_dim"), py::arg("head_v_dim"),
+        py::arg("use_qk_l2norm") = true, py::arg("stream") = 0);
+
+    m.def("gated_deltanet_chunk_qwen36_bf16",
+        [](uintptr_t q, uintptr_t k, uintptr_t v,
+           uintptr_t g, uintptr_t beta,
+           uintptr_t state, uintptr_t out,
+           int S, int num_v_heads, int head_k_dim, int head_v_dim,
+           bool use_qk_l2norm, uintptr_t stream) {
+            flash_rt::kernels::gated_deltanet_chunk_qwen36_bf16(
+                to_ptr(q), to_ptr(k), to_ptr(v),
+                to_ptr(g), to_ptr(beta),
+                to_ptr(state), to_ptr(out),
+                S, num_v_heads, head_k_dim, head_v_dim,
+                use_qk_l2norm, to_stream(stream));
+        },
+        py::arg("q"), py::arg("k"), py::arg("v"),
+        py::arg("g"), py::arg("beta"),
+        py::arg("state"), py::arg("out"),
+        py::arg("S"), py::arg("num_v_heads"),
+        py::arg("head_k_dim"), py::arg("head_v_dim"),
+        py::arg("use_qk_l2norm") = true, py::arg("stream") = 0);
+
+    m.def("gated_deltanet_chunk_smem_qwen36_bf16",
+        [](uintptr_t q, uintptr_t k, uintptr_t v,
+           uintptr_t g, uintptr_t beta,
+           uintptr_t state, uintptr_t out,
+           int S, int num_v_heads, int head_k_dim, int head_v_dim,
+           bool use_qk_l2norm, uintptr_t stream) {
+            flash_rt::kernels::gated_deltanet_chunk_smem_qwen36_bf16(
+                to_ptr(q), to_ptr(k), to_ptr(v),
+                to_ptr(g), to_ptr(beta),
+                to_ptr(state), to_ptr(out),
+                S, num_v_heads, head_k_dim, head_v_dim,
+                use_qk_l2norm, to_stream(stream));
+        },
+        py::arg("q"), py::arg("k"), py::arg("v"),
+        py::arg("g"), py::arg("beta"),
+        py::arg("state"), py::arg("out"),
+        py::arg("S"), py::arg("num_v_heads"),
+        py::arg("head_k_dim"), py::arg("head_v_dim"),
+        py::arg("use_qk_l2norm") = true, py::arg("stream") = 0);
+
+    m.def("qwen36_lin_split_qkv_broadcast_bf16",
+        [](uintptr_t conv_out, uintptr_t q48,
+           uintptr_t k48, uintptr_t v48,
+           int S, uintptr_t stream) {
+            flash_rt::kernels::qwen36_lin_split_qkv_broadcast_bf16(
+                to_ptr(conv_out), to_ptr(q48),
+                to_ptr(k48), to_ptr(v48),
+                S, to_stream(stream));
+        },
+        py::arg("conv_out"), py::arg("q48"),
+        py::arg("k48"), py::arg("v48"),
+        py::arg("S"), py::arg("stream") = 0);
+
+    m.def("qwen36_lin_split_qkv_gqa_bf16",
+        [](uintptr_t conv_out, uintptr_t q16,
+           uintptr_t k16, uintptr_t v48,
+           int S, uintptr_t stream) {
+            flash_rt::kernels::qwen36_lin_split_qkv_gqa_bf16(
+                to_ptr(conv_out), to_ptr(q16),
+                to_ptr(k16), to_ptr(v48),
+                S, to_stream(stream));
+        },
+        py::arg("conv_out"), py::arg("q16"),
+        py::arg("k16"), py::arg("v48"),
+        py::arg("S"), py::arg("stream") = 0);
+
+    m.def("qwen36_split_q_gate_bf16",
+        [](uintptr_t q_proj, uintptr_t q_pre,
+           uintptr_t gate, int S, uintptr_t stream) {
+            flash_rt::kernels::qwen36_split_q_gate_bf16(
+                to_ptr(q_proj), to_ptr(q_pre), to_ptr(gate),
+                S, to_stream(stream));
+        },
+        py::arg("q_proj"), py::arg("q_pre"), py::arg("gate"),
+        py::arg("S"), py::arg("stream") = 0);
+
+    m.def("qwen36_gdn_gating_bf16",
+        [](uintptr_t a, uintptr_t b,
+           uintptr_t neg_exp_A_log, uintptr_t dt_bias,
+           uintptr_t g_out, uintptr_t beta_out,
+           int S, int num_heads, uintptr_t stream) {
+            flash_rt::kernels::qwen36_gdn_gating_bf16(
+                to_ptr(a), to_ptr(b),
+                reinterpret_cast<const float*>(neg_exp_A_log),
+                reinterpret_cast<const float*>(dt_bias),
+                to_ptr(g_out), to_ptr(beta_out),
+                S, num_heads, to_stream(stream));
+        },
+        py::arg("a"), py::arg("b"),
+        py::arg("neg_exp_A_log"), py::arg("dt_bias"),
+        py::arg("g_out"), py::arg("beta_out"),
+        py::arg("S"), py::arg("num_heads"),
+        py::arg("stream") = 0);
+
+    m.def("qwen36_gdn_gating_strided_bf16",
+        [](uintptr_t a, uintptr_t b,
+           uintptr_t neg_exp_A_log, uintptr_t dt_bias,
+           uintptr_t g_out, uintptr_t beta_out,
+           int S, int num_heads, int a_stride, int b_stride,
+           uintptr_t stream) {
+            flash_rt::kernels::qwen36_gdn_gating_strided_bf16(
+                to_ptr(a), to_ptr(b),
+                reinterpret_cast<const float*>(neg_exp_A_log),
+                reinterpret_cast<const float*>(dt_bias),
+                to_ptr(g_out), to_ptr(beta_out),
+                S, num_heads, a_stride, b_stride, to_stream(stream));
+        },
+        py::arg("a"), py::arg("b"),
+        py::arg("neg_exp_A_log"), py::arg("dt_bias"),
+        py::arg("g_out"), py::arg("beta_out"),
+        py::arg("S"), py::arg("num_heads"),
+        py::arg("a_stride"), py::arg("b_stride"),
+        py::arg("stream") = 0);
+
+    m.def("qwen36_gdn_chunk_from_conv_smem_bf16",
+        [](uintptr_t conv_out, uintptr_t a, uintptr_t b,
+           uintptr_t neg_exp_A_log, uintptr_t dt_bias,
+           uintptr_t state, uintptr_t out,
+           int S, int num_v_heads, bool use_qk_l2norm,
+           uintptr_t stream) {
+            flash_rt::kernels::qwen36_gdn_chunk_from_conv_smem_bf16(
+                to_ptr(conv_out), to_ptr(a), to_ptr(b),
+                reinterpret_cast<const float*>(neg_exp_A_log),
+                reinterpret_cast<const float*>(dt_bias),
+                to_ptr(state), to_ptr(out),
+                S, num_v_heads, use_qk_l2norm, to_stream(stream));
+        },
+        py::arg("conv_out"), py::arg("a"), py::arg("b"),
+        py::arg("neg_exp_A_log"), py::arg("dt_bias"),
+        py::arg("state"), py::arg("out"),
+        py::arg("S"), py::arg("num_v_heads"),
+        py::arg("use_qk_l2norm") = true, py::arg("stream") = 0);
+
+    m.def("qwen36_gdn_chunk_from_conv_smem_strided_bf16",
+        [](uintptr_t conv_out, uintptr_t a, uintptr_t b,
+           uintptr_t neg_exp_A_log, uintptr_t dt_bias,
+           uintptr_t state, uintptr_t out,
+           int S, int num_v_heads, int a_stride, int b_stride,
+           bool use_qk_l2norm, uintptr_t stream) {
+            flash_rt::kernels::qwen36_gdn_chunk_from_conv_smem_strided_bf16(
+                to_ptr(conv_out), to_ptr(a), to_ptr(b),
+                reinterpret_cast<const float*>(neg_exp_A_log),
+                reinterpret_cast<const float*>(dt_bias),
+                to_ptr(state), to_ptr(out),
+                S, num_v_heads, a_stride, b_stride,
+                use_qk_l2norm, to_stream(stream));
+        },
+        py::arg("conv_out"), py::arg("a"), py::arg("b"),
+        py::arg("neg_exp_A_log"), py::arg("dt_bias"),
+        py::arg("state"), py::arg("out"),
+        py::arg("S"), py::arg("num_v_heads"),
+        py::arg("a_stride"), py::arg("b_stride"),
         py::arg("use_qk_l2norm") = true, py::arg("stream") = 0);
 
 #ifdef ENABLE_CUTLASS_SM120_BLOCK_FP8
@@ -4553,6 +5044,19 @@ N must be a multiple of 32; K must be a multiple of 64.
         py::arg("packed"), py::arg("sf_swz"),
         py::arg("rows"), py::arg("cols"), py::arg("stream") = 0);
 
+    m.def("silu_mul_merged_to_nvfp4_swizzled_bf16",
+        [](uintptr_t merged_gate_up,
+           uintptr_t packed, uintptr_t sf_swz,
+           int rows, int cols, uintptr_t stream) -> int {
+            return flash_rt::kernels::silu_mul_merged_to_nvfp4_swizzled_bf16(
+                to_ptr(merged_gate_up),
+                to_ptr(packed), to_ptr(sf_swz),
+                rows, cols, to_stream(stream));
+        },
+        py::arg("merged_gate_up"),
+        py::arg("packed"), py::arg("sf_swz"),
+        py::arg("rows"), py::arg("cols"), py::arg("stream") = 0);
+
     m.def("qwen3_k_norm_rope_kvwrite_bf16",
         [](uintptr_t k_pre, uintptr_t v_pre, uintptr_t k_norm_w,
            uintptr_t cos, uintptr_t sin,
@@ -4820,6 +5324,36 @@ N must be a multiple of 32; K must be a multiple of 64.
                 to_ptr(y_fp4), to_ptr(y_sf),
                 B, C, T, H, W, eps, to_stream(stream));
         });
+#endif
+
+#ifdef ENABLE_QWEN36_FLASHINFER_XQA
+    m.def("qwen36_flashinfer_xqa_bf16_fp8kv_spec",
+        [](uintptr_t q, uintptr_t k_cache, uintptr_t v_cache,
+           uintptr_t page_table, uintptr_t seq_lens, uintptr_t mask,
+           uintptr_t out, uintptr_t semaphores, uintptr_t scratch,
+           int max_seq_len, int q_seq_len, int sm_count,
+           float q_scale, float kv_scale, bool enable_pdl,
+           int64_t k_stride_page, int64_t k_stride_token,
+           int64_t k_stride_head, uintptr_t stream) {
+            qwen36_flashinfer_xqa_bf16_fp8kv_spec(
+                to_ptr(q), to_ptr(k_cache), to_ptr(v_cache),
+                reinterpret_cast<const int32_t*>(to_ptr(page_table)),
+                reinterpret_cast<const uint32_t*>(to_ptr(seq_lens)),
+                reinterpret_cast<const uint32_t*>(to_ptr(mask)),
+                to_ptr(out),
+                reinterpret_cast<uint32_t*>(to_ptr(semaphores)),
+                to_ptr(scratch),
+                max_seq_len, q_seq_len, sm_count, q_scale, kv_scale,
+                enable_pdl, k_stride_page, k_stride_token, k_stride_head,
+                to_stream(stream));
+        },
+        py::arg("q"), py::arg("k_cache"), py::arg("v_cache"),
+        py::arg("page_table"), py::arg("seq_lens"), py::arg("mask"),
+        py::arg("out"), py::arg("semaphores"), py::arg("scratch"),
+        py::arg("max_seq_len"), py::arg("q_seq_len"), py::arg("sm_count"),
+        py::arg("q_scale"), py::arg("kv_scale"), py::arg("enable_pdl"),
+        py::arg("k_stride_page"), py::arg("k_stride_token"),
+        py::arg("k_stride_head"), py::arg("stream") = 0);
 #endif
 
 #ifdef ENABLE_LINGBOT

--- a/csrc/kernels/bf16_matmul_qwen36.cu
+++ b/csrc/kernels/bf16_matmul_qwen36.cu
@@ -118,6 +118,71 @@ __global__ void bf16_matmul_warp_kernel_generic(
     }
 }
 
+template<int K_FIXED>
+__global__ void bf16_matmul_ab96_pair_kernel(
+    const __nv_bfloat16* __restrict__ x,        // (M, K)
+    const __nv_bfloat16* __restrict__ W,        // (96, K)
+    __nv_bfloat16* __restrict__ out,            // (M, 96)
+    int M) {
+    __shared__ __nv_bfloat16 x_sh[K_FIXED];
+
+    const int m = blockIdx.y;
+    if (m >= M) return;
+
+    const int4* x_i4 = reinterpret_cast<const int4*>(x + m * K_FIXED);
+    int4* x_sh_i4 = reinterpret_cast<int4*>(x_sh);
+    const int K_int4 = K_FIXED / 8;
+    #pragma unroll 1
+    for (int j = threadIdx.x; j < K_int4; j += kThreads) {
+        x_sh_i4[j] = x_i4[j];
+    }
+    __syncthreads();
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x & 31;
+    const int n0 = blockIdx.x * (kWarpsPerBlock * 2) + warp_id * 2;
+    const int n1 = n0 + 1;
+    if (n0 >= 96) return;
+
+    const int4* w0_row_i4 = reinterpret_cast<const int4*>(W + n0 * K_FIXED);
+    const int4* w1_row_i4 = reinterpret_cast<const int4*>(W + n1 * K_FIXED);
+
+    float acc0 = 0.0f;
+    float acc1 = 0.0f;
+    #pragma unroll 1
+    for (int i4 = lane; i4 < K_int4; i4 += 32) {
+        int4 xv = x_sh_i4[i4];
+        int4 w0v = w0_row_i4[i4];
+        int4 w1v = w1_row_i4[i4];
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            __nv_bfloat162 xb = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&xv)[k]));
+            __nv_bfloat162 w0b = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&w0v)[k]));
+            __nv_bfloat162 w1b = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&w1v)[k]));
+            float2 xf = __bfloat1622float2(xb);
+            float2 w0f = __bfloat1622float2(w0b);
+            float2 w1f = __bfloat1622float2(w1b);
+            acc0 = fmaf(xf.x, w0f.x, acc0);
+            acc0 = fmaf(xf.y, w0f.y, acc0);
+            acc1 = fmaf(xf.x, w1f.x, acc1);
+            acc1 = fmaf(xf.y, w1f.y, acc1);
+        }
+    }
+
+    #pragma unroll
+    for (int off = 16; off > 0; off /= 2) {
+        acc0 += __shfl_xor_sync(0xffffffff, acc0, off);
+        acc1 += __shfl_xor_sync(0xffffffff, acc1, off);
+    }
+    if (lane == 0) {
+        out[m * 96 + n0] = __float2bfloat16(acc0);
+        out[m * 96 + n1] = __float2bfloat16(acc1);
+    }
+}
+
 }  // namespace
 
 void bf16_matmul_qwen36_bf16(
@@ -143,6 +208,17 @@ void bf16_matmul_qwen36_bf16(
         bf16_matmul_warp_kernel_generic
             <<<grid, kThreads, smem_bytes, stream>>>(x, W, out, M, N, K);
     }
+}
+
+void bf16_matmul_qwen36_ab96_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W_ab,
+    __nv_bfloat16* out_ab,
+    int M,
+    cudaStream_t stream) {
+    dim3 grid((96 + (kWarpsPerBlock * 2) - 1) / (kWarpsPerBlock * 2), M);
+    bf16_matmul_ab96_pair_kernel<5120>
+        <<<grid, kThreads, 0, stream>>>(x, W_ab, out_ab, M);
 }
 
 }  // namespace flash_rt::kernels

--- a/csrc/kernels/bf16_matmul_qwen36.cuh
+++ b/csrc/kernels/bf16_matmul_qwen36.cuh
@@ -39,4 +39,11 @@ void bf16_matmul_qwen36_bf16(
     int K,
     cudaStream_t stream);
 
+void bf16_matmul_qwen36_ab96_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W_ab,
+    __nv_bfloat16* out_ab,
+    int M,
+    cudaStream_t stream);
+
 }  // namespace flash_rt::kernels

--- a/csrc/kernels/causal_conv1d_qwen36.cu
+++ b/csrc/kernels/causal_conv1d_qwen36.cu
@@ -131,6 +131,132 @@ __global__ void causal_conv1d_update_kernel(
   }
 }
 
+__global__ void causal_conv1d_update_chunk_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ w,
+    const __nv_bfloat16* __restrict__ bias,
+    __nv_bfloat16* __restrict__ out,
+    __nv_bfloat16* __restrict__ state,
+    int B, int S, int conv_dim, int k,
+    bool apply_silu)
+{
+  const int c = blockIdx.x * kThreadsX + threadIdx.x;
+  const int b = blockIdx.y;
+  if (c >= conv_dim) return;
+
+  const int sk = k - 1;
+  const int state_base = (b * conv_dim + c) * sk;
+
+  float wv[kMaxK];
+  #pragma unroll
+  for (int i = 0; i < kMaxK; ++i) {
+    wv[i] = (i < k) ? static_cast<float>(w[c * k + i]) : 0.0f;
+  }
+
+  float sv[kMaxK];
+  #pragma unroll
+  for (int i = 0; i < kMaxK; ++i) {
+    sv[i] = (i < sk)
+        ? static_cast<float>(state[state_base + i])
+        : 0.0f;
+  }
+
+  for (int s = 0; s < S; ++s) {
+    const float x_v = static_cast<float>(
+        x[(size_t)b * S * conv_dim + (size_t)s * conv_dim + c]);
+
+    float acc = (bias != nullptr) ? static_cast<float>(bias[c]) : 0.0f;
+    #pragma unroll
+    for (int i = 0; i < kMaxK; ++i) {
+      if (i < sk) acc = fmaf(sv[i], wv[i], acc);
+    }
+    acc = fmaf(x_v, wv[sk], acc);
+
+    if (apply_silu) acc = silu(acc);
+    out[(size_t)b * S * conv_dim + (size_t)s * conv_dim + c] =
+        __float2bfloat16(acc);
+
+    #pragma unroll
+    for (int i = 0; i < kMaxK - 1; ++i) {
+      if (i < sk - 1) sv[i] = sv[i + 1];
+    }
+    if (sk >= 1) {
+      sv[sk - 1] = x_v;
+    }
+  }
+
+  #pragma unroll
+  for (int i = 0; i < kMaxK; ++i) {
+    if (i < sk) {
+      state[state_base + i] = __float2bfloat16(sv[i]);
+    }
+  }
+}
+
+__global__ void causal_conv1d_update_chunk_parallel_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ w,
+    const __nv_bfloat16* __restrict__ bias,
+    const __nv_bfloat16* __restrict__ state,
+    __nv_bfloat16* __restrict__ out,
+    int B, int S, int conv_dim, int k,
+    bool apply_silu)
+{
+  const int c = blockIdx.x * kThreadsX + threadIdx.x;
+  const int s = blockIdx.y;
+  const int b = blockIdx.z;
+  if (c >= conv_dim) return;
+
+  const int sk = k - 1;
+  const int state_base = (b * conv_dim + c) * sk;
+  float acc = (bias != nullptr) ? static_cast<float>(bias[c]) : 0.0f;
+
+  #pragma unroll
+  for (int i = 0; i < kMaxK; ++i) {
+    if (i < k) {
+      const int t = s + i - sk;
+      float xv = 0.0f;
+      if (t >= 0) {
+        xv = static_cast<float>(
+            x[(size_t)b * S * conv_dim + (size_t)t * conv_dim + c]);
+      } else if (t >= -sk) {
+        xv = static_cast<float>(state[state_base + (t + sk)]);
+      }
+      const float wv = static_cast<float>(w[c * k + i]);
+      acc = fmaf(xv, wv, acc);
+    }
+  }
+
+  if (apply_silu) acc = silu(acc);
+  out[(size_t)b * S * conv_dim + (size_t)s * conv_dim + c] =
+      __float2bfloat16(acc);
+}
+
+__global__ void causal_conv1d_update_chunk_state_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    __nv_bfloat16* __restrict__ state,
+    int B, int S, int conv_dim, int k)
+{
+  const int c = blockIdx.x * kThreadsX + threadIdx.x;
+  const int b = blockIdx.y;
+  if (c >= conv_dim) return;
+
+  const int sk = k - 1;
+  const int state_base = (b * conv_dim + c) * sk;
+  #pragma unroll
+  for (int i = 0; i < kMaxK; ++i) {
+    if (i < sk) {
+      const int t = S - sk + i;
+      if (t >= 0) {
+        state[state_base + i] = x[
+            (size_t)b * S * conv_dim + (size_t)t * conv_dim + c];
+      } else {
+        state[state_base + i] = state[state_base + S + i];
+      }
+    }
+  }
+}
+
 }  // namespace
 
 void causal_conv1d_qwen36_bf16(
@@ -166,6 +292,50 @@ void causal_conv1d_qwen36_update_bf16(
       reinterpret_cast<__nv_bfloat16*>(out),
       reinterpret_cast<__nv_bfloat16*>(state),
       B, conv_dim, k, apply_silu);
+}
+
+void causal_conv1d_qwen36_update_chunk_bf16(
+    const void* x, const void* w, const void* bias,
+    void* out, void* state,
+    int B, int S, int conv_dim, int k,
+    bool apply_silu,
+    cudaStream_t stream)
+{
+  dim3 grid((conv_dim + kThreadsX - 1) / kThreadsX, B);
+  dim3 block(kThreadsX);
+  causal_conv1d_update_chunk_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(x),
+      reinterpret_cast<const __nv_bfloat16*>(w),
+      reinterpret_cast<const __nv_bfloat16*>(bias),
+      reinterpret_cast<__nv_bfloat16*>(out),
+      reinterpret_cast<__nv_bfloat16*>(state),
+      B, S, conv_dim, k, apply_silu);
+}
+
+void causal_conv1d_qwen36_update_chunk_parallel_bf16(
+    const void* x, const void* w, const void* bias,
+    void* out, void* state,
+    int B, int S, int conv_dim, int k,
+    bool apply_silu,
+    cudaStream_t stream)
+{
+  dim3 conv_grid((conv_dim + kThreadsX - 1) / kThreadsX, S, B);
+  dim3 block(kThreadsX);
+  causal_conv1d_update_chunk_parallel_kernel<<<
+      conv_grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(x),
+      reinterpret_cast<const __nv_bfloat16*>(w),
+      reinterpret_cast<const __nv_bfloat16*>(bias),
+      reinterpret_cast<const __nv_bfloat16*>(state),
+      reinterpret_cast<__nv_bfloat16*>(out),
+      B, S, conv_dim, k, apply_silu);
+
+  dim3 state_grid((conv_dim + kThreadsX - 1) / kThreadsX, B);
+  causal_conv1d_update_chunk_state_kernel<<<
+      state_grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(x),
+      reinterpret_cast<__nv_bfloat16*>(state),
+      B, S, conv_dim, k);
 }
 
 // In/out-state variant: reads state from state_in, writes shifted

--- a/csrc/kernels/causal_conv1d_qwen36.cuh
+++ b/csrc/kernels/causal_conv1d_qwen36.cuh
@@ -76,5 +76,33 @@ void causal_conv1d_qwen36_update_inout_bf16(
     bool apply_silu,
     cudaStream_t stream);
 
+// Multi-token decode update with persistent state cache.
+// Processes S consecutive tokens and writes only the final state, so
+// speculative verify paths that need per-step state snapshots should
+// keep using causal_conv1d_qwen36_update_inout_bf16.
+void causal_conv1d_qwen36_update_chunk_bf16(
+    const void* x,
+    const void* w,
+    const void* bias,
+    void*       out,
+    void*       state,
+    int B, int S, int conv_dim, int k,
+    bool apply_silu,
+    cudaStream_t stream);
+
+// Parallel prefill variant: computes each (S, channel) output
+// independently, then updates the final state in a second tiny kernel.
+// This trades extra global loads for much higher S-dimension
+// parallelism on long chunks.
+void causal_conv1d_qwen36_update_chunk_parallel_bf16(
+    const void* x,
+    const void* w,
+    const void* bias,
+    void*       out,
+    void*       state,
+    int B, int S, int conv_dim, int k,
+    bool apply_silu,
+    cudaStream_t stream);
+
 }  // namespace kernels
 }  // namespace flash_rt

--- a/csrc/kernels/elementwise.cu
+++ b/csrc/kernels/elementwise.cu
@@ -2247,6 +2247,34 @@ void gpu_copy_async(void* dst, const void* src, size_t nbytes, cudaStream_t stre
     cudaMemcpyAsync(dst, src, nbytes, cudaMemcpyDeviceToDevice, stream);
 }
 
+__global__ void concat2_bf16_kernel(
+    const __nv_bfloat16* __restrict__ a,
+    const __nv_bfloat16* __restrict__ b,
+    __nv_bfloat16* __restrict__ out,
+    int rows, int cols_a, int cols_b) {
+    int r = blockIdx.x;
+    int c = threadIdx.x;
+    if (r >= rows) return;
+    const int cols = cols_a + cols_b;
+    for (int cc = c; cc < cols; cc += blockDim.x) {
+        if (cc < cols_a) {
+            out[r * cols + cc] = a[r * cols_a + cc];
+        } else {
+            const int bc = cc - cols_a;
+            out[r * cols + cc] = b[r * cols_b + bc];
+        }
+    }
+}
+
+void concat2_bf16(const __nv_bfloat16* a, const __nv_bfloat16* b,
+                  __nv_bfloat16* out,
+                  int rows, int cols_a, int cols_b,
+                  cudaStream_t stream) {
+    const int cols = cols_a + cols_b;
+    concat2_bf16_kernel<<<rows, min(256, cols), 0, stream>>>(
+        a, b, out, rows, cols_a, cols_b);
+}
+
 // Fill FP16 buffer with large negative (for softmax masking in attention)
 __global__ void fill_neginf_fp16_kernel(__half* data, int n) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;

--- a/csrc/kernels/elementwise.cuh
+++ b/csrc/kernels/elementwise.cuh
@@ -54,6 +54,11 @@ void add_bf16_out(const __nv_bfloat16* a, const __nv_bfloat16* b,
                   __nv_bfloat16* out, int n,
                   cudaStream_t stream = 0);
 
+void concat2_bf16(const __nv_bfloat16* a, const __nv_bfloat16* b,
+                  __nv_bfloat16* out,
+                  int rows, int cols_a, int cols_b,
+                  cudaStream_t stream = 0);
+
 void euler_step_bf16_out(const __nv_bfloat16* latent,
                          const __nv_bfloat16* velocity,
                          __nv_bfloat16* out,

--- a/csrc/kernels/gated_deltanet_qwen36.cu
+++ b/csrc/kernels/gated_deltanet_qwen36.cu
@@ -22,6 +22,7 @@ namespace {
 
 constexpr int kHD = 128;   // Qwen3.6 head_k_dim == head_v_dim
 constexpr float kEps = 1e-6f;
+constexpr int kSplitThreads = 256;
 
 template <int HD>
 __device__ __forceinline__ float block_reduce_sum(float val, float* smem) {
@@ -300,6 +301,699 @@ void gated_deltanet_recurrent_inout_qwen36_bf16(
       reinterpret_cast<__nv_bfloat16*>(state_out),
       reinterpret_cast<__nv_bfloat16*>(out),
       num_v_heads, use_qk_l2norm);
+}
+
+namespace {
+
+template <int HD>
+__global__ void gated_deltanet_chunk_kernel(
+    const __nv_bfloat16* __restrict__ q_in,
+    const __nv_bfloat16* __restrict__ k_in,
+    const __nv_bfloat16* __restrict__ v_in,
+    const __nv_bfloat16* __restrict__ g_in,
+    const __nv_bfloat16* __restrict__ beta_in,
+    __nv_bfloat16* __restrict__ state,
+    __nv_bfloat16* __restrict__ out_,
+    int S,
+    int num_v_heads,
+    bool use_qk_l2norm)
+{
+  static_assert(HD == 128, "HD must be 128 for Qwen3.6");
+  const int h = blockIdx.x;
+  const int b = blockIdx.y;
+  const int t = threadIdx.x;
+  if (t >= HD) return;
+
+  __shared__ float smem[2 * HD + 32];
+  float* qs = smem;
+  float* ks = smem + HD;
+  float* scratch = smem + 2 * HD;
+
+  const size_t state_h_off =
+      (((size_t)b * num_v_heads + h)) * HD * HD;
+  float col[HD];
+  #pragma unroll 16
+  for (int i = 0; i < HD; ++i) {
+    col[i] = static_cast<float>(
+        state[state_h_off + (size_t)i * HD + t]);
+  }
+
+  for (int s = 0; s < S; ++s) {
+    const size_t qkv_off = ((size_t)s * num_v_heads + h) * HD + t;
+    qs[t] = static_cast<float>(q_in[qkv_off]);
+    ks[t] = static_cast<float>(k_in[qkv_off]);
+    __syncthreads();
+
+    if (use_qk_l2norm) {
+      float q_sq = qs[t] * qs[t];
+      float k_sq = ks[t] * ks[t];
+      q_sq = block_reduce_sum<HD>(q_sq, scratch);
+      k_sq = block_reduce_sum<HD>(k_sq, scratch);
+      const float q_inv = rsqrtf(q_sq + kEps);
+      const float k_inv = rsqrtf(k_sq + kEps);
+      qs[t] *= q_inv;
+      ks[t] *= k_inv;
+      __syncthreads();
+    }
+
+    qs[t] *= rsqrtf(static_cast<float>(HD));
+    __syncthreads();
+
+    const float g_t =
+        __expf(static_cast<float>(g_in[s * num_v_heads + h]));
+    const float beta_t =
+        static_cast<float>(beta_in[s * num_v_heads + h]);
+
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      col[i] *= g_t;
+    }
+
+    float kv_mem = 0.0f;
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      kv_mem = fmaf(col[i], ks[i], kv_mem);
+    }
+
+    const float v_t = static_cast<float>(v_in[qkv_off]);
+    const float delta = (v_t - kv_mem) * beta_t;
+
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      col[i] = fmaf(ks[i], delta, col[i]);
+    }
+
+    float out_t = 0.0f;
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      out_t = fmaf(col[i], qs[i], out_t);
+    }
+    out_[qkv_off] = __float2bfloat16(out_t);
+
+    // Serial decode stores bf16 state after each token, so the next
+    // token reads bf16-quantized state. Mirror that quantization point
+    // without paying global memory traffic for intermediate states.
+    if (s + 1 < S) {
+      #pragma unroll 16
+      for (int i = 0; i < HD; ++i) {
+        col[i] = static_cast<float>(__float2bfloat16(col[i]));
+      }
+    }
+    __syncthreads();
+  }
+
+  #pragma unroll 16
+  for (int i = 0; i < HD; ++i) {
+    state[state_h_off + (size_t)i * HD + t] = __float2bfloat16(col[i]);
+  }
+}
+
+template <int HD>
+__global__ void gated_deltanet_chunk_smem_kernel(
+    const __nv_bfloat16* __restrict__ q_in,
+    const __nv_bfloat16* __restrict__ k_in,
+    const __nv_bfloat16* __restrict__ v_in,
+    const __nv_bfloat16* __restrict__ g_in,
+    const __nv_bfloat16* __restrict__ beta_in,
+    __nv_bfloat16* __restrict__ state,
+    __nv_bfloat16* __restrict__ out_,
+    int S,
+    int num_v_heads,
+    bool use_qk_l2norm)
+{
+  static_assert(HD == 128, "HD must be 128 for Qwen3.6");
+  const int h = blockIdx.x;
+  const int b = blockIdx.y;
+  const int t = threadIdx.x;
+  if (t >= HD) return;
+
+  extern __shared__ float smem[];
+  float* state_s = smem;
+  float* qs = state_s + HD * HD;
+  float* ks = qs + HD;
+  float* scratch = ks + HD;
+
+  const size_t state_h_off =
+      (((size_t)b * num_v_heads + h)) * HD * HD;
+  #pragma unroll 16
+  for (int i = 0; i < HD; ++i) {
+    state_s[i * HD + t] = static_cast<float>(
+        state[state_h_off + (size_t)i * HD + t]);
+  }
+  __syncthreads();
+
+  for (int s = 0; s < S; ++s) {
+    const size_t qkv_off = ((size_t)s * num_v_heads + h) * HD + t;
+    qs[t] = static_cast<float>(q_in[qkv_off]);
+    ks[t] = static_cast<float>(k_in[qkv_off]);
+    __syncthreads();
+
+    if (use_qk_l2norm) {
+      float q_sq = qs[t] * qs[t];
+      float k_sq = ks[t] * ks[t];
+      q_sq = block_reduce_sum<HD>(q_sq, scratch);
+      k_sq = block_reduce_sum<HD>(k_sq, scratch);
+      const float q_inv = rsqrtf(q_sq + kEps);
+      const float k_inv = rsqrtf(k_sq + kEps);
+      qs[t] *= q_inv;
+      ks[t] *= k_inv;
+      __syncthreads();
+    }
+
+    qs[t] *= rsqrtf(static_cast<float>(HD));
+    __syncthreads();
+
+    const float g_t =
+        __expf(static_cast<float>(g_in[s * num_v_heads + h]));
+    const float beta_t =
+        static_cast<float>(beta_in[s * num_v_heads + h]);
+
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      state_s[i * HD + t] *= g_t;
+    }
+
+    float kv_mem = 0.0f;
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      kv_mem = fmaf(state_s[i * HD + t], ks[i], kv_mem);
+    }
+
+    const float v_t = static_cast<float>(v_in[qkv_off]);
+    const float delta = (v_t - kv_mem) * beta_t;
+
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      state_s[i * HD + t] =
+          fmaf(ks[i], delta, state_s[i * HD + t]);
+    }
+
+    float out_t = 0.0f;
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      out_t = fmaf(state_s[i * HD + t], qs[i], out_t);
+    }
+    out_[qkv_off] = __float2bfloat16(out_t);
+
+    if (s + 1 < S) {
+      #pragma unroll 16
+      for (int i = 0; i < HD; ++i) {
+        state_s[i * HD + t] =
+            static_cast<float>(__float2bfloat16(state_s[i * HD + t]));
+      }
+    }
+    __syncthreads();
+  }
+
+  #pragma unroll 16
+  for (int i = 0; i < HD; ++i) {
+    state[state_h_off + (size_t)i * HD + t] =
+        __float2bfloat16(state_s[i * HD + t]);
+  }
+}
+
+__global__ void qwen36_lin_split_qkv_broadcast_kernel(
+    const __nv_bfloat16* __restrict__ conv_out,
+    __nv_bfloat16* __restrict__ q48,
+    __nv_bfloat16* __restrict__ k48,
+    __nv_bfloat16* __restrict__ v48,
+    int S)
+{
+  const int idx = blockIdx.x * kSplitThreads + threadIdx.x;
+  const int total = S * 48 * kHD;
+  if (idx >= total) return;
+
+  const int t = idx % kHD;
+  const int h = (idx / kHD) % 48;
+  const int s = idx / (48 * kHD);
+  const int src_h = h / 3;
+  const size_t row = static_cast<size_t>(s) * 10240;
+  q48[idx] = conv_out[row + src_h * kHD + t];
+  k48[idx] = conv_out[row + 2048 + src_h * kHD + t];
+  v48[idx] = conv_out[row + 4096 + h * kHD + t];
+}
+
+__global__ void qwen36_lin_split_qkv_gqa_kernel(
+    const __nv_bfloat16* __restrict__ conv_out,
+    __nv_bfloat16* __restrict__ q16,
+    __nv_bfloat16* __restrict__ k16,
+    __nv_bfloat16* __restrict__ v48,
+    int S)
+{
+  const int idx = blockIdx.x * kSplitThreads + threadIdx.x;
+  const int total = S * 10240;
+  if (idx >= total) return;
+
+  const int col = idx % 10240;
+  const int row = idx / 10240;
+  const __nv_bfloat16 x = conv_out[idx];
+  if (col < 2048) {
+    q16[static_cast<size_t>(row) * 2048 + col] = x;
+  } else if (col < 4096) {
+    k16[static_cast<size_t>(row) * 2048 + (col - 2048)] = x;
+  } else {
+    v48[static_cast<size_t>(row) * 6144 + (col - 4096)] = x;
+  }
+}
+
+__global__ void qwen36_split_q_gate_kernel(
+    const __nv_bfloat16* __restrict__ q_proj,
+    __nv_bfloat16* __restrict__ q_pre,
+    __nv_bfloat16* __restrict__ gate,
+    int S)
+{
+  const int idx = blockIdx.x * kSplitThreads + threadIdx.x;
+  const int total = S * 24 * 256;
+  if (idx >= total) return;
+
+  const int t = idx % 256;
+  const int h = (idx / 256) % 24;
+  const int s = idx / (24 * 256);
+  const size_t src = (static_cast<size_t>(s) * 24 + h) * 512 + t;
+  q_pre[idx] = q_proj[src];
+  gate[idx] = q_proj[src + 256];
+}
+
+__global__ void qwen36_gdn_gating_kernel(
+    const __nv_bfloat16* __restrict__ a,
+    const __nv_bfloat16* __restrict__ b,
+    const float* __restrict__ neg_exp_A_log,
+    const float* __restrict__ dt_bias,
+    __nv_bfloat16* __restrict__ g_out,
+    __nv_bfloat16* __restrict__ beta_out,
+    int S,
+    int num_heads)
+{
+  const int idx = blockIdx.x * kSplitThreads + threadIdx.x;
+  const int total = S * num_heads;
+  if (idx >= total) return;
+  const int h = idx % num_heads;
+
+  const float av = static_cast<float>(a[idx]) + dt_bias[h];
+  const float sp = log1pf(__expf(av));
+  const float gv = neg_exp_A_log[h] * sp;
+  const float bv = static_cast<float>(b[idx]);
+  const float beta = 1.0f / (1.0f + __expf(-bv));
+  g_out[idx] = __float2bfloat16(gv);
+  beta_out[idx] = __float2bfloat16(beta);
+}
+
+__global__ void qwen36_gdn_gating_strided_kernel(
+    const __nv_bfloat16* __restrict__ a,
+    const __nv_bfloat16* __restrict__ b,
+    const float* __restrict__ neg_exp_A_log,
+    const float* __restrict__ dt_bias,
+    __nv_bfloat16* __restrict__ g_out,
+    __nv_bfloat16* __restrict__ beta_out,
+    int S,
+    int num_heads,
+    int a_stride,
+    int b_stride)
+{
+  const int idx = blockIdx.x * kSplitThreads + threadIdx.x;
+  const int total = S * num_heads;
+  if (idx >= total) return;
+  const int row = idx / num_heads;
+  const int h = idx - row * num_heads;
+
+  const float av = static_cast<float>(a[row * a_stride + h]) + dt_bias[h];
+  const float sp = log1pf(__expf(av));
+  const float gv = neg_exp_A_log[h] * sp;
+  const float bv = static_cast<float>(b[row * b_stride + h]);
+  const float beta = 1.0f / (1.0f + __expf(-bv));
+  g_out[idx] = __float2bfloat16(gv);
+  beta_out[idx] = __float2bfloat16(beta);
+}
+
+template <int HD>
+__global__ void qwen36_gdn_chunk_from_conv_smem_kernel(
+    const __nv_bfloat16* __restrict__ conv_out,
+    const __nv_bfloat16* __restrict__ a_in,
+    const __nv_bfloat16* __restrict__ b_in,
+    const float* __restrict__ neg_exp_A_log,
+    const float* __restrict__ dt_bias,
+    __nv_bfloat16* __restrict__ state,
+    __nv_bfloat16* __restrict__ out_,
+    int S,
+    int num_v_heads,
+    int a_stride,
+    int b_stride,
+    bool use_qk_l2norm)
+{
+  static_assert(HD == 128, "HD must be 128 for Qwen3.6");
+  const int h = blockIdx.x;
+  const int b = blockIdx.y;
+  const int t = threadIdx.x;
+  if (t >= HD) return;
+
+  extern __shared__ float smem[];
+  float* state_s = smem;
+  float* qs = state_s + HD * HD;
+  float* ks = qs + HD;
+  float* scratch = ks + HD;
+
+  const size_t state_h_off =
+      (((size_t)b * num_v_heads + h)) * HD * HD;
+  #pragma unroll 16
+  for (int i = 0; i < HD; ++i) {
+    state_s[i * HD + t] = static_cast<float>(
+        state[state_h_off + (size_t)i * HD + t]);
+  }
+  __syncthreads();
+
+  const int src_h = h / 3;
+  for (int s = 0; s < S; ++s) {
+    const size_t row = static_cast<size_t>(s) * 10240;
+    const size_t out_off = ((size_t)s * num_v_heads + h) * HD + t;
+    qs[t] = static_cast<float>(conv_out[row + src_h * HD + t]);
+    ks[t] = static_cast<float>(conv_out[row + 2048 + src_h * HD + t]);
+    __syncthreads();
+
+    if (use_qk_l2norm) {
+      float q_sq = qs[t] * qs[t];
+      float k_sq = ks[t] * ks[t];
+      q_sq = block_reduce_sum<HD>(q_sq, scratch);
+      k_sq = block_reduce_sum<HD>(k_sq, scratch);
+      const float q_inv = rsqrtf(q_sq + kEps);
+      const float k_inv = rsqrtf(k_sq + kEps);
+      qs[t] *= q_inv;
+      ks[t] *= k_inv;
+      __syncthreads();
+    }
+
+    qs[t] *= rsqrtf(static_cast<float>(HD));
+    __syncthreads();
+
+    const float av =
+        static_cast<float>(a_in[s * a_stride + h]) + dt_bias[h];
+    const float sp = log1pf(__expf(av));
+    const float g_log = static_cast<float>(
+        __float2bfloat16(neg_exp_A_log[h] * sp));
+    const float g_t = __expf(g_log);
+    const float bv = static_cast<float>(b_in[s * b_stride + h]);
+    const float beta_t = static_cast<float>(
+        __float2bfloat16(1.0f / (1.0f + __expf(-bv))));
+
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      state_s[i * HD + t] *= g_t;
+    }
+
+    float kv_mem = 0.0f;
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      kv_mem = fmaf(state_s[i * HD + t], ks[i], kv_mem);
+    }
+
+    const float v_t =
+        static_cast<float>(conv_out[row + 4096 + h * HD + t]);
+    const float delta = (v_t - kv_mem) * beta_t;
+
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      state_s[i * HD + t] =
+          fmaf(ks[i], delta, state_s[i * HD + t]);
+    }
+
+    float out_t = 0.0f;
+    #pragma unroll 16
+    for (int i = 0; i < HD; ++i) {
+      out_t = fmaf(state_s[i * HD + t], qs[i], out_t);
+    }
+    out_[out_off] = __float2bfloat16(out_t);
+
+    if (s + 1 < S) {
+      #pragma unroll 16
+      for (int i = 0; i < HD; ++i) {
+        state_s[i * HD + t] =
+            static_cast<float>(__float2bfloat16(state_s[i * HD + t]));
+      }
+    }
+    __syncthreads();
+  }
+
+  #pragma unroll 16
+  for (int i = 0; i < HD; ++i) {
+    state[state_h_off + (size_t)i * HD + t] =
+        __float2bfloat16(state_s[i * HD + t]);
+  }
+}
+
+}  // namespace
+
+void gated_deltanet_chunk_qwen36_bf16(
+    const void* q,
+    const void* k,
+    const void* v,
+    const void* g,
+    const void* beta,
+    void*       state,
+    void*       out,
+    int S, int num_v_heads, int head_k_dim, int head_v_dim,
+    bool use_qk_l2norm,
+    cudaStream_t stream)
+{
+  if (head_k_dim != kHD || head_v_dim != kHD || S <= 0) {
+    return;
+  }
+  dim3 grid(num_v_heads, 1);
+  dim3 block(kHD);
+  gated_deltanet_chunk_kernel<kHD><<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q),
+      reinterpret_cast<const __nv_bfloat16*>(k),
+      reinterpret_cast<const __nv_bfloat16*>(v),
+      reinterpret_cast<const __nv_bfloat16*>(g),
+      reinterpret_cast<const __nv_bfloat16*>(beta),
+      reinterpret_cast<__nv_bfloat16*>(state),
+      reinterpret_cast<__nv_bfloat16*>(out),
+      S, num_v_heads, use_qk_l2norm);
+}
+
+void qwen36_lin_split_qkv_broadcast_bf16(
+    const void* conv_out,
+    void*       q48,
+    void*       k48,
+    void*       v48,
+    int S,
+    cudaStream_t stream)
+{
+  if (S <= 0) return;
+  const int total = S * 48 * kHD;
+  dim3 grid((total + kSplitThreads - 1) / kSplitThreads);
+  dim3 block(kSplitThreads);
+  qwen36_lin_split_qkv_broadcast_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(conv_out),
+      reinterpret_cast<__nv_bfloat16*>(q48),
+      reinterpret_cast<__nv_bfloat16*>(k48),
+      reinterpret_cast<__nv_bfloat16*>(v48),
+      S);
+}
+
+void qwen36_lin_split_qkv_gqa_bf16(
+    const void* conv_out,
+    void*       q16,
+    void*       k16,
+    void*       v48,
+    int S,
+    cudaStream_t stream)
+{
+  if (S <= 0) return;
+  const int total = S * 10240;
+  dim3 grid((total + kSplitThreads - 1) / kSplitThreads);
+  dim3 block(kSplitThreads);
+  qwen36_lin_split_qkv_gqa_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(conv_out),
+      reinterpret_cast<__nv_bfloat16*>(q16),
+      reinterpret_cast<__nv_bfloat16*>(k16),
+      reinterpret_cast<__nv_bfloat16*>(v48),
+      S);
+}
+
+void qwen36_split_q_gate_bf16(
+    const void* q_proj,
+    void*       q_pre,
+    void*       gate,
+    int S,
+    cudaStream_t stream)
+{
+  if (S <= 0) return;
+  const int total = S * 24 * 256;
+  dim3 grid((total + kSplitThreads - 1) / kSplitThreads);
+  dim3 block(kSplitThreads);
+  qwen36_split_q_gate_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q_proj),
+      reinterpret_cast<__nv_bfloat16*>(q_pre),
+      reinterpret_cast<__nv_bfloat16*>(gate),
+      S);
+}
+
+void qwen36_gdn_gating_bf16(
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       g_out,
+    void*       beta_out,
+    int S,
+    int num_heads,
+    cudaStream_t stream)
+{
+  if (S <= 0 || num_heads <= 0) return;
+  const int total = S * num_heads;
+  dim3 grid((total + kSplitThreads - 1) / kSplitThreads);
+  dim3 block(kSplitThreads);
+  qwen36_gdn_gating_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(a),
+      reinterpret_cast<const __nv_bfloat16*>(b),
+      neg_exp_A_log,
+      dt_bias,
+      reinterpret_cast<__nv_bfloat16*>(g_out),
+      reinterpret_cast<__nv_bfloat16*>(beta_out),
+      S, num_heads);
+}
+
+void qwen36_gdn_gating_strided_bf16(
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       g_out,
+    void*       beta_out,
+    int S,
+    int num_heads,
+    int a_stride,
+    int b_stride,
+    cudaStream_t stream)
+{
+  if (S <= 0 || num_heads <= 0) return;
+  const int total = S * num_heads;
+  dim3 grid((total + kSplitThreads - 1) / kSplitThreads);
+  dim3 block(kSplitThreads);
+  qwen36_gdn_gating_strided_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(a),
+      reinterpret_cast<const __nv_bfloat16*>(b),
+      neg_exp_A_log,
+      dt_bias,
+      reinterpret_cast<__nv_bfloat16*>(g_out),
+      reinterpret_cast<__nv_bfloat16*>(beta_out),
+      S, num_heads, a_stride, b_stride);
+}
+
+void qwen36_gdn_chunk_from_conv_smem_bf16(
+    const void* conv_out,
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       state,
+    void*       out,
+    int S,
+    int num_v_heads,
+    bool use_qk_l2norm,
+    cudaStream_t stream)
+{
+  if (S <= 0 || num_v_heads <= 0) return;
+  dim3 grid(num_v_heads, 1);
+  dim3 block(kHD);
+  constexpr size_t kSmemBytes =
+      (kHD * kHD + 2 * kHD + 32) * sizeof(float);
+  static bool attr_set = false;
+  if (!attr_set) {
+    cudaFuncSetAttribute(
+        qwen36_gdn_chunk_from_conv_smem_kernel<kHD>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(kSmemBytes));
+    attr_set = true;
+  }
+  qwen36_gdn_chunk_from_conv_smem_kernel<kHD><<<
+      grid, block, kSmemBytes, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(conv_out),
+      reinterpret_cast<const __nv_bfloat16*>(a),
+      reinterpret_cast<const __nv_bfloat16*>(b),
+      neg_exp_A_log,
+      dt_bias,
+      reinterpret_cast<__nv_bfloat16*>(state),
+      reinterpret_cast<__nv_bfloat16*>(out),
+      S, num_v_heads, num_v_heads, num_v_heads, use_qk_l2norm);
+}
+
+void qwen36_gdn_chunk_from_conv_smem_strided_bf16(
+    const void* conv_out,
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       state,
+    void*       out,
+    int S,
+    int num_v_heads,
+    int a_stride,
+    int b_stride,
+    bool use_qk_l2norm,
+    cudaStream_t stream)
+{
+  if (S <= 0 || num_v_heads <= 0) return;
+  dim3 grid(num_v_heads, 1);
+  dim3 block(kHD);
+  constexpr size_t kSmemBytes =
+      (kHD * kHD + 2 * kHD + 32) * sizeof(float);
+  static bool attr_set = false;
+  if (!attr_set) {
+    cudaFuncSetAttribute(
+        qwen36_gdn_chunk_from_conv_smem_kernel<kHD>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(kSmemBytes));
+    attr_set = true;
+  }
+  qwen36_gdn_chunk_from_conv_smem_kernel<kHD><<<
+      grid, block, kSmemBytes, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(conv_out),
+      reinterpret_cast<const __nv_bfloat16*>(a),
+      reinterpret_cast<const __nv_bfloat16*>(b),
+      neg_exp_A_log,
+      dt_bias,
+      reinterpret_cast<__nv_bfloat16*>(state),
+      reinterpret_cast<__nv_bfloat16*>(out),
+      S, num_v_heads, a_stride, b_stride, use_qk_l2norm);
+}
+
+void gated_deltanet_chunk_smem_qwen36_bf16(
+    const void* q,
+    const void* k,
+    const void* v,
+    const void* g,
+    const void* beta,
+    void*       state,
+    void*       out,
+    int S, int num_v_heads, int head_k_dim, int head_v_dim,
+    bool use_qk_l2norm,
+    cudaStream_t stream)
+{
+  if (head_k_dim != kHD || head_v_dim != kHD || S <= 0) {
+    return;
+  }
+  dim3 grid(num_v_heads, 1);
+  dim3 block(kHD);
+  constexpr size_t kSmemBytes =
+      (kHD * kHD + 2 * kHD + 32) * sizeof(float);
+  static bool attr_set = false;
+  if (!attr_set) {
+    cudaFuncSetAttribute(
+        gated_deltanet_chunk_smem_kernel<kHD>,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        static_cast<int>(kSmemBytes));
+    attr_set = true;
+  }
+  gated_deltanet_chunk_smem_kernel<kHD><<<
+      grid, block, kSmemBytes, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q),
+      reinterpret_cast<const __nv_bfloat16*>(k),
+      reinterpret_cast<const __nv_bfloat16*>(v),
+      reinterpret_cast<const __nv_bfloat16*>(g),
+      reinterpret_cast<const __nv_bfloat16*>(beta),
+      reinterpret_cast<__nv_bfloat16*>(state),
+      reinterpret_cast<__nv_bfloat16*>(out),
+      S, num_v_heads, use_qk_l2norm);
 }
 
 }  // namespace kernels

--- a/csrc/kernels/gated_deltanet_qwen36.cuh
+++ b/csrc/kernels/gated_deltanet_qwen36.cuh
@@ -73,5 +73,131 @@ void gated_deltanet_recurrent_inout_qwen36_bf16(
     bool use_qk_l2norm,
     cudaStream_t stream);
 
+// Multi-token recurrent scan for prefill chunks. Reads initial state,
+// loops S tokens inside one launch, writes all S outputs and final state.
+// It intentionally does not materialize per-token state snapshots, so
+// speculative verify with partial-reject recovery keeps using the
+// recurrent_inout variant above.
+void gated_deltanet_chunk_qwen36_bf16(
+    const void* q,
+    const void* k,
+    const void* v,
+    const void* g,
+    const void* beta,
+    void*       state,
+    void*       out,
+    int S, int num_v_heads, int head_k_dim, int head_v_dim,
+    bool use_qk_l2norm,
+    cudaStream_t stream);
+
+// Shared-memory state variant for profiling/tuning long prefill.
+// Same ABI and math as gated_deltanet_chunk_qwen36_bf16.
+void gated_deltanet_chunk_smem_qwen36_bf16(
+    const void* q,
+    const void* k,
+    const void* v,
+    const void* g,
+    const void* beta,
+    void*       state,
+    void*       out,
+    int S, int num_v_heads, int head_k_dim, int head_v_dim,
+    bool use_qk_l2norm,
+    cudaStream_t stream);
+
+// Split linear-attention conv output and broadcast Q/K heads.
+// conv_out: (S, 10240) = Q(16*128), K(16*128), V(48*128)
+// q48/k48/v48: contiguous (S, 48, 128), with Q/K head h sourced
+// from floor(h / 3).
+void qwen36_lin_split_qkv_broadcast_bf16(
+    const void* conv_out,
+    void*       q48,
+    void*       k48,
+    void*       v48,
+    int S,
+    cudaStream_t stream);
+
+// Split linear-attention conv output for the chunk/WY GQA path.
+// conv_out: (S, 10240) = Q(16*128), K(16*128), V(48*128)
+// q16/k16:  contiguous (S, 16, 128)
+// v48:      contiguous (S, 48, 128)
+void qwen36_lin_split_qkv_gqa_bf16(
+    const void* conv_out,
+    void*       q16,
+    void*       k16,
+    void*       v48,
+    int S,
+    cudaStream_t stream);
+
+// Split full-attention q_proj output:
+// q_proj: (S, 24, 512) = [q_pre(256), gate(256)] per head.
+// q_pre:  (S, 24, 256), contiguous.
+// gate:   (S, 24*256), contiguous.
+void qwen36_split_q_gate_bf16(
+    const void* q_proj,
+    void*       q_pre,
+    void*       gate,
+    int S,
+    cudaStream_t stream);
+
+// Fused Gated DeltaNet gate preparation:
+//   beta = sigmoid(b)
+//   g    = neg_exp_A_log[h] * log1p(exp(a + dt_bias[h]))
+// Inputs a/b are (S, 48) bf16, per-head constants are (48) fp32,
+// outputs beta/g are (S, 48) bf16.
+void qwen36_gdn_gating_bf16(
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       g_out,
+    void*       beta_out,
+    int S,
+    int num_heads,
+    cudaStream_t stream);
+
+void qwen36_gdn_gating_strided_bf16(
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       g_out,
+    void*       beta_out,
+    int S,
+    int num_heads,
+    int a_stride,
+    int b_stride,
+    cudaStream_t stream);
+
+// Long-prefill fused path: read conv_out directly, broadcast Q/K,
+// compute g/beta from a/b, and run the shared-memory Gated DeltaNet
+// recurrent scan in one kernel.
+void qwen36_gdn_chunk_from_conv_smem_bf16(
+    const void* conv_out,
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       state,
+    void*       out,
+    int S,
+    int num_v_heads,
+    bool use_qk_l2norm,
+    cudaStream_t stream);
+
+void qwen36_gdn_chunk_from_conv_smem_strided_bf16(
+    const void* conv_out,
+    const void* a,
+    const void* b,
+    const float* neg_exp_A_log,
+    const float* dt_bias,
+    void*       state,
+    void*       out,
+    int S,
+    int num_v_heads,
+    int a_stride,
+    int b_stride,
+    bool use_qk_l2norm,
+    cudaStream_t stream);
+
 }  // namespace kernels
 }  // namespace flash_rt

--- a/csrc/kernels/quantize.cu
+++ b/csrc/kernels/quantize.cu
@@ -165,6 +165,35 @@ void dequantize_fp8_static_bf16(const __nv_fp8_e4m3* input,
         input, output, d_scale, n);
 }
 
+__global__ void dequantize_fp8_static_bf16_2_kernel(
+        const __nv_fp8_e4m3* __restrict__ in0,
+        const __nv_fp8_e4m3* __restrict__ in1,
+        __nv_bfloat16* __restrict__ out0,
+        __nv_bfloat16* __restrict__ out1,
+        const float* __restrict__ s0,
+        const float* __restrict__ s1,
+        int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    float fs0 = *s0;
+    float fs1 = *s1;
+    for (int i = idx; i < n; i += gridDim.x * blockDim.x) {
+        out0[i] = __float2bfloat16(static_cast<float>(in0[i]) * fs0);
+        out1[i] = __float2bfloat16(static_cast<float>(in1[i]) * fs1);
+    }
+}
+
+void dequantize_fp8_static_bf16_2(
+        const __nv_fp8_e4m3* in0, const __nv_fp8_e4m3* in1,
+        __nv_bfloat16* out0, __nv_bfloat16* out1,
+        const float* s0, const float* s1,
+        int n, cudaStream_t stream) {
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    if (blocks > 4096) blocks = 4096;
+    dequantize_fp8_static_bf16_2_kernel<<<blocks, threads, 0, stream>>>(
+        in0, in1, out0, out1, s0, s1, n);
+}
+
 __global__ void dequantize_fp8_static_bf16_6_kernel(
         const __nv_fp8_e4m3* __restrict__ in0,
         const __nv_fp8_e4m3* __restrict__ in1,

--- a/csrc/kernels/quantize.cuh
+++ b/csrc/kernels/quantize.cuh
@@ -25,6 +25,12 @@ void quantize_fp8_static(const __nv_bfloat16* input, __nv_fp8_e4m3* output,
 void dequantize_fp8_static_bf16(const __nv_fp8_e4m3* input, __nv_bfloat16* output,
                                 const float* d_scale, int n, cudaStream_t stream = 0);
 
+void dequantize_fp8_static_bf16_2(
+    const __nv_fp8_e4m3* in0, const __nv_fp8_e4m3* in1,
+    __nv_bfloat16* out0, __nv_bfloat16* out1,
+    const float* s0, const float* s1,
+    int n, cudaStream_t stream = 0);
+
 void dequantize_fp8_static_bf16_6(
     const __nv_fp8_e4m3* in0, const __nv_fp8_e4m3* in1,
     const __nv_fp8_e4m3* in2, const __nv_fp8_e4m3* in3,

--- a/csrc/kernels/qwen36_flashinfer_xqa.cu
+++ b/csrc/kernels/qwen36_flashinfer_xqa.cu
@@ -1,0 +1,52 @@
+#include "qwen36_flashinfer_xqa.cuh"
+
+#include "mha.h"
+
+void qwen36_flashinfer_xqa_bf16_fp8kv_spec(
+    const void* q,
+    const void* k_cache,
+    const void* v_cache,
+    const int32_t* page_table,
+    const uint32_t* seq_lens,
+    const uint32_t* mask,
+    void* out,
+    uint32_t* semaphores,
+    void* scratch,
+    int max_seq_len,
+    int q_seq_len,
+    int sm_count,
+    float q_scale,
+    float kv_scale,
+    bool enable_pdl,
+    int64_t k_stride_page,
+    int64_t k_stride_token,
+    int64_t k_stride_head,
+    cudaStream_t stream) {
+  launchMHAFlashInfer(
+      static_cast<uint32_t>(sm_count),
+      4,
+      0,
+      q_scale,
+      nullptr,
+      reinterpret_cast<OutputHead*>(out),
+      reinterpret_cast<InputHead const*>(q),
+      nullptr,
+      reinterpret_cast<GMemCacheHead*>(const_cast<void*>(k_cache)),
+      reinterpret_cast<GMemCacheHead*>(const_cast<void*>(v_cache)),
+      reinterpret_cast<KVCachePageIndex const*>(page_table),
+      static_cast<uint32_t>(max_seq_len),
+      seq_lens,
+      1,
+      kv_scale,
+      nullptr,
+      static_cast<uint32_t>(q_seq_len),
+      nullptr,
+      reinterpret_cast<MaskType const*>(mask),
+      semaphores,
+      scratch,
+      enable_pdl,
+      static_cast<uint64_t>(k_stride_page),
+      static_cast<uint64_t>(k_stride_token),
+      static_cast<uint64_t>(k_stride_head),
+      stream);
+}

--- a/csrc/kernels/qwen36_flashinfer_xqa.cuh
+++ b/csrc/kernels/qwen36_flashinfer_xqa.cuh
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+void qwen36_flashinfer_xqa_bf16_fp8kv_spec(
+    const void* q,
+    const void* k_cache,
+    const void* v_cache,
+    const int32_t* page_table,
+    const uint32_t* seq_lens,
+    const uint32_t* mask,
+    void* out,
+    uint32_t* semaphores,
+    void* scratch,
+    int max_seq_len,
+    int q_seq_len,
+    int sm_count,
+    float q_scale,
+    float kv_scale,
+    bool enable_pdl,
+    int64_t k_stride_page,
+    int64_t k_stride_token,
+    int64_t k_stride_head,
+    cudaStream_t stream);

--- a/csrc/kernels/qwen36_misc.cu
+++ b/csrc/kernels/qwen36_misc.cu
@@ -1,0 +1,376 @@
+#include "qwen36_misc.cuh"
+
+#include <limits>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kThreads = 256;
+
+__global__ void embedding_lookup_bf16_kernel(
+    const int64_t* __restrict__ token_ids,
+    const __nv_bfloat16* __restrict__ embed,
+    __nv_bfloat16* __restrict__ out,
+    int rows,
+    int hidden)
+{
+  const int row = blockIdx.y;
+  if (row >= rows) return;
+  const int col = blockIdx.x * blockDim.x + threadIdx.x;
+  if (col >= hidden) return;
+  const int64_t tok = token_ids[row];
+  out[row * hidden + col] = embed[tok * hidden + col];
+}
+
+__device__ __forceinline__ __nv_bfloat16 partial_rope_value(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ cos,
+    const __nv_bfloat16* __restrict__ sin,
+    int row,
+    int head,
+    int col,
+    int heads,
+    int head_dim,
+    int rope_dim)
+{
+  const size_t base = (static_cast<size_t>(row) * heads + head) * head_dim;
+  if (col >= rope_dim) return x[base + col];
+
+  const int half = rope_dim >> 1;
+  const int rot_col = (col < half) ? (col + half) : (col - half);
+  float rot = static_cast<float>(x[base + rot_col]);
+  if (col < half) rot = -rot;
+  const float xv = static_cast<float>(x[base + col]);
+  const float cv = static_cast<float>(cos[row * rope_dim + col]);
+  const float sv = static_cast<float>(sin[row * rope_dim + col]);
+  const float rot_sin_bf = static_cast<float>(__float2bfloat16(rot * sv));
+  return __float2bfloat16(rot_sin_bf + xv * cv);
+}
+
+__global__ void partial_rope_qk_bf16_kernel(
+    const __nv_bfloat16* __restrict__ q_in,
+    const __nv_bfloat16* __restrict__ k_in,
+    const __nv_bfloat16* __restrict__ cos,
+    const __nv_bfloat16* __restrict__ sin,
+    __nv_bfloat16* __restrict__ q_out,
+    __nv_bfloat16* __restrict__ k_out,
+    int rows,
+    int q_heads,
+    int k_heads,
+    int head_dim,
+    int rope_dim)
+{
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int q_total = rows * q_heads * head_dim;
+  const int k_total = rows * k_heads * head_dim;
+  const int total = q_total + k_total;
+  if (idx >= total) return;
+
+  if (idx < q_total) {
+    const int col = idx % head_dim;
+    const int head = (idx / head_dim) % q_heads;
+    const int row = idx / (head_dim * q_heads);
+    q_out[idx] = partial_rope_value(
+        q_in, cos, sin, row, head, col, q_heads, head_dim, rope_dim);
+  } else {
+    const int k_idx = idx - q_total;
+    const int col = k_idx % head_dim;
+    const int head = (k_idx / head_dim) % k_heads;
+    const int row = k_idx / (head_dim * k_heads);
+    k_out[k_idx] = partial_rope_value(
+        k_in, cos, sin, row, head, col, k_heads, head_dim, rope_dim);
+  }
+}
+
+__global__ void tq_prepare_scalars_kernel(
+    const __half* __restrict__ k_norm,
+    const __half* __restrict__ k_rnorm,
+    const __half* __restrict__ v_norm,
+    float* __restrict__ norm_k,
+    float* __restrict__ coef_rnorm,
+    float* __restrict__ norm_v,
+    int n,
+    float coef)
+{
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= n) return;
+  norm_k[idx] = __half2float(k_norm[idx]);
+  coef_rnorm[idx] = __half2float(k_rnorm[idx]) * coef;
+  norm_v[idx] = __half2float(v_norm[idx]);
+}
+
+__global__ void spec_argmax_bf16_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    int64_t* __restrict__ argmax_out,
+    int rows,
+    int vocab)
+{
+  extern __shared__ unsigned char smem[];
+  float* s_val = reinterpret_cast<float*>(smem);
+  int* s_idx = reinterpret_cast<int*>(s_val + blockDim.x);
+
+  const int row = blockIdx.x;
+  if (row >= rows) return;
+  const __nv_bfloat16* row_logits =
+      logits + static_cast<size_t>(row) * vocab;
+
+  float best_val = -std::numeric_limits<float>::infinity();
+  int best_idx = 0;
+  for (int col = threadIdx.x; col < vocab; col += blockDim.x) {
+    const float v = static_cast<float>(row_logits[col]);
+    if (v > best_val || (v == best_val && col < best_idx)) {
+      best_val = v;
+      best_idx = col;
+    }
+  }
+  s_val[threadIdx.x] = best_val;
+  s_idx[threadIdx.x] = best_idx;
+  __syncthreads();
+
+  for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      const float other_val = s_val[threadIdx.x + stride];
+      const int other_idx = s_idx[threadIdx.x + stride];
+      const float cur_val = s_val[threadIdx.x];
+      const int cur_idx = s_idx[threadIdx.x];
+      if (other_val > cur_val
+          || (other_val == cur_val && other_idx < cur_idx)) {
+        s_val[threadIdx.x] = other_val;
+        s_idx[threadIdx.x] = other_idx;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    argmax_out[row] = static_cast<int64_t>(s_idx[0]);
+  }
+}
+
+__global__ void spec_argmax_bf16_partition_kernel(
+    const __nv_bfloat16* __restrict__ logits,
+    float* __restrict__ partial_vals,
+    int* __restrict__ partial_idx,
+    int rows,
+    int vocab,
+    int parts)
+{
+  extern __shared__ unsigned char smem[];
+  float* s_val = reinterpret_cast<float*>(smem);
+  int* s_idx = reinterpret_cast<int*>(s_val + blockDim.x);
+
+  const int row = blockIdx.x;
+  const int part = blockIdx.y;
+  if (row >= rows || part >= parts) return;
+
+  const int cols_per_part = (vocab + parts - 1) / parts;
+  const int begin = part * cols_per_part;
+  const int end = min(vocab, begin + cols_per_part);
+  const __nv_bfloat16* row_logits =
+      logits + static_cast<size_t>(row) * vocab;
+
+  float best_val = -std::numeric_limits<float>::infinity();
+  int best_idx = 0;
+  for (int col = begin + threadIdx.x; col < end; col += blockDim.x) {
+    const float v = static_cast<float>(row_logits[col]);
+    if (v > best_val || (v == best_val && col < best_idx)) {
+      best_val = v;
+      best_idx = col;
+    }
+  }
+  s_val[threadIdx.x] = best_val;
+  s_idx[threadIdx.x] = best_idx;
+  __syncthreads();
+
+  for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride) {
+      const float other_val = s_val[threadIdx.x + stride];
+      const int other_idx = s_idx[threadIdx.x + stride];
+      const float cur_val = s_val[threadIdx.x];
+      const int cur_idx = s_idx[threadIdx.x];
+      if (other_val > cur_val
+          || (other_val == cur_val && other_idx < cur_idx)) {
+        s_val[threadIdx.x] = other_val;
+        s_idx[threadIdx.x] = other_idx;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    const int out = row * parts + part;
+    partial_vals[out] = s_val[0];
+    partial_idx[out] = s_idx[0];
+  }
+}
+
+__global__ void spec_reduce_accept_partition_kernel(
+    const float* __restrict__ partial_vals,
+    const int* __restrict__ partial_idx,
+    const int64_t* __restrict__ drafts,
+    int64_t* __restrict__ argmax_out,
+    int* __restrict__ accept_n,
+    int rows,
+    int parts,
+    int spec_k)
+{
+  for (int row = threadIdx.x; row < rows; row += blockDim.x) {
+    float best_val = -std::numeric_limits<float>::infinity();
+    int best_idx = 0;
+    for (int part = 0; part < parts; ++part) {
+      const int off = row * parts + part;
+      const float v = partial_vals[off];
+      const int idx = partial_idx[off];
+      if (v > best_val || (v == best_val && idx < best_idx)) {
+        best_val = v;
+        best_idx = idx;
+      }
+    }
+    argmax_out[row] = static_cast<int64_t>(best_idx);
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    int n = 0;
+    for (; n < spec_k; ++n) {
+      if (argmax_out[n] != drafts[n]) break;
+    }
+    accept_n[0] = n;
+  }
+}
+
+__global__ void spec_accept_kernel(
+    const int64_t* __restrict__ argmax_out,
+    const int64_t* __restrict__ drafts,
+    int* __restrict__ accept_n,
+    int spec_k)
+{
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  int n = 0;
+  for (; n < spec_k; ++n) {
+    if (argmax_out[n] != drafts[n]) break;
+  }
+  accept_n[0] = n;
+}
+
+}  // namespace
+
+void qwen36_embedding_lookup_bf16(
+    const int64_t* token_ids,
+    const __nv_bfloat16* embed,
+    __nv_bfloat16* out,
+    int rows,
+    int hidden,
+    cudaStream_t stream)
+{
+  if (rows <= 0 || hidden <= 0) return;
+  const dim3 block(kThreads);
+  const dim3 grid((hidden + kThreads - 1) / kThreads, rows);
+  embedding_lookup_bf16_kernel<<<grid, block, 0, stream>>>(
+      token_ids, embed, out, rows, hidden);
+}
+
+void qwen36_partial_rope_qk_bf16(
+    const __nv_bfloat16* q_in,
+    const __nv_bfloat16* k_in,
+    const __nv_bfloat16* cos,
+    const __nv_bfloat16* sin,
+    __nv_bfloat16* q_out,
+    __nv_bfloat16* k_out,
+    int rows,
+    int q_heads,
+    int k_heads,
+    int head_dim,
+    int rope_dim,
+    cudaStream_t stream)
+{
+  if (rows <= 0 || q_heads <= 0 || k_heads <= 0 || head_dim <= 0
+      || rope_dim <= 0) {
+    return;
+  }
+  const int total = rows * (q_heads + k_heads) * head_dim;
+  const dim3 block(kThreads);
+  const dim3 grid((total + kThreads - 1) / kThreads);
+  partial_rope_qk_bf16_kernel<<<grid, block, 0, stream>>>(
+      q_in, k_in, cos, sin, q_out, k_out,
+      rows, q_heads, k_heads, head_dim, rope_dim);
+}
+
+void qwen36_tq_prepare_scalars(
+    const __half* k_norm,
+    const __half* k_rnorm,
+    const __half* v_norm,
+    float* norm_k,
+    float* coef_rnorm,
+    float* norm_v,
+    int n,
+    float coef,
+    cudaStream_t stream)
+{
+  if (n <= 0) return;
+  const dim3 block(kThreads);
+  const dim3 grid((n + kThreads - 1) / kThreads);
+  tq_prepare_scalars_kernel<<<grid, block, 0, stream>>>(
+      k_norm, k_rnorm, v_norm, norm_k, coef_rnorm, norm_v, n, coef);
+}
+
+void qwen36_argmax_bf16(
+    const __nv_bfloat16* logits,
+    int64_t* argmax_out,
+    int rows,
+    int vocab,
+    cudaStream_t stream)
+{
+  if (rows <= 0 || vocab <= 0) return;
+  const int threads = 1024;
+  const size_t smem = threads * (sizeof(float) + sizeof(int));
+  spec_argmax_bf16_kernel<<<rows, threads, smem, stream>>>(
+      logits, argmax_out, rows, vocab);
+}
+
+void qwen36_spec_accept_greedy_bf16(
+    const __nv_bfloat16* logits,
+    const int64_t* drafts,
+    int64_t* argmax_out,
+    int* accept_n,
+    int rows,
+    int vocab,
+    int spec_k,
+    cudaStream_t stream)
+{
+  if (rows <= 0 || vocab <= 0) return;
+  const int threads = 1024;
+  const size_t smem = threads * (sizeof(float) + sizeof(int));
+  spec_argmax_bf16_kernel<<<rows, threads, smem, stream>>>(
+      logits, argmax_out, rows, vocab);
+  spec_accept_kernel<<<1, 1, 0, stream>>>(
+      argmax_out, drafts, accept_n, spec_k);
+}
+
+void qwen36_spec_accept_partitioned_bf16(
+    const __nv_bfloat16* logits,
+    const int64_t* drafts,
+    int64_t* argmax_out,
+    int* accept_n,
+    float* partial_vals,
+    int* partial_idx,
+    int rows,
+    int vocab,
+    int spec_k,
+    int parts,
+    cudaStream_t stream)
+{
+  if (rows <= 0 || vocab <= 0 || parts <= 0) return;
+  parts = min(parts, 128);
+  const int threads = 256;
+  const size_t smem = threads * (sizeof(float) + sizeof(int));
+  const dim3 grid(rows, parts);
+  spec_argmax_bf16_partition_kernel<<<grid, threads, smem, stream>>>(
+      logits, partial_vals, partial_idx, rows, vocab, parts);
+  spec_reduce_accept_partition_kernel<<<1, 128, 0, stream>>>(
+      partial_vals, partial_idx, drafts, argmax_out, accept_n,
+      rows, parts, spec_k);
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen36_misc.cuh
+++ b/csrc/kernels/qwen36_misc.cuh
@@ -1,0 +1,75 @@
+// Small Qwen3.6 hot-path helpers that do not belong to GEMM/attention files.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt::kernels {
+
+void qwen36_embedding_lookup_bf16(
+    const int64_t* token_ids,
+    const __nv_bfloat16* embed,
+    __nv_bfloat16* out,
+    int rows,
+    int hidden,
+    cudaStream_t stream);
+
+void qwen36_partial_rope_qk_bf16(
+    const __nv_bfloat16* q_in,
+    const __nv_bfloat16* k_in,
+    const __nv_bfloat16* cos,
+    const __nv_bfloat16* sin,
+    __nv_bfloat16* q_out,
+    __nv_bfloat16* k_out,
+    int rows,
+    int q_heads,
+    int k_heads,
+    int head_dim,
+    int rope_dim,
+    cudaStream_t stream);
+
+void qwen36_tq_prepare_scalars(
+    const __half* k_norm,
+    const __half* k_rnorm,
+    const __half* v_norm,
+    float* norm_k,
+    float* coef_rnorm,
+    float* norm_v,
+    int n,
+    float coef,
+    cudaStream_t stream);
+
+void qwen36_argmax_bf16(
+    const __nv_bfloat16* logits,
+    int64_t* argmax_out,
+    int rows,
+    int vocab,
+    cudaStream_t stream);
+
+void qwen36_spec_accept_greedy_bf16(
+    const __nv_bfloat16* logits,
+    const int64_t* drafts,
+    int64_t* argmax_out,
+    int* accept_n,
+    int rows,
+    int vocab,
+    int spec_k,
+    cudaStream_t stream);
+
+void qwen36_spec_accept_partitioned_bf16(
+    const __nv_bfloat16* logits,
+    const int64_t* drafts,
+    int64_t* argmax_out,
+    int* accept_n,
+    float* partial_vals,
+    int* partial_idx,
+    int rows,
+    int vocab,
+    int spec_k,
+    int parts,
+    cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/silu_mul_qwen36.cu
+++ b/csrc/kernels/silu_mul_qwen36.cu
@@ -39,6 +39,21 @@ __global__ void silu_mul_kernel(
   out[idx] = __float2bfloat16(silu_g_bf_rt * u);
 }
 
+__global__ void sigmoid_mul_kernel(
+    const __nv_bfloat16* __restrict__ gate,
+    const __nv_bfloat16* __restrict__ x,
+    __nv_bfloat16* __restrict__ out,
+    int n)
+{
+  const int idx = blockIdx.x * kThreadsX + threadIdx.x;
+  if (idx >= n) return;
+  const float g = static_cast<float>(gate[idx]);
+  const float xv = static_cast<float>(x[idx]);
+  const float sig = 1.0f / (1.0f + expf(-g));
+  const float sig_bf_rt = static_cast<float>(__float2bfloat16(sig));
+  out[idx] = __float2bfloat16(xv * sig_bf_rt);
+}
+
 }  // namespace
 
 void silu_mul_qwen36_bf16(
@@ -50,6 +65,17 @@ void silu_mul_qwen36_bf16(
 {
   const int grid = (n + kThreadsX - 1) / kThreadsX;
   silu_mul_kernel<<<grid, kThreadsX, 0, stream>>>(gate, up, out, n);
+}
+
+void sigmoid_mul_qwen36_bf16(
+    const __nv_bfloat16* gate,
+    const __nv_bfloat16* x,
+    __nv_bfloat16* out,
+    int n,
+    cudaStream_t stream)
+{
+  const int grid = (n + kThreadsX - 1) / kThreadsX;
+  sigmoid_mul_kernel<<<grid, kThreadsX, 0, stream>>>(gate, x, out, n);
 }
 
 }  // namespace flash_rt::kernels

--- a/csrc/kernels/silu_mul_qwen36.cuh
+++ b/csrc/kernels/silu_mul_qwen36.cuh
@@ -24,4 +24,11 @@ void silu_mul_qwen36_bf16(
     int n,
     cudaStream_t stream);
 
+void sigmoid_mul_qwen36_bf16(
+    const __nv_bfloat16* gate,
+    const __nv_bfloat16* x,
+    __nv_bfloat16* out,
+    int n,
+    cudaStream_t stream);
+
 }  // namespace flash_rt::kernels

--- a/csrc/kernels/silu_mul_to_nvfp4_swizzled.cu
+++ b/csrc/kernels/silu_mul_to_nvfp4_swizzled.cu
@@ -164,6 +164,85 @@ __global__ void silu_mul_to_nvfp4_swizzled_kernel(
   }
 }
 
+// Same output as silu_mul_to_nvfp4_swizzled_kernel, but reads gate/up
+// from one row-major [gate | up] buffer. This is the correct consumer
+// for a fused gate_up GEMM at rows > 1; split pointers would otherwise
+// see a row stride of 2*cols.
+__global__ void silu_mul_merged_to_nvfp4_swizzled_kernel(
+    const __nv_bfloat16* __restrict__ merged_gate_up,
+    uint8_t* __restrict__ packed,
+    uint8_t* __restrict__ sf_swz,
+    int cols,
+    int num_blocks,
+    int n_col_blocks) {
+  int row = blockIdx.x;
+  const __nv_bfloat16* gate_row =
+      merged_gate_up + (size_t)row * (2 * cols);
+  const __nv_bfloat16* up_row = gate_row + cols;
+  uint8_t* packed_row = packed + (size_t)row * (cols / 2);
+
+  extern __shared__ __align__(16) uint8_t smem_raw[];
+  float* smem_scales = reinterpret_cast<float*>(smem_raw);
+  __nv_bfloat16* smem_silu_mul = reinterpret_cast<__nv_bfloat16*>(
+      smem_raw + num_blocks * sizeof(float));
+
+  for (int b = threadIdx.x; b < num_blocks; b += blockDim.x) {
+    smem_scales[b] = 0.0f;
+  }
+  __syncthreads();
+
+  for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+    float g = __bfloat162float(gate_row[i]);
+    float u = __bfloat162float(up_row[i]);
+    float silu_g = silu_f32(g);
+    float silu_g_bf = static_cast<float>(__float2bfloat16(silu_g));
+    __nv_bfloat16 silu_mul_bf = __float2bfloat16(silu_g_bf * u);
+    smem_silu_mul[i] = silu_mul_bf;
+
+    float val = fabsf(static_cast<float>(silu_mul_bf));
+    int blk = i >> 4;
+    atomicMax((int*)&smem_scales[blk], __float_as_int(val));
+  }
+  __syncthreads();
+
+  int rb = row / 128;
+  int ri = row % 128;
+  for (int b = threadIdx.x; b < num_blocks; b += blockDim.x) {
+    float amax = __int_as_float(*(int*)&smem_scales[b]);
+    float scale = amax / 6.0f;
+    uint8_t ue_scale = float_to_ue4m3_ceil(scale);
+    int cb = b / 4;
+    int ci = b % 4;
+    int out_idx = (rb * n_col_blocks + cb) * 512
+                + (ri % 32) * 16 + (ri / 32) * 4 + ci;
+    sf_swz[out_idx] = ue_scale;
+    smem_scales[b] = ue4m3_to_float(ue_scale);
+  }
+  __syncthreads();
+
+  int half_cols = cols >> 1;
+  for (int p = threadIdx.x; p < half_cols; p += blockDim.x) {
+    int i = p * 2;
+    int blk = i >> 4;
+    float scale = smem_scales[blk];
+    float inv_scale = (scale > 0.0f) ? (1.0f / scale) : 0.0f;
+
+    float v0 = __bfloat162float(smem_silu_mul[i]) * inv_scale;
+    float v1 = __bfloat162float(smem_silu_mul[i + 1]) * inv_scale;
+
+    int blk1 = (i + 1) >> 4;
+    if (blk1 != blk) {
+      float scale1 = smem_scales[blk1];
+      float inv1 = (scale1 > 0.0f) ? (1.0f / scale1) : 0.0f;
+      v1 = __bfloat162float(smem_silu_mul[i + 1]) * inv1;
+    }
+
+    uint8_t fp4_lo = float_to_fp4_e2m1(v0);
+    uint8_t fp4_hi = float_to_fp4_e2m1(v1);
+    packed_row[p] = (fp4_hi << 4) | (fp4_lo & 0x0F);
+  }
+}
+
 }  // namespace
 
 int silu_mul_to_nvfp4_swizzled_bf16(
@@ -194,6 +273,36 @@ int silu_mul_to_nvfp4_swizzled_bf16(
   silu_mul_to_nvfp4_swizzled_kernel<<<rows, threads, smem_size, stream>>>(
       reinterpret_cast<const __nv_bfloat16*>(gate),
       reinterpret_cast<const __nv_bfloat16*>(up),
+      reinterpret_cast<uint8_t*>(packed),
+      reinterpret_cast<uint8_t*>(sf_swz),
+      cols, num_blocks, n_col_blocks);
+  return 0;
+}
+
+int silu_mul_merged_to_nvfp4_swizzled_bf16(
+    const void* merged_gate_up,
+    void*       packed,
+    void*       sf_swz,
+    int         rows,
+    int         cols,
+    cudaStream_t stream) {
+  if (!merged_gate_up || !packed || !sf_swz) return 1;
+  if (rows <= 0 || cols <= 0 || (cols & 0xF) != 0) return 2;
+
+  int num_blocks = (cols + 15) / 16;
+  int n_col_blocks = (num_blocks + 3) / 4;
+  int threads = 256;
+  size_t smem_size = num_blocks * sizeof(float)
+                   + cols * sizeof(__nv_bfloat16);
+  if (smem_size > 48 * 1024) {
+    cudaFuncSetAttribute(
+        silu_mul_merged_to_nvfp4_swizzled_kernel,
+        cudaFuncAttributeMaxDynamicSharedMemorySize,
+        100 * 1024);
+  }
+  silu_mul_merged_to_nvfp4_swizzled_kernel<<<
+      rows, threads, smem_size, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(merged_gate_up),
       reinterpret_cast<uint8_t*>(packed),
       reinterpret_cast<uint8_t*>(sf_swz),
       cols, num_blocks, n_col_blocks);

--- a/csrc/kernels/silu_mul_to_nvfp4_swizzled.cuh
+++ b/csrc/kernels/silu_mul_to_nvfp4_swizzled.cuh
@@ -41,5 +41,15 @@ int silu_mul_to_nvfp4_swizzled_bf16(
     int         cols,
     cudaStream_t stream);
 
+// merged_gate_up : (rows, 2 * cols) bf16, row layout [gate | up].
+// packed/sf_swz are the same outputs as silu_mul_to_nvfp4_swizzled_bf16.
+int silu_mul_merged_to_nvfp4_swizzled_bf16(
+    const void* merged_gate_up,
+    void*       packed,
+    void*       sf_swz,
+    int         rows,
+    int         cols,
+    cudaStream_t stream);
+
 }  // namespace kernels
 }  // namespace flash_rt

--- a/csrc/quantize/fp8_per_token_block_quant.cu
+++ b/csrc/quantize/fp8_per_token_block_quant.cu
@@ -71,6 +71,62 @@ __global__ void fp8_per_token_block_quant_kernel(
   }
 }
 
+__global__ void fp8_per_token_block_quant_linear_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int M, int K)
+{
+  const int k_blocks = K / kBlock;
+  const int tile = blockIdx.x;
+  const int m = tile / k_blocks;
+  const int kb = tile - m * k_blocks;
+  if (m >= M || kb * kBlock >= K) return;
+
+  const int t = threadIdx.x;
+  const int k = kb * kBlock + t;
+
+  // Load.
+  const float v = (k < K)
+      ? static_cast<float>(input[m * K + k])
+      : 0.0f;
+  const float a = fabsf(v);
+
+  // Block-reduce |max| across 128 threads (4 warps).
+  float amax = a;
+  for (int off = 16; off > 0; off >>= 1) {
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, off));
+  }
+  __shared__ float warp_amax[4];
+  const int lane = t & 31;
+  const int warp = t >> 5;
+  if (lane == 0) warp_amax[warp] = amax;
+  __syncthreads();
+
+  // Final reduce in warp 0.
+  if (warp == 0) {
+    amax = (lane < 4) ? warp_amax[lane] : 0.0f;
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, 1));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, 2));
+    if (lane == 0) {
+      // Avoid div-by-zero; use small epsilon equivalent to fp8-eps.
+      const float s = fmaxf(amax / kFp8Max, 1.0e-12f);
+      warp_amax[0] = s;
+      scale[m * (K / kBlock) + kb] = s;
+    }
+  }
+  __syncthreads();
+
+  const float inv_s = 1.0f / warp_amax[0];
+
+  // Quantize and store.
+  if (k < K) {
+    float q = v * inv_s;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    output[m * K + k] = __nv_fp8_e4m3(q);
+  }
+}
+
 }  // namespace
 
 void fp8_per_token_block128_quant_bf16(
@@ -80,13 +136,22 @@ void fp8_per_token_block128_quant_bf16(
     int M, int K,
     cudaStream_t stream)
 {
-  dim3 grid(K / kBlock, M);
   dim3 block(kBlock);
-  fp8_per_token_block_quant_kernel<<<grid, block, 0, stream>>>(
-      reinterpret_cast<const __nv_bfloat16*>(input),
-      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
-      output_scale,
-      M, K);
+  if (M <= 65535) {
+    dim3 grid(K / kBlock, M);
+    fp8_per_token_block_quant_kernel<<<grid, block, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(input),
+        reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+        output_scale,
+        M, K);
+  } else {
+    dim3 grid((K / kBlock) * M);
+    fp8_per_token_block_quant_linear_kernel<<<grid, block, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(input),
+        reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+        output_scale,
+        M, K);
+  }
 }
 
 }  // namespace quantize

--- a/csrc/quantize/tq_dequant_kv.cu
+++ b/csrc/quantize/tq_dequant_kv.cu
@@ -37,8 +37,11 @@
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cublas_v2.h>
+#include <cublasLt.h>
 #include <cstdint>
 #include <cstdio>
+#include <mutex>
+#include <unordered_map>
 
 namespace {
 
@@ -48,6 +51,87 @@ constexpr int IDX_PACKED_BYTES = D / 2;     // 128
 constexpr int QJL_PACKED_BYTES = D / 8;     // 32
 constexpr int CB_K_MAX = 16;       // up to 4-bit codebook
 constexpr int CB_V_MAX = 16;
+
+struct TqLtFp32Plan {
+    cublasLtMatmulDesc_t desc = nullptr;
+    cublasLtMatrixLayout_t a_desc = nullptr;
+    cublasLtMatrixLayout_t b_desc = nullptr;
+    cublasLtMatrixLayout_t c_desc = nullptr;
+    cublasLtMatmulAlgo_t algo{};
+    bool valid = false;
+};
+
+static inline uint64_t tq_lt_plan_key(
+    int M, int N, int K, int algo_idx, int trans_b)
+{
+    return ((uint64_t)(uint32_t)M << 32)
+        ^ ((uint64_t)(uint32_t)N << 22)
+        ^ ((uint64_t)(uint32_t)K << 12)
+        ^ ((uint64_t)(uint32_t)(algo_idx & 0xff) << 4)
+        ^ (uint64_t)(trans_b & 0xf);
+}
+
+static TqLtFp32Plan* tq_get_lt_fp32_plan(
+    cublasLtHandle_t lt,
+    int M, int N, int K, int algo_idx, bool trans_b,
+    size_t workspace_size)
+{
+    static std::mutex mu;
+    static std::unordered_map<uint64_t, TqLtFp32Plan> cache;
+
+    if (algo_idx < 0) algo_idx = 0;
+    const uint64_t key = tq_lt_plan_key(M, N, K, algo_idx, trans_b ? 1 : 0);
+    std::lock_guard<std::mutex> lock(mu);
+    auto it = cache.find(key);
+    if (it != cache.end()) return &it->second;
+
+    TqLtFp32Plan plan;
+    cublasOperation_t opN = CUBLAS_OP_N;
+    cublasOperation_t opB = trans_b ? CUBLAS_OP_T : CUBLAS_OP_N;
+    cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
+
+    cublasLtMatmulDescCreate(&plan.desc, CUBLAS_COMPUTE_32F, CUDA_R_32F);
+    cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSA, &opN, sizeof(opN));
+    cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSB, &opB, sizeof(opB));
+
+    cublasLtMatrixLayoutCreate(&plan.a_desc, CUDA_R_32F, M, K, K);
+    cublasLtMatrixLayoutSetAttribute(
+        plan.a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+        &row_order, sizeof(row_order));
+    cublasLtMatrixLayoutCreate(
+        &plan.b_desc, CUDA_R_32F, trans_b ? N : K, trans_b ? K : N,
+        trans_b ? K : N);
+    cublasLtMatrixLayoutSetAttribute(
+        plan.b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+        &row_order, sizeof(row_order));
+    cublasLtMatrixLayoutCreate(&plan.c_desc, CUDA_R_32F, M, N, N);
+    cublasLtMatrixLayoutSetAttribute(
+        plan.c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER,
+        &row_order, sizeof(row_order));
+
+    cublasLtMatmulPreference_t pref = nullptr;
+    cublasLtMatmulPreferenceCreate(&pref);
+    cublasLtMatmulPreferenceSetAttribute(
+        pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &workspace_size, sizeof(workspace_size));
+    constexpr int kMaxAlgos = 32;
+    cublasLtMatmulHeuristicResult_t heuristics[kMaxAlgos]{};
+    int returned = 0;
+    cublasLtMatmulAlgoGetHeuristic(
+        lt, plan.desc, plan.a_desc, plan.b_desc, plan.c_desc, plan.c_desc,
+        pref, kMaxAlgos, heuristics, &returned);
+    cublasLtMatmulPreferenceDestroy(pref);
+    if (returned > 0) {
+        if (algo_idx >= returned) algo_idx = returned - 1;
+        plan.algo = heuristics[algo_idx].algo;
+        plan.valid = true;
+    }
+
+    auto [inserted_it, _] = cache.emplace(key, plan);
+    return &inserted_it->second;
+}
 
 // ── Unpack kernel ───────────────────────────────────────────────────
 // Block: D threads, one per output coord.  Grid: M blocks (M = S*NUM_KV).
@@ -1049,6 +1133,164 @@ void tq_fp32_gemm_tf32_launch(
         c_fp32, CUDA_R_32F, N,
         CUBLAS_COMPUTE_32F_FAST_TF32,
         CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+}
+
+extern "C"
+void tq_fp32_gemm_fp32_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream)
+{
+    static cublasHandle_t handle = nullptr;
+    if (handle == nullptr) {
+        cublasCreate(&handle);
+        cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH);
+    }
+    cublasSetStream(handle, stream);
+
+    const float alpha = 1.0f, beta = 0.0f;
+    cublasGemmEx(
+        handle,
+        CUBLAS_OP_N,
+        CUBLAS_OP_N,
+        N, M, K,
+        &alpha,
+        b_fp32, CUDA_R_32F, N,
+        a_fp32, CUDA_R_32F, K,
+        &beta,
+        c_fp32, CUDA_R_32F, N,
+        CUBLAS_COMPUTE_32F,
+        CUBLAS_GEMM_DEFAULT);
+}
+
+extern "C"
+void tq_fp32_gemm_fp32_bt_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream)
+{
+    static cublasHandle_t handle = nullptr;
+    if (handle == nullptr) {
+        cublasCreate(&handle);
+        cublasSetMathMode(handle, CUBLAS_DEFAULT_MATH);
+    }
+    cublasSetStream(handle, stream);
+
+    const float alpha = 1.0f, beta = 0.0f;
+    cublasGemmEx(
+        handle,
+        CUBLAS_OP_T,
+        CUBLAS_OP_N,
+        N, M, K,
+        &alpha,
+        b_fp32, CUDA_R_32F, K,
+        a_fp32, CUDA_R_32F, K,
+        &beta,
+        c_fp32, CUDA_R_32F, N,
+        CUBLAS_COMPUTE_32F,
+        CUBLAS_GEMM_DEFAULT);
+}
+
+extern "C"
+void tq_fp32_gemm_lt_algo_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    int algo_idx,
+    cudaStream_t stream);
+
+extern "C"
+void tq_fp32_gemm_lt_bt_algo_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    int algo_idx,
+    cudaStream_t stream);
+
+extern "C"
+void tq_fp32_gemm_lt_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream)
+{
+    tq_fp32_gemm_lt_algo_launch(
+        a_fp32, b_fp32, c_fp32, M, N, K, 0, stream);
+}
+
+extern "C"
+void tq_fp32_gemm_lt_bt_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    cudaStream_t stream)
+{
+    tq_fp32_gemm_lt_bt_algo_launch(
+        a_fp32, b_fp32, c_fp32, M, N, K, 0, stream);
+}
+
+extern "C"
+void tq_fp32_gemm_lt_algo_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    int algo_idx,
+    cudaStream_t stream)
+{
+    static cublasLtHandle_t lt = nullptr;
+    static void* workspace = nullptr;
+    static size_t workspace_size = 32 * 1024 * 1024;
+    if (lt == nullptr) {
+        cublasLtCreate(&lt);
+        cudaMalloc(&workspace, workspace_size);
+    }
+
+    TqLtFp32Plan* plan = tq_get_lt_fp32_plan(
+        lt, M, N, K, algo_idx, false, workspace_size);
+    const float alpha = 1.0f, beta = 0.0f;
+    if (plan->valid) {
+        cublasLtMatmul(
+            lt, plan->desc, &alpha,
+            a_fp32, plan->a_desc,
+            b_fp32, plan->b_desc,
+            &beta,
+            c_fp32, plan->c_desc,
+            c_fp32, plan->c_desc,
+            &plan->algo, workspace, workspace_size, stream);
+    }
+}
+
+extern "C"
+void tq_fp32_gemm_lt_bt_algo_launch(
+    const void* a_fp32, const void* b_fp32,
+    void* c_fp32,
+    int M, int N, int K,
+    int algo_idx,
+    cudaStream_t stream)
+{
+    static cublasLtHandle_t lt = nullptr;
+    static void* workspace = nullptr;
+    static size_t workspace_size = 32 * 1024 * 1024;
+    if (lt == nullptr) {
+        cublasLtCreate(&lt);
+        cudaMalloc(&workspace, workspace_size);
+    }
+
+    TqLtFp32Plan* plan = tq_get_lt_fp32_plan(
+        lt, M, N, K, algo_idx, true, workspace_size);
+    const float alpha = 1.0f, beta = 0.0f;
+    if (plan->valid) {
+        cublasLtMatmul(
+            lt, plan->desc, &alpha,
+            a_fp32, plan->a_desc,
+            b_fp32, plan->b_desc,
+            &beta,
+            c_fp32, plan->c_desc,
+            c_fp32, plan->c_desc,
+            &plan->algo, workspace, workspace_size, stream);
+    }
 }
 
 // ── BF16 act × FP32 weight → FP32 out  (cuBLAS gemmEx mixed-type) ──

--- a/docs/qwen36_nvfp4.md
+++ b/docs/qwen36_nvfp4.md
@@ -13,8 +13,18 @@ compatible HTTP server, see
 ## 0. Quickstart
 
 The minimum to run Qwen3.6-27B NVFP4 with K=6 speculative decode at
-~129 tok/s decode on RTX 5090. Step 1 is one-time; step 2 is the
+~134 tok/s decode on the short standard prompt. Step 1 is one-time; step 2 is the
 inference call.
+
+Install the Torch frontend extra before building/running Qwen. It
+includes the Qwen long-context runtime dependencies (`einops`,
+`triton>=3.2`, and `packaging`):
+
+```bash
+pip install -e ".[torch]"
+# Add the server extra too if you use examples/qwen36_openai_server.py:
+# pip install -e ".[torch,server]"
+```
 
 ```python
 # 1) Build the kernels (one-time, from the FlashRT repo root)
@@ -45,7 +55,7 @@ text = fe._tokenizer.decode(out[0, input_ids.shape[1]:].tolist())
 print(text)
 ```
 
-`K=6` is the recommended default (peaks at ~129 tok/s decode on RTX
+`K=6` is the recommended default (peaks at ~134 tok/s decode on RTX
 5090 for short prompts). For sustained / long generations, drop to
 `K=5` or `K=3` — see §3 for the full curve.
 
@@ -56,16 +66,19 @@ The NVFP4 inference path needs **two** checkpoints:
 | Role | Format | Source |
 |---|---|---|
 | Main model | NVFP4 W4A16 (`compressed-tensors` `nvfp4-pack-quantized`) | [`prithivMLmods/Qwen3.6-27B-NVFP4`](https://huggingface.co/prithivMLmods/Qwen3.6-27B-NVFP4) |
-| MTP head | FP8 e4m3 block-128 (only `mtp.safetensors` is consumed) | the upstream FP8 ckpt (Qwen3.6-Next-27B-FP8) |
+| MTP head | FP8 e4m3 block-128 or community BF16/native `mtp.safetensors` | paired Qwen3.6-Next-27B MTP ckpt |
 
 Pass the main NVFP4 ckpt directory as the `checkpoint_path` argument
 to `Qwen36TorchFrontendRtx`. The NVFP4 ckpt does **not** ship an MTP
-module — `compressed-tensors` strips it — so the FP8 ckpt directory
-that contains `mtp.safetensors` is loaded separately via the
-`FLASHRT_QWEN36_MTP_CKPT_DIR` environment variable; we convert
-FP8 → BF16 → NVFP4 once at load (no FP8 in the hot path). Without
-the env var, MTP is None and speculative decode is disabled (pure
-single-token decode still works at ~36 tok/s).
+module — `compressed-tensors` strips it — so the ckpt directory that
+contains `mtp.safetensors` is loaded separately via the
+`FLASHRT_QWEN36_MTP_CKPT_DIR` environment variable. FP8-source MTP is
+converted FP8 → BF16 → NVFP4 once at load (no FP8 in the hot path).
+BF16/native MTP checkpoints keep BF16 projection weights by default for
+better drafter alignment; set `FLASHRT_QWEN36_MTP_KEEP_BF16=0` to force
+the lower-memory NVFP4-converted path. Without the env var, MTP is None
+and speculative decode is disabled (pure single-token decode still
+works at ~36 tok/s).
 
 ### Can I use a different NVFP4 Qwen3.6 checkpoint?
 
@@ -101,12 +114,11 @@ Single representative prompt (`"Explain quantum entanglement in one
 short paragraph."`, 11 tokens), max_new_tokens=128, default `K=6`:
 
 ```
-TTFT (prefill)        :   ~237 ms      (one-shot, doesn't recur)
-TPOT                  :   ~7.74 ms/token
-★ decode tok/s        :   128.87       ← v1 headline
-end-to-end tok/s      :   ~104         (with prefill amortized)
+TTFT (prefill)        :   ~233 ms      (one-shot, doesn't recur)
+TPOT                  :   ~7.45 ms/token
+★ decode tok/s        :   134.18
 
-spec stats: K=6  attempts=31  p_full=0.290  p_ind=0.522  AL=4.10
+spec stats: K=6  attempts=29  p_full=0.345  p_ind=0.575  AL=4.38
 ```
 
 `AL=4.10` means each spec cycle emits 4.1 tokens on average; `p_full`
@@ -217,46 +229,110 @@ Set via `TEST_K=<n>` env var when running `standard_bench`, or pass
 
 ## 4. Long-context throughput
 
-Decode tok/s at fixed context length (synthetic-filled KV cache, no
-spec — single-token forward then reported as if spec amortization
-applied at AL=3.17). Uses the TurboQuant packed KV cache.
+When `max_seq` is above the long-context threshold, the frontend keeps
+a small BF16 KV/spec working window and allocates a compressed KV cache
+for requests routed beyond it. The default compressed route is FP8 KV;
+TurboQuant remains available for memory/accuracy bisection. The default
+long-route threshold is 512 prompt tokens, preserving the peak BF16/spec
+decode path for very short prompts while using chunked FP8-KV for
+512-token and larger prompts. Short prompts route to FP8-KV only if the
+full request exceeds the retained BF16 window.
 
-```
-   ctx     forward ms    decode tok/s  (eager)    CUDA-Graph replay
-  8 K        26.6              119.3                36.0 ms /  88.6
- 16 K        30.4              105.4                ─    (capture only at 32 K+)
- 32 K        38.7               81.3                35.7 ms /  88.7
- 64 K        55.5               57.1                51.8 ms /  61.2
-128 K        87.7               36.2                85.3 ms /  37.1
-200 K       120.5               26.3                ─
-256 K       153.4               20.7               150.8 ms /  21.0
-```
-
-Replay cos vs eager = **1.000000** at every ctx (32 K / 64 K / 128 K /
-256 K) — bit-identical token output across replays.
-
-Spec decode (K=3..6) is **not yet integrated with the long-ctx
-TurboQuant path** — that's a Phase 3D follow-up. The numbers above are
-single-token forward throughput at long ctx, projected to AL=3.17.
+Spec decode is wired to the long-ctx compressed-KV path. Short requests
+that fit in the retained BF16 window still use the normal CUDA-Graph
+MTP spec path; longer requests use MTP draft plus compressed-KV verify.
+The default long-context route is `FLASHRT_QWEN36_LONG_KV_CACHE=fp8`,
+matching the community-style e4m3 FP8 KV serving direction. That path
+stores persistent full-attn KV as FP8. On SM120, long verify attention
+uses the vendored FlashInfer XQA native FP8-KV kernel once the KV length
+passes the measured `FLASHRT_QWEN36_FP8_XQA_MIN_CTX=auto` bucket policy,
+and keeps the older FP8->BF16-stage + FA2 bridge in buckets where that
+path measured faster.
+Set `FLASHRT_QWEN36_LONG_KV_CACHE=tq` to use the TurboQuant
+packed path for memory/accuracy bisection.
+The current measured FP8-KV warm decode table, including 256K, is in
+the TTFT section below.
+The long TQ/spec path uses measured K buckets by default: `3` below 6K
+prompt tokens, `4` from 6K to 12K, `5` from 12K to 24K, `4` from 24K
+to 48K, `7` from 48K to below 160K, and `6` elsewhere, then
+adaptively drops from K≥4 to `K=3` inside a request when early accept
+stats show a low-hit prompt; set
+`FLASHRT_QWEN36_TQ_SPEC_K` to force a fixed K. TQ verify and the MTP
+draft chain are CUDA-Graph captured per `(cur_pos, K)` in warm state.
+Long-context MTP prompt-tail prefill seeds the drafter's private K/V
+cache with 1024 prompt-tail rows for 12K+ prompts by default, which
+keeps long-context draft acceptance materially higher without full MTP
+prompt prefill.
+Long-context prefill uses the same TQ S=K forward in chunks (default
+chunk size = `MAX_Q_SEQ`, currently 2048) instead of one full forward
+per prompt token; full-attention layers use the vendored FA2 causal
+hdim=256 path for one q_seq=S attention call per chunk, and
+linear-attention layers use vendored FLA-style chunk/WY Gated DeltaNet
+scans for prefill chunks. Long-context NVFP4 defaults to the fused MLP
+gate/up GEMM when the checkpoint's gate/up scales allow it; the separate
+non-widen tile remains available by setting
+`FLASHRT_QWEN36_FUSE_MLP_GATE_UP=0`.
+Linear-attention A/B projections use a deterministic fused AB96 BF16
+kernel in prefill chunks, and the default Gated DeltaNet prefill route
+uses the vendored FLA-style chunk/WY backend because it is currently
+much faster for large prompt chunks. Intermediate prompt chunks skip
+final-norm/lm-head logits entirely, and the final chunk computes logits
+only for the last prompt row. The large K-row logits workspace is
+allocated lazily only for explicit all-logits diagnostic calls. Set
+`FLASHRT_QWEN36_TQ_PREFILL_GDN_BACKEND=native` to force the fully
+FlashRT-kernel direct-conv path for cleanup/bisection work.
 
 ## 5. TTFT (prefill latency)
 
-Prefill is one S=1 forward per prompt token, captured per-cur_pos as
-CUDA Graphs. Cost scales linearly:
+The recommended full-context serving profile keeps the 2048-row BF16
+working window for chunk size, uses FP8 persistent KV, and routes
+512-token and larger prompts through the chunked compressed-KV path:
 
-```
-prompt_len   TTFT (ms)       per-token (ms)
-        11   ~237            21.5
-        17   ~370            21.8
-        22   ~480            21.8
-        41   ~890            21.7
-       100   ~2200           22.0
+```bash
+export FLASHRT_QWEN36_LONG_KV_CACHE=fp8
+export FLASHRT_QWEN36_LONG_CTX_ROUTE_MIN_SEQ=512
 ```
 
-≈ 22 ms / token of prefill, prompt-length-independent rate. For a 128
-prompt-token call, TTFT ≈ 2.8 s. The TPOT (decode) measured from the
-spec loop is independent of TTFT and dominates total wall time when
-output ≫ prompt.
+Warm measurements on RTX 5090, `max_new_tokens=64`, repeated text
+prompt. The 128-token row uses BF16/spec because it is still the highest
+decode-throughput route there; 512 tokens and above use FP8-KV.
+
+| prompt ctx | route | K | MTP tail | TTFT / prefill | prefill tok/s | decode ms | decode tok/s | spec attempts / accepts / full |
+|---:|---|---:|---:|---:|---:|---:|---:|---:|
+| 128 | BF16/spec | 6 | full | 2.72 s | 47 | 454.0 | 141.0 | 14 / 49 / 7 |
+| 512 | FP8-KV | 4 | 512 | 66.6 ms | 7,683 | 534.6 | 119.7 | 19 / 44 / 9 |
+| 1 K | FP8-KV | 5 | 2048 | 122.9 ms | 8,334 | 554.9 | 115.3 | 18 / 46 / 7 |
+| 2 K | FP8-KV | 6 | 2048 | 238.9 ms | 8,572 | 427.7 | 149.6 | 13 / 51 / 8 |
+| 4 K | FP8-KV | 3 | 512 | 333.4 ms | 12,285 | 561.9 | 113.9 | 21 / 43 / 10 |
+| 8 K | FP8-KV | 5 | 2048 | 749.7 ms | 10,926 | 406.2 | 157.5 | 13 / 50 / 6 |
+| 16 K | FP8-KV | 7 | 2048 | 1.55 s | 10,587 | 375.2 | 170.6 | 10 / 53 / 5 |
+| 32 K | FP8-KV | 6 | 2048 | 3.54 s | 9,262 | 406.4 | 157.5 | 12 / 52 / 5 |
+| 64 K | FP8-KV | 7 | 2048 | 9.11 s | 7,195 | 363.3 | 176.1 | 10 / 53 / 3 |
+| 128 K | FP8-KV | 7 | 2048 | 26.64 s | 4,920 | 415.9 | 153.9 | 11 / 52 / 2 |
+| 200 K | FP8-KV | 6 | 2048 | 56.81 s | 3,605 | 558.0 | 114.7 | 14 / 49 / 3 |
+| 256 K | FP8-KV | 6 | 2048 | 87.71 s | 2,989 | 493.5 | 129.7 | 12 / 51 / 4 |
+
+`decode tok/s` excludes TTFT and is the TPOT-style LLM serving metric.
+The low-TTFT FP8-KV route is available below 512 tokens, but it trades
+away decode throughput on the measured prompt distribution.
+
+FP8 KV also improves prefill versus the TurboQuant cache, but the gain
+is modest until very large contexts because prefill is dominated by the
+full prompt forward. Local FP8-vs-TQ prefill deltas:
+
+| ctx | FP8 prefill | TQ prefill | FP8 gain |
+|---:|---:|---:|---:|
+| 4 K | 320.6 ms | 329.9 ms | 2.8% |
+| 16 K | 1.506 s | 1.557 s | 3.3% |
+| 64 K | 9.073 s | 9.451 s | 4.0% |
+| 128 K | 26.70 s | 27.78 s | 3.9% |
+| 200 K | 56.75 s | 63.60 s | 10.8% |
+| 256 K | 87.55 s | 99.63 s | 12.1% |
+
+The table is measured with the public frontend API below: run one
+same-shape warmup generation, then time a second generation with CUDA
+events around the prefill and decode windows. Developer-only micro-bench
+probes live outside the tracked public tree.
 
 ## 6. Reproduction
 
@@ -296,4 +372,5 @@ HF_HUB_OFFLINE=1
 TRANSFORMERS_OFFLINE=1
 ```
 
-`internal-tests/` is gitignored — micro-bench probes are dev-local.
+Developer-only micro-bench probes are intentionally kept out of the
+tracked public tree.

--- a/docs/qwen36_usage.md
+++ b/docs/qwen36_usage.md
@@ -5,6 +5,23 @@ high-level intro / quickstart / measured throughput, see
 [`qwen36_nvfp4.md`](qwen36_nvfp4.md). Only the **NVFP4** path is
 documented here (FP8 path exists but is not the v1 surface).
 
+## Installation
+
+Install the Torch frontend extra from the repository root:
+
+```bash
+pip install -e ".[torch]"
+```
+
+The Qwen3.6 long-context path uses the vendored FLA-style
+Python/Triton subset in `flash_rt.ops.fla`; the `torch` extra declares
+its runtime dependencies (`einops`, `triton>=3.2`, and `packaging`).
+For the OpenAI-compatible server, install:
+
+```bash
+pip install -e ".[torch,server]"
+```
+
 ## Constructor
 
 ```python
@@ -24,7 +41,7 @@ fe = Qwen36TorchFrontendRtx(
 |---|---|---|---|
 | `checkpoint_path` | `str` | (required) | Directory of the NVFP4 main ckpt. Must contain `compressed-tensors` `nvfp4-pack-quantized` safetensors **and** the tokenizer files (`tokenizer.json` / `tokenizer_config.json` / etc). The HuggingFace ckpt `prithivMLmods/Qwen3.6-27B-NVFP4` ships these together. |
 | `device` | `str` | `'cuda:0'` | CUDA device string. Single-GPU only; multi-GPU not supported in v1. |
-| `max_seq` | `int` | `2048` | Max output sequence length the KV cache + per-token scratch is sized for. **Increase** if you plan to generate (or feed) more than 2048 tokens — the long-ctx grid in `qwen36_nvfp4.md` was measured at `max_seq=8192..262144`. Larger `max_seq` raises baseline VRAM proportionally to KV cache size (~10 MB / 1K tokens). |
+| `max_seq` | `int` | `2048` | Max output sequence length. For NVFP4, values above the long-context threshold allocate a compressed KV cache for long requests while retaining a small BF16/spec window. Increase this if you plan to generate or feed more than 2048 tokens; requests above `FLASHRT_QWEN36_LONG_CTX_ROUTE_MIN_SEQ` use MTP draft plus compressed-KV verify. |
 | `alloc_own_forward_buffers` | `bool` | `True` | Pre-allocate every per-step buffer the own-forward / spec decode path consumes (zero per-call alloc; required for stable CUDA Graph capture). Set `False` only for memory-introspection unit tests. |
 | `quant` | `str` | `'fp8'` | Set to `'nvfp4'` to get the v1 NVFP4 path. The default `'fp8'` is the legacy FP8 baseline path documented separately. |
 
@@ -45,7 +62,7 @@ output_ids = fe.generate_own_speculative_KN_nvfp4(
     input_ids,                # required, (1, prompt_len) cuda long
     *,                        # everything below is keyword-only
     max_new_tokens,           # required
-    K=5,
+    K=6,
 )
 ```
 
@@ -53,10 +70,36 @@ output_ids = fe.generate_own_speculative_KN_nvfp4(
 |---|---|---|---|
 | `input_ids` | `torch.LongTensor` of shape `(1, prompt_len)` on CUDA | (required) | Tokenized prompt. Use `fe._tokenizer(prompt, return_tensors='pt').input_ids.cuda()`. Batch size must be `1`; multi-batch not supported in v1. |
 | `max_new_tokens` | `int` | (required) | Number of tokens to generate. The output tensor is `(1, prompt_len + max_new_tokens)`. |
-| `K` | `int` | `5` | MTP draft chain length per spec cycle. Verify processes `K+1` tokens at once. Valid range: `1 ≤ K ≤ MAX_Q_SEQ - 1` (MAX_Q_SEQ defaults to 16). The recommended value is `K=6` for short generations (≤ 256 output tokens) — see `qwen36_nvfp4.md` §3. |
+| `K` | `int` | `6` | MTP draft chain length per spec cycle. Verify processes `K+1` tokens at once. Valid range: `1 ≤ K ≤ 15` in the public path. `K=6` is the default for short generations (≤ 256 output tokens) — see `qwen36_nvfp4.md` §3. |
 
 Greedy-only in v1 — no `temperature`, `top_p`, or `top_k`. Returns a
 deterministic argmax sequence.
+
+When `quant='nvfp4'` is constructed with a large `max_seq`, this method
+auto-routes per request: short requests that fit inside the retained
+BF16/spec window still run MTP speculative decode, while larger
+requests use MTP speculative decode with the compressed-KV verify path.
+Long-context prefill is chunked with the same S=K
+forward (`FLASHRT_QWEN36_TQ_PREFILL_CHUNK`, capped by `MAX_Q_SEQ`;
+default cap 2048), and full-attention prefill chunks use the vendored FA2
+causal hdim=256 path. Linear-attention prefill chunks use chunked
+causal-conv and the vendored FLA-style chunk/WY Gated DeltaNet backend
+by default because it is currently much faster for large chunks. Set
+`FLASHRT_QWEN36_TQ_PREFILL_GDN_BACKEND=native` to force the fully
+FlashRT-kernel direct-conv recurrent scan for bisection/cleanup work, or
+`FVK_QWEN36_CHUNK_CONV_PARALLEL=0` to force the older serial chunk
+conv update. Experimental fused gate/up and cuBLAS AB paths are
+available behind environment variables but default off because they
+were either slower or not elementwise-stable in local checks. The
+default linear-attention A/B path uses a deterministic AB96 kernel that
+is bit-identical to the previous two-matmul path while saving a small
+amount of prefill time. During long prefill, intermediate chunks skip
+lm-head logits and the final chunk computes only the last prompt row's
+logits; verify/spec decode still computes all required logits. The
+large all-row logits workspace is allocated lazily only for explicit
+diagnostic calls, so the default long-context working set stays smaller.
+The long-context verify path and MTP draft chain are CUDA-Graph captured
+in warm state when the corresponding graph env vars are left enabled.
 
 If `FLASHRT_QWEN36_MTP_CKPT_DIR` was not set at construction, the MTP
 head is not loaded and this method raises `RuntimeError`. Use
@@ -91,7 +134,8 @@ for p in range(prompt_len + max_new_tokens):
     cur_pos += 1
 ```
 
-This path tops out at ~36 tok/s decode (vs spec K=6's ~129 tok/s) but
+This path tops out at ~36 tok/s decode (vs spec K=6's ~134 tok/s on the
+short standard prompt) but
 needs only the NVFP4 ckpt — no MTP head dependency.
 
 ## Environment variables
@@ -102,8 +146,41 @@ frontend is built has no effect.
 | Env var | Required? | Default | Meaning |
 |---|---|---|---|
 | `FLASHRT_QWEN36_MTP_CKPT_DIR` | Required for spec decode | unset | Directory containing `mtp.safetensors` (FP8 e4m3 block-128) from a paired Qwen3.6-Next-27B-FP8 ckpt. Loaded once at construction and converted FP8 → BF16 → NVFP4. If unset, MTP is `None` and `generate_own_speculative_KN_nvfp4` raises; pure-decode still works. |
+| `FLASHRT_QWEN36_MTP_KEEP_BF16` | Optional | BF16-source MTP: `1`; FP8-source MTP: n/a | For community BF16/native MTP checkpoints, keep BF16 projection weights and use them in the drafter hot path. This improves MTP alignment at the cost of extra VRAM. Set `0` to force the lower-memory NVFP4-converted MTP path. |
 | `FLASHRT_QWEN36_HF_PATCH` | Optional | unset | Path to a HF FP8 dispatch monkey-patch script. Only consulted by the legacy FP8 path; the NVFP4 path doesn't need it. If unset or path doesn't exist, the patch step is silently skipped. |
 | `FLASHRT_QWEN36_DFLASH_CKPT_DIR` | Optional | unset | Drafter ckpt directory for the DFlash add-on path. Required only if you call `init_dflash_drafter()`; raises a clear error if unset and `ckpt_dir` is also not passed. |
+| `FLASHRT_QWEN36_MAX_Q_SEQ` | Optional | `2048` | Maximum S=K working-set rows for verify/prefill buffers. Long prefill chunking is additionally capped by the retained BF16 working window. |
+| `FLASHRT_QWEN36_LONG_CTX_BF16_WINDOW` | Optional | `min(2048, MAX_Q_SEQ)` | Retained BF16 working-window rows in long-context mode. Raising this can enable larger prompt chunks but costs substantial VRAM. |
+| `FLASHRT_QWEN36_LONG_CTX_ROUTE_MIN_SEQ` | Optional | `512` in long-ctx mode | Prompt length at or above which a long-context frontend routes through the chunked compressed-KV path. Short prompts stay on BF16/spec unless the full request exceeds the retained BF16 window. |
+| `FLASHRT_QWEN36_LONG_KV_CACHE` | Optional | `fp8` | Long-context persistent KV format. `fp8` uses an e4m3 FP8 KV cache. On SM120, long verify attention uses the vendored FlashInfer XQA FP8-KV kernel above the XQA threshold and falls back to BF16 FA2 staging below it. Set `tq` to use the TurboQuant packed path for memory/accuracy bisection. |
+| `FLASHRT_QWEN36_FP8_XQA` | Optional | `1` | Enable the SM120 FlashInfer XQA native FP8-KV verify path for long-context FP8 KV. Set `0` to force the previous FP8->BF16-stage + FA2 path. |
+| `FLASHRT_QWEN36_FP8_XQA_MIN_CTX` | Optional | `auto` | XQA gating for FP8-KV verify. `auto` uses measured buckets: off below 6K, on from 6K to 12K, off from 12K to 24K, and on from 24K upward. Set a number to force the older minimum-KV-length threshold. |
+| `FLASHRT_QWEN36_FP8_XQA_SCRATCH_MB` | Optional | `256` | Scratch workspace reserved for XQA multi-block reductions. |
+| `FLASHRT_QWEN36_TQ_SPEC_K` | Optional | unset | Override the effective speculative K for long-context TQ/spec requests. If unset, long TQ/spec uses measured buckets: `4` around 512 tokens, `5` around 1K/8K, `6` around 2K/32K/200K+, `3` around 4K, and `7` around 16K/64K/128K. Passing K below 6 keeps that lower caller cap. Short BF16/spec requests keep the caller K unchanged. |
+| `FLASHRT_QWEN36_TQ_ADAPTIVE_K` | Optional | `1` | When long TQ/spec uses the default K≥4 policy, drop to K=3 inside a request if the early accept statistics show a low-hit prompt. Explicit `FLASHRT_QWEN36_TQ_SPEC_K` disables this adaptation. |
+| `FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL` | Optional | `auto` | Long-context MTP prompt-tail prefill. `auto` uses measured KV-only buckets: disabled below 512 tokens, 512 rows around 512/4K, and 2048 rows for 1K-2K and 8K+. Set `0` to disable or a positive value to force a fixed tail length. |
+| `FLASHRT_QWEN36_LONG_MTP_TAIL_KV_ONLY` | Optional | `1` | When prompt-tail prefill is enabled and the MTP checkpoint has BF16 projection weights, populate only the MTP K/V cache rows needed by the drafter. Set `0` to force the older full-MTP-head tail loop for bisection. |
+| `FLASHRT_QWEN36_TQ_STRICT_NEXT` | Optional | `0` | Debug/validation mode that recomputes the correction or bonus token on the sequential target path after batched TQ verify. This preserves greedy next-token invariance for tail-prefill experiments but is much slower than the default batched verify path. |
+| `FLASHRT_QWEN36_TQ_STRICT_NEXT_GRAPH` | Optional | `1` | Use per-position K=1 TQ verify graphs for the strict-next recompute. Only consulted when `FLASHRT_QWEN36_TQ_STRICT_NEXT=1`. |
+| `FLASHRT_QWEN36_TQ_VERIFY_EXACT_GATING` | Optional | `0` | Use the torch-style gating math in the small-K long TQ verify linear-attention path for GDN bisection. This is slower than the fused gating kernel and does not force full bit equality for the whole batched verifier. |
+| `FLASHRT_QWEN36_TQ_VERIFY_GRAPH` | Optional | `1` | Capture/replay the long-context TQ verify forward as per-`(cur_pos, K)` CUDA Graphs. This is the fastest warm path. Set `0` only when optimizing first-request latency without prewarm or debugging graph capture. |
+| `FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH` | Optional | `1` | Capture/replay the long-context MTP draft chain. This is the fastest warm path. Set `0` only when optimizing first-request latency without prewarm or debugging graph capture. |
+| `FLASHRT_QWEN36_LONG_WARMUP_MIN_FREE_MB` | Optional | `1024` | Stop long-context startup graph warmup once free VRAM falls below this waterline. This prevents 200K+ buckets from over-capturing graphs and leaving too little memory for the first real request. |
+| `FLASHRT_QWEN36_LONG_GRAPH_MIN_FREE_MB` | Optional | `768` | During a real long-context decode, skip new TQ verify graph capture and run eager verify when free VRAM is below this waterline. Already-warmed graphs are still replayed. |
+| `FLASHRT_QWEN36_TQ_PER_LAYER_STAGE_MAX_SEQ` | Optional | `132000` | Maximum TQ cache length eligible for per-layer BF16 KV staging. Auto uses 16 staged full-attn layers up to ~64K and 8 layers around 128K; larger servers fall back to shared staging to avoid 32 GB OOM. |
+| `FLASHRT_QWEN36_TQ_PER_LAYER_STAGE_LAYERS` | Optional | `auto` | Override the number of full-attn layers with persistent BF16 KV stage (`0..16`). More layers reduce repeated TQ dequant in long decode but cost about `prompt_len * 4 KB` per layer at BF16 K+V. |
+| `FLASHRT_QWEN36_TQ_HOT_STAGE_LAYERS` | Optional | `auto` | Extra 128K-tier BF16 staging layers for servers sized to 200K+. Auto keeps this conservative so CUDA Graph capture still has free VRAM. Set an integer to force a more aggressive hot tier for benchmarking. |
+| `FLASHRT_QWEN36_TQ_HOT_STAGE_RESERVE_MB` | Optional | `1536` | Free-memory reserve used when auto-sizing the 128K hot stage. Increase for safer serving; lower only for controlled benchmarking. |
+| `FLASHRT_QWEN36_FP8_STAGE_LAYERS` | Optional | `auto` | Extra per-layer BF16 stage count for the FP8-KV bridge. Auto keeps one 200K-cap layer on 32GB cards to avoid repeated full-prefix FP8 dequant while preserving CUDA Graph memory headroom. |
+| `FLASHRT_QWEN36_FP8_HOT_STAGE_LAYERS` | Optional | `auto` | Extra 128K-tier FP8-KV stage count. Auto keeps one hot layer when a larger 200K stage is active. Higher values can block CUDA Graph capture on 32GB GPUs. |
+| `FLASHRT_QWEN36_FP8_STAGE_RESERVE_MB` / `FLASHRT_QWEN36_FP8_HOT_STAGE_RESERVE_MB` | Optional | `1024` | Free-memory reserves used by FP8 stage auto-sizing. Lower only for controlled benchmarking. |
+| `FVK_QWEN36_TQ_CUTLASS` | Optional | `auto` | Use CUTLASS fused TQ dequant for shared staging. `auto` enables it up to the 128K profile and leaves 256K on the lower-memory path. Set `0`/`1` to force. |
+| `FLASHRT_QWEN36_TQ_KERNEL_WRITE` | Optional | `1` | Use explicit cuBLASLt/cuBLAS wrappers for TurboQuant write-side GEMMs. Set `0` to force the older `torch.matmul` write GEMMs for correctness bisection. |
+| `FLASHRT_QWEN36_FUSE_MLP_GATE_UP` | Optional | long NVFP4: `1`; otherwise `0` | Runs MLP gate/up as one fused NVFP4 GEMM when the checkpoint has homogeneous gate/up scales. This is the default long-context path because it improves warm TQ/spec decode and reduces scratch memory; set `0` to force the older two-GEMM path. |
+| `FLASHRT_QWEN36_FUSE_SILU_MUL_QUANT` | Optional | `0` | Experimental fused `silu(gate)*up -> NVFP4` activation path. Forced on when fused gate/up is enabled for correct merged-buffer stride handling; otherwise default off because it was slower locally. |
+| `FLASHRT_QWEN36_LIN_AB96_KERNEL` | Optional | `1` | Deterministic fused kernel for the tiny linear-attention A/B projections in long-prefill chunks. Bit-identical to the old two-call BF16 path; set `0` to force the previous path. |
+| `FLASHRT_QWEN36_LIN_AB_TORCH_MM_MIN_K` | Optional | `0` | Experimental cuBLAS/Torch path for the tiny linear-attention A/B projections when `K` is at least this value. Default `0` disables it; local checks showed it is much faster but not elementwise-stable enough to default on. |
+| `FLASHRT_QWEN36_FULL_GATE_SIGMOID_MUL` | Optional | `0` | Experimental fused full-attention output gate `sigmoid(gate) * attn` kernel. Bit-identical in random checks but did not improve the 1024-token chunk benchmark, so it defaults off. |
 | `FLASHRT_NVFP4_LOAD_DEBUG` | Optional | `0` | Set to `1` for verbose VRAM-tracking prints during NVFP4 weight load. |
 | `FLASHRT_DFLASH_LOAD_DEBUG` | Optional | `0` | Same, for DFlash drafter load. |
 | `PYTORCH_CUDA_ALLOC_CONF` | Recommended | system default | Set to `expandable_segments:True` to avoid fragmentation when the long-ctx grid pushes past 30 GB. The standard bench was run with this. |
@@ -134,6 +211,9 @@ The bundled OpenAI-compatible server accepts OpenAI-shaped `tools` on
 `/v1/chat/completions`. Qwen's chat template injects the function
 schema into the prompt, and the server parses model-emitted
 `<tool_call>...</tool_call>` blocks into OpenAI `tool_calls`.
+Qwen thinking mode is disabled by default so ordinary chat responses do
+not start inside `<think>`. Pass `"enable_thinking": true` in the JSON
+request body if you want the model's thinking-mode template.
 
 ```python
 from openai import OpenAI
@@ -193,29 +273,45 @@ final chunk.
 
 ## Cold-start vs warm-state
 
-The headline 90-130 tok/s decode rate is the **warm-state** number —
-what you measure after CUDA Graphs for the relevant `cur_pos` range
-have been captured. The **first call** at a previously-unseen
-`(prompt_len, max_new_tokens)` shape pays a one-time graph-capture
-cost of roughly 5-25 s (proportional to `prompt_len + max_new_tokens`
-and to whether spec-K verify graphs at those positions are also new),
-manifesting as ~20-40 tok/s for that first call only.
+The headline decode rate is the **warm-state** number -- what you
+measure after CUDA Graphs for the relevant `cur_pos` range have been
+captured. The first call at a previously unseen
+`(prompt_len, max_new_tokens)` shape pays a one-time graph-capture cost
+that can dominate decode latency. This is a property of the CUDA Graph
+capture/replay model: fastest steady-state decode requires paying
+capture either during warmup or on the first live request.
 
-This is a property of the CUDA Graph capture/replay model, shared
-with SGLang and vLLM's compile mode. TensorRT-LLM avoids it by AOT
-engine compilation (paid at deploy time instead). vLLM eager and TGI
-avoid it by not capturing graphs (paying per-launch overhead per
-step instead).
+For server deployment, run dummy generations at startup over the
+prompt_len/max_tokens buckets you expect to see. This populates graph
+cache, allocator state, kernel state, and library plans before live
+traffic. The bundled OpenAI server example does this with
+`--warmup-preset auto` by default; add explicit buckets with `--warmup`
+when your traffic includes larger contexts:
 
-For a server deployment, run a dummy generation at startup over the
-prompt_len/max_tokens shapes you expect to see — this populates the
-graph cache before live traffic arrives. The bundled OpenAI server
-example does this automatically via `--warmup` (default
-`32:128,128:256`); see [`examples/qwen36_openai_server.py`](../examples/qwen36_openai_server.py).
+```bash
+export FLASHRT_QWEN36_LONG_KV_CACHE=fp8
+python examples/qwen36_openai_server.py \
+  --checkpoint /path/to/qwen36_nvfp4 \
+  --max-seq 262208 \
+  --warmup-preset all \
+  --warmup "262144:16"
+```
 
-After warmup, requests at the same shape stay warm. Requests at
-different shapes will still pay capture cost on the parts of their
-`cur_pos` range not yet covered.
+The default long-context route threshold is 512 prompt tokens: very
+short prompts stay on BF16/spec for peak decode unless the requested
+completion exceeds the retained BF16 window, while 512-token and larger
+prompts use the tuned chunked FP8-KV path. `--warmup-preset auto`
+warms 64-token short-chat buckets plus 2K/4K/8K/16K/32K/64K/128K/256K
+buckets that fit inside `--max-seq`. Add explicit `--warmup`
+`prompt_len:max_tokens` entries for longer completion caps.
+The 256K prompt bucket requires `--max-seq` larger than `262144` by at
+least the requested completion length. See
+[`examples/qwen36_openai_server.py`](../examples/qwen36_openai_server.py).
+
+If first-request latency matters more than warm decode throughput, set
+`FLASHRT_QWEN36_TQ_VERIFY_GRAPH=0` and
+`FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH=0`. That avoids per-position graph
+capture, but the warm decode rate is lower.
 
 ## Known limits in v1
 
@@ -236,7 +332,7 @@ different shapes will still pay capture cost on the parts of their
 
 | Output length | Recommended K | Why |
 |---|:---:|---|
-| ≤ 128 tokens | **6** | Peak measured (129 tok/s on the standard prompt). |
+| ≤ 128 tokens | **6** | Peak measured (134 tok/s on the standard prompt). |
 | 128–256 tokens | **5** | K=6 starts losing acceptance past ~150 tokens; K=5 is more robust. |
 | ≥ 512 tokens | **3** | All K values converge near 113 tok/s by NTOK=512; K=3 has the lowest CV across prompts. |
 

--- a/examples/qwen36_openai_server.py
+++ b/examples/qwen36_openai_server.py
@@ -14,19 +14,20 @@ Usage:
 
     python examples/qwen36_openai_server.py \\
         --checkpoint /path/to/qwen36_nvfp4 \\
+        --max-seq 32768 \\
         --port 8000 \\
         --K 6 \\
-        --warmup 8:512
+        --warmup-preset auto
 
-    # The --warmup flag pre-captures CUDA Graphs for the listed
-    # (prompt_len:max_tokens) shapes at startup so the FIRST real
-    # request hits the warm 90-130 tok/s speed range. Without
-    # warmup, that first request pays a ~5-25 s graph-capture
-    # penalty (standard CUDA Graph cold-start cost — same trade-off
-    # as SGLang / vLLM compile mode). Each warmed shape covers
-    # cur_pos in [prompt_len, prompt_len + max_tokens]; the default
-    # 8:512 covers the common short-chat range in one pass.
-    # Pick shape(s) that span your traffic distribution.
+    # Startup warmup pre-captures CUDA Graphs for bucketed
+    # (prompt_len:max_tokens) shapes so the FIRST real request usually
+    # hits warm graphs. Short buckets run a dummy generation; long
+    # buckets default to decode-graph-only warmup, avoiding minutes of
+    # synthetic 200K/256K prompt prefill. 128K+ buckets warm every early
+    # decode position by default; tune with
+    # FLASHRT_QWEN36_LONG_WARMUP_STRIDE/MAX_GRAPHS. Add --warmup
+    # "32768:64,65536:64,131072:64,204800:64,262144:16" for an explicit
+    # serving envelope, or --warmup-preset none to skip.
 
     # Test (non-streaming):
     curl http://localhost:8000/v1/chat/completions \\
@@ -56,6 +57,8 @@ Limits in v1 (see docs/qwen36_usage.md):
       multiple workers against one GPU).
     * Greedy decode only — temperature / top_p / top_k / n / seed
       / stop / logit_bias are accepted but ignored.
+    * Qwen thinking mode is disabled by default. Pass
+      "enable_thinking": true in the JSON body to opt in.
     * stream=True returns one chunk with the full response (true
       token-by-token streaming requires a frontend modification).
 """
@@ -70,7 +73,7 @@ import re
 import sys
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # ────────────────────────────────────────────────────────────────────
 # Logger
@@ -175,15 +178,41 @@ class Qwen36Engine:
         else:
             self.spec_enabled = True
             log.info('MTP head loaded; spec K=%d enabled', self.K)
+        log.info(
+            'long-ctx route=%s tq_stage_layers=%s tq_stage_cap=%s '
+            'tq_hot_layers=%s tq_hot_cap=%s',
+            getattr(self.fe, '_long_kv_cache_mode', 'bf16'),
+            getattr(self.fe, '_tq_per_layer_stage_layers', 'n/a'),
+            getattr(self.fe, '_tq_per_layer_stage_cap', 'n/a'),
+            getattr(self.fe, '_tq_hot_stage_layers', 'n/a'),
+            getattr(self.fe, '_tq_hot_stage_cap', 'n/a'),
+        )
 
-    def warmup(self, shapes: List[tuple]) -> None:
+    def _dummy_input_ids(self, prompt_len: int):
+        """Build exact-length CUDA token ids without tokenizer drift."""
+        torch = self._torch
+        prompt_len = int(prompt_len)
+        if prompt_len <= 0:
+            raise ValueError(f'prompt_len must be >0, got {prompt_len}')
+        token_ids = self.fe._tokenizer(
+            ' warmup', add_special_tokens=False).input_ids
+        token = int(token_ids[0] if token_ids else 1)
+        return torch.full(
+            (1, prompt_len), token, device='cuda', dtype=torch.long)
+
+    def _effective_long_k(self, prompt_len: int) -> int:
+        """Mirror frontend long TQ default K policy for logging."""
+        if hasattr(self.fe, '_long_tq_effective_k'):
+            return self.fe._long_tq_effective_k(prompt_len, self.K)
+        return min(self.K, 6)
+
+    def warmup(self, shapes: List[Tuple[int, int]]) -> None:
         """Pre-capture CUDA Graphs for typical (prompt_len, max_tokens)
-        shapes by running dummy generations. Without this, the FIRST
-        request at each new (prompt_len, max_tokens) shape pays a
-        ~5-25 s graph-capture penalty (the headline 90-130 tok/s
-        warm number applies only to requests AFTER the cur_pos range
-        is captured). Standard practice for graph-based inference
-        engines (SGLang, vLLM compile mode, etc.).
+        shapes. Short-context buckets run dummy generations; long-context
+        buckets default to decode-graph-only warmup to avoid paying full
+        synthetic prompt prefill at startup. Without this, the FIRST
+        request at each new (prompt_len, max_tokens) shape pays CUDA
+        Graph capture latency.
 
         Args:
           shapes: list of (prompt_len, max_tokens) tuples to pre-warm.
@@ -194,23 +223,46 @@ class Qwen36Engine:
         torch = self._torch
         log.info('warmup: pre-capturing graphs for %d shape(s) ...',
                  len(shapes))
-        # Dummy text — only the token count matters for graph capture,
-        # not the content. Pad with 'a's.
+        long_graph_only = (
+            os.environ.get(
+                'FLASHRT_QWEN36_SERVER_LONG_WARMUP', 'graphs').lower()
+            in ('graphs', 'graph', 'decode_graphs', '1', 'true', 'yes')
+        )
         for prompt_len, max_tok in shapes:
+            if prompt_len + max_tok > self.fe._user_max_seq:
+                log.warning(
+                    '  skip warmup shape=(prompt=%d, max_tok=%d): '
+                    'exceeds max_seq=%d',
+                    prompt_len, max_tok, self.fe._user_max_seq)
+                continue
             t0 = time.perf_counter()
-            dummy_text = 'a ' * (prompt_len - 1)  # ~1 token each
-            input_ids = self.fe._tokenizer(
-                dummy_text, return_tensors='pt').input_ids.cuda()
-            # Trim/pad to exact prompt_len.
-            if input_ids.shape[1] >= prompt_len:
-                input_ids = input_ids[:, :prompt_len]
-            else:
-                pad = torch.full(
-                    (1, prompt_len - input_ids.shape[1]),
-                    self.fe._tokenizer.pad_token_id or 0,
-                    device='cuda', dtype=torch.long)
-                input_ids = torch.cat([input_ids, pad], dim=1)
             torch.cuda.synchronize()
+            if hasattr(self.fe, '_should_use_long_ctx_route'):
+                is_long = self.fe._should_use_long_ctx_route(
+                    prompt_len, max_tok)
+            else:
+                route_min = getattr(
+                    self.fe, '_long_ctx_route_min_seq',
+                    getattr(self.fe, '_short_ctx_spec_max_seq', 2048))
+                bf16_cap = getattr(
+                    self.fe, '_short_ctx_spec_max_seq', route_min)
+                is_long = (
+                    getattr(self.fe, '_long_ctx_mode', False)
+                    and (prompt_len >= route_min
+                         or prompt_len + max_tok > bf16_cap)
+                )
+            if self.spec_enabled and is_long and long_graph_only:
+                warmed = self.fe.warmup_long_ctx_decode_graphs(
+                    [(prompt_len, max_tok)], K=self.K)
+                torch.cuda.synchronize()
+                log.info(
+                    '  warmup shape=(prompt=%d, max_tok=%d, eff_K=%s) '
+                    'decode-graphs=%d in %.1f s',
+                    prompt_len, max_tok, self._effective_long_k(prompt_len),
+                    len(warmed), time.perf_counter() - t0)
+                continue
+
+            input_ids = self._dummy_input_ids(prompt_len)
             if self.spec_enabled:
                 _ = self.fe.generate_own_speculative_KN_nvfp4(
                     input_ids, max_new_tokens=max_tok, K=self.K)
@@ -218,15 +270,21 @@ class Qwen36Engine:
                 _ = self._single_token_decode(input_ids, max_tok)
             torch.cuda.synchronize()
             log.info(
-                '  warmup shape=(prompt=%d, max_tok=%d) in %.1f s',
-                prompt_len, max_tok, time.perf_counter() - t0)
-        log.info('warmup done — first real request will be at the warm '
-                 '(~90-130 tok/s) speed range')
+                '  warmup shape=(prompt=%d, max_tok=%d, eff_K=%s) '
+                'in %.1f s',
+                prompt_len, max_tok,
+                self._effective_long_k(prompt_len)
+                if getattr(self.fe, '_long_ctx_mode', False) else self.K,
+                time.perf_counter() - t0)
+        log.info('warmup done — warmed buckets should avoid most '
+                 'first-request CUDA Graph capture latency')
 
     def _render_chat(
         self,
         messages: List[Dict[str, Any]],
         tools: Optional[List[Dict[str, Any]]],
+        *,
+        enable_thinking: bool = False,
     ) -> str:
         """Apply Qwen's chat template to a list of messages."""
         normalized = []
@@ -239,6 +297,7 @@ class Qwen36Engine:
             tools=tools or None,
             tokenize=False,
             add_generation_prompt=True,
+            enable_thinking=enable_thinking,
         )
 
     async def generate(
@@ -246,12 +305,15 @@ class Qwen36Engine:
         messages: List[Dict[str, Any]],
         tools: Optional[List[Dict[str, Any]]],
         max_tokens: int,
+        *,
+        enable_thinking: bool = False,
     ) -> Dict[str, Any]:
         """Run one chat-completion. Returns a dict with the new
         text and basic timing/stat fields."""
         torch = self._torch
         async with self.lock:
-            prompt = self._render_chat(messages, tools)
+            prompt = self._render_chat(
+                messages, tools, enable_thinking=enable_thinking)
             input_ids = self.fe._tokenizer(
                 prompt, return_tensors='pt').input_ids.cuda()
             prompt_len = int(input_ids.shape[1])
@@ -270,22 +332,47 @@ class Qwen36Engine:
             new_tokens = out[0, prompt_len:].tolist()
             raw_text = self.fe._tokenizer.decode(
                 new_tokens, skip_special_tokens=False)
+            for boundary in ('<|im_start|>', '<|im_end|>'):
+                idx = raw_text.find(boundary)
+                if idx >= 0:
+                    raw_text = raw_text[:idx]
             for special in (
                 self.fe._tokenizer.eos_token,
                 self.fe._tokenizer.pad_token,
             ):
                 if special:
                     raw_text = raw_text.replace(special, '')
+            if not enable_thinking:
+                raw_text = re.sub(
+                    r'<think>.*?</think>\s*', '', raw_text,
+                    flags=re.DOTALL,
+                )
+                raw_text = raw_text.replace('<think>', '').replace(
+                    '</think>', '')
             text, tool_calls = ToolCallParser().parse(raw_text)
             text = text.strip()
+            completion_tokens = len(new_tokens)
+            prefill_ms = float(getattr(self.fe, '_long_ctx_prefill_ms', 0.0)
+                               or 0.0)
+            decode_ms = float(getattr(self.fe, '_long_ctx_decode_ms', 0.0)
+                              or 0.0)
+            decode_tok_per_s = (
+                completion_tokens * 1000.0 / decode_ms
+                if decode_ms > 0 else 0.0
+            )
+            e2e_tok_per_s = completion_tokens / wall_s if wall_s else 0.0
 
             return {
                 'text': text,
                 'tool_calls': tool_calls,
                 'prompt_tokens': prompt_len,
-                'completion_tokens': len(new_tokens),
+                'completion_tokens': completion_tokens,
+                'prefill_ms': prefill_ms,
+                'decode_ms': decode_ms,
                 'wall_s': wall_s,
-                'tok_per_s': len(new_tokens) / wall_s if wall_s else 0,
+                'decode_tok_per_s': decode_tok_per_s,
+                'e2e_tok_per_s': e2e_tok_per_s,
+                'route': getattr(self.fe, '_long_ctx_route', 'unknown'),
             }
 
     def _single_token_decode(self, input_ids, max_tokens):
@@ -347,6 +434,7 @@ def build_app(engine: Qwen36Engine):
         tools = req.get('tools')
         max_tokens = int(req.get('max_tokens') or 256)
         stream = bool(req.get('stream', False))
+        enable_thinking = bool(req.get('enable_thinking', False))
         # Validate roles — Qwen template accepts OpenAI chat roles.
         for m in messages:
             role = m.get('role')
@@ -360,16 +448,25 @@ def build_app(engine: Qwen36Engine):
                 raise HTTPException(
                     400, 'message.content must be a string')
 
-        result = await engine.generate(messages, tools, max_tokens)
+        result = await engine.generate(
+            messages, tools, max_tokens,
+            enable_thinking=enable_thinking,
+        )
         completion_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())
 
         log.info(
-            'chat.completions: %d -> %d tokens in %.2fs (%.1f tok/s)',
+            'chat.completions: prompt=%d completion=%d route=%s '
+            'prefill=%.1fms + decode=%.1fms wall=%.1fms '
+            'decode_tok/s=%.1f e2e_tok/s=%.1f',
             result['prompt_tokens'],
             result['completion_tokens'],
-            result['wall_s'],
-            result['tok_per_s'],
+            result['route'],
+            result['prefill_ms'],
+            result['decode_ms'],
+            result['wall_s'] * 1000.0,
+            result['decode_tok_per_s'],
+            result['e2e_tok_per_s'],
         )
 
         usage = {
@@ -463,9 +560,88 @@ def build_app(engine: Qwen36Engine):
     async def health():
         return {'status': 'ok', 'model': engine.model_name,
                 'spec_enabled': engine.spec_enabled,
-                'K': engine.K}
+                'K': engine.K,
+                'long_kv_cache': getattr(
+                    engine.fe, '_long_kv_cache_mode', 'bf16'),
+                'tq_stage_layers': getattr(
+                    engine.fe, '_tq_per_layer_stage_layers', None),
+                'tq_stage_cap': getattr(
+                    engine.fe, '_tq_per_layer_stage_cap', None),
+                'tq_hot_stage_layers': getattr(
+                    engine.fe, '_tq_hot_stage_layers', None),
+                'tq_hot_stage_cap': getattr(
+                    engine.fe, '_tq_hot_stage_cap', None)}
 
     return app
+
+
+def _parse_warmup_shapes(spec_csv: str) -> List[Tuple[int, int]]:
+    shapes: List[Tuple[int, int]] = []
+    if not spec_csv.strip():
+        return shapes
+    for spec in spec_csv.split(','):
+        spec = spec.strip()
+        if not spec:
+            continue
+        try:
+            pl, mt = spec.split(':')
+            shapes.append((int(pl), int(mt)))
+        except ValueError:
+            sys.exit(f'invalid --warmup spec: {spec!r} '
+                     '(expected "prompt_len:max_tokens")')
+    return shapes
+
+
+def _warmup_preset_shapes(preset: str, max_seq: int) -> List[Tuple[int, int]]:
+    """Return startup graph-warm buckets that fit inside max_seq.
+
+    The default buckets use 64 generated tokens because that captures
+    the common early decode range where user-visible cold latency is
+    most painful without making server startup spend minutes on long
+    synthetic short-prompt completions. Add explicit --warmup entries
+    for larger completion caps.
+    """
+    preset = (preset or 'auto').lower()
+    if preset in ('none', 'off', 'false', '0'):
+        return []
+    if preset not in ('auto', 'short', 'long', 'all'):
+        sys.exit(
+            f'invalid --warmup-preset {preset!r}; expected '
+            'auto, short, long, all, or none')
+
+    short = [(8, 64), (128, 64), (512, 64), (1024, 64)]
+    long = [
+        (2048, 64),
+        (4096, 64),
+        (8192, 64),
+        (16384, 64),
+        (32768, 64),
+        (65536, 64),
+        (131072, 64),
+        (204800, 64),
+        (262144, 16),
+    ]
+    if preset == 'short':
+        candidates = short
+    elif preset == 'long':
+        candidates = long
+    elif preset == 'all':
+        candidates = short + long
+    else:
+        candidates = short + long
+
+    max_seq = int(max_seq)
+    return [(p, n) for p, n in candidates if p + n <= max_seq]
+
+
+def _dedupe_shapes(shapes: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    out: List[Tuple[int, int]] = []
+    seen = set()
+    for shape in shapes:
+        if shape not in seen:
+            out.append(shape)
+            seen.add(shape)
+    return out
 
 
 def main():
@@ -477,36 +653,29 @@ def main():
     p.add_argument('--K', type=int, default=6,
                    help='MTP draft chain length per spec cycle. '
                    'Default 6 (peak for short generations on RTX 5090).')
-    p.add_argument('--max-seq', type=int, default=2048,
+    p.add_argument('--max-seq', type=int, default=32768,
                    help='KV cache + scratch dim. Increase for long ctx.')
     p.add_argument('--device', default='cuda:0')
     p.add_argument('--model-name', default='qwen3.6-27b-nvfp4',
                    help='Identifier returned by /v1/models and echoed '
                    'in completion responses.')
     p.add_argument(
-        '--warmup', default='8:512',
+        '--warmup-preset', default='auto',
+        help='Startup graph warmup preset: auto, short, long, all, or '
+        'none. auto warms short buckets plus long buckets that fit in '
+        '--max-seq. Use all with --max-seq 262208+ to include 256K.')
+    p.add_argument(
+        '--warmup', default='',
         help='Comma-separated list of "prompt_len:max_tokens" shapes '
-        'to pre-capture CUDA Graphs for at startup. Without this, the '
-        'first request at each new shape pays a ~5-25 s graph-capture '
-        'penalty before reaching the headline 90-130 tok/s warm speed. '
-        'Default 8:512 pre-captures cur_pos in [8, 520], covering the '
-        'common short-chat range so requests with prompt_len < 32 '
-        '(which the prior 32:128,128:256 default missed) start warm. '
-        'Set to empty string to skip warmup.')
+        'to additionally pre-capture at startup. These are appended to '
+        '--warmup-preset. Set --warmup-preset none and --warmup "" to '
+        'skip all startup warmup.')
     args = p.parse_args()
 
-    warmup_shapes = []
-    if args.warmup.strip():
-        for spec in args.warmup.split(','):
-            spec = spec.strip()
-            if not spec:
-                continue
-            try:
-                pl, mt = spec.split(':')
-                warmup_shapes.append((int(pl), int(mt)))
-            except ValueError:
-                sys.exit(f'invalid --warmup spec: {spec!r} '
-                         '(expected "prompt_len:max_tokens")')
+    warmup_shapes = _dedupe_shapes(
+        _warmup_preset_shapes(args.warmup_preset, args.max_seq)
+        + _parse_warmup_shapes(args.warmup)
+    )
 
     if 'FLASHRT_QWEN36_MTP_CKPT_DIR' not in os.environ:
         log.warning(

--- a/flash_rt/frontends/torch/_qwen36_rtx_nvfp4_weights.py
+++ b/flash_rt/frontends/torch/_qwen36_rtx_nvfp4_weights.py
@@ -145,6 +145,103 @@ def _load_quantized_proj(
     out_dict[prefix + '_alpha'] = inv_global
 
 
+def _load_quantized_mlp_gate_up(
+    handles: WeightHandles,
+    out_dict: dict,
+    safetensors_handle,
+    base_mlp_key: str,
+    fvk,
+    device: str,
+    stream: int = 0,
+) -> None:
+    """Load MLP gate/up as one row-concatenated NVFP4 projection.
+
+    Qwen3.6's gate_proj and up_proj share the same global scale across
+    all observed layers. Keeping them as one physical tensor lets the
+    prefill path issue one large GEMM while the legacy fields remain
+    valid pointers into the fused tensor, without duplicating weights.
+    """
+    gate_key = base_mlp_key + '.gate_proj'
+    up_key = base_mlp_key + '.up_proj'
+    gate_glb_cpu = safetensors_handle.get_tensor(
+        gate_key + '.weight_global_scale')
+    up_glb_cpu = safetensors_handle.get_tensor(
+        up_key + '.weight_global_scale')
+    gate_global = float(gate_glb_cpu.to(torch.float32).item())
+    up_global = float(up_glb_cpu.to(torch.float32).item())
+    gate_alpha = 1.0 / gate_global if gate_global != 0.0 else 0.0
+    up_alpha = 1.0 / up_global if up_global != 0.0 else 0.0
+
+    if abs(gate_alpha - up_alpha) > 1e-12 * max(gate_alpha, 1e-12):
+        _load_quantized_proj(
+            handles, out_dict, 'mlp_gate',
+            safetensors_handle, gate_key, fvk, device, stream)
+        _load_quantized_proj(
+            handles, out_dict, 'mlp_up',
+            safetensors_handle, up_key, fvk, device, stream)
+        out_dict['mlp_gate_up_homogeneous_alpha'] = False
+        return
+
+    gate_packed = safetensors_handle.get_tensor(
+        gate_key + '.weight_packed').to(device, non_blocking=True).contiguous()
+    up_packed = safetensors_handle.get_tensor(
+        up_key + '.weight_packed').to(device, non_blocking=True).contiguous()
+    gate_sf_lin = safetensors_handle.get_tensor(
+        gate_key + '.weight_scale').to(device, non_blocking=True).contiguous()
+    up_sf_lin = safetensors_handle.get_tensor(
+        up_key + '.weight_scale').to(device, non_blocking=True).contiguous()
+
+    rows_gate, cols_div16 = gate_sf_lin.shape
+    rows_up, cols_div16_up = up_sf_lin.shape
+    if rows_gate != rows_up or cols_div16 != cols_div16_up:
+        raise RuntimeError(
+            'Qwen3.6 MLP gate/up shape mismatch: '
+            f'gate={tuple(gate_sf_lin.shape)} up={tuple(up_sf_lin.shape)}')
+
+    packed = torch.cat([gate_packed, up_packed], dim=0).contiguous()
+    sf_lin = torch.cat([gate_sf_lin, up_sf_lin], dim=0).contiguous()
+    rows_fused = rows_gate + rows_up
+    cols_in = cols_div16 * 16
+    n_blocks = cols_in // 16
+    n_col_super = (n_blocks + 3) // 4
+    n_row_super_fused = (rows_fused + 127) // 128
+    sf_bytes = n_row_super_fused * n_col_super * 512
+    sf_swz = torch.zeros(sf_bytes, dtype=torch.uint8, device=device)
+
+    fvk.nvfp4_sf_linear_to_swizzled(
+        int(sf_lin.data_ptr()),
+        int(sf_swz.data_ptr()),
+        rows_fused, cols_in, False, stream,
+    )
+
+    packed_base = _ensure_anchored(handles, packed)
+    sf_base = _ensure_anchored(handles, sf_swz)
+    gate_packed_bytes = int(gate_packed.numel() * gate_packed.element_size())
+    gate_row_super = (rows_gate + 127) // 128
+    gate_sf_bytes = int(gate_row_super * n_col_super * 512)
+
+    out_dict['mlp_gate_up_packed'] = packed_base
+    out_dict['mlp_gate_up_sf'] = sf_base
+    out_dict['mlp_gate_up_alpha'] = gate_alpha
+    out_dict['mlp_gate_up_N'] = int(rows_fused)
+    out_dict['mlp_gate_up_homogeneous_alpha'] = True
+
+    out_dict['mlp_gate_packed'] = packed_base
+    out_dict['mlp_up_packed'] = packed_base + gate_packed_bytes
+    out_dict['mlp_gate_sf'] = sf_base
+    out_dict['mlp_up_sf'] = sf_base + gate_sf_bytes
+    glb_f32 = gate_glb_cpu.to(torch.float32).to(device).contiguous()
+    glb_ptr = _ensure_anchored(handles, glb_f32)
+    out_dict['mlp_gate_global'] = glb_ptr
+    out_dict['mlp_up_global'] = glb_ptr
+    out_dict['mlp_gate_global_value'] = gate_global
+    out_dict['mlp_up_global_value'] = up_global
+    out_dict['mlp_gate_alpha'] = gate_alpha
+    out_dict['mlp_up_alpha'] = up_alpha
+
+    del gate_packed, up_packed, gate_sf_lin, up_sf_lin, sf_lin
+
+
 def _bf16_anchor(handles: WeightHandles, t: torch.Tensor,
                  device: str = 'cuda:0') -> int:
     """Move CPU tensor to GPU bf16 contiguous, anchor, return ptr."""
@@ -259,6 +356,10 @@ def extract_weights_nvfp4(
             handles, final_norm_eff)
 
         lm_head_cpu = f.get_tensor('lm_head.weight')
+        if bool(int(os.environ.get(
+                'FLASHRT_QWEN36_KEEP_BF16_LM_HEAD', '0') or '0')):
+            handles.ptrs['lm_head_w_bf16'] = _bf16_anchor(
+                handles, lm_head_cpu, device)
         # G8: quantize lm_head to NVFP4 at load time. lm_head is the
         # single largest weight in MTP-spec hot path (2.5 GB BF16 read
         # per call × K+1 calls per cycle). NVFP4 cuts it to 0.6 GB.
@@ -296,11 +397,13 @@ def extract_weights_nvfp4(
             ld['input_norm_eff_w'] = _ensure_anchored(handles, in_eff)
             ld['post_attn_norm_eff_w'] = _ensure_anchored(handles, post_eff)
 
-            # MLP (NVFP4 quantized in every layer).
-            for short in ('gate', 'up', 'down'):
-                _load_quantized_proj(
-                    handles, ld, 'mlp_' + short,
-                    f, base + f'mlp.{short}_proj', fvk, device)
+            # MLP (NVFP4 quantized in every layer). Gate/up share one
+            # fused physical tensor and expose legacy offset pointers.
+            _load_quantized_mlp_gate_up(
+                handles, ld, f, base + 'mlp', fvk, device)
+            _load_quantized_proj(
+                handles, ld, 'mlp_down',
+                f, base + 'mlp.down_proj', fvk, device)
 
             if t == 'linear_attention':
                 la = base + 'linear_attn.'
@@ -331,6 +434,7 @@ def extract_weights_nvfp4(
                 # cheap and shared across all 48 lin layers' init.
                 ab_w = torch.cat([a_w, b_w], dim=0).contiguous()
                 ld['in_proj_ab_w'] = _ensure_anchored(handles, ab_w)
+                ld['in_proj_ab_w_t'] = ab_w
                 _quant_bf16_lin_proj(
                     handles, ld, 'out_proj',
                     f.get_tensor(la + 'out_proj.weight'),
@@ -518,6 +622,72 @@ def extract_mtp_weights_nvfp4(mtp: dict, handles: WeightHandles, fvk,
     return out
 
 
+def extract_mtp_weights_bf16_nvfp4(mtp: dict, handles: WeightHandles, fvk,
+                                   device: str = 'cuda:0') -> dict:
+    """Quantize a BF16/native MTP head to NVFP4 and add to handles.
+
+    Some community Qwen3.6 MTP-preserved checkpoints publish the MTP
+    head as plain BF16 tensors rather than the official FP8
+    ``weight + weight_scale_inv`` layout. The runtime hot path still
+    expects the same NVFP4 MTP schema as :func:`extract_mtp_weights_nvfp4`,
+    so this loader mirrors it but uses the BF16 -> NVFP4 converter used
+    elsewhere in the NVFP4 frontend.
+    """
+    out: dict = {
+        'type': 'mtp',
+        'quant_format': 'nvfp4',
+        'source_format': 'bf16',
+    }
+
+    in_eff = _eff_rmsnorm_weight(mtp['layers.0.input_layernorm.weight'])
+    post_eff = _eff_rmsnorm_weight(
+        mtp['layers.0.post_attention_layernorm.weight'])
+    out['input_norm_eff_w'] = _ensure_anchored(handles, in_eff.to(device))
+    out['post_attn_norm_eff_w'] = _ensure_anchored(
+        handles, post_eff.to(device))
+
+    bf16_pairs = (
+        ('q_proj',   'layers.0.self_attn.q_proj'),
+        ('k_proj',   'layers.0.self_attn.k_proj'),
+        ('v_proj',   'layers.0.self_attn.v_proj'),
+        ('o_proj',   'layers.0.self_attn.o_proj'),
+        ('mlp_gate', 'layers.0.mlp.gate_proj'),
+        ('mlp_up',   'layers.0.mlp.up_proj'),
+        ('mlp_down', 'layers.0.mlp.down_proj'),
+    )
+
+    keep_bf16 = bool(int(os.environ.get(
+        'FLASHRT_QWEN36_MTP_KEEP_BF16', '1') or '0'))
+
+    for prefix, base in bf16_pairs:
+        _quant_bf16_lin_proj(
+            handles, out, prefix, mtp[base + '.weight'], fvk, device)
+        if keep_bf16:
+            w = mtp[base + '.weight'].to(torch.bfloat16).to(
+                device).contiguous()
+            out[prefix + '_w_bf16'] = _ensure_anchored(handles, w)
+
+    q_eff = _eff_rmsnorm_weight(mtp['layers.0.self_attn.q_norm.weight'])
+    k_eff = _eff_rmsnorm_weight(mtp['layers.0.self_attn.k_norm.weight'])
+    out['q_norm_eff_w'] = _ensure_anchored(handles, q_eff.to(device))
+    out['k_norm_eff_w'] = _ensure_anchored(handles, k_eff.to(device))
+
+    pre_h_eff = _eff_rmsnorm_weight(mtp['pre_fc_norm_hidden.weight'])
+    pre_e_eff = _eff_rmsnorm_weight(mtp['pre_fc_norm_embedding.weight'])
+    final_eff = _eff_rmsnorm_weight(mtp['norm.weight'])
+    out['pre_fc_norm_hidden_eff_w'] = _ensure_anchored(
+        handles, pre_h_eff.to(device))
+    out['pre_fc_norm_embedding_eff_w'] = _ensure_anchored(
+        handles, pre_e_eff.to(device))
+    out['final_norm_eff_w'] = _ensure_anchored(
+        handles, final_eff.to(device))
+
+    fc_w = mtp['fc.weight'].to(torch.bfloat16).to(device).contiguous()
+    out['fc_w'] = _ensure_anchored(handles, fc_w)
+
+    return out
+
+
 def assert_extraction_invariants_nvfp4(handles: WeightHandles) -> None:
     """Verify all NVFP4 ptr fields populated. Run once at frontend init."""
     p = handles.ptrs
@@ -533,6 +703,8 @@ def assert_extraction_invariants_nvfp4(handles: WeightHandles) -> None:
         'input_norm_eff_w', 'post_attn_norm_eff_w', 'quant_format',
         'mlp_gate_packed', 'mlp_gate_sf', 'mlp_gate_global',
         'mlp_up_packed', 'mlp_up_sf', 'mlp_up_global',
+        'mlp_gate_up_packed', 'mlp_gate_up_sf', 'mlp_gate_up_alpha',
+        'mlp_gate_up_N', 'mlp_gate_up_homogeneous_alpha',
         'mlp_down_packed', 'mlp_down_sf', 'mlp_down_global',
     }
     lin_keys = common_keys | {

--- a/flash_rt/frontends/torch/_qwen36_rtx_turboquant.py
+++ b/flash_rt/frontends/torch/_qwen36_rtx_turboquant.py
@@ -50,6 +50,7 @@ Validation entry points:
 from __future__ import annotations
 
 import math
+import os
 
 import torch
 
@@ -548,12 +549,12 @@ class TurboQuantKVCache:
     def write_kv_fast(self, layer: int, pos_start: int, pos_end: int,
                       k: torch.Tensor, v: torch.Tensor) -> None:
         """Phase 3A B9-S10: capture-safe quantize+pack via 4 small CUDA
-        kernels + 3 cuBLAS GEMMs (torch.matmul).
+        kernels + 3 explicit GEMM wrappers by default.
 
-        Bit-exact with the slow Python reference because the GEMMs go
-        through the same cuBLAS path (same tile order, same TF32
-        reduction).  No torch tensor allocations on the hot path
-        (all scratch pre-alloc'd here, GEMM outputs use `out=` views).
+        The default kernel GEMM route uses cuBLASLt tactics (A=3, B=0,
+        C=3) validated against the torch reference on real 2048-token
+        long-prefill chunks.  Set FLASHRT_QWEN36_TQ_KERNEL_WRITE=0 to
+        force the older torch.matmul GEMM route for bisection.
         """
         if not self.packed:
             raise RuntimeError(
@@ -568,13 +569,13 @@ class TurboQuantKVCache:
         M = S * nkv
         d = self.setup.head_dim
 
-        # Lazy scratch — write_kv operates per-call on a single new
-        # token (S=1 for decode, ≤16 for prefill), so cap is small
-        # regardless of max_seq.  Sized to W_CAP_S * nkv = 256 rows
-        # comfortably (covers any q_seq ≤ 64).
-        W_CAP_S = 64
-        cap_M = W_CAP_S * nkv
-        if not hasattr(self, '_w_kv_unit'):
+        # Lazy scratch.  Decode writes one token, but chunked long
+        # prefill can write larger S.  Grow the scratch to the largest
+        # observed M; fixed 64-token capacity silently overflowed when
+        # experimenting with 128-token prefill chunks.
+        cap_M = max(64 * nkv, M)
+        if (not hasattr(self, '_w_kv_unit')
+                or int(getattr(self, '_w_cap_M', 0)) < cap_M):
             t = lambda *shape: torch.empty(  # noqa: E731
                 *shape, dtype=torch.float32, device=self.device)
             self._w_kv_unit = t(2 * cap_M, d)        # [k_unit; v_unit]
@@ -584,12 +585,20 @@ class TurboQuantKVCache:
             self._w_residual = t(cap_M, d)
             self._w_Sr = t(cap_M, d)
             self._w_norms = t(3 * cap_M)            # [norm_k|norm_v|rnorm_k]
+            self._w_cap_M = cap_M
+        else:
+            cap_M = int(self._w_cap_M)
 
         rot_fp32 = self.setup.rotations[layer]
         jl_fp32 = self.setup.jl[layer]
         cb_k = self.setup.codebooks[self.setup.b_k_mse]
         cb_v = self.setup.codebooks[self.setup.b_v]
         s = torch.cuda.current_stream().cuda_stream
+        use_kernel_gemm = (
+            os.environ.get('FLASHRT_QWEN36_TQ_KERNEL_WRITE', '1') == '1'
+            and hasattr(fvk, 'tq_fp32_gemm_lt_bt_algo')
+            and hasattr(fvk, 'tq_fp32_gemm_lt_algo')
+        )
 
         # Slice the scratch (views, no alloc).
         k_unit = self._w_kv_unit[:M]
@@ -612,9 +621,15 @@ class TurboQuantKVCache:
             M, self.setup.b_k_mse, self.setup.b_v, s,
         )
         # GEMM A: [k_unit; v_unit] @ rotation^T → [y_k; y_v]
-        # rot_fp32.T is a view (no alloc).
-        torch.matmul(self._w_kv_unit[:2 * M], rot_fp32.T,
-                     out=self._w_kv_rotated[:2 * M])
+        if use_kernel_gemm:
+            fvk.tq_fp32_gemm_lt_bt_algo(
+                self._w_kv_unit[:2 * M].data_ptr(), rot_fp32.data_ptr(),
+                self._w_kv_rotated[:2 * M].data_ptr(),
+                2 * M, d, d, 3, s,
+            )
+        else:
+            torch.matmul(self._w_kv_unit[:2 * M], rot_fp32.T,
+                         out=self._w_kv_rotated[:2 * M])
 
         # K2: argmin → idx, pack 4-bit to cache, gather cb_k[idx_k] for dq
         fvk.tq_write_k2_argmin_pack(
@@ -627,7 +642,13 @@ class TurboQuantKVCache:
             self.setup.b_k_mse, self.setup.b_v, s,
         )
         # GEMM B: cb_k[idx_k] @ rotation → dq_k
-        torch.matmul(dq_in, rot_fp32, out=dq_out)
+        if use_kernel_gemm:
+            fvk.tq_fp32_gemm_lt_algo(
+                dq_in.data_ptr(), rot_fp32.data_ptr(), dq_out.data_ptr(),
+                M, d, d, 0, s,
+            )
+        else:
+            torch.matmul(dq_in, rot_fp32, out=dq_out)
 
         # K3: residual = k_unit - dq_k ; rnorm_k = ‖residual‖
         fvk.tq_write_k3_residual_rnorm(
@@ -636,7 +657,13 @@ class TurboQuantKVCache:
             M, s,
         )
         # GEMM C: residual @ jl^T → Sr
-        torch.matmul(residual, jl_fp32.T, out=Sr)
+        if use_kernel_gemm:
+            fvk.tq_fp32_gemm_lt_bt_algo(
+                residual.data_ptr(), jl_fp32.data_ptr(), Sr.data_ptr(),
+                M, d, d, 3, s,
+            )
+        else:
+            torch.matmul(residual, jl_fp32.T, out=Sr)
 
         # K4: pack qjl bits + write all norms (fp16) to cache slot
         fvk.tq_write_k4_qjl_norms(
@@ -654,6 +681,22 @@ class TurboQuantKVCache:
     # Writes into caller-supplied (max_seq, num_kv, head_dim) bf16
     # staging buffers — saves the read_kv allocator round-trip.
     # ────────────────────────────────────────────────────────────────
+    def _ensure_fast_dequant_scratch(self, cap_M: int) -> None:
+        """Grow fp32 dequant scratch to the active window, not max_seq."""
+        d = self.setup.head_dim
+        cap_M = int(cap_M)
+        if int(getattr(self, '_fast_cap_M', 0)) >= cap_M:
+            return
+        self._fast_yk_yv = torch.empty(
+            2 * cap_M, d, dtype=torch.float32, device=self.device)
+        self._fast_qjl = torch.empty(
+            cap_M, d, dtype=torch.float32, device=self.device)
+        self._fast_rotated_fp32 = torch.empty(
+            2 * cap_M, d, dtype=torch.float32, device=self.device)
+        self._fast_kqjl_fp32 = torch.empty(
+            cap_M, d, dtype=torch.float32, device=self.device)
+        self._fast_cap_M = cap_M
+
     def read_kv_fast(self, layer: int, pos_end: int,
                      k_stage: torch.Tensor, v_stage: torch.Tensor) -> None:
         """B9 dequant: packed[layer, :pos_end] → k_stage[:pos_end] / v_stage.
@@ -665,25 +708,28 @@ class TurboQuantKVCache:
         if not self.packed:
             raise RuntimeError(
                 'read_kv_fast requires packed=True (B8 layout)')
+        if pos_end <= 0:
+            return
+        # cuBLASLt's bitwise match to torch.matmul is shape/tactic
+        # sensitive.  The validated production unit is the 2048-token
+        # long-prefill window, so larger full-prefix reads are assembled
+        # from the same exact window kernel.
+        chunk = 2048
+        if pos_end > chunk:
+            for ps in range(0, pos_end, chunk):
+                self.read_kv_fast_window(
+                    layer, ps, min(ps + chunk, pos_end),
+                    k_stage, v_stage)
+            return
         from flash_rt import flash_rt_kernels as fvk
         d = self.setup.head_dim
         nkv = self.num_kv
         M = pos_end * nkv
 
-        # Scratch pre-allocated to max_seq (CUDA-Graph friendly: no
-        # dynamic resize on the hot path).  All buffers fp32 since the
-        # unpack kernel emits fp32 directly (skips the bf16-intermediate
-        # + `.float()` cast that previously cost a 256 MB temp / call).
-        cap_M = self.max_seq * nkv
-        if not hasattr(self, '_fast_yk_yv'):
-            self._fast_yk_yv = torch.empty(
-                2 * cap_M, d, dtype=torch.float32, device=self.device)
-            self._fast_qjl = torch.empty(
-                cap_M, d, dtype=torch.float32, device=self.device)
-            self._fast_rotated_fp32 = torch.empty(
-                2 * cap_M, d, dtype=torch.float32, device=self.device)
-            self._fast_kqjl_fp32 = torch.empty(
-                cap_M, d, dtype=torch.float32, device=self.device)
+        # Scratch is sized to the active dequant window.  The full-prefix
+        # path above decomposes long reads into 2048-token windows, so
+        # allocating by max_seq would waste multiple GB at 128K/256K.
+        self._ensure_fast_dequant_scratch(M)
 
         yk = self._fast_yk_yv[:M]
         yv = self._fast_yk_yv[M:2 * M]
@@ -708,11 +754,17 @@ class TurboQuantKVCache:
             yk.data_ptr(), qjl_f.data_ptr(), yv.data_ptr(),
             M, self.setup.b_k_mse, self.setup.b_v, s,
         )
-        # 2) fp32 GEMMs via torch.matmul (capture-safe, well-tested with
-        #    CUDA Graph; same perf as our cuBLAS TF32 wrapper since
-        #    PyTorch 2.x uses TF32 on sm≥80 by default for fp32 matmul).
-        torch.matmul(self._fast_yk_yv[:2 * M], rot_fp32, out=rotated)
-        torch.matmul(qjl_f, jl_fp32, out=kqjl)
+        # 2) fp32 GEMMs via explicit wrappers.  PyTorch chooses different
+        # tactics for the two shapes: Lt algo 1 matches the rotation GEMM,
+        # while ordinary cuBLAS matches the JL GEMM bit-for-bit.
+        fvk.tq_fp32_gemm_lt_algo(
+            self._fast_yk_yv[:2 * M].data_ptr(), rot_fp32.data_ptr(),
+            rotated.data_ptr(), 2 * M, d, d, 1, s,
+        )
+        fvk.tq_fp32_gemm_fp32(
+            qjl_f.data_ptr(), jl_fp32.data_ptr(), kqjl.data_ptr(),
+            M, d, d, s,
+        )
         # 3) combine fp32 in → bf16 out
         coef = math.sqrt(math.pi / 2.0) / d
         k_flat = k_stage[:pos_end].view(M, d)
@@ -753,18 +805,7 @@ class TurboQuantKVCache:
         nkv = self.num_kv
         M = (pos_end - pos_start) * nkv
 
-        # Reuse the same fp32 scratches as read_kv_fast — sized to
-        # max_seq * nkv, which always covers any window M.
-        cap_M = self.max_seq * nkv
-        if not hasattr(self, '_fast_yk_yv'):
-            self._fast_yk_yv = torch.empty(
-                2 * cap_M, d, dtype=torch.float32, device=self.device)
-            self._fast_qjl = torch.empty(
-                cap_M, d, dtype=torch.float32, device=self.device)
-            self._fast_rotated_fp32 = torch.empty(
-                2 * cap_M, d, dtype=torch.float32, device=self.device)
-            self._fast_kqjl_fp32 = torch.empty(
-                cap_M, d, dtype=torch.float32, device=self.device)
+        self._ensure_fast_dequant_scratch(M)
 
         yk = self._fast_yk_yv[:M]
         yv = self._fast_yk_yv[M:2 * M]
@@ -794,8 +835,14 @@ class TurboQuantKVCache:
             yk.data_ptr(), qjl_f.data_ptr(), yv.data_ptr(),
             M, self.setup.b_k_mse, self.setup.b_v, s,
         )
-        torch.matmul(self._fast_yk_yv[:2 * M], rot_fp32, out=rotated)
-        torch.matmul(qjl_f, jl_fp32, out=kqjl)
+        fvk.tq_fp32_gemm_lt_algo(
+            self._fast_yk_yv[:2 * M].data_ptr(), rot_fp32.data_ptr(),
+            rotated.data_ptr(), 2 * M, d, d, 1, s,
+        )
+        fvk.tq_fp32_gemm_fp32(
+            qjl_f.data_ptr(), jl_fp32.data_ptr(), kqjl.data_ptr(),
+            M, d, d, s,
+        )
         coef = math.sqrt(math.pi / 2.0) / d
         k_flat = k_stage[pos_start:pos_end].view(M, d)
         v_flat = v_stage[pos_start:pos_end].view(M, d)
@@ -828,4 +875,3 @@ class TurboQuantKVCache:
         v_hat = self.setup.dequant_v(idx_v, norm_v, layer)
 
         return k_hat.to(torch.bfloat16), v_hat.to(torch.bfloat16)
-

--- a/flash_rt/frontends/torch/qwen36_rtx.py
+++ b/flash_rt/frontends/torch/qwen36_rtx.py
@@ -40,6 +40,18 @@ if _PATCH_PATH and os.path.isfile(_PATCH_PATH):
 from flash_rt.models.qwen36 import Qwen36Pipeline  # noqa: E402
 
 
+_QWEN36_FLA_CHUNK = None
+
+
+def _load_qwen36_fla_chunk():
+    """Load the vendored FLA chunk/WY Gated DeltaNet prefill kernel."""
+    global _QWEN36_FLA_CHUNK
+    if _QWEN36_FLA_CHUNK is None:
+        from flash_rt.ops.fla.chunk import chunk_gated_delta_rule_inference
+        _QWEN36_FLA_CHUNK = chunk_gated_delta_rule_inference
+    return _QWEN36_FLA_CHUNK
+
+
 class Qwen36TorchFrontendRtx:
     """Qwen3.6-27B inference frontend (PyTorch + RTX SM120).
 
@@ -104,26 +116,41 @@ class Qwen36TorchFrontendRtx:
         # (16 layers × max_seq × 4 × 256 × 2 bytes for K + V = 32 KB
         # per token, so 32K context = 1 GB just for K, 2 GB for K+V,
         # on top of a ~30 GB baseline). The fix is to route to the
-        # TurboQuant (TQ) packed-cache path: BF16 KV is shrunk to a
-        # 64-row dummy and persistent KV lives in NVFP4-packed form
-        # (~1.83x compression at 1-byte idx, ~5x at bit-pack).
-        # Spec decode is *not* yet integrated with TQ (Phase 3D
-        # follow-up), so long-ctx mode falls back to single-token
-        # decode (~30-40 tok/s eager, vs ~100-130 tok/s spec on
-        # short-ctx). This is the documented trade-off and matches
-        # the perf grid in docs/qwen36_nvfp4.md §4.
+        # TurboQuant (TQ) packed-cache path: BF16 KV is retained only
+        # for a small short-request spec window and persistent long KV
+        # lives in NVFP4-packed form (~1.83x compression at 1-byte idx,
+        # ~5x at bit-pack).
+        # Requests beyond the retained BF16 spec window run MTP draft
+        # plus TQ-packed verify. Short requests still use the normal
+        # BF16-KV/CUDA-Graph MTP spec path even when the frontend was
+        # constructed for long context.
         if quant == 'nvfp4' and self._user_max_seq > self.LONG_CTX_THRESHOLD:
-            # Long-ctx mode: allocate BF16 buffers at a small floor
-            # (the BF16 KV cache will be shrunk to a 64-row dummy
-            # immediately after init, and the per-step bf16 scratches
-            # like _h_a/_h_b only ever read [:1] or [:K] rows so they
-            # don't need to scale with max_seq). The TQ packed cache
-            # then grows KV coverage out to ``user_max_seq``.
-            bf16_init_seq = 2048
+            # Long-ctx mode: allocate BF16 buffers at a small spec
+            # window. The TQ packed cache then grows KV coverage out
+            # to ``user_max_seq``. Keeping this small BF16 window avoids
+            # penalising ordinary short requests just because the server
+            # was configured for occasional long-context traffic.
+            default_window = min(2048, self.MAX_Q_SEQ)
+            bf16_init_seq = int(os.environ.get(
+                'FLASHRT_QWEN36_LONG_CTX_BF16_WINDOW',
+                str(default_window),
+            ) or str(default_window))
+            bf16_init_seq = max(1, min(bf16_init_seq, self._user_max_seq))
             self._long_ctx_mode = True
         else:
             bf16_init_seq = self._user_max_seq
             self._long_ctx_mode = False
+        self._short_ctx_spec_max_seq = int(bf16_init_seq)
+        route_default = (
+            min(self._short_ctx_spec_max_seq, 512)
+            if self._long_ctx_mode else self._short_ctx_spec_max_seq
+        )
+        self._long_ctx_route_min_seq = int(os.environ.get(
+            'FLASHRT_QWEN36_LONG_CTX_ROUTE_MIN_SEQ',
+            str(route_default),
+        ) or str(route_default))
+        self._long_ctx_route_min_seq = max(
+            0, min(self._long_ctx_route_min_seq, self._user_max_seq))
         # ``self.max_seq`` is the value used to size the BF16 init.
         # ``self._user_max_seq`` is what the user asked for — that's
         # what the TQ packed cache grows to in long-ctx mode, and
@@ -233,14 +260,14 @@ class Qwen36TorchFrontendRtx:
     # ---------- Phase 2.3b4 own-forward state ----------
 
     # Phase 6 D4: maximum query-seq length for S=K decode paths
-    # (speculative verify, multi-token batched decode). Originally 8 to
-    # support K=5 spec (verify q_seq = K+1 = 6). Bumped to 16 in N6-A4
-    # to host the DFlash drafter's block_size=16 verify forward
-    # (input layout [prev_token, draft_0..draft_14]). Per-K-row scratches
-    # scale linearly: full set is ~12 MB at K=16 (the dominant
-    # _K_logits_buf at vocab=248320 is 16*248320*2 = 7.6 MB), tiny vs
-    # the 28-30 GB main weight footprint.
-    MAX_Q_SEQ: int = 16
+    # (speculative verify, multi-token batched decode, and long-context
+    # TQ prefill chunks). Originally 8 to support K=5 spec, then 16 to
+    # host DFlash's block_size=16 verify forward. Bumped to 1024 so
+    # long-context prefill can amortize the 64-layer forward over larger
+    # chunks. Public speculative K remains conservatively capped by
+    # _MAX_PUBLIC_SPEC_K.
+    MAX_Q_SEQ: int = int(os.environ.get('FLASHRT_QWEN36_MAX_Q_SEQ', '2048'))
+    _MAX_PUBLIC_SPEC_K: int = 15
 
     # Per-cache LRU bound on lazily captured CUDA Graphs. Each
     # ``_ensure_*_graph_*`` method captures a graph keyed by cur_pos
@@ -270,10 +297,9 @@ class Qwen36TorchFrontendRtx:
     # the constructor switches into long-ctx mode: BF16 KV buffers
     # are allocated at this threshold (small) and persistent KV is
     # served by the TurboQuant packed cache, which compresses 1.83x
-    # at 1-byte idx (~5x at bit-pack). Spec decode is currently only
-    # available below the threshold; long-ctx mode does single-token
-    # decode (~30-40 tok/s) but supports up to 256 K context on a
-    # 32 GB card.
+    # at 1-byte idx (~5x at bit-pack). Requests inside the retained
+    # short BF16 window use the normal graph-captured spec path;
+    # requests beyond that window use eager MTP draft + TQ-packed verify.
     #
     # Tuning notes:
     #   - 16384 is the default because at max_seq=16K the BF16 KV is
@@ -706,6 +732,24 @@ class Qwen36TorchFrontendRtx:
         self._K_lin_attn_out = torch.empty(
             Kmax, 48, 128, device=device, dtype=bf16,
         )
+        self._K_lin_q16 = torch.empty(
+            Kmax, 16, 128, device=device, dtype=bf16,
+        )
+        self._K_lin_k16 = torch.empty(
+            Kmax, 16, 128, device=device, dtype=bf16,
+        )
+        self._K_fla_q16_l2 = torch.empty(
+            1, Kmax, 16, 128, device=device, dtype=bf16,
+        )
+        self._K_fla_k16_l2 = torch.empty(
+            1, Kmax, 16, 128, device=device, dtype=bf16,
+        )
+        self._K_fla_g_cumsum = torch.empty(
+            1, Kmax, 48, device=device, dtype=fp32,
+        )
+        self._K_lin_v48 = torch.empty(
+            Kmax, 48, 128, device=device, dtype=bf16,
+        )
         self._K_lin_norm_out = torch.empty(
             Kmax, 48, 128, device=device, dtype=bf16,
         )
@@ -840,6 +884,7 @@ class Qwen36TorchFrontendRtx:
         from flash_rt import flash_rt_kernels as fvk
         from flash_rt.frontends.torch._qwen36_rtx_nvfp4_weights import (
             assert_extraction_invariants_nvfp4,
+            extract_mtp_weights_bf16_nvfp4,
             extract_mtp_weights_nvfp4,
             extract_weights_nvfp4,
         )
@@ -856,17 +901,20 @@ class Qwen36TorchFrontendRtx:
         assert_extraction_invariants_nvfp4(handles)
         self._weights = handles
 
-        # MTP head from FP8 ckpt → NVFP4 swizzled (pure-NVFP4 spec).
-        # The compressed-tensors NVFP4 ckpt has no MTP module; we pull
-        # it from a paired FP8 ckpt (Qwen3.6-Next-27B-FP8) via the
-        # FLASHRT_QWEN36_MTP_CKPT_DIR env var. If unset, MTP is None
-        # and speculative decode is unavailable (pure-decode still works).
+        # MTP head from an external ckpt → NVFP4 swizzled (pure-NVFP4
+        # spec). Supports both official FP8 MTP files and community
+        # BF16/native MTP-preserved files.
         mtp_dir = os.environ.get('FLASHRT_QWEN36_MTP_CKPT_DIR')
-        mtp_path = (os.path.join(mtp_dir, 'mtp.safetensors')
-                    if mtp_dir else None)
+        mtp_path = None
+        if mtp_dir:
+            for filename in ('mtp.safetensors', 'model_mtp.safetensors'):
+                candidate = os.path.join(mtp_dir, filename)
+                if os.path.exists(candidate):
+                    mtp_path = candidate
+                    break
         if mtp_path is not None and os.path.exists(mtp_path):
             import safetensors.torch
-            raw = safetensors.torch.load_file(mtp_path, device=self.device)
+            raw = safetensors.torch.load_file(mtp_path, device='cpu')
             mtp_dict: dict = {}
             for k, t in raw.items():
                 if not k.startswith('mtp.'):
@@ -879,8 +927,34 @@ class Qwen36TorchFrontendRtx:
                 else:
                     mtp_dict[short] = t.to(torch.bfloat16).contiguous()
             self._mtp_tensors = mtp_dict
-            handles.ptrs['mtp'] = extract_mtp_weights_nvfp4(
-                mtp_dict, handles, fvk, device=self.device)
+            mtp_proj_bases = (
+                'layers.0.self_attn.q_proj',
+                'layers.0.self_attn.k_proj',
+                'layers.0.self_attn.v_proj',
+                'layers.0.self_attn.o_proj',
+                'layers.0.mlp.gate_proj',
+                'layers.0.mlp.up_proj',
+                'layers.0.mlp.down_proj',
+            )
+            has_fp8_scales = all(
+                base + '.weight_scale_inv' in mtp_dict
+                for base in mtp_proj_bases)
+            if has_fp8_scales:
+                handles.ptrs['mtp'] = extract_mtp_weights_nvfp4(
+                    mtp_dict, handles, fvk, device=self.device)
+            else:
+                missing = [
+                    base + '.weight'
+                    for base in mtp_proj_bases
+                    if base + '.weight' not in mtp_dict
+                ]
+                if missing:
+                    raise RuntimeError(
+                        'MTP checkpoint is missing projection weights: '
+                        + ', '.join(missing)
+                    )
+                handles.ptrs['mtp'] = extract_mtp_weights_bf16_nvfp4(
+                    mtp_dict, handles, fvk, device=self.device)
         else:
             self._mtp_tensors = None
             handles.ptrs['mtp'] = None
@@ -932,6 +1006,8 @@ class Qwen36TorchFrontendRtx:
         # Hidden ping-pong (same shape as FP8 path).
         self._h_a = torch.empty(max_seq, hidden, device=device, dtype=bf16)
         self._h_b = torch.empty(max_seq, hidden, device=device, dtype=bf16)
+        self._embed_buf = torch.empty(
+            1, 1, hidden, device=device, dtype=bf16)
 
         # NVFP4 scratch per (N, K) shape:
         #   act_packed  (max_seq, K/2)         u8
@@ -945,12 +1021,35 @@ class Qwen36TorchFrontendRtx:
             n_col_super = (n_blocks + 3) // 4
             return n_row_super * n_col_super * 512
 
+        layers = self._weights.ptrs['layers']
+        gate_up_default = '1' if self._long_ctx_mode else '0'
+        self._enable_mlp_gate_up_fusion = (
+            bool(int(os.environ.get(
+                'FLASHRT_QWEN36_FUSE_MLP_GATE_UP',
+                gate_up_default) or '0'))
+            and all(ld.get('mlp_gate_up_homogeneous_alpha') for ld in layers)
+        )
+        self._enable_silu_mul_quant_fusion = bool(int(os.environ.get(
+            'FLASHRT_QWEN36_FUSE_SILU_MUL_QUANT', '0') or '0'))
+        if self._enable_mlp_gate_up_fusion:
+            self._enable_silu_mul_quant_fusion = True
+        self._lin_ab_torch_mm_min_k = int(os.environ.get(
+            'FLASHRT_QWEN36_LIN_AB_TORCH_MM_MIN_K', '0') or '0')
+        self._enable_lin_ab96_kernel = bool(int(os.environ.get(
+            'FLASHRT_QWEN36_LIN_AB96_KERNEL', '1') or '0'))
+        self._enable_full_gate_sigmoid_mul = bool(int(os.environ.get(
+            'FLASHRT_QWEN36_FULL_GATE_SIGMOID_MUL', '0') or '0'))
+
         self._nvfp4_scratch: dict[tuple[int, int],
                                   tuple[torch.Tensor, ...]] = {}
         for N, K in self._NVFP4_SHAPES:
             ap = torch.empty(max_seq, K // 2, device=device, dtype=u8)
             sf = torch.zeros(_swz_bytes(max_seq, K), device=device, dtype=u8)
-            out = torch.empty(max_seq, N, device=device, dtype=bf16)
+            out_rows = 1 if (
+                self._enable_mlp_gate_up_fusion
+                and (N, K) == (17408, 5120)
+            ) else max_seq
+            out = torch.empty(out_rows, N, device=device, dtype=bf16)
             self._nvfp4_scratch[(N, K)] = (ap, sf, out)
 
         # BF16 scratch for unquantized linear-attn projections. Inputs
@@ -987,6 +1086,8 @@ class Qwen36TorchFrontendRtx:
             1, 48, 128, device=device, dtype=bf16)
         self._lin_k48 = torch.empty(
             1, 48, 128, device=device, dtype=bf16)
+        self._lin_v48 = torch.empty(
+            1, 48, 128, device=device, dtype=bf16)
         self._lin_broadcast_idx = torch.arange(
             16, device=device, dtype=torch.long).repeat_interleave(3)
 
@@ -996,7 +1097,13 @@ class Qwen36TorchFrontendRtx:
         # Separate up output buf (gate scratch comes from NVFP4 scratch
         # of (17408, 5120)).
         self._mlp_up_out = torch.empty(
-            self.max_seq, 17408, device=device, dtype=bf16)
+            1 if self._enable_mlp_gate_up_fusion else self.max_seq,
+            17408, device=device, dtype=bf16)
+        self._K_mlp_gate_up_out = (
+            torch.empty(self.MAX_Q_SEQ, 34816, device=device, dtype=bf16)
+            if self._enable_mlp_gate_up_fusion
+            else None
+        )
 
         # Layer-output ping-pong + intermediate residual.
         self._layer_out_a = torch.empty(
@@ -1065,11 +1172,14 @@ class Qwen36TorchFrontendRtx:
             1, Kmax, hidden, device=device, dtype=bf16)
         self._K_layer_out_b = torch.empty(
             1, Kmax, hidden, device=device, dtype=bf16)
+        self._K_embed_buf = torch.empty(
+            1, Kmax, hidden, device=device, dtype=bf16)
         self._K_res_mid = torch.empty(
             1, Kmax, hidden, device=device, dtype=bf16)
         # linear-attn small per-row scratches (K rows × 48 heads)
-        self._K_lin_a_vec = torch.empty(Kmax, 48, device=device, dtype=bf16)
-        self._K_lin_b_vec = torch.empty(Kmax, 48, device=device, dtype=bf16)
+        self._K_lin_ab_vec = torch.empty(Kmax, 96, device=device, dtype=bf16)
+        self._K_lin_a_vec = self._K_lin_ab_vec[:, :48]
+        self._K_lin_b_vec = self._K_lin_ab_vec[:, 48:]
         self._K_lin_beta = torch.empty(Kmax, 48, device=device, dtype=bf16)
         self._K_lin_a_f32 = torch.empty(Kmax, 48, device=device, dtype=fp32)
         self._K_lin_g_f32 = torch.empty(Kmax, 48, device=device, dtype=fp32)
@@ -1081,16 +1191,45 @@ class Qwen36TorchFrontendRtx:
         # Linear-attn S=K accumulators (each (48, 128) per row).
         self._K_lin_attn_out = torch.empty(
             Kmax, 48, 128, device=device, dtype=bf16)
+        self._K_lin_q16 = torch.empty(
+            Kmax, 16, 128, device=device, dtype=bf16)
+        self._K_lin_k16 = torch.empty(
+            Kmax, 16, 128, device=device, dtype=bf16)
+        self._K_fla_q16_l2 = torch.empty(
+            1, Kmax, 16, 128, device=device, dtype=bf16)
+        self._K_fla_k16_l2 = torch.empty(
+            1, Kmax, 16, 128, device=device, dtype=bf16)
+        self._K_fla_g_cumsum = torch.empty(
+            1, Kmax, 48, device=device, dtype=fp32)
+        self._K_lin_v48 = torch.empty(
+            Kmax, 48, 128, device=device, dtype=bf16)
         self._K_lin_norm_out = torch.empty(
             Kmax, 48, 128, device=device, dtype=bf16)
         # Conv1d update output staging: K rows of (1, 10240).
         self._K_lin_conv_out = torch.empty(
             Kmax, 10240, device=device, dtype=bf16)
         # logits at K rows + last hidden at K rows (spec chaining).
+        # Public spec only needs K+1 rows (<= _MAX_PUBLIC_SPEC_K+1).
+        # Large-K prefill now asks for last/none logits, so keep the
+        # eager all-logits buffer small and allocate a large fallback
+        # lazily only for explicit diagnostic calls.
+        logits_rows = min(Kmax, self._MAX_PUBLIC_SPEC_K + 1)
         self._K_logits_buf = torch.empty(
-            Kmax, vocab, device=device, dtype=bf16)
+            logits_rows, vocab, device=device, dtype=bf16)
+        self._K_logits_large_buf = None
         self._K_last_hidden_buf = torch.empty(
             1, Kmax, hidden, device=device, dtype=bf16)
+        self._spec_argmax_buf = torch.empty(
+            self.MAX_Q_SEQ, device=device, dtype=torch.long)
+        self._spec_accept_n_buf = torch.empty(
+            1, device=device, dtype=torch.int32)
+        self._spec_argmax_partial_vals = torch.empty(
+            self.MAX_Q_SEQ * 128, device=device, dtype=fp32)
+        self._spec_argmax_partial_idx = torch.empty(
+            self.MAX_Q_SEQ * 128, device=device, dtype=torch.int32)
+        self._gen_out_buf = torch.empty(
+            1, int(getattr(self, '_user_max_seq', max_seq)),
+            device=device, dtype=torch.long)
 
         # ---------- N5-stage6: spec-decode snap buffers (NVFP4) ----------
         # Pre-allocated snap buffers + dedicated stream so the partial-
@@ -1131,6 +1270,8 @@ class Qwen36TorchFrontendRtx:
         self._K_lin_q48 = torch.empty(
             self.MAX_Q_SEQ, 48, 128, device=device, dtype=bf16)
         self._K_lin_k48 = torch.empty(
+            self.MAX_Q_SEQ, 48, 128, device=device, dtype=bf16)
+        self._K_lin_v48 = torch.empty(
             self.MAX_Q_SEQ, 48, 128, device=device, dtype=bf16)
         self._K_lin_attn_out = torch.empty(
             self.MAX_Q_SEQ, 48, 128, device=device, dtype=bf16)
@@ -1178,6 +1319,9 @@ class Qwen36TorchFrontendRtx:
         self._captured_verify_graphs: collections.OrderedDict[
             tuple[int, int], torch.cuda.CUDAGraph,
         ] = collections.OrderedDict()
+        self._captured_verify_graphs_tq: collections.OrderedDict[
+            tuple[int, int], torch.cuda.CUDAGraph,
+        ] = collections.OrderedDict()
 
         # MTP scratches (only when MTP is loaded). Mirror FP8 path's
         # MTP buffers — these are BF16/FP32 scratches and independent
@@ -1201,6 +1345,8 @@ class Qwen36TorchFrontendRtx:
                 n_splits, 1, 24, 1, 256, device=device, dtype=fp32)
             self._mtp_h_norm_buf = torch.empty(
                 1, 1, hidden, device=device, dtype=bf16)
+            self._mtp_embed_buf = torch.empty(
+                1, 1, hidden, device=device, dtype=bf16)
             self._mtp_e_norm_buf = torch.empty(
                 1, 1, hidden, device=device, dtype=bf16)
             self._mtp_cat_buf = torch.empty(
@@ -1219,14 +1365,15 @@ class Qwen36TorchFrontendRtx:
             self._captured_mtp_graphs: collections.OrderedDict[
                 int, torch.cuda.CUDAGraph,
             ] = collections.OrderedDict()
-            # G9: per-(base_pos, K) chain graph that captures the
-            # entire K-step MTP chain (forward + argmax + inter-step
-            # state copies) in one graph. Eliminates K-1 Python-level
-            # replay/copy/argmax launches per spec cycle.
+            # G9: chain graph that captures the entire K-step MTP chain
+            # (forward + argmax + inter-step state copies) in one graph.
+            # Short ctx keys by (base_pos, K); long ctx keys by
+            # (base_pos, cache_base_pos, K) because RoPE position and
+            # compact MTP-cache position intentionally differ there.
             self._chain_drafts_buf = torch.zeros(
                 self.MAX_Q_SEQ - 1, 1, device=device, dtype=torch.long)
             self._captured_chain_graphs: collections.OrderedDict[
-                tuple[int, int], torch.cuda.CUDAGraph,
+                tuple[int, ...], torch.cuda.CUDAGraph,
             ] = collections.OrderedDict()
 
         # Bundle the integer-pointer view forward consumers expect.
@@ -1348,34 +1495,25 @@ class Qwen36TorchFrontendRtx:
             1, 10240, 4, True, s,
         )
 
-        # 6) split conv_out -> q (2048), k (2048), v (6144).
-        q_flat = conv_out[:, :2048]
-        k_flat = conv_out[:, 2048:4096]
-        v_flat = conv_out[:, 4096:10240]
-        q = q_flat.view(1, 1, 16, 128)
-        k = k_flat.view(1, 1, 16, 128)
-        v = v_flat.view(1, 1, 48, 128)
-
-        # 7) beta = sigmoid(b); g = -A_log.exp() * softplus(a + dt_bias).
-        torch.sigmoid(b_vec, out=self._lin_beta)
-        self._lin_a_f32.copy_(a_vec)
-        self._lin_a_f32.add_(lw['dt_bias_fp32_t'])
-        torch.exp(self._lin_a_f32, out=self._lin_sp_buf)
-        torch.log1p(self._lin_sp_buf, out=self._lin_sp_buf)
-        torch.mul(lw['neg_A_log_exp_fp32_t'], self._lin_sp_buf,
-                  out=self._lin_g_f32)
-        self._lin_g_bf.copy_(self._lin_g_f32)
-        beta = self._lin_beta
-        g_bf = self._lin_g_bf
-
-        # 8) Broadcast Q,K from 16 to 48 heads.
-        q_2d = q.view(1, 16, 128)
-        k_2d = k.view(1, 16, 128)
-        torch.index_select(q_2d, 1, self._lin_broadcast_idx, out=self._lin_q48)
-        torch.index_select(k_2d, 1, self._lin_broadcast_idx, out=self._lin_k48)
+        # 6) Split conv_out and broadcast q/k 16 -> 48 heads.
         q3 = self._lin_q48
         k3 = self._lin_k48
-        v3 = v.view(1, 48, 128).contiguous()
+        v3 = self._lin_v48
+        fvk.qwen36_lin_split_qkv_broadcast_bf16(
+            conv_out.data_ptr(), q3.data_ptr(), k3.data_ptr(),
+            v3.data_ptr(), 1, s,
+        )
+
+        # 7) beta = sigmoid(b); g = -A_log.exp() * softplus(a + dt_bias).
+        fvk.qwen36_gdn_gating_bf16(
+            a_vec.data_ptr(), b_vec.data_ptr(),
+            lw['neg_A_log_exp_fp32_t'].data_ptr(),
+            lw['dt_bias_fp32_t'].data_ptr(),
+            self._lin_g_bf.data_ptr(), self._lin_beta.data_ptr(),
+            1, 48, s,
+        )
+        beta = self._lin_beta
+        g_bf = self._lin_g_bf
         attn_out_buf = self._lin_attn_out
 
         fvk.gated_deltanet_recurrent_qwen36_bf16(
@@ -1416,7 +1554,10 @@ class Qwen36TorchFrontendRtx:
 
         # 11) residual.
         attn_proj = out_op_buf[:1].view(1, 1, 5120)
-        torch.add(h_in, attn_proj, out=self._res_mid)
+        fvk.add_bf16_out(
+            h_in.data_ptr(), attn_proj.data_ptr(),
+            self._res_mid.data_ptr(), 5120, s,
+        )
         h_post = self._res_mid
 
         # 12) post-attn layernorm.
@@ -1487,7 +1628,10 @@ class Qwen36TorchFrontendRtx:
 
         # 16) final residual.
         h_out = self._layer_out_a if (L % 2 == 0) else self._layer_out_b
-        torch.add(h_post, mlp_out, out=h_out)
+        fvk.add_bf16_out(
+            h_post.data_ptr(), mlp_out.data_ptr(),
+            h_out.data_ptr(), 5120, s,
+        )
         return h_out
 
     def _layer_forward_full_nvfp4(self, L: int, h_in, cos, sin, cur_pos: int):
@@ -1534,9 +1678,11 @@ class Qwen36TorchFrontendRtx:
             float(lw['q_proj_alpha']),
             s,
         )
-        q_full = q_proj_out_buf[:1].view(1, 1, 24, 512)
-        q_pre, gate = torch.chunk(q_full, 2, dim=-1)
-        gate_flat = gate.reshape(1, 1, 24 * 256)
+        q_pre_2d = self._full_q_rot.view(24, 256)
+        gate_flat = self._full_gate_sig.view(1, 1, 24 * 256)
+        fvk.qwen36_split_q_gate_bf16(
+            q_proj_out_buf[:1].data_ptr(), q_pre_2d.data_ptr(),
+            gate_flat.data_ptr(), 1, s)
 
         # 4) k_proj -> (1, 1024).
         kv_proj_out_buf = self._nvfp4_scratch[(1024, 5120)][2]
@@ -1551,7 +1697,6 @@ class Qwen36TorchFrontendRtx:
         k_pre = kv_proj_out_buf[:1].view(1, 1, 4, 256).contiguous()
 
         # 5) q_norm / k_norm.
-        q_pre_2d = q_pre.contiguous().view(24, 256)
         fvk.rms_norm(
             q_pre_2d.data_ptr(), int(lw['q_norm_eff_w']),
             self._full_q_norm_out.data_ptr(), 24, 256, eps, s,
@@ -1562,32 +1707,17 @@ class Qwen36TorchFrontendRtx:
             self._full_k_norm_out.data_ptr(), 4, 256, eps, s,
         )
 
-        # 6) Inline RoPE on partial (rotary_dim=64) Q/K.
-        q_for_rope = self._full_q_norm_out.view(1, 1, 24, 256)
-        k_for_rope = self._full_k_norm_out.view(1, 1, 4, 256)
-        cos4 = cos.view(1, 1, 1, 64)
-        sin4 = sin.view(1, 1, 1, 64)
-
-        def _rope_inline(x_in, x_out, tmp):
-            x_out[..., 64:].copy_(x_in[..., 64:])
-            torch.index_select(
-                x_in[..., :64], -1, self._rope_rotate_idx, out=tmp,
-            )
-            tmp[..., :32].neg_()
-            tmp.mul_(sin4)
-            tmp.addcmul_(x_in[..., :64], cos4)
-            x_out[..., :64].copy_(tmp)
-
-        _rope_inline(q_for_rope, self._full_q_rot, self._full_rope_tmp_q)
-        _rope_inline(k_for_rope, self._full_k_rot, self._full_rope_tmp_k)
-        q_rot = self._full_q_rot
-        k_rot = self._full_k_rot
-
-        # 7) Stage Q + write K, V to KV cache.
-        self._attn.Q_buf[:, :1].copy_(q_rot)
-        self._attn.K_cache[full_rank, cur_pos:cur_pos + 1].copy_(
-            k_rot.view(1, 4, 256)
+        # 6) Partial RoPE, staging Q and K directly to their hot buffers.
+        q_dst = self._attn.Q_buf[:, :1]
+        k_dst = self._attn.K_cache[full_rank, cur_pos:cur_pos + 1]
+        fvk.qwen36_partial_rope_qk_bf16(
+            self._full_q_norm_out.data_ptr(),
+            self._full_k_norm_out.data_ptr(),
+            cos.data_ptr(), sin.data_ptr(),
+            q_dst.data_ptr(), k_dst.data_ptr(),
+            1, 24, 4, 256, 64, s,
         )
+        # 7) Write V to KV cache.
         # v_proj — reuse kv_proj_out_buf (k already in cache).
         fvk.fp4_w4a16_gemm_sm120_bf16out(
             ap_5120.data_ptr(), int(lw['v_proj_packed']),
@@ -1598,7 +1728,11 @@ class Qwen36TorchFrontendRtx:
             s,
         )
         v_new = kv_proj_out_buf[:1].view(1, 4, 256)
-        self._attn.V_cache[full_rank, cur_pos:cur_pos + 1].copy_(v_new)
+        fvk.gpu_copy(
+            self._attn.V_cache[
+                full_rank, cur_pos:cur_pos + 1].data_ptr(),
+            v_new.data_ptr(), 4 * 256 * 2, s,
+        )
 
         # N7-B4: TurboQuant inject (no-op when disabled or graph-capturing).
         # Replaces just-written K/V in cache with their TQ round-tripped
@@ -1617,8 +1751,10 @@ class Qwen36TorchFrontendRtx:
 
         # 9) Output gate: attn * sigmoid(gate).
         attn_flat = attn_out.reshape(1, 1, 24 * 256)
-        torch.sigmoid(gate_flat, out=self._full_gate_sig)
-        torch.mul(attn_flat, self._full_gate_sig, out=self._full_gated)
+        fvk.sigmoid_mul_qwen36_bf16(
+            gate_flat.data_ptr(), attn_flat.data_ptr(),
+            self._full_gated.data_ptr(), 24 * 256, s,
+        )
         gated = self._full_gated
 
         # 10) o_proj NVFP4: K=6144 -> N=5120.
@@ -1640,7 +1776,10 @@ class Qwen36TorchFrontendRtx:
 
         # 11) Residual.
         attn_proj = out_op_buf[:1].view(1, 1, 5120)
-        torch.add(h_in, attn_proj, out=self._res_mid)
+        fvk.add_bf16_out(
+            h_in.data_ptr(), attn_proj.data_ptr(),
+            self._res_mid.data_ptr(), 5120, s,
+        )
         h_post = self._res_mid
 
         # 12) post-attn layernorm.
@@ -1704,7 +1843,10 @@ class Qwen36TorchFrontendRtx:
 
         # 16) Final residual.
         h_out = self._layer_out_a if (L % 2 == 0) else self._layer_out_b
-        torch.add(h_post, mlp_out, out=h_out)
+        fvk.add_bf16_out(
+            h_post.data_ptr(), mlp_out.data_ptr(),
+            h_out.data_ptr(), 5120, s,
+        )
         return h_out
 
     # ---------- N5-stage3: NVFP4 S=K linear-attn layer ----------
@@ -1735,7 +1877,7 @@ class Qwen36TorchFrontendRtx:
         )
         eps = float(self._cfg['rms_norm_eps'])
 
-        h2 = h_in_K.view(K, 5120).contiguous()
+        h2 = h_in_K.view(K, 5120)
         x_norm = self._h_b[:K].view(K, 5120)
 
         # 1) input layernorm M=K.
@@ -1778,14 +1920,29 @@ class Qwen36TorchFrontendRtx:
         # matmul each.
         a_vec_K = self._K_lin_a_vec[:K]
         b_vec_K = self._K_lin_b_vec[:K]
-        fvk.bf16_matmul_qwen36_bf16(
-            x_norm.data_ptr(), int(lw['in_proj_a_w']),
-            a_vec_K.data_ptr(), K, 48, 5120, s,
-        )
-        fvk.bf16_matmul_qwen36_bf16(
-            x_norm.data_ptr(), int(lw['in_proj_b_w']),
-            b_vec_K.data_ptr(), K, 48, 5120, s,
-        )
+        if self._enable_lin_ab96_kernel:
+            fvk.bf16_matmul_qwen36_ab96_bf16(
+                x_norm.data_ptr(), int(lw['in_proj_ab_w']),
+                self._K_lin_ab_vec[:K].data_ptr(), K, s,
+            )
+        elif (
+            self._lin_ab_torch_mm_min_k > 0
+            and K >= self._lin_ab_torch_mm_min_k
+            and 'in_proj_ab_w_t' in lw
+        ):
+            torch.mm(
+                x_norm, lw['in_proj_ab_w_t'].t(),
+                out=self._K_lin_ab_vec[:K],
+            )
+        else:
+            fvk.bf16_matmul_qwen36_bf16(
+                x_norm.data_ptr(), int(lw['in_proj_a_w']),
+                a_vec_K.data_ptr(), K, 48, 5120, s,
+            )
+            fvk.bf16_matmul_qwen36_bf16(
+                x_norm.data_ptr(), int(lw['in_proj_b_w']),
+                b_vec_K.data_ptr(), K, 48, 5120, s,
+            )
 
         # 5) Per-token conv1d_update with chained per-step state save.
         # A2c-3: conv1d in/out variant chains state through the
@@ -1819,36 +1976,132 @@ class Qwen36TorchFrontendRtx:
             conv_state.copy_(
                 self._K_lin_conv_state_per_step[K - 1, lin_rank])
         else:
-            for k in range(K):
-                qkv_row = qkv_K_view[k:k + 1]
-                conv_out_row = self._K_lin_conv_out[k:k + 1]
-                fvk.causal_conv1d_qwen36_update_bf16(
-                    qkv_row.data_ptr(), int(lw['conv1d_w']),
+            use_conv_chunk = (
+                hasattr(fvk, 'causal_conv1d_qwen36_update_chunk_bf16')
+                and os.environ.get(
+                    'FVK_QWEN36_CHUNK_CONV_PREFILL', '1') == '1'
+            )
+            if use_conv_chunk:
+                conv_chunk = fvk.causal_conv1d_qwen36_update_chunk_bf16
+                if (
+                    hasattr(
+                        fvk,
+                        'causal_conv1d_qwen36_update_chunk_parallel_bf16')
+                    and os.environ.get(
+                        'FVK_QWEN36_CHUNK_CONV_PARALLEL', '1') == '1'
+                ):
+                    conv_chunk = (
+                        fvk.causal_conv1d_qwen36_update_chunk_parallel_bf16
+                    )
+                conv_chunk(
+                    qkv_K_view.data_ptr(), int(lw['conv1d_w']),
                     int(lw['conv1d_b']),
-                    conv_out_row.data_ptr(), conv_state.data_ptr(),
-                    1, 10240, 4, True, s,
+                    self._K_lin_conv_out[:K].data_ptr(),
+                    conv_state.data_ptr(),
+                    1, K, 10240, 4, True, s,
                 )
+            else:
+                for k in range(K):
+                    qkv_row = qkv_K_view[k:k + 1]
+                    conv_out_row = self._K_lin_conv_out[k:k + 1]
+                    fvk.causal_conv1d_qwen36_update_bf16(
+                        qkv_row.data_ptr(), int(lw['conv1d_w']),
+                        int(lw['conv1d_b']),
+                        conv_out_row.data_ptr(), conv_state.data_ptr(),
+                        1, 10240, 4, True, s,
+                    )
 
-        # 5b) Split conv output into Q (K, 16, 128), K (K, 16, 128),
-        # V (K, 48, 128). Layout: [Q_dim=2048, K_dim=2048, V_dim=6144].
+        # 5b) Split conv output into Q/K/V and broadcast Q/K heads from
+        # 16 to 48. The chunk kernel avoids three contiguous materializes
+        # and two torch.index_select launches in long prefill chunks.
         conv_K = self._K_lin_conv_out[:K]
-        q_K_heads = conv_K[:, :2048].contiguous().view(1, K, 16, 128)
-        k_K_heads = conv_K[:, 2048:4096].contiguous().view(1, K, 16, 128)
-        v_K_heads = conv_K[:, 4096:10240].contiguous().view(1, K, 48, 128)
+        use_direct_gdn = (
+            K > self._K_save_max
+            and os.environ.get(
+                'FVK_QWEN36_CHUNK_GDN_PREFILL', '1') == '1'
+            and hasattr(fvk, 'qwen36_gdn_chunk_from_conv_smem_bf16')
+            and hasattr(fvk, 'qwen36_gdn_chunk_from_conv_smem_strided_bf16')
+            and os.environ.get('FVK_QWEN36_GDN_DIRECT_CONV', '1') == '1'
+        )
+        if not use_direct_gdn:
+            q_K_48 = self._K_lin_q48[:K]
+            k_K_48 = self._K_lin_k48[:K]
+            v_K_3d = self._K_lin_v48[:K]
+            use_split_kernel = (
+                hasattr(fvk, 'qwen36_lin_split_qkv_broadcast_bf16')
+                and os.environ.get(
+                    'FVK_QWEN36_LIN_SPLIT_BROADCAST', '1') == '1'
+            )
+            if use_split_kernel:
+                fvk.qwen36_lin_split_qkv_broadcast_bf16(
+                    conv_K.data_ptr(), q_K_48.data_ptr(),
+                    k_K_48.data_ptr(), v_K_3d.data_ptr(), K, s,
+                )
+            else:
+                q_K_heads = conv_K[:, :2048].contiguous().view(
+                    1, K, 16, 128)
+                k_K_heads = conv_K[:, 2048:4096].contiguous().view(
+                    1, K, 16, 128)
+                v_K_heads = conv_K[:, 4096:10240].contiguous().view(
+                    1, K, 48, 128)
+                q_K_2d = q_K_heads.view(K, 16, 128)
+                k_K_2d = k_K_heads.view(K, 16, 128)
+                torch.index_select(q_K_2d, 1, self._lin_broadcast_idx,
+                                   out=q_K_48)
+                torch.index_select(k_K_2d, 1, self._lin_broadcast_idx,
+                                   out=k_K_48)
+                v_K_3d = v_K_heads.view(K, 48, 128)
 
-        # 5c) Compute g, beta for all K tokens (M=K vector ops).
-        beta_K = self._K_lin_beta[:K]
-        torch.sigmoid(b_vec_K, out=beta_K)
-        a_f32_K = self._K_lin_a_f32[:K]
-        a_f32_K.copy_(a_vec_K)
-        a_f32_K.add_(lw['dt_bias_fp32_t'])
-        sp_K = self._K_lin_sp_buf[:K]
-        torch.exp(a_f32_K, out=sp_K)
-        torch.log1p(sp_K, out=sp_K)
-        g_f32_K = self._K_lin_g_f32[:K]
-        torch.mul(lw['neg_A_log_exp_fp32_t'], sp_K, out=g_f32_K)
-        g_bf_K = self._K_lin_g_bf[:K]
-        g_bf_K.copy_(g_f32_K)
+            # 5c) Compute g, beta for all K tokens (M=K vector ops).
+            beta_K = self._K_lin_beta[:K]
+            g_bf_K = self._K_lin_g_bf[:K]
+            exact_verify_gating = (
+                os.environ.get(
+                    'FLASHRT_QWEN36_TQ_VERIFY_EXACT_GATING', '0') == '1'
+            )
+            use_fused_gating = (
+                not exact_verify_gating
+                and hasattr(fvk, 'qwen36_gdn_gating_bf16')
+                and (
+                    (a_vec_K.stride(0) == 48 and b_vec_K.stride(0) == 48)
+                    or hasattr(fvk, 'qwen36_gdn_gating_strided_bf16')
+                )
+                and os.environ.get(
+                    'FVK_QWEN36_GDN_FUSED_GATING', '1') == '1'
+            )
+            if use_fused_gating:
+                a_stride = a_vec_K.stride(0)
+                b_stride = b_vec_K.stride(0)
+                if (
+                    (a_stride != 48 or b_stride != 48)
+                    and hasattr(fvk, 'qwen36_gdn_gating_strided_bf16')
+                ):
+                    fvk.qwen36_gdn_gating_strided_bf16(
+                        a_vec_K.data_ptr(), b_vec_K.data_ptr(),
+                        lw['neg_A_log_exp_fp32_t'].data_ptr(),
+                        lw['dt_bias_fp32_t'].data_ptr(),
+                        g_bf_K.data_ptr(), beta_K.data_ptr(),
+                        K, 48, a_stride, b_stride, s,
+                    )
+                else:
+                    fvk.qwen36_gdn_gating_bf16(
+                        a_vec_K.data_ptr(), b_vec_K.data_ptr(),
+                        lw['neg_A_log_exp_fp32_t'].data_ptr(),
+                        lw['dt_bias_fp32_t'].data_ptr(),
+                        g_bf_K.data_ptr(), beta_K.data_ptr(),
+                        K, 48, s,
+                    )
+            else:
+                torch.sigmoid(b_vec_K, out=beta_K)
+                a_f32_K = self._K_lin_a_f32[:K]
+                a_f32_K.copy_(a_vec_K)
+                a_f32_K.add_(lw['dt_bias_fp32_t'])
+                sp_K = self._K_lin_sp_buf[:K]
+                torch.exp(a_f32_K, out=sp_K)
+                torch.log1p(sp_K, out=sp_K)
+                g_f32_K = self._K_lin_g_f32[:K]
+                torch.mul(lw['neg_A_log_exp_fp32_t'], sp_K, out=g_f32_K)
+                g_bf_K.copy_(g_f32_K)
 
         # 5d) K-iter recurrent (replaces FLA chunk_gated_delta_rule).
         # A2c-3: chain state through per-step save slots via the in/out
@@ -1857,19 +2110,77 @@ class Qwen36TorchFrontendRtx:
         # lin_state for k=0) and writes to slot k. After K steps,
         # lin_state ← per_step[K-1] (1 final copy per layer instead
         # of K copies inside the loop).
-        q_K_2d = q_K_heads.view(K, 16, 128)
-        k_K_2d = k_K_heads.view(K, 16, 128)
-        q_K_48 = self._K_lin_q48[:K]
-        k_K_48 = self._K_lin_k48[:K]
-        torch.index_select(q_K_2d, 1, self._lin_broadcast_idx,
-                           out=q_K_48)
-        torch.index_select(k_K_2d, 1, self._lin_broadcast_idx,
-                           out=k_K_48)
         rec_state_view = self._lin_state[lin_rank]  # (1, 48, 128, 128)
-        v_K_3d = v_K_heads.view(K, 48, 128)
         attn_out_K_buf = self._K_lin_attn_out[:K]
+        attn_out_K = None
+        gdn_backend = os.environ.get(
+            'FLASHRT_QWEN36_TQ_PREFILL_GDN_BACKEND', 'fla_chunk')
+        use_fla_chunk = (
+            K > self._K_save_max
+            and gdn_backend in ('fla', 'fla_chunk', 'fla_ref')
+        )
         use_inout = K <= self._K_save_max
-        if use_inout:
+        if use_fla_chunk:
+            if (
+                hasattr(fvk, 'qwen36_lin_split_qkv_gqa_bf16')
+                and os.environ.get(
+                    'FVK_QWEN36_LIN_SPLIT_GQA', '1') == '1'
+            ):
+                q16_K = self._K_lin_q16[:K]
+                k16_K = self._K_lin_k16[:K]
+                v48_K = self._K_lin_v48[:K]
+                fvk.qwen36_lin_split_qkv_gqa_bf16(
+                    conv_K.data_ptr(), q16_K.data_ptr(),
+                    k16_K.data_ptr(), v48_K.data_ptr(), K, s,
+                )
+                q_K_heads = q16_K.view(1, K, 16, 128)
+                k_K_heads = k16_K.view(1, K, 16, 128)
+                v_K_heads = v48_K.view(1, K, 48, 128)
+            else:
+                q_K_heads = conv_K[:, :2048].contiguous().view(
+                    1, K, 16, 128)
+                k_K_heads = conv_K[:, 2048:4096].contiguous().view(
+                    1, K, 16, 128)
+                v_K_heads = conv_K[:, 4096:10240].contiguous().view(
+                    1, K, 48, 128)
+
+            beta_K = self._K_lin_beta[:K]
+            g_bf_K = self._K_lin_g_bf[:K]
+            a_stride = a_vec_K.stride(0)
+            b_stride = b_vec_K.stride(0)
+            if (
+                (a_stride != 48 or b_stride != 48)
+                and hasattr(fvk, 'qwen36_gdn_gating_strided_bf16')
+            ):
+                fvk.qwen36_gdn_gating_strided_bf16(
+                    a_vec_K.data_ptr(), b_vec_K.data_ptr(),
+                    lw['neg_A_log_exp_fp32_t'].data_ptr(),
+                    lw['dt_bias_fp32_t'].data_ptr(),
+                    g_bf_K.data_ptr(), beta_K.data_ptr(),
+                    K, 48, a_stride, b_stride, s,
+                )
+            else:
+                fvk.qwen36_gdn_gating_bf16(
+                    a_vec_K.data_ptr(), b_vec_K.data_ptr(),
+                    lw['neg_A_log_exp_fp32_t'].data_ptr(),
+                    lw['dt_bias_fp32_t'].data_ptr(),
+                    g_bf_K.data_ptr(), beta_K.data_ptr(),
+                    K, 48, s,
+                )
+            chunk_gated_delta_rule = _load_qwen36_fla_chunk()
+            attn_out_K, new_state = chunk_gated_delta_rule(
+                q_K_heads, k_K_heads, v_K_heads,
+                g_bf_K.view(1, K, 48), beta_K.view(1, K, 48),
+                initial_state=rec_state_view,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                q_l2_out=self._K_fla_q16_l2[:, :K],
+                k_l2_out=self._K_fla_k16_l2[:, :K],
+                g_cumsum_out=self._K_fla_g_cumsum[:, :K],
+                o_out=self._K_lin_attn_out[:K].view(1, K, 48, 128),
+            )
+            rec_state_view.copy_(new_state)
+        elif use_inout:
             for k in range(K):
                 state_in_ptr = (
                     rec_state_view.data_ptr() if k == 0
@@ -1889,20 +2200,80 @@ class Qwen36TorchFrontendRtx:
             rec_state_view.copy_(
                 self._K_lin_state_per_step[K - 1, lin_rank])
         else:
-            # Fallback for K beyond save buffer: original in-place + copy path.
-            for k in range(K):
-                fvk.gated_deltanet_recurrent_qwen36_bf16(
-                    q_K_48[k].data_ptr(), k_K_48[k].data_ptr(),
-                    v_K_3d[k].data_ptr(),
-                    g_bf_K[k].data_ptr(), beta_K[k].data_ptr(),
-                    rec_state_view.data_ptr(),
-                    attn_out_K_buf[k].data_ptr(),
-                    1, 48, 128, 128, True, s,
+            use_chunk_scan = (
+                hasattr(fvk, 'gated_deltanet_chunk_qwen36_bf16')
+                and os.environ.get(
+                    'FVK_QWEN36_CHUNK_GDN_PREFILL', '1') == '1'
+            )
+            if use_chunk_scan:
+                use_direct_gdn = (
+                    hasattr(fvk, 'qwen36_gdn_chunk_from_conv_smem_bf16')
+                    and hasattr(
+                        fvk, 'qwen36_gdn_chunk_from_conv_smem_strided_bf16')
+                    and os.environ.get(
+                        'FVK_QWEN36_GDN_DIRECT_CONV', '1') == '1'
                 )
-        attn_out_K = attn_out_K_buf.view(1, K, 48, 128)
+                if use_direct_gdn:
+                    a_stride = a_vec_K.stride(0)
+                    b_stride = b_vec_K.stride(0)
+                    if (
+                        (a_stride != 48 or b_stride != 48)
+                        and hasattr(
+                            fvk,
+                            'qwen36_gdn_chunk_from_conv_smem_strided_bf16')
+                    ):
+                        fvk.qwen36_gdn_chunk_from_conv_smem_strided_bf16(
+                            conv_K.data_ptr(),
+                            a_vec_K.data_ptr(), b_vec_K.data_ptr(),
+                            lw['neg_A_log_exp_fp32_t'].data_ptr(),
+                            lw['dt_bias_fp32_t'].data_ptr(),
+                            rec_state_view.data_ptr(),
+                            attn_out_K_buf.data_ptr(),
+                            K, 48, a_stride, b_stride, True, s,
+                        )
+                    else:
+                        fvk.qwen36_gdn_chunk_from_conv_smem_bf16(
+                            conv_K.data_ptr(),
+                            a_vec_K.data_ptr(), b_vec_K.data_ptr(),
+                            lw['neg_A_log_exp_fp32_t'].data_ptr(),
+                            lw['dt_bias_fp32_t'].data_ptr(),
+                            rec_state_view.data_ptr(),
+                            attn_out_K_buf.data_ptr(),
+                            K, 48, True, s,
+                        )
+                else:
+                    gdn_chunk = fvk.gated_deltanet_chunk_qwen36_bf16
+                    if (
+                        os.environ.get(
+                            'FVK_QWEN36_CHUNK_GDN_SMEM', '1') == '1'
+                        and hasattr(
+                            fvk, 'gated_deltanet_chunk_smem_qwen36_bf16')
+                    ):
+                        gdn_chunk = fvk.gated_deltanet_chunk_smem_qwen36_bf16
+                    gdn_chunk(
+                        q_K_48.data_ptr(), k_K_48.data_ptr(),
+                        v_K_3d.data_ptr(),
+                        g_bf_K.data_ptr(), beta_K.data_ptr(),
+                        rec_state_view.data_ptr(),
+                        attn_out_K_buf.data_ptr(),
+                        K, 48, 128, 128, True, s,
+                    )
+            else:
+                # Fallback for K beyond save buffer: original in-place path.
+                for k in range(K):
+                    fvk.gated_deltanet_recurrent_qwen36_bf16(
+                        q_K_48[k].data_ptr(), k_K_48[k].data_ptr(),
+                        v_K_3d[k].data_ptr(),
+                        g_bf_K[k].data_ptr(), beta_K[k].data_ptr(),
+                        rec_state_view.data_ptr(),
+                        attn_out_K_buf[k].data_ptr(),
+                        1, 48, 128, 128, True, s,
+                    )
+        if attn_out_K is None:
+            attn_out_K = attn_out_K_buf.view(1, K, 48, 128)
 
         # 5e) rms_norm_gated_silu over (K*48, 128) rows in one call.
-        attn_out_flat = attn_out_K.contiguous().view(K * 48, 128)
+        attn_out_flat = attn_out_K.view(K * 48, 128)
         z_flat = out_z_K.view(K * 48, 128)
         norm_out_flat = self._K_lin_norm_out[:K].view(K * 48, 128)
         fvk.rms_norm_gated_silu_qwen36_bf16(
@@ -1945,39 +2316,67 @@ class Qwen36TorchFrontendRtx:
             K, 5120, eps, s,
         )
         h_post = res_mid_K
-        gate_out_buf = self._nvfp4_scratch[(17408, 5120)][2]
-        up_out_buf = self._mlp_up_out
         # 8b) MLP gate / up: NVFP4 GEMM at M=K.
-        fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
-            ap_5120.data_ptr(), int(lw['mlp_gate_packed']),
-            gate_out_buf.data_ptr(),
-            K, 17408, 5120,
-            sf_5120.data_ptr(), int(lw['mlp_gate_sf']),
-            float(lw['mlp_gate_alpha']),
-            s,
-        )
-        fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
-            ap_5120.data_ptr(), int(lw['mlp_up_packed']),
-            up_out_buf.data_ptr(),
-            K, 17408, 5120,
-            sf_5120.data_ptr(), int(lw['mlp_up_sf']),
-            float(lw['mlp_up_alpha']),
-            s,
-        )
-        # 8c) silu(gate) * up over K*17408 elements.
-        gate_v = gate_out_buf[:K].view(K, 17408)
-        up_v = up_out_buf[:K].view(K, 17408)
-        silu_out = self._K_mlp_silu_mul_out[:K]
-        fvk.silu_mul_qwen36_bf16(
-            gate_v.data_ptr(), up_v.data_ptr(),
-            silu_out.data_ptr(), K * 17408, s,
-        )
-        # 8d) MLP down: NVFP4 quant act (M=K, K_in=17408), NVFP4 GEMM.
+        if self._enable_mlp_gate_up_fusion:
+            gate_up_buf = self._K_mlp_gate_up_out[:K]
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_5120.data_ptr(), int(lw['mlp_gate_up_packed']),
+                gate_up_buf.data_ptr(),
+                K, int(lw['mlp_gate_up_N']), 5120,
+                sf_5120.data_ptr(), int(lw['mlp_gate_up_sf']),
+                float(lw['mlp_gate_up_alpha']),
+                s,
+            )
+            gate_out_buf = gate_up_buf[:, :17408]
+            up_out_buf = gate_up_buf[:, 17408:]
+        else:
+            gate_out_buf = self._nvfp4_scratch[(17408, 5120)][2]
+            up_out_buf = self._mlp_up_out
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_5120.data_ptr(), int(lw['mlp_gate_packed']),
+                gate_out_buf.data_ptr(),
+                K, 17408, 5120,
+                sf_5120.data_ptr(), int(lw['mlp_gate_sf']),
+                float(lw['mlp_gate_alpha']),
+                s,
+            )
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_5120.data_ptr(), int(lw['mlp_up_packed']),
+                up_out_buf.data_ptr(),
+                K, 17408, 5120,
+                sf_5120.data_ptr(), int(lw['mlp_up_sf']),
+                float(lw['mlp_up_alpha']),
+                s,
+            )
         ap_17408, sf_17408, _ = self._nvfp4_scratch[(5120, 17408)]
-        fvk.quantize_bf16_to_nvfp4_swizzled(
-            silu_out.data_ptr(), ap_17408.data_ptr(),
-            sf_17408.data_ptr(), K, 17408, s,
-        )
+        if self._enable_silu_mul_quant_fusion:
+            if self._enable_mlp_gate_up_fusion:
+                fvk.silu_mul_merged_to_nvfp4_swizzled_bf16(
+                    gate_up_buf.data_ptr(),
+                    ap_17408.data_ptr(), sf_17408.data_ptr(),
+                    K, 17408, s,
+                )
+            else:
+                gate_v = gate_out_buf[:K].view(K, 17408)
+                up_v = up_out_buf[:K].view(K, 17408)
+                fvk.silu_mul_to_nvfp4_swizzled_bf16(
+                    gate_v.data_ptr(), up_v.data_ptr(),
+                    ap_17408.data_ptr(), sf_17408.data_ptr(),
+                    K, 17408, s,
+                )
+        else:
+            gate_v = gate_out_buf[:K].view(K, 17408)
+            up_v = up_out_buf[:K].view(K, 17408)
+            silu_out = self._K_mlp_silu_mul_out[:K]
+            fvk.silu_mul_qwen36_bf16(
+                gate_v.data_ptr(), up_v.data_ptr(),
+                silu_out.data_ptr(), K * 17408, s,
+            )
+            fvk.quantize_bf16_to_nvfp4_swizzled(
+                silu_out.data_ptr(), ap_17408.data_ptr(),
+                sf_17408.data_ptr(), K, 17408, s,
+            )
+        # 8d) MLP down: NVFP4 GEMM.
         down_out_buf = self._nvfp4_scratch[(5120, 17408)][2]
         fvk.fp4_w4a16_gemm_sm120_bf16out(
             ap_17408.data_ptr(), int(lw['mlp_down_packed']),
@@ -1993,7 +2392,10 @@ class Qwen36TorchFrontendRtx:
         h_out = (self._K_layer_out_a if (L % 2 == 0)
                  else self._K_layer_out_b)
         h_out_K = h_out[:, :K]
-        torch.add(h_post, mlp_out, out=h_out_K)
+        fvk.add_bf16_out(
+            h_post.data_ptr(), mlp_out.data_ptr(),
+            h_out_K.data_ptr(), K * 5120, s,
+        )
         return h_out_K
 
     # ---------- N5-stage4: NVFP4 S=K full-attn layer ----------
@@ -2009,9 +2411,9 @@ class Qwen36TorchFrontendRtx:
             activation, then ``fp4_w4a16_gemm_sm120_bf16out`` at M=K.
           * MLP gate / up / down: same NVFP4 quant + GEMM pattern.
 
-        The K serial q_seq=1 FA2 calls (workaround for fwd_bf16's
-        missing causal flag) are identical to the FP8 path — kernel
-        ABI is format-agnostic.
+        The attention step prefers one causal q_seq=K FA2 call, with a
+        guarded fallback to the historical K serial q_seq=1 calls on
+        older builds.
         """
         import torch
         from flash_rt import flash_rt_kernels as fvk
@@ -2024,7 +2426,7 @@ class Qwen36TorchFrontendRtx:
         eps = float(self._cfg['rms_norm_eps'])
         full_rank = self._full_layer_rank(L)
 
-        h2 = h_in_K.view(K, 5120).contiguous()
+        h2 = h_in_K.view(K, 5120)
 
         # 1) input layernorm + NVFP4 quant — fused (B1).
         # Output (packed + swizzled SF) is reused by q/k/v projections;
@@ -2046,9 +2448,11 @@ class Qwen36TorchFrontendRtx:
             float(lw['q_proj_alpha']),
             s,
         )
-        q_full = q_proj_out_buf[:K].view(1, K, 24, 512)
-        q_pre, gate = torch.chunk(q_full, 2, dim=-1)
-        gate_flat = gate.reshape(1, K, 24 * 256)
+        q_pre_2d = self._K_full_q_rot[:, :K].view(K * 24, 256)
+        gate_flat = self._K_full_gate_sig[:, :K]
+        fvk.qwen36_split_q_gate_bf16(
+            q_proj_out_buf[:K].data_ptr(), q_pre_2d.data_ptr(),
+            gate_flat.data_ptr(), K, s)
 
         # 4) k_proj — M=K, N=1024.
         kv_proj_out_buf = self._nvfp4_scratch[(1024, 5120)][2]
@@ -2060,10 +2464,9 @@ class Qwen36TorchFrontendRtx:
             float(lw['k_proj_alpha']),
             s,
         )
-        k_pre = kv_proj_out_buf[:K].view(1, K, 4, 256).contiguous()
+        k_pre = kv_proj_out_buf[:K].view(1, K, 4, 256)
 
         # 5) q_norm / k_norm — per-head RMSNorm (M = K * heads).
-        q_pre_2d = q_pre.contiguous().view(K * 24, 256)
         q_norm_out = self._K_full_q_norm_out[:K * 24]
         fvk.rms_norm(
             q_pre_2d.data_ptr(), int(lw['q_norm_eff_w']),
@@ -2078,33 +2481,25 @@ class Qwen36TorchFrontendRtx:
             K * 4, 256, eps, s,
         )
 
-        # 6) RoPE inline over K positions (cos_K / sin_K shape (1, K, 64)).
-        q_for_rope = q_norm_out.view(1, K, 24, 256)
-        k_for_rope = k_norm_out.view(1, K, 4, 256)
-        cos4 = cos_K.view(1, K, 1, 64)
-        sin4 = sin_K.view(1, K, 1, 64)
-        q_rot_K = self._K_full_q_rot[:, :K]
-        k_rot_K = self._K_full_k_rot[:, :K]
-        tmp_q = self._K_full_rope_tmp_q[:, :K]
-        tmp_k = self._K_full_rope_tmp_k[:, :K]
-
-        def _rope_inline_K(x_in, x_out, tmp):
-            x_out[..., 64:].copy_(x_in[..., 64:])
-            torch.index_select(
-                x_in[..., :64], -1, self._rope_rotate_idx, out=tmp,
-            )
-            tmp[..., :32].neg_()
-            tmp.mul_(sin4)
-            tmp.addcmul_(x_in[..., :64], cos4)
-            x_out[..., :64].copy_(tmp)
-
-        _rope_inline_K(q_for_rope, q_rot_K, tmp_q)
-        _rope_inline_K(k_for_rope, k_rot_K, tmp_k)
-
-        # 7) Stage Q in backend Q_buf [:, :K]; write K rows of K/V.
-        self._attn.Q_buf[:, :K].copy_(q_rot_K)
-        self._attn.K_cache[full_rank, cur_pos:cur_pos + K].copy_(
-            k_rot_K.view(K, 4, 256))
+        # 6) Partial RoPE over K positions. Q is staged directly for FA2;
+        # K writes either to the BF16 cache or to a compressed-KV scratch
+        # before being quantized into the long-context cache.
+        use_tq_verify = bool(getattr(self, '_tq_verify_active', False))
+        use_fp8_verify = bool(getattr(
+            self, '_fp8_kv_verify_active', False))
+        use_compressed_kv = use_tq_verify or use_fp8_verify
+        q_dst = self._attn.Q_buf[:, :K]
+        if use_compressed_kv:
+            k_new_K = self._K_full_k_rot[:, :K].view(K, 4, 256)
+        else:
+            k_new_K = self._attn.K_cache[
+                full_rank, cur_pos:cur_pos + K]
+        fvk.qwen36_partial_rope_qk_bf16(
+            q_norm_out.data_ptr(), k_norm_out.data_ptr(),
+            cos_K.view(K, 64).data_ptr(), sin_K.view(K, 64).data_ptr(),
+            q_dst.data_ptr(), k_new_K.data_ptr(),
+            K, 24, 4, 256, 64, s,
+        )
 
         # v_proj — M=K (overwrite kv_proj_out_buf, K already in cache).
         fvk.fp4_w4a16_gemm_sm120_bf16out(
@@ -2116,30 +2511,65 @@ class Qwen36TorchFrontendRtx:
             s,
         )
         v_new_K = kv_proj_out_buf[:K].view(K, 4, 256)
-        self._attn.V_cache[full_rank, cur_pos:cur_pos + K].copy_(v_new_K)
+        if use_tq_verify:
+            cache = self._tq_cache_packed
+            if cache.packed and hasattr(fvk, 'tq_write_k1_unit_norm'):
+                cache.write_kv_fast(
+                    full_rank, cur_pos, cur_pos + K, k_new_K, v_new_K)
+            else:
+                cache.write_kv(
+                    full_rank, cur_pos, cur_pos + K, k_new_K, v_new_K)
+            k_stage, v_stage = self._tq_stage_for_layer(
+                full_rank, cur_pos + K)
+        elif use_fp8_verify:
+            self._fp8_write_kv(
+                full_rank, cur_pos, cur_pos + K, k_new_K, v_new_K)
+            if self._fp8_xqa_enabled(K, cur_pos + K):
+                k_stage = None
+                v_stage = None
+            else:
+                k_stage, v_stage = self._fp8_stage_for_layer(
+                    full_rank, cur_pos + K)
+        else:
+            fvk.gpu_copy(
+                self._attn.V_cache[
+                    full_rank, cur_pos:cur_pos + K].data_ptr(),
+                v_new_K.data_ptr(), K * 4 * 256 * 2, s,
+            )
+            # N7-B4: TurboQuant inject for the K rows just written.
+            self._tq_inject_kv(full_rank, cur_pos, count=K)
 
-        # N7-B4: TurboQuant inject for the K rows just written.
-        self._tq_inject_kv(full_rank, cur_pos, count=K)
-
-        # 8) FA2 — K serial q_seq=1 calls (fwd_bf16 has no causal flag).
-        # Each call's kv_seq is bound by Q's own position so K[j>i] is
-        # not read. Mirror of FP8 path (commit 2e16c11).
+        # 8) FA2. Prefer one causal q_seq=K call when the vendored
+        # hdim=256 causal entry is present; older builds fall back to K
+        # serial q_seq=1 calls, binding kv_seq to each Q position.
         scaling = float(self._cfg['head_dim']) ** -0.5
-        for k in range(K):
-            q_view = self._attn.Q_buf[:, k:k + 1]
-            kv_seq_k = cur_pos + k + 1
-            k_view = self._attn.K_cache[
-                full_rank:full_rank + 1, :kv_seq_k]
-            v_view = self._attn.V_cache[
-                full_rank:full_rank + 1, :kv_seq_k]
-            o_view = self._attn.O_buf[:, k:k + 1]
-            self._attn._fa2_fwd(
+        use_causal_fa2 = (
+            K > 1
+            and getattr(self._attn, '_fa2_fwd_causal', None) is not None
+            and os.environ.get('FVK_QWEN36_CAUSAL_PREFILL_FA2', '1') == '1'
+        )
+        if use_fp8_verify and self._fp8_xqa_enabled(K, cur_pos + K):
+            self._fp8_xqa_attn(full_rank, cur_pos + K, K, s)
+        elif use_causal_fa2:
+            if use_compressed_kv:
+                k_view = k_stage[:cur_pos + K].view(
+                    1, cur_pos + K, 4, 256)
+                v_view = v_stage[:cur_pos + K].view(
+                    1, cur_pos + K, 4, 256)
+            else:
+                k_view = self._attn.K_cache[
+                    full_rank:full_rank + 1, :cur_pos + K]
+                v_view = self._attn.V_cache[
+                    full_rank:full_rank + 1, :cur_pos + K]
+            q_view = self._attn.Q_buf[:, :K]
+            o_view = self._attn.O_buf[:, :K]
+            self._attn._fa2_fwd_causal(
                 Q=q_view.data_ptr(), K=k_view.data_ptr(),
                 V=v_view.data_ptr(), O=o_view.data_ptr(),
                 softmax_lse=self._attn.lse_buf.data_ptr(),
                 softmax_lse_accum=self._attn.lse_accum.data_ptr(),
                 o_accum=self._attn.o_accum.data_ptr(),
-                batch=1, seqlen_q=1, seqlen_k=kv_seq_k,
+                batch=1, seqlen_q=K, seqlen_k=cur_pos + K,
                 num_heads_q=24, num_heads_kv=4,
                 head_dim=256,
                 q_strides=(q_view.stride(0), q_view.stride(1),
@@ -2154,18 +2584,55 @@ class Qwen36TorchFrontendRtx:
                 num_sms=self._attn._num_sms,
                 stream=s,
             )
+        else:
+            for k in range(K):
+                q_view = self._attn.Q_buf[:, k:k + 1]
+                kv_seq_k = cur_pos + k + 1
+                if use_compressed_kv:
+                    k_view = k_stage[:kv_seq_k].view(
+                        1, kv_seq_k, 4, 256)
+                    v_view = v_stage[:kv_seq_k].view(
+                        1, kv_seq_k, 4, 256)
+                else:
+                    k_view = self._attn.K_cache[
+                        full_rank:full_rank + 1, :kv_seq_k]
+                    v_view = self._attn.V_cache[
+                        full_rank:full_rank + 1, :kv_seq_k]
+                o_view = self._attn.O_buf[:, k:k + 1]
+                self._attn._fa2_fwd(
+                    Q=q_view.data_ptr(), K=k_view.data_ptr(),
+                    V=v_view.data_ptr(), O=o_view.data_ptr(),
+                    softmax_lse=self._attn.lse_buf.data_ptr(),
+                    softmax_lse_accum=self._attn.lse_accum.data_ptr(),
+                    o_accum=self._attn.o_accum.data_ptr(),
+                    batch=1, seqlen_q=1, seqlen_k=kv_seq_k,
+                    num_heads_q=24, num_heads_kv=4,
+                    head_dim=256,
+                    q_strides=(q_view.stride(0), q_view.stride(1),
+                               q_view.stride(2)),
+                    k_strides=(k_view.stride(0), k_view.stride(1),
+                               k_view.stride(2)),
+                    v_strides=(v_view.stride(0), v_view.stride(1),
+                               v_view.stride(2)),
+                    o_strides=(o_view.stride(0), o_view.stride(1),
+                               o_view.stride(2)),
+                    softmax_scale=scaling,
+                    num_sms=self._attn._num_sms,
+                    stream=s,
+                )
         attn_out = self._attn.O_buf[:, :K]  # (1, K, 24, 256)
 
         # 9) Output gate: attn * sigmoid(gate). K rows.
         attn_flat = attn_out.reshape(1, K, 24 * 256)
-        gate_sig = self._K_full_gate_sig[:, :K]
         gated = self._K_full_gated[:, :K]
-        torch.sigmoid(gate_flat, out=gate_sig)
-        torch.mul(attn_flat, gate_sig, out=gated)
+        fvk.sigmoid_mul_qwen36_bf16(
+            gate_flat.data_ptr(), attn_flat.data_ptr(),
+            gated.data_ptr(), K * 24 * 256, s,
+        )
 
         # 10) o_proj NVFP4 — M=K, N=5120, K_in=6144.
         ap_6144, sf_6144, _ = self._nvfp4_scratch[(5120, 6144)]
-        gated_2d = gated.view(K, 6144).contiguous()
+        gated_2d = gated.view(K, 6144)
         fvk.quantize_bf16_to_nvfp4_swizzled(
             gated_2d.data_ptr(), ap_6144.data_ptr(),
             sf_6144.data_ptr(), K, 6144, s,
@@ -2192,40 +2659,68 @@ class Qwen36TorchFrontendRtx:
             K, 5120, eps, s,
         )
         h_post = res_mid_K
-        gate_out_buf = self._nvfp4_scratch[(17408, 5120)][2]
-        up_out_buf = self._mlp_up_out
-        fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
-            ap_mlp.data_ptr(), int(lw['mlp_gate_packed']),
-            gate_out_buf.data_ptr(),
-            K, 17408, 5120,
-            sf_mlp.data_ptr(), int(lw['mlp_gate_sf']),
-            float(lw['mlp_gate_alpha']),
-            s,
-        )
-        fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
-            ap_mlp.data_ptr(), int(lw['mlp_up_packed']),
-            up_out_buf.data_ptr(),
-            K, 17408, 5120,
-            sf_mlp.data_ptr(), int(lw['mlp_up_sf']),
-            float(lw['mlp_up_alpha']),
-            s,
-        )
+        if self._enable_mlp_gate_up_fusion:
+            gate_up_buf = self._K_mlp_gate_up_out[:K]
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_mlp.data_ptr(), int(lw['mlp_gate_up_packed']),
+                gate_up_buf.data_ptr(),
+                K, int(lw['mlp_gate_up_N']), 5120,
+                sf_mlp.data_ptr(), int(lw['mlp_gate_up_sf']),
+                float(lw['mlp_gate_up_alpha']),
+                s,
+            )
+            gate_out_buf = gate_up_buf[:, :17408]
+            up_out_buf = gate_up_buf[:, 17408:]
+        else:
+            gate_out_buf = self._nvfp4_scratch[(17408, 5120)][2]
+            up_out_buf = self._mlp_up_out
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_mlp.data_ptr(), int(lw['mlp_gate_packed']),
+                gate_out_buf.data_ptr(),
+                K, 17408, 5120,
+                sf_mlp.data_ptr(), int(lw['mlp_gate_sf']),
+                float(lw['mlp_gate_alpha']),
+                s,
+            )
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_mlp.data_ptr(), int(lw['mlp_up_packed']),
+                up_out_buf.data_ptr(),
+                K, 17408, 5120,
+                sf_mlp.data_ptr(), int(lw['mlp_up_sf']),
+                float(lw['mlp_up_alpha']),
+                s,
+            )
 
-        # 14) silu(gate) * up over K*17408 elements.
-        gate_v = gate_out_buf[:K].view(K, 17408)
-        up_v = up_out_buf[:K].view(K, 17408)
-        silu_out = self._K_mlp_silu_mul_out[:K]
-        fvk.silu_mul_qwen36_bf16(
-            gate_v.data_ptr(), up_v.data_ptr(),
-            silu_out.data_ptr(), K * 17408, s,
-        )
-
-        # 15) MLP down: NVFP4 quant + GEMM at M=K.
         ap_dn, sf_dn, _ = self._nvfp4_scratch[(5120, 17408)]
-        fvk.quantize_bf16_to_nvfp4_swizzled(
-            silu_out.data_ptr(), ap_dn.data_ptr(),
-            sf_dn.data_ptr(), K, 17408, s,
-        )
+        if self._enable_silu_mul_quant_fusion:
+            if self._enable_mlp_gate_up_fusion:
+                fvk.silu_mul_merged_to_nvfp4_swizzled_bf16(
+                    gate_up_buf.data_ptr(),
+                    ap_dn.data_ptr(), sf_dn.data_ptr(),
+                    K, 17408, s,
+                )
+            else:
+                gate_v = gate_out_buf[:K].view(K, 17408)
+                up_v = up_out_buf[:K].view(K, 17408)
+                fvk.silu_mul_to_nvfp4_swizzled_bf16(
+                    gate_v.data_ptr(), up_v.data_ptr(),
+                    ap_dn.data_ptr(), sf_dn.data_ptr(),
+                    K, 17408, s,
+                )
+        else:
+            gate_v = gate_out_buf[:K].view(K, 17408)
+            up_v = up_out_buf[:K].view(K, 17408)
+            silu_out = self._K_mlp_silu_mul_out[:K]
+            fvk.silu_mul_qwen36_bf16(
+                gate_v.data_ptr(), up_v.data_ptr(),
+                silu_out.data_ptr(), K * 17408, s,
+            )
+            fvk.quantize_bf16_to_nvfp4_swizzled(
+                silu_out.data_ptr(), ap_dn.data_ptr(),
+                sf_dn.data_ptr(), K, 17408, s,
+            )
+
+        # 15) MLP down: NVFP4 GEMM at M=K.
         down_out_buf = self._nvfp4_scratch[(5120, 17408)][2]
         fvk.fp4_w4a16_gemm_sm120_bf16out(
             ap_dn.data_ptr(), int(lw['mlp_down_packed']),
@@ -2241,7 +2736,10 @@ class Qwen36TorchFrontendRtx:
         h_out = (self._K_layer_out_a if (L % 2 == 0)
                  else self._K_layer_out_b)
         h_out_K = h_out[:, :K]
-        torch.add(h_post, mlp_out, out=h_out_K)
+        fvk.add_bf16_out(
+            h_post.data_ptr(), mlp_out.data_ptr(),
+            h_out_K.data_ptr(), K * 5120, s,
+        )
         return h_out_K
 
     def forward_own_decode_nvfp4(self, token_id, cos_pos, sin_pos,
@@ -2268,15 +2766,13 @@ class Qwen36TorchFrontendRtx:
                 [token_id], device=self.device, dtype=torch.long)
         if token_id.ndim == 1:
             token_id = token_id.view(1, 1)
-        # embed_w (vocab, hidden) bf16; anchors[0] is embed_w
-        # (per extract_weights_nvfp4 ordering: top-level first).
-        embed_w_ptr = self._weights.ptrs['embed_w']
-        # Reconstruct an indexable view by walking handles.anchors —
-        # the embed weight is the first anchor pushed in our loader.
-        embed_t = self._weights.anchors[0]  # (vocab, hidden) bf16
-        h = embed_t[token_id.view(-1)].view(1, 1, hidden).contiguous()
-        if h.dtype != bf16:
-            h = h.to(bf16)
+        fvk.qwen36_embedding_lookup_bf16(
+            token_id.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            self._embed_buf.data_ptr(),
+            1, hidden, s,
+        )
+        h = self._embed_buf
 
         for L in range(self._cfg['num_hidden_layers']):
             t = types[L]
@@ -2295,6 +2791,14 @@ class Qwen36TorchFrontendRtx:
             h2.data_ptr(), int(self._weights.ptrs['final_norm_eff_w']),
             x_norm.data_ptr(), 1, hidden, eps, s,
         )
+
+        if 'lm_head_w_bf16' in self._weights.ptrs:
+            fvk.bf16_matvec_qwen36_bf16(
+                x_norm.data_ptr(),
+                int(self._weights.ptrs['lm_head_w_bf16']),
+                self._logits_buf.data_ptr(), vocab, hidden, s,
+            )
+            return self._logits_buf
 
         # G8: lm_head NVFP4 GEMM (was BF16 matvec). Reuse the K=5120
         # activation scratch from any existing (*, 5120) entry — they
@@ -2318,7 +2822,8 @@ class Qwen36TorchFrontendRtx:
 
     def forward_own_decode_K_nvfp4(self, token_ids_K, cos_K, sin_K,
                                     cur_pos: int, K: int,
-                                    tap_buf=None):
+                                    tap_buf=None,
+                                    logits_mode: str = 'all'):
         """NVFP4 S=K decode: 64 layers + final norm + lm_head at K rows.
 
         Mirror of FP8 ``forward_own_decode_K`` but routes through the
@@ -2351,10 +2856,13 @@ class Qwen36TorchFrontendRtx:
             token_ids_K = torch.tensor(
                 token_ids_K, device=self.device, dtype=torch.long)
         token_ids_K = token_ids_K.view(K)
-        embed_t = self._weights.anchors[0]  # (vocab, hidden) bf16
-        h = embed_t[token_ids_K].view(1, K, hidden).contiguous()
-        if h.dtype != bf16:
-            h = h.to(bf16)
+        fvk.qwen36_embedding_lookup_bf16(
+            token_ids_K.data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            self._K_embed_buf.data_ptr(),
+            K, hidden, s,
+        )
+        h = self._K_embed_buf[:, :K]
 
         # 1) 64 decoder layers at S=K.
         for L in range(self._cfg['num_hidden_layers']):
@@ -2375,18 +2883,56 @@ class Qwen36TorchFrontendRtx:
                 if tap_idx >= 0:
                     tap_buf[tap_idx, :K].copy_(h.view(K, hidden))
 
+        if logits_mode not in ('all', 'last', 'none', 'hidden', 'hidden_last'):
+            raise ValueError(
+                "logits_mode must be 'all', 'last', 'none', 'hidden', "
+                "'hidden_last', got "
+                f"{logits_mode!r}")
+
         # 2) Stash pre-final-norm hidden so MTP head / chained spec
-        # can consume per-row hiddens.
-        self._K_last_hidden_buf[:, :K].copy_(h)
+        # can consume per-row hiddens. Long prefill only needs the last
+        # row and intermediate prompt chunks need no logits at all.
+        if logits_mode in ('all', 'hidden', 'hidden_last'):
+            self._K_last_hidden_buf[:, :K].copy_(h)
+        else:
+            self._K_last_hidden_buf[:, :1].copy_(h[:, K - 1:K, :])
+        if logits_mode in ('none', 'hidden'):
+            return None
 
         # 3) Final RMSNorm M=K.
-        h2 = h.view(K, hidden).contiguous()
-        x_norm = self._h_b[:K].view(K, hidden)
+        if logits_mode in ('last', 'hidden_last'):
+            rows = 1
+            h2 = h[:, K - 1:K, :].view(1, hidden)
+            x_norm = self._h_b[:1].view(1, hidden)
+        else:
+            rows = K
+            h2 = h.view(K, hidden)
+            x_norm = self._h_b[:K].view(K, hidden)
         fvk.rms_norm(
             h2.data_ptr(), int(self._weights.ptrs['final_norm_eff_w']),
             x_norm.data_ptr(),
-            K, hidden, eps, s,
+            rows, hidden, eps, s,
         )
+
+        if logits_mode in ('last', 'hidden_last'):
+            out_K = self._logits_buf
+        elif K <= self._K_logits_buf.shape[0]:
+            out_K = self._K_logits_buf[:K]
+        else:
+            large = getattr(self, '_K_logits_large_buf', None)
+            if large is None or large.shape[0] < K:
+                import torch
+                large = torch.empty(
+                    K, vocab, device=self.device, dtype=torch.bfloat16)
+                self._K_logits_large_buf = large
+            out_K = large[:K]
+        if 'lm_head_w_bf16' in self._weights.ptrs:
+            fvk.bf16_matmul_qwen36_bf16(
+                x_norm.data_ptr(),
+                int(self._weights.ptrs['lm_head_w_bf16']),
+                out_K.data_ptr(), rows, vocab, hidden, s,
+            )
+            return out_K
 
         # 4) G8: lm_head NVFP4 GEMM (M=K). NVFP4 weight is 4× smaller
         # than BF16 (0.6 GB vs 2.5 GB). Reads weight ONCE for all K
@@ -2394,20 +2940,69 @@ class Qwen36TorchFrontendRtx:
         ap, sf, _ = self._nvfp4_scratch[(10240, 5120)]
         fvk.quantize_bf16_to_nvfp4_swizzled(
             x_norm.data_ptr(), ap.data_ptr(), sf.data_ptr(),
-            K, hidden, s,
+            rows, hidden, s,
         )
-        out_K = self._K_logits_buf[:K]
         fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
             ap.data_ptr(), int(self._weights.ptrs['lm_head_packed']),
             out_K.data_ptr(),
-            K, vocab, hidden,
+            rows, vocab, hidden,
             sf.data_ptr(), int(self._weights.ptrs['lm_head_sf']),
             float(self._weights.ptrs['lm_head_alpha']),
             s,
         )
-        return self._K_logits_buf[:K]
+        return out_K
 
-    def forward_mtp_head_nvfp4(self, prev_h, prev_token_id, cur_pos: int):
+    def forward_own_decode_K_nvfp4_tq(self, token_ids_K, cos_K, sin_K,
+                                      cur_pos: int, K: int,
+                                      tap_buf=None,
+                                      logits_mode: str = 'all'):
+        """S=K NVFP4 verify forward over the TurboQuant packed KV cache.
+
+        Linear-attention state handling and per-step recovery saves are
+        identical to ``forward_own_decode_K_nvfp4``. Full-attention
+        layers write the K new rows into the TQ packed cache and read
+        dequantized BF16 staging buffers instead of ``_attn.K_cache``.
+        """
+        self._tq_verify_active = True
+        try:
+            return self.forward_own_decode_K_nvfp4(
+                token_ids_K, cos_K, sin_K, cur_pos, K, tap_buf=tap_buf,
+                logits_mode=logits_mode)
+        finally:
+            self._tq_verify_active = False
+
+    def forward_own_decode_K_nvfp4_fp8kv(self, token_ids_K, cos_K, sin_K,
+                                         cur_pos: int, K: int,
+                                         tap_buf=None,
+                                         logits_mode: str = 'all'):
+        """S=K NVFP4 verify forward over an FP8 persistent KV cache.
+
+        This is the first-stage FP8-KV bridge: K/V writes are quantized
+        into e4m3 storage, then dequantized into the shared BF16 stage
+        consumed by the existing FA2 BF16 ABI.  Direct FP8 attention
+        replaces the staging step in the follow-up kernel pass.
+        """
+        self._fp8_kv_verify_active = True
+        try:
+            return self.forward_own_decode_K_nvfp4(
+                token_ids_K, cos_K, sin_K, cur_pos, K, tap_buf=tap_buf,
+                logits_mode=logits_mode)
+        finally:
+            self._fp8_kv_verify_active = False
+
+    def _forward_long_kv_K_nvfp4(self, token_ids_K, cos_K, sin_K,
+                                 cur_pos: int, K: int,
+                                 logits_mode: str = 'all'):
+        if getattr(self, '_long_kv_cache_mode', 'tq') == 'fp8':
+            return self.forward_own_decode_K_nvfp4_fp8kv(
+                token_ids_K, cos_K, sin_K, cur_pos, K,
+                logits_mode=logits_mode)
+        return self.forward_own_decode_K_nvfp4_tq(
+            token_ids_K, cos_K, sin_K, cur_pos, K,
+            logits_mode=logits_mode)
+
+    def forward_mtp_head_nvfp4(self, prev_h, prev_token_id, cur_pos: int,
+                               mtp_cache_pos: int | None = None):
         """NVFP4 MTP head forward (1-layer DeepSeek-V3 draft).
 
         Same math as ``forward_mtp_head`` (FP8 path) but every FP8 GEMM
@@ -2425,20 +3020,24 @@ class Qwen36TorchFrontendRtx:
         if mtp is None:
             raise RuntimeError(
                 'MTP head not loaded — set FLASHRT_QWEN36_MTP_CKPT_DIR')
+        use_bf16_mtp = 'q_proj_w_bf16' in mtp
         eps = float(self._cfg['rms_norm_eps'])
         vocab = self._cfg['vocab_size']
 
         # 0) Embed prev_token via anchored embed_w table.
         if prev_token_id.ndim == 1:
             prev_token_id = prev_token_id.view(1, 1)
-        embed_t = self._weights.anchors[0]   # (vocab, hidden) bf16
-        e = embed_t[prev_token_id.view(-1)].view(1, 1, 5120).contiguous()
-        if e.dtype != torch.bfloat16:
-            e = e.to(torch.bfloat16)
+        fvk.qwen36_embedding_lookup_bf16(
+            prev_token_id.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            self._mtp_embed_buf.data_ptr(),
+            1, 5120, s,
+        )
+        e = self._mtp_embed_buf
 
         # 1) pre-fc norms.
-        prev_h_2d = prev_h.view(1, 5120).contiguous()
-        e_2d = e.view(1, 5120).contiguous()
+        prev_h_2d = prev_h.view(1, 5120)
+        e_2d = e.view(1, 5120)
         h_norm = self._mtp_h_norm_buf.view(1, 5120)
         e_norm = self._mtp_e_norm_buf.view(1, 5120)
         fvk.rms_norm(
@@ -2465,6 +3064,7 @@ class Qwen36TorchFrontendRtx:
         # 4) Full-attn layer body (NVFP4) on MTP-private KV cache.
         h_in_full = self._mtp_fc_out_buf
         cos, sin = self._rope_cos_sin(cur_pos)
+        cache_pos = cur_pos if mtp_cache_pos is None else int(mtp_cache_pos)
 
         # 4a) input layernorm.
         h2 = h_in_full.view(1, 5120)
@@ -2483,32 +3083,43 @@ class Qwen36TorchFrontendRtx:
 
         # 4c) q_proj fused.
         q_proj_out_buf = self._nvfp4_scratch[(12288, 5120)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
-            ap_5120.data_ptr(), int(mtp['q_proj_packed']),
-            q_proj_out_buf.data_ptr(),
-            1, 12288, 5120,
-            sf_5120.data_ptr(), int(mtp['q_proj_sf']),
-            float(mtp['q_proj_alpha']),
-            s,
-        )
-        q_full = q_proj_out_buf[:1].view(1, 1, 24, 512)
-        q_pre, gate = torch.chunk(q_full, 2, dim=-1)
-        gate_flat = gate.reshape(1, 1, 24 * 256)
+        if use_bf16_mtp:
+            fvk.bf16_matvec_qwen36_bf16(
+                x_norm.data_ptr(), int(mtp['q_proj_w_bf16']),
+                q_proj_out_buf.data_ptr(), 12288, 5120, s)
+        else:
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_5120.data_ptr(), int(mtp['q_proj_packed']),
+                q_proj_out_buf.data_ptr(),
+                1, 12288, 5120,
+                sf_5120.data_ptr(), int(mtp['q_proj_sf']),
+                float(mtp['q_proj_alpha']),
+                s,
+            )
+        q_pre_2d = self._full_q_rot.view(24, 256)
+        gate_flat = self._full_gate_sig.view(1, 1, 24 * 256)
+        fvk.qwen36_split_q_gate_bf16(
+            q_proj_out_buf[:1].data_ptr(), q_pre_2d.data_ptr(),
+            gate_flat.data_ptr(), 1, s)
 
         # 4d) k_proj.
         kv_proj_out_buf = self._nvfp4_scratch[(1024, 5120)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
-            ap_5120.data_ptr(), int(mtp['k_proj_packed']),
-            kv_proj_out_buf.data_ptr(),
-            1, 1024, 5120,
-            sf_5120.data_ptr(), int(mtp['k_proj_sf']),
-            float(mtp['k_proj_alpha']),
-            s,
-        )
-        k_pre = kv_proj_out_buf[:1].view(1, 1, 4, 256).contiguous()
+        if use_bf16_mtp:
+            fvk.bf16_matvec_qwen36_bf16(
+                x_norm.data_ptr(), int(mtp['k_proj_w_bf16']),
+                kv_proj_out_buf.data_ptr(), 1024, 5120, s)
+        else:
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_5120.data_ptr(), int(mtp['k_proj_packed']),
+                kv_proj_out_buf.data_ptr(),
+                1, 1024, 5120,
+                sf_5120.data_ptr(), int(mtp['k_proj_sf']),
+                float(mtp['k_proj_alpha']),
+                s,
+            )
+        k_pre = kv_proj_out_buf[:1].view(1, 1, 4, 256)
 
         # 4e) q_norm / k_norm.
-        q_pre_2d = q_pre.contiguous().view(24, 256)
         fvk.rms_norm(
             q_pre_2d.data_ptr(), int(mtp['q_norm_eff_w']),
             self._full_q_norm_out.data_ptr(), 24, 256, eps, s,
@@ -2519,46 +3130,38 @@ class Qwen36TorchFrontendRtx:
             self._full_k_norm_out.data_ptr(), 4, 256, eps, s,
         )
 
-        # 4f) RoPE inline.
-        q_for_rope = self._full_q_norm_out.view(1, 1, 24, 256)
-        k_for_rope = self._full_k_norm_out.view(1, 1, 4, 256)
-        cos4 = cos.view(1, 1, 1, 64)
-        sin4 = sin.view(1, 1, 1, 64)
-
-        def _rope_inline(x_in, x_out, tmp):
-            x_out[..., 64:].copy_(x_in[..., 64:])
-            torch.index_select(
-                x_in[..., :64], -1, self._rope_rotate_idx, out=tmp,
-            )
-            tmp[..., :32].neg_()
-            tmp.mul_(sin4)
-            tmp.addcmul_(x_in[..., :64], cos4)
-            x_out[..., :64].copy_(tmp)
-
-        _rope_inline(q_for_rope, self._full_q_rot, self._full_rope_tmp_q)
-        _rope_inline(k_for_rope, self._full_k_rot, self._full_rope_tmp_k)
-        q_rot = self._full_q_rot
-        k_rot = self._full_k_rot
-
-        # 4g) Stage Q + write K to MTP cache.
-        self._mtp_Q_buf[:, :1].copy_(q_rot)
-        self._mtp_K_cache[cur_pos:cur_pos + 1].copy_(
-            k_rot.view(1, 4, 256))
-
-        # v_proj (NVFP4).
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
-            ap_5120.data_ptr(), int(mtp['v_proj_packed']),
-            kv_proj_out_buf.data_ptr(),
-            1, 1024, 5120,
-            sf_5120.data_ptr(), int(mtp['v_proj_sf']),
-            float(mtp['v_proj_alpha']),
-            s,
+        # 4f) Partial RoPE, staging Q and K directly.
+        fvk.qwen36_partial_rope_qk_bf16(
+            self._full_q_norm_out.data_ptr(),
+            self._full_k_norm_out.data_ptr(),
+            cos.data_ptr(), sin.data_ptr(),
+            self._mtp_Q_buf[:, :1].data_ptr(),
+            self._mtp_K_cache[cache_pos:cache_pos + 1].data_ptr(),
+            1, 24, 4, 256, 64, s,
         )
+
+        # 4g) v_proj (NVFP4).
+        if use_bf16_mtp:
+            fvk.bf16_matvec_qwen36_bf16(
+                x_norm.data_ptr(), int(mtp['v_proj_w_bf16']),
+                kv_proj_out_buf.data_ptr(), 1024, 5120, s)
+        else:
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_5120.data_ptr(), int(mtp['v_proj_packed']),
+                kv_proj_out_buf.data_ptr(),
+                1, 1024, 5120,
+                sf_5120.data_ptr(), int(mtp['v_proj_sf']),
+                float(mtp['v_proj_alpha']),
+                s,
+            )
         v_new = kv_proj_out_buf[:1].view(1, 4, 256)
-        self._mtp_V_cache[cur_pos:cur_pos + 1].copy_(v_new)
+        fvk.gpu_copy(
+            self._mtp_V_cache[cache_pos:cache_pos + 1].data_ptr(),
+            v_new.data_ptr(), 4 * 256 * 2, s,
+        )
 
         # 4h) FA2 on MTP cache.
-        kv_seq = cur_pos + 1
+        kv_seq = cache_pos + 1
         scaling = float(self._cfg['head_dim']) ** -0.5
         q_view = self._mtp_Q_buf[:, :1]
         k_view = self._mtp_K_cache[:kv_seq].view(1, kv_seq, 4, 256)
@@ -2589,30 +3192,40 @@ class Qwen36TorchFrontendRtx:
 
         # 4i) output gate.
         attn_flat = attn_out.reshape(1, 1, 24 * 256)
-        torch.sigmoid(gate_flat, out=self._full_gate_sig)
-        torch.mul(attn_flat, self._full_gate_sig, out=self._full_gated)
+        fvk.sigmoid_mul_qwen36_bf16(
+            gate_flat.data_ptr(), attn_flat.data_ptr(),
+            self._full_gated.data_ptr(), 24 * 256, s,
+        )
         gated = self._full_gated
 
         # 4j) o_proj NVFP4.
         ap_6144, sf_6144, _ = self._nvfp4_scratch[(5120, 6144)]
-        gated_2d = gated.view(1, 6144).contiguous()
-        fvk.quantize_bf16_to_nvfp4_swizzled(
-            gated_2d.data_ptr(), ap_6144.data_ptr(),
-            sf_6144.data_ptr(), 1, 6144, s,
-        )
+        gated_2d = gated.view(1, 6144)
         out_op_buf = self._nvfp4_scratch[(5120, 6144)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
-            ap_6144.data_ptr(), int(mtp['o_proj_packed']),
-            out_op_buf.data_ptr(),
-            1, 5120, 6144,
-            sf_6144.data_ptr(), int(mtp['o_proj_sf']),
-            float(mtp['o_proj_alpha']),
-            s,
-        )
+        if use_bf16_mtp:
+            fvk.bf16_matvec_qwen36_bf16(
+                gated_2d.data_ptr(), int(mtp['o_proj_w_bf16']),
+                out_op_buf.data_ptr(), 5120, 6144, s)
+        else:
+            fvk.quantize_bf16_to_nvfp4_swizzled(
+                gated_2d.data_ptr(), ap_6144.data_ptr(),
+                sf_6144.data_ptr(), 1, 6144, s,
+            )
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_6144.data_ptr(), int(mtp['o_proj_packed']),
+                out_op_buf.data_ptr(),
+                1, 5120, 6144,
+                sf_6144.data_ptr(), int(mtp['o_proj_sf']),
+                float(mtp['o_proj_alpha']),
+                s,
+            )
 
         # 4k) residual.
         attn_proj = out_op_buf[:1].view(1, 1, 5120)
-        torch.add(h_in_full, attn_proj, out=self._res_mid)
+        fvk.add_bf16_out(
+            h_in_full.data_ptr(), attn_proj.data_ptr(),
+            self._res_mid.data_ptr(), 5120, s,
+        )
         h_post = self._res_mid
 
         # 4l) post-attn norm + MLP NVFP4.
@@ -2629,22 +3242,30 @@ class Qwen36TorchFrontendRtx:
         )
         gate_out_buf = self._nvfp4_scratch[(17408, 5120)][2]
         up_out_buf = self._mlp_up_out
-        fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
-            ap_mlp.data_ptr(), int(mtp['mlp_gate_packed']),
-            gate_out_buf.data_ptr(),
-            1, 17408, 5120,
-            sf_mlp.data_ptr(), int(mtp['mlp_gate_sf']),
-            float(mtp['mlp_gate_alpha']),
-            s,
-        )
-        fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
-            ap_mlp.data_ptr(), int(mtp['mlp_up_packed']),
-            up_out_buf.data_ptr(),
-            1, 17408, 5120,
-            sf_mlp.data_ptr(), int(mtp['mlp_up_sf']),
-            float(mtp['mlp_up_alpha']),
-            s,
-        )
+        if use_bf16_mtp:
+            fvk.bf16_matvec_qwen36_bf16(
+                x_mlp.data_ptr(), int(mtp['mlp_gate_w_bf16']),
+                gate_out_buf.data_ptr(), 17408, 5120, s)
+            fvk.bf16_matvec_qwen36_bf16(
+                x_mlp.data_ptr(), int(mtp['mlp_up_w_bf16']),
+                up_out_buf.data_ptr(), 17408, 5120, s)
+        else:
+            fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
+                ap_mlp.data_ptr(), int(mtp['mlp_gate_packed']),
+                gate_out_buf.data_ptr(),
+                1, 17408, 5120,
+                sf_mlp.data_ptr(), int(mtp['mlp_gate_sf']),
+                float(mtp['mlp_gate_alpha']),
+                s,
+            )
+            fvk.fp4_w4a16_gemm_sm120_bf16out_widen(
+                ap_mlp.data_ptr(), int(mtp['mlp_up_packed']),
+                up_out_buf.data_ptr(),
+                1, 17408, 5120,
+                sf_mlp.data_ptr(), int(mtp['mlp_up_sf']),
+                float(mtp['mlp_up_alpha']),
+                s,
+            )
         gate_v = gate_out_buf[:1].view(1, 17408)
         up_v = up_out_buf[:1].view(1, 17408)
         fvk.silu_mul_qwen36_bf16(
@@ -2654,24 +3275,32 @@ class Qwen36TorchFrontendRtx:
         gate_silu_up = self._mlp_silu_mul_out
 
         ap_dn, sf_dn, _ = self._nvfp4_scratch[(5120, 17408)]
-        fvk.quantize_bf16_to_nvfp4_swizzled(
-            gate_silu_up.data_ptr(), ap_dn.data_ptr(),
-            sf_dn.data_ptr(), 1, 17408, s,
-        )
         down_out_buf = self._nvfp4_scratch[(5120, 17408)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
-            ap_dn.data_ptr(), int(mtp['mlp_down_packed']),
-            down_out_buf.data_ptr(),
-            1, 5120, 17408,
-            sf_dn.data_ptr(), int(mtp['mlp_down_sf']),
-            float(mtp['mlp_down_alpha']),
-            s,
-        )
+        if use_bf16_mtp:
+            fvk.bf16_matvec_qwen36_bf16(
+                gate_silu_up.data_ptr(), int(mtp['mlp_down_w_bf16']),
+                down_out_buf.data_ptr(), 5120, 17408, s)
+        else:
+            fvk.quantize_bf16_to_nvfp4_swizzled(
+                gate_silu_up.data_ptr(), ap_dn.data_ptr(),
+                sf_dn.data_ptr(), 1, 17408, s,
+            )
+            fvk.fp4_w4a16_gemm_sm120_bf16out(
+                ap_dn.data_ptr(), int(mtp['mlp_down_packed']),
+                down_out_buf.data_ptr(),
+                1, 5120, 17408,
+                sf_dn.data_ptr(), int(mtp['mlp_down_sf']),
+                float(mtp['mlp_down_alpha']),
+                s,
+            )
         mlp_out = down_out_buf[:1].view(1, 1, 5120)
 
         # 4m) final residual.
         next_h = self._mtp_layer_out_buf
-        torch.add(h_post, mlp_out, out=next_h)
+        fvk.add_bf16_out(
+            h_post.data_ptr(), mlp_out.data_ptr(),
+            next_h.data_ptr(), 5120, s,
+        )
 
         # 5) MTP final norm + lm_head.
         next_h_view = next_h.view(1, 5120)
@@ -2680,6 +3309,14 @@ class Qwen36TorchFrontendRtx:
             next_h_view.data_ptr(), int(mtp['final_norm_eff_w']),
             x_final_norm.data_ptr(), 1, 5120, eps, s,
         )
+        if 'lm_head_w_bf16' in self._weights.ptrs:
+            fvk.bf16_matvec_qwen36_bf16(
+                x_final_norm.data_ptr(),
+                int(self._weights.ptrs['lm_head_w_bf16']),
+                self._mtp_logits_buf.data_ptr(), vocab, 5120, s,
+            )
+            return next_h, self._mtp_logits_buf
+
         # G8: lm_head NVFP4 GEMM. Reuses (10240, 5120) scratch for
         # the K=5120 activation packed/SF buffers.
         ap_lm, sf_lm, _ = self._nvfp4_scratch[(10240, 5120)]
@@ -2697,18 +3334,144 @@ class Qwen36TorchFrontendRtx:
         )
         return next_h, self._mtp_logits_buf
 
+    def _ensure_mtp_tail_kv_buffers(self, rows: int) -> None:
+        import torch
+
+        rows = int(rows)
+        hidden = self._cfg['hidden_size']
+        bf16 = torch.bfloat16
+        cap = int(getattr(self, '_mtp_tail_kv_rows', 0))
+        if cap >= rows:
+            return
+        self._mtp_tail_kv_rows = rows
+        self._mtp_tail_embed_buf = torch.empty(
+            rows, hidden, device=self.device, dtype=bf16)
+        self._mtp_tail_h_norm_buf = torch.empty_like(
+            self._mtp_tail_embed_buf)
+        self._mtp_tail_e_norm_buf = torch.empty_like(
+            self._mtp_tail_embed_buf)
+        self._mtp_tail_cat_buf = torch.empty(
+            rows, hidden * 2, device=self.device, dtype=bf16)
+        self._mtp_tail_fc_out_buf = torch.empty(
+            rows, hidden, device=self.device, dtype=bf16)
+        self._mtp_tail_x_norm_buf = torch.empty_like(
+            self._mtp_tail_fc_out_buf)
+        self._mtp_tail_k_proj_buf = torch.empty(
+            rows, 4 * 256, device=self.device, dtype=bf16)
+        self._mtp_tail_v_proj_buf = torch.empty_like(
+            self._mtp_tail_k_proj_buf)
+        self._mtp_tail_k_norm_buf = torch.empty(
+            rows * 4, 256, device=self.device, dtype=bf16)
+        self._mtp_tail_dummy_q_in = torch.empty(
+            rows, 1, 256, device=self.device, dtype=bf16)
+        self._mtp_tail_dummy_q_out = torch.empty_like(
+            self._mtp_tail_dummy_q_in)
+
+    def _prefill_mtp_tail_kv_nvfp4(
+            self, prev_h_rows, token_ids, pos_start: int,
+            cache_base_pos: int) -> bool:
+        """Populate MTP prompt-tail K/V cache without full MTP decode."""
+        import torch
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        mtp = self._weights.ptrs.get('mtp')
+        if mtp is None or 'k_proj_w_bf16' not in mtp:
+            return False
+        rows = int(token_ids.numel())
+        if rows <= 0:
+            return True
+
+        hidden = self._cfg['hidden_size']
+        eps = float(self._cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        self._ensure_mtp_tail_kv_buffers(rows)
+
+        embed = self._mtp_tail_embed_buf[:rows]
+        h_norm = self._mtp_tail_h_norm_buf[:rows]
+        e_norm = self._mtp_tail_e_norm_buf[:rows]
+        cat_buf = self._mtp_tail_cat_buf[:rows]
+        fc_out = self._mtp_tail_fc_out_buf[:rows]
+        x_norm = self._mtp_tail_x_norm_buf[:rows]
+        k_proj = self._mtp_tail_k_proj_buf[:rows]
+        v_proj = self._mtp_tail_v_proj_buf[:rows]
+        k_norm = self._mtp_tail_k_norm_buf[:rows * 4]
+
+        fvk.qwen36_embedding_lookup_bf16(
+            token_ids.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            embed.data_ptr(), rows, hidden, s,
+        )
+        fvk.rms_norm(
+            prev_h_rows.view(rows, hidden).data_ptr(),
+            int(mtp['pre_fc_norm_hidden_eff_w']),
+            h_norm.data_ptr(), rows, hidden, eps, s,
+        )
+        fvk.rms_norm(
+            embed.data_ptr(), int(mtp['pre_fc_norm_embedding_eff_w']),
+            e_norm.data_ptr(), rows, hidden, eps, s,
+        )
+
+        fvk.concat2_bf16(
+            e_norm.data_ptr(), h_norm.data_ptr(),
+            cat_buf.data_ptr(), rows, hidden, hidden, s,
+        )
+        fvk.bf16_matmul_qwen36_bf16(
+            cat_buf.data_ptr(), int(mtp['fc_w']),
+            fc_out.data_ptr(), rows, hidden, hidden * 2, s,
+        )
+        fvk.rms_norm(
+            fc_out.data_ptr(), int(mtp['input_norm_eff_w']),
+            x_norm.data_ptr(), rows, hidden, eps, s,
+        )
+
+        fvk.bf16_matmul_qwen36_bf16(
+            x_norm.data_ptr(), int(mtp['k_proj_w_bf16']),
+            k_proj.data_ptr(), rows, 4 * 256, hidden, s,
+        )
+        fvk.bf16_matmul_qwen36_bf16(
+            x_norm.data_ptr(), int(mtp['v_proj_w_bf16']),
+            v_proj.data_ptr(), rows, 4 * 256, hidden, s,
+        )
+        fvk.rms_norm(
+            k_proj.view(rows * 4, 256).data_ptr(),
+            int(mtp['k_norm_eff_w']),
+            k_norm.data_ptr(), rows * 4, 256, eps, s,
+        )
+
+        cos = self._rope_cos_table[
+            pos_start:pos_start + rows].view(rows, self._rope_dim)
+        sin = self._rope_sin_table[
+            pos_start:pos_start + rows].view(rows, self._rope_dim)
+        q_dummy = self._mtp_tail_dummy_q_in[:rows]
+        q_dummy_out = self._mtp_tail_dummy_q_out[:rows]
+        fvk.qwen36_partial_rope_qk_bf16(
+            q_dummy.data_ptr(), k_norm.data_ptr(),
+            cos.data_ptr(), sin.data_ptr(),
+            q_dummy_out.data_ptr(),
+            self._mtp_K_cache[
+                cache_base_pos:cache_base_pos + rows].data_ptr(),
+            rows, 1, 4, 256, self._rope_dim, s,
+        )
+        fvk.gpu_copy(
+            self._mtp_V_cache[
+                cache_base_pos:cache_base_pos + rows].data_ptr(),
+            v_proj.data_ptr(), rows * 4 * 256 * 2, s,
+        )
+        return True
+
     # ---------- N5-stage6: NVFP4 speculative decode (K-generic) ----------
 
     def generate_own_speculative_KN_nvfp4(
-            self, input_ids, *, max_new_tokens: int, K: int = 5):
+            self, input_ids, *, max_new_tokens: int, K: int = 6):
         """K-generic speculative decode on the NVFP4 path.
 
         In long-ctx mode (auto-routed when ``max_seq`` exceeds
-        ``LONG_CTX_THRESHOLD`` at construction time) this method
-        falls back to single-token decode through the TurboQuant
-        packed cache — spec decode on the TQ path is a Phase 3D
-        follow-up. The K argument is silently treated as 1; the
-        caller does not need to know which path is active.
+        ``LONG_CTX_THRESHOLD`` at construction time), requests that fit
+        below ``FLASHRT_QWEN36_LONG_CTX_ROUTE_MIN_SEQ`` still use this
+        BF16-KV MTP path. Larger requests use MTP draft plus the
+        compressed-KV verify route selected by
+        ``FLASHRT_QWEN36_LONG_KV_CACHE``.
 
         Mirror of FP8 generate_own_speculative_KN. Differences vs. FP8:
           1. Prefill is DIY: walk prompt tokens through
@@ -2736,8 +3499,8 @@ class Qwen36TorchFrontendRtx:
         Args:
             input_ids: (1, prompt_len) cuda long.
             max_new_tokens: how many tokens to generate.
-            K: MTP chain length per cycle. K+1 must be <= MAX_Q_SEQ.
-                Default 5 (Qwen3-Next official spec).
+            K: MTP chain length per cycle. K+1 must fit the verify
+                buffer. Default 5 (Qwen3-Next official spec).
 
         Returns:
             (1, prompt_len + N) cuda long, trimmed to max_new_tokens.
@@ -2745,25 +3508,36 @@ class Qwen36TorchFrontendRtx:
         import torch
         from flash_rt import flash_rt_kernels as fvk
 
-        # Long-ctx auto-route: TQ packed cache supports any context up
-        # to ``self._user_max_seq``, but spec decode is not yet wired
-        # on top of TQ (Phase 3D). Fall back to single-token decode —
-        # caller does not need to know the path changed.
+        prompt_len = int(input_ids.shape[1])
+        max_pos = prompt_len + int(max_new_tokens)
+
+        # Long-ctx auto-route: keep the fast BF16/MTP spec path for
+        # actual short prompts, even when the caller asks for a larger
+        # completion, as long as the retained BF16 window can hold the
+        # full request. Route by prompt bucket once the prompt reaches
+        # the measured long-context threshold.
         if getattr(self, '_long_ctx_mode', False):
-            return self._generate_long_ctx_single_token(
-                input_ids, max_new_tokens)
+            use_long_route = self._should_use_long_ctx_route(
+                prompt_len, max_new_tokens)
+            if use_long_route and self._weights.ptrs.get('mtp') is not None:
+                return self._generate_long_ctx_speculative_KN_nvfp4(
+                    input_ids, max_new_tokens=max_new_tokens, K=K)
+            if use_long_route and self._weights.ptrs.get('mtp') is None:
+                return self._generate_long_ctx_single_token(
+                    input_ids, max_new_tokens)
 
         if self._weights.ptrs.get('mtp') is None:
             raise RuntimeError(
                 'MTP head not loaded — speculative decode unavailable')
-        if K < 1 or K + 1 > self.MAX_Q_SEQ:
+        max_spec_k = min(self.MAX_Q_SEQ - 1, self._MAX_PUBLIC_SPEC_K)
+        if K < 1 or K > max_spec_k:
             raise ValueError(
-                f'K={K} out of range — need 1<=K<={self.MAX_Q_SEQ - 1}')
+                f'K={K} out of range — need 1<=K<={max_spec_k}')
 
         bf16 = torch.bfloat16
-        prompt_len = int(input_ids.shape[1])
         hidden = self._cfg['hidden_size']
         eps = float(self._cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
 
         self.reset_state()
         self.reset_mtp_state()
@@ -2771,6 +3545,10 @@ class Qwen36TorchFrontendRtx:
             self._build_rope_table()
 
         with torch.no_grad():
+            ev_pf0 = torch.cuda.Event(enable_timing=True)
+            ev_pf1 = torch.cuda.Event(enable_timing=True)
+            ev_dec1 = torch.cuda.Event(enable_timing=True)
+            ev_pf0.record()
             # 1) Prefill: walk prompt tokens S=1 through main forward
             # using PER-CUR_POS captured graphs. Each step writes
             # pre-final-norm hidden to _last_hidden_buf; we capture
@@ -2815,6 +3593,7 @@ class Qwen36TorchFrontendRtx:
                 prompt_len - 1:prompt_len].view(1, 1, hidden).contiguous()
             self.forward_mtp_head_nvfp4(h_last_prompt, tok, prompt_len)
             h = h_last_prompt
+            ev_pf1.record()
 
             self._spec_attempts = 0
             self._spec_accepts = 0
@@ -2914,10 +3693,16 @@ class Qwen36TorchFrontendRtx:
                     # harmlessly overwritten by the next cycle's writes
                     # before any read (FA2 writes BEFORE reading at each
                     # q_seq=1 step).
-                    self._lin_state.copy_(
-                        self._K_lin_state_per_step[N])
-                    self._lin_conv_state.copy_(
-                        self._K_lin_conv_state_per_step[N])
+                    fvk.gpu_copy(
+                        self._lin_state.data_ptr(),
+                        self._K_lin_state_per_step[N].data_ptr(),
+                        self._lin_state.numel() * 2, s,
+                    )
+                    fvk.gpu_copy(
+                        self._lin_conv_state.data_ptr(),
+                        self._K_lin_conv_state_per_step[N].data_ptr(),
+                        self._lin_conv_state.numel() * 2, s,
+                    )
                     h = self._K_last_hidden_buf[
                         :, N:N + 1, :].contiguous()
                     tok = argmax_at(N)
@@ -2925,6 +3710,12 @@ class Qwen36TorchFrontendRtx:
 
             if len(generated) > max_new_tokens:
                 generated = generated[:max_new_tokens]
+
+            ev_dec1.record()
+            torch.cuda.synchronize()
+            self._long_ctx_prefill_ms = ev_pf0.elapsed_time(ev_pf1)
+            self._long_ctx_decode_ms = ev_pf1.elapsed_time(ev_dec1)
+            self._long_ctx_route = 'short_spec'
 
         return torch.cat([input_ids] + generated, dim=1)
 
@@ -3257,7 +4048,7 @@ class Qwen36TorchFrontendRtx:
         )
         eps = float(self._pipeline.hf.config.rms_norm_eps)
 
-        h2 = h_in_K.view(K, 5120).contiguous()
+        h2 = h_in_K.view(K, 5120)
 
         # Buffers / scratch.
         x_norm = self._h_b[:K].view(K, 5120)
@@ -3343,29 +4134,58 @@ class Qwen36TorchFrontendRtx:
         # V (K, 48, 128). Layout in conv_out: [Q_dim=2048, K_dim=2048,
         # V_dim=6144] per row.
         conv_K = self._K_lin_conv_out[:K]  # (K, 10240)
-        q_K_heads = conv_K[:, :2048].contiguous().view(1, K, 16, 128)
-        k_K_heads = conv_K[:, 2048:4096].contiguous().view(1, K, 16, 128)
-        v_K_heads = conv_K[:, 4096:10240].contiguous().view(1, K, 48, 128)
+        if (
+            hasattr(fvk, 'qwen36_lin_split_qkv_gqa_bf16')
+            and os.environ.get('FVK_QWEN36_LIN_SPLIT_GQA', '1') == '1'
+        ):
+            q16_K = self._K_lin_q16[:K]
+            k16_K = self._K_lin_k16[:K]
+            v48_K = self._K_lin_v48[:K]
+            fvk.qwen36_lin_split_qkv_gqa_bf16(
+                conv_K.data_ptr(), q16_K.data_ptr(), k16_K.data_ptr(),
+                v48_K.data_ptr(), K, s,
+            )
+            q_K_heads = q16_K.view(1, K, 16, 128)
+            k_K_heads = k16_K.view(1, K, 16, 128)
+            v_K_heads = v48_K.view(1, K, 48, 128)
+        else:
+            q_K_heads = conv_K[:, :2048].contiguous().view(1, K, 16, 128)
+            k_K_heads = conv_K[:, 2048:4096].contiguous().view(
+                1, K, 16, 128)
+            v_K_heads = conv_K[:, 4096:10240].contiguous().view(
+                1, K, 48, 128)
 
         # 6c) Compute g, beta for all K tokens at once (M=K vector ops).
         beta_K = self._K_lin_beta[:K]
-        torch.sigmoid(b_vec_K, out=beta_K)
-        a_f32_K = self._K_lin_a_f32[:K]
-        a_f32_K.copy_(a_vec_K)
-        a_f32_K.add_(lw['dt_bias_fp32_t'])
-        sp_K = self._K_lin_sp_buf[:K]
-        torch.exp(a_f32_K, out=sp_K)
-        torch.log1p(sp_K, out=sp_K)
-        g_f32_K = self._K_lin_g_f32[:K]
-        torch.mul(lw['neg_A_log_exp_fp32_t'], sp_K, out=g_f32_K)
         g_bf_K = self._K_lin_g_bf[:K]
-        g_bf_K.copy_(g_f32_K)
+        if (
+            hasattr(fvk, 'qwen36_gdn_gating_strided_bf16')
+            and os.environ.get('FVK_QWEN36_GDN_FUSED_GATING', '1') == '1'
+        ):
+            fvk.qwen36_gdn_gating_strided_bf16(
+                a_vec_K.data_ptr(), b_vec_K.data_ptr(),
+                lw['neg_A_log_exp_fp32_t'].data_ptr(),
+                lw['dt_bias_fp32_t'].data_ptr(),
+                g_bf_K.data_ptr(), beta_K.data_ptr(),
+                K, 48, a_vec_K.stride(0), b_vec_K.stride(0), s,
+            )
+        else:
+            torch.sigmoid(b_vec_K, out=beta_K)
+            a_f32_K = self._K_lin_a_f32[:K]
+            a_f32_K.copy_(a_vec_K)
+            a_f32_K.add_(lw['dt_bias_fp32_t'])
+            sp_K = self._K_lin_sp_buf[:K]
+            torch.exp(a_f32_K, out=sp_K)
+            torch.log1p(sp_K, out=sp_K)
+            g_f32_K = self._K_lin_g_f32[:K]
+            torch.mul(lw['neg_A_log_exp_fp32_t'], sp_K, out=g_f32_K)
+            g_bf_K.copy_(g_f32_K)
 
         # 6d) FLA chunked recurrent — one call processes all K tokens
         # natively, with internal L2-norm on q/k. GVA (16 K-heads,
         # 48 V-heads) handled by the kernel without needing the
         # 16->48 explicit broadcast.
-        from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+        chunk_gated_delta_rule = _load_qwen36_fla_chunk()
         rec_state_view = self._lin_state[lin_rank]  # (1, 48, 128, 128)
         beta_FLA = beta_K.view(1, K, 48)
         g_FLA = g_bf_K.view(1, K, 48)
@@ -3375,12 +4195,16 @@ class Qwen36TorchFrontendRtx:
             initial_state=rec_state_view,
             output_final_state=True,
             use_qk_l2norm_in_kernel=True,
+            q_l2_out=self._K_fla_q16_l2[:, :K],
+            k_l2_out=self._K_fla_k16_l2[:, :K],
+            g_cumsum_out=self._K_fla_g_cumsum[:, :K],
+            o_out=self._K_lin_attn_out[:K].view(1, K, 48, 128),
         )
         # attn_out_K: (1, K, 48, 128); new_state: (1, 48, 128, 128).
         rec_state_view.copy_(new_state)
 
         # 6e) rms_norm_gated_silu over (K*48, 128) rows in one call.
-        attn_out_flat = attn_out_K.contiguous().view(K * 48, 128)
+        attn_out_flat = attn_out_K.view(K * 48, 128)
         z_flat = out_z_buf[:K].view(K * 48, 128)
         norm_out_flat = self._K_lin_norm_out[:K].view(K * 48, 128)
         fvk.rms_norm_gated_silu_qwen36_bf16(
@@ -3734,7 +4558,7 @@ class Qwen36TorchFrontendRtx:
         eps = float(self._pipeline.hf.config.rms_norm_eps)
         full_rank = self._full_layer_rank(L)
 
-        h2 = h_in_K.view(K, 5120).contiguous()
+        h2 = h_in_K.view(K, 5120)
 
         # 1) input layernorm — M=K rows.
         x_norm = self._h_b[:K].view(K, 5120)
@@ -3760,9 +4584,11 @@ class Qwen36TorchFrontendRtx:
             scale_5120.data_ptr(), int(lw['q_proj_s']),
             s,
         )
-        q_full = q_proj_out_buf[:K].view(1, K, 24, 512)
-        q_pre, gate = torch.chunk(q_full, 2, dim=-1)
-        gate_flat = gate.reshape(1, K, 24 * 256)
+        q_pre_2d = self._K_full_q_rot[:, :K].view(K * 24, 256)
+        gate_flat = self._K_full_gate_sig[:, :K]
+        fvk.qwen36_split_q_gate_bf16(
+            q_proj_out_buf[:K].data_ptr(), q_pre_2d.data_ptr(),
+            gate_flat.data_ptr(), K, s)
 
         # 4) k_proj — M=K.
         kv_proj_out_buf = self._fp8_scratch[(1024, 5120)][2]
@@ -3773,10 +4599,9 @@ class Qwen36TorchFrontendRtx:
             scale_5120.data_ptr(), int(lw['k_proj_s']),
             s,
         )
-        k_pre = kv_proj_out_buf[:K].view(1, K, 4, 256).contiguous()
+        k_pre = kv_proj_out_buf[:K].view(1, K, 4, 256)
 
         # 5) q_norm / k_norm — per-head RMSNorm. M = K*heads.
-        q_pre_2d = q_pre.contiguous().view(K * 24, 256)
         q_norm_out = self._K_full_q_norm_out[:K * 24]
         fvk.rms_norm(
             q_pre_2d.data_ptr(), int(lw['q_norm_eff_w']),
@@ -3831,30 +4656,29 @@ class Qwen36TorchFrontendRtx:
         v_new_K = kv_proj_out_buf[:K].view(K, 4, 256)
         self._attn.V_cache[full_rank, cur_pos:cur_pos + K].copy_(v_new_K)
 
-        # 8) FA2 — vendored fvk fa2 fwd_bf16 has no causal flag, so a
-        # single q_seq=K call would let Q[i] attend to K[j>i] (future)
-        # because K[cur_pos+j] for j>i was just written by step 7
-        # batched K_cache write. Predicting at position cur_pos+i+1
-        # would then be corrupted by K[cur_pos+i+1..cur_pos+K-1].
-        # Workaround: K serial q_seq=1 calls, each with
-        # kv_seq=cur_pos+k+1 — bound by Q's own position. Each call's
-        # FA2 only reads the valid causal prefix of K_cache.
+        # 8) FA2. Prefer one causal q_seq=K call when available. The
+        # fallback keeps the historical K serial q_seq=1 calls, binding
+        # kv_seq to each Q position.
         scaling = float(self._pipeline.hf.config.head_dim) ** -0.5
-        for k in range(K):
-            q_view = self._attn.Q_buf[:, k:k + 1]
-            kv_seq_k = cur_pos + k + 1
+        use_causal_fa2 = (
+            K > 1
+            and getattr(self._attn, '_fa2_fwd_causal', None) is not None
+            and os.environ.get('FVK_QWEN36_CAUSAL_PREFILL_FA2', '1') == '1'
+        )
+        if use_causal_fa2:
+            q_view = self._attn.Q_buf[:, :K]
             k_view = self._attn.K_cache[
-                full_rank:full_rank + 1, :kv_seq_k]
+                full_rank:full_rank + 1, :cur_pos + K]
             v_view = self._attn.V_cache[
-                full_rank:full_rank + 1, :kv_seq_k]
-            o_view = self._attn.O_buf[:, k:k + 1]
-            self._attn._fa2_fwd(
+                full_rank:full_rank + 1, :cur_pos + K]
+            o_view = self._attn.O_buf[:, :K]
+            self._attn._fa2_fwd_causal(
                 Q=q_view.data_ptr(), K=k_view.data_ptr(),
                 V=v_view.data_ptr(), O=o_view.data_ptr(),
                 softmax_lse=self._attn.lse_buf.data_ptr(),
                 softmax_lse_accum=self._attn.lse_accum.data_ptr(),
                 o_accum=self._attn.o_accum.data_ptr(),
-                batch=1, seqlen_q=1, seqlen_k=kv_seq_k,
+                batch=1, seqlen_q=K, seqlen_k=cur_pos + K,
                 num_heads_q=24, num_heads_kv=4,
                 head_dim=256,
                 q_strides=(q_view.stride(0), q_view.stride(1),
@@ -3869,6 +4693,36 @@ class Qwen36TorchFrontendRtx:
                 num_sms=self._attn._num_sms,
                 stream=s,
             )
+        else:
+            for k in range(K):
+                q_view = self._attn.Q_buf[:, k:k + 1]
+                kv_seq_k = cur_pos + k + 1
+                k_view = self._attn.K_cache[
+                    full_rank:full_rank + 1, :kv_seq_k]
+                v_view = self._attn.V_cache[
+                    full_rank:full_rank + 1, :kv_seq_k]
+                o_view = self._attn.O_buf[:, k:k + 1]
+                self._attn._fa2_fwd(
+                    Q=q_view.data_ptr(), K=k_view.data_ptr(),
+                    V=v_view.data_ptr(), O=o_view.data_ptr(),
+                    softmax_lse=self._attn.lse_buf.data_ptr(),
+                    softmax_lse_accum=self._attn.lse_accum.data_ptr(),
+                    o_accum=self._attn.o_accum.data_ptr(),
+                    batch=1, seqlen_q=1, seqlen_k=kv_seq_k,
+                    num_heads_q=24, num_heads_kv=4,
+                    head_dim=256,
+                    q_strides=(q_view.stride(0), q_view.stride(1),
+                               q_view.stride(2)),
+                    k_strides=(k_view.stride(0), k_view.stride(1),
+                               k_view.stride(2)),
+                    v_strides=(v_view.stride(0), v_view.stride(1),
+                               v_view.stride(2)),
+                    o_strides=(o_view.stride(0), o_view.stride(1),
+                               o_view.stride(2)),
+                    softmax_scale=scaling,
+                    num_sms=self._attn._num_sms,
+                    stream=s,
+                )
         attn_out = self._attn.O_buf[:, :K]  # (1, K, 24, 256)
 
         # 9) output gate: attn * sigmoid(gate). K rows.
@@ -4158,8 +5012,8 @@ class Qwen36TorchFrontendRtx:
             e = e.to(torch.bfloat16)
 
         # 1) pre-fc norms on (h, e) -> bf16 (1, 5120) each.
-        prev_h_2d = prev_h.view(1, 5120).contiguous()
-        e_2d = e.view(1, 5120).contiguous()
+        prev_h_2d = prev_h.view(1, 5120)
+        e_2d = e.view(1, 5120)
         h_norm = self._mtp_h_norm_buf.view(1, 5120)
         e_norm = self._mtp_e_norm_buf.view(1, 5120)
         fvk.rms_norm(
@@ -4572,6 +5426,8 @@ class Qwen36TorchFrontendRtx:
                 '_captured_mtp_graphs',
                 '_captured_chain_graphs',
                 '_captured_graphs_tq',
+                '_captured_verify_graphs_tq',
+                '_captured_verify_graphs_fp8kv',
                 '_captured_verify_graphs_dflash',
                 '_captured_drafter_graphs_dflash',
         ):
@@ -4891,8 +5747,8 @@ class Qwen36TorchFrontendRtx:
         Args:
             input_ids: (1, prompt_len) cuda long.
             max_new_tokens: how many tokens to generate.
-            K: number of MTP chain drafts per cycle. K+1 must be
-                <= MAX_Q_SEQ. Default 5 (Qwen3-Next official spec).
+            K: number of MTP chain drafts per cycle. K+1 must fit the
+                verify buffer. Default 5 (Qwen3-Next official spec).
 
         Returns:
             (1, prompt_len + N) cuda long, trimmed to max_new_tokens.
@@ -4902,9 +5758,10 @@ class Qwen36TorchFrontendRtx:
         if self._weights.ptrs.get('mtp') is None:
             raise RuntimeError(
                 'MTP head not loaded — speculative decode unavailable')
-        if K < 1 or K + 1 > self.MAX_Q_SEQ:
+        max_spec_k = min(self.MAX_Q_SEQ - 1, self._MAX_PUBLIC_SPEC_K)
+        if K < 1 or K > max_spec_k:
             raise ValueError(
-                f'K={K} out of range — need 1<=K<={self.MAX_Q_SEQ - 1}')
+                f'K={K} out of range — need 1<=K<={max_spec_k}')
 
         prompt_len = int(input_ids.shape[1])
         self.reset_state()
@@ -5546,6 +6403,299 @@ class Qwen36TorchFrontendRtx:
         self._graph_cache_put(self._captured_verify_graphs, key, g)
         return g
 
+    def _tq_mark_dequant_valid_end(self, end_pos: int) -> None:
+        """Set every TQ per-layer staging high-water mark.
+
+        Graph-captured TQ verify records the dequant kernels for a fixed
+        window. Python bookkeeping is not replayed by CUDA Graphs, so the
+        orchestration updates the high-water mark explicitly before
+        capture and after accept/reject handling.
+        """
+        cache = getattr(self, '_tq_cache_packed', None)
+        valid = getattr(cache, '_dequant_valid_end', None)
+        if valid is None:
+            return
+        end_pos = int(end_pos)
+        for i in range(len(valid)):
+            valid[i] = end_pos
+        hot_valid = getattr(self, '_tq_hot_stage_valid_end', None)
+        if hot_valid is not None:
+            for i in range(len(hot_valid)):
+                hot_valid[i] = end_pos
+
+    def _long_tq_effective_k(self, prompt_len: int, K: int) -> int:
+        """Return the long-context TQ spec K used by generation."""
+        tq_spec_k = os.environ.get('FLASHRT_QWEN36_TQ_SPEC_K', '')
+        if tq_spec_k:
+            return int(tq_spec_k)
+        prompt_len = int(prompt_len)
+        caller_k = int(K)
+        if prompt_len < 768:
+            target_k = 4
+        elif prompt_len < 1536:
+            target_k = 5
+        elif prompt_len < 3072:
+            target_k = 6
+        elif prompt_len < 6144:
+            target_k = 3
+        elif prompt_len < 12288:
+            target_k = 5
+        elif prompt_len < 24576:
+            target_k = 7
+        elif prompt_len < 49152:
+            target_k = 6
+        elif 49152 <= prompt_len < 160000:
+            target_k = 7
+        else:
+            target_k = 6
+        if caller_k < 6:
+            return min(caller_k, target_k)
+        return target_k
+
+    def _should_use_long_ctx_route(
+            self, prompt_len: int, max_new_tokens: int) -> bool:
+        if not getattr(self, '_long_ctx_mode', False):
+            return False
+        prompt_len = int(prompt_len)
+        max_pos = prompt_len + int(max_new_tokens)
+        route_min = int(getattr(
+            self, '_long_ctx_route_min_seq',
+            getattr(self, '_short_ctx_spec_max_seq',
+                    self.LONG_CTX_THRESHOLD)))
+        bf16_cap = int(getattr(
+            self, '_short_ctx_spec_max_seq', route_min))
+        return prompt_len >= route_min or max_pos > bf16_cap
+
+    def warmup_long_ctx_decode_graphs(
+            self, shapes: list[tuple[int, int]], K: int = 6
+    ) -> list[tuple[int, int, int]]:
+        """Pre-capture long-context TQ decode graphs without prompt prefill.
+
+        Full dummy generation for a 200K/256K warmup bucket spends most of
+        its time in prefill.  Serving still needs that real prefill per
+        request, but the avoidable cold-start cost is CUDA Graph capture for
+        the first decode positions.  For 128K+ buckets, auto warmup captures
+        every early decode position because partial MTP accepts otherwise
+        land on graph keys that a high-acceptance-only warmup misses.
+
+        Returns a list of ``(cur_pos, verify_qseq, mtp_K)`` graph keys that
+        were requested. Existing cached graphs are reused.
+        """
+        import torch
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        if not getattr(self, '_long_ctx_mode', False):
+            return []
+        kv_mode = getattr(self, '_long_kv_cache_mode', 'tq')
+        if kv_mode not in ('tq', 'fp8'):
+            return []
+        if kv_mode == 'tq' and not hasattr(self, '_tq_cache_packed'):
+            return []
+        if kv_mode == 'fp8' and not hasattr(self, '_fp8_K_cache'):
+            return []
+        if not hasattr(self, '_rope_cos_table'):
+            self._build_rope_table()
+
+        warmed: list[tuple[int, int, int]] = []
+        d = self._rope_dim
+        s = torch.cuda.current_stream().cuda_stream
+        has_mtp = self._weights.ptrs.get('mtp') is not None
+        stride_raw = os.environ.get(
+            'FLASHRT_QWEN36_LONG_WARMUP_STRIDE', 'auto').lower()
+        max_graphs_per_shape = int(os.environ.get(
+            'FLASHRT_QWEN36_LONG_WARMUP_MAX_GRAPHS', '96') or '96')
+        min_free_mb = int(os.environ.get(
+            'FLASHRT_QWEN36_LONG_WARMUP_MIN_FREE_MB', '1024') or '0')
+
+        with torch.no_grad():
+            for prompt_len, max_new_tokens in shapes:
+                prompt_len = int(prompt_len)
+                max_new_tokens = int(max_new_tokens)
+                if not self._should_use_long_ctx_route(
+                        prompt_len, max_new_tokens):
+                    continue
+                if prompt_len + max_new_tokens > self._user_max_seq:
+                    continue
+                eff_k = self._long_tq_effective_k(prompt_len, K)
+                verify_qseq = eff_k + 1
+                if verify_qseq < 1 or verify_qseq > self.MAX_Q_SEQ:
+                    continue
+                self._ensure_long_mtp_cache_capacity(
+                    prompt_len, max_new_tokens, eff_k)
+                mtp_tail = self._long_mtp_prefill_tail_for_prompt(prompt_len)
+                if stride_raw == 'auto':
+                    step = 1 if prompt_len >= 131072 else verify_qseq
+                else:
+                    step = max(1, int(stride_raw))
+                limit = max(1, max_new_tokens)
+                emitted = 0
+                for offset in range(0, limit, step):
+                    if max_graphs_per_shape > 0 and emitted >= max_graphs_per_shape:
+                        break
+                    if min_free_mb > 0:
+                        try:
+                            free_bytes, _ = torch.cuda.mem_get_info()
+                            if int(free_bytes) < (min_free_mb << 20):
+                                break
+                        except Exception:
+                            pass
+                    cur_pos = prompt_len + offset
+                    if cur_pos + verify_qseq > self._user_max_seq:
+                        break
+                    cos = self._rope_cos_table[
+                        cur_pos:cur_pos + verify_qseq].view(
+                            1, verify_qseq, d)
+                    sin = self._rope_sin_table[
+                        cur_pos:cur_pos + verify_qseq].view(
+                            1, verify_qseq, d)
+                    fvk.gpu_copy(
+                        self._verify_static_cos[:, :verify_qseq].data_ptr(),
+                        cos.data_ptr(), verify_qseq * d * 2, s,
+                    )
+                    fvk.gpu_copy(
+                        self._verify_static_sin[:, :verify_qseq].data_ptr(),
+                        sin.data_ptr(), verify_qseq * d * 2, s,
+                    )
+                    if kv_mode == 'tq':
+                        self._tq_mark_dequant_valid_end(cur_pos)
+                        self._ensure_verify_graph_nvfp4_tq(
+                            cur_pos, verify_qseq)
+                    else:
+                        self._ensure_verify_graph_nvfp4_fp8kv(
+                            cur_pos, verify_qseq)
+                    if has_mtp:
+                        self._ensure_mtp_chain_graph_nvfp4(
+                            cur_pos, eff_k,
+                            cache_base_pos=mtp_tail + offset)
+                    warmed.append((cur_pos, verify_qseq, eff_k))
+                    emitted += 1
+
+        self.reset_state()
+        self.reset_mtp_state()
+        return warmed
+
+    def _long_tq_graph_capture_allowed(self) -> bool:
+        min_free_mb = int(os.environ.get(
+            'FLASHRT_QWEN36_LONG_GRAPH_MIN_FREE_MB', '768') or '0')
+        if min_free_mb <= 0:
+            return True
+        try:
+            import torch
+            free_bytes, _ = torch.cuda.mem_get_info()
+            return int(free_bytes) >= (min_free_mb << 20)
+        except Exception:
+            return True
+
+    def _ensure_verify_graph_nvfp4_tq(self, cur_pos: int, K: int):
+        """Lazy CUDA Graph capture for TQ-packed S=K verify.
+
+        Captures ``forward_own_decode_K_nvfp4_tq`` against the static
+        verify token/RoPE buffers. The graph includes the TQ write,
+        window dequant ``[cur_pos, cur_pos + K)``, FA2, and the full
+        64-layer verify forward. Recurrent lin/conv state is restored
+        after warmup/capture; future TQ rows do not need restoration
+        because replay overwrites the same rows before attention reads.
+        """
+        import torch
+
+        if not hasattr(self, '_captured_verify_graphs_tq'):
+            self._captured_verify_graphs_tq = collections.OrderedDict()
+
+        key = (cur_pos, K)
+        g = self._graph_cache_get(self._captured_verify_graphs_tq, key)
+        if g is not None:
+            return g
+
+        gs = self._graph_stream
+        snap_lin = self._lin_state.clone()
+        snap_conv = self._lin_conv_state.clone()
+
+        def _restore():
+            self._lin_state.copy_(snap_lin)
+            self._lin_conv_state.copy_(snap_conv)
+            self._tq_mark_dequant_valid_end(cur_pos)
+
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.no_grad():
+            tokens_K = self._verify_static_tokens[:, :K]
+            cos_K = self._verify_static_cos[:, :K]
+            sin_K = self._verify_static_sin[:, :K]
+            for _ in range(2):
+                self._tq_mark_dequant_valid_end(cur_pos)
+                self.forward_own_decode_K_nvfp4_tq(
+                    tokens_K, cos_K, sin_K, cur_pos, K=K)
+                _restore()
+
+        gs.synchronize()
+        self._tq_mark_dequant_valid_end(cur_pos)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
+            self.forward_own_decode_K_nvfp4_tq(
+                tokens_K, cos_K, sin_K, cur_pos, K=K)
+        with torch.cuda.stream(gs), torch.no_grad():
+            _restore()
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+
+        self._graph_cache_put(self._captured_verify_graphs_tq, key, g)
+        return g
+
+    def _ensure_verify_graph_nvfp4_fp8kv(self, cur_pos: int, K: int):
+        """Lazy CUDA Graph capture for FP8-KV S=K verify.
+
+        This mirrors the TQ graph path but binds
+        ``forward_own_decode_K_nvfp4_fp8kv``. The graph records FP8 KV
+        writes, FP8->BF16 staging, FA2, and the 64-layer verifier.
+        """
+        import torch
+
+        if not hasattr(self, '_captured_verify_graphs_fp8kv'):
+            self._captured_verify_graphs_fp8kv = collections.OrderedDict()
+
+        key = (cur_pos, K)
+        g = self._graph_cache_get(self._captured_verify_graphs_fp8kv, key)
+        if g is not None:
+            return g
+
+        gs = self._graph_stream
+        snap_lin = self._lin_state.clone()
+        snap_conv = self._lin_conv_state.clone()
+
+        def _restore():
+            self._lin_state.copy_(snap_lin)
+            self._lin_conv_state.copy_(snap_conv)
+            self._fp8_mark_dequant_valid_end(cur_pos)
+
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.no_grad():
+            tokens_K = self._verify_static_tokens[:, :K]
+            cos_K = self._verify_static_cos[:, :K]
+            sin_K = self._verify_static_sin[:, :K]
+            for _ in range(2):
+                self._fp8_mark_dequant_valid_end(cur_pos)
+                self.forward_own_decode_K_nvfp4_fp8kv(
+                    tokens_K, cos_K, sin_K, cur_pos, K=K)
+                _restore()
+
+        gs.synchronize()
+        self._fp8_mark_dequant_valid_end(cur_pos)
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+                g, stream=gs, pool=self._graph_mempool,
+        ), torch.no_grad():
+            self.forward_own_decode_K_nvfp4_fp8kv(
+                tokens_K, cos_K, sin_K, cur_pos, K=K)
+        with torch.cuda.stream(gs), torch.no_grad():
+            _restore()
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+
+        self._graph_cache_put(self._captured_verify_graphs_fp8kv, key, g)
+        return g
+
     # ---------- Stage 7 G2: NVFP4 MTP chain graph capture ----------
 
     def _ensure_mtp_graph_nvfp4(self, mtp_pos: int):
@@ -5602,7 +6752,8 @@ class Qwen36TorchFrontendRtx:
 
     # ---------- G9: NVFP4 MTP CHAIN graph (K steps in one graph) ------
 
-    def _ensure_mtp_chain_graph_nvfp4(self, base_pos: int, K: int):
+    def _ensure_mtp_chain_graph_nvfp4(
+            self, base_pos: int, K: int, cache_base_pos: int | None = None):
         """Capture the entire K-step MTP chain as ONE CUDA Graph.
 
         Inputs (filled by caller before replay):
@@ -5620,42 +6771,88 @@ class Qwen36TorchFrontendRtx:
         calls inside the graph — no Python in the inner loop at replay
         time.
 
-        State integrity: each MTP step writes to mtp_K_cache[base_pos+k]
-        / mtp_V_cache[base_pos+k]. Snap+restore those K rows so the
-        warmup/capture writes don't perturb the live cache.
+        ``base_pos`` is the absolute RoPE position. ``cache_base_pos``
+        defaults to ``base_pos`` for the short-context path. Long-context
+        TQ spec keeps a compact MTP cache over generated tokens only, so
+        it passes a separate cache base while preserving absolute RoPE.
+
+        State integrity: each MTP step writes to
+        mtp_K_cache[cache_base_pos+k] / mtp_V_cache[cache_base_pos+k].
+        Snap+restore those K rows so warmup/capture does not perturb the
+        live cache.
         """
         import torch
 
-        key = (base_pos, K)
+        from flash_rt import flash_rt_kernels as fvk
+
+        if cache_base_pos is None:
+            cache_base_pos = base_pos
+            key = (base_pos, K)
+        else:
+            cache_base_pos = int(cache_base_pos)
+            key = (base_pos, cache_base_pos, K)
         g = self._graph_cache_get(self._captured_chain_graphs, key)
         if g is not None:
             return g
 
         gs = self._graph_stream
 
-        snap_K = self._mtp_K_cache[base_pos:base_pos + K].clone()
-        snap_V = self._mtp_V_cache[base_pos:base_pos + K].clone()
+        snap_K = self._mtp_K_cache[
+            cache_base_pos:cache_base_pos + K].clone()
+        snap_V = self._mtp_V_cache[
+            cache_base_pos:cache_base_pos + K].clone()
 
         def _restore():
-            self._mtp_K_cache[base_pos:base_pos + K].copy_(snap_K)
-            self._mtp_V_cache[base_pos:base_pos + K].copy_(snap_V)
+            self._mtp_K_cache[
+                cache_base_pos:cache_base_pos + K].copy_(snap_K)
+            self._mtp_V_cache[
+                cache_base_pos:cache_base_pos + K].copy_(snap_V)
 
         def _run_chain():
+            mtp_argmax_parts = int(os.environ.get(
+                'FLASHRT_QWEN36_MTP_ARGMAX_PARTS', '96') or '96')
             for k in range(K):
                 self.forward_mtp_head_nvfp4(
                     self._mtp_static_prev_h,
                     self._mtp_static_prev_token,
-                    base_pos + k)
-                # argmax → drafts buf row k
-                d_k = self._mtp_logits_buf.argmax(
-                    dim=-1, keepdim=True).view(1, 1)
-                self._chain_drafts_buf[k:k + 1].copy_(d_k.view(1, 1))
+                    base_pos + k,
+                    mtp_cache_pos=cache_base_pos + k)
+                if (
+                    mtp_argmax_parts > 1
+                    and hasattr(fvk, 'qwen36_spec_accept_partitioned_bf16')
+                ):
+                    fvk.qwen36_spec_accept_partitioned_bf16(
+                        self._mtp_logits_buf.data_ptr(),
+                        self._chain_drafts_buf.data_ptr(),
+                        self._chain_drafts_buf[k:k + 1].data_ptr(),
+                        self._spec_accept_n_buf.data_ptr(),
+                        self._spec_argmax_partial_vals.data_ptr(),
+                        self._spec_argmax_partial_idx.data_ptr(),
+                        1, self._cfg['vocab_size'], 0,
+                        mtp_argmax_parts,
+                        torch.cuda.current_stream().cuda_stream,
+                    )
+                else:
+                    fvk.qwen36_argmax_bf16(
+                        self._mtp_logits_buf.data_ptr(),
+                        self._chain_drafts_buf[k:k + 1].data_ptr(),
+                        1, self._cfg['vocab_size'],
+                        torch.cuda.current_stream().cuda_stream,
+                    )
                 if k < K - 1:
                     # Chain: prev_h ← layer_out, prev_token ← d_k
-                    self._mtp_static_prev_h.copy_(
-                        self._mtp_layer_out_buf)
-                    self._mtp_static_prev_token.copy_(
-                        self._chain_drafts_buf[k:k + 1])
+                    stream = torch.cuda.current_stream().cuda_stream
+                    fvk.gpu_copy(
+                        self._mtp_static_prev_h.data_ptr(),
+                        self._mtp_layer_out_buf.data_ptr(),
+                        self._mtp_static_prev_h.numel() * 2,
+                        stream,
+                    )
+                    fvk.gpu_copy(
+                        self._mtp_static_prev_token.data_ptr(),
+                        self._chain_drafts_buf[k:k + 1].data_ptr(),
+                        8, stream,
+                    )
 
         gs.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(gs), torch.no_grad():
@@ -5685,39 +6882,712 @@ class Qwen36TorchFrontendRtx:
         """Switch a freshly-initialised NVFP4 frontend onto the TQ path.
 
         Called from ``__init__`` when ``max_seq > LONG_CTX_THRESHOLD``.
-        Buffers were sized at the threshold; this method extends KV
-        coverage out to the user-requested max_seq via the TurboQuant
-        packed cache and shrinks the now-unused BF16 KV cache to a
-        64-row dummy.
+        Buffers were sized at a short spec window; this method extends
+        KV coverage out to the user-requested max_seq via the
+        TurboQuant packed cache while retaining that BF16 window for
+        ordinary short speculative requests.
 
         Sequence (matches the canonical pattern from the team's own
         long-ctx benches, but without exposing the private steps to
         callers):
 
-          1. Drop the BF16 KV cache (its rows are now stand-ins; the
-             TQ packed cache is the source of truth).
+          1. Keep/shrink the BF16 KV cache to the retained short spec
+             window. The TQ packed cache is the source of truth for
+             requests beyond that window.
           2. Extend the precomputed RoPE table out to the user's
              max_seq + a small slack (the BF16 path's rope table was
              sized at the threshold).
           3. Allocate the TQ packed cache + BF16 single-layer staging
              at ``max_seq_tq = user_max_seq + 16``.
 
-        After this returns, ``forward_own_decode_nvfp4_tq`` (eager) is
-        the correct decode entry. Captured-graph TQ replay is not
-        used here because its KV-cache write is skipped at capture
-        time, so replay only produces correct attention if the slot
-        was already populated for *this exact token* — fine for
-        bench (synthetic-fill, fixed token) but wrong for serving.
+        After this returns, long requests use the compressed KV route
+        selected by ``FLASHRT_QWEN36_LONG_KV_CACHE``.  ``fp8`` is the
+        default long-context route and allocates an e4m3 persistent KV
+        cache; until the direct FP8 attention kernel lands, it
+        dequantizes into the shared BF16 stage before calling FA2.
+        ``tq`` keeps the TurboQuant packed cache available for memory
+        and accuracy bisection.
         """
         # b_v=4, b_k_total=4, bit_packed=True matches the long-ctx
         # bench config (docs/qwen36_nvfp4.md §4): 1.83x compression
-        # at 1-byte idx → ~5x at bit-pack = the documented profile.
-        self._shrink_bf16_kv_cache(new_max_seq=64)
+        # at 1-byte idx -> ~5x at bit-pack = the documented profile.
+        # Keep the retained BF16 window so long-context-capable servers
+        # do not lose MTP spec throughput on short requests.
+        self._shrink_bf16_kv_cache(
+            new_max_seq=int(getattr(
+                self, '_short_ctx_spec_max_seq', 2048)))
         self._extend_rope_table_to(self._user_max_seq + 16)
-        self._load_turboquant_packed(
-            max_seq_tq=self._user_max_seq + 16,
-            b_v=4, b_k_total=4, bit_packed=True,
+        mode = os.environ.get(
+            'FLASHRT_QWEN36_LONG_KV_CACHE', 'fp8').strip().lower()
+        if mode not in ('tq', 'fp8'):
+            raise ValueError(
+                'FLASHRT_QWEN36_LONG_KV_CACHE must be tq or fp8, '
+                f'got {mode!r}')
+        self._long_kv_cache_mode = mode
+        if mode == 'fp8':
+            self._load_fp8_kv_cache(max_seq=self._user_max_seq + 16)
+        else:
+            self._load_turboquant_packed(
+                max_seq_tq=self._user_max_seq + 16,
+                b_v=4, b_k_total=4, bit_packed=True,
+            )
+        if self._weights.ptrs.get('mtp') is not None:
+            # Long-context MTP uses compact cache positions for prompt
+            # tail + generated tokens; the main long KV cache owns the
+            # full prompt.  Allocating BF16 MTP KV for the full 128K+
+            # user max_seq wastes several hundred MB on 32 GB cards.
+            compact_mtp = int(os.environ.get(
+                'FLASHRT_QWEN36_LONG_MTP_CACHE_TOKENS', '4096') or '4096')
+            compact_mtp = max(
+                int(getattr(self, '_short_ctx_spec_max_seq', 2048)),
+                compact_mtp,
+            )
+            self._extend_mtp_cache_to(
+                min(self._user_max_seq + 16, compact_mtp))
+
+    def _extend_mtp_cache_to(self, target_max_seq: int) -> None:
+        """Resize the MTP private KV cache for long-context spec decode."""
+        import torch
+
+        if self._weights.ptrs.get('mtp') is None:
+            return
+        bf16 = torch.bfloat16
+        fp32 = torch.float32
+        target_max_seq = int(target_max_seq)
+        cur = int(getattr(getattr(self, '_mtp_K_cache', None), 'shape',
+                          (0,))[0])
+        if cur >= target_max_seq:
+            return
+        self._mtp_K_cache = torch.empty(
+            target_max_seq, 4, 256, device=self.device, dtype=bf16)
+        self._mtp_V_cache = torch.empty_like(self._mtp_K_cache)
+        n_splits = min(128, (target_max_seq + 63) // 64)
+        self._mtp_n_splits = n_splits
+        self._mtp_lse_accum = torch.empty(
+            n_splits, 1, 24, 1, device=self.device, dtype=fp32)
+        self._mtp_o_accum = torch.empty(
+            n_splits, 1, 24, 1, 256, device=self.device, dtype=fp32)
+        if hasattr(self, '_captured_mtp_graphs'):
+            self._captured_mtp_graphs.clear()
+        if hasattr(self, '_captured_chain_graphs'):
+            self._captured_chain_graphs.clear()
+
+    def _ensure_long_mtp_cache_capacity(
+            self, prompt_len: int, max_new_tokens: int, K: int) -> None:
+        if self._weights.ptrs.get('mtp') is None:
+            return
+        mtp_tail = self._long_mtp_prefill_tail_for_prompt(int(prompt_len))
+        need = mtp_tail + int(max_new_tokens) + int(K) + 8
+        need = max(int(getattr(self, '_short_ctx_spec_max_seq', 2048)), need)
+        self._extend_mtp_cache_to(min(self._user_max_seq + 16, need))
+
+    def _long_mtp_prefill_tail_for_prompt(self, prompt_len: int) -> int:
+        raw = os.environ.get(
+            'FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL', 'auto') or 'auto'
+        if raw.lower() != 'auto':
+            return max(0, int(raw))
+        prompt_len = int(prompt_len)
+        if prompt_len < 512:
+            return 0
+        if prompt_len < 768:
+            return 512
+        if prompt_len < 3072:
+            return 2048
+        if prompt_len < 6144:
+            return 512
+        return 2048
+
+    def _prefill_long_ctx_tq_chunked(self, input_ids):
+        """Chunked prompt prefill for long-context TQ mode.
+
+        Reuses the S=K TQ verify forward to process prompt tokens in
+        chunks up to ``MAX_Q_SEQ``. This is still an eager bridge, but it
+        avoids the pathological one-full-forward-per-token prefill.
+        """
+        import os
+        import torch
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        prompt_len = int(input_ids.shape[1])
+        if prompt_len <= 0:
+            raise ValueError('input_ids must contain at least one token')
+        hidden = self._cfg['hidden_size']
+        chunk = int(os.environ.get(
+            'FLASHRT_QWEN36_TQ_PREFILL_CHUNK', str(self.MAX_Q_SEQ)))
+        mtp_tail = self._long_mtp_prefill_tail_for_prompt(prompt_len)
+        self._long_mtp_prefill_tail_effective = mtp_tail
+        hidden_save_start = max(0, prompt_len - mtp_tail - 1)
+        if mtp_tail > 0:
+            tail_rows = prompt_len - hidden_save_start
+            if (not hasattr(self, '_long_mtp_h_tail')
+                    or int(self._long_mtp_h_tail.shape[0]) < tail_rows):
+                import torch
+                self._long_mtp_h_tail = torch.empty(
+                    tail_rows, hidden, device=self.device,
+                    dtype=torch.bfloat16)
+            self._long_mtp_h_tail_start = hidden_save_start
+            self._long_mtp_h_tail_rows = tail_rows
+        # Long-ctx BF16 working buffers are intentionally capped at the
+        # retained short spec window (2048 by default). Allow larger
+        # MAX_Q_SEQ experiments to allocate, but never choose a prefill
+        # chunk that cannot fit the hidden ping-pong buffers.
+        chunk_cap = min(self.MAX_Q_SEQ, int(self._h_b.shape[0]))
+        chunk = max(1, min(chunk, chunk_cap))
+        d = self._rope_dim
+        s = torch.cuda.current_stream().cuda_stream
+
+        last_h = None
+        last_logits = None
+        for start in range(0, prompt_len, chunk):
+            end = min(start + chunk, prompt_len)
+            S = end - start
+            cos_S = self._rope_cos_table[start:end].view(1, S, d)
+            sin_S = self._rope_sin_table[start:end].view(1, S, d)
+            is_last = end == prompt_len
+            save_hidden = mtp_tail > 0 and end > hidden_save_start
+            if save_hidden:
+                mode = 'hidden_last' if is_last else 'hidden'
+            else:
+                mode = 'last' if is_last else 'none'
+            if getattr(self, '_long_kv_cache_mode', 'tq') == 'fp8':
+                logits = self.forward_own_decode_K_nvfp4_fp8kv(
+                    input_ids[:, start:end], cos_S, sin_S, start, S,
+                    logits_mode=mode)
+            else:
+                logits = self.forward_own_decode_K_nvfp4_tq(
+                    input_ids[:, start:end], cos_S, sin_S, start, S,
+                    logits_mode=mode)
+            if save_hidden:
+                copy_start = max(start, hidden_save_start)
+                src_start = copy_start - start
+                rows = end - copy_start
+                dst_start = copy_start - hidden_save_start
+                fvk.gpu_copy(
+                    self._long_mtp_h_tail[
+                        dst_start:dst_start + rows].data_ptr(),
+                    self._K_last_hidden_buf[
+                        :, src_start:src_start + rows, :].data_ptr(),
+                    rows * hidden * 2, s,
+                )
+            if is_last:
+                if save_hidden:
+                    last_h = self._K_last_hidden_buf[:, S - 1:S, :]
+                else:
+                    last_h = self._K_last_hidden_buf[:, :1, :]
+                last_logits = logits
+
+        assert last_h is not None and last_logits is not None
+        fvk.gpu_copy(
+            self._last_hidden_buf.data_ptr(), last_h.data_ptr(),
+            hidden * 2, s,
         )
+        if last_logits.data_ptr() != self._logits_buf.data_ptr():
+            fvk.gpu_copy(
+                self._logits_buf.data_ptr(), last_logits.data_ptr(),
+                self._cfg['vocab_size'] * 2, s,
+            )
+        return last_h.view(1, 1, hidden), last_logits
+
+    def _generate_long_ctx_speculative_KN_nvfp4(
+            self, input_ids, *, max_new_tokens: int, K: int = 6):
+        """Long-context MTP spec decode over the compressed KV cache.
+
+        The default route uses the TQ packed cache.  With
+        ``FLASHRT_QWEN36_LONG_KV_CACHE=fp8``, prefill and verify use an
+        e4m3 FP8 persistent cache with BF16 staging.  MTP draft
+        generation keeps its private BF16 KV cache.
+        """
+        import torch
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        prompt_len = int(input_ids.shape[1])
+        tq_spec_k = os.environ.get('FLASHRT_QWEN36_TQ_SPEC_K', '')
+        if tq_spec_k:
+            K = int(tq_spec_k)
+        else:
+            K = self._long_tq_effective_k(prompt_len, K)
+        adaptive_k = (
+            not tq_spec_k
+            and K >= 4
+            and os.environ.get('FLASHRT_QWEN36_TQ_ADAPTIVE_K', '1') == '1'
+        )
+        use_kernel_accept = (
+            os.environ.get('FLASHRT_QWEN36_KERNEL_ACCEPT', '1') == '1'
+        )
+        strict_next = (
+            os.environ.get('FLASHRT_QWEN36_TQ_STRICT_NEXT', '0') == '1'
+        )
+        strict_next_graph = (
+            strict_next
+            and os.environ.get(
+                'FLASHRT_QWEN36_TQ_STRICT_NEXT_GRAPH', '1') == '1'
+        )
+        accept_parts = int(os.environ.get(
+            'FLASHRT_QWEN36_ACCEPT_PARTS', '32') or '32')
+        use_partitioned_accept = (
+            use_kernel_accept
+            and accept_parts > 1
+            and hasattr(fvk, 'qwen36_spec_accept_partitioned_bf16')
+            and hasattr(self, '_spec_argmax_partial_vals')
+        )
+        max_spec_k = min(self.MAX_Q_SEQ - 1, self._MAX_PUBLIC_SPEC_K)
+        if K < 1 or K > max_spec_k:
+            raise ValueError(
+                f'K={K} out of range — need 1<=K<={max_spec_k}')
+        max_pos = prompt_len + int(max_new_tokens)
+        if max_pos > self._user_max_seq:
+            raise ValueError(
+                f'prompt_len ({prompt_len}) + max_new_tokens '
+                f'({max_new_tokens}) = {max_pos} exceeds the '
+                f'frontend max_seq ({self._user_max_seq})'
+            )
+        self._ensure_long_mtp_cache_capacity(prompt_len, max_new_tokens, K)
+
+        hidden = self._cfg['hidden_size']
+        self.reset_state()
+        self.reset_mtp_state()
+        if not hasattr(self, '_rope_cos_table'):
+            self._build_rope_table()
+
+        generated_len = 0
+
+        with torch.no_grad():
+            s = torch.cuda.current_stream().cuda_stream
+            fvk.gpu_copy(
+                self._gen_out_buf[:, :prompt_len].data_ptr(),
+                input_ids.data_ptr(), prompt_len * 8, s,
+            )
+            ev_pf0 = torch.cuda.Event(enable_timing=True)
+            ev_pf1 = torch.cuda.Event(enable_timing=True)
+            ev_dec1 = torch.cuda.Event(enable_timing=True)
+            ev_pf0.record()
+            # Main TQ prefill. Use the existing S=K verify forward as a
+            # chunked prompt forward so we do not run one full decode
+            # call per prompt token.
+            last_h, last_logits = self._prefill_long_ctx_tq_chunked(
+                input_ids)
+            if use_kernel_accept:
+                if use_partitioned_accept:
+                    fvk.qwen36_spec_accept_partitioned_bf16(
+                        last_logits.data_ptr(),
+                        self._spec_argmax_buf.data_ptr(),
+                        self._spec_argmax_buf.data_ptr(),
+                        self._spec_accept_n_buf.data_ptr(),
+                        self._spec_argmax_partial_vals.data_ptr(),
+                        self._spec_argmax_partial_idx.data_ptr(),
+                        1, self._cfg['vocab_size'], 0, accept_parts, s,
+                    )
+                else:
+                    fvk.qwen36_spec_accept_greedy_bf16(
+                        last_logits.data_ptr(),
+                        self._spec_argmax_buf.data_ptr(),
+                        self._spec_argmax_buf.data_ptr(),
+                        self._spec_accept_n_buf.data_ptr(),
+                        1, self._cfg['vocab_size'], 0, s,
+                    )
+                tok = self._spec_argmax_buf[:1].view(1, 1)
+            else:
+                tok = last_logits.argmax(
+                    dim=-1, keepdim=True).view(1, 1)
+            fvk.gpu_copy(
+                self._gen_out_buf[:, prompt_len:prompt_len + 1].data_ptr(),
+                tok.data_ptr(), 8, s,
+            )
+            generated_len = 1
+            cur_pos = prompt_len
+            mtp_tail = self._long_mtp_prefill_tail_for_prompt(prompt_len)
+            mtp_base = 0
+            if mtp_tail > 0:
+                # Experimental bridge toward the standard short-context
+                # MTP semantics: seed the drafter cache with the prompt
+                # tail instead of starting it empty at the first generated
+                # token.  We keep this tail-bounded because full prompt MTP
+                # prefill would dominate long-context TTFT.
+                first = max(1, prompt_len - mtp_tail)
+                tail_start = int(getattr(
+                    self, '_long_mtp_h_tail_start', first - 1))
+                tail_h = self._long_mtp_h_tail
+                used_kv_only = False
+                if os.environ.get(
+                        'FLASHRT_QWEN36_LONG_MTP_TAIL_KV_ONLY',
+                        '1') == '1':
+                    rows = prompt_len - first
+                    h_start = (first - 1) - tail_start
+                    used_kv_only = self._prefill_mtp_tail_kv_nvfp4(
+                        tail_h[h_start:h_start + rows],
+                        input_ids[:, first:prompt_len].view(-1),
+                        first, mtp_base)
+                    if used_kv_only:
+                        mtp_base += rows
+                if not used_kv_only:
+                    for p in range(first, prompt_len):
+                        h_idx = (p - 1) - tail_start
+                        prev_h_p = tail_h[
+                            h_idx:h_idx + 1].view(
+                                1, 1, hidden).contiguous()
+                        prev_tok_p = input_ids[:, p:p + 1]
+                        self.forward_mtp_head_nvfp4(
+                            prev_h_p, prev_tok_p, p,
+                            mtp_cache_pos=mtp_base)
+                        mtp_base += 1
+            self.forward_mtp_head_nvfp4(
+                last_h, tok, cur_pos, mtp_cache_pos=mtp_base)
+            h = last_h
+            ev_pf1.record()
+
+            self._spec_attempts = 0
+            self._spec_accepts = 0
+            self._spec_full = 0
+
+            while generated_len < max_new_tokens:
+                # MTP chain. Graph replay is the fastest warm path; set
+                # FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH=0 only when optimizing
+                # first-request latency without prewarm.
+                if os.environ.get(
+                        'FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH', '1') == '1':
+                    gs = self._graph_stream
+                    cg = self._ensure_mtp_chain_graph_nvfp4(
+                        cur_pos, K, cache_base_pos=mtp_base)
+                    gs.wait_stream(torch.cuda.current_stream())
+                    with torch.cuda.stream(gs):
+                        fvk.gpu_copy(
+                            self._mtp_static_prev_h.data_ptr(),
+                            h.data_ptr(), hidden * 2, gs.cuda_stream,
+                        )
+                        fvk.gpu_copy(
+                            self._mtp_static_prev_token.data_ptr(),
+                            tok.data_ptr(), 8, gs.cuda_stream,
+                        )
+                        cg.replay()
+                    torch.cuda.current_stream().wait_stream(gs)
+                    drafts_t = self._chain_drafts_buf[:K]
+                else:
+                    drafts = []
+                    h_mtp = h
+                    tok_mtp = tok
+                    for j in range(K):
+                        h_mtp, logits_mtp = self.forward_mtp_head_nvfp4(
+                            h_mtp, tok_mtp, cur_pos + j,
+                            mtp_cache_pos=mtp_base + j)
+                        tok_mtp = logits_mtp.argmax(
+                            dim=-1, keepdim=True).view(1, 1)
+                        drafts.append(tok_mtp)
+                    drafts_t = torch.cat(drafts, dim=0).view(K, 1)
+
+                d = self._rope_dim
+                cos_KN = self._rope_cos_table[
+                    cur_pos:cur_pos + K + 1].view(1, K + 1, d)
+                sin_KN = self._rope_sin_table[
+                    cur_pos:cur_pos + K + 1].view(1, K + 1, d)
+                Kv = K + 1
+                fvk.gpu_copy(
+                    self._verify_static_tokens[:, 0:1].data_ptr(),
+                    tok.data_ptr(), 8, s,
+                )
+                fvk.gpu_copy(
+                    self._verify_static_tokens[:, 1:Kv].data_ptr(),
+                    drafts_t.view(1, K).data_ptr(), K * 8, s,
+                )
+                fvk.gpu_copy(
+                    self._verify_static_cos[:, :Kv].data_ptr(),
+                    cos_KN.data_ptr(), Kv * d * 2, s,
+                )
+                fvk.gpu_copy(
+                    self._verify_static_sin[:, :Kv].data_ptr(),
+                    sin_KN.data_ptr(), Kv * d * 2, s,
+                )
+                if strict_next:
+                    fvk.gpu_copy(
+                        self._snap_lin_buf.data_ptr(),
+                        self._lin_state.data_ptr(),
+                        self._lin_state.numel() * 2, s,
+                    )
+                    fvk.gpu_copy(
+                        self._snap_conv_buf.data_ptr(),
+                        self._lin_conv_state.data_ptr(),
+                        self._lin_conv_state.numel() * 2, s,
+                    )
+
+                kv_mode = getattr(self, '_long_kv_cache_mode', 'tq')
+                use_verify_graph = (
+                    os.environ.get(
+                        'FLASHRT_QWEN36_TQ_VERIFY_GRAPH', '1') == '1'
+                )
+                if kv_mode == 'tq' and use_verify_graph:
+                    self._tq_mark_dequant_valid_end(cur_pos)
+                    graph_key = (cur_pos, Kv)
+                    vg = self._graph_cache_get(
+                        self._captured_verify_graphs_tq, graph_key)
+                    if vg is None and self._long_tq_graph_capture_allowed():
+                        vg = self._ensure_verify_graph_nvfp4_tq(cur_pos, Kv)
+                    if vg is not None:
+                        gs = self._graph_stream
+                        gs.wait_stream(torch.cuda.current_stream())
+                        with torch.cuda.stream(gs):
+                            vg.replay()
+                        torch.cuda.current_stream().wait_stream(gs)
+                        self._tq_mark_dequant_valid_end(cur_pos + Kv)
+                        logits_KN = self._K_logits_buf[:Kv]
+                    else:
+                        logits_KN = self._forward_long_kv_K_nvfp4(
+                            self._verify_static_tokens[:, :Kv],
+                            self._verify_static_cos[:, :Kv],
+                            self._verify_static_sin[:, :Kv],
+                            cur_pos, Kv)
+                elif kv_mode == 'fp8' and use_verify_graph:
+                    graph_key = (cur_pos, Kv)
+                    cache = getattr(
+                        self, '_captured_verify_graphs_fp8kv', None)
+                    vg = (self._graph_cache_get(cache, graph_key)
+                          if cache is not None else None)
+                    if vg is None and self._long_tq_graph_capture_allowed():
+                        vg = self._ensure_verify_graph_nvfp4_fp8kv(
+                            cur_pos, Kv)
+                    if vg is not None:
+                        gs = self._graph_stream
+                        gs.wait_stream(torch.cuda.current_stream())
+                        with torch.cuda.stream(gs):
+                            vg.replay()
+                        torch.cuda.current_stream().wait_stream(gs)
+                        self._fp8_mark_dequant_valid_end(cur_pos + Kv)
+                        logits_KN = self._K_logits_buf[:Kv]
+                    else:
+                        logits_KN = self._forward_long_kv_K_nvfp4(
+                            self._verify_static_tokens[:, :Kv],
+                            self._verify_static_cos[:, :Kv],
+                            self._verify_static_sin[:, :Kv],
+                            cur_pos, Kv)
+                else:
+                    logits_KN = self._forward_long_kv_K_nvfp4(
+                        self._verify_static_tokens[:, :Kv],
+                        self._verify_static_cos[:, :Kv],
+                        self._verify_static_sin[:, :Kv],
+                        cur_pos, Kv)
+
+                if use_kernel_accept:
+                    if use_partitioned_accept:
+                        fvk.qwen36_spec_accept_partitioned_bf16(
+                            logits_KN.data_ptr(),
+                            drafts_t.view(-1).data_ptr(),
+                            self._spec_argmax_buf.data_ptr(),
+                            self._spec_accept_n_buf.data_ptr(),
+                            self._spec_argmax_partial_vals.data_ptr(),
+                            self._spec_argmax_partial_idx.data_ptr(),
+                            Kv, self._cfg['vocab_size'], K,
+                            accept_parts, s,
+                        )
+                    else:
+                        fvk.qwen36_spec_accept_greedy_bf16(
+                            logits_KN.data_ptr(),
+                            drafts_t.view(-1).data_ptr(),
+                            self._spec_argmax_buf.data_ptr(),
+                            self._spec_accept_n_buf.data_ptr(),
+                            Kv, self._cfg['vocab_size'], K, s,
+                        )
+                    all_argmax = self._spec_argmax_buf[:Kv]
+                    N = int(fvk.cuda_read_i32_sync(
+                        self._spec_accept_n_buf.data_ptr(), s))
+                else:
+                    all_argmax = logits_KN.argmax(dim=-1)
+                    drafts_stack = drafts_t.view(-1)
+                    matches = (all_argmax[:K] == drafts_stack).long()
+                    matches_pad = torch.cat([
+                        matches,
+                        torch.zeros(1, device=matches.device,
+                                    dtype=matches.dtype),
+                    ])
+                    N = int(matches_pad.argmin().item())
+                self._spec_attempts += 1
+                self._spec_accepts += N
+
+                argmax_at = (lambda j: all_argmax[j:j + 1].view(1, 1))
+                strict_tok = None
+                if strict_next:
+                    process = K + 1 if N == K else N + 1
+                    fvk.gpu_copy(
+                        self._lin_state.data_ptr(),
+                        self._snap_lin_buf.data_ptr(),
+                        self._lin_state.numel() * 2, s,
+                    )
+                    fvk.gpu_copy(
+                        self._lin_conv_state.data_ptr(),
+                        self._snap_conv_buf.data_ptr(),
+                        self._lin_conv_state.numel() * 2, s,
+                    )
+                    for j in range(process):
+                        if strict_next_graph:
+                            if j != 0:
+                                fvk.gpu_copy(
+                                    self._verify_static_tokens[
+                                        :, :1].data_ptr(),
+                                    self._verify_static_tokens[
+                                        :, j:j + 1].data_ptr(), 8, s,
+                                )
+                                fvk.gpu_copy(
+                                    self._verify_static_cos[
+                                        :, :1].data_ptr(),
+                                    self._verify_static_cos[
+                                        :, j:j + 1].data_ptr(),
+                                    d * 2, s,
+                                )
+                            fvk.gpu_copy(
+                                self._verify_static_sin[
+                                    :, :1].data_ptr(),
+                                self._verify_static_sin[
+                                    :, j:j + 1].data_ptr(),
+                                d * 2, s,
+                            )
+                            if getattr(
+                                    self, '_long_kv_cache_mode',
+                                    'tq') == 'fp8':
+                                self._fp8_mark_dequant_valid_end(
+                                    cur_pos + j)
+                                sg = self._ensure_verify_graph_nvfp4_fp8kv(
+                                    cur_pos + j, 1)
+                            else:
+                                self._tq_mark_dequant_valid_end(cur_pos + j)
+                                sg = self._ensure_verify_graph_nvfp4_tq(
+                                    cur_pos + j, 1)
+                            gs = self._graph_stream
+                            gs.wait_stream(torch.cuda.current_stream())
+                            with torch.cuda.stream(gs):
+                                sg.replay()
+                            torch.cuda.current_stream().wait_stream(gs)
+                            if getattr(
+                                    self, '_long_kv_cache_mode',
+                                    'tq') == 'fp8':
+                                self._fp8_mark_dequant_valid_end(
+                                    cur_pos + j + 1)
+                            else:
+                                self._tq_mark_dequant_valid_end(
+                                    cur_pos + j + 1)
+                        else:
+                            mode = 'last' if j == process - 1 else 'none'
+                            self._forward_long_kv_K_nvfp4(
+                                self._verify_static_tokens[:, j:j + 1],
+                                self._verify_static_cos[:, j:j + 1],
+                                self._verify_static_sin[:, j:j + 1],
+                                cur_pos + j, 1, logits_mode=mode)
+                    strict_logits = (self._K_logits_buf[:1]
+                                     if strict_next_graph
+                                     else self._logits_buf)
+                    fvk.qwen36_spec_accept_greedy_bf16(
+                        strict_logits.data_ptr(),
+                        self._spec_argmax_buf[Kv:Kv + 1].data_ptr(),
+                        self._spec_argmax_buf[Kv:Kv + 1].data_ptr(),
+                        self._spec_accept_n_buf.data_ptr(),
+                        1, self._cfg['vocab_size'], 0, s,
+                    )
+                    strict_tok = self._spec_argmax_buf[
+                        Kv:Kv + 1].view(1, 1)
+                if N == K:
+                    self._spec_full += 1
+                    take = min(K + 1, max_new_tokens - generated_len)
+                    if take > 0:
+                        if strict_next:
+                            prefix = min(K, take)
+                            if prefix > 0:
+                                fvk.gpu_copy(
+                                    self._gen_out_buf[
+                                        :, prompt_len + generated_len:
+                                        prompt_len + generated_len + prefix
+                                    ].data_ptr(),
+                                    all_argmax[:prefix].data_ptr(),
+                                    prefix * 8, s,
+                                )
+                            if take > K:
+                                fvk.gpu_copy(
+                                    self._gen_out_buf[
+                                        :, prompt_len + generated_len + K:
+                                        prompt_len + generated_len + K + 1
+                                    ].data_ptr(),
+                                    strict_tok.data_ptr(), 8, s,
+                                )
+                        else:
+                            fvk.gpu_copy(
+                                self._gen_out_buf[
+                                    :, prompt_len + generated_len:
+                                    prompt_len + generated_len + take
+                                ].data_ptr(),
+                                all_argmax[:take].data_ptr(),
+                                take * 8, s,
+                            )
+                        generated_len += take
+                    tok = strict_tok if strict_next else argmax_at(K)
+                    h = (self._K_last_hidden_buf[:, :1, :] if strict_next
+                         else self._K_last_hidden_buf[:, K:K + 1, :])
+                    cur_pos += K + 1
+                    mtp_base += K + 1
+                    self._tq_mark_dequant_valid_end(cur_pos)
+                    self._fp8_mark_dequant_valid_end(cur_pos)
+                else:
+                    take = min(N + 1, max_new_tokens - generated_len)
+                    if take > 0:
+                        if strict_next:
+                            prefix = min(N, take)
+                            if prefix > 0:
+                                fvk.gpu_copy(
+                                    self._gen_out_buf[
+                                        :, prompt_len + generated_len:
+                                        prompt_len + generated_len + prefix
+                                    ].data_ptr(),
+                                    all_argmax[:prefix].data_ptr(),
+                                    prefix * 8, s,
+                                )
+                            if take > N:
+                                fvk.gpu_copy(
+                                    self._gen_out_buf[
+                                        :, prompt_len + generated_len + N:
+                                        prompt_len + generated_len + N + 1
+                                    ].data_ptr(),
+                                    strict_tok.data_ptr(), 8, s,
+                                )
+                        else:
+                            fvk.gpu_copy(
+                                self._gen_out_buf[
+                                    :, prompt_len + generated_len:
+                                    prompt_len + generated_len + take
+                                ].data_ptr(),
+                                all_argmax[:take].data_ptr(),
+                                take * 8, s,
+                            )
+                        generated_len += take
+                    if not strict_next:
+                        fvk.gpu_copy(
+                            self._lin_state.data_ptr(),
+                            self._K_lin_state_per_step[N].data_ptr(),
+                            self._lin_state.numel() * 2, s,
+                        )
+                        fvk.gpu_copy(
+                            self._lin_conv_state.data_ptr(),
+                            self._K_lin_conv_state_per_step[N].data_ptr(),
+                            self._lin_conv_state.numel() * 2, s,
+                        )
+                    h = (self._K_last_hidden_buf[:, :1, :] if strict_next
+                         else self._K_last_hidden_buf[:, N:N + 1, :])
+                    tok = strict_tok if strict_next else argmax_at(N)
+                    cur_pos += N + 1
+                    mtp_base += N + 1
+                    self._tq_mark_dequant_valid_end(cur_pos)
+                    self._fp8_mark_dequant_valid_end(cur_pos)
+
+                if (adaptive_k and K > 3
+                        and self._spec_attempts >= 8
+                        and self._spec_full == 0
+                        and (self._spec_accepts / self._spec_attempts)
+                        < 1.25):
+                    K = 3
+
+            ev_dec1.record()
+            torch.cuda.synchronize()
+            self._long_ctx_prefill_ms = ev_pf0.elapsed_time(ev_pf1)
+            self._long_ctx_decode_ms = ev_pf1.elapsed_time(ev_dec1)
+            self._long_ctx_route = (
+                f'{getattr(self, "_long_kv_cache_mode", "tq")}_spec')
+
+        return self._gen_out_buf[:, :prompt_len + generated_len]
 
     def _generate_long_ctx_single_token(
             self, input_ids, max_new_tokens: int):
@@ -5725,14 +7595,13 @@ class Qwen36TorchFrontendRtx:
 
         Single-token decode through the eager TQ forward — supports
         any prompt length up to ``self._user_max_seq`` and any output
-        length up to the same bound. Slower than spec (~30-40 tok/s
-        decode at 8-32 K ctx, dropping to ~20 tok/s at 256 K) but
-        works at every context length the TQ packed cache covers.
+        length up to the same bound. Slower than spec, but works at
+        every context length the TQ packed cache covers.
 
         Spec decode on the TQ path is the Phase 3D follow-up; until
         that lands, calling
-        ``generate_own_speculative_KN_nvfp4(..., K=N)`` in long-ctx
-        mode silently uses K=1 and logs a one-time info line.
+        ``generate_own_speculative_KN_nvfp4(..., K=N)`` for a request
+        beyond the short spec window silently uses K=1.
         """
         import torch
 
@@ -5746,12 +7615,19 @@ class Qwen36TorchFrontendRtx:
             )
 
         self.reset_state()
+        self._spec_attempts = 0
+        self._spec_accepts = 0
+        self._spec_full = 0
         if not hasattr(self, '_rope_cos_table'):
             self._build_rope_table()
 
         generated = list(input_ids[0].tolist())
         cur_pos = 0
         with torch.no_grad():
+            ev_pf0 = torch.cuda.Event(enable_timing=True)
+            ev_pf1 = torch.cuda.Event(enable_timing=True)
+            ev_dec1 = torch.cuda.Event(enable_timing=True)
+            ev_pf0.record()
             # Prefill: one TQ forward per prompt token.
             for p in range(prompt_len):
                 tok = input_ids[:, p:p + 1]
@@ -5763,6 +7639,7 @@ class Qwen36TorchFrontendRtx:
             tok = self._logits_buf.argmax(
                 dim=-1, keepdim=True).view(1, 1)
             generated.append(int(tok.item()))
+            ev_pf1.record()
             # Decode loop.
             for _ in range(int(max_new_tokens) - 1):
                 cos, sin = self._rope_cos_sin(cur_pos)
@@ -5772,6 +7649,11 @@ class Qwen36TorchFrontendRtx:
                     dim=-1, keepdim=True).view(1, 1)
                 generated.append(int(tok.item()))
                 cur_pos += 1
+            ev_dec1.record()
+            torch.cuda.synchronize()
+            self._long_ctx_prefill_ms = ev_pf0.elapsed_time(ev_pf1)
+            self._long_ctx_decode_ms = ev_pf1.elapsed_time(ev_dec1)
+            self._long_ctx_route = 'tq_single'
 
         return torch.tensor(
             [generated], device=input_ids.device, dtype=input_ids.dtype)
@@ -5879,6 +7761,339 @@ class Qwen36TorchFrontendRtx:
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 
+    def _load_fp8_kv_cache(self, max_seq: int) -> None:
+        """Allocate an e4m3 persistent KV cache for long-context serving.
+
+        This is the community-style memory layout: full-attn KV is stored
+        at one byte per element instead of BF16.  The first implementation
+        deliberately keeps attention math on the existing BF16 FA2 ABI by
+        dequantizing a layer prefix into a shared BF16 stage.  That makes
+        it a clean pipeline/memory bridge; replacing ``_fp8_stage_for_layer``
+        with a direct FP8-attention call is the next optimization step.
+        """
+        import os
+        import torch
+
+        max_seq = int(max_seq)
+        xqa_page = 128
+        max_seq = ((max_seq + xqa_page - 1) // xqa_page) * xqa_page
+        fp8 = torch.float8_e4m3fn
+        bf16 = torch.bfloat16
+        d = self.device
+        nl = self._attn.NUM_FULL_LAYERS
+        nkv = self._attn.NUM_KV_HEADS
+        hd = self._attn.HEAD_DIM
+
+        self._fp8_K_cache = torch.empty(
+            nl, max_seq, nkv, hd, dtype=fp8, device=d)
+        self._fp8_V_cache = torch.empty_like(self._fp8_K_cache)
+        self._fp8_k_stage = torch.empty(
+            max_seq, nkv, hd, dtype=bf16, device=d)
+        self._fp8_v_stage = torch.empty_like(self._fp8_k_stage)
+        self._fp8_kv_scale = torch.ones(1, dtype=torch.float32, device=d)
+        self._fp8_kv_max_seq = max_seq
+        self._fp8_xqa_page = xqa_page
+        self._fp8_xqa_pages = max_seq // xqa_page
+        self._fp8_xqa_page_table = torch.arange(
+            self._fp8_xqa_pages, dtype=torch.int32, device=d).view(
+                1, self._fp8_xqa_pages)
+        self._fp8_xqa_seqlens: dict[int, torch.Tensor] = {}
+        self._fp8_xqa_masks: dict[int, torch.Tensor] = {}
+        xqa_sem_count = nkv * (
+            (max(self._MAX_PUBLIC_SPEC_K + 1, int(self.MAX_Q_SEQ))
+             * (self._attn.NUM_Q_HEADS // nkv) + 31) // 32)
+        self._fp8_xqa_semaphores = torch.zeros(
+            max(256, xqa_sem_count), dtype=torch.uint32, device=d)
+        scratch_mb = int(os.environ.get(
+            'FLASHRT_QWEN36_FP8_XQA_SCRATCH_MB', '256') or '256')
+        self._fp8_xqa_scratch = torch.zeros(
+            max(1, scratch_mb) << 20, dtype=torch.uint8, device=d)
+        self._fp8_xqa_enable_pdl = (
+            os.environ.get('FLASHRT_QWEN36_FP8_XQA_PDL', '1') == '1')
+
+        stage_cap_raw = os.environ.get(
+            'FLASHRT_QWEN36_FP8_STAGE_CAP', 'auto').lower()
+        if stage_cap_raw == 'auto':
+            stage_cap = min(max_seq, 204864)
+        else:
+            stage_cap = max(1, min(max_seq, int(stage_cap_raw)))
+        stage_layers_raw = os.environ.get(
+            'FLASHRT_QWEN36_FP8_STAGE_LAYERS', 'auto').lower()
+        if stage_layers_raw == 'auto':
+            policy_cap = 2 if stage_cap <= 132096 else 1
+            bytes_per_layer = stage_cap * nkv * hd * 2 * 2
+            reserve_mb = int(os.environ.get(
+                'FLASHRT_QWEN36_FP8_STAGE_RESERVE_MB', '1024') or '0')
+            try:
+                free_bytes, _ = torch.cuda.mem_get_info()
+                mem_cap = max(
+                    0, (int(free_bytes) - (reserve_mb << 20))
+                    // bytes_per_layer)
+            except Exception:
+                mem_cap = policy_cap
+            stage_layers = max(0, min(16, policy_cap, int(mem_cap)))
+        else:
+            stage_layers = max(0, min(16, int(stage_layers_raw)))
+        self._fp8_stage_layers = stage_layers
+        self._fp8_stage_cap = stage_cap
+        self._fp8_stage_valid_end = [0] * stage_layers
+        if stage_layers > 0:
+            self._fp8_k_stage_per_layer = torch.empty(
+                stage_layers, stage_cap, nkv, hd,
+                dtype=bf16, device=d)
+            self._fp8_v_stage_per_layer = torch.empty_like(
+                self._fp8_k_stage_per_layer)
+
+        hot_cap_raw = os.environ.get(
+            'FLASHRT_QWEN36_FP8_HOT_STAGE_CAP', 'auto').lower()
+        if hot_cap_raw == 'auto':
+            hot_cap = min(max_seq, 132096)
+        else:
+            hot_cap = max(1, min(max_seq, int(hot_cap_raw)))
+        hot_layers_raw = os.environ.get(
+            'FLASHRT_QWEN36_FP8_HOT_STAGE_LAYERS', 'auto').lower()
+        if hot_layers_raw == 'auto':
+            hot_policy = 1 if hot_cap < stage_cap else 0
+            hot_bytes_per_layer = hot_cap * nkv * hd * 2 * 2
+            reserve_mb = int(os.environ.get(
+                'FLASHRT_QWEN36_FP8_HOT_STAGE_RESERVE_MB', '1024') or '0')
+            try:
+                free_bytes, _ = torch.cuda.mem_get_info()
+                hot_mem_cap = max(
+                    0, (int(free_bytes) - (reserve_mb << 20))
+                    // hot_bytes_per_layer)
+            except Exception:
+                hot_mem_cap = hot_policy
+            hot_layers = max(
+                0, min(16 - stage_layers, hot_policy, int(hot_mem_cap)))
+        else:
+            hot_layers = max(
+                0, min(16 - stage_layers, int(hot_layers_raw)))
+        self._fp8_hot_stage_start_layer = stage_layers
+        self._fp8_hot_stage_layers = hot_layers
+        self._fp8_hot_stage_cap = hot_cap
+        self._fp8_hot_stage_valid_end = [0] * hot_layers
+        if hot_layers > 0:
+            self._fp8_k_stage_hot = torch.empty(
+                hot_layers, hot_cap, nkv, hd,
+                dtype=bf16, device=d)
+            self._fp8_v_stage_hot = torch.empty_like(
+                self._fp8_k_stage_hot)
+
+    def _fp8_xqa_enabled(
+            self, q_seq: int | None = None,
+            end_pos: int | None = None) -> bool:
+        if os.environ.get('FLASHRT_QWEN36_FP8_XQA', '1') == '0':
+            return False
+        if q_seq is not None and int(q_seq) > self._MAX_PUBLIC_SPEC_K + 1:
+            return False
+        if end_pos is not None:
+            min_ctx_raw = os.environ.get(
+                'FLASHRT_QWEN36_FP8_XQA_MIN_CTX', 'auto') or '0'
+            if min_ctx_raw.lower() == 'auto':
+                if not self._fp8_xqa_auto_bucket_enabled(
+                        q_seq, int(end_pos)):
+                    return False
+            else:
+                min_ctx = int(min_ctx_raw)
+                if int(end_pos) < min_ctx:
+                    return False
+        try:
+            from flash_rt import flash_rt_kernels as fvk
+            return hasattr(fvk, 'qwen36_flashinfer_xqa_bf16_fp8kv_spec')
+        except Exception:
+            return False
+
+    def _fp8_xqa_auto_bucket_enabled(
+            self, q_seq: int | None, end_pos: int) -> bool:
+        """Measured default XQA policy for short and long FP8-KV verify."""
+        end_pos = int(end_pos)
+        if end_pos < 6144:
+            return False
+        if end_pos < 12288:
+            return True
+        if end_pos < 24576:
+            return False
+        return True
+
+    def _fp8_xqa_seq_lens(self, end_pos: int):
+        import torch
+
+        end_pos = int(end_pos)
+        t = self._fp8_xqa_seqlens.get(end_pos)
+        if t is None:
+            t = torch.full(
+                (1, 1), end_pos, dtype=torch.uint32, device=self.device)
+            self._fp8_xqa_seqlens[end_pos] = t
+        return t
+
+    def _fp8_xqa_mask(self, q_seq: int):
+        import torch
+
+        q_seq = int(q_seq)
+        t = self._fp8_xqa_masks.get(q_seq)
+        if t is None:
+            words = (q_seq + 31) // 32
+            rows = torch.zeros((q_seq, words), dtype=torch.int32)
+            for i in range(q_seq):
+                upto = i + 1
+                full = upto // 32
+                rem = upto % 32
+                if full:
+                    rows[i, :full] = -1
+                if rem:
+                    rows[i, full] = (1 << rem) - 1
+            t = rows.to(device=self.device)
+            self._fp8_xqa_masks[q_seq] = t
+        return t
+
+    def _fp8_xqa_attn(self, layer: int, end_pos: int, q_seq: int,
+                      stream: int) -> None:
+        from flash_rt import flash_rt_kernels as fvk
+
+        page = int(self._fp8_xqa_page)
+        max_seq_len = ((int(end_pos) + page - 1) // page) * page
+        q_view = self._attn.Q_buf[:, :q_seq].view(1, 1, q_seq, 24, 256)
+        o_view = self._attn.O_buf[:, :q_seq].view(1, 1, q_seq, 24, 256)
+        fvk.qwen36_flashinfer_xqa_bf16_fp8kv_spec(
+            q_view.data_ptr(),
+            self._fp8_K_cache[layer].data_ptr(),
+            self._fp8_V_cache[layer].data_ptr(),
+            self._fp8_xqa_page_table.data_ptr(),
+            self._fp8_xqa_seq_lens(end_pos).data_ptr(),
+            self._fp8_xqa_mask(q_seq).data_ptr(),
+            o_view.data_ptr(),
+            self._fp8_xqa_semaphores.data_ptr(),
+            self._fp8_xqa_scratch.data_ptr(),
+            max_seq_len,
+            int(q_seq),
+            int(self._attn._num_sms),
+            1.0,
+            1.0,
+            bool(self._fp8_xqa_enable_pdl),
+            page * 4 * 256,
+            4 * 256,
+            256,
+            stream,
+        )
+
+    def _fp8_mark_dequant_valid_end(self, end_pos: int) -> None:
+        end_pos = int(end_pos)
+        valid = getattr(self, '_fp8_stage_valid_end', None)
+        if valid is not None:
+            for i in range(len(valid)):
+                valid[i] = end_pos
+        hot_valid = getattr(self, '_fp8_hot_stage_valid_end', None)
+        if hot_valid is not None:
+            for i in range(len(hot_valid)):
+                hot_valid[i] = end_pos
+
+    def _fp8_write_kv(self, layer: int, pos_start: int, pos_end: int,
+                      k, v) -> None:
+        from flash_rt import flash_rt_kernels as fvk
+        import torch
+
+        S = int(pos_end) - int(pos_start)
+        if S <= 0:
+            return
+        s = torch.cuda.current_stream().cuda_stream
+        n = S * 4 * 256
+        k_dst = self._fp8_K_cache[layer, pos_start:pos_end]
+        v_dst = self._fp8_V_cache[layer, pos_start:pos_end]
+        # k/v are produced by fixed contiguous scratch buffers in the
+        # verify forward. Avoid a defensive Tensor.contiguous() here so
+        # the FP8-KV write path stays allocation-free before graph capture.
+        fvk.quantize_fp8_static(
+            k.data_ptr(), k_dst.data_ptr(),
+            self._fp8_kv_scale.data_ptr(), n, s)
+        fvk.quantize_fp8_static(
+            v.data_ptr(), v_dst.data_ptr(),
+            self._fp8_kv_scale.data_ptr(), n, s)
+
+    def _fp8_stage_for_layer(self, layer: int, end_pos: int):
+        from flash_rt import flash_rt_kernels as fvk
+        import torch
+
+        end_pos = int(end_pos)
+        if end_pos <= 0:
+            return self._fp8_k_stage, self._fp8_v_stage
+        stage_layers = int(getattr(self, '_fp8_stage_layers', 0))
+        if (stage_layers > 0
+                and layer < stage_layers
+                and end_pos <= int(getattr(self, '_fp8_stage_cap', 0))):
+            return self._fp8_stage_for_layer_into(
+                layer, end_pos,
+                self._fp8_k_stage_per_layer[layer],
+                self._fp8_v_stage_per_layer[layer],
+                self._fp8_stage_valid_end,
+                layer)
+        hot_start = int(getattr(self, '_fp8_hot_stage_start_layer', 0))
+        hot_layers = int(getattr(self, '_fp8_hot_stage_layers', 0))
+        hot_idx = layer - hot_start
+        if (hot_layers > 0
+                and hot_idx >= 0
+                and hot_idx < hot_layers
+                and end_pos <= int(getattr(
+                    self, '_fp8_hot_stage_cap', 0))):
+            return self._fp8_stage_for_layer_into(
+                layer, end_pos,
+                self._fp8_k_stage_hot[hot_idx],
+                self._fp8_v_stage_hot[hot_idx],
+                self._fp8_hot_stage_valid_end,
+                hot_idx)
+        s = torch.cuda.current_stream().cuda_stream
+        n = end_pos * 4 * 256
+        if hasattr(fvk, 'dequantize_fp8_static_bf16_2'):
+            fvk.dequantize_fp8_static_bf16_2(
+                self._fp8_K_cache[layer, :end_pos].data_ptr(),
+                self._fp8_V_cache[layer, :end_pos].data_ptr(),
+                self._fp8_k_stage[:end_pos].data_ptr(),
+                self._fp8_v_stage[:end_pos].data_ptr(),
+                self._fp8_kv_scale.data_ptr(),
+                self._fp8_kv_scale.data_ptr(), n, s)
+        else:
+            fvk.dequantize_fp8_static_bf16(
+                self._fp8_K_cache[layer, :end_pos].data_ptr(),
+                self._fp8_k_stage[:end_pos].data_ptr(),
+                self._fp8_kv_scale.data_ptr(), n, s)
+            fvk.dequantize_fp8_static_bf16(
+                self._fp8_V_cache[layer, :end_pos].data_ptr(),
+                self._fp8_v_stage[:end_pos].data_ptr(),
+                self._fp8_kv_scale.data_ptr(), n, s)
+        return self._fp8_k_stage, self._fp8_v_stage
+
+    def _fp8_stage_for_layer_into(
+            self, layer: int, end_pos: int, k_stage, v_stage,
+            valid_list: list[int], valid_idx: int):
+        from flash_rt import flash_rt_kernels as fvk
+        import torch
+
+        valid = int(valid_list[valid_idx])
+        end_pos = int(end_pos)
+        if valid < end_pos:
+            s = torch.cuda.current_stream().cuda_stream
+            rows = end_pos - valid
+            n = rows * 4 * 256
+            if hasattr(fvk, 'dequantize_fp8_static_bf16_2'):
+                fvk.dequantize_fp8_static_bf16_2(
+                    self._fp8_K_cache[layer, valid:end_pos].data_ptr(),
+                    self._fp8_V_cache[layer, valid:end_pos].data_ptr(),
+                    k_stage[valid:end_pos].data_ptr(),
+                    v_stage[valid:end_pos].data_ptr(),
+                    self._fp8_kv_scale.data_ptr(),
+                    self._fp8_kv_scale.data_ptr(), n, s)
+            else:
+                fvk.dequantize_fp8_static_bf16(
+                    self._fp8_K_cache[layer, valid:end_pos].data_ptr(),
+                    k_stage[valid:end_pos].data_ptr(),
+                    self._fp8_kv_scale.data_ptr(), n, s)
+                fvk.dequantize_fp8_static_bf16(
+                    self._fp8_V_cache[layer, valid:end_pos].data_ptr(),
+                    v_stage[valid:end_pos].data_ptr(),
+                    self._fp8_kv_scale.data_ptr(), n, s)
+            valid_list[valid_idx] = end_pos
+        return k_stage, v_stage
+
     def _load_turboquant_packed(self, max_seq_tq: int = 65536,
                                   b_v: int = 4, b_k_total: int = 4,
                                   bit_packed: bool = False) -> None:
@@ -5929,28 +8144,117 @@ class Qwen36TorchFrontendRtx:
             self._tq_max_seq = max_seq_tq
 
             # Phase 3B-β: per-layer BF16 staging for incremental dequant.
-            # Enabled only at ≤ BETA_MAX_SEQ (β-0.2 probe: 64K user ctx
-            # = 65552 max_seq leaves 6.8 GB headroom — safe; 128K user
-            # ctx leaves 1 GB and OOMs under forward overhead).  100000
-            # is the cushion-safe upper bound for 64K user ctx.  Above
-            # threshold, fallback to the shared single-layer stage above.
-            BETA_MAX_SEQ = 100000
-            self._tq_use_per_layer = (max_seq_tq <= BETA_MAX_SEQ)
+            # Staged layers dequant only newly-written rows while unstaged
+            # layers fall back to shared full-prefix dequant.  This is the
+            # main speed/memory knob for 128K+ decode.
+            #
+            # The stage capacity may be smaller than max_seq_tq.  This lets
+            # a 256K-capable server prioritize the 128K/200K buckets with
+            # multiple staged layers instead of spending all VRAM on a single
+            # 256K-wide staged layer.  Requests beyond the staged capacity
+            # remain correct and use the shared full-prefix fallback.
+            stage_reserve_mb = int(os.environ.get(
+                'FLASHRT_QWEN36_TQ_PER_LAYER_STAGE_RESERVE_MB', '1024'))
+            stage_cap_raw = os.environ.get(
+                'FLASHRT_QWEN36_TQ_PER_LAYER_STAGE_CAP', 'auto').lower()
+            if stage_cap_raw == 'auto':
+                # 200K serving envelope: prompt=204800 plus decode warm slack.
+                stage_cap = min(max_seq_tq, 204864)
+            else:
+                stage_cap = max(1, min(max_seq_tq, int(stage_cap_raw)))
+            stage_layers_raw = os.environ.get(
+                'FLASHRT_QWEN36_TQ_PER_LAYER_STAGE_LAYERS', 'auto').lower()
+            if stage_layers_raw == 'auto':
+                if stage_cap <= 100000:
+                    policy_cap = 16
+                elif stage_cap <= 132000:
+                    policy_cap = 8
+                elif stage_cap <= 205000:
+                    policy_cap = 4
+                else:
+                    policy_cap = 3
+                if max_seq_tq > stage_cap + 4096 and stage_cap > 132000:
+                    policy_cap = min(policy_cap, 3)
+                # One staged layer holds K and V:
+                # stage_cap * num_kv * head_dim * sizeof(bf16) * 2.
+                bytes_per_layer = stage_cap * 4 * 256 * 2 * 2
+                try:
+                    free_bytes, _ = torch.cuda.mem_get_info()
+                    reserve = max(0, stage_reserve_mb) << 20
+                    mem_cap = max(0, (int(free_bytes) - reserve)
+                                  // bytes_per_layer)
+                except Exception:
+                    # If CUDA memory introspection is unavailable, keep the
+                    # old safe envelope plus a small 200K-priority tier.
+                    if stage_cap <= 100000:
+                        mem_cap = 16
+                    elif stage_cap <= 132000:
+                        mem_cap = 8
+                    else:
+                        mem_cap = 3
+                stage_layers = max(0, min(16, policy_cap, int(mem_cap)))
+            else:
+                stage_layers = max(0, min(16, int(stage_layers_raw)))
+            self._tq_per_layer_stage_layers = stage_layers
+            self._tq_per_layer_stage_cap = stage_cap
+            self._tq_use_per_layer = stage_layers > 0
             if self._tq_use_per_layer:
                 self._tq_k_stage_per_layer = torch.empty(
-                    16, max_seq_tq, 4, 256,
+                    stage_layers, stage_cap, 4, 256,
                     dtype=torch.bfloat16, device=self.device)
                 self._tq_v_stage_per_layer = torch.empty_like(
                     self._tq_k_stage_per_layer)
+
+            hot_cap_raw = os.environ.get(
+                'FLASHRT_QWEN36_TQ_HOT_STAGE_CAP', 'auto').lower()
+            if hot_cap_raw == 'auto':
+                hot_cap = min(max_seq_tq, 132096)
+            else:
+                hot_cap = max(1, min(max_seq_tq, int(hot_cap_raw)))
+            hot_layers_raw = os.environ.get(
+                'FLASHRT_QWEN36_TQ_HOT_STAGE_LAYERS', 'auto').lower()
+            if hot_layers_raw == 'auto':
+                # If the server is sized for a 200K/256K envelope, the
+                # long-cap per-layer stage can only cover a few layers on
+                # 32GB cards. Reuse the remaining VRAM for a 128K hot tier
+                # so common 128K requests still avoid shared full-prefix
+                # dequant on more layers while 200K+ remains correct.
+                hot_policy = 0
+                if hot_cap <= 132096 and stage_cap > hot_cap:
+                    hot_policy = max(0, min(1, 8 - stage_layers))
+                hot_bytes_per_layer = hot_cap * 4 * 256 * 2 * 2
+                try:
+                    free_bytes, _ = torch.cuda.mem_get_info()
+                    hot_reserve_mb = int(os.environ.get(
+                        'FLASHRT_QWEN36_TQ_HOT_STAGE_RESERVE_MB', '1536'))
+                    reserve = max(0, hot_reserve_mb) << 20
+                    hot_mem_cap = max(0, (int(free_bytes) - reserve)
+                                      // hot_bytes_per_layer)
+                except Exception:
+                    hot_mem_cap = hot_policy
+                hot_layers = max(
+                    0, min(16 - stage_layers, hot_policy, int(hot_mem_cap)))
+            else:
+                hot_layers = max(
+                    0, min(16 - stage_layers, int(hot_layers_raw)))
+            self._tq_hot_stage_start_layer = stage_layers
+            self._tq_hot_stage_layers = hot_layers
+            self._tq_hot_stage_cap = hot_cap
+            if hot_layers > 0:
+                self._tq_k_stage_hot = torch.empty(
+                    hot_layers, hot_cap, 4, 256,
+                    dtype=torch.bfloat16, device=self.device)
+                self._tq_v_stage_hot = torch.empty_like(
+                    self._tq_k_stage_hot)
+                self._tq_hot_stage_valid_end = [0] * hot_layers
 
     def _tq_dequant_into_stage(self, layer: int, end_pos: int) -> None:
         """Batched dequant TQ cache layer rows [0, end_pos) into BF16
         staging buffers _tq_k_stage / _tq_v_stage.
 
         Phase 3A B9: when the kernels are available and the cache is in
-        packed (B8) layout, use the CUDA unpack + cuBLAS GEMM + combine
-        fast path (≈ 0.68 ms @ 32K vs 3.0 ms Python).  Otherwise fall
-        back to the Python read_kv path.
+        packed (B8) layout, use the CUDA unpack + explicit GEMM + combine
+        fast path.  Otherwise fall back to the Python read_kv path.
 
         Phase 3B α-S3 (CUTLASS): set FVK_QWEN36_TQ_CUTLASS=1 to route
         through CUTLASS EVT-fused dequant — eliminates the fp32
@@ -5962,15 +8266,24 @@ class Qwen36TorchFrontendRtx:
         try:
             from flash_rt import flash_rt_kernels as _fvk
             fast_ok = (cache.packed
-                       and hasattr(_fvk, 'tq_unpack_packed_bf16')
-                       and hasattr(_fvk, 'tq_combine_kv_bf16'))
+                       and hasattr(_fvk, 'tq_unpack_packed_fp32')
+                       and hasattr(_fvk, 'tq_fp32_gemm_lt_algo')
+                       and hasattr(_fvk, 'tq_fp32_gemm_fp32')
+                       and hasattr(_fvk, 'tq_combine_kv_fp32_in'))
             cutlass_ok = (fast_ok
                           and hasattr(_fvk, 'tq_cutlass_k_combine')
                           and hasattr(_fvk, 'tq_cutlass_v_combine'))
         except ImportError:
             fast_ok = False
             cutlass_ok = False
-        if cutlass_ok and os.environ.get('FVK_QWEN36_TQ_CUTLASS', '1') == '1':
+        cutlass_mode = os.environ.get(
+            'FVK_QWEN36_TQ_CUTLASS', 'auto').lower()
+        use_cutlass = (
+            cutlass_mode == '1'
+            or (cutlass_mode == 'auto'
+                and int(getattr(cache, 'max_seq', 0)) <= 132000)
+        )
+        if cutlass_ok and use_cutlass:
             self._tq_dequant_cutlass(layer, end_pos)
             return
         if fast_ok:
@@ -6058,16 +8371,22 @@ class Qwen36TorchFrontendRtx:
         )
 
         # 2. Compute per-row scalars (in fp32, on device).
-        # cache.k_norm/k_rnorm are fp16; cast to fp32 for CUTLASS aux load.
-        norm_k_fp32.copy_(cache.k_norm[layer, :end_pos].view(-1).float())
-        norm_v_fp32.copy_(cache.v_norm[layer, :end_pos].view(-1).float())
-        torch.mul(
-            cache.k_rnorm[layer, :end_pos].view(-1).float(), coef,
-            out=coef_rnorm)
+        # cache.k_norm/k_rnorm/v_norm are fp16; convert and scale in one
+        # CUDA kernel instead of three PyTorch dispatches.
+        fvk.qwen36_tq_prepare_scalars(
+            cache.k_norm[layer, :end_pos].data_ptr(),
+            cache.k_rnorm[layer, :end_pos].data_ptr(),
+            cache.v_norm[layer, :end_pos].data_ptr(),
+            norm_k_fp32.data_ptr(), coef_rnorm.data_ptr(),
+            norm_v_fp32.data_ptr(), M, coef, s,
+        )
 
         # 3. Sr = qjl_fp32 @ jl_fp32 → fp32 (B9 precision, no bf16 cast).
         jl_fp32_layer = setup.jl[layer]
-        torch.matmul(qjl_fp, jl_fp32_layer, out=sr_fp)
+        fvk.tq_fp32_gemm_tf32(
+            qjl_fp.data_ptr(), jl_fp32_layer.data_ptr(),
+            sr_fp.data_ptr(), M, d, d, s,
+        )
 
         # 4. CUTLASS K combine: yk @ Π^T → bf16 K_stage with combine inline.
         rot_T = setup._cu_rot_T_bf16[layer]
@@ -6085,6 +8404,83 @@ class Qwen36TorchFrontendRtx:
             self._tq_v_stage[:end_pos].data_ptr(),
             M, d, d, s,
         )
+
+    def _tq_stage_for_layer(self, layer: int, end_pos: int):
+        """Return BF16 K/V staging for ``layer`` up to ``end_pos``.
+
+        In long-context mode we keep an optional per-layer BF16 stage.
+        When available, only newly-written TQ rows are dequantized via
+        ``read_kv_fast_window``; previous rows stay resident and FA2 can
+        read the full prefix from the per-layer stage. This removes the
+        repeated full-prefix dequant from chunked prefill and TQ verify.
+        """
+        cache = self._tq_cache_packed
+        use_per_layer = bool(getattr(self, '_tq_use_per_layer', False))
+        has_stage = (
+            use_per_layer
+            and hasattr(self, '_tq_k_stage_per_layer')
+            and hasattr(self, '_tq_v_stage_per_layer')
+            and layer < int(getattr(
+                self, '_tq_per_layer_stage_layers', 0))
+            and end_pos <= int(getattr(
+                self, '_tq_per_layer_stage_cap', 0))
+        )
+        if not has_stage:
+            hot_start = int(getattr(self, '_tq_hot_stage_start_layer', 0))
+            hot_layers = int(getattr(self, '_tq_hot_stage_layers', 0))
+            hot_idx = layer - hot_start
+            has_hot_stage = (
+                hot_layers > 0
+                and hasattr(self, '_tq_k_stage_hot')
+                and hasattr(self, '_tq_v_stage_hot')
+                and hot_idx >= 0
+                and hot_idx < hot_layers
+                and end_pos <= int(getattr(self, '_tq_hot_stage_cap', 0))
+            )
+            if not has_hot_stage:
+                self._tq_dequant_into_stage(layer, end_pos)
+                return self._tq_k_stage, self._tq_v_stage
+            return self._tq_stage_for_layer_into(
+                layer, end_pos,
+                self._tq_k_stage_hot[hot_idx],
+                self._tq_v_stage_hot[hot_idx],
+                self._tq_hot_stage_valid_end,
+                hot_idx)
+
+        k_stage = self._tq_k_stage_per_layer[layer]
+        v_stage = self._tq_v_stage_per_layer[layer]
+        return self._tq_stage_for_layer_into(
+            layer, end_pos, k_stage, v_stage,
+            cache._dequant_valid_end, layer)
+
+    def _tq_stage_for_layer_into(self, layer: int, end_pos: int,
+                                 k_stage, v_stage,
+                                 valid_list: list[int], valid_idx: int):
+        cache = self._tq_cache_packed
+        valid_end = int(valid_list[valid_idx])
+        if valid_end < end_pos:
+            try:
+                from flash_rt import flash_rt_kernels as _fvk
+                window_ok = (
+                    cache.packed
+                    and hasattr(_fvk, 'tq_unpack_packed_fp32')
+                    and hasattr(_fvk, 'tq_fp32_gemm_lt_algo')
+                    and hasattr(_fvk, 'tq_fp32_gemm_fp32')
+                    and hasattr(_fvk, 'tq_combine_kv_fp32_in')
+                    and hasattr(cache, 'read_kv_fast_window')
+                )
+            except ImportError:
+                window_ok = False
+
+            if window_ok:
+                cache.read_kv_fast_window(
+                    layer, valid_end, end_pos, k_stage, v_stage)
+            else:
+                k_hat, v_hat = cache.read_kv(layer, end_pos)
+                k_stage[:end_pos].copy_(k_hat)
+                v_stage[:end_pos].copy_(v_hat)
+            valid_list[valid_idx] = end_pos
+        return k_stage, v_stage
 
     def _layer_forward_full_nvfp4_tq(self, L: int, h_in, cos, sin,
                                        cur_pos: int):
@@ -6159,26 +8555,16 @@ class Qwen36TorchFrontendRtx:
             self._full_k_norm_out.data_ptr(), 4, 256, eps, s,
         )
 
-        # ---- 5) inline RoPE ----
-        q_for_rope = self._full_q_norm_out.view(1, 1, 24, 256)
-        k_for_rope = self._full_k_norm_out.view(1, 1, 4, 256)
-        cos4 = cos.view(1, 1, 1, 64)
-        sin4 = sin.view(1, 1, 1, 64)
-
-        def _rope_inline(x_in, x_out, tmp):
-            x_out[..., 64:].copy_(x_in[..., 64:])
-            torch.index_select(
-                x_in[..., :64], -1, self._rope_rotate_idx, out=tmp,
-            )
-            tmp[..., :32].neg_()
-            tmp.mul_(sin4)
-            tmp.addcmul_(x_in[..., :64], cos4)
-            x_out[..., :64].copy_(tmp)
-
-        _rope_inline(q_for_rope, self._full_q_rot, self._full_rope_tmp_q)
-        _rope_inline(k_for_rope, self._full_k_rot, self._full_rope_tmp_k)
-        q_rot = self._full_q_rot
-        k_rot = self._full_k_rot
+        # ---- 5) Partial RoPE: Q staged for FA2, K staged for TQ write ----
+        k_for_cache = self._full_k_rot.view(1, 4, 256)
+        fvk.qwen36_partial_rope_qk_bf16(
+            self._full_q_norm_out.data_ptr(),
+            self._full_k_norm_out.data_ptr(),
+            cos.data_ptr(), sin.data_ptr(),
+            self._attn.Q_buf[:, :1].data_ptr(),
+            k_for_cache.data_ptr(),
+            1, 24, 4, 256, 64, s,
+        )
 
         # ---- 6) v_proj ----
         fvk.fp4_w4a16_gemm_sm120_bf16out(
@@ -6192,13 +8578,11 @@ class Qwen36TorchFrontendRtx:
         v_new = kv_proj_out_buf[:1].view(1, 4, 256)
 
         # ---- 7) Write K/V to TQ packed cache (no BF16 cache write) ----
-        # k_rot shape (1, 1, 4, 256) -> (1, 4, 256)
-        k_for_cache = k_rot.view(1, 4, 256)
         v_for_cache = v_new
         cache = self._tq_cache_packed
         # B9-S10: bit-exact capture-safe write_kv_fast (4 small CUDA
-        # kernels + 3 cuBLAS GEMMs via torch.matmul).  Auto-route when
-        # available — read-back cosine 1.000000 vs Python ref.
+        # kernels + explicit GEMM wrappers by default).  Auto-route when
+        # available.
         if cache.packed and hasattr(fvk, 'tq_write_k1_unit_norm'):
             cache.write_kv_fast(
                 full_rank, cur_pos, cur_pos + 1, k_for_cache, v_for_cache)
@@ -6208,15 +8592,12 @@ class Qwen36TorchFrontendRtx:
 
         # ---- 8) Dequant TQ[0:cur_pos+1] into BF16 staging ----
         kv_seq = cur_pos + 1
-        self._tq_dequant_into_stage(full_rank, kv_seq)
+        k_stage, v_stage = self._tq_stage_for_layer(full_rank, kv_seq)
 
-        # ---- 9) Stage Q + run FA2 directly (read from staging) ----
-        self._attn.Q_buf[:, :1].copy_(q_rot)
+        # ---- 9) Run FA2 directly (Q staged above; K/V from staging) ----
         scaling = float(self._cfg['head_dim']) ** -0.5
-
-        # Build views for _fa2_fwd: K, V shape (1, kv_seq, 4, 256).
-        k_view = self._tq_k_stage[:kv_seq].view(1, kv_seq, 4, 256)
-        v_view = self._tq_v_stage[:kv_seq].view(1, kv_seq, 4, 256)
+        k_view = k_stage[:kv_seq].view(1, kv_seq, 4, 256)
+        v_view = v_stage[:kv_seq].view(1, kv_seq, 4, 256)
         q_view = self._attn.Q_buf[:, :1]  # (1, 1, 24, 256)
         o_view = self._attn.O_buf[:, :1]
         self._attn._fa2_fwd(
@@ -6229,10 +8610,14 @@ class Qwen36TorchFrontendRtx:
             num_heads_q=self._attn.NUM_Q_HEADS,
             num_heads_kv=self._attn.NUM_KV_HEADS,
             head_dim=self._attn.HEAD_DIM,
-            q_strides=(q_view.stride(0), q_view.stride(1), q_view.stride(2)),
-            k_strides=(k_view.stride(0), k_view.stride(1), k_view.stride(2)),
-            v_strides=(v_view.stride(0), v_view.stride(1), v_view.stride(2)),
-            o_strides=(o_view.stride(0), o_view.stride(1), o_view.stride(2)),
+            q_strides=(q_view.stride(0), q_view.stride(1),
+                       q_view.stride(2)),
+            k_strides=(k_view.stride(0), k_view.stride(1),
+                       k_view.stride(2)),
+            v_strides=(v_view.stride(0), v_view.stride(1),
+                       v_view.stride(2)),
+            o_strides=(o_view.stride(0), o_view.stride(1),
+                       o_view.stride(2)),
             softmax_scale=scaling,
             num_sms=self._attn._num_sms,
             stream=s,
@@ -6242,8 +8627,10 @@ class Qwen36TorchFrontendRtx:
         # ---- 10) output gate + o_proj + residual + post-attn + MLP ----
         # (rest identical to _layer_forward_full_nvfp4)
         attn_flat = attn_out.reshape(1, 1, 24 * 256)
-        torch.sigmoid(gate_flat, out=self._full_gate_sig)
-        torch.mul(attn_flat, self._full_gate_sig, out=self._full_gated)
+        fvk.sigmoid_mul_qwen36_bf16(
+            gate_flat.data_ptr(), attn_flat.data_ptr(),
+            self._full_gated.data_ptr(), 24 * 256, s,
+        )
         gated = self._full_gated
 
         ap_6144, sf_6144, _ = self._nvfp4_scratch[(5120, 6144)]
@@ -6263,7 +8650,10 @@ class Qwen36TorchFrontendRtx:
         )
 
         attn_proj = out_op_buf[:1].view(1, 1, 5120)
-        torch.add(h_in, attn_proj, out=self._res_mid)
+        fvk.add_bf16_out(
+            h_in.data_ptr(), attn_proj.data_ptr(),
+            self._res_mid.data_ptr(), 5120, s,
+        )
         h_post = self._res_mid
 
         h_post_view = h_post.view(1, 5120)
@@ -6321,7 +8711,10 @@ class Qwen36TorchFrontendRtx:
         mlp_out = down_out_buf[:1].view(1, 1, 5120)
 
         h_out = self._layer_out_a if (L % 2 == 0) else self._layer_out_b
-        torch.add(h_post, mlp_out, out=h_out)
+        fvk.add_bf16_out(
+            h_post.data_ptr(), mlp_out.data_ptr(),
+            h_out.data_ptr(), 5120, s,
+        )
         return h_out
 
     def forward_own_decode_nvfp4_tq(self, token_id, cos_pos, sin_pos,
@@ -6348,10 +8741,13 @@ class Qwen36TorchFrontendRtx:
                 [token_id], device=self.device, dtype=torch.long)
         if token_id.ndim == 1:
             token_id = token_id.view(1, 1)
-        embed_t = self._weights.anchors[0]
-        h = embed_t[token_id.view(-1)].view(1, 1, hidden).contiguous()
-        if h.dtype != bf16:
-            h = h.to(bf16)
+        fvk.qwen36_embedding_lookup_bf16(
+            token_id.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            self._embed_buf.data_ptr(),
+            1, hidden, s,
+        )
+        h = self._embed_buf
 
         for L in range(self._cfg['num_hidden_layers']):
             t = types[L]
@@ -6763,9 +9159,10 @@ class Qwen36TorchFrontendRtx:
             raise RuntimeError(
                 'DFlash drafter not loaded — call _load_dflash_drafter '
                 'first or set FLASHRT_QWEN36_DFLASH_CKPT_DIR')
-        if K < 1 or K + 1 > self.MAX_Q_SEQ:
+        max_spec_k = min(self.MAX_Q_SEQ - 1, self._MAX_PUBLIC_SPEC_K)
+        if K < 1 or K > max_spec_k:
             raise ValueError(
-                f'K={K} out of range — need 1<=K<={self.MAX_Q_SEQ - 1}')
+                f'K={K} out of range — need 1<=K<={max_spec_k}')
 
         prompt_len = int(input_ids.shape[1])
 
@@ -6988,6 +9385,18 @@ class Qwen36TorchFrontendRtx:
         # β: independent prompt → per-layer dequant stage is stale.
         if hasattr(self, '_tq_cache_packed'):
             self._tq_cache_packed.invalidate_all()
+        hot_valid = getattr(self, '_tq_hot_stage_valid_end', None)
+        if hot_valid is not None:
+            for i in range(len(hot_valid)):
+                hot_valid[i] = 0
+        fp8_valid = getattr(self, '_fp8_stage_valid_end', None)
+        if fp8_valid is not None:
+            for i in range(len(fp8_valid)):
+                fp8_valid[i] = 0
+        fp8_hot_valid = getattr(self, '_fp8_hot_stage_valid_end', None)
+        if fp8_hot_valid is not None:
+            for i in range(len(fp8_hot_valid)):
+                fp8_hot_valid[i] = 0
 
     def buffer_summary(self) -> dict:
         """Return a summary of pre-allocated buffer sizes (debug / tests)."""

--- a/flash_rt/hardware/rtx/attn_backend_qwen36.py
+++ b/flash_rt/hardware/rtx/attn_backend_qwen36.py
@@ -113,6 +113,7 @@ class RtxFlashAttnBackendQwen36:
         from flash_rt import flash_rt_fa2 as _fa2
         self._fa2 = _fa2
         self._fa2_fwd = _fa2.fwd_bf16
+        self._fa2_fwd_causal = getattr(_fa2, "fwd_bf16_causal", None)
         self._num_sms = torch.cuda.get_device_properties(
             torch.cuda.current_device()
         ).multi_processor_count

--- a/flash_rt/ops/fla/LICENSE.flash-linear-attention
+++ b/flash_rt/ops/fla/LICENSE.flash-linear-attention
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 Songlin Yang, Yu Zhang, Zhiyuan Li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/flash_rt/ops/fla/NOTICE
+++ b/flash_rt/ops/fla/NOTICE
@@ -1,0 +1,22 @@
+FlashRT FLA subset
+==================
+
+This directory includes a small, modified subset of Flash Linear Attention
+and SGLang FLA integration files for Qwen3.6 Gated DeltaNet inference.
+
+Flash Linear Attention
+----------------------
+
+Source: https://github.com/fla-org/flash-linear-attention
+Source baseline: abfa403de2146b9a2ab762a603f8fdb61cc3c166
+License: MIT; see LICENSE.flash-linear-attention in this directory.
+
+SGLang
+------
+
+Source: https://github.com/sgl-project/sglang
+Source baseline: 93fa577bb95a37699e7f1f56a486e436d5792b71
+License: Apache-2.0; see the FlashRT repository root LICENSE for the
+Apache-2.0 license text.
+
+No upstream SGLang NOTICE file was present at the source baseline above.

--- a/flash_rt/ops/fla/VENDOR.md
+++ b/flash_rt/ops/fla/VENDOR.md
@@ -1,0 +1,52 @@
+# FlashRT FLA Subset Vendor Notes
+
+`flash_rt/ops/fla/` is a minimal Python/Triton subset used by the
+Qwen3.6 Gated DeltaNet long-prefill path. It is vendored to avoid a
+runtime dependency on the full FLA or SGLang packages.
+
+## Source Baselines
+
+| Upstream | Commit | License |
+|---|---|---|
+| [`fla-org/flash-linear-attention`](https://github.com/fla-org/flash-linear-attention) | `abfa403de2146b9a2ab762a603f8fdb61cc3c166` | MIT |
+| [`sgl-project/sglang`](https://github.com/sgl-project/sglang) | `93fa577bb95a37699e7f1f56a486e436d5792b71` | Apache-2.0 |
+
+See [`LICENSE.flash-linear-attention`](LICENSE.flash-linear-attention)
+and [`NOTICE`](NOTICE) in this directory.
+
+## Imported Subset
+
+| Local file | Upstream role |
+|---|---|
+| `chunk.py` | `fla/ops/gated_delta_rule/chunk.py` plus SGLang Qwen integration shape |
+| `wy_fast.py` | `fla/ops/gated_delta_rule/wy_fast.py` |
+| `chunk_delta_h.py` | `fla/ops/common/chunk_delta_h.py` |
+| `chunk_o.py` | `fla/ops/common/chunk_o.py` |
+| `chunk_scaled_dot_kkt.py` | `fla/ops/common/chunk_scaled_dot_kkt.py` |
+| `cumsum.py` | `fla/ops/utils/cumsum.py` |
+| `index.py` | `fla/ops/utils/index.py` |
+| `l2norm.py` | `fla/modules/l2norm.py` |
+| `op.py` | `fla/ops/utils/op.py` |
+| `solve_tril.py` | `fla/ops/utils/solve_tril.py` |
+| `utils.py` | `fla/utils.py` |
+
+Every source file keeps an `Adapted from ...` header with the original
+upstream path.
+
+## FlashRT Changes
+
+- Namespace imports are redirected from upstream package names to
+  `flash_rt.ops.fla`.
+- Only inference-forward pieces needed by Qwen3.6 Gated DeltaNet are
+  retained; unrelated training/autograd surface is not vendored.
+- Several entry points accept caller-owned output buffers so long
+  prefill can reuse FlashRT-managed memory and avoid per-call allocation.
+- Optional final-state and diagnostic outputs are suppressed on the hot
+  path unless explicitly requested by the Qwen frontend.
+- The subset is intentionally Python/Triton-only. CUDA/CUTLASS kernels
+  that are production hot paths live under `csrc/`.
+
+## Runtime Dependencies
+
+This subset imports `torch`, `triton`, `einops`, and `packaging`.
+They are declared by the `flash-rt[torch]` extra in `pyproject.toml`.

--- a/flash_rt/ops/fla/chunk.py
+++ b/flash_rt/ops/fla/chunk.py
@@ -1,0 +1,341 @@
+# Adapted from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/gated_delta_rule/chunk.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/chunk.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+import torch
+from einops import rearrange
+
+from flash_rt.ops.fla.chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from flash_rt.ops.fla.chunk_o import chunk_fwd_o, chunk_fwd_o_out
+from flash_rt.ops.fla.chunk_scaled_dot_kkt import \
+    chunk_scaled_dot_kkt_fwd
+from flash_rt.ops.fla.cumsum import (chunk_local_cumsum,
+                                     chunk_local_cumsum_scalar_out)
+from flash_rt.ops.fla.l2norm import l2norm_fwd, l2norm_fwd_out
+from flash_rt.ops.fla.solve_tril import solve_tril
+from flash_rt.ops.fla.utils import (SUPPRESS_LEVEL,
+                                                   autocast_custom_fwd,
+                                                   input_guard)
+from flash_rt.ops.fla.wy_fast import recompute_w_u_fwd
+
+
+def chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    initial_state_indices: Optional[torch.Tensor],
+    inplace_indexed_state_update: bool,
+    output_final_state: bool,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    g_cumsum_out: Optional[torch.Tensor] = None,
+    o_out: Optional[torch.Tensor] = None,
+):
+    if g_cumsum_out is not None:
+        g = chunk_local_cumsum_scalar_out(
+            g, g_cumsum_out, chunk_size=64, cu_seqlens=cu_seqlens)
+    else:
+        g = chunk_local_cumsum(g, chunk_size=64, cu_seqlens=cu_seqlens)
+    # obtain WY representation. u is actually the new v.
+    A = chunk_scaled_dot_kkt_fwd(k=k,
+                                 beta=beta,
+                                 g_cumsum=g,
+                                 cu_seqlens=cu_seqlens,
+                                 output_dtype=torch.float32)
+    A = solve_tril(A=A, cu_seqlens=cu_seqlens, output_dtype=k.dtype)
+    w, u = recompute_w_u_fwd(
+        k=k,
+        v=v,
+        beta=beta,
+        A=A,
+        g_cumsum=g,
+        cu_seqlens=cu_seqlens,
+    )
+    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        output_final_state=output_final_state,
+        inplace_indexed_state_update=inplace_indexed_state_update,
+        cu_seqlens=cu_seqlens,
+    )
+    if o_out is not None:
+        o = chunk_fwd_o_out(
+            q=q,
+            k=k,
+            v=v_new,
+            h=h,
+            o=o_out,
+            g=g,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+    else:
+        o = chunk_fwd_o(
+            q=q,
+            k=k,
+            v=v_new,
+            h=h,
+            g=g,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+    if SUPPRESS_LEVEL < 3:
+        return g, o, A, final_state, None, None, None
+    elif SUPPRESS_LEVEL >= 3:
+        return g, o, A, final_state, w, h, v_new
+
+
+class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard(exclude_args="initial_state")
+    @autocast_custom_fwd
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor,
+        initial_state_indices: Optional[torch.Tensor],
+        inplace_indexed_state_update: bool,
+        output_final_state: bool,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        use_qk_l2norm_in_kernel: bool = False,
+    ):
+        if use_qk_l2norm_in_kernel:
+            q = l2norm_fwd(q)
+            k = l2norm_fwd(k)
+
+        g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            initial_state_indices=initial_state_indices,
+            inplace_indexed_state_update=inplace_indexed_state_update,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+        )
+        return o.to(q.dtype), final_state
+
+
+def chunk_gated_delta_rule_inference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    inplace_indexed_state_update: bool = False,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    head_first: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    q_l2_out: Optional[torch.Tensor] = None,
+    k_l2_out: Optional[torch.Tensor] = None,
+    g_cumsum_out: Optional[torch.Tensor] = None,
+    o_out: Optional[torch.Tensor] = None,
+):
+    """Inference-only FLA Gated DeltaNet entrypoint.
+
+    This bypasses ``torch.autograd.Function.apply`` and the generic
+    contiguity/autocast guard. Qwen3.6 feeds preallocated contiguous
+    tensors and runs under inference/no-grad, so the direct forward call
+    preserves the math while avoiding Python/Torch wrapper overhead in
+    long-context prefill chunks.
+    """
+    if head_first:
+        raise DeprecationWarning(
+            "head_first is deprecated and is not supported by the "
+            "inference-only fast path.")
+    if scale is None:
+        scale = k.shape[-1]**-0.5
+    if use_qk_l2norm_in_kernel:
+        if q_l2_out is not None:
+            q = l2norm_fwd_out(q, q_l2_out)
+        else:
+            q = l2norm_fwd(q)
+        if k_l2_out is not None:
+            k = l2norm_fwd_out(k, k_l2_out)
+        else:
+            k = l2norm_fwd(k)
+    _g, o, _A, final_state, _w, _h, _v_new = chunk_gated_delta_rule_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        inplace_indexed_state_update=inplace_indexed_state_update,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        g_cumsum_out=g_cumsum_out,
+        o_out=o_out,
+    )
+    if o.dtype != q.dtype:
+        o = o.to(q.dtype)
+    return o, final_state
+
+
+@torch.compiler.disable
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    inplace_indexed_state_update: bool = False,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    head_first: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+):
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+        g (torch.Tensor):
+            (forget) gating tensor (in log space!) of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+        scale (Optional[int]):
+            Scale factor for the RetNet attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        initial_state_indices (Optional[torch.Tensor]):
+            Optional state-pool indices of shape `[N]` selecting the slots to
+            read from `initial_state`.
+        inplace_indexed_state_update (Optional[bool]):
+            Explicit opt-in for writing indexed final states back into
+            `initial_state` in-place. Callers are responsible for ensuring the
+            selected slots are safe to update without aliasing races.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        head_first (Optional[bool]):
+            Whether the inputs are in the head-first format, which is not supported for variable-length inputs.
+            Default: `False`.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+        # inputs with equal lengths
+        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+        >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
+        >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
+        >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
+        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> o, ht = chunk_gated_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, beta, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, g))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o_var, ht_var = chunk_gated_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    assert q.dtype == k.dtype == v.dtype
+    assert (
+        q.dtype != torch.float32
+    ), "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
+    assert (
+        len(beta.shape) == 3
+    ), "beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
+
+    if head_first:
+        raise DeprecationWarning(
+            "head_first is deprecated and will be removed in a future version. "
+            "Please use head_first=False for now instead.")
+        q, k, v, beta, g = map(lambda x: rearrange(x, "b h t ... -> b t h ..."),
+                               (q, k, v, beta, g))
+    # if not head_first and q.shape[1] < q.shape[2]:
+    #     warnings.warn(
+    #         f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+    #         "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
+    #         "when head_first=False was specified. "
+    #         "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
+    #     )
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing.")
+        num_sequences = len(cu_seqlens) - 1
+        if initial_state_indices is not None:
+            if initial_state_indices.shape[0] != num_sequences:
+                raise ValueError(
+                    f"The number of initial-state indices is expected to be equal to the number of input "
+                    f"sequences, i.e., {num_sequences} rather than {initial_state_indices.shape[0]}."
+                )
+        elif initial_state is not None and initial_state.shape[
+                0] != num_sequences:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {num_sequences} rather than {initial_state.shape[0]}.")
+    if scale is None:
+        scale = k.shape[-1]**-0.5
+    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state,
+        initial_state_indices,
+        inplace_indexed_state_update,
+        output_final_state,
+        cu_seqlens,
+        use_qk_l2norm_in_kernel,
+    )
+    if head_first:
+        o = rearrange(o, "b t h ... -> b h t ...")
+    return o, final_state

--- a/flash_rt/ops/fla/chunk_delta_h.py
+++ b/flash_rt/ops/fla/chunk_delta_h.py
@@ -1,0 +1,313 @@
+# Adapted from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/common/chunk_delta_h.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/chunk_delta_h.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flash_rt.ops.fla.index import (prepare_chunk_indices,
+                                                   prepare_chunk_offsets)
+from flash_rt.ops.fla.op import exp, safe_exp
+from flash_rt.ops.fla.utils import is_nvidia_hopper
+
+NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
+
+
+@triton.heuristics({
+    "USE_G": lambda args: args["g"] is not None,
+    "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+    "USE_INDEXED_STATE": lambda args: args["h0_i"] is not None,
+    "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+    "SAVE_NEW_VALUE": lambda args: args["v_new"] is not None,
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=nw, num_stages=ns)
+        for nw in NUM_WARPS for ns in [2, 3, 4] for BV in [32, 64]
+    ],
+    key=["H", "K", "V", "BT", "USE_G"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
+    k,
+    v,
+    w,
+    v_new,
+    g,
+    h,
+    h0,
+    h0_i,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    stride_h0,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    USE_INDEXED_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    SAVE_NEW_VALUE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        boh = i_n * NT
+
+    # [BK, BV]
+    b_h1 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 64:
+        b_h2 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 128:
+        b_h3 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 192:
+        b_h4 = tl.zeros([64, BV], dtype=tl.float32)
+
+    # calculate offset
+    h += (boh * H + i_h) * K * V
+    v += (bos * H + i_h) * V
+    k += (bos * Hg + i_h // (H // Hg)) * K
+    w += (bos * H + i_h) * K
+    if SAVE_NEW_VALUE:
+        v_new += (bos * H + i_h) * V
+    stride_v = H * V
+    stride_h = H * K * V
+    stride_k = Hg * K
+    stride_w = H * K
+    if USE_INDEXED_STATE:
+        state_index = tl.load(h0_i + i_n).to(tl.int64)
+        h0 = h0 + state_index * stride_h0
+        ht = h0
+    if USE_INITIAL_STATE:
+        h0 = h0 + ((i_h if USE_INDEXED_STATE else i_nh) * K * V)
+    if STORE_FINAL_STATE:
+        ht = ht + i_nh * K * V
+    elif USE_INDEXED_STATE:
+        ht = ht + i_h * K * V
+
+    # load initial state
+    if USE_INITIAL_STATE:
+        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV),
+                                   (1, 0))
+        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        if K > 64:
+            p_h0_2 = tl.make_block_ptr(h0, (K, V), (V, 1), (64, i_v * BV),
+                                       (64, BV), (1, 0))
+            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+        if K > 128:
+            p_h0_3 = tl.make_block_ptr(h0, (K, V), (V, 1), (128, i_v * BV),
+                                       (64, BV), (1, 0))
+            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+        if K > 192:
+            p_h0_4 = tl.make_block_ptr(h0, (K, V), (V, 1), (192, i_v * BV),
+                                       (64, BV), (1, 0))
+            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+
+    # main recurrence
+    for i_t in range(NT):
+        p_h1 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1),
+                                 (0, i_v * BV), (64, BV), (1, 0))
+        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_h2 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1),
+                                     (64, i_v * BV), (64, BV), (1, 0))
+            tl.store(p_h2,
+                     b_h2.to(p_h2.dtype.element_ty),
+                     boundary_check=(0, 1))
+        if K > 128:
+            p_h3 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1),
+                                     (128, i_v * BV), (64, BV), (1, 0))
+            tl.store(p_h3,
+                     b_h3.to(p_h3.dtype.element_ty),
+                     boundary_check=(0, 1))
+        if K > 192:
+            p_h4 = tl.make_block_ptr(h + i_t * stride_h, (K, V), (V, 1),
+                                     (192, i_v * BV), (64, BV), (1, 0))
+            tl.store(p_h4,
+                     b_h4.to(p_h4.dtype.element_ty),
+                     boundary_check=(0, 1))
+
+        p_v = tl.make_block_ptr(v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV),
+                                (BT, BV), (1, 0))
+        p_v_new = (tl.make_block_ptr(v_new, (T, V), (stride_v, 1),
+                                     (i_t * BT, i_v * BV), (BT, BV),
+                                     (1, 0)) if SAVE_NEW_VALUE else None)
+        b_v_new = tl.zeros([BT, BV], dtype=tl.float32)
+        p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 0),
+                                (BT, 64), (1, 0))
+        b_w = tl.load(p_w, boundary_check=(0, 1))
+        b_v_new += tl.dot(b_w, b_h1.to(b_w.dtype))
+        if K > 64:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 64),
+                                    (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v_new += tl.dot(b_w, b_h2.to(b_w.dtype))
+        if K > 128:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 128),
+                                    (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v_new += tl.dot(b_w, b_h3.to(b_w.dtype))
+        if K > 192:
+            p_w = tl.make_block_ptr(w, (T, K), (stride_w, 1), (i_t * BT, 192),
+                                    (BT, 64), (1, 0))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_v_new += tl.dot(b_w, b_h4.to(b_w.dtype))
+        b_v_new = -b_v_new + tl.load(p_v, boundary_check=(0, 1))
+
+        if SAVE_NEW_VALUE:
+            p_v_new = tl.make_block_ptr(v_new, (T, V), (stride_v, 1),
+                                        (i_t * BT, i_v * BV), (BT, BV), (1, 0))
+            tl.store(p_v_new,
+                     b_v_new.to(p_v_new.dtype.element_ty),
+                     boundary_check=(0, 1))
+
+        if USE_G:
+            last_idx = min((i_t + 1) * BT, T) - 1
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+            p_g = tl.make_block_ptr(g + bos * H + i_h, (T, ), (H, ),
+                                    (i_t * BT, ), (BT, ), (0, ))
+            b_g = tl.load(p_g, boundary_check=(0, ))
+            b_v_new = b_v_new * safe_exp(b_g_last - b_g)[:, None]
+            b_g_last = exp(b_g_last)
+            b_h1 = b_h1 * b_g_last
+            if K > 64:
+                b_h2 = b_h2 * b_g_last
+            if K > 128:
+                b_h3 = b_h3 * b_g_last
+            if K > 192:
+                b_h4 = b_h4 * b_g_last
+        b_v_new = b_v_new.to(k.dtype.element_ty)
+        p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (0, i_t * BT),
+                                (64, BT), (0, 1))
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_h1 += tl.dot(b_k, b_v_new)
+        if K > 64:
+            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (64, i_t * BT),
+                                    (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h2 += tl.dot(b_k, b_v_new)
+        if K > 128:
+            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (128, i_t * BT),
+                                    (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h3 += tl.dot(b_k, b_v_new)
+        if K > 192:
+            p_k = tl.make_block_ptr(k, (K, T), (1, stride_k), (192, i_t * BT),
+                                    (64, BT), (0, 1))
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_h4 += tl.dot(b_k, b_v_new)
+
+    # epilogue
+    if STORE_FINAL_STATE or USE_INDEXED_STATE:
+        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV),
+                                 (1, 0))
+        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (64, i_v * BV),
+                                     (64, BV), (1, 0))
+            tl.store(p_ht,
+                     b_h2.to(p_ht.dtype.element_ty),
+                     boundary_check=(0, 1))
+        if K > 128:
+            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (128, i_v * BV),
+                                     (64, BV), (1, 0))
+            tl.store(p_ht,
+                     b_h3.to(p_ht.dtype.element_ty),
+                     boundary_check=(0, 1))
+        if K > 192:
+            p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (192, i_v * BV),
+                                     (64, BV), (1, 0))
+            tl.store(p_ht,
+                     b_h4.to(p_ht.dtype.element_ty),
+                     boundary_check=(0, 1))
+
+
+def chunk_gated_delta_rule_fwd_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    initial_state_indices: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    inplace_indexed_state_update: bool = False,
+    chunk_size: int = 64,  # SY: remove this argument and force chunk size 64?
+    save_new_value: bool = True,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    B, T, Hg, K, V = *k.shape, u.shape[-1]
+    H = u.shape[-2]
+    BT = chunk_size
+
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, chunk_size)
+                     if cu_seqlens is not None else None)
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    if cu_seqlens is None:
+        N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
+    else:
+        N, NT, chunk_offsets = (
+            len(cu_seqlens) - 1,
+            len(chunk_indices),
+            prepare_chunk_offsets(cu_seqlens, BT),
+        )
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    h = k.new_empty(B, NT, H, K, V)
+    use_indexed_state = initial_state is not None and initial_state_indices is not None
+    if use_indexed_state and not inplace_indexed_state_update:
+        raise ValueError(
+            "Indexed chunk state updates require inplace_indexed_state_update=True."
+        )
+    store_final_state_in_kernel = output_final_state and not use_indexed_state
+    final_state = (k.new_empty(N, H, K, V, dtype=torch.float32)
+                   if store_final_state_in_kernel else None)
+
+    v_new = torch.empty_like(u) if save_new_value else None
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), N * H)
+
+    chunk_gated_delta_rule_fwd_kernel_h_blockdim64[grid](
+        k=k,
+        v=u,
+        w=w,
+        v_new=v_new,
+        g=g,
+        h=h,
+        h0=initial_state,
+        h0_i=initial_state_indices,
+        ht=final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        stride_h0=initial_state.stride(0) if initial_state is not None else 0,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    if output_final_state and use_indexed_state:
+        # The indexed kernel path updates h0 in-place, so returning
+        # the final state means gathering those updated slots back out.
+        final_state = initial_state.index_select(
+            0, initial_state_indices.to(torch.long))
+    return h, v_new, final_state

--- a/flash_rt/ops/fla/chunk_o.py
+++ b/flash_rt/ops/fla/chunk_o.py
@@ -1,0 +1,211 @@
+# Adapted from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/common/chunk_o.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/chunk_o.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from flash_rt.ops.fla.index import prepare_chunk_indices
+from flash_rt.ops.fla.op import exp, safe_exp
+from flash_rt.ops.fla.utils import (check_shared_mem,
+                                                   is_nvidia_hopper)
+
+BKV_LIST = [64, 128] if check_shared_mem() else [32, 64]
+NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
+
+
+@triton.heuristics({
+    "USE_G": lambda args: args["g"] is not None,
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({
+            "BK": BK,
+            "BV": BV
+        }, num_warps=nw, num_stages=ns) for BK in BKV_LIST for BV in BKV_LIST
+        for nw in NUM_WARPS for ns in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_fwd_kernel_o(
+    q,
+    k,
+    v,
+    h,
+    g,
+    o,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    # offset calculation
+    q += (bos * Hg + i_h // (H // Hg)) * K
+    k += (bos * Hg + i_h // (H // Hg)) * K
+    v += (bos * H + i_h) * V
+    o += (bos * H + i_h) * V
+    h += (i_tg * H + i_h).to(tl.int64) * K * V
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(q, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK),
+                                (BT, BK), (1, 0))
+        p_k = tl.make_block_ptr(k, (K, T), (1, Hg * K), (i_k * BK, i_t * BT),
+                                (BK, BT), (0, 1))
+        p_h = tl.make_block_ptr(h, (K, V), (V, 1), (i_k * BK, i_v * BV),
+                                (BK, BV), (1, 0))
+        # [BT, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        # [BK, BT]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [BK, BV]
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+
+        # [BT, BK] @ [BK, BV] -> [BT, BV]
+        b_o += tl.dot(b_q, b_h)
+        # [BT, BK] @ [BK, BT] -> [BT, BT]
+        b_A += tl.dot(b_q, b_k)
+
+    if USE_G:
+        g += bos * H + i_h
+        p_g = tl.make_block_ptr(g, (T, ), (H, ), (i_t * BT, ), (BT, ), (0, ))
+        b_g = tl.load(p_g, boundary_check=(0, ))
+        b_o = b_o * exp(b_g)[:, None]
+        b_A = b_A * safe_exp(b_g[:, None] - b_g[None, :])
+
+    o_i = tl.arange(0, BT)
+    m_A = o_i[:, None] >= o_i[None, :]
+    b_A = tl.where(m_A, b_A, 0)
+
+    p_v = tl.make_block_ptr(v, (T, V), (H * V, 1), (i_t * BT, i_v * BV),
+                            (BT, BV), (1, 0))
+    p_o = tl.make_block_ptr(o, (T, V), (H * V, 1), (i_t * BT, i_v * BV),
+                            (BT, BV), (1, 0))
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+
+    # to fix mma -> mma layout conversion
+    # already solved by triton v3.2 or higher
+    b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_fwd_o(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: Optional[torch.Tensor] = None,  # cumsum of log decay
+    scale: Optional[float] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    B, T, Hg, K, V = *q.shape, v.shape[-1]
+    H = v.shape[-2]
+    BT = min(chunk_size, max(16, triton.next_power_of_2(T)))
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, BT)
+                     if cu_seqlens is not None else None)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    if scale is None:
+        scale = k.shape[-1]**-0.5
+
+    o = torch.empty_like(v)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * H)
+
+    chunk_fwd_kernel_o[grid](
+        q,
+        k,
+        v,
+        h,
+        g,
+        o,
+        cu_seqlens,
+        chunk_indices,
+        scale,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o
+
+
+def chunk_fwd_o_out(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    o: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    B, T, Hg, K, V = *q.shape, v.shape[-1]
+    H = v.shape[-2]
+    if o.shape != v.shape:
+        raise ValueError(f'chunk_fwd_o_out shape mismatch: {o.shape} vs '
+                         f'{v.shape}')
+    BT = min(chunk_size, max(16, triton.next_power_of_2(T)))
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, BT)
+                     if cu_seqlens is not None else None)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    if scale is None:
+        scale = k.shape[-1]**-0.5
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * H)
+
+    chunk_fwd_kernel_o[grid](
+        q,
+        k,
+        v,
+        h,
+        g,
+        o,
+        cu_seqlens,
+        chunk_indices,
+        scale,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o

--- a/flash_rt/ops/fla/chunk_scaled_dot_kkt.py
+++ b/flash_rt/ops/fla/chunk_scaled_dot_kkt.py
@@ -1,0 +1,143 @@
+# Adapted from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/common/chunk_scaled_dot_kkt.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/chunk_scaled_dot_kkt.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from flash_rt.ops.fla.index import prepare_chunk_indices
+from flash_rt.ops.fla.op import safe_exp
+
+
+@triton.heuristics({
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    "USE_G": lambda args: args["g_cumsum"] is not None,
+})
+# @triton.autotune(
+#     configs=[
+#         triton.Config({"BK": BK}, num_warps=num_warps, num_stages=num_stages)
+#         for BK in [32, 64, 128]
+#         for num_warps in [2, 4, 8]
+#         for num_stages in [2, 3, 4]
+#     ],
+#     key=["H", "K", "BT", "IS_VARLEN"],
+# )
+@triton.jit(do_not_specialize=["T"])
+def chunk_scaled_dot_kkt_fwd_kernel(
+    k,
+    beta,
+    g_cumsum,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    USE_G: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    o_t = tl.arange(0, BT)
+
+    p_beta = tl.make_block_ptr(beta + bos * H + i_h, (T, ), (H, ), (i_t * BT, ),
+                               (BT, ), (0, ))
+    b_beta = tl.load(p_beta, boundary_check=(0, ))
+
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(
+            k + (bos * Hg + i_h // (H // Hg)) * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = b_k * b_beta[:, None]
+        b_A += tl.dot(b_kb.to(b_k.dtype), tl.trans(b_k))
+
+    if USE_G:
+        p_g = tl.make_block_ptr(g_cumsum + bos * H + i_h, (T, ), (H, ),
+                                (i_t * BT, ), (BT, ), (0, ))
+        b_g = tl.load(p_g, boundary_check=(0, ))
+        b_g_diff = b_g[:, None] - b_g[None, :]
+        b_A = b_A * safe_exp(b_g_diff)
+
+    b_A = tl.where(o_t[:, None] > o_t[None, :], b_A, 0)
+    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (T, BT), (BT * H, 1),
+                            (i_t * BT, 0), (BT, BT), (1, 0))
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_scaled_dot_kkt_fwd(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    g_cumsum: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    r"""
+    Compute beta * K * K^T.
+
+    Args:
+        k (torch.Tensor):
+            The key tensor of shape `[B, T, H, K]`.
+        beta (torch.Tensor):
+            The beta tensor of shape `[B, T, H]`.
+        g_cumsum (torch.Tensor):
+            The cumulative sum of the gate tensor of shape `[B, T, H]`.
+            Default: None
+        cu_seqlens (torch.LongTensor):
+            The cumulative sequence lengths of the input tensor.
+            Default: None
+        chunk_size (int):
+            The chunk size. Default: 64.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float32`
+
+    Returns:
+        beta * K * K^T of shape `[B, T, H, BT]` where `BT` is the chunk size.
+    """
+
+    B, T, Hg, K = k.shape
+
+    H = beta.shape[-1]
+    BT = chunk_size
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, BT)
+                     if cu_seqlens is not None else None)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    A = torch.empty(B, T, H, BT, device=k.device, dtype=output_dtype)
+    chunk_scaled_dot_kkt_fwd_kernel[(NT, B * H)](
+        k=k,
+        beta=beta,
+        g_cumsum=g_cumsum,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        BT=BT,
+        BK=64,
+        num_warps=8,
+        num_stages=3,
+    )
+    return A

--- a/flash_rt/ops/fla/cumsum.py
+++ b/flash_rt/ops/fla/cumsum.py
@@ -1,0 +1,323 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/utils/cumsum.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/cumsum.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from flash_rt.ops.fla.index import prepare_chunk_indices
+from flash_rt.ops.fla.utils import check_shared_mem, input_guard
+
+BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.heuristics({
+    "HAS_SCALE": lambda args: args["scale"] is not None,
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+})
+# @triton.autotune(
+#     configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+#     key=["B", "H", "BT", "IS_VARLEN", "REVERSE"],
+# )
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_scalar_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if HEAD_FIRST:
+        p_s = tl.make_block_ptr(s + bos * H + i_h * T, (T, ), (1, ),
+                                (i_t * BT, ), (BT, ), (0, ))
+        p_o = tl.make_block_ptr(o + bos * H + i_h * T, (T, ), (1, ),
+                                (i_t * BT, ), (BT, ), (0, ))
+    else:
+        p_s = tl.make_block_ptr(s + bos * H + i_h, (T, ), (H, ), (i_t * BT, ),
+                                (BT, ), (0, ))
+        p_o = tl.make_block_ptr(o + bos * H + i_h, (T, ), (H, ), (i_t * BT, ),
+                                (BT, ), (0, ))
+    # [BT]
+    b_s = tl.load(p_s, boundary_check=(0, )).to(tl.float32)
+    b_o = tl.cumsum(b_s, axis=0)
+    if REVERSE:
+        b_z = tl.sum(b_s, axis=0)
+        b_o = -b_o + b_z[None] + b_s
+    if HAS_SCALE:
+        b_o *= scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, ))
+
+
+@triton.heuristics({
+    "HAS_SCALE": lambda args: args["scale"] is not None,
+    "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+})
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": BS}, num_warps=num_warps) for BS in BS_LIST
+        for num_warps in [2, 4, 8]
+    ],
+    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_vector_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    o_i = tl.arange(0, BT)
+    if REVERSE:
+        m_s = tl.where(o_i[:, None] <= o_i[None, :], 1.0, 0.0)
+    else:
+        m_s = tl.where(o_i[:, None] >= o_i[None, :], 1.0, 0.0)
+
+    if HEAD_FIRST:
+        p_s = tl.make_block_ptr(
+            s + (bos * H + i_h * T) * S,
+            (T, S),
+            (S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+        p_o = tl.make_block_ptr(
+            o + (bos * H + i_h * T) * S,
+            (T, S),
+            (S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+    else:
+        p_s = tl.make_block_ptr(
+            s + (bos * H + i_h) * S,
+            (T, S),
+            (H * S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+        p_o = tl.make_block_ptr(
+            o + (bos * H + i_h) * S,
+            (T, S),
+            (H * S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+    # [BT, BS]
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_o = tl.dot(m_s, b_s, allow_tf32=False)
+    if HAS_SCALE:
+        b_o *= scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_local_cumsum_scalar(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    head_first: bool = False,
+    output_dtype: Optional[torch.dtype] = torch.float,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T = g.shape
+    else:
+        B, T, H = g.shape
+    assert chunk_size == 2**(chunk_size.bit_length() -
+                             1), "chunk_size must be a power of 2"
+    BT = chunk_size
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, BT)
+                     if cu_seqlens is not None else None)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+    grid = (NT, B * H)
+    chunk_local_cumsum_scalar_kernel[grid](
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+        num_warps=8,
+        num_stages=3,
+    )
+    return g
+
+
+def chunk_local_cumsum_scalar_out(
+    g: torch.Tensor,
+    out: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    head_first: bool = False,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T = g.shape
+    else:
+        B, T, H = g.shape
+    if out.shape != g.shape:
+        raise ValueError(f'chunk_local_cumsum_scalar_out shape mismatch: '
+                         f'{out.shape} vs {g.shape}')
+    assert chunk_size == 2**(chunk_size.bit_length() -
+                             1), "chunk_size must be a power of 2"
+    BT = chunk_size
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, BT)
+                     if cu_seqlens is not None else None)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    grid = (NT, B * H)
+    chunk_local_cumsum_scalar_kernel[grid](
+        s=g,
+        o=out,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+        num_warps=8,
+        num_stages=3,
+    )
+    return out
+
+
+def chunk_local_cumsum_vector(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    head_first: bool = False,
+    output_dtype: Optional[torch.dtype] = torch.float,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T, S = g.shape
+    else:
+        B, T, H, S = g.shape
+    BT = chunk_size
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, chunk_size)
+                     if cu_seqlens is not None else None)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    assert chunk_size == 2**(chunk_size.bit_length() -
+                             1), "chunk_size must be a power of 2"
+
+    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+
+    def grid(meta):
+        return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
+
+    # keep cumulative normalizer in fp32
+    # this kernel is equivalent to
+    # g = g.view(B, H, NT, BT, -1).cumsum(-2).view(B, H, T, -1)
+    chunk_local_cumsum_vector_kernel[grid](
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        S=S,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return g
+
+
+@input_guard
+def chunk_local_cumsum(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    head_first: bool = False,
+    output_dtype: Optional[torch.dtype] = torch.float,
+    **kwargs,
+) -> torch.Tensor:
+    if cu_seqlens is not None:
+        assert (g.shape[0] == 1
+                ), "Only batch size 1 is supported when cu_seqlens are provided"
+    if len(g.shape) == 3:
+        return chunk_local_cumsum_scalar(
+            g=g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+        )
+    elif len(g.shape) == 4:
+        return chunk_local_cumsum_vector(
+            g=g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+        )
+    else:
+        raise ValueError(f"Unsupported input shape {g.shape}, "
+                         f"which should be (B, T, H, D) if `head_first=False` "
+                         f"or (B, H, T, D) otherwise")

--- a/flash_rt/ops/fla/index.py
+++ b/flash_rt/ops/fla/index.py
@@ -1,0 +1,32 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/utils/index.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/index.py
+# -*- coding: utf-8 -*-
+
+import torch
+import triton
+
+from flash_rt.ops.fla.utils import tensor_cache
+
+
+@tensor_cache
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+@tensor_cache
+def prepare_chunk_indices(cu_seqlens: torch.LongTensor,
+                          chunk_size: int) -> torch.LongTensor:
+    indices = torch.cat([
+        torch.arange(n)
+        for n in triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()
+    ])
+    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+
+
+@tensor_cache
+def prepare_chunk_offsets(cu_seqlens: torch.LongTensor,
+                          chunk_size: int) -> torch.LongTensor:
+    return torch.cat([
+        cu_seqlens.new_tensor([0]),
+        triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
+    ]).cumsum(-1)

--- a/flash_rt/ops/fla/l2norm.py
+++ b/flash_rt/ops/fla/l2norm.py
@@ -1,0 +1,195 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/modules/l2norm.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/l2norm.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import triton
+import triton.language as tl
+
+from flash_rt.ops.fla.utils import input_guard
+
+BT_LIST = [8, 16, 32, 64, 128]
+
+
+# @triton.autotune(
+#     configs=[
+#         triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8, 16, 32]
+#     ],
+#     key=["D"],
+# )
+@triton.jit
+def l2norm_fwd_kernel1(
+    x,
+    y,
+    D,
+    BD: tl.constexpr,
+    eps,
+):
+    i_t = tl.program_id(0)
+    x += i_t * D
+    y += i_t * D
+    # Compute mean and variance
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    b_x = tl.load(x + cols, mask=mask, other=0.0).to(tl.float32)
+    b_var = tl.sum(b_x * b_x, axis=0)
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+    # tl.store(Rstd + i_t, rstd)
+    # Normalize and apply linear transformation
+    b_y = b_x * b_rstd
+    tl.store(y + cols, b_y, mask=mask)
+
+
+# @triton.autotune(
+#     configs=[
+#         triton.Config({"BT": BT}, num_warps=num_warps)
+#         for num_warps in [1, 2, 4, 8, 16]
+#         for BT in BT_LIST
+#     ],
+#     key=["D", "NB"],
+# )
+@triton.jit
+def l2norm_fwd_kernel(
+    x,
+    y,
+    eps,
+    T,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    b_var = tl.sum(b_x * b_x, axis=1)
+    b_y = b_x / tl.sqrt(b_var + eps)[:, None]
+    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+
+
+def l2norm_fwd(x: torch.Tensor,
+               eps: float = 1e-6,
+               output_dtype: Optional[torch.dtype] = None):
+    x_shape_og = x.shape
+    x = x.view(-1, x.shape[-1])
+    # allocate output
+    if output_dtype is None:
+        y = torch.empty_like(x)
+    else:
+        y = torch.empty_like(x, dtype=output_dtype)
+    assert y.stride(-1) == 1
+    T, D = x.shape[0], x.shape[-1]
+    # rstd = torch.empty((T,), dtype=torch.float32, device=x.device)
+    # Less than 64KB per feature: enqueue fused kernel
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+
+    if D <= 512:
+
+        def grid(meta):
+            return (triton.cdiv(T, meta["BT"]), )
+
+        l2norm_fwd_kernel[grid](
+            x,
+            y,
+            eps,
+            T=T,
+            D=D,
+            BD=BD,
+            BT=16,
+            num_warps=8,
+            num_stages=3,
+        )
+    else:
+        l2norm_fwd_kernel1[(T, )](
+            x,
+            y,
+            eps=eps,
+            D=D,
+            BD=BD,
+            num_warps=8,
+            num_stages=3,
+        )
+
+    return y.view(x_shape_og)
+
+
+def l2norm_fwd_out(x: torch.Tensor,
+                   y: torch.Tensor,
+                   eps: float = 1e-6) -> torch.Tensor:
+    x_shape_og = x.shape
+    x = x.view(-1, x.shape[-1])
+    y_view = y.view(-1, y.shape[-1])
+    if x.shape != y_view.shape:
+        raise ValueError(f'l2norm_fwd_out shape mismatch: {x.shape} vs '
+                         f'{y_view.shape}')
+    if y_view.stride(-1) != 1:
+        raise ValueError('l2norm_fwd_out requires contiguous last dim')
+    T, D = x.shape[0], x.shape[-1]
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+
+    if D <= 512:
+
+        def grid(meta):
+            return (triton.cdiv(T, meta["BT"]), )
+
+        l2norm_fwd_kernel[grid](
+            x,
+            y_view,
+            eps,
+            T=T,
+            D=D,
+            BD=BD,
+            BT=16,
+            num_warps=8,
+            num_stages=3,
+        )
+    else:
+        l2norm_fwd_kernel1[(T, )](
+            x,
+            y_view,
+            eps=eps,
+            D=D,
+            BD=BD,
+            num_warps=8,
+            num_stages=3,
+        )
+    return y.view(x_shape_og)
+
+
+class L2NormFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(ctx, x, eps=1e-6, output_dtype=None):
+        return l2norm_fwd(x, eps, output_dtype)
+
+
+def l2norm(x: torch.Tensor,
+           eps: float = 1e-6,
+           output_dtype: Optional[torch.dtype] = None) -> torch.Tensor:
+    return L2NormFunction.apply(x, eps, output_dtype)
+
+
+l2_norm = l2norm
+
+
+class L2Norm(nn.Module):
+
+    def __init__(self,
+                 eps: float = 1e-6,
+                 output_dtype: Optional[torch.dtype] = None):
+        super().__init__()
+        self.eps = eps
+        self.output_dtype = output_dtype
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return l2norm(x, self.eps, self.output_dtype)

--- a/flash_rt/ops/fla/op.py
+++ b/flash_rt/ops/fla/op.py
@@ -1,0 +1,65 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/utils/op.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/op.py
+# -*- coding: utf-8 -*-
+
+import os
+
+import triton
+import triton.language as tl
+import triton.language.extra.libdevice as tldevice
+
+from flash_rt.ops.fla.utils import is_gather_supported
+
+if os.environ.get("FLA_USE_FAST_OPS", "0") == "1":
+    exp = tldevice.fast_expf
+    exp2 = tldevice.exp2
+    log = tldevice.fast_logf
+    log2 = tldevice.fast_log2f
+else:
+    exp = tl.exp
+    exp2 = tl.math.exp2
+    log = tl.log
+    log2 = tl.log2
+
+
+@triton.jit
+def safe_exp(x):
+    return exp(tl.where(x <= 0, x, float("-inf")))
+
+
+if not is_gather_supported:
+
+    @triton.jit
+    def gather(src, index, axis, _builder=None):
+        """
+        Gather operation that works when tl.gather is not supported.
+        This is a fallback implementation that returns None.
+        Just to make triton compiler happy.
+        """
+        return None
+
+else:
+    gather = tl.gather
+
+if hasattr(triton.language, "_experimental_make_tensor_descriptor"):
+    # For Triton 3.3.x
+    make_tensor_descriptor = triton.language._experimental_make_tensor_descriptor
+elif hasattr(triton.language, "make_tensor_descriptor"):
+    # For Triton 3.4.x and later
+    make_tensor_descriptor = triton.language.make_tensor_descriptor
+else:
+    """
+    Fallback implementation when TMA is not supported.
+    Returns None to indicate TMA descriptors are unavailable.
+    Just make triton compiler happy.
+    """
+
+    @triton.jit
+    def make_tensor_descriptor(
+        base,
+        shape,
+        strides,
+        block_shape,
+        _builder=None,
+    ):
+        return None

--- a/flash_rt/ops/fla/solve_tril.py
+++ b/flash_rt/ops/fla/solve_tril.py
@@ -1,0 +1,426 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/utils/solve_tril.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/solve_tril.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+from flash_rt.ops.fla.index import prepare_chunk_indices
+from flash_rt.ops.fla.utils import input_guard
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+# @triton.autotune(
+#     configs=[
+#         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+#         for num_warps in [1, 2, 4, 8]
+#         for num_stages in [2, 3, 4, 5]
+#     ],
+#     key=["BT"],
+# )
+@triton.jit(do_not_specialize=["T"])
+def solve_tril_16x16_kernel(
+    A,
+    Ad,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    A = A + (bos * H + i_h) * BT
+    Ad = Ad + (bos * H + i_h) * 16
+
+    offset = (i_t * 16) % BT
+    p_A = tl.make_block_ptr(A, (T, BT), (H * BT, 1), (i_t * 16, offset),
+                            (16, 16), (1, 0))
+    p_Ai = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 16, 0), (16, 16),
+                             (1, 0))
+    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+    b_A = -tl.where(
+        tl.arange(0, 16)[:, None] > tl.arange(0, 16)[None, :], b_A, 0)
+
+    o_i = tl.arange(0, 16)
+    for i in range(1, min(16, T - i_t * 16)):
+        b_a = -tl.load(A + (i_t * 16 + i) * H * BT + o_i + offset)
+        b_a = b_a + tl.sum(b_a[:, None] * b_A, 0)
+        mask = o_i == i
+        b_A = tl.where(mask[:, None], b_a, b_A)
+    b_A += o_i[:, None] == o_i[None, :]
+    tl.store(
+        p_Ai,
+        b_A.to(p_Ai.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+# @triton.autotune(
+#     configs=[
+#         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+#         for num_warps in [1, 2, 4, 8]
+#         for num_stages in [2, 3, 4, 5]
+#     ],
+#     key=["H", "BT", "IS_VARLEN"],
+# )
+@triton.jit(do_not_specialize=["T"])
+def merge_16x16_to_32x32_inverse_kernel(
+    A,
+    Ad,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    A += (bos * H + i_h) * 32
+    Ad += (bos * H + i_h) * 16
+    Ai += (bos * H + i_h) * 32
+
+    p_A_21 = tl.make_block_ptr(A, (T, 32), (H * 32, 1), (i_t * 32 + 16, 0),
+                               (16, 16), (1, 0))
+    p_Ad_11 = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 32, 0),
+                                (16, 16), (1, 0))
+    p_Ad_22 = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 32 + 16, 0),
+                                (16, 16), (1, 0))
+    p_Ai_11 = tl.make_block_ptr(Ai, (T, 32), (H * 32, 1), (i_t * 32, 0),
+                                (16, 16), (1, 0))
+    p_Ai_22 = tl.make_block_ptr(Ai, (T, 32), (H * 32, 1), (i_t * 32 + 16, 16),
+                                (16, 16), (1, 0))
+    p_Ai_21 = tl.make_block_ptr(Ai, (T, 32), (H * 32, 1), (i_t * 32 + 16, 0),
+                                (16, 16), (1, 0))
+
+    A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+    Ai_11 = tl.load(p_Ad_11, boundary_check=(0, 1)).to(tl.float32)
+    Ai_22 = tl.load(p_Ad_22, boundary_check=(0, 1)).to(tl.float32)
+    Ai_21 = -tl.dot(tl.dot(Ai_22, A_21, input_precision="ieee"),
+                    Ai_11,
+                    input_precision="ieee")
+    tl.store(
+        p_Ai_11,
+        Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_22,
+        Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_21,
+        Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+# @triton.autotune(
+#     configs=[
+#         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+#         for num_warps in [2, 4, 8]
+#         for num_stages in [2, 3, 4, 5]
+#     ],
+#     key=["H", "BT", "IS_VARLEN"],
+# )
+@triton.jit(do_not_specialize=["T"])
+def merge_16x16_to_64x64_inverse_kernel(
+    A,
+    Ad,
+    Ai,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    A += (bos * H + i_h) * 64
+    Ad += (bos * H + i_h) * 16
+    Ai += (bos * H + i_h) * 64
+
+    p_A_21 = tl.make_block_ptr(A, (T, 64), (H * 64, 1), (i_t * 64 + 16, 0),
+                               (16, 16), (1, 0))
+    p_A_32 = tl.make_block_ptr(A, (T, 64), (H * 64, 1), (i_t * 64 + 32, 16),
+                               (16, 16), (1, 0))
+    p_A_31 = tl.make_block_ptr(A, (T, 64), (H * 64, 1), (i_t * 64 + 32, 0),
+                               (16, 16), (1, 0))
+    p_A_43 = tl.make_block_ptr(A, (T, 64), (H * 64, 1), (i_t * 64 + 48, 32),
+                               (16, 16), (1, 0))
+    p_A_42 = tl.make_block_ptr(A, (T, 64), (H * 64, 1), (i_t * 64 + 48, 16),
+                               (16, 16), (1, 0))
+    p_A_41 = tl.make_block_ptr(A, (T, 64), (H * 64, 1), (i_t * 64 + 48, 0),
+                               (16, 16), (1, 0))
+    p_Ad_11 = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 64, 0),
+                                (16, 16), (1, 0))
+    p_Ad_22 = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 64 + 16, 0),
+                                (16, 16), (1, 0))
+    p_Ad_33 = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 64 + 32, 0),
+                                (16, 16), (1, 0))
+    p_Ad_44 = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 64 + 48, 0),
+                                (16, 16), (1, 0))
+
+    A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
+    A_32 = tl.load(p_A_32, boundary_check=(0, 1)).to(tl.float32)
+    A_31 = tl.load(p_A_31, boundary_check=(0, 1)).to(tl.float32)
+    A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
+    A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
+    A_41 = tl.load(p_A_41, boundary_check=(0, 1)).to(tl.float32)
+
+    Ai_11 = tl.load(p_Ad_11, boundary_check=(0, 1)).to(tl.float32)
+    Ai_22 = tl.load(p_Ad_22, boundary_check=(0, 1)).to(tl.float32)
+    Ai_33 = tl.load(p_Ad_33, boundary_check=(0, 1)).to(tl.float32)
+    Ai_44 = tl.load(p_Ad_44, boundary_check=(0, 1)).to(tl.float32)
+
+    Ai_21 = -tl.dot(tl.dot(Ai_22, A_21, input_precision="ieee"),
+                    Ai_11,
+                    input_precision="ieee")
+    Ai_32 = -tl.dot(tl.dot(Ai_33, A_32, input_precision="ieee"),
+                    Ai_22,
+                    input_precision="ieee")
+    Ai_43 = -tl.dot(tl.dot(Ai_44, A_43, input_precision="ieee"),
+                    Ai_33,
+                    input_precision="ieee")
+
+    Ai_31 = -tl.dot(
+        Ai_33,
+        tl.dot(A_31, Ai_11, input_precision="ieee") +
+        tl.dot(A_32, Ai_21, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    Ai_42 = -tl.dot(
+        Ai_44,
+        tl.dot(A_42, Ai_22, input_precision="ieee") +
+        tl.dot(A_43, Ai_32, input_precision="ieee"),
+        input_precision="ieee",
+    )
+    Ai_41 = -tl.dot(
+        Ai_44,
+        tl.dot(A_41, Ai_11, input_precision="ieee") +
+        tl.dot(A_42, Ai_21, input_precision="ieee") +
+        tl.dot(A_43, Ai_31, input_precision="ieee"),
+        input_precision="ieee",
+    )
+
+    p_Ai_11 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64, 0),
+                                (16, 16), (1, 0))
+    p_Ai_22 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 16),
+                                (16, 16), (1, 0))
+    p_Ai_33 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 32),
+                                (16, 16), (1, 0))
+    p_Ai_44 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 48),
+                                (16, 16), (1, 0))
+    p_Ai_21 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 0),
+                                (16, 16), (1, 0))
+    p_Ai_31 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 0),
+                                (16, 16), (1, 0))
+    p_Ai_32 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 16),
+                                (16, 16), (1, 0))
+    p_Ai_41 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 0),
+                                (16, 16), (1, 0))
+    p_Ai_42 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 16),
+                                (16, 16), (1, 0))
+    p_Ai_43 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 32),
+                                (16, 16), (1, 0))
+    tl.store(
+        p_Ai_11,
+        Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_22,
+        Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_33,
+        Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_44,
+        Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_21,
+        Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_31,
+        Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_32,
+        Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_41,
+        Ai_41.to(p_Ai_41.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_42,
+        Ai_42.to(p_Ai_42.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_43,
+        Ai_43.to(p_Ai_43.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+
+    fill_zeros = tl.zeros((16, 16), dtype=tl.float32)
+    p_Ai_12 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64, 16),
+                                (16, 16), (1, 0))
+    p_Ai_13 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64, 32),
+                                (16, 16), (1, 0))
+    p_Ai_14 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64, 48),
+                                (16, 16), (1, 0))
+    p_Ai_23 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 32),
+                                (16, 16), (1, 0))
+    p_Ai_24 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 48),
+                                (16, 16), (1, 0))
+    p_Ai_34 = tl.make_block_ptr(Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 48),
+                                (16, 16), (1, 0))
+    tl.store(
+        p_Ai_12,
+        fill_zeros.to(p_Ai_12.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_13,
+        fill_zeros.to(p_Ai_13.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_14,
+        fill_zeros.to(p_Ai_14.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_23,
+        fill_zeros.to(p_Ai_23.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_24,
+        fill_zeros.to(p_Ai_24.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_Ai_34,
+        fill_zeros.to(p_Ai_34.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+
+
+@input_guard
+def solve_tril(
+    A: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    output_dtype: torch.dtype = torch.float,
+) -> torch.Tensor:
+    """
+    Compute the inverse of the lower triangular matrix
+    A should be strictly lower triangular, i.e., A.triu() == 0.
+
+    Args:
+        A (torch.Tensor):
+            [B, T, H, K]
+        cu_seqlens (torch.Tensor):
+            The cumulative sequence lengths of the input tensor.
+            Default: None.
+        output_dtype (torch.dtype):
+            The dtype of the output tensor. Default: `torch.float`
+
+    Returns:
+        (I + A)^-1 with the same shape as A
+    """
+    assert A.shape[-1] in [16, 32, 64]
+
+    B, T, H, BT = A.shape
+    Ad = torch.empty(B,
+                     T,
+                     H,
+                     16,
+                     device=A.device,
+                     dtype=torch.float if BT != 16 else output_dtype)
+
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, 16)
+                     if cu_seqlens is not None else None)
+    NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, 16)
+    solve_tril_16x16_kernel[NT, B * H](
+        A=A,
+        Ad=Ad,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        BT=BT,
+        num_warps=1,
+        num_stages=4,
+    )
+    if BT == 16:
+        return Ad
+
+    Ai = torch.empty(B, T, H, BT, device=A.device, dtype=output_dtype)
+    merge_fn = (merge_16x16_to_32x32_inverse_kernel
+                if BT == 32 else merge_16x16_to_64x64_inverse_kernel)
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, BT)
+                     if cu_seqlens is not None else None)
+    NT = len(chunk_indices) if cu_seqlens is not None else triton.cdiv(T, BT)
+    merge_fn[NT, B * H](
+        A=A,
+        Ad=Ad,
+        Ai=Ai,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        BT=BT,
+        num_warps=4,
+        num_stages=3,
+    )
+    return Ai

--- a/flash_rt/ops/fla/utils.py
+++ b/flash_rt/ops/fla/utils.py
@@ -1,0 +1,376 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/utils.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/utils.py
+# -*- coding: utf-8 -*-
+
+import contextlib
+import functools
+import inspect
+import logging
+import os
+import sys
+from enum import Enum
+from functools import lru_cache
+from typing import Any, Callable, Dict, Literal, Optional, Tuple
+
+import torch
+import triton
+from packaging import version
+
+logger = logging.getLogger(__name__)
+
+COMPILER_MODE = os.getenv("FLA_COMPILER_MODE") == "1"
+FLA_CI_ENV = os.getenv("FLA_CI_ENV") == "1"
+
+
+@lru_cache(maxsize=1)
+def check_environments():
+    """
+    Checks the current operating system, Triton version, and Python version,
+    issuing warnings if they don't meet recommendations.
+    This function's body only runs once due to lru_cache.
+    """
+    # Check Operating System
+    if sys.platform == "win32":
+        logger.warning(
+            "Detected Windows operating system. Triton does not have an official Windows release, "
+            "thus FLA will not be adapted for Windows, and any potential errors will not be fixed. "
+            "Please consider using a Linux environment for compatibility.")
+
+    triton_version = version.parse(triton.__version__)
+    required_triton_version = version.parse("3.2.0")
+
+    if triton_version < required_triton_version:
+        logger.warning(
+            f"Current Triton version {triton_version} is below the recommended 3.2.0 version. "
+            "Errors may occur and these issues will not be fixed. "
+            "Please consider upgrading Triton.")
+
+    # Check Python version
+    py_version = version.parse(
+        f"{sys.version_info.major}.{sys.version_info.minor}")
+    required_py_version = version.parse("3.11")
+
+    if py_version < required_py_version:
+        logger.warning(
+            f"Current Python version {py_version} is below the recommended 3.11 version. "
+            "It is recommended to upgrade to Python 3.11 or higher for the best experience."
+        )
+
+    return None
+
+
+check_environments()
+
+
+def get_abs_err(x, y):
+    return (x.detach() - y.detach()).flatten().abs().max().item()
+
+
+def get_err_ratio(x, y):
+    err = (x.detach() - y.detach()).flatten().square().mean().sqrt().item()
+    base = (x.detach()).flatten().square().mean().sqrt().item()
+    return err / (base + 1e-8)
+
+
+def assert_close(prefix, ref, tri, ratio, warning=False, err_atol=1e-6):
+    abs_atol = get_abs_err(ref, tri)
+    msg = f"{prefix} diff: {abs_atol:.6f} ratio: {get_err_ratio(ref, tri):.6f}"
+    logger.info(msg)
+    error_rate = get_err_ratio(ref, tri)
+    if abs_atol <= err_atol:
+        return
+    if warning or (FLA_CI_ENV and (error_rate < 0.01 or abs_atol <= 0.3)):
+        if error_rate > ratio:
+            import warnings
+
+            warnings.warn(msg)
+    else:
+        assert error_rate < ratio, msg
+
+
+SUPPRESS_LEVEL = int(os.getenv("GDN_RECOMPUTE_SUPPRESS_LEVEL", "0"))
+
+
+def tensor_cache(
+        fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+    """
+    A decorator that caches the most recent results of a function with tensor inputs.
+    This decorator will store the output of the decorated function for the most recent set of input tensors.
+    The cache is limited to a fixed size (default is 4). When the cache is full, the oldest entry will be removed.
+    Args:
+        fn (Callable[..., torch.Tensor]):
+            The function to be decorated. It should take tensor inputs and return tensor outputs.
+    Returns:
+        Callable[..., torch.Tensor]:
+            A wrapped version of the input function with single-entry caching.
+    """
+
+    cache_entries: Tuple[Optional[Tuple], Optional[Dict], Any] = []
+    cache_size = 4
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        nonlocal cache_entries, cache_size
+        for i, entry in enumerate(cache_entries):
+            last_args, last_kwargs, last_result = entry
+            if len(args) == len(last_args) and len(kwargs) == len(last_kwargs):
+                if all(a is b for a, b in zip(args, last_args)) and all(
+                        k in last_kwargs and v is last_kwargs[k]
+                        for k, v in kwargs.items()):
+                    cache_entries = (cache_entries[:i] + cache_entries[i + 1:] +
+                                     [(args, kwargs, last_result)])
+                    return last_result
+
+        result = fn(*args, **kwargs)
+
+        if len(cache_entries) >= cache_size:
+            cache_entries = cache_entries[1:]
+        cache_entries.append((args, kwargs, result))
+        return result
+
+    return wrapper
+
+
+def input_guard(fn=None, *, exclude_args: Optional[list[str]] = None):
+    """
+    A decorator to make sure all input tensors are contiguous and set the
+    device based on input tensors.
+
+    Args:
+        exclude_args: Optional list of parameter names whose tensor arguments
+            should not be made contiguous.
+
+    Usage::
+
+        @input_guard
+        def foo(a, b): ...
+
+        @input_guard(exclude_args=["initial_state_source"])
+        def bar(a, initial_state_source): ...
+    """
+
+    def _contiguous_if_needed(value: torch.Tensor) -> torch.Tensor:
+        if value.is_contiguous():
+            return value
+        return value.contiguous()
+
+    def decorator(
+            func: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+        sig = inspect.signature(func) if exclude_args else None
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if exclude_args and sig is not None:
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                for name, value in bound.arguments.items():
+                    if isinstance(value,
+                                  torch.Tensor) and name not in exclude_args:
+                        bound.arguments[name] = _contiguous_if_needed(value)
+                contiguous_args = bound.args
+                contiguous_kwargs = bound.kwargs
+            else:
+                contiguous_args = tuple(
+                    i if not isinstance(i, torch.Tensor)
+                    else _contiguous_if_needed(i)
+                    for i in args)
+                contiguous_kwargs = {
+                    k:
+                    (v if not isinstance(v, torch.Tensor)
+                     else _contiguous_if_needed(v))
+                    for k, v in kwargs.items()
+                }
+
+            tensor = None
+            for arg in args:
+                if isinstance(arg, torch.Tensor):
+                    tensor = arg
+                    break
+            if tensor is None:
+                for value in kwargs.values():
+                    if isinstance(value, torch.Tensor):
+                        tensor = value
+                        break
+
+            if tensor is not None:
+                ctx = custom_device_ctx(tensor.device.index)
+            else:
+                ctx = contextlib.nullcontext()
+
+            with ctx:
+                return func(*contiguous_args, **contiguous_kwargs)
+
+        return wrapper
+
+    if fn is not None:
+        # Called as @input_guard without arguments
+        return decorator(fn)
+    # Called as @input_guard(exclude_args=[...])
+    return decorator
+
+
+contiguous = input_guard
+
+
+def require_version(version, hint):
+    """
+    Perform a runtime check of the dependency versions, using the exact same syntax used by pip.
+    """
+
+    def decorator(fn):
+
+        def _contiguous_if_needed(value: torch.Tensor) -> torch.Tensor:
+            if value.is_contiguous():
+                return value
+            return value.contiguous()
+
+        @functools.wraps(fn)
+        def wrapper(ctx, *args, **kwargs):
+            from transformers.utils.versions import require_version
+
+            require_version(version, hint)
+            return fn(
+                ctx,
+                *(i if not isinstance(i, torch.Tensor)
+                  else _contiguous_if_needed(i)
+                  for i in args),
+                **{
+                    k:
+                    (v if not isinstance(v, torch.Tensor)
+                     else _contiguous_if_needed(v))
+                    for k, v in kwargs.items()
+                },
+            )
+
+        return wrapper
+
+    return decorator
+
+
+def checkpoint(fn):
+
+    def wrapper(*args, **kwargs):
+        return torch.utils.checkpoint.checkpoint(fn, *args, **kwargs)
+
+    return wrapper
+
+
+@lru_cache(maxsize=None)
+def check_pytorch_version(version_s: str = "2.4") -> bool:
+    return version.parse(torch.__version__) >= version.parse(version_s)
+
+
+def _cpu_device_warning():
+    import warnings
+
+    warnings.warn(
+        ("Triton is not supported on current platform, roll back to CPU."),
+        stacklevel=1)
+
+
+@lru_cache(maxsize=None)
+def get_multiprocessor_count(tensor_idx: int = 0) -> int:
+    try:
+        return triton.runtime.driver.active.utils.get_device_properties(
+            tensor_idx)["multiprocessor_count"]
+    except BaseException:
+        _cpu_device_warning()
+        return -1
+
+
+@lru_cache(maxsize=None)
+def get_available_device() -> str:
+    try:
+        return triton.runtime.driver.active.get_current_target().backend
+    except BaseException:
+        _cpu_device_warning()
+        return "cpu"
+
+
+@lru_cache(maxsize=None)
+def _check_platform() -> Literal["nvidia", "amd", "intel", "musa"]:
+    device = get_available_device()
+    if device == "cuda":
+        return "nvidia"
+    elif device == "hip":
+        return "amd"
+    elif device == "xpu":
+        return "intel"
+    else:
+        return device
+
+
+# For AMD GPUs, the triton backend is 'hip', while for Nvidia GPUs, the triton backend is 'cuda'.
+# However, the torch backend is 'cuda' for both Nvidia and AMD GPUs.
+# Therefore, we need to check the triton backend to determine the actual GPU vendor.
+device = get_available_device() if get_available_device() != "hip" else "cuda"
+device_torch_lib = getattr(torch, device)
+device_platform = _check_platform()
+
+is_amd = device_platform == "amd"
+is_intel = device_platform == "intel"
+is_nvidia = device_platform == "nvidia"
+is_intel_alchemist = is_intel and "Intel(R) Arc(TM) A" in torch.xpu.get_device_name(
+    0)
+is_nvidia_hopper = is_nvidia and ("NVIDIA H" in torch.cuda.get_device_name(0)
+                                  or torch.cuda.get_device_capability()[0] >= 9)
+use_cuda_graph = is_nvidia and os.environ.get("FLA_USE_CUDA_GRAPH", "0") == "1"
+
+# Nvidia Ampere or newer, haven't check AMD and intel yet.
+is_tf32_supported = is_nvidia and torch.cuda.get_device_capability(0)[0] >= 8
+is_gather_supported = hasattr(triton.language, "gather")
+
+
+def get_all_max_shared_mem():
+    try:
+        return [
+            triton.runtime.driver.active.utils.get_device_properties(i)
+            ["max_shared_mem"] for i in range(device_torch_lib.device_count())
+        ]
+    except BaseException:
+        _cpu_device_warning()
+        return [-1]
+
+
+class Backend(Enum):
+    ADA = 101376  # RTX 4090
+    AMPERE = 166912  # A100
+    HOPPER = 232448  # H100
+    DEFAULT = 102400  # Default
+
+    @classmethod
+    def get_shared_memory(cls, arch: str) -> int:
+        try:
+            return cls[arch.upper()].value
+        except KeyError:
+            return cls.DEFAULT.value
+
+
+@lru_cache(maxsize=None)
+def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
+    try:
+        device_shared_mem_list = get_all_max_shared_mem()
+        max_shared_memory = device_shared_mem_list[tensor_idx]
+        return max_shared_memory >= Backend.get_shared_memory(arch)
+    except Exception:
+        return False
+
+
+if check_pytorch_version("2.4"):
+    device = "cuda" if device == "cpu" else device
+    autocast_custom_fwd = functools.partial(torch.amp.custom_fwd,
+                                            device_type=device)
+    autocast_custom_bwd = functools.partial(torch.amp.custom_bwd,
+                                            device_type=device)
+
+    def custom_device_ctx(index: int):
+        return device_torch_lib.device(index)
+
+else:
+    assert (device == "cuda"
+            ), "Only cuda device is supported for PyTorch version < 2.4.0."
+    autocast_custom_fwd = device_torch_lib.amp.custom_fwd
+    autocast_custom_bwd = device_torch_lib.amp.custom_bwd
+
+    def custom_device_ctx(index: int):
+        return torch.cuda.device(index)

--- a/flash_rt/ops/fla/wy_fast.py
+++ b/flash_rt/ops/fla/wy_fast.py
@@ -1,0 +1,152 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/gated_delta_rule/wy_fast.py
+# Adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/layers/attention/fla/wy_fast.py
+# -*- coding: utf-8 -*-
+
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flash_rt.ops.fla.index import prepare_chunk_indices
+
+
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+# @triton.autotune(
+#     configs=[
+#         triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+#         for num_warps in [2, 4, 8]
+#         for num_stages in [2, 3, 4]
+#     ],
+#     key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+# )
+@triton.jit(do_not_specialize=["T"])
+def recompute_w_u_fwd_kernel(
+    k,
+    v,
+    beta,
+    w,
+    u,
+    A,
+    g,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(
+            tl.int32), tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(
+            tl.int32), tl.load(cu_seqlens + i_n + 1).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    p_beta = tl.make_block_ptr(beta + bos * H + i_h, (T, ), (H, ), (i_t * BT, ),
+                               (BT, ), (0, ))
+    p_g = tl.make_block_ptr(g + (bos * H + i_h), (T, ), (H, ), (i_t * BT, ),
+                            (BT, ), (0, ))
+    p_A = tl.make_block_ptr(A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1),
+                            (i_t * BT, 0), (BT, BT), (1, 0))
+    b_beta = tl.load(p_beta, boundary_check=(0, ))
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_g = tl.exp(tl.load(p_g, boundary_check=(0, )))
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_u = tl.make_block_ptr(
+            u + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
+        b_u = tl.dot(b_A, b_vb, allow_tf32=False)
+        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(
+            k + (bos * Hg + i_h // (H // Hg)) * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_w = tl.make_block_ptr(
+            w + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_kb = (b_k * b_beta[:, None] * b_g[:, None]).to(b_k.dtype)
+        b_w = tl.dot(b_A, b_kb)
+        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+
+
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g_cumsum: torch.Tensor,
+    A: torch.Tensor,
+    cu_seqlens: Optional[torch.LongTensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    B, T, Hg, K, V = *k.shape, v.shape[-1]
+    H = v.shape[-2]
+    BT = A.shape[-1]
+
+    chunk_indices = (prepare_chunk_indices(cu_seqlens, BT)
+                     if cu_seqlens is not None else None)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BK = 64
+    BV = 64
+    u = torch.empty_like(v)
+    w = k.new_empty(B, T, H, K)
+    recompute_w_u_fwd_kernel[(NT, B * H)](
+        k=k,
+        v=v,
+        beta=beta,
+        w=w,
+        u=u,
+        A=A,
+        g=g_cumsum,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+        num_warps=4,
+        num_stages=3,
+    )
+    return w, u
+
+
+fwd_recompute_w_u = recompute_w_u_fwd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-torch = ["torch", "safetensors", "sentencepiece"]
+torch = ["torch", "safetensors", "sentencepiece", "einops", "triton>=3.2", "packaging"]
 jax = ["jax", "jaxlib", "ml_dtypes", "orbax-checkpoint", "flax"]
 server = ["fastapi", "uvicorn"]
 eval = ["opencv-python", "tqdm"]
@@ -42,3 +42,4 @@ include = ["flash_rt*"]
 
 [tool.setuptools.package-data]
 flash_rt = ["*.so", "*.yaml", "*.model"]
+"flash_rt.ops.fla" = ["VENDOR.md", "NOTICE", "LICENSE.flash-linear-attention"]

--- a/tests/test_qwen36_nvfp4_long_ctx_auto_route.py
+++ b/tests/test_qwen36_nvfp4_long_ctx_auto_route.py
@@ -39,10 +39,19 @@ all three must pass after.
     regression net: ensures the auto-route logic does not silently
     rewire short-context.
 
+  * ``test_long_ctx_short_request_still_specs`` — ``max_seq=32768``,
+    short prompt, ``max_new=128``. Enabling long-context serving must
+    not silently route ordinary short requests away from the documented
+    MTP spec path.
+
   * ``test_long_prompt_doesnt_oom`` — ``max_seq=32768``,
-    ``prompt_len=1024``, ``max_new=16``. This is the exact failure
-    the bug report described; on main it OOMs, post-fix it must
-    succeed and produce ``max_new`` tokens.
+    ``prompt_len=1024``, ``max_new=16``. This stays inside the retained
+    short spec window but uses the long-context-capable frontend.
+
+  * Requests beyond the retained short spec window route through eager
+    TQ-spec (MTP draft + TurboQuant verify). The full long-context
+    performance grid is kept as an explicit benchmark because real
+    prompt prefill is expensive.
 
   * ``test_auto_route_init_at_each_tier`` — constructor at
     ``max_seq ∈ [2K, 8K, 16K, 32K, 64K, 128K]`` all succeed, all
@@ -162,6 +171,59 @@ def test_short_ctx_spec_path_unchanged():
             f'(expected ≥70, docs claim 90-130)'
         )
         assert new_tokens == 128
+    finally:
+        _free_frontend(fe)
+
+
+def test_long_ctx_short_request_still_specs():
+    """max_seq=32768 keeps short requests on the MTP spec path."""
+    import time
+    import torch
+
+    os.environ.setdefault('FLASHRT_QWEN36_MTP_CKPT_DIR', CKPT_MTP)
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    fe = Qwen36TorchFrontendRtx(
+        CKPT_NVFP4, quant='nvfp4', max_seq=32768)
+    try:
+        assert getattr(fe, '_long_ctx_mode', False) is True
+        assert getattr(fe, '_short_ctx_spec_max_seq', 0) >= 2048
+
+        prompt = 'Explain quantum entanglement in one short paragraph.'
+        ids = fe._tokenizer(
+            prompt, return_tensors='pt').input_ids.cuda()
+        assert ids.shape[1] + 128 <= fe._short_ctx_spec_max_seq
+
+        # Warmup.
+        _ = fe.generate_own_speculative_KN_nvfp4(
+            ids, max_new_tokens=128, K=6)
+        torch.cuda.synchronize()
+
+        fe.reset_state()
+        fe.reset_mtp_state()
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        out = fe.generate_own_speculative_KN_nvfp4(
+            ids, max_new_tokens=128, K=6)
+        torch.cuda.synchronize()
+        dt = time.perf_counter() - t0
+
+        new_tokens = out.shape[1] - ids.shape[1]
+        tps = new_tokens / dt
+        print(
+            f'\n[long-ctx short-request] prompt={ids.shape[1]} '
+            f'new={new_tokens} time={dt:.3f}s tok/s={tps:.1f} '
+            f'attempts={fe._spec_attempts}'
+        )
+
+        assert new_tokens == 128
+        assert fe._spec_attempts > 0, (
+            'short request in long-ctx frontend must use MTP spec'
+        )
+        assert tps >= 70.0, (
+            f'long-ctx short-request warm decode degraded: {tps:.1f} '
+            'tok/s (expected spec path)'
+        )
     finally:
         _free_frontend(fe)
 

--- a/tests/test_qwen36_server_warmup.py
+++ b/tests/test_qwen36_server_warmup.py
@@ -1,0 +1,161 @@
+from examples.qwen36_openai_server import (
+    Qwen36Engine,
+    _dedupe_shapes,
+    _parse_warmup_shapes,
+    _warmup_preset_shapes,
+)
+
+
+def test_warmup_preset_auto_respects_max_seq():
+    shapes = _warmup_preset_shapes('auto', 32768)
+    assert (8, 64) in shapes
+    assert (128, 64) in shapes
+    assert (512, 64) in shapes
+    assert (2048, 64) in shapes
+    assert (4096, 64) in shapes
+    assert (8192, 64) in shapes
+    assert (16384, 64) in shapes
+    assert (32768, 64) not in shapes
+
+
+def test_warmup_preset_all_covers_long_buckets_when_they_fit():
+    shapes = _warmup_preset_shapes('all', 262208)
+    assert (2048, 64) in shapes
+    assert (32768, 64) in shapes
+    assert (65536, 64) in shapes
+    assert (131072, 64) in shapes
+    assert (204800, 64) in shapes
+    assert (262144, 16) in shapes
+
+
+def test_parse_and_dedupe_custom_shapes():
+    shapes = _dedupe_shapes(
+        _parse_warmup_shapes('4096:64,8192:64,4096:64'))
+    assert shapes == [(4096, 64), (8192, 64)]
+
+
+def test_server_chat_template_disables_thinking_by_default():
+    class FakeTokenizer:
+        def __init__(self):
+            self.kwargs = None
+
+        def apply_chat_template(self, normalized, **kwargs):
+            self.kwargs = kwargs
+            return 'rendered'
+
+    class FakeFrontend:
+        def __init__(self):
+            self._tokenizer = FakeTokenizer()
+
+    engine = Qwen36Engine.__new__(Qwen36Engine)
+    engine.fe = FakeFrontend()
+
+    assert engine._render_chat([{'role': 'user', 'content': 'hi'}], None) == (
+        'rendered')
+    assert engine.fe._tokenizer.kwargs['enable_thinking'] is False
+
+    engine._render_chat(
+        [{'role': 'user', 'content': 'hi'}], None, enable_thinking=True)
+    assert engine.fe._tokenizer.kwargs['enable_thinking'] is True
+
+
+def test_long_mtp_tail_auto_policy(monkeypatch):
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    monkeypatch.delenv('FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL',
+                       raising=False)
+    fe = Qwen36TorchFrontendRtx.__new__(Qwen36TorchFrontendRtx)
+
+    assert fe._long_mtp_prefill_tail_for_prompt(128) == 0
+    assert fe._long_mtp_prefill_tail_for_prompt(512) == 512
+    assert fe._long_mtp_prefill_tail_for_prompt(1024) == 2048
+    assert fe._long_mtp_prefill_tail_for_prompt(4096) == 512
+    assert fe._long_mtp_prefill_tail_for_prompt(8192) == 2048
+    assert fe._long_mtp_prefill_tail_for_prompt(204800) == 2048
+
+    monkeypatch.setenv('FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL', '512')
+    assert fe._long_mtp_prefill_tail_for_prompt(204800) == 512
+
+
+def test_long_tq_effective_k_uses_measured_context_buckets(monkeypatch):
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    monkeypatch.delenv('FLASHRT_QWEN36_TQ_SPEC_K', raising=False)
+    fe = Qwen36TorchFrontendRtx.__new__(Qwen36TorchFrontendRtx)
+
+    assert fe._long_tq_effective_k(512, 6) == 4
+    assert fe._long_tq_effective_k(1024, 6) == 5
+    assert fe._long_tq_effective_k(2048, 6) == 6
+    assert fe._long_tq_effective_k(4096, 6) == 3
+    assert fe._long_tq_effective_k(8192, 6) == 5
+    assert fe._long_tq_effective_k(16384, 7) == 7
+    assert fe._long_tq_effective_k(32768, 6) == 6
+    assert fe._long_tq_effective_k(65536, 6) == 7
+    assert fe._long_tq_effective_k(131072, 6) == 7
+    assert fe._long_tq_effective_k(204800, 6) == 6
+
+    assert fe._long_tq_effective_k(65536, 5) == 5
+    monkeypatch.setenv('FLASHRT_QWEN36_TQ_SPEC_K', '4')
+    assert fe._long_tq_effective_k(65536, 6) == 4
+
+
+def test_long_ctx_route_uses_prompt_bucket_before_total_length():
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    fe = Qwen36TorchFrontendRtx.__new__(Qwen36TorchFrontendRtx)
+    fe._long_ctx_mode = True
+    fe._long_ctx_route_min_seq = 512
+    fe._short_ctx_spec_max_seq = 2048
+
+    assert fe._should_use_long_ctx_route(128, 512) is False
+    assert fe._should_use_long_ctx_route(511, 64) is False
+    assert fe._should_use_long_ctx_route(512, 64) is True
+    assert fe._should_use_long_ctx_route(128, 2048) is True
+
+
+def test_fp8_xqa_auto_bucket_policy():
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    fe = Qwen36TorchFrontendRtx.__new__(Qwen36TorchFrontendRtx)
+
+    assert not fe._fp8_xqa_auto_bucket_enabled(4, 4096)
+    assert fe._fp8_xqa_auto_bucket_enabled(5, 8192)
+    assert not fe._fp8_xqa_auto_bucket_enabled(6, 16384)
+    assert fe._fp8_xqa_auto_bucket_enabled(5, 32768)
+    assert fe._fp8_xqa_auto_bucket_enabled(8, 65536)
+
+
+def test_long_mtp_cache_capacity_is_compact(monkeypatch):
+    from types import SimpleNamespace
+
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    monkeypatch.delenv('FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL',
+                       raising=False)
+    fe = Qwen36TorchFrontendRtx.__new__(Qwen36TorchFrontendRtx)
+    fe._weights = SimpleNamespace(ptrs={'mtp': object()})
+    fe._short_ctx_spec_max_seq = 2048
+    fe._user_max_seq = 262208
+    calls = []
+
+    def record_extend(target):
+        calls.append(int(target))
+
+    fe._extend_mtp_cache_to = record_extend
+
+    fe._ensure_long_mtp_cache_capacity(
+        prompt_len=204800, max_new_tokens=64, K=6)
+    assert calls[-1] == 2126
+
+    fe._ensure_long_mtp_cache_capacity(
+        prompt_len=204800, max_new_tokens=4096, K=6)
+    assert calls[-1] == 6158
+
+
+def test_long_graph_capture_waterline_can_be_disabled(monkeypatch):
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+    fe = Qwen36TorchFrontendRtx.__new__(Qwen36TorchFrontendRtx)
+    monkeypatch.setenv('FLASHRT_QWEN36_LONG_GRAPH_MIN_FREE_MB', '0')
+
+    assert fe._long_tq_graph_capture_allowed() is True


### PR DESCRIPTION
## Summary
- optimize Qwen3.6-27B NVFP4 long-context serving with FP8-KV verify, tuned MTP/spec buckets, compact MTP cache, and startup graph warmup
- add SM120 FlashInfer XQA FP8-KV integration and Qwen-specific fused kernels for prefill/decode cleanup
- update Qwen README/docs/server defaults and OpenAI-compatible server logging to separate prefill, decode, and wall-time metrics
- add FLA subset vendor/license/notice metadata and declare the Qwen long-context Python/Triton runtime dependencies

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_qwen36_server_warmup.py tests/test_qwen36_nvfp4_long_ctx_auto_route.py -q`
  - 10 passed, 9 skipped
- `cmake -S . -B build-sm120 -DGPU_ARCH=120 -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build-sm120 --target flash_rt_kernels -j 8`
  - built successfully; nvcc emitted existing unused-variable warnings only
- clean-history scan: no maintainer-local paths or checkpoint paths in the PR commit patch

## SM120 smoke / benchmark

Environment:
- RTX 5090 / sm_120
- Qwen3.6-27B NVFP4 main weights
- paired Qwen3.6 MTP checkpoint enabled through `FLASHRT_QWEN36_MTP_CKPT_DIR`
- default FP8-KV long-context path, startup graph warmup enabled

Short standard decode benchmark, prompt length 11, `max_new_tokens=128`, `K=6`:
- TTFT / prefill: 233.14 ms
- decode: 945.42 ms for 127 measured decode tokens
- TPOT: 7.444 ms/token
- decode throughput: 134.33 tok/s

Warm long-context smoke, `max_new_tokens=128`:

| prompt ctx | TTFT / prefill | decode time | decode tok/s |
|---:|---:|---:|---:|
| 512 | 66.5 ms | 1097.2 ms | 116.7 |
| 8K | 748.0 ms | 932.7 ms | 137.2 |
| 64K | 9.093 s | 947.9 ms | 135.0 |
