### PR TITLE
Fix/pi05 state prompt buckets

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -97,6 +97,25 @@ strictly easier for fresh setups. The frontend accepts a tokenizer
 loaded from either source as long as you point
 `$FLASH_RT_PALIGEMMA_TOKENIZER` at it.
 
+### Pi0.5 State Prompts
+
+Pi0.5 follows openpi's discrete-state prompt format. Passing `state`
+through the stable API discretizes normalized state values into 0..255 bins
+and embeds:
+
+```python
+actions = model.predict(
+    images=[base_img, wrist_img],
+    prompt="pick up the red block",
+    state=robot_state,
+)
+```
+
+State changes update the prompt embeddings. RTX keeps a per-prompt-length
+pipeline cache and updates same-length language buffers in place, so repeated
+state-token lengths do not repeatedly rebuild CUDA Graphs or rerun autotune.
+Thor updates same-length prompt embeddings in place after graph capture.
+
 **Q: I'm getting `FileNotFoundError: paligemma_tokenizer.model not found`.**
 A: Run the download script above (or `curl` directly into one of
 the search paths). The error message is itself the fix — it spells

--- a/USAGE.md
+++ b/USAGE.md
@@ -243,6 +243,27 @@ ad-hoc extra fields) and prewarm representative states from the deployment
 range. This avoids turning continuous state changes into an unbounded stream
 of one-off prompt lengths.
 
+Example bucket prewarm for states that may tokenize to different lengths:
+
+```python
+# Use realistic states from reset / mid-rollout / near-goal observations.
+# These examples deliberately include values with different digit counts after
+# discretization, which can land in different prompt-token buckets.
+state_bucket_samples = [
+    np.zeros(8, dtype=np.float32),
+    np.array([0.0, 0.1, -0.1, 0.25, -0.25, 0.5, -0.5, 1.0], dtype=np.float32),
+    np.array([-1.0, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1.0], dtype=np.float32),
+    np.asarray(first_rollout_obs["state"], dtype=np.float32),
+]
+
+warmed_lengths = model.warm_state_prompt_buckets(
+    images=[base_img, wrist_img],
+    prompt="pick up the red block",
+    states=state_bucket_samples,
+)
+print("prewarmed state prompt token lengths:", warmed_lengths)
+```
+
 ### Pi0.5 RTX full-FP16 opt-in path
 
 The default Pi0.5 RTX path remains FP8/BF16. For RTX 5090 / SM120 and

--- a/USAGE.md
+++ b/USAGE.md
@@ -235,6 +235,14 @@ model still sees the same prompt distribution as OpenPI. For best results,
 use several states sampled from the deployment domain or from the first
 few rollout frames.
 
+Serving note: FlashRT reuses the cached pipeline for recurring prompt token
+lengths. A previously unseen state-token length still needs one first-time
+bucket build and graph capture. In production, keep state serialization
+stable (same state dimension, same numeric precision/rounding policy, no
+ad-hoc extra fields) and prewarm representative states from the deployment
+range. This avoids turning continuous state changes into an unbounded stream
+of one-off prompt lengths.
+
 ### Pi0.5 RTX full-FP16 opt-in path
 
 The default Pi0.5 RTX path remains FP8/BF16. For RTX 5090 / SM120 and

--- a/USAGE.md
+++ b/USAGE.md
@@ -184,6 +184,57 @@ model = flash_rt.load_model(
 | `vision_num_layers` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Number of SigLIP vision layers to run. |
 | `cache_frames` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Temporal encoder K/V cache period; `1` means no temporal reuse. |
 
+### Pi0.5 state prompt bucket warmup
+
+Pi0.5 follows the OpenPI contract where robot state is discretized into
+the language prefix:
+
+```text
+Task: <prompt>, State: <0..255 bins>;
+Action:
+```
+
+Because those state bins are tokenized as text, different state values can
+produce different prompt lengths. FlashRT keeps the original OpenPI text
+format for accuracy, and caches RTX Pi0.5 runtime pipelines by prompt
+length. If your control loop passes a changing `state` every step, warm the
+representative prompt-length buckets before entering the realtime loop:
+
+```python
+states = [
+    np.zeros(8, dtype=np.float32),
+    np.linspace(-1.0, 1.0, 8, dtype=np.float32),
+    rollout_state_sample,
+]
+
+model = flash_rt.load_model(
+    "/path/to/pi05_libero_pytorch",
+    framework="torch",
+    config="pi05",
+    hardware="auto",
+    num_views=2,
+)
+
+warmed_lengths = model.warm_state_prompt_buckets(
+    images=[base_img, wrist_img],
+    prompt="pick up the red block",
+    states=states,
+)
+print("warmed prompt lengths:", warmed_lengths)
+
+actions = model.predict(
+    images=[base_img, wrist_img],
+    prompt="pick up the red block",
+    state=current_state,
+)
+```
+
+This front-loads graph capture/autotune for the token lengths reached by
+the supplied states. It does not zero-pad or reformat state tokens, so the
+model still sees the same prompt distribution as OpenPI. For best results,
+use several states sampled from the deployment domain or from the first
+few rollout frames.
+
 ### Pi0.5 RTX full-FP16 opt-in path
 
 The default Pi0.5 RTX path remains FP8/BF16. For RTX 5090 / SM120 and

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -160,9 +160,11 @@ You only need to install `flash-attn` if:
 
 - You set `FVK_RTX_FA2=0` to fall back to the legacy upstream path, or
 - You set `FVK_RTX_FA2_SITES=…` to bisect a subset of attention
-  sites against the upstream reference, or
-- You run the **GROOT N1.6 / N1.7** backend (its current attention
-  path is upstream `flash_attn_func`).
+  sites against the upstream reference.
+
+The GROOT N1.6 / N1.7 RTX backends also use FlashRT's vendored
+attention modules by default; they should not require the upstream
+`flash-attn` wheel.
 
 When you do need it, prefer a prebuilt wheel matching your
 torch / CUDA / Python combo from

--- a/docs/extension/attention_backend.md
+++ b/docs/extension/attention_backend.md
@@ -114,7 +114,7 @@ The pipeline sees the same call sequence on every hardware target. Only the kern
 
 Backends are allowed to differ on **who allocates the buffers**:
 
-- **Backend-owned** (RTX): the backend allocates Q / K / V as torch tensors in `__init__`. The pipeline writes Q / K / V into the published pointers. Output is allocated by `flash_attn_func` per call; the backend holds a reference so the torch caching allocator doesn't reassign across capture / replay.
+- **Backend-owned** (RTX): the backend allocates Q / K / V as torch tensors in `__init__`. The pipeline writes Q / K / V into the published pointers. Modern vendored FA2 backends also own stable output tensors; legacy pip `flash_attn_func` fallback paths keep a torch output reference so the caching allocator doesn't reassign across capture / replay.
 - **Pipeline-owned** (Thor): the pipeline allocates its own Q (which doubles as the output buffer post-attn), plus per-layer K / V cache as part of the weights dict. The backend is a thin wrapper around `fvk.attention_qkv_fp16` and takes pointers at `run()` time.
 
 A pipeline written to the protocol does not care which storage model fires — it always reads pointers via `get_slot_ptrs` and lets `run()` return the output pointer. This is the key portability property.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -148,6 +148,11 @@ class VLAModel:
   representative robot state. The return value is the sorted list of
   warmed prompt lengths. The method preserves the OpenPI state prompt
   text format; it does not zero-pad or otherwise rewrite state tokens.
+  A recurring prompt token length reuses its cached runtime pipeline, but
+  a previously unseen state-token length still pays one first-time bucket
+  build/capture cost. Serving code should keep state serialization stable
+  (fixed state dimension and numeric rounding/precision policy) and prewarm
+  representative states from the deployment range.
 
 - `recalibrate()` — clear FP8 calibration cache and force re-calibration
   on the next `predict()` call.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -152,7 +152,9 @@ class VLAModel:
   a previously unseen state-token length still pays one first-time bucket
   build/capture cost. Serving code should keep state serialization stable
   (fixed state dimension and numeric rounding/precision policy) and prewarm
-  representative states from the deployment range.
+  representative states from the deployment range, for example reset,
+  mid-rollout, near-goal, and a few recorded rollout observations whose
+  discretized values may tokenize to different lengths.
 
 - `recalibrate()` — clear FP8 calibration cache and force re-calibration
   on the next `predict()` call.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -128,9 +128,11 @@ class VLAModel:
   `state` is part of the VLA observation schema; each model encodes it through
   its own reference contract:
   - Pi0 uses a continuous state token in the action-expert suffix.
-  - Pi0.5's openpi reference encodes state as discretized prompt tokens. The
-    current FlashRT Pi0.5 frontend still tokenizes prompts without that state
-    argument, so this is the remaining Pi0.5 API gap.
+  - Pi0.5 encodes state as openpi-compatible discretized prompt tokens:
+    `Task: <prompt>, State: <0..255 bins>;\nAction: `. RTX/Thor torch
+    frontends accept `state` in `set_prompt()` and through `predict()`.
+    Same-length state prompt updates reuse the captured graph; recurring
+    RTX prompt lengths reuse the cached pipeline instead of rebuilding.
   - Pi0-FAST encodes state in the FAST token prefix.
   - GROOT N1.6 consumes proprioceptive state from `obs["state"]`; if omitted,
     the backend uses zeros.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -96,6 +96,7 @@ class VLAModel:
     def set_prompt(self, *args, **kwargs): ...
     def infer(self, *args, **kwargs): ...
     def predict(self, images, prompt=None, state=None) -> np.ndarray: ...
+    def warm_state_prompt_buckets(self, images, prompt, states) -> list[int]: ...
     def recalibrate(self) -> None: ...
 
     @property
@@ -139,6 +140,14 @@ class VLAModel:
   - GROOT N1.7 currently uses the lower-level
     `normalize_state(...)` + `infer(state_normalized, initial_noise=...)`
     contract rather than the image-list `predict()` contract.
+
+- `warm_state_prompt_buckets(images, prompt, states)` — Pi0.5 RTX torch
+  helper for realtime loops that pass changing state through the prompt.
+  It calls the selected frontend's bucket warmup hook, using `images` as
+  the calibration/capture observation and each item in `states` as a
+  representative robot state. The return value is the sorted list of
+  warmed prompt lengths. The method preserves the OpenPI state prompt
+  text format; it does not zero-pad or otherwise rewrite state tokens.
 
 - `recalibrate()` — clear FP8 calibration cache and force re-calibration
   on the next `predict()` call.

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -44,8 +44,9 @@ class VLAModel:
         # ``infer()``; Thor / rtx GROOT lazy-calibrate inside ``infer()``.
         # Track whether we still need to bootstrap calibration so that
         # first predict() can call it exactly once.
-        self._needs_real_data_calibration = hasattr(
-            pipe, "calibrate_with_real_data"
+        self._needs_real_data_calibration = (
+            hasattr(pipe, "calibrate_with_real_data")
+            and hasattr(pipe, "calibrated")
         )
 
     @staticmethod

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -130,14 +130,51 @@ class VLAModel:
         if state is not None and "state" not in obs:
             obs["state"] = state
 
-        # rtx Pi0.5 expects an explicit calibration bootstrap before the
-        # first infer(); fire it lazily here so user code stays "3 lines".
-        if self._needs_real_data_calibration:
+        # RTX Pi0.5 can swap in a different cached pipeline when a changing
+        # state prompt hits a new token length. Re-check that frontend's
+        # calibration flag instead of relying only on the first-call latch.
+        needs_real_data_calibration = self._needs_real_data_calibration
+        if (hasattr(self._pipe, "_prompt_pipeline_cache")
+                and not getattr(self._pipe, "calibrated", False)):
+            needs_real_data_calibration = True
+        if (needs_real_data_calibration
+                and hasattr(self._pipe, "calibrate_with_real_data")):
             self._pipe.calibrate_with_real_data([obs])
             self._needs_real_data_calibration = False
 
         result = self._pipe.infer(obs)
         return result['actions']
+
+    def warm_state_prompt_buckets(self, images, prompt, states):
+        """Pre-build Pi0.5 state-prompt runtime buckets.
+
+        Pi0.5 encodes robot state in the text prompt. Different state
+        values can tokenize to different lengths; warming representative
+        states up front prevents the control loop from paying graph
+        capture/autotune the first time each length appears.
+        """
+        if not hasattr(self._pipe, "warm_state_prompt_buckets"):
+            raise NotImplementedError(
+                "This frontend does not expose state prompt bucket warmup.")
+
+        if isinstance(images, dict):
+            obs = dict(images)
+        elif isinstance(images, (list, tuple)):
+            if len(images) == 0:
+                raise ValueError("images list must have at least one frame")
+            obs = {"images": list(images), "image": images[0]}
+            if len(images) >= 2:
+                obs["wrist_image"] = images[1]
+            if len(images) >= 3:
+                obs["wrist_image_right"] = images[2]
+        else:
+            raise ValueError("images must be a list of numpy arrays or a dict")
+
+        lengths = self._pipe.warm_state_prompt_buckets(prompt, states, obs)
+        self._needs_real_data_calibration = False
+        self._current_prompt = None
+        self._current_prompt_state = None
+        return lengths
 
     def set_prompt(self, *args, **kwargs):
         """Delegate prompt setup to the selected frontend."""

--- a/flash_rt/core/thor_frontend_utils.py
+++ b/flash_rt/core/thor_frontend_utils.py
@@ -19,6 +19,8 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+from flash_rt.core.utils.pi05_prompt import format_pi05_prompt
+
 
 # Resolved once at import time; all Thor frontends use the same FP8 dtype.
 _FP8 = torch.float8_e4m3fn
@@ -85,7 +87,8 @@ def _tokenize_sentencepiece(prompt_text: str):
     return [sp.bos_id()] + sp.Encode(prompt_text) + [108]
 
 
-def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48):
+def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48,
+                       state=None):
     """Torch-side tokenize + embed.
 
     Tries openpi's PaligemmaTokenizer first (matches training exactly);
@@ -98,12 +101,20 @@ def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48):
     try:
         from openpi.models.tokenizer import PaligemmaTokenizer
         tokenizer = PaligemmaTokenizer(max_len=max_len)
-        tokens_np, mask_np = tokenizer.tokenize(prompt_text)
+        tokens_np, mask_np = tokenizer.tokenize(prompt_text, state=state)
         prompt_len = int(mask_np.sum())
         token_ids = torch.tensor(
             tokens_np[:prompt_len], dtype=torch.long, device='cuda')
     except (ImportError, FileNotFoundError, OSError, RuntimeError):
-        tokens = _tokenize_sentencepiece(prompt_text)
+        if state is None:
+            tokens = _tokenize_sentencepiece(prompt_text)
+        else:
+            from flash_rt.utils.paligemma_tokenizer import (
+                load_paligemma_sentencepiece,
+            )
+            sp = load_paligemma_sentencepiece()
+            tokens = sp.Encode(format_pi05_prompt(prompt_text, state),
+                               add_bos=True)
         token_ids = torch.tensor(tokens, dtype=torch.long, device='cuda')
         prompt_len = len(token_ids)
 

--- a/flash_rt/core/utils/pi05_prompt.py
+++ b/flash_rt/core/utils/pi05_prompt.py
@@ -1,0 +1,35 @@
+"""Pi0.5 prompt helpers.
+
+Pi0.5 follows the openpi convention where proprioceptive state is
+discretized and represented in the language prefix:
+
+    Task: <task>, State: <bins>;\nAction:
+
+Keep this logic in one small module so RTX/Thor frontends and tests use the
+same state formatting.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+PI05_STATE_PROMPT_MAX_LEN = 200
+
+
+def discretize_pi05_state(state) -> np.ndarray:
+    """Discretize normalized Pi0.5 state to openpi's 256 language bins."""
+    arr = np.asarray(state, dtype=np.float32).reshape(-1)
+    bins = np.linspace(-1, 1, 256 + 1, dtype=np.float32)[:-1]
+    tokens = np.digitize(arr, bins=bins) - 1
+    return np.clip(tokens, 0, 255).astype(np.int64)
+
+
+def format_pi05_prompt(prompt: str, state=None) -> str:
+    """Format a text prompt, optionally with Pi0.5 discrete state tokens."""
+    cleaned = str(prompt).strip().replace("_", " ").replace("\n", " ")
+    if state is None:
+        return cleaned
+    state_tokens = discretize_pi05_state(state)
+    state_str = " ".join(map(str, state_tokens.tolist()))
+    return f"Task: {cleaned}, State: {state_str};\nAction: "

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -261,6 +261,11 @@ class GrootN17TorchFrontendThor:
           * ``self._visual_pos_masks``           — bool device (S,)
           * ``self.Se``                          — int = S
         """
+        if hasattr(self, "_backbone_features"):
+            raise RuntimeError(
+                "set_prompt() after GROOT N1.7 prompt runtime initialization "
+                "is not supported; construct a new frontend instance for a new prompt")
+
         from flash_rt.models.groot_n17 import calibration as cal
         from flash_rt.models.groot_n17.calibration import build_vit_rope_tables
 

--- a/flash_rt/frontends/torch/groot_thor.py
+++ b/flash_rt/frontends/torch/groot_thor.py
@@ -726,13 +726,31 @@ class GrootTorchFrontendThor:
         return h.unsqueeze(0)  # [1, 1, D_dit]
 
     def _copy_state_feature_to_dit(self, state):
-        """Encode current robot state into the captured DiT input buffer."""
+        """Encode current robot state into the captured DiT input buffer.
+
+        Uses the DiT head's own state encoder (``self._g_dit.se_w1/se_w2``) —
+        the same path the capture-time encode in ``_capture_all_graphs`` takes.
+        (``self._state_encode`` relies on ``_state_enc_w1``, which is only
+        populated by the unused single-graph ``_load_embodiment_weights`` path
+        and is absent on this g_dit pipeline.)
+        """
         if isinstance(state, np.ndarray):
             state = torch.from_numpy(state).to(torch.float32).cuda()
         elif not isinstance(state, torch.Tensor):
             state = torch.as_tensor(state, dtype=torch.float32, device='cuda')
-        state_feat = self._state_encode(state).squeeze(0)
-        self._g_dit.b_state_feat.copy_(state_feat)
+        state_fp16 = state.to(fp16).contiguous()
+        if state_fp16.dim() == 1:
+            state_fp16 = state_fp16.unsqueeze(0)
+        h = torch.empty(1, 1024, dtype=fp16, device='cuda')
+        self._g_dit.gemm.fp16_nn(state_fp16.data_ptr(), self._g_dit.se_w1.data_ptr(),
+                                 h.data_ptr(), 1, 1024, self.state_dim, 0)
+        fvk.add_bias_fp16(h.data_ptr(), self._g_dit.se_b1.data_ptr(), 1, 1024, 0)
+        fvk.relu_inplace_fp16(h.data_ptr(), 1024, 0)
+        sf = torch.empty(1, self.D_dit, dtype=fp16, device='cuda')
+        self._g_dit.gemm.fp16_nn(h.data_ptr(), self._g_dit.se_w2.data_ptr(),
+                                 sf.data_ptr(), 1, self.D_dit, 1024, 0)
+        fvk.add_bias_fp16(sf.data_ptr(), self._g_dit.se_b2.data_ptr(), 1, self.D_dit, 0)
+        self._g_dit.b_state_feat.copy_(sf)
 
     def _action_encode(self, actions, t_disc, action_horizon):
         """[1, T, action_dim] + timestep → [1, T, D_dit]."""

--- a/flash_rt/frontends/torch/groot_thor.py
+++ b/flash_rt/frontends/torch/groot_thor.py
@@ -738,7 +738,7 @@ class GrootTorchFrontendThor:
             state = torch.from_numpy(state).to(torch.float32).cuda()
         elif not isinstance(state, torch.Tensor):
             state = torch.as_tensor(state, dtype=torch.float32, device='cuda')
-        state_fp16 = state.to(fp16).contiguous()
+        state_fp16 = state.to(device='cuda', dtype=fp16).contiguous()
         if state_fp16.dim() == 1:
             state_fp16 = state_fp16.unsqueeze(0)
         h = torch.empty(1, 1024, dtype=fp16, device='cuda')

--- a/flash_rt/frontends/torch/groot_thor.py
+++ b/flash_rt/frontends/torch/groot_thor.py
@@ -725,6 +725,15 @@ class GrootTorchFrontendThor:
         h = self._fp16_gemm(h, self._state_enc_w2, 1, self.D_dit, 1024) + self._state_enc_b2
         return h.unsqueeze(0)  # [1, 1, D_dit]
 
+    def _copy_state_feature_to_dit(self, state):
+        """Encode current robot state into the captured DiT input buffer."""
+        if isinstance(state, np.ndarray):
+            state = torch.from_numpy(state).to(torch.float32).cuda()
+        elif not isinstance(state, torch.Tensor):
+            state = torch.as_tensor(state, dtype=torch.float32, device='cuda')
+        state_feat = self._state_encode(state).squeeze(0)
+        self._g_dit.b_state_feat.copy_(state_feat)
+
     def _action_encode(self, actions, t_disc, action_horizon):
         """[1, T, action_dim] + timestep → [1, T, D_dit]."""
         T = action_horizon
@@ -848,6 +857,11 @@ class GrootTorchFrontendThor:
 
     def set_prompt(self, prompt):
         """Tokenize prompt and prepare text embeddings for Qwen3 backbone."""
+        if getattr(self, '_graphs_built', False):
+            raise RuntimeError(
+                "set_prompt() after the pipeline is built is not supported; "
+                "construct a new GrootTorchFrontendThor instance for a new prompt")
+
         from transformers import AutoTokenizer
 
         if not hasattr(self, '_tokenizer'):
@@ -1416,6 +1430,8 @@ class GrootTorchFrontendThor:
 
         # Precompute cross-attention K/V projections (runs once, reused across 4 steps)
         self._g_dit.precompute_cross_kv()
+        self._copy_state_feature_to_dit(
+            obs.get('state', np.zeros(self.state_dim, dtype=np.float32)))
         self._g_dit.b_actions.normal_()
 
         # ── 5. DiT graph replay ──

--- a/flash_rt/frontends/torch/groot_thor.py
+++ b/flash_rt/frontends/torch/groot_thor.py
@@ -1877,24 +1877,10 @@ class GrootTorchFrontendThor:
         self._g_dit.precompute_cross_kv()
         torch.cuda.synchronize()
 
-        # State encode → b_state_feat
-        state = obs.get('state', np.zeros(self.state_dim, dtype=np.float32))
-        if isinstance(state, np.ndarray):
-            state = torch.from_numpy(state).to(torch.float32).cuda()
-        state_fp16 = state.to(fp16).contiguous()
-        if state_fp16.dim() == 1:
-            state_fp16 = state_fp16.unsqueeze(0)
-        h = torch.empty(1, 1024, dtype=fp16, device='cuda')
-        self._g_dit.gemm.fp16_nn(state_fp16.data_ptr(), self._g_dit.se_w1.data_ptr(),
-                                  h.data_ptr(), 1, 1024, self.state_dim, 0)
-        fvk.add_bias_fp16(h.data_ptr(), self._g_dit.se_b1.data_ptr(), 1, 1024, 0)
-        fvk.relu_inplace_fp16(h.data_ptr(), 1024, 0)
-        sf = torch.empty(1, self.D_dit, dtype=fp16, device='cuda')
-        self._g_dit.gemm.fp16_nn(h.data_ptr(), self._g_dit.se_w2.data_ptr(),
-                                  sf.data_ptr(), 1, self.D_dit, 1024, 0)
-        fvk.add_bias_fp16(sf.data_ptr(), self._g_dit.se_b2.data_ptr(), 1, self.D_dit, 0)
+        # State encode → b_state_feat (shared helper, see _copy_state_feature_to_dit)
+        self._copy_state_feature_to_dit(
+            obs.get('state', np.zeros(self.state_dim, dtype=np.float32)))
         torch.cuda.synchronize()
-        self._g_dit.b_state_feat.copy_(sf)
 
         amax = self._collect_dit_amax()
         return np.asarray(amax, dtype=np.float32)
@@ -2167,24 +2153,10 @@ class GrootTorchFrontendThor:
         # Calibrate DiT activation scales (needs precomputed KV)
         self._calibrate_dit()
 
-        # State encode (outside graph)
-        state = obs.get('state', np.zeros(self.state_dim, dtype=np.float32))
-        if isinstance(state, np.ndarray):
-            state = torch.from_numpy(state).to(torch.float32).cuda()
-        state_fp16 = state.to(fp16).contiguous()
-        if state_fp16.dim() == 1:
-            state_fp16 = state_fp16.unsqueeze(0)
-        h = torch.empty(1, 1024, dtype=fp16, device='cuda')
-        self._g_dit.gemm.fp16_nn(state_fp16.data_ptr(), self._g_dit.se_w1.data_ptr(),
-                                  h.data_ptr(), 1, 1024, self.state_dim, 0)
-        fvk.add_bias_fp16(h.data_ptr(), self._g_dit.se_b1.data_ptr(), 1, 1024, 0)
-        fvk.relu_inplace_fp16(h.data_ptr(), 1024, 0)
-        sf = torch.empty(1, self.D_dit, dtype=fp16, device='cuda')
-        self._g_dit.gemm.fp16_nn(h.data_ptr(), self._g_dit.se_w2.data_ptr(),
-                                  sf.data_ptr(), 1, self.D_dit, 1024, 0)
-        fvk.add_bias_fp16(sf.data_ptr(), self._g_dit.se_b2.data_ptr(), 1, self.D_dit, 0)
+        # State encode (outside graph) — shared helper
+        self._copy_state_feature_to_dit(
+            obs.get('state', np.zeros(self.state_dim, dtype=np.float32)))
         torch.cuda.synchronize()
-        self._g_dit.b_state_feat.copy_(sf)
 
         # ── 5. DiT graph capture (before Qwen3 graph for optimal cuBLAS tactic) ──
         stream_d = torch.cuda.Stream()

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -49,6 +49,7 @@ from flash_rt.hardware.rtx.attn_backend_batched_pi05 import (
     RtxFlashAttnBatchedBackendPi05,
 )
 from flash_rt.core.utils.hardware import supports_fp8
+from flash_rt.core.utils.pi05_prompt import PI05_STATE_PROMPT_MAX_LEN, format_pi05_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -294,7 +295,7 @@ def convert_pi05_safetensors(safetensors_path: Union[str, pathlib.Path]) -> dict
 
 
 def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
-                  max_len: int = 48) -> tuple[torch.Tensor, int]:
+                  max_len: int = 48, state=None) -> tuple[torch.Tensor, int]:
     """Tokenise + embed via PaliGemma embedding table (CUDA, bf16)."""
     # PaliGemma tokenizer resolution — see
     # `flash_rt.utils.paligemma_tokenizer` for the search order and
@@ -304,7 +305,7 @@ def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
         # same prompt prefix logic FlashRT was built against).
         from openpi.models.tokenizer import PaligemmaTokenizer
         tokenizer = PaligemmaTokenizer(max_len=max_len)
-        tokens_np, mask_np = tokenizer.tokenize(prompt_text)
+        tokens_np, mask_np = tokenizer.tokenize(prompt_text, state=state)
         prompt_len = int(mask_np.sum())
         token_ids = torch.tensor(
             tokens_np[:prompt_len], dtype=torch.long, device="cuda")
@@ -316,9 +317,13 @@ def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
             load_paligemma_sentencepiece,
         )
         sp = load_paligemma_sentencepiece()
-        # 108 is PaliGemma's `\n` token, used by openpi as the
-        # prompt-end separator before the action prefix.
-        tokens = [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+        if state is None:
+            # 108 is PaliGemma's `\n` token, used by openpi as the
+            # prompt-end separator before the action prefix.
+            tokens = [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+        else:
+            tokens = sp.Encode(format_pi05_prompt(prompt_text, state),
+                               add_bos=True)
         token_ids = torch.tensor(tokens, dtype=torch.long, device="cuda")
         prompt_len = len(token_ids)
 
@@ -511,6 +516,7 @@ class Pi05TorchFrontendRtx:
         self.graph_recorded = False
         self.current_prompt_len = 0
         self.pipeline: Optional[Pi05Pipeline] = None
+        self._prompt_pipeline_cache: dict[int, Pi05Pipeline] = {}
         # RL inference configuration. ``None`` = default behaviour (single
         # forward, no advantage-conditioned prompt injection). When set
         # by :meth:`set_rl_mode`, the next :meth:`set_prompt` call builds
@@ -620,6 +626,25 @@ class Pi05TorchFrontendRtx:
         logger.info(
             "Pi05TorchFrontendRtx initialised (num_views=%d, chunk=%d, fp8_layout=%s)",
             self.num_views, self.chunk_size, self.fp8_layout)
+
+    def _ensure_prompt_capacity(self, required_prompt_len: int) -> None:
+        """Grow RTX attention buffers before building longer prompt pipelines."""
+        if required_prompt_len <= self.max_prompt_len:
+            return
+        self.max_prompt_len = int(required_prompt_len)
+        enc_seq_max = self.num_views * 256 + self.max_prompt_len
+        self.attn_backend = RtxFlashAttnBackend(
+            num_views=self.num_views,
+            encoder_seq_max=enc_seq_max,
+            chunk_size=self.chunk_size,
+            num_encoder_layers=ENC_L)
+        self._prompt_pipeline_cache.clear()
+        self.pipeline = None
+        self.current_prompt_len = 0
+        self.graph_recorded = False
+        self.calibrated = False
+        logger.info("Grew Pi0.5 RTX prompt capacity to %d tokens",
+                    self.max_prompt_len)
 
     def _pipeline_precision_kwargs(self) -> dict:
         if self._force_int8_decoder or getattr(self, "_int8_encoder_only", False):
@@ -960,7 +985,7 @@ class Pi05TorchFrontendRtx:
             "RL mode enabled: cfg_beta=%.2f, advantage_positive=%s",
             new_config["cfg_beta"], new_config["advantage_positive"])
 
-    def set_prompt(self, prompt_text: str) -> None:
+    def set_prompt(self, prompt_text: str, state=None) -> None:
         """Tokenise prompt + (re)build the pipeline for the exact prompt length.
 
         When RL mode is enabled (see :meth:`set_rl_mode`), this also
@@ -968,42 +993,65 @@ class Pi05TorchFrontendRtx:
         the CFG-aware pipeline.
         """
         if self._rl_config is not None:
+            if state is not None:
+                raise ValueError(
+                    "Pi0.5 RL CFG mode does not support state-in-prompt yet")
             self._set_prompt_rl(prompt_text)
             return
 
+        max_len = (PI05_STATE_PROMPT_MAX_LEN if state is not None
+                   else MAX_PROMPT_LEN_DEFAULT)
         embeds, prompt_len = _embed_prompt(
-            prompt_text, self.embedding_weight, max_len=MAX_PROMPT_LEN_DEFAULT)
+            prompt_text, self.embedding_weight, max_len=max_len, state=state)
+        required_capacity = (PI05_STATE_PROMPT_MAX_LEN if state is not None
+                             else prompt_len)
+        self._ensure_prompt_capacity(required_capacity)
 
         if self.pipeline is None or prompt_len != self.current_prompt_len:
-            logger.info("Building Pi05Pipeline for prompt_len=%d...", prompt_len)
-            # Rebuild the pipeline with the exact prompt length to avoid
-            # wasted compute on padding tokens.
+            cached = self._prompt_pipeline_cache.get(prompt_len)
             self.current_prompt_len = prompt_len
-            self.graph_recorded = False
-            self.calibrated = False
+            if cached is not None:
+                self.pipeline = cached
+                self.graph_recorded = getattr(cached, "_graph", None) is not None
+                self.calibrated = (
+                    self.graph_recorded
+                    or bool(getattr(cached, "fp8_calibrated", False)))
+                logger.info("Reusing cached Pi05Pipeline for prompt_len=%d",
+                            prompt_len)
+            else:
+                logger.info("Building Pi05Pipeline for prompt_len=%d...",
+                            prompt_len)
+                # Rebuild the pipeline with the exact prompt length to avoid
+                # wasted compute on padding tokens. The instance is cached so
+                # Pi0.5 discrete-state prompt lengths do not repeatedly pay
+                # build/autotune/capture when they recur.
+                self.graph_recorded = False
+                self.calibrated = False
 
-            pipeline_weights = self._build_pipeline_weights()
-            self.pipeline = Pi05Pipeline(
-                gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
-                weights=pipeline_weights,
-                num_views=self.num_views,
-                max_prompt_len=prompt_len,
-                chunk_size=self.chunk_size,
-                num_steps=self._num_steps,
-                vision_pool_factor=self._vision_pool_factor,
-                vision_num_layers=self._vision_num_layers,
-                **self._pipeline_precision_kwargs())
-            # Static INT8 vision scales are per-pipeline-instance.
-            # Reset so calibrate_single_frame collects fresh scales.
-            if self.pipeline.use_int8_vision_static:
-                self.pipeline.vis_int8_static_calibrated = False
-                self.pipeline.vis_int8_static_scales = {}
+                pipeline_weights = self._build_pipeline_weights()
+                self.pipeline = Pi05Pipeline(
+                    gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
+                    weights=pipeline_weights,
+                    num_views=self.num_views,
+                    max_prompt_len=prompt_len,
+                    chunk_size=self.chunk_size,
+                    num_steps=self._num_steps,
+                    vision_pool_factor=self._vision_pool_factor,
+                    vision_num_layers=self._vision_num_layers,
+                    **self._pipeline_precision_kwargs())
+                self._prompt_pipeline_cache[prompt_len] = self.pipeline
+                # Static INT8 vision scales are per-pipeline-instance.
+                # Reset so calibrate_single_frame collects fresh scales.
+                if self.pipeline.use_int8_vision_static:
+                    self.pipeline.vis_int8_static_calibrated = False
+                    self.pipeline.vis_int8_static_scales = {}
 
         # Upload language embeds into pipeline's encoder_x slot
         embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
         self.pipeline.set_language_embeds(embeds_np)
         self._frame_count = 0
-        logger.info("Set prompt: '%s' (%d tokens)", prompt_text, prompt_len)
+        logger.info("Set prompt: '%s' (%d tokens, state=%s)",
+                    prompt_text, prompt_len, state is not None)
 
     def _set_prompt_rl(self, prompt_text: str) -> None:
         """RL-mode set_prompt: build conditioned + unconditioned embeddings.

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -1053,6 +1053,37 @@ class Pi05TorchFrontendRtx:
         logger.info("Set prompt: '%s' (%d tokens, state=%s)",
                     prompt_text, prompt_len, state is not None)
 
+    def warm_state_prompt_buckets(self, prompt_text: str, states,
+                                  sample_observation: dict) -> list[int]:
+        """Pre-build runtime buckets for Pi0.5 state-in-prompt lengths.
+
+        The prompt text is kept in the OpenPI format. This method only
+        front-loads graph capture/autotune for the token lengths reached
+        by the supplied representative states.
+        """
+        if self._rl_config is not None:
+            raise ValueError(
+                "Pi0.5 RL CFG mode does not support state prompt bucket warmup")
+        if isinstance(states, np.ndarray) and states.ndim == 1:
+            state_list = [states]
+        else:
+            state_list = list(states)
+        if not state_list:
+            raise ValueError("states must contain at least one representative state")
+
+        warmed: set[int] = set()
+        for state in state_list:
+            self.set_prompt(prompt_text, state=state)
+            prompt_len = int(self.current_prompt_len)
+            if prompt_len in warmed and getattr(self.pipeline, "_graph", None) is not None:
+                continue
+            if not self.calibrated:
+                self.calibrate_with_real_data([sample_observation])
+            warmed.add(prompt_len)
+
+        logger.info("Warmed Pi0.5 state prompt buckets: %s", sorted(warmed))
+        return sorted(warmed)
+
     def _set_prompt_rl(self, prompt_text: str) -> None:
         """RL-mode set_prompt: build conditioned + unconditioned embeddings.
 

--- a/flash_rt/frontends/torch/pi05_rtx_fp16.py
+++ b/flash_rt/frontends/torch/pi05_rtx_fp16.py
@@ -49,6 +49,7 @@ from flash_rt.hardware.rtx.attn_backend_batched_pi05 import (
     RtxFlashAttnBatchedBackendPi05,
 )
 from flash_rt.core.utils.hardware import supports_fp8
+from flash_rt.core.utils.pi05_prompt import PI05_STATE_PROMPT_MAX_LEN, format_pi05_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +300,7 @@ def convert_pi05_safetensors(safetensors_path: Union[str, pathlib.Path]) -> dict
 
 
 def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
-                  max_len: int = 48) -> tuple[torch.Tensor, int]:
+                  max_len: int = 48, state=None) -> tuple[torch.Tensor, int]:
     """Tokenise + embed via PaliGemma embedding table (CUDA, bf16)."""
     # PaliGemma tokenizer resolution — see
     # `flash_rt.utils.paligemma_tokenizer` for the search order and
@@ -309,7 +310,7 @@ def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
         # same prompt prefix logic FlashRT was built against).
         from openpi.models.tokenizer import PaligemmaTokenizer
         tokenizer = PaligemmaTokenizer(max_len=max_len)
-        tokens_np, mask_np = tokenizer.tokenize(prompt_text)
+        tokens_np, mask_np = tokenizer.tokenize(prompt_text, state=state)
         prompt_len = int(mask_np.sum())
         token_ids = torch.tensor(
             tokens_np[:prompt_len], dtype=torch.long, device="cuda")
@@ -321,9 +322,13 @@ def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
             load_paligemma_sentencepiece,
         )
         sp = load_paligemma_sentencepiece()
-        # 108 is PaliGemma's `\n` token, used by openpi as the
-        # prompt-end separator before the action prefix.
-        tokens = [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+        if state is None:
+            # 108 is PaliGemma's `\n` token, used by openpi as the
+            # prompt-end separator before the action prefix.
+            tokens = [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+        else:
+            tokens = sp.Encode(format_pi05_prompt(prompt_text, state),
+                               add_bos=True)
         token_ids = torch.tensor(tokens, dtype=torch.long, device="cuda")
         prompt_len = len(token_ids)
 
@@ -521,6 +526,7 @@ class Pi05TorchFrontendRtxFP16:
         self.graph_recorded = False
         self.current_prompt_len = 0
         self.pipeline: Optional[Pi05Pipeline] = None
+        self._prompt_pipeline_cache: dict[int, Pi05Pipeline] = {}
         # RL inference configuration. ``None`` = default behaviour (single
         # forward, no advantage-conditioned prompt injection). When set
         # by :meth:`set_rl_mode`, the next :meth:`set_prompt` call builds
@@ -623,6 +629,26 @@ class Pi05TorchFrontendRtxFP16:
         logger.info(
             "Pi05TorchFrontendRtxFP16 initialised (num_views=%d, chunk=%d, fp8_layout=%s)",
             self.num_views, self.chunk_size, self.fp8_layout)
+
+    def _ensure_prompt_capacity(self, required_prompt_len: int) -> None:
+        """Grow RTX attention buffers before building longer prompt pipelines."""
+        if required_prompt_len <= self.max_prompt_len:
+            return
+        self.max_prompt_len = int(required_prompt_len)
+        enc_seq_max = self.num_views * 256 + self.max_prompt_len
+        self.attn_backend = RtxFlashAttnBackend(
+            num_views=self.num_views,
+            encoder_seq_max=enc_seq_max,
+            chunk_size=self.chunk_size,
+            num_encoder_layers=ENC_L,
+            dtype=bf16)
+        self._prompt_pipeline_cache.clear()
+        self.pipeline = None
+        self.current_prompt_len = 0
+        self.graph_recorded = False
+        self.calibrated = False
+        logger.info("Grew Pi0.5 RTX FP16 prompt capacity to %d tokens",
+                    self.max_prompt_len)
 
     def _pipeline_precision_kwargs(self) -> dict:
         return {
@@ -938,7 +964,7 @@ class Pi05TorchFrontendRtxFP16:
             "RL mode enabled: cfg_beta=%.2f, advantage_positive=%s",
             new_config["cfg_beta"], new_config["advantage_positive"])
 
-    def set_prompt(self, prompt_text: str) -> None:
+    def set_prompt(self, prompt_text: str, state=None) -> None:
         """Tokenise prompt + (re)build the pipeline for the exact prompt length.
 
         When RL mode is enabled (see :meth:`set_rl_mode`), this also
@@ -946,42 +972,61 @@ class Pi05TorchFrontendRtxFP16:
         the CFG-aware pipeline.
         """
         if self._rl_config is not None:
+            if state is not None:
+                raise ValueError(
+                    "Pi0.5 RL CFG mode does not support state-in-prompt yet")
             self._set_prompt_rl(prompt_text)
             return
 
+        max_len = (PI05_STATE_PROMPT_MAX_LEN if state is not None
+                   else MAX_PROMPT_LEN_DEFAULT)
         embeds, prompt_len = _embed_prompt(
-            prompt_text, self.embedding_weight, max_len=MAX_PROMPT_LEN_DEFAULT)
+            prompt_text, self.embedding_weight, max_len=max_len, state=state)
+        required_capacity = (PI05_STATE_PROMPT_MAX_LEN if state is not None
+                             else prompt_len)
+        self._ensure_prompt_capacity(required_capacity)
 
         if self.pipeline is None or prompt_len != self.current_prompt_len:
-            logger.info("Building Pi05Pipeline for prompt_len=%d...", prompt_len)
-            # Rebuild the pipeline with the exact prompt length to avoid
-            # wasted compute on padding tokens.
+            cached = self._prompt_pipeline_cache.get(prompt_len)
             self.current_prompt_len = prompt_len
-            self.graph_recorded = False
-            self.calibrated = False
+            if cached is not None:
+                self.pipeline = cached
+                self.graph_recorded = getattr(cached, "_graph", None) is not None
+                self.calibrated = (
+                    self.graph_recorded
+                    or bool(getattr(cached, "fp8_calibrated", False)))
+                logger.info("Reusing cached Pi05Pipeline for prompt_len=%d",
+                            prompt_len)
+            else:
+                logger.info("Building Pi05Pipeline for prompt_len=%d...",
+                            prompt_len)
+                self.graph_recorded = False
+                self.calibrated = False
 
-            pipeline_weights = self._build_pipeline_weights()
-            self.pipeline = Pi05Pipeline(
-                gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
-                weights=pipeline_weights,
-                num_views=self.num_views,
-                max_prompt_len=prompt_len,
-                chunk_size=self.chunk_size,
-                num_steps=self._num_steps,
-                vision_pool_factor=self._vision_pool_factor,
-                vision_num_layers=self._vision_num_layers,
-                **self._pipeline_precision_kwargs())
-            # Static INT8 vision scales are per-pipeline-instance.
-            # Reset so calibrate_single_frame collects fresh scales.
-            if self.pipeline.use_int8_vision_static:
-                self.pipeline.vis_int8_static_calibrated = False
-                self.pipeline.vis_int8_static_scales = {}
+                pipeline_weights = self._build_pipeline_weights()
+                self.pipeline = Pi05Pipeline(
+                    gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
+                    weights=pipeline_weights,
+                    num_views=self.num_views,
+                    max_prompt_len=prompt_len,
+                    chunk_size=self.chunk_size,
+                    num_steps=self._num_steps,
+                    vision_pool_factor=self._vision_pool_factor,
+                    vision_num_layers=self._vision_num_layers,
+                    **self._pipeline_precision_kwargs())
+                self._prompt_pipeline_cache[prompt_len] = self.pipeline
+                # Static INT8 vision scales are per-pipeline-instance.
+                # Reset so calibrate_single_frame collects fresh scales.
+                if self.pipeline.use_int8_vision_static:
+                    self.pipeline.vis_int8_static_calibrated = False
+                    self.pipeline.vis_int8_static_scales = {}
 
         # Upload language embeds into pipeline's encoder_x slot
         embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
         self.pipeline.set_language_embeds(embeds_np)
         self._frame_count = 0
-        logger.info("Set prompt: '%s' (%d tokens)", prompt_text, prompt_len)
+        logger.info("Set prompt: '%s' (%d tokens, state=%s)",
+                    prompt_text, prompt_len, state is not None)
 
     def _set_prompt_rl(self, prompt_text: str) -> None:
         """RL-mode set_prompt: build conditioned + unconditioned embeddings.

--- a/flash_rt/frontends/torch/pi05_rtx_fp16.py
+++ b/flash_rt/frontends/torch/pi05_rtx_fp16.py
@@ -1028,6 +1028,32 @@ class Pi05TorchFrontendRtxFP16:
         logger.info("Set prompt: '%s' (%d tokens, state=%s)",
                     prompt_text, prompt_len, state is not None)
 
+    def warm_state_prompt_buckets(self, prompt_text: str, states,
+                                  sample_observation: dict) -> list[int]:
+        """Pre-build runtime buckets for Pi0.5 state-in-prompt lengths."""
+        if self._rl_config is not None:
+            raise ValueError(
+                "Pi0.5 RL CFG mode does not support state prompt bucket warmup")
+        if isinstance(states, np.ndarray) and states.ndim == 1:
+            state_list = [states]
+        else:
+            state_list = list(states)
+        if not state_list:
+            raise ValueError("states must contain at least one representative state")
+
+        warmed: set[int] = set()
+        for state in state_list:
+            self.set_prompt(prompt_text, state=state)
+            prompt_len = int(self.current_prompt_len)
+            if prompt_len in warmed and getattr(self.pipeline, "_graph", None) is not None:
+                continue
+            if not self.calibrated:
+                self.calibrate_with_real_data([sample_observation])
+            warmed.add(prompt_len)
+
+        logger.info("Warmed Pi0.5 state prompt buckets: %s", sorted(warmed))
+        return sorted(warmed)
+
     def _set_prompt_rl(self, prompt_text: str) -> None:
         """RL-mode set_prompt: build conditioned + unconditioned embeddings.
 

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -39,6 +39,7 @@ import torch.nn.functional as F
 import flash_rt.flash_rt_kernels as fvk
 from flash_rt.core.cuda_buffer import CudaBuffer
 from flash_rt.core.utils.actions import unnormalize_actions, LIBERO_ACTION_DIM
+from flash_rt.core.utils.pi05_prompt import PI05_STATE_PROMPT_MAX_LEN
 from flash_rt.core.quant.calibrator import load_calibration, save_calibration
 
 logger = logging.getLogger(__name__)
@@ -889,7 +890,7 @@ class Pi05TorchFrontendThor:
                 self._cfg_pipeline.cfg_beta)
         return {"actions": robot_actions}
 
-    def set_prompt(self, prompt_text):
+    def set_prompt(self, prompt_text, state=None):
         """Tokenize prompt, compute time conditioning, calibrate scales, capture graphs.
 
         When :meth:`set_rl_mode` has activated CFG inference and the
@@ -903,6 +904,9 @@ class Pi05TorchFrontendThor:
         if (self._rl_config is not None
                 and not getattr(self, "_in_rl_set_prompt", False)
                 and isinstance(prompt_text, str)):
+            if state is not None:
+                raise ValueError(
+                    "Pi0.5 RL CFG mode does not support state-in-prompt yet")
             self._in_rl_set_prompt = True
             try:
                 self._set_prompt_rl(prompt_text)
@@ -921,12 +925,28 @@ class Pi05TorchFrontendThor:
                 torch.from_numpy(token_ids).long().cuda(), self.embedding_weight)
             embeds = embeds * float(embeds.shape[-1] ** 0.5)
         else:
-            embeds, prompt_len = embed_prompt(prompt_text, self.embedding_weight, max_len=48)
+            max_len = PI05_STATE_PROMPT_MAX_LEN if state is not None else 48
+            embeds, prompt_len = embed_prompt(
+                prompt_text, self.embedding_weight, max_len=max_len,
+                state=state)
 
         # Se must be EVEN for cuBLASLt FP8
         Se = S_sig + prompt_len
         if Se % 2 != 0:
             Se += 1
+        actual_lang = Se - S_sig
+        if actual_lang > prompt_len:
+            embeds = torch.cat([embeds, embeds[-1:]], dim=0)
+
+        if (self.graph_captured and self._lang_emb is not None
+                and self._S_lang == actual_lang and self.Se == Se):
+            self._lang_emb.copy_(embeds)
+            logger.info(
+                "Updated Pi0.5 Thor prompt in place: '%s' "
+                "(%d tokens, Se=%d, state=%s)",
+                prompt_text, prompt_len, Se, state is not None)
+            return
+
         self.Se = Se
         self.total_keys = Se + self.Sa
 
@@ -970,9 +990,6 @@ class Pi05TorchFrontendThor:
             },
         )
 
-        actual_lang = Se - S_sig
-        if actual_lang > prompt_len:
-            embeds = torch.cat([embeds, embeds[-1:]], dim=0)
         self._lang_emb = embeds
         self._S_lang = actual_lang
 

--- a/flash_rt/hardware/backend.py
+++ b/flash_rt/hardware/backend.py
@@ -21,11 +21,12 @@ The existing Thor and rtx attention backends do NOT agree on who owns
 Q/K/V/O memory:
 
 * **Backend-owned** (rtx): The backend allocates Q/K/V as torch tensors
-  in its ``__init__``. Output tensors are freshly allocated by
-  ``flash_attn_func`` per call and the backend holds a reference so the
-  torch caching allocator pins them across CUDA Graph capture + replay.
-  The pipeline writes Q/K/V into the backend's pre-allocated slots via
-  pointers returned from :meth:`AttentionBackend.get_slot_ptrs`.
+  in its ``__init__``. Modern vendored FA2 backends also own stable
+  output tensors; legacy pip ``flash_attn_func`` fallback paths keep an
+  output reference so the torch caching allocator pins the allocation
+  across CUDA Graph capture + replay. The pipeline writes Q/K/V into
+  the backend's pre-allocated slots via pointers returned from
+  :meth:`AttentionBackend.get_slot_ptrs`.
 
 * **Pipeline-owned** (Thor): The pipeline allocates its own ``attn_out``
   scratch (which stores Q *before* the attention call and the output
@@ -244,13 +245,14 @@ class AttentionBackend(Protocol):
     for the lifetime of the backend. ``get_slot_ptrs`` returns the
     current mapping.
 
-    Not every backend exposes every role. The rtx Pi0.5 backend exposes
-    ``Q``, ``K``, ``V`` per slot; output is allocated by
-    ``flash_attn_func`` and the pointer is returned by ``run()``. The
-    Thor backend exposes ``Q`` (which is also the output buffer,
-    aliased with ``O``), plus ``K`` and ``V`` per layer. Pipelines MUST
-    only read keys they know the target backend provides for a given
-    site.
+    Not every backend exposes every role. The rtx backends expose
+    ``Q``, ``K``, ``V`` per slot and return the output pointer from
+    ``run()``; vendored FA2 paths usually keep ``O`` backend-owned, while
+    legacy fallback paths may keep only a reference to the allocated
+    output tensor. The Thor backend exposes ``Q`` (which is also the
+    output buffer, aliased with ``O``), plus ``K`` and ``V`` per layer.
+    Pipelines MUST only read keys they know the target backend provides
+    for a given site.
     """
 
     def sites(self) -> tuple[str, ...]:

--- a/flash_rt/hardware/rtx/attn_backend_groot.py
+++ b/flash_rt/hardware/rtx/attn_backend_groot.py
@@ -7,17 +7,16 @@ GROOT has four distinct attention shapes:
   - DiT self    :  (1, Sa=51,  heads=32, head_dim=48)  self
   - DiT cross   :  Q (1, Sa, 32, 48)  vs  K/V (1, Se, 32, 48)  cross
 
-flash_attention covers all four head_dims (48 → kHeadDim=64, 72 → 96,
-128 direct) so we can route everything through one ``flash_attn_func``
-backend on RTX 5090.
+FlashRT's vendored FA2 covers all four head_dims (48 → kHeadDim=96,
+72 → 96, 128 direct) so we can route everything through the
+``flash_rt_fa2`` backend on RTX 5090 without requiring the upstream
+``flash-attn`` pip wheel.
 
 This is a separate backend from ``RtxFlashAttnBackend`` (the Pi0/Pi0.5
 one) because the attention sites and shapes are entirely different.
 The protocol matches: ``get_ptrs()`` returns a dict of input pointers
 for the pipeline to write into via fvk kernels, and each ``*_attn``
-method returns the raw device pointer of flash_attn's output tensor
-(no copy — torch's caching allocator pins the slot during graph
-capture, exactly the same trick as the Pi0.5 backend).
+method returns the raw device pointer of a backend-owned output tensor.
 
 Future revision will replace this with a pure-C
 ``CFlashAttnBackend`` that calls into ``libfmha_fp16.so``. The
@@ -112,7 +111,7 @@ class RtxFlashAttnBackendGroot:
         # ── DiT cross-attention ──
         # Q is the action stream (rewritten per layer by the pipeline).
         # K/V are 16 per-block precomputed projections of the Qwen3 backbone,
-        # owned by the backend so flash_attn can read them as torch tensors.
+        # owned by the backend so vendored FA2 can read them as torch tensors.
         # The pipeline writes these via fp16_nn GEMMs in precompute_cross_kv().
         self.dit_cross_Q = torch.empty(num_dit_actions, 32, 48, dtype=fp16, device=d)
         self.dit_cross_K = [
@@ -130,27 +129,89 @@ class RtxFlashAttnBackendGroot:
         self._dit_kv_seq = dit_kv_seq
         self._num_dit_cross_blocks = num_dit_cross_blocks
 
-        # Output references for caching-allocator stability
-        self._vis_out_ref = None
-        self._qwen3_out_ref = None
-        self._dit_self_out_ref = None
-        self._dit_cross_out_ref = None
-
-        # GROOT currently routes attention through the upstream
-        # ``flash-attn`` pip wheel as its primary path; defer the import
-        # to backend instantiation (not module import) so users without
-        # the wheel can still ``import flash_rt`` and run Pi0 / Pi0.5.
         try:
-            from flash_attn import flash_attn_func
+            from flash_rt import flash_rt_fa2 as fa2
         except ImportError as e:
-            raise ImportError(
-                "GROOT RTX backend requires the upstream `flash-attn` "
-                "pip package. Install a prebuilt wheel for your "
-                "torch/CUDA combo from "
-                "https://github.com/Dao-AILab/flash-attention/releases "
-                "(building the sdist takes 30+ minutes on cold images)."
+            raise RuntimeError(
+                "GROOT RTX backend requires FlashRT's vendored FA2 module "
+                "(`flash_rt.flash_rt_fa2`). Build it with CMake on RTX "
+                "targets; do not install/use the upstream `flash_attn` pip "
+                f"package for this path. Import error: {e}"
             ) from e
-        self._flash_attn_func = flash_attn_func
+        self._fa2 = fa2
+        self._fa2_fwd = fa2.fwd_fp16
+        self._num_sms = torch.cuda.get_device_properties(
+            torch.cuda.current_device()).multi_processor_count
+
+        def lse(batch: int, heads: int, seq: int):
+            return torch.empty(
+                batch, heads, self._round_up_128(seq),
+                dtype=torch.float32, device=d)
+
+        def split_scratch(batch: int, heads: int, q_seq: int,
+                          kv_seq: int, head_dim: int):
+            block_n = 256 if head_dim <= 64 else (128 if head_dim <= 128 else 64)
+            max_splits = max(1, min(128, (kv_seq + block_n - 1) // block_n))
+            lse_accum = torch.empty(
+                max_splits, batch, heads, q_seq,
+                dtype=torch.float32, device=d)
+            o_accum = torch.empty(
+                max_splits, batch, heads, q_seq,
+                self._round_head_dim(head_dim),
+                dtype=torch.float32, device=d)
+            return lse_accum, o_accum
+
+        # Preallocated outputs and LSE/splitkv scratch. Returned pointers stay
+        # stable across CUDA Graph capture and replay.
+        self.vis_O = torch.empty_like(self.vis_Q)
+        self._vis_lse = lse(num_views, 16, 256)
+        self._vis_lse_accum, self._vis_o_accum = split_scratch(
+            num_views, 16, 256, 256, 72)
+
+        self.qwen3_O = torch.empty_like(self.qwen3_Q)
+        self._qwen3_lse = lse(1, 16, encoder_seq_max)
+        self._qwen3_lse_accum, self._qwen3_o_accum = split_scratch(
+            1, 16, encoder_seq_max, encoder_seq_max, 128)
+
+        self.dit_self_O = torch.empty_like(self.dit_self_Q)
+        self._dit_self_lse = lse(1, 32, num_dit_actions)
+        self._dit_self_lse_accum, self._dit_self_o_accum = split_scratch(
+            1, 32, num_dit_actions, num_dit_actions, 48)
+
+        self.dit_cross_O = torch.empty_like(self.dit_cross_Q)
+        self._dit_cross_lse = lse(1, 32, num_dit_actions)
+        self._dit_cross_lse_accum, self._dit_cross_o_accum = split_scratch(
+            1, 32, num_dit_actions, dit_kv_seq, 48)
+
+    def _run_fa2(self, q, k, v, o, lse, *, stream: int = 0,
+                 lse_accum=None, o_accum=None) -> int:
+        B, Sq, Hq, D = q.shape
+        Sk, Hk = k.shape[1], k.shape[2]
+        self._fa2_fwd(
+            Q=q.data_ptr(), K=k.data_ptr(), V=v.data_ptr(),
+            O=o.data_ptr(), softmax_lse=lse.data_ptr(),
+            softmax_lse_accum=(lse_accum.data_ptr()
+                               if lse_accum is not None else 0),
+            o_accum=(o_accum.data_ptr() if o_accum is not None else 0),
+            batch=B, seqlen_q=Sq, seqlen_k=Sk,
+            num_heads_q=Hq, num_heads_kv=Hk, head_dim=D,
+            q_strides=(q.stride(0), q.stride(1), q.stride(2)),
+            k_strides=(k.stride(0), k.stride(1), k.stride(2)),
+            v_strides=(v.stride(0), v.stride(1), v.stride(2)),
+            o_strides=(o.stride(0), o.stride(1), o.stride(2)),
+            softmax_scale=1.0 / (D ** 0.5),
+            num_sms=self._num_sms,
+            stream=stream,
+        )
+        return o.data_ptr()
+
+    @staticmethod
+    def _round_up_128(x: int) -> int:
+        return ((int(x) + 127) // 128) * 128
+
+    @staticmethod
+    def _round_head_dim(x: int) -> int:
+        return (int(x) + 31) & ~31
 
     # ── Pointer interface (for pipeline's fvk kernel calls) ──
 
@@ -172,9 +233,7 @@ class RtxFlashAttnBackendGroot:
 
     # ── Attention calls ──
     #
-    # All four return the raw device pointer of flash_attn_func's output tensor.
-    # Torch's caching allocator reuses the same slot once warmed up; the
-    # pointer stays valid across CUDA Graph replays.
+    # All four return stable pointers to backend-owned output tensors.
 
     def vision_attn(self, stream: int = 0) -> int:
         """Per-view SigLIP2 self-attention.
@@ -183,10 +242,11 @@ class RtxFlashAttnBackendGroot:
         Downstream the pipeline reshapes/views this as (num_views * 256, 1152)
         and feeds it to the next FP8 GEMM (out projection).
         """
-        out = self._flash_attn_func(
-            self.vis_Q, self.vis_K, self.vis_V, causal=False)
-        self._vis_out_ref = out
-        return out.data_ptr()
+        return self._run_fa2(
+            self.vis_Q, self.vis_K, self.vis_V, self.vis_O,
+            self._vis_lse, stream=stream,
+            lse_accum=self._vis_lse_accum,
+            o_accum=self._vis_o_accum)
 
     def qwen3_attn(self, layer_idx: int, seq: int, stream: int = 0) -> int:
         """Qwen3 GQA self-attention for one layer (16Q/8KV, head_dim=128).
@@ -197,9 +257,11 @@ class RtxFlashAttnBackendGroot:
         q = self.qwen3_Q[:seq].unsqueeze(0)        # (1, seq, 16, 128)
         k = self.qwen3_K[:seq].unsqueeze(0)        # (1, seq, 8,  128)
         v = self.qwen3_V[:seq].unsqueeze(0)        # (1, seq, 8,  128)
-        out = self._flash_attn_func(q, k, v, causal=False)
-        self._qwen3_out_ref = out
-        return out.data_ptr()
+        o = self.qwen3_O[:seq].unsqueeze(0)
+        return self._run_fa2(
+            q, k, v, o, self._qwen3_lse, stream=stream,
+            lse_accum=self._qwen3_lse_accum,
+            o_accum=self._qwen3_o_accum)
 
     def dit_self_attn(self, layer_idx: int, sa: int, stream: int = 0) -> int:
         """DiT self-attention (32 heads × 48 head_dim) over Sa tokens.
@@ -209,9 +271,11 @@ class RtxFlashAttnBackendGroot:
         q = self.dit_self_Q[:sa].unsqueeze(0)
         k = self.dit_self_K[:sa].unsqueeze(0)
         v = self.dit_self_V[:sa].unsqueeze(0)
-        out = self._flash_attn_func(q, k, v, causal=False)
-        self._dit_self_out_ref = out
-        return out.data_ptr()
+        o = self.dit_self_O[:sa].unsqueeze(0)
+        return self._run_fa2(
+            q, k, v, o, self._dit_self_lse, stream=stream,
+            lse_accum=self._dit_self_lse_accum,
+            o_accum=self._dit_self_o_accum)
 
     def dit_cross_attn(self, cross_block_idx: int, sa: int,
                        kv_seq: int, stream: int = 0) -> int:
@@ -226,15 +290,17 @@ class RtxFlashAttnBackendGroot:
         q = self.dit_cross_Q[:sa].unsqueeze(0)
         k = self.dit_cross_K[cross_block_idx][:kv_seq].unsqueeze(0)
         v = self.dit_cross_V[cross_block_idx][:kv_seq].unsqueeze(0)
-        out = self._flash_attn_func(q, k, v, causal=False)
-        self._dit_cross_out_ref = out
-        return out.data_ptr()
+        o = self.dit_cross_O[:sa].unsqueeze(0)
+        return self._run_fa2(
+            q, k, v, o, self._dit_cross_lse, stream=stream,
+            lse_accum=self._dit_cross_lse_accum,
+            o_accum=self._dit_cross_o_accum)
 
     # ──────────────────────────────────────────────────────────────
-    # AttentionBackend protocol implementation. Wraps the same
-    # flash_attn_func calls as the legacy methods above. The legacy
-    # half will be retired once the GROOT pipeline routes entirely
-    # through the protocol methods.
+    # AttentionBackend protocol implementation. Wraps the same vendored
+    # FA2 dispatches as the legacy methods above. The legacy half will
+    # be retired once the GROOT pipeline routes entirely through the
+    # protocol methods.
     # ──────────────────────────────────────────────────────────────
 
     _PROTOCOL_SITES = ("siglip", "qwen3", "dit_self", "dit_cross")
@@ -333,10 +399,9 @@ class RtxFlashAttnBackendGroot:
     ) -> int:
         """Dispatch to the legacy attention call for the given site.
 
-        Wraps the same ``flash_attn_func`` invocations as the legacy
-        methods. Returns the freshly-allocated output tensor's data_ptr,
-        which is stable across CUDA Graph capture + replay because the
-        backend holds a reference in ``_{site}_out_ref``.
+        Wraps the same vendored FA2 invocations as the legacy methods.
+        Returns a backend-owned output tensor pointer that is stable
+        across CUDA Graph capture and replay.
         """
         if site == "siglip":
             # Pi0.5's SigLIP was 2-view × 256 tokens, GROOT's SigLIP

--- a/flash_rt/hardware/thor/fa4_backend.py
+++ b/flash_rt/hardware/thor/fa4_backend.py
@@ -14,8 +14,7 @@ import isolated from the rest of FlashRT:
   ``csrc/attention/flash_attn_4_src/VENDOR.md``). It is loaded by transiently
   adding the vendor dir to ``sys.path`` and importing ``flashrt_fa4.cute`` —
   the vendor path is removed from ``sys.path`` again right after import, and the
-  private name guarantees it never shadows a pip-installed ``flash_attn`` (the
-  RTX backends use ``from flash_attn import flash_attn_func``).
+  private name guarantees it never shadows upstream ``flash_attn``.
 - It is an **optional fast path**. If the FA4 runtime deps
   (``nvidia-cutlass-dsl`` + ``quack-kernels``, the ``thor-fa4`` pip extra) are
   missing, every accessor returns ``None`` and the caller falls back to the

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -1939,8 +1939,15 @@ class Pi05Pipeline:
         assert lang_embeds_np.shape[1] == ENC_D
 
         # Store a persistent device copy of the (prompt_len, ENC_D) embeds.
+        # CUDA Graph capture bakes the source pointer used by
+        # _copy_lang_embeds_to_encoder_x(), so same-shape prompt updates must
+        # upload into the existing buffer instead of replacing it.
         arr = np.ascontiguousarray(lang_embeds_np)
-        self._lang_embeds_buf = CudaBuffer.from_numpy(arr)
+        if (hasattr(self, "_lang_embeds_buf")
+                and self._lang_embeds_buf.nbytes == arr.nbytes):
+            self._lang_embeds_buf.upload(arr)
+        else:
+            self._lang_embeds_buf = CudaBuffer.from_numpy(arr)
         self._current_prompt_len = prompt_len
 
         # Update decoder RoPE slice for this prompt length

--- a/flash_rt/models/pi05/pipeline_rtx_batched.py
+++ b/flash_rt/models/pi05/pipeline_rtx_batched.py
@@ -303,7 +303,11 @@ class Pi05BatchedPipeline(Pi05Pipeline):
         import numpy as np
         for b, e in enumerate(embeds_np_list):
             arr = np.ascontiguousarray(e)
-            self._lang_embeds_buf_b2[b] = CudaBuffer.from_numpy(arr)
+            old = self._lang_embeds_buf_b2[b]
+            if old is not None and old.nbytes == arr.nbytes:
+                old.upload(arr)
+            else:
+                self._lang_embeds_buf_b2[b] = CudaBuffer.from_numpy(arr)
         self._current_prompt_len_b2 = prompt_len
         # Reuse the parent's decoder-RoPE setup for this prompt length.
         self._set_decoder_rope_for_prompt(prompt_len)

--- a/flash_rt/models/pi05/pipeline_rtx_cfg.py
+++ b/flash_rt/models/pi05/pipeline_rtx_cfg.py
@@ -191,8 +191,17 @@ class Pi05CFGPipeline(Pi05Pipeline):
         cond_padded = self._pad_prompt(cond_embeds_np, target_len)
         uncond_padded = self._pad_prompt(uncond_embeds_np, target_len)
 
-        self._lang_embeds_buf_cond = CudaBuffer.from_numpy(cond_padded)
-        self._lang_embeds_buf_uncond = CudaBuffer.from_numpy(uncond_padded)
+        if (self._lang_embeds_buf_cond is not None
+                and self._lang_embeds_buf_cond.nbytes == cond_padded.nbytes):
+            self._lang_embeds_buf_cond.upload(cond_padded)
+        else:
+            self._lang_embeds_buf_cond = CudaBuffer.from_numpy(cond_padded)
+        if (self._lang_embeds_buf_uncond is not None
+                and self._lang_embeds_buf_uncond.nbytes
+                == uncond_padded.nbytes):
+            self._lang_embeds_buf_uncond.upload(uncond_padded)
+        else:
+            self._lang_embeds_buf_uncond = CudaBuffer.from_numpy(uncond_padded)
         self._cfg_prompt_len = target_len
 
         # Reuse the parent's RoPE setup for the padded length so the

--- a/flash_rt/models/pi05/pipeline_rtx_fp16.py
+++ b/flash_rt/models/pi05/pipeline_rtx_fp16.py
@@ -2076,8 +2076,15 @@ class Pi05PipelineFP16:
         assert lang_embeds_np.shape[1] == ENC_D
 
         # Store a persistent device copy of the (prompt_len, ENC_D) embeds.
+        # CUDA Graph capture bakes the source pointer used by
+        # _copy_lang_embeds_to_encoder_x(), so same-shape prompt updates must
+        # upload into the existing buffer instead of replacing it.
         arr = np.ascontiguousarray(lang_embeds_np)
-        self._lang_embeds_buf = CudaBuffer.from_numpy(arr)
+        if (hasattr(self, "_lang_embeds_buf")
+                and self._lang_embeds_buf.nbytes == arr.nbytes):
+            self._lang_embeds_buf.upload(arr)
+        else:
+            self._lang_embeds_buf = CudaBuffer.from_numpy(arr)
         self._current_prompt_len = prompt_len
 
         # Update decoder RoPE slice for this prompt length

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -18,7 +18,7 @@ prevented at build / import time, so this file is the regression net:
    torch 2.5.1 / CUDA 12.5 / Py3.12 → 30–60 min sdist compile per
    cold image). The vendored ``flash_rt_fa2.so`` is enough for the
    default path; ``flash-attn`` is only needed for legacy bisection
-   sites and the GROOT backend.
+   sites.
 
 Run:
     PYTHONPATH=. python -m pytest tests/test_install_smoke.py -v
@@ -53,7 +53,7 @@ def test_kernels_so_lives_in_flash_rt():
 def test_import_without_flash_attn(monkeypatch):
     """``import flash_rt`` must not require the upstream flash-attn
     pip package. The default RTX path uses ``flash_rt_fa2.so``; the
-    upstream wheel is only needed for legacy / GROOT paths.
+    upstream wheel is only needed for legacy bisection paths.
     """
     # Block flash_attn from importing — sys.modules[name] = None makes
     # `import flash_attn` raise ImportError without touching the real
@@ -75,6 +75,8 @@ def test_import_without_flash_attn(monkeypatch):
     # touching upstream flash_attn. Backend instantiation is GPU-bound
     # and is exercised separately in tests/test_pi05_*.py.
     importlib.import_module("flash_rt.hardware.rtx.attn_backend")
+    importlib.import_module("flash_rt.hardware.rtx.attn_backend_groot")
+    importlib.import_module("flash_rt.hardware.rtx.attn_backend_groot_n17")
 
 
 def test_legacy_path_raises_clear_error_without_flash_attn(monkeypatch):

--- a/tests/test_pi05_state_prompt.py
+++ b/tests/test_pi05_state_prompt.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+
+def test_pi05_state_prompt_matches_openpi_format():
+    from flash_rt.core.utils.pi05_prompt import (
+        discretize_pi05_state,
+        format_pi05_prompt,
+    )
+
+    state = np.array([-1.0, 0.0, 1.0, 2.0, -2.0], dtype=np.float32)
+
+    assert discretize_pi05_state(state).tolist() == [0, 128, 255, 255, 0]
+    assert format_pi05_prompt("pick_up\nred", state) == (
+        "Task: pick up red, State: 0 128 255 255 0;\nAction: "
+    )
+
+
+def test_pi05_state_prompt_without_state_keeps_text_only_format():
+    from flash_rt.core.utils.pi05_prompt import format_pi05_prompt
+
+    assert format_pi05_prompt(" pick_up\nred ") == "pick up red"

--- a/tests/test_prompt_runtime_lifecycle.py
+++ b/tests/test_prompt_runtime_lifecycle.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+import numpy as np
+
+
+def test_pi05_rtx_caches_recurring_state_prompt_lengths(monkeypatch):
+    import torch
+    from flash_rt.frontends.torch import pi05_rtx
+
+    class FakePipeline:
+        instances = []
+
+        def __init__(self, *args, max_prompt_len, **kwargs):
+            self.max_prompt_len = max_prompt_len
+            self.use_int8_vision_static = False
+            self.fp8_calibrated = False
+            self.uploads = []
+            type(self).instances.append(self)
+
+        def set_language_embeds(self, embeds_np):
+            self.uploads.append(embeds_np.shape)
+
+    lengths = iter([17, 23, 17])
+
+    def fake_embed_prompt(prompt_text, embedding_weight, max_len=48, state=None):
+        prompt_len = next(lengths)
+        return torch.zeros(prompt_len, 8, dtype=torch.bfloat16), prompt_len
+
+    pipe = object.__new__(pi05_rtx.Pi05TorchFrontendRtx)
+    pipe._rl_config = None
+    pipe.embedding_weight = None
+    pipe.max_prompt_len = 200
+    pipe.num_views = 2
+    pipe.chunk_size = 10
+    pipe._num_steps = 10
+    pipe._vision_pool_factor = 1
+    pipe._vision_num_layers = 27
+    pipe.pipeline = None
+    pipe.current_prompt_len = 0
+    pipe._prompt_pipeline_cache = {}
+    pipe.graph_recorded = False
+    pipe.calibrated = False
+    pipe.gemm = None
+    pipe.fvk = None
+    pipe.attn_backend = None
+    pipe._build_pipeline_weights = lambda: {}
+    pipe._pipeline_precision_kwargs = lambda: {}
+
+    monkeypatch.setattr(pi05_rtx, "_embed_prompt", fake_embed_prompt)
+    monkeypatch.setattr(pi05_rtx, "Pi05Pipeline", FakePipeline)
+
+    state = np.zeros(8, dtype=np.float32)
+    pipe.set_prompt("pick up", state=state)
+    first = pipe.pipeline
+    pipe.set_prompt("pick up", state=state)
+    second = pipe.pipeline
+    pipe.set_prompt("pick up", state=state)
+
+    assert [p.max_prompt_len for p in FakePipeline.instances] == [17, 23]
+    assert pipe.pipeline is first
+    assert pipe._prompt_pipeline_cache == {17: first, 23: second}
+    assert first.uploads
+    assert second.uploads
+
+
+def test_groot_thor_rejects_prompt_changes_after_graph_build():
+    source = Path("flash_rt/frontends/torch/groot_thor.py").read_text()
+    set_prompt_pos = source.index("    def set_prompt(self, prompt):")
+    guard_pos = source.index("getattr(self, '_graphs_built', False)",
+                             set_prompt_pos)
+    tokenizer_pos = source.index("from transformers import AutoTokenizer",
+                                 set_prompt_pos)
+
+    assert guard_pos < tokenizer_pos
+
+
+def test_groot_thor_infer_refreshes_state_before_dit_graph_replay():
+    source = Path("flash_rt/frontends/torch/groot_thor.py").read_text()
+    infer_pos = source.index("    def infer(self, obs):")
+    replay_pos = source.index("self._dit_graph.replay()", infer_pos)
+    state_pos = source.index("_copy_state_feature_to_dit", infer_pos)
+
+    assert state_pos < replay_pos
+
+
+def test_groot_n17_rejects_second_prompt_runtime():
+    source = Path("flash_rt/frontends/torch/groot_n17_thor.py").read_text()
+    set_prompt_pos = source.index("    def set_prompt(\n")
+    guard_pos = source.index('hasattr(self, "_backbone_features")',
+                             set_prompt_pos)
+    calibration_pos = source.index("from flash_rt.models.groot_n17",
+                                   set_prompt_pos)
+
+    assert guard_pos < calibration_pos

--- a/tests/test_prompt_runtime_lifecycle.py
+++ b/tests/test_prompt_runtime_lifecycle.py
@@ -63,6 +63,108 @@ def test_pi05_rtx_caches_recurring_state_prompt_lengths(monkeypatch):
     assert second.uploads
 
 
+def test_vla_model_warms_pi05_state_prompt_buckets(monkeypatch):
+    import torch
+    from flash_rt.api import VLAModel
+    from flash_rt.frontends.torch import pi05_rtx
+
+    class FakePipeline:
+        instances = []
+
+        def __init__(self, *args, max_prompt_len, **kwargs):
+            self.max_prompt_len = max_prompt_len
+            self.use_int8_vision_static = False
+            self.fp8_calibrated = False
+            type(self).instances.append(self)
+
+        def set_language_embeds(self, embeds_np):
+            return None
+
+    lengths = iter([17, 23, 17])
+
+    def fake_embed_prompt(prompt_text, embedding_weight, max_len=48, state=None):
+        prompt_len = next(lengths)
+        return torch.zeros(prompt_len, 8, dtype=torch.bfloat16), prompt_len
+
+    pipe = object.__new__(pi05_rtx.Pi05TorchFrontendRtx)
+    pipe._rl_config = None
+    pipe.embedding_weight = None
+    pipe.max_prompt_len = 200
+    pipe.num_views = 2
+    pipe.chunk_size = 10
+    pipe._num_steps = 10
+    pipe._vision_pool_factor = 1
+    pipe._vision_num_layers = 27
+    pipe.pipeline = None
+    pipe.current_prompt_len = 0
+    pipe._prompt_pipeline_cache = {}
+    pipe.graph_recorded = False
+    pipe.calibrated = False
+    pipe.gemm = None
+    pipe.fvk = None
+    pipe.attn_backend = None
+    pipe._build_pipeline_weights = lambda: {}
+    pipe._pipeline_precision_kwargs = lambda: {}
+
+    def fake_calibrate(sample_observations):
+        pipe.pipeline._graph = object()
+        pipe.calibrated = True
+        pipe.graph_recorded = True
+
+    pipe.calibrate_with_real_data = fake_calibrate
+
+    monkeypatch.setattr(pi05_rtx, "_embed_prompt", fake_embed_prompt)
+    monkeypatch.setattr(pi05_rtx, "Pi05Pipeline", FakePipeline)
+
+    model = VLAModel(pipe, framework="torch")
+    image = np.zeros((224, 224, 3), dtype=np.uint8)
+    states = [
+        np.zeros(8, dtype=np.float32),
+        np.ones(8, dtype=np.float32),
+        np.full(8, 0.5, dtype=np.float32),
+    ]
+
+    warmed = model.warm_state_prompt_buckets([image, image], "pick up", states)
+
+    assert warmed == [17, 23]
+    assert [p.max_prompt_len for p in FakePipeline.instances] == [17, 23]
+    assert model._needs_real_data_calibration is False
+    assert model.prompt is None
+
+
+def test_predict_recalibrates_when_prompt_bucket_changes():
+    from flash_rt.api import VLAModel
+
+    class BucketFrontend:
+        calibrated = False
+        calibrations = 0
+        prompt_states = []
+        _prompt_pipeline_cache = {}
+
+        def set_prompt(self, prompt, state=None):
+            type(self).prompt_states.append(tuple(state))
+            self.calibrated = False
+
+        def calibrate_with_real_data(self, observations):
+            type(self).calibrations += 1
+            self.calibrated = True
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    BucketFrontend.calibrations = 0
+    BucketFrontend.prompt_states = []
+    model = VLAModel(BucketFrontend(), framework="torch")
+
+    image = object()
+    model.predict([image], prompt="pick", state=[0.0])
+    model.predict([image], state=[0.0])
+    model.predict([image], state=[1.0])
+
+    assert BucketFrontend.prompt_states == [(0.0,), (1.0,)]
+    assert BucketFrontend.calibrations == 2
+
+
 def test_groot_thor_rejects_prompt_changes_after_graph_build():
     source = Path("flash_rt/frontends/torch/groot_thor.py").read_text()
     set_prompt_pos = source.index("    def set_prompt(self, prompt):")


### PR DESCRIPTION
## Summary
- Fix Pi0.5 state prompt handling through `VLAModel.predict(..., state=...)`.
- Cache Pi0.5 RTX / FP16 prompt runtime pipelines by prompt token length to avoid repeated autotune on recurring state prompt lengths.
- Add `warm_state_prompt_buckets(...)` for serving-time prewarm of representative state prompt lengths.
- Reset prompt/cache state on Thor Pi0.5 prompt changes.
- Guard GROOT Thor / N1.7 prompt runtime reuse.
- Route GROOT N1.6 RTX attention through vendored FA2 instead of requiring pip `flash_attn`.
- Update API/docs and add regression tests.

add example：reset / mid-rollout / near-goal / recorded rollout state as state_bucket_samples
usage e.g,：
```
warmed_lengths = model.warm_state_prompt_buckets(
    images=[base_img, wrist_img],
    prompt="pick up the red block",
    states=state_bucket_samples,
)
```