### PR TITLE
fix(pi05): restore strict bf16 bias gelu semantics

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -5146,15 +5146,15 @@ N must be a multiple of 32; K must be a multiple of 64.
                                 int seq_len, int dim, uintptr_t stream) {
         bias_gelu_inplace_bf16(typed_ptr<__nv_bfloat16>(x),
                                typed_ptr<__nv_bfloat16>(bias),
-                               seq_len * dim, dim, to_stream(stream));
+                               seq_len, dim, to_stream(stream));
     }, py::arg("x"), py::arg("bias"), py::arg("seq_len"), py::arg("dim"),
        py::arg("stream") = 0);
 
     m.def("bias_gelu_bf16_strict", [](uintptr_t x, uintptr_t bias,
                                        int seq_len, int dim, uintptr_t stream) {
-        bias_gelu_inplace_bf16(typed_ptr<__nv_bfloat16>(x),
-                               typed_ptr<__nv_bfloat16>(bias),
-                               seq_len * dim, dim, to_stream(stream));
+        bias_gelu_inplace_bf16_strict(typed_ptr<__nv_bfloat16>(x),
+                                      typed_ptr<__nv_bfloat16>(bias),
+                                      seq_len, dim, to_stream(stream));
     }, py::arg("x"), py::arg("bias"), py::arg("seq_len"), py::arg("dim"),
        py::arg("stream") = 0);
 

--- a/csrc/kernels/activation.cu
+++ b/csrc/kernels/activation.cu
@@ -94,10 +94,45 @@ __global__ void bias_gelu_kernel(T* __restrict__ x,
     (void)row;  // silence unused warning if compiler optimizes it out
 }
 
+template<typename T>
+__global__ void bias_gelu_strict_kernel(T* __restrict__ x,
+                                        const T* __restrict__ bias,
+                                        int M, int N) {
+    using T2 = typename packed2<T>::type;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total2 = (M * N) >> 1;
+    if (idx >= total2) return;
+    int n2 = N >> 1;
+    int row = idx / n2;
+    int col_pair = idx - row * n2;
+    T2* x2 = reinterpret_cast<T2*>(x);
+    const T2* b2 = reinterpret_cast<const T2*>(bias);
+    T2 v = x2[idx];
+    T2 b = b2[col_pair];
+    T v0_bf16 = from_f32<T>(to_f32(v.x) + to_f32(b.x));
+    T v1_bf16 = from_f32<T>(to_f32(v.y) + to_f32(b.y));
+    float v0 = to_f32(v0_bf16);
+    float v1 = to_f32(v1_bf16);
+    float t0 = tanhf(0.7978845608f * (v0 + 0.044715f * v0 * v0 * v0));
+    float t1 = tanhf(0.7978845608f * (v1 + 0.044715f * v1 * v1 * v1));
+    x2[idx] = make_packed2<T>(
+        from_f32<T>(v0 * 0.5f * (1.0f + t0)),
+        from_f32<T>(v1 * 0.5f * (1.0f + t1)));
+    (void)row;
+}
+
 void bias_gelu_inplace_bf16(__nv_bfloat16* x, const __nv_bfloat16* bias,
                               int M, int N, cudaStream_t stream) {
     int total2 = (M * N) >> 1;
     bias_gelu_kernel<__nv_bfloat16><<<(total2 + 255) / 256, 256, 0, stream>>>(
+        x, bias, M, N);
+}
+
+void bias_gelu_inplace_bf16_strict(__nv_bfloat16* x,
+                                   const __nv_bfloat16* bias,
+                                   int M, int N, cudaStream_t stream) {
+    int total2 = (M * N) >> 1;
+    bias_gelu_strict_kernel<__nv_bfloat16><<<(total2 + 255) / 256, 256, 0, stream>>>(
         x, bias, M, N);
 }
 

--- a/csrc/kernels/activation.cuh
+++ b/csrc/kernels/activation.cuh
@@ -23,6 +23,12 @@ void gelu_inplace(__nv_bfloat16* x, int n, cudaStream_t stream = 0);
 void bias_gelu_inplace_bf16(__nv_bfloat16* x, const __nv_bfloat16* bias,
                               int M, int N, cudaStream_t stream = 0);
 
+// Strict variant matching add_bias_bf16 + gelu_inplace numerics: the
+// bias-add result is rounded back to BF16 before applying GELU.
+void bias_gelu_inplace_bf16_strict(__nv_bfloat16* x,
+                                   const __nv_bfloat16* bias,
+                                   int M, int N, cudaStream_t stream = 0);
+
 void gate_silu_mul_merged(const __nv_bfloat16* merged, __nv_bfloat16* out,
                            int seq, int half_dim, cudaStream_t stream = 0);
 


### PR DESCRIPTION

## Summary

This PR is a follow-up to the Pi0.5 `bias_gelu_bf16(_strict)` alias issue discussed in #40 and #41.

#40 fixed the binding shape bug, and #41 later documented the remaining alias-contract issue around strict BF16 roundtrip semantics:

> Restore true strict bf16-roundtrip semantics for `bias_gelu_bf16_strict`, or rename/document it as non-strict if exact Orin INT8 parity is no longer required.

This PR takes the first option: keep the `bias_gelu_bf16_strict` public binding name and restore true strict BF16 roundtrip behavior.

## What Changed

The PR updates only:

- `csrc/bindings.cpp`
- `csrc/kernels/activation.cu`
- `csrc/kernels/activation.cuh`

Changes:

- Re-applies the corrected `(seq_len, dim)` binding shape forwarding for:
  - `bias_gelu_bf16`
  - `bias_gelu_bf16_strict`
- Adds `bias_gelu_inplace_bf16_strict(...)`.
- Routes `bias_gelu_bf16_strict` to the new strict helper.

The regular `bias_gelu_bf16` path remains the fast fused helper:

```text
tmp = fp32(x + bias)
out = bf16(gelu(tmp))
```

The strict path now matches the old unfused reference order:

```text
tmp = bf16(x + bias)
out = bf16(gelu(tmp))
```

That is equivalent to:

```text
add_bias_bf16(...)
gelu_inplace(...)
```

## Why

The existing public binding name `bias_gelu_bf16_strict` implies strict/reference-order BF16 behavior. Before this PR, it still called the same non-strict fused helper as `bias_gelu_bf16`, so the name and behavior did not match.

Pi0.5 INT8 uses this strict fused BF16 activation path during the vision FFN. Restoring the strict roundtrip semantics keeps the alias contract aligned with the integration checklist added in #41.

## What This PR Does Not Do

- It does not change the default BF16 Pi0.5 pipeline.
- It does not add a new performance path.
- It does not change CMake target ownership.
- It does not change public Python arguments or routing.

## Validation Environment

Validated on Jetson AGX Orin 32G:

| Field | Value |
| --- | --- |
| Device | Jetson AGX Orin 32G |
| SoC | tegra234 |
| Arch | aarch64 |
| L4T | R36.4.7 |
| Ubuntu | 22.04.5 LTS |
| CUDA Toolkit | 12.6.68 |
| Python | 3.10.12 |
| PyTorch | 2.8.0 |
| Torch CUDA | 12.6 |
| GPU capability | SM87 / compute capability 8.7 |
| Checkpoint | `/root/models/pi05_libero_finetuned_v044` |

## Build

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
cmake --build build -j4 --target flash_rt_kernels
```

Result: build completed successfully.

## BF16 Smoke Test

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
unset FVK_PI05_RTX_FORCE_INT8

python examples/orin/bench_pi05.py \
  --checkpoint /root/models/pi05_libero_finetuned_v044 \
  --num-views 2 \
  --pool 1 \
  --layers 27 \
  --steps 10 \
  --cache-frames 1 \
  --no-int8 \
  --warmup 3 \
  --reps 5
```

Result:

```text
Config : num_views=2 pool=1 layers=27 steps=10 cache_frames=1
Actions: (10, 7)
p50    : 218.2 ms -> 4.58 Hz
p95    : 218.5 ms
min    : 216.1 ms -> 4.63 Hz
```

## INT8 Smoke Test

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
export FVK_PI05_RTX_FORCE_INT8=1

python examples/orin/bench_pi05.py \
  --checkpoint /root/models/pi05_libero_finetuned_v044 \
  --num-views 2 \
  --pool 1 \
  --layers 27 \
  --steps 10 \
  --cache-frames 1 \
  --warmup 3 \
  --reps 5
```

Result:

```text
Config : num_views=2 pool=1 layers=27 steps=10 cache_frames=1
Actions: (10, 7)
p50    : 164.9 ms -> 6.06 Hz
p95    : 165.7 ms
min    : 163.4 ms -> 6.12 Hz
```

The INT8 calibration and benchmark completed successfully.

## Strict Parity Check

With the Torch RNG seed fixed so both runs use the same diffusion noise, I compared the strict helper path against the unfused reference sequence:

```text
add_bias_bf16(...)
gelu_inplace(...)
```

Result:

```text
mae=0.0
max_abs=0.0
cos=1.0
```

This confirms that the strict helper matches the unfused BF16 roundtrip path for the tested Pi0.5 input.

## Checklist

- [x] Re-applies corrected binding shape mapping.
- [x] Restores strict BF16 roundtrip semantics for `bias_gelu_bf16_strict`.
- [x] Leaves `bias_gelu_bf16` as the fast non-strict fused helper.
- [x] Does not change the default BF16 pipeline.
- [x] Rebuilt `flash_rt_kernels` on Jetson AGX Orin.
- [x] Verified BF16 bench smoke.
- [x] Verified full INT8 bench smoke.
- [x] Compared strict fused output against unfused BF16 reference with fixed seed.
