### PR TITLE
Optimize Qwen OpenAI server TTFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ Text-only OpenAI-compatible serving path for
 | OAI server warm decode | **150 tok/s** |
 | VRAM @ P=1024 + N=256 | 7.30 GiB |
 
+TTFT rows are direct CUDA Graph replay numbers. OpenAI HTTP/SSE
+clients add tokenizer, Python server, SSE, network, and client-side
+overhead; use the server log's `prefill + ttft + decode` fields when
+comparing the HTTP path.
+
 See [`docs/qwen3_8b_nvfp4.md`](docs/qwen3_8b_nvfp4.md) for the
 quickstart, server command, architecture notes, and caveats.
 

--- a/docs/qwen3_8b_nvfp4.md
+++ b/docs/qwen3_8b_nvfp4.md
@@ -31,9 +31,11 @@ ckpt: JunHowie/Qwen3-8B-Instruct-2512-SFT-NVFP4
 | OAI server warm tok/s   | n/a | **150 tok/s** |
 | VRAM @ P=1024 + N=256   | 5.99 GiB | 7.30 GiB |
 
-The OAI server warm tok/s lands at the engine's standalone bench —
-the FastAPI / uvicorn / asyncio / SSE / per-token decode layers add
-no measurable overhead at this throughput class.
+The TTFT rows are direct fixed-shape CUDA Graph replay measurements.
+OpenAI HTTP/SSE clients also include tokenizer/chat-template work,
+Python/FastAPI/SSE serialization, network stack, client parsing, and
+OS scheduling. The server warm decode tok/s lands at the engine's
+standalone bench at this throughput class.
 
 ---
 
@@ -43,7 +45,8 @@ no measurable overhead at this throughput class.
 # 1. Start the server (after the FlashRT install in ../USAGE.md)
 python examples/qwen3_openai_server.py \
     --checkpoint /path/to/Qwen3-8B-Instruct-2512-SFT-NVFP4 \
-    --port 8000
+    --port 8000 \
+    --warmup-preset auto
 
 # 2. Call it like any OpenAI v1 endpoint
 curl http://localhost:8000/v1/chat/completions \
@@ -248,7 +251,7 @@ python examples/qwen3_openai_server.py \
     --max-q-seq 128 \
     --device cuda:0 \
     --model-name qwen3-8b-nvfp4 \
-    --warmup 32:128,128:256
+    --warmup-preset auto
 ```
 
 | Flag | Default | Notes |
@@ -258,14 +261,21 @@ python examples/qwen3_openai_server.py \
 | `--host` | 0.0.0.0 | |
 | `--max-seq` | 2048 | Total prompt + generation length budget |
 | `--max-q-seq` | 128 | Max prefill chunk |
-| `--warmup` | `32:128,128:256` | Comma-separated `prompt_len:max_tokens` pairs to pre-capture at startup. Set to `""` to skip. |
+| `--warmup-preset` | `auto` | Startup graph warmup preset: `auto`, `short`, `all`, or `none` |
+| `--warmup` | `""` | Additional comma-separated `prompt_len:max_tokens` pairs to pre-capture at startup |
 
-Pre-startup `--warmup` pre-captures CUDA Graphs for the listed
-shapes plus all six prefill buckets (32 / 64 / 128 / 256 / 512 /
-1024) — so the first real request hits warm graphs immediately. A
-prompt that lands outside the listed `(prompt_len, max_tokens)`
-shapes pays a one-time graph capture (~10-20 ms) on the first hit
-at that shape; subsequent hits at the same shape are warm.
+Startup warmup captures the prefill graph buckets that fit within
+`--max-q-seq`, then captures decode graphs for the selected warmup
+shapes. With the default `--max-q-seq 128`, `auto` covers 32 / 64 /
+128-token prompts for short-chat TTFT. If you benchmark larger prompt
+graphs such as P=512 or P=1024, start with `--max-q-seq 1024`; the
+same `auto` preset then expands to 256 / 512 / 1024 prompt buckets.
+You can append exact production shapes with `--warmup`.
+
+Online requests do not pre-capture the whole decode range before the
+first token. Warm shapes replay immediately; missing decode positions
+are captured lazily when reached so first-content latency is not
+blocked by an entire request-length graph-capture sweep.
 
 ### Concurrency
 

--- a/examples/qwen36_openai_server.py
+++ b/examples/qwen36_openai_server.py
@@ -106,6 +106,60 @@ def _sse(obj: Any) -> str:
     return f'data: {_json_dumps(obj)}\n\n'
 
 
+def _parse_bool_field(req: Dict[str, Any], name: str,
+                      default: bool) -> bool:
+    value = req.get(name, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in ('1', 'true', 'yes', 'on'):
+            return True
+        if v in ('0', 'false', 'no', 'off'):
+            return False
+    raise ValueError(f'{name} must be boolean')
+
+
+def _parse_int_field(req: Dict[str, Any], name: str, default: int,
+                     *, min_value: Optional[int] = None) -> int:
+    value = req.get(name, default)
+    try:
+        out = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be an integer') from exc
+    if min_value is not None and out < min_value:
+        raise ValueError(f'{name} must be >= {min_value}')
+    return out
+
+
+def _validate_messages(messages: Any) -> List[Dict[str, Any]]:
+    if not isinstance(messages, list) or not messages:
+        raise ValueError('messages is required (non-empty list)')
+    for m in messages:
+        if not isinstance(m, dict):
+            raise ValueError('each message must be an object')
+        role = m.get('role')
+        if role not in ('system', 'user', 'assistant', 'tool'):
+            raise ValueError(f'unsupported role: {role!r}')
+        content = m.get('content')
+        if content is None and role == 'assistant':
+            continue
+        if not isinstance(content, str):
+            raise ValueError('message.content must be a string')
+    return messages
+
+
+def _validate_tools(tools: Any) -> Optional[List[Dict[str, Any]]]:
+    if tools is None:
+        return None
+    if not isinstance(tools, list):
+        raise ValueError('tools must be a list')
+    for tool in tools:
+        if not isinstance(tool, dict):
+            raise ValueError('each tool must be an object')
+    return tools
+
+
 class ToolCallParser:
     """Split Qwen tool-call blocks from a complete assistant response."""
 
@@ -321,6 +375,26 @@ class Qwen36Engine:
             enable_thinking=enable_thinking,
         )
 
+    def prepare_request(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        max_tokens: int,
+        *,
+        enable_thinking: bool = False,
+    ):
+        prompt = self._render_chat(
+            messages, tools, enable_thinking=enable_thinking)
+        input_ids_cpu = self.fe._tokenizer(
+            prompt, return_tensors='pt').input_ids
+        prompt_len = int(input_ids_cpu.shape[1])
+        max_seq = int(getattr(self.fe, '_user_max_seq', 0) or 0)
+        if max_seq and prompt_len + int(max_tokens) > max_seq:
+            raise ValueError(
+                f'prompt + max_tokens = {prompt_len + int(max_tokens)} '
+                f'exceeds --max-seq {max_seq}')
+        return input_ids_cpu
+
     async def generate(
         self,
         messages: List[Dict[str, Any]],
@@ -328,15 +402,18 @@ class Qwen36Engine:
         max_tokens: int,
         *,
         enable_thinking: bool = False,
+        input_ids_cpu=None,
     ) -> Dict[str, Any]:
         """Run one chat-completion. Returns a dict with the new
         text and basic timing/stat fields."""
         torch = self._torch
         async with self.lock:
-            prompt = self._render_chat(
-                messages, tools, enable_thinking=enable_thinking)
-            input_ids = self.fe._tokenizer(
-                prompt, return_tensors='pt').input_ids.cuda()
+            if input_ids_cpu is None:
+                input_ids_cpu = self.prepare_request(
+                    messages, tools, max_tokens,
+                    enable_thinking=enable_thinking,
+                )
+            input_ids = input_ids_cpu.cuda()
             prompt_len = int(input_ids.shape[1])
 
             torch.cuda.synchronize()
@@ -452,29 +529,25 @@ def build_app(engine: Qwen36Engine):
 
     @app.post('/v1/chat/completions')
     async def chat_completions(req: Dict[str, Any]):
-        messages = req.get('messages')
-        if not messages or not isinstance(messages, list):
-            raise HTTPException(400, 'messages is required')
-        tools = req.get('tools')
-        max_tokens = int(req.get('max_tokens') or 256)
-        stream = bool(req.get('stream', False))
-        enable_thinking = bool(req.get('enable_thinking', False))
-        # Validate roles — Qwen template accepts OpenAI chat roles.
-        for m in messages:
-            role = m.get('role')
-            if role not in ('system', 'user', 'assistant', 'tool'):
-                raise HTTPException(
-                    400, f'unsupported role: {role!r}')
-            content = m.get('content')
-            if content is None and role == 'assistant':
-                continue
-            if not isinstance(content, str):
-                raise HTTPException(
-                    400, 'message.content must be a string')
+        try:
+            messages = _validate_messages(req.get('messages'))
+            tools = _validate_tools(req.get('tools'))
+            max_tokens = _parse_int_field(
+                req, 'max_tokens', 256, min_value=1)
+            stream = _parse_bool_field(req, 'stream', False)
+            enable_thinking = _parse_bool_field(
+                req, 'enable_thinking', False)
+            input_ids_cpu = engine.prepare_request(
+                messages, tools, max_tokens,
+                enable_thinking=enable_thinking,
+            )
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
 
         result = await engine.generate(
             messages, tools, max_tokens,
             enable_thinking=enable_thinking,
+            input_ids_cpu=input_ids_cpu,
         )
         completion_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())

--- a/examples/qwen36_openai_server.py
+++ b/examples/qwen36_openai_server.py
@@ -370,7 +370,10 @@ class Qwen36Engine:
                 )
                 raw_text = raw_text.replace('<think>', '').replace(
                     '</think>', '')
-            text, tool_calls = ToolCallParser().parse(raw_text)
+            if tools:
+                text, tool_calls = ToolCallParser().parse(raw_text)
+            else:
+                text, tool_calls = raw_text, []
             text = text.strip()
             completion_tokens = len(new_tokens)
             prefill_ms = float(getattr(self.fe, '_long_ctx_prefill_ms', 0.0)

--- a/examples/qwen36_openai_server.py
+++ b/examples/qwen36_openai_server.py
@@ -91,6 +91,19 @@ log = logging.getLogger('qwen36_openai_server')
 #   <tool_call>{"name": "fn_name", "arguments": {...}}</tool_call>
 _TOOL_CALL_OPEN = '<tool_call>'
 _TOOL_CALL_CLOSE = '</tool_call>'
+_JSON_SEPARATORS = (',', ':')
+_SSE_HEADERS = {
+    'Cache-Control': 'no-cache, no-transform',
+    'X-Accel-Buffering': 'no',
+}
+
+
+def _json_dumps(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, separators=_JSON_SEPARATORS)
+
+
+def _sse(obj: Any) -> str:
+    return f'data: {_json_dumps(obj)}\n\n'
 
 
 class ToolCallParser:
@@ -504,7 +517,7 @@ def build_app(engine: Qwen36Engine):
                 }
                 if result['text']:
                     first['choices'][0]['delta']['content'] = result['text']
-                yield f'data: {json.dumps(first)}\n\n'
+                yield _sse(first)
                 for tc in result['tool_calls']:
                     chunk = {
                         'id': completion_id,
@@ -517,7 +530,7 @@ def build_app(engine: Qwen36Engine):
                             'finish_reason': None,
                         }],
                     }
-                    yield f'data: {json.dumps(chunk)}\n\n'
+                    yield _sse(chunk)
                 last = {
                     'id': completion_id,
                     'object': 'chat.completion.chunk',
@@ -533,10 +546,11 @@ def build_app(engine: Qwen36Engine):
                     }],
                     'usage': usage,
                 }
-                yield f'data: {json.dumps(last)}\n\n'
+                yield _sse(last)
                 yield 'data: [DONE]\n\n'
 
-            return StreamingResponse(gen(), media_type='text/event-stream')
+            return StreamingResponse(
+                gen(), media_type='text/event-stream', headers=_SSE_HEADERS)
 
         content = (
             result['text'] if result['text'] or not result['tool_calls']

--- a/examples/qwen3_openai_server.py
+++ b/examples/qwen3_openai_server.py
@@ -468,14 +468,19 @@ class Qwen3Engine:
                     yield ('tool_calls', tcs)
 
             wall = time.perf_counter() - t0
+            decode_s = max(0.0, wall - prefill_s)
             usage = {
                 'prompt_tokens': P,
                 'completion_tokens': len(new_tokens),
                 'total_tokens': P + len(new_tokens),
                 'prefill_ms': round(prefill_s * 1000, 1),
                 'ttft_ms': round((first_token_s or prefill_s) * 1000, 1),
+                'decode_ms': round(decode_s * 1000, 1),
                 'wall_s': round(wall, 3),
-                'tok_per_s': round(len(new_tokens) / wall, 1) if wall else 0,
+                'tok_per_s': (
+                    round(len(new_tokens) / decode_s, 1)
+                    if decode_s > 0 else 0
+                ),
             }
             yield ('finish', finish_reason, usage)
 
@@ -551,9 +556,13 @@ def build_app(engine: 'Qwen3Engine'):
             if tool_calls:
                 msg['tool_calls'] = tool_calls
             log.info(
-                'non-stream done: %s -> %s tok in %ss (%s tok/s)',
+                'non-stream done: prompt=%s completion=%s '
+                'prefill=%sms ttft=%sms decode=%sms wall=%ss '
+                'decode_tok/s=%s',
                 usage.get('prompt_tokens'), usage.get('completion_tokens'),
-                usage.get('wall_s'), usage.get('tok_per_s'),
+                usage.get('prefill_ms'), usage.get('ttft_ms'),
+                usage.get('decode_ms'), usage.get('wall_s'),
+                usage.get('tok_per_s'),
             )
             return {
                 'id': completion_id,
@@ -650,11 +659,13 @@ def build_app(engine: 'Qwen3Engine'):
                     yield 'data: [DONE]\n\n'
                     log.info(
                         'stream done: prompt=%s completion=%s '
-                        'prefill=%sms ttft=%sms wall=%ss (%s tok/s)',
+                        'prefill=%sms ttft=%sms decode=%sms wall=%ss '
+                        'decode_tok/s=%s',
                         usage.get('prompt_tokens'),
                         usage.get('completion_tokens'),
                         usage.get('prefill_ms'), usage.get('ttft_ms'),
-                        usage.get('wall_s'), usage.get('tok_per_s'),
+                        usage.get('decode_ms'), usage.get('wall_s'),
+                        usage.get('tok_per_s'),
                     )
                     return
 

--- a/examples/qwen3_openai_server.py
+++ b/examples/qwen3_openai_server.py
@@ -372,6 +372,26 @@ class Qwen3Engine:
             tokenize=False,
         )
 
+    def prepare_request(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        max_tokens: int,
+    ):
+        prompt = self._render(messages, tools)
+        input_ids_cpu = self.fe._tokenizer(
+            prompt, return_tensors='pt').input_ids
+        P = int(input_ids_cpu.shape[1])
+        if P > self.fe.max_q_seq:
+            raise ValueError(
+                f'prompt has {P} tokens, exceeds --max-q-seq '
+                f'{self.fe.max_q_seq}')
+        if P + int(max_tokens) > self.fe.max_seq:
+            raise ValueError(
+                f'prompt + max_tokens = {P + int(max_tokens)} exceeds '
+                f'--max-seq {self.fe.max_seq}')
+        return input_ids_cpu
+
     async def stream_generate(
         self,
         messages: List[Dict[str, Any]],
@@ -382,6 +402,7 @@ class Qwen3Engine:
         top_k: int,
         seed: Optional[int],
         stop: Optional[List[str]],
+        input_ids_cpu=None,
     ):
         """Async generator yielding (kind, payload) events:
           ('content', str)               — content delta
@@ -390,9 +411,10 @@ class Qwen3Engine:
         """
         torch = self._torch
         async with self.lock:
-            prompt = self._render(messages, tools)
-            input_ids = self.fe._tokenizer(
-                prompt, return_tensors='pt').input_ids.to('cuda')
+            if input_ids_cpu is None:
+                input_ids_cpu = self.prepare_request(
+                    messages, tools, max_tokens)
+            input_ids = input_ids_cpu.to('cuda')
             P = int(input_ids.shape[1])
 
             rng = None
@@ -557,6 +579,11 @@ def build_app(engine: 'Qwen3Engine'):
 
         completion_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())
+        try:
+            input_ids_cpu = engine.prepare_request(
+                messages, tools, max_tokens)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
 
         if not stream:
             content = ''
@@ -565,7 +592,7 @@ def build_app(engine: 'Qwen3Engine'):
             usage: dict = {}
             async for ev in engine.stream_generate(
                 messages, tools, max_tokens, temperature, top_p, top_k,
-                seed, stop,
+                seed, stop, input_ids_cpu,
             ):
                 if ev[0] == 'content':
                     content += ev[1]
@@ -604,7 +631,7 @@ def build_app(engine: 'Qwen3Engine'):
             tc_seen = False
             async for ev in engine.stream_generate(
                 messages, tools, max_tokens, temperature, top_p, top_k,
-                seed, stop,
+                seed, stop, input_ids_cpu,
             ):
                 if ev[0] == 'content':
                     delta = {}

--- a/examples/qwen3_openai_server.py
+++ b/examples/qwen3_openai_server.py
@@ -134,13 +134,15 @@ class StreamParser:
     Plus stop-string detection for early termination.
     """
 
-    def __init__(self, tokenizer, stop_strings: Optional[List[str]] = None):
+    def __init__(self, tokenizer, stop_strings: Optional[List[str]] = None,
+                 enable_tools: bool = False):
         self.tok = tokenizer
         self._buffer = ''         # un-flushed text (may contain partial tags)
         self._content_pos = 0     # index up to which we have flushed content
         self._in_tool = False
         self._tool_buffer = ''
         self._stop_strings = stop_strings or []
+        self._enable_tools = bool(enable_tools)
         self._tool_calls_emitted: List[dict] = []
         # OAI tool_call indexer.
         self._tool_call_idx = 0
@@ -202,8 +204,12 @@ class StreamParser:
         )
         hold = (
             0 if (final or stop_hit)
-            else max(len(_TOOL_CALL_OPEN), max_stop_len) - 1
+            else max(
+                len(_TOOL_CALL_OPEN) if self._enable_tools else 0,
+                max_stop_len,
+            ) - 1
         )
+        hold = max(0, hold)
 
         while True:
             if self._in_tool:
@@ -223,7 +229,10 @@ class StreamParser:
                     self._tool_calls_emitted.append(tc)
                 continue
 
-            open_idx = self._buffer.find(_TOOL_CALL_OPEN)
+            open_idx = (
+                self._buffer.find(_TOOL_CALL_OPEN)
+                if self._enable_tools else -1
+            )
             if open_idx < 0:
                 # No open tag in buffer — flush all but the hold-back tail.
                 safe = max(0, len(self._buffer) - hold)
@@ -391,7 +400,11 @@ class Qwen3Engine:
                 rng = torch.Generator(device='cuda')
                 rng.manual_seed(int(seed))
 
-            parser = StreamParser(self.fe._tokenizer, stop_strings=stop)
+            parser = StreamParser(
+                self.fe._tokenizer,
+                stop_strings=stop,
+                enable_tools=bool(tools),
+            )
             eos = self.fe._tokenizer.eos_token_id
 
             t0 = time.perf_counter()

--- a/examples/qwen3_openai_server.py
+++ b/examples/qwen3_openai_server.py
@@ -31,7 +31,7 @@ Usage::
     python examples/qwen3_openai_server.py \\
         --checkpoint /path/to/Qwen3-8B-Instruct-NVFP4 \\
         --port 8000 \\
-        --warmup 32:128,128:256,256:256
+        --warmup-preset auto
 
     curl http://localhost:8000/v1/chat/completions \\
         -H 'Content-Type: application/json' \\
@@ -65,6 +65,19 @@ log = logging.getLogger('qwen3_openai_server')
 # anywhere in the assistant turn. We parse incrementally during stream.
 _TOOL_CALL_OPEN = '<tool_call>'
 _TOOL_CALL_CLOSE = '</tool_call>'
+_JSON_SEPARATORS = (',', ':')
+_SSE_HEADERS = {
+    'Cache-Control': 'no-cache, no-transform',
+    'X-Accel-Buffering': 'no',
+}
+
+
+def _json_dumps(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, separators=_JSON_SEPARATORS)
+
+
+def _sse(obj: Any) -> str:
+    return f'data: {_json_dumps(obj)}\n\n'
 
 
 # ────────────────────────────────────────────────────────────────────
@@ -390,19 +403,12 @@ class Qwen3Engine:
                 # the largest bucket. _logits_buf[:1] holds the next-
                 # token logits either way.
                 self.fe.prefill_with_graph(input_ids)
-                ttft = time.perf_counter() - t0
-
-                # Make sure decode graphs over [P, P+max_tokens) are
-                # warm. Must stay inside inference_mode — torch 2.9+
-                # rejects graph capture that touches inference tensors
-                # (the prefill above marks _logits_buf / KV cache /
-                # hidden buffers as inference tensors) from outside
-                # an inference_mode context.
-                self.fe.warmup_decode_graphs(P, P + max_tokens)
+                prefill_s = time.perf_counter() - t0
 
             new_tokens: List[int] = []
             cur_pos = P
             finish_reason = 'length'
+            first_token_s: Optional[float] = None
 
             for step in range(max_tokens):
                 # Sample from the current logits buffer.
@@ -413,6 +419,8 @@ class Qwen3Engine:
                     top_k=top_k,
                     rng=rng,
                 )
+                if first_token_s is None:
+                    first_token_s = time.perf_counter() - t0
                 new_tokens.append(tok)
 
                 # EOS check (engine-side, before emitting).
@@ -464,7 +472,8 @@ class Qwen3Engine:
                 'prompt_tokens': P,
                 'completion_tokens': len(new_tokens),
                 'total_tokens': P + len(new_tokens),
-                'ttft_ms': round(ttft * 1000, 1),
+                'prefill_ms': round(prefill_s * 1000, 1),
+                'ttft_ms': round((first_token_s or prefill_s) * 1000, 1),
                 'wall_s': round(wall, 3),
                 'tok_per_s': round(len(new_tokens) / wall, 1) if wall else 0,
             }
@@ -561,26 +570,18 @@ def build_app(engine: 'Qwen3Engine'):
 
         # ── Streaming SSE ──
         async def gen():
-            # Emit role first.
-            first = {
-                'id': completion_id,
-                'object': 'chat.completion.chunk',
-                'created': created,
-                'model': engine.model_name,
-                'choices': [{
-                    'index': 0,
-                    'delta': {'role': 'assistant', 'content': ''},
-                    'finish_reason': None,
-                }],
-            }
-            yield f'data: {json.dumps(first)}\n\n'
-
+            role_sent = False
             tc_seen = False
             async for ev in engine.stream_generate(
                 messages, tools, max_tokens, temperature, top_p, top_k,
                 seed, stop,
             ):
                 if ev[0] == 'content':
+                    delta = {}
+                    if not role_sent:
+                        delta['role'] = 'assistant'
+                        role_sent = True
+                    delta['content'] = ev[1]
                     chunk = {
                         'id': completion_id,
                         'object': 'chat.completion.chunk',
@@ -588,14 +589,19 @@ def build_app(engine: 'Qwen3Engine'):
                         'model': engine.model_name,
                         'choices': [{
                             'index': 0,
-                            'delta': {'content': ev[1]},
+                            'delta': delta,
                             'finish_reason': None,
                         }],
                     }
-                    yield f'data: {json.dumps(chunk)}\n\n'
+                    yield _sse(chunk)
                 elif ev[0] == 'tool_calls':
                     tc_seen = True
                     for tc in ev[1]:
+                        delta = {}
+                        if not role_sent:
+                            delta['role'] = 'assistant'
+                            role_sent = True
+                        delta['tool_calls'] = [tc]
                         chunk = {
                             'id': completion_id,
                             'object': 'chat.completion.chunk',
@@ -603,13 +609,27 @@ def build_app(engine: 'Qwen3Engine'):
                             'model': engine.model_name,
                             'choices': [{
                                 'index': 0,
-                                'delta': {'tool_calls': [tc]},
+                                'delta': delta,
                                 'finish_reason': None,
                             }],
                         }
-                        yield f'data: {json.dumps(chunk)}\n\n'
+                        yield _sse(chunk)
                 elif ev[0] == 'finish':
                     _, finish, usage = ev
+                    if not role_sent:
+                        empty = {
+                            'id': completion_id,
+                            'object': 'chat.completion.chunk',
+                            'created': created,
+                            'model': engine.model_name,
+                            'choices': [{
+                                'index': 0,
+                                'delta': {'role': 'assistant'},
+                                'finish_reason': None,
+                            }],
+                        }
+                        role_sent = True
+                        yield _sse(empty)
                     last = {
                         'id': completion_id,
                         'object': 'chat.completion.chunk',
@@ -626,19 +646,99 @@ def build_app(engine: 'Qwen3Engine'):
                         }],
                         'usage': usage,
                     }
-                    yield f'data: {json.dumps(last)}\n\n'
+                    yield _sse(last)
                     yield 'data: [DONE]\n\n'
                     log.info(
-                        'stream done: %s -> %s tok in %ss (%s tok/s)',
+                        'stream done: prompt=%s completion=%s '
+                        'prefill=%sms ttft=%sms wall=%ss (%s tok/s)',
                         usage.get('prompt_tokens'),
                         usage.get('completion_tokens'),
+                        usage.get('prefill_ms'), usage.get('ttft_ms'),
                         usage.get('wall_s'), usage.get('tok_per_s'),
                     )
                     return
 
-        return StreamingResponse(gen(), media_type='text/event-stream')
+        return StreamingResponse(
+            gen(), media_type='text/event-stream', headers=_SSE_HEADERS)
 
     return app
+
+
+def _parse_warmup_shapes(spec_csv: str) -> List[Tuple[int, int]]:
+    shapes: List[Tuple[int, int]] = []
+    if not spec_csv.strip():
+        return shapes
+    for spec in spec_csv.split(','):
+        spec = spec.strip()
+        if not spec:
+            continue
+        try:
+            pl, mt = spec.split(':')
+            shapes.append((int(pl), int(mt)))
+        except ValueError:
+            sys.exit(f'invalid --warmup spec: {spec!r} '
+                     '(expected "prompt_len:max_tokens")')
+    return shapes
+
+
+def _warmup_preset_shapes(
+    preset: str, max_seq: int, max_q_seq: int,
+) -> List[Tuple[int, int]]:
+    """Return startup graph-warm buckets for the Qwen3-8B server.
+
+    The default is intentionally short-context heavy: these are the
+    request sizes where OpenAI/SSE users notice TTFT most. Larger or
+    exact production envelopes can still be appended via --warmup.
+    """
+    preset = (preset or 'auto').lower()
+    if preset in ('none', 'off', 'false', '0'):
+        return []
+    if preset not in ('auto', 'short', 'all'):
+        sys.exit(
+            f'invalid --warmup-preset {preset!r}; expected '
+            'auto, short, all, or none')
+
+    candidates = [
+        (32, 128),
+        (64, 128),
+        (128, 256),
+        (256, 256),
+        (512, 256),
+        (1024, 256),
+    ]
+    max_seq = int(max_seq)
+    max_q_seq = int(max_q_seq)
+    return [
+        (p, n) for p, n in candidates
+        if p <= max_q_seq and p + n <= max_seq
+    ]
+
+
+def _dedupe_shapes(shapes: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    out: List[Tuple[int, int]] = []
+    seen = set()
+    for shape in shapes:
+        if shape not in seen:
+            out.append(shape)
+            seen.add(shape)
+    return out
+
+
+def _validate_warmup_shapes(
+    shapes: List[Tuple[int, int]], max_seq: int, max_q_seq: int,
+) -> None:
+    for p, n in shapes:
+        if p < 1 or n < 1:
+            sys.exit(
+                f'invalid warmup shape {p}:{n}; values must be positive')
+        if p > max_q_seq:
+            sys.exit(
+                f'invalid warmup shape {p}:{n}; prompt_len exceeds '
+                f'--max-q-seq={max_q_seq}')
+        if p + n > max_seq:
+            sys.exit(
+                f'invalid warmup shape {p}:{n}; prompt_len + max_tokens '
+                f'exceeds --max-seq={max_seq}')
 
 
 def main():
@@ -652,20 +752,21 @@ def main():
                     help='Max prompt prefill length (in tokens).')
     p.add_argument('--device', default='cuda:0')
     p.add_argument('--model-name', default='qwen3-8b-nvfp4')
-    p.add_argument('--warmup', default='32:128,128:256',
-                    help='Comma-separated "P:max_tok" shapes to warm.')
+    p.add_argument(
+        '--warmup-preset', default='auto',
+        help='Startup graph warmup preset: auto, short, all, or none. '
+        'auto warms common short-prompt decode ranges before serving.')
+    p.add_argument(
+        '--warmup', default='',
+        help='Comma-separated "P:max_tok" shapes to additionally warm.')
     args = p.parse_args()
 
-    warm: List[Tuple[int, int]] = []
-    for spec in args.warmup.split(','):
-        spec = spec.strip()
-        if not spec:
-            continue
-        try:
-            pl, mt = spec.split(':')
-            warm.append((int(pl), int(mt)))
-        except ValueError:
-            sys.exit(f'invalid --warmup spec: {spec!r}')
+    warm = _dedupe_shapes(
+        _warmup_preset_shapes(
+            args.warmup_preset, args.max_seq, args.max_q_seq)
+        + _parse_warmup_shapes(args.warmup)
+    )
+    _validate_warmup_shapes(warm, args.max_seq, args.max_q_seq)
 
     try:
         import uvicorn

--- a/examples/qwen3_openai_server.py
+++ b/examples/qwen3_openai_server.py
@@ -400,7 +400,8 @@ class Qwen3Engine:
                 rng = torch.Generator(device='cuda')
                 rng.manual_seed(int(seed))
 
-            parser = StreamParser(
+            fast_text_stream = not tools and not stop
+            parser = None if fast_text_stream else StreamParser(
                 self.fe._tokenizer,
                 stop_strings=stop,
                 enable_tools=bool(tools),
@@ -438,33 +439,39 @@ class Qwen3Engine:
 
                 # EOS check (engine-side, before emitting).
                 if eos is not None and tok == eos:
-                    delta, tcs, _ = parser.feed([], final=True)
-                    if delta:
-                        yield ('content', delta)
-                    if tcs:
-                        yield ('tool_calls', tcs)
+                    if parser is not None:
+                        delta, tcs, _ = parser.feed([], final=True)
+                        if delta:
+                            yield ('content', delta)
+                        if tcs:
+                            yield ('tool_calls', tcs)
                     finish_reason = (
-                        'tool_calls' if parser._tool_calls_emitted
+                        'tool_calls' if parser is not None
+                        and parser._tool_calls_emitted
                         and not parser._buffer.strip() else 'stop'
                     )
                     break
 
                 # Stream parse the new token.
-                delta, tcs, stop_hit = parser.feed([tok])
-                if delta:
-                    yield ('content', delta)
-                if tcs:
-                    yield ('tool_calls', tcs)
-                if stop_hit:
-                    finish_reason = 'stop'
-                    break
+                if fast_text_stream:
+                    delta = self.fe._tokenizer.decode(
+                        [tok], skip_special_tokens=False)
+                    if delta:
+                        yield ('content', delta)
+                else:
+                    assert parser is not None
+                    delta, tcs, stop_hit = parser.feed([tok])
+                    if delta:
+                        yield ('content', delta)
+                    if tcs:
+                        yield ('tool_calls', tcs)
+                    if stop_hit:
+                        finish_reason = 'stop'
+                        break
 
                 # Advance KV cache via the warm decode graph.
                 with torch.inference_mode():
-                    self.fe.decode_step_with_graph(
-                        torch.tensor([[tok]], device='cuda', dtype=torch.long),
-                        cur_pos,
-                    )
+                    self.fe.decode_step_with_graph(tok, cur_pos)
                 cur_pos += 1
 
                 # Yield to event loop so the SSE chunks can flush.
@@ -474,11 +481,12 @@ class Qwen3Engine:
             else:
                 # Loop exhausted max_tokens.
                 # Final flush of any buffered text.
-                delta, tcs, _ = parser.feed([], final=True)
-                if delta:
-                    yield ('content', delta)
-                if tcs:
-                    yield ('tool_calls', tcs)
+                if parser is not None:
+                    delta, tcs, _ = parser.feed([], final=True)
+                    if delta:
+                        yield ('content', delta)
+                    if tcs:
+                        yield ('tool_calls', tcs)
 
             wall = time.perf_counter() - t0
             decode_s = max(0.0, wall - prefill_s)

--- a/examples/qwen3_openai_server.py
+++ b/examples/qwen3_openai_server.py
@@ -80,6 +80,90 @@ def _sse(obj: Any) -> str:
     return f'data: {_json_dumps(obj)}\n\n'
 
 
+def _parse_bool_field(req: Dict[str, Any], name: str,
+                      default: bool) -> bool:
+    value = req.get(name, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in ('1', 'true', 'yes', 'on'):
+            return True
+        if v in ('0', 'false', 'no', 'off'):
+            return False
+    raise ValueError(f'{name} must be boolean')
+
+
+def _parse_int_field(req: Dict[str, Any], name: str, default: int,
+                     *, min_value: Optional[int] = None) -> int:
+    value = req.get(name, default)
+    try:
+        out = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be an integer') from exc
+    if min_value is not None and out < min_value:
+        raise ValueError(f'{name} must be >= {min_value}')
+    return out
+
+
+def _parse_float_field(req: Dict[str, Any], name: str, default: float,
+                       *, min_value: Optional[float] = None,
+                       max_value: Optional[float] = None) -> float:
+    value = req.get(name, default)
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{name} must be a number') from exc
+    if out != out:
+        raise ValueError(f'{name} must not be NaN')
+    if min_value is not None and out < min_value:
+        raise ValueError(f'{name} must be >= {min_value}')
+    if max_value is not None and out > max_value:
+        raise ValueError(f'{name} must be <= {max_value}')
+    return out
+
+
+def _validate_messages(messages: Any) -> List[Dict[str, Any]]:
+    if not isinstance(messages, list) or not messages:
+        raise ValueError('messages is required (non-empty list)')
+    for m in messages:
+        if not isinstance(m, dict):
+            raise ValueError('each message must be an object')
+        role = m.get('role')
+        if role not in ('system', 'user', 'assistant', 'tool'):
+            raise ValueError(f'unsupported role: {role!r}')
+        content = m.get('content')
+        if content is None and role == 'assistant':
+            continue
+        if not isinstance(content, str):
+            raise ValueError('message.content must be a string')
+    return messages
+
+
+def _validate_tools(tools: Any) -> Optional[List[Dict[str, Any]]]:
+    if tools is None:
+        return None
+    if not isinstance(tools, list):
+        raise ValueError('tools must be a list')
+    for tool in tools:
+        if not isinstance(tool, dict):
+            raise ValueError('each tool must be an object')
+    return tools
+
+
+def _normalize_stop(stop: Any) -> List[str]:
+    if stop is None:
+        return []
+    if isinstance(stop, str):
+        stop = [stop]
+    elif not isinstance(stop, list):
+        raise ValueError('stop must be string or list')
+    for s in stop:
+        if not isinstance(s, str) or not s:
+            raise ValueError('stop entries must be non-empty strings')
+    return stop
+
+
 # ────────────────────────────────────────────────────────────────────
 # Sampling
 # ────────────────────────────────────────────────────────────────────
@@ -555,27 +639,26 @@ def build_app(engine: 'Qwen3Engine'):
 
     @app.post('/v1/chat/completions')
     async def chat_completions(req: Dict[str, Any]):
-        messages = req.get('messages')
-        if not isinstance(messages, list) or not messages:
-            raise HTTPException(400, 'messages is required (non-empty list)')
-        for m in messages:
-            role = m.get('role')
-            if role not in ('system', 'user', 'assistant', 'tool'):
-                raise HTTPException(400, f'unsupported role: {role!r}')
-        tools = req.get('tools')          # OAI tools spec
-        max_tokens = int(req.get('max_tokens') or 256)
-        stream = bool(req.get('stream', False))
-        temperature = float(req.get('temperature', 0.0))
-        top_p = float(req.get('top_p', 1.0))
-        top_k = int(req.get('top_k', 0))
+        try:
+            messages = _validate_messages(req.get('messages'))
+            tools = _validate_tools(req.get('tools'))
+            max_tokens = _parse_int_field(
+                req, 'max_tokens', 256, min_value=1)
+            stream = _parse_bool_field(req, 'stream', False)
+            temperature = _parse_float_field(
+                req, 'temperature', 0.0, min_value=0.0)
+            top_p = _parse_float_field(
+                req, 'top_p', 1.0, min_value=0.0, max_value=1.0)
+            top_k = _parse_int_field(req, 'top_k', 0, min_value=0)
+            stop = _normalize_stop(req.get('stop'))
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
         seed = req.get('seed')
-        stop = req.get('stop')
-        if isinstance(stop, str):
-            stop = [stop]
-        elif stop is None:
-            stop = []
-        elif not isinstance(stop, list):
-            raise HTTPException(400, 'stop must be string or list')
+        if seed is not None:
+            try:
+                seed = int(seed)
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(400, 'seed must be an integer') from exc
 
         completion_id = f'chatcmpl-{uuid.uuid4().hex[:24]}'
         created = int(time.time())

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -1260,15 +1260,14 @@ class Qwen3TorchFrontendRtx:
         Returns ``self._logits_buf[:1]`` (1, vocab) bf16.
         """
         import torch
-        if not isinstance(token_id, torch.Tensor):
-            token_id = torch.tensor(
-                [[int(token_id)]], device=self.device, dtype=torch.long,
-            )
-        if token_id.ndim == 1:
-            token_id = token_id.view(1, 1)
         # Stage the new token id into the static input buffer the
         # captured graph reads from.
-        self._static_token_id.copy_(token_id)
+        if isinstance(token_id, torch.Tensor):
+            if token_id.ndim == 1:
+                token_id = token_id.view(1, 1)
+            self._static_token_id.copy_(token_id)
+        else:
+            self._static_token_id.fill_(int(token_id))
         g = self._ensure_decode_graph(cur_pos)
         g.replay()
         return self._logits_buf[:1]

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -316,8 +316,20 @@ class Qwen3TorchFrontendRtx:
             self._gate_up_fused_out = torch.empty(
                 1, gu_N, device=device, dtype=bf16,
             )
+            self._gate_up_prefill_out = torch.empty(
+                Sq_max, gu_N, device=device, dtype=bf16,
+            )
         else:
             self._gate_up_fused_out = None
+            self._gate_up_prefill_out = None
+        # On this dense 8B prefill ladder (S<=1024), the regular
+        # CUTLASS W4A16 kernel beats the pingpong variant for the
+        # short buckets and is tied at the largest bucket.
+        self._prefill_gemm = self._fvk.fp4_w4a16_gemm_sm120_bf16out
+        self._prefill_silu_merged = getattr(
+            self._fvk, 'silu_mul_merged_to_nvfp4_swizzled_grouped32_bf16',
+            self._fvk.silu_mul_merged_to_nvfp4_swizzled_bf16,
+        )
 
         # CUDA Graph capture state.
         #   _captured_decode_graphs  : dict[cur_pos    -> torch.cuda.CUDAGraph]
@@ -925,23 +937,17 @@ class Qwen3TorchFrontendRtx:
 
         h2 = h_in_S.view(S, hidden).contiguous()
 
-        # 1) input layernorm (M=S).
-        x_norm = self._h_b[:S].view(S, hidden)
-        fvk.rms_norm(
-            h2.data_ptr(), int(lw['input_norm_w']),
-            x_norm.data_ptr(), S, hidden, eps, s,
-        )
-
-        # 2) NVFP4 quantize x_norm at M=S (K=hidden).
+        # 1+2) input layernorm + NVFP4 quantize at M=S.
         ap_h, sf_h, _ = self._nvfp4_scratch[(n_q * hd, hidden)]
-        fvk.quantize_bf16_to_nvfp4_swizzled(
-            x_norm.data_ptr(), ap_h.data_ptr(), sf_h.data_ptr(),
-            S, hidden, s,
+        fvk.rms_norm_to_nvfp4_swizzled_bf16(
+            h2.data_ptr(), int(lw['input_norm_w']),
+            ap_h.data_ptr(), sf_h.data_ptr(), S, hidden, eps, s,
         )
 
         # 3) q/k/v_proj NVFP4 GEMMs at M=S.
+        prefill_gemm = self._prefill_gemm
         q_proj_out_buf = self._nvfp4_scratch[(n_q * hd, hidden)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
+        prefill_gemm(
             ap_h.data_ptr(), int(lw['q_proj_packed']),
             q_proj_out_buf.data_ptr(),
             S, n_q * hd, hidden,
@@ -950,7 +956,7 @@ class Qwen3TorchFrontendRtx:
             s,
         )
         kv_proj_out_buf = self._nvfp4_scratch[(n_kv * hd, hidden)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
+        prefill_gemm(
             ap_h.data_ptr(), int(lw['k_proj_packed']),
             kv_proj_out_buf.data_ptr(),
             S, n_kv * hd, hidden,
@@ -995,7 +1001,7 @@ class Qwen3TorchFrontendRtx:
         )
 
         # 7) v_proj — reuse kv_proj_out_buf, write into V_cache.
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
+        prefill_gemm(
             ap_h.data_ptr(), int(lw['v_proj_packed']),
             kv_proj_out_buf.data_ptr(),
             S, n_kv * hd, hidden,
@@ -1022,7 +1028,7 @@ class Qwen3TorchFrontendRtx:
             S, n_q * hd, s,
         )
         out_op_buf = self._nvfp4_scratch[(hidden, hidden)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
+        prefill_gemm(
             ap_h2.data_ptr(), int(lw['o_proj_packed']),
             out_op_buf.data_ptr(),
             S, hidden, n_q * hd,
@@ -1033,60 +1039,61 @@ class Qwen3TorchFrontendRtx:
 
         # 10) Residual 1.
         attn_proj = out_op_buf[:S].view(1, S, hidden)
-        torch.add(h_in_S, attn_proj, out=self._res_mid[:, :S])
         h_post = self._res_mid[:, :S]
-
-        # 11) post-attn layernorm at M=S.
-        h_post_view = h_post.view(S, hidden)
-        x_mlp = self._h_b[:S].view(S, hidden)
-        fvk.rms_norm(
-            h_post_view.data_ptr(), int(lw['post_attn_norm_w']),
-            x_mlp.data_ptr(), S, hidden, eps, s,
-        )
-
-        # 12) MLP gate / up at M=S, K=hidden, N=intermediate.
         ap_mlp, sf_mlp, _ = self._nvfp4_scratch[(inter, hidden)]
-        fvk.quantize_bf16_to_nvfp4_swizzled(
-            x_mlp.data_ptr(), ap_mlp.data_ptr(), sf_mlp.data_ptr(),
-            S, hidden, s,
-        )
-        gate_out_buf = self._nvfp4_scratch[(inter, hidden)][2]
-        up_out_buf = self._mlp_up_out
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
-            ap_mlp.data_ptr(), int(lw['mlp_gate_packed']),
-            gate_out_buf.data_ptr(),
-            S, inter, hidden,
-            sf_mlp.data_ptr(), int(lw['mlp_gate_sf']),
-            float(lw['mlp_gate_alpha']),
-            s,
-        )
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
-            ap_mlp.data_ptr(), int(lw['mlp_up_packed']),
-            up_out_buf.data_ptr(),
-            S, inter, hidden,
-            sf_mlp.data_ptr(), int(lw['mlp_up_sf']),
-            float(lw['mlp_up_alpha']),
-            s,
+        fvk.residual_add_rms_norm_to_nvfp4_swizzled_bf16(
+            h_in_S.data_ptr(), attn_proj.data_ptr(), h_post.data_ptr(),
+            int(lw['post_attn_norm_w']),
+            ap_mlp.data_ptr(), sf_mlp.data_ptr(), S, hidden, eps, s,
         )
 
-        # 13) silu(gate)*up at flat n_elements = S*inter (kernel is dim-agnostic).
-        gate_v = gate_out_buf[:S].view(S * inter)
-        up_v = up_out_buf[:S].view(S * inter)
-        out_v = self._mlp_silu_mul_out[:S].view(S * inter)
-        fvk.silu_mul_qwen36_bf16(
-            gate_v.data_ptr(), up_v.data_ptr(),
-            out_v.data_ptr(), S * inter, s,
-        )
-        gate_silu_up = self._mlp_silu_mul_out[:S]
-
-        # 14) MLP down at M=S, K=intermediate, N=hidden.
+        # 11) MLP gate/up at M=S. Use the packed fused weight when the
+        # checkpoint has homogeneous gate/up alpha, then consume the
+        # merged [gate|up] output directly in the silu+quant kernel.
         ap_dn, sf_dn, _ = self._nvfp4_scratch[(hidden, inter)]
-        fvk.quantize_bf16_to_nvfp4_swizzled(
-            gate_silu_up.data_ptr(), ap_dn.data_ptr(), sf_dn.data_ptr(),
-            S, inter, s,
-        )
+        if self._gate_up_prefill_out is not None:
+            gate_up_buf = self._gate_up_prefill_out[:S]
+            prefill_gemm(
+                ap_mlp.data_ptr(), int(lw['gate_up_packed']),
+                gate_up_buf.data_ptr(),
+                S, int(lw['gate_up_N']), hidden,
+                sf_mlp.data_ptr(), int(lw['gate_up_sf']),
+                float(lw['gate_up_alpha']),
+                s,
+            )
+            self._prefill_silu_merged(
+                gate_up_buf.data_ptr(),
+                ap_dn.data_ptr(), sf_dn.data_ptr(),
+                S, inter, s,
+            )
+        else:
+            gate_out_buf = self._nvfp4_scratch[(inter, hidden)][2]
+            up_out_buf = self._mlp_up_out
+            prefill_gemm(
+                ap_mlp.data_ptr(), int(lw['mlp_gate_packed']),
+                gate_out_buf.data_ptr(),
+                S, inter, hidden,
+                sf_mlp.data_ptr(), int(lw['mlp_gate_sf']),
+                float(lw['mlp_gate_alpha']),
+                s,
+            )
+            prefill_gemm(
+                ap_mlp.data_ptr(), int(lw['mlp_up_packed']),
+                up_out_buf.data_ptr(),
+                S, inter, hidden,
+                sf_mlp.data_ptr(), int(lw['mlp_up_sf']),
+                float(lw['mlp_up_alpha']),
+                s,
+            )
+            fvk.silu_mul_to_nvfp4_swizzled_bf16(
+                gate_out_buf[:S].data_ptr(), up_out_buf[:S].data_ptr(),
+                ap_dn.data_ptr(), sf_dn.data_ptr(),
+                S, inter, s,
+            )
+
+        # 12) MLP down at M=S, K=intermediate, N=hidden.
         down_out_buf = self._nvfp4_scratch[(hidden, inter)][2]
-        fvk.fp4_w4a16_gemm_sm120_bf16out(
+        prefill_gemm(
             ap_dn.data_ptr(), int(lw['mlp_down_packed']),
             down_out_buf.data_ptr(),
             S, hidden, inter,

--- a/tests/test_qwen36_server_warmup.py
+++ b/tests/test_qwen36_server_warmup.py
@@ -106,7 +106,7 @@ def test_long_mtp_tail_auto_policy(monkeypatch):
         'ptrs': {'mtp': {'k_proj_w_bf16': 1}},
     })()
 
-    assert fe._long_mtp_prefill_tail_for_prompt(128) == 0
+    assert fe._long_mtp_prefill_tail_for_prompt(128) == 128
     assert fe._long_mtp_prefill_tail_for_prompt(512) == 512
     assert fe._long_mtp_prefill_tail_for_prompt(1024) == 2048
     assert fe._long_mtp_prefill_tail_for_prompt(4096) == 512
@@ -164,7 +164,10 @@ def test_long_ctx_route_uses_prompt_bucket_before_total_length():
     fe._long_ctx_route_min_seq = 512
     fe._short_ctx_spec_max_seq = 2048
 
-    assert fe._should_use_long_ctx_route(128, 512) is False
+    assert fe._should_use_long_ctx_route(127, 512) is False
+    assert fe._should_use_long_ctx_route(128, 512) is True
+    assert fe._should_use_long_ctx_route(191, 512) is True
+    assert fe._should_use_long_ctx_route(192, 512) is False
     assert fe._should_use_long_ctx_route(511, 64) is False
     assert fe._should_use_long_ctx_route(512, 64) is True
     assert fe._should_use_long_ctx_route(128, 2048) is True


### PR DESCRIPTION
## Summary
- Reduce Qwen OpenAI-server first-token latency by moving graph warmup out of the first live request and keeping warmed prefill/decode graphs on the serving path.
- Trim Qwen3 streaming overhead for no-tool text requests and avoid per-token CUDA tensor allocation in graph decode staging.
- Normalize server timing logs around prefill + decode and harden request validation before streaming starts.
- Carry safe Qwen3.6 prefill-fusion ideas into Qwen3-8B dense prefill: fused norm-to-NVFP4, residual/norm/quant fusion, and fused gate/up + merged silu-to-NVFP4.

## Validation
- Qwen3-8B NVFP4 direct warm path, short prompt: prefill about 9.3 ms and decode about 150 tok/s.
- Qwen3-8B prefill graph checks: exact-bucket and partial-bucket graph/eager argmax match with cosine 1.000000; replay determinism max diff 0.
- Qwen3-8B prefill buckets after fusion: P64 about 10.0 ms, P256 about 11.9 ms, P512 about 14.4-15.4 ms, P1024 about 25.2 ms.
- Qwen3 and Qwen3.6 OpenAI request validation smoke checks pass for malformed max_tokens / prompt-length cases.
