### PR TITLE
feat(async_loader): add camera_map parameter to make_step_dataloader

### DIFF
--- a/tests/test_recap_async_camera_map.py
+++ b/tests/test_recap_async_camera_map.py
@@ -1,0 +1,87 @@
+import sys
+import types
+
+import numpy as np
+import torch
+
+
+checkpoint_stub = types.ModuleType("training.rl.checkpoint")
+checkpoint_stub.save_lora_state = lambda trainer, path: path
+sys.modules.setdefault("training.rl.checkpoint", checkpoint_stub)
+
+trainer_stub = types.ModuleType("training.trainers.pi05_torch_trainer")
+trainer_stub.Pi05Trainer = object
+sys.modules.setdefault("training.trainers.pi05_torch_trainer", trainer_stub)
+
+from training.rl import train_recap as tr
+
+
+class _FakeConfig:
+    action_dim = 7
+
+
+class _FakeModel:
+    config = _FakeConfig()
+
+
+class _FakeTrainer:
+    is_compiled = True
+    device = "cpu"
+    model = _FakeModel()
+
+    def __init__(self):
+        self._param = torch.nn.Parameter(torch.zeros(()))
+
+    def trainable_parameters(self):
+        return [self._param]
+
+    def reset_peak_memory(self):
+        pass
+
+    def peak_memory_bytes(self):
+        return 0
+
+
+class _FakeDataset:
+    def build_chunk_starts(self, *, action_horizon):
+        assert action_horizon == 10
+        return np.array([0, 1, 2], dtype=np.int64)
+
+    def has_acp_column(self):
+        return False
+
+
+def test_train_recap_policy_passes_camera_map_to_async_loader(monkeypatch):
+    seen = {}
+
+    def fake_loader(*args, **kwargs):
+        seen["camera_map"] = kwargs.get("camera_map")
+        seen["action_dim_target"] = kwargs.get("action_dim_target")
+        return []
+
+    monkeypatch.setattr(tr, "make_step_dataloader", fake_loader)
+
+    camera_map = {
+        "base_0_rgb": "front",
+        "left_wrist_0_rgb": "wrist",
+        "right_wrist_0_rgb": None,
+    }
+    cfg = tr.RecapTrainConfig(
+        num_steps=1,
+        batch_size=2,
+        use_acp=False,
+        camera_map=camera_map,
+    )
+
+    tr.train_recap_policy(
+        _FakeTrainer(),
+        _FakeDataset(),
+        tokenizer=lambda tasks: (_ for _ in ()).throw(
+            AssertionError("tokenizer should not be called")),
+        observation_builder=lambda *args, **kwargs: None,
+        config=cfg,
+        derive_acp_if_missing=False,
+    )
+
+    assert seen["camera_map"] == camera_map
+    assert seen["action_dim_target"] == 7

--- a/training/README.md
+++ b/training/README.md
@@ -230,18 +230,26 @@ tokenizer = PaligemmaTokenizer(
 
 # 5. Run the generic driver. Identical to the LIBERO call below;
 # the difference is just *what dataset class* you hand in.
-cfg = RecapTrainConfig(num_steps=1000, batch_size=4, lr=2.5e-5, acp_dropout=0.30)
+cfg = RecapTrainConfig(
+    num_steps=1000,
+    batch_size=4,
+    lr=2.5e-5,
+    acp_dropout=0.30,
+    camera_map=MY_CAMERA_MAP,
+)
 result = train_recap_policy(
     trainer, MyDataset(), tokenizer, my_obs_builder,
     config=cfg, output_dir="<your-run-output-dir>",
 )
 ```
 
-Pass your `MY_CAMERA_MAP` to
-`make_step_dataloader(..., camera_map=MY_CAMERA_MAP)` (or use the
-`frames_to_observation(..., camera_map=...)` argument directly if
-you skip the async loader). The default is `LIBERO_CAMERA_MAP`,
-which is what the LIBERO example below uses implicitly.
+Put your `MY_CAMERA_MAP` on `RecapTrainConfig.camera_map`; the
+generic driver forwards it to the async step loader before images
+reach your `observation_builder`. If you bypass the driver, pass the
+same map to `make_step_dataloader(..., camera_map=MY_CAMERA_MAP)` or
+`frames_to_observation(..., camera_map=...)` directly. The default is
+`LIBERO_CAMERA_MAP`, which is what the LIBERO example below uses
+implicitly.
 
 The driver matches the openpi JAX baseline's optimiser + LR
 schedule 1-for-1: AdamW (`weight_decay=1e-10`) + warmup-cosine
@@ -331,9 +339,9 @@ Any dataset satisfying
 generic [`train_recap_policy`](rl/train_recap.py) entry point;
 LIBERO is the first concrete implementation. For a dataset with
 the same parquet layout but a different camera / state schema,
-pass a custom ``camera_map`` to
-``training/rl/observation.py:frames_to_observation`` (default is
-``LIBERO_CAMERA_MAP``).
+pass a custom ``camera_map`` through ``RecapTrainConfig``. The async
+loader applies the map before the decoded pi0.5 camera slots reach
+the observation builder. The default is ``LIBERO_CAMERA_MAP``.
 
 ### Async data prep + ``torch.compile`` (production fast path)
 

--- a/training/rl/async_loader.py
+++ b/training/rl/async_loader.py
@@ -1,4 +1,4 @@
-"""Async batch preparation for the LIBERO RECAP training driver.
+"""Async batch preparation for the RECAP training driver.
 
 Why this exists: a step-level ``torch.profiler`` trace
 (B=4, lora_rank=16, RTX 5090 SM120) showed that ~47 % of the per-step
@@ -66,6 +66,7 @@ class _Pi05StepDataset(Dataset):
         *,
         action_horizon: int,
         action_dim_target: int,
+        camera_map: dict[str, str | None] | None = None,
     ):
         if per_step_starts.ndim != 2:
             raise ValueError(
@@ -76,6 +77,7 @@ class _Pi05StepDataset(Dataset):
         self._starts = per_step_starts.astype(np.int64, copy=False)
         self._horizon = int(action_horizon)
         self._adim = int(action_dim_target)
+        self._camera_map = camera_map
 
     def __len__(self) -> int:
         return self._starts.shape[0]
@@ -103,7 +105,7 @@ class _Pi05StepDataset(Dataset):
                 f"action_dim {action_chunks.shape[-1]} > target {self._adim}"
             )
 
-        decoded = decode_frame_images(frames)
+        decoded = decode_frame_images(frames, camera_map=self._camera_map)
         states_np = np.stack([f.state for f in frames], axis=0).astype(np.float32)
         states_pad = pad_states(states_np)
         tasks = [f.task_name for f in frames]
@@ -153,6 +155,7 @@ def make_step_dataloader(
     action_dim_target: int,
     num_workers: int = 0,
     prefetch_factor: int = 2,
+    camera_map: dict[str, str | None] | None = None,
 ) -> DataLoader:
     """Wrap :class:`_Pi05StepDataset` in a ``DataLoader``.
 
@@ -162,12 +165,17 @@ def make_step_dataloader(
             the main thread (the synchronous reference path).
         prefetch_factor: Number of batches each worker prefetches.
             Ignored when ``num_workers == 0``.
+        camera_map: Mapping from pi0.5 camera keys to source keys in
+            ``frame.image_bytes``. ``None`` falls back to the LIBERO
+            default (see decode_frame_images() in training.rl.observation).
+            Pass a custom map for non-LIBERO datasets.
     """
     ds = _Pi05StepDataset(
         dataset,
         per_step_starts,
         action_horizon=action_horizon,
         action_dim_target=action_dim_target,
+        camera_map=camera_map,
     )
     kwargs: dict = dict(
         dataset=ds,

--- a/training/rl/train_recap.py
+++ b/training/rl/train_recap.py
@@ -24,9 +24,9 @@ The async loader expects the dataset to expose ``get_frame``,
 ``get_action_chunk``, and the camera-name → bytes-decoder
 contract that's currently fixed inside
 ``training.rl.async_loader.make_step_dataloader``. New datasets
-that need a different camera mapping should pass their own
-``camera_decoder`` to that loader (next step on the cleanup
-roadmap — out of scope for this driver).
+that need a different camera mapping should set
+``RecapTrainConfig.camera_map``; the async loader applies that map
+before handing decoded pi0.5 camera slots to ``observation_builder``.
 """
 
 from __future__ import annotations
@@ -96,6 +96,7 @@ class RecapTrainConfig:
     # overlapped with the GPU step.
     dataloader_workers: int = 0
     dataloader_prefetch_factor: int = 2
+    camera_map: dict[str, str | None] | None = None
 
     # ``torch.compile`` mode applied to ``trainer.model`` for the
     # training step. ``None`` keeps eager mode.
@@ -293,6 +294,7 @@ def train_recap_policy(
         action_dim_target=trainer.model.config.action_dim,
         num_workers=cfg.dataloader_workers,
         prefetch_factor=cfg.dataloader_prefetch_factor,
+        camera_map=cfg.camera_map,
     )
 
     losses: list[float] = []


### PR DESCRIPTION
While finetuning the model, I had a camera naming issues because the default libero cameras were hardcoded, so it wasn't possible to finetune on my dataset without patching the code.

This pr adds camera_map parameter to make_step_dataloader. If not provided, the code falls back to the libero default.