### PR TITLE
Feat/qwen36 agent capsule serving

### DIFF
--- a/docs/serving_production.md
+++ b/docs/serving_production.md
@@ -1,0 +1,300 @@
+# FlashRT Qwen3.6 agent serving — production architecture (seam-locking design)
+
+> **Status: APPROVED — decisions in §7 resolved (thinnest, coding-agent-first).**
+> This document locks the *interfaces* (seams) of the
+> production agent server so the core is designed once and never rewritten, then
+> stages the *implementation* correctness-first. It builds on
+> [`serving_design.md`](serving_design.md) (the capsule rationale) and is governed
+> by the mechanism-not-policy rule in [`exec_contract.md`](exec_contract.md) §9.
+> Nothing here adds a session/cache/schedule verb to the execution contract; all
+> of it lives in `serving/`. The one possible contract addition (host-backed
+> Buffer + cross-space copy) is already sanctioned by serving_design §3 and is
+> needed only by stage D.
+
+---
+
+## 0. Scope and non-goals
+
+**In scope (this document locks the interfaces for):** a single-node,
+latency-first OpenAI-compatible server for *agent* workloads — coding agents,
+multi-agent setups, and long-horizon tasks — on one consumer/edge GPU, around the
+existing single hot stateful Qwen3.6 frontend.
+
+**Explicitly NOT built (and the interfaces must not assume them):**
+
+- a **radix tree / paged-block KV** — impossible on hybrid recurrent state and
+  fatal to full-graph replay (serving_design §1, §3). Multi-session is
+  capsule swap-in/out, not paged concurrency.
+- a **heavy scheduler / continuous batching** — the engine is a single serial
+  stateful consumer; the worker is a thin serial loop, not a vLLM-style scheduler.
+- **multi-GPU routing now** — the interface must leave room for it (one worker =
+  one GPU/context, router by session affinity later) but we do not build it.
+
+The discipline: lock the seams comprehensively *now*; implement the thin correct
+version behind them; defer the heavy implementations without blocking them in the
+interface. "Design once" means the seams, not every feature.
+
+---
+
+## 1. What the workloads demand, and the three invariants
+
+Target workloads and the pressure each puts on the server:
+
+- **Coding agent / multi-agent.** Large reused prefix (system + tool schemas +
+  repo index, 10k–50k tokens); every turn a small user/tool/diff/log suffix; tool
+  calls always present; concurrent requests from parallel sub-agents; try/revert
+  branches.
+- **Long-horizon task.** Minutes-to-hours sessions; sustained decode near
+  `max_seq`; must survive client disconnect / server restart; KV memory pressure;
+  the user must be able to cancel a long generation cleanly.
+
+Three invariants the design must never violate (they come from the engine, not
+taste):
+
+1. **One stateful engine.** The Qwen3.6 frontend is a single hot GPU state
+   (KV + recurrent + conv + MTP). Exactly one request mutates it at a time.
+2. **KV must never lead the visible transcript.** If generation aborts (disconnect,
+   exception, cancel, stop-token lookahead) the GPU state may be ahead of the
+   committed journal; that session is then unsafe to hot-append and must be
+   invalidated (rebuild/restore next turn). The current `completed=False →
+   hot_session_id=None` guard in `service.py` is this invariant; every new path
+   must preserve it.
+3. **Full-graph replay is positional.** Decode graphs are keyed by exact
+   `(cur_pos, draft_k, mtp_cache_base)`; a request can only be cancelled at an
+   accept boundary, and prefix reuse on hybrid state is snapshot/restore, never
+   block gather.
+
+### Measured finding (2026-05-30): contiguous append does not survive EOS
+
+A turn that ends on a stop token (the realistic agent case — every answer / tool
+call ends with `<|im_end|>`) commits the stop token + any spec-verified lookahead
+into the GPU KV but **not** into the visible journal, so the KV leads the journal
+and `_mark_reusable` correctly invalidates the hot session
+(`hot_session_id = None`). Verified end-to-end: a 3-turn session of EOS-terminated
+turns reports `append(cold) → rebuild → rebuild`, full re-prefill each turn, never
+hot. Contiguous append only stays hot for turns capped by `max_tokens` (no EOS),
+which is **not** the agent workload. Consequence: **the coding-agent flat-prefill
+win comes from capsule restore (a clean committed boundary), not contiguous
+append.** This reorders the stages below (B before A) and means the
+`serving_design.md` §7 "prefix reuse keeps prefill flat" table was measured on
+`max_tokens`-capped turns; the serving README should say so to stay honest.
+
+---
+
+## 2. The five seams (the heart of this design)
+
+Each seam is an interface to lock now. Sketches are design-level Python, not final
+code.
+
+### Seam 1 — engine ⟷ worker boundary
+
+One worker thread owns the engine exclusively. The async HTTP layer only parses,
+enqueues, and forwards; it never touches the engine. This moves blocking GPU work
+off the event loop (fixes `/health` starvation) and gives one place for admission,
+ordering, and cancellation.
+
+```python
+@dataclass
+class WorkItem:
+    request: AgentRequest
+    submitted_at: float
+    cancel: "CancelToken"          # cooperative; checked at accept boundaries
+    sink: "ResultSink"             # future (non-stream) or bounded channel (stream)
+
+class EngineWorker:
+    """Single thread; owns AgentEngine + SessionRegistry. Serial consumer."""
+    def submit(self, item: WorkItem) -> None: ...      # called from event loop, non-blocking
+    def _run(self) -> None: ...                        # pop queue → prefill → decode → emit
+    def depth(self) -> int: ...                        # queued count, for /health + admission
+
+class CancelToken:
+    def cancel(self) -> None: ...
+    @property
+    def cancelled(self) -> bool: ...
+```
+
+- Non-stream request: handler `await`s a future the worker resolves.
+- Stream request: worker pushes `DecodeChunk`s into a **bounded** channel; the SSE
+  handler drains it. A slow client fills the channel → the worker applies
+  backpressure or (policy) drops the stream and invalidates the session — GPU
+  progress is decoupled from client read.
+- Cancellation: `cancel.cancelled` is checked at each accept boundary inside
+  `generate_stream`; on cancel the worker stops, then runs the existing
+  invalidation guard (invariant 2).
+
+The worker is intentionally a serial loop, **not** a scheduler. Multi-GPU later =
+N workers + an affinity router in front of `submit`; `AgentService`/engine
+unchanged.
+
+### Seam 2 — request lifecycle FSM
+
+Every request carries a small state record with a timestamp per transition. This
+*is* the observability schema (Seam 5) and the cancel/reject semantics in one.
+
+```
+  ENQUEUED ──(admission ok)──▶ QUEUED ──(worker picks up)──▶ PREFILL ──▶ DECODE ──▶ DONE
+      │                          │                              │           │
+      └──(admission reject)──▶ REJECTED                         │           ├──(cancel/disconnect)──▶ CANCELLED
+                                 (429 / 413 / 503)              └───────────┴──(engine error)──────▶ ERROR
+
+  Invariant: any exit that is not DONE-at-a-clean-boundary  ⇒  invalidate hot session.
+```
+
+Transitions stamp: `enqueued_at, started_at, first_token_at, finished_at`, plus
+`terminal_state`. CANCELLED and ERROR both trip invariant 2.
+
+### Seam 3 — session / capsule policy interface
+
+Extend the existing `SessionRegistry` + `PrefixPlan` (do not replace). Add the
+`restore` and `fork` actions and a capsule store; this is serving_design §6
+steps 2–3 made into a locked interface.
+
+```python
+# PrefixPlan.action ∈ {exact, append, message_append, restore, rebuild, fork, truncate}
+#   restore  : incoming extends a PINNED capsule (not the hot session) → restore + suffix prefill
+#   fork     : restore one capsule into an independent branch (tree-of-thought / retry)
+
+class CapsuleStore:
+    def pin(self, key: str, capsule, *, budget_bytes: int) -> None: ...
+    def get(self, key: str): ...
+    def evict_lru(self) -> None: ...
+    def footprint(self) -> int: ...        # for the budget (Seam 4)
+
+class SessionPolicy:                       # what the worker asks before each request
+    def plan(self, session, incoming_tokens, *, tools, salt) -> PrefixPlan: ...
+    def on_commit(self, session, tokens, *, lookahead: int) -> None: ...   # invariant 2
+```
+
+Pin source: an OpenAI-side field (`flashrt_pin_prefix`) or a `/v1/sessions`
+capsule option. Restore-vs-rebuild and which boundary to pin stay here (policy),
+never in the contract.
+
+### Seam 4 — resource budget / admission
+
+One limits object consulted at enqueue (admission) and at pin (capsule budget).
+Reject before OOM; never crash.
+
+```python
+@dataclass(frozen=True)
+class Limits:
+    max_prompt_tokens: int
+    max_output_tokens: int
+    max_active_sessions: int
+    max_queue_depth: int
+    session_idle_ttl_s: float
+    capsule_budget_bytes: int          # GPU + host tiers
+# admission → REJECTED(429 queue full / 413 too large / 503 over budget) at Seam 2.
+```
+
+### Seam 5 — metrics schema
+
+One structured record per request, derived from Seam 2 timestamps + engine stats.
+Emitted as the existing one-line log and an aggregate on `/health` (optionally a
+`/metrics` endpoint later).
+
+```
+  queued_ms, tokenize_ms, prefill_ms, first_delta_ms, decode_ms, decode_tok_per_s,
+  spec_attempts, spec_accepts, accept_length, graph_capture_count,
+  prefix_action, cached_tokens, new_prefill_tokens, terminal_state
+```
+
+(`GenerationStats.graph_misses` already exists as a placeholder; wire it here.)
+
+---
+
+## 3. How the gaps map onto the seams
+
+| gap | what it is | seam(s) that make it safe | stage |
+| --- | --- | --- | --- |
+| **B** | capsule not wired into the server (pin/restore policy, VRAM budget). The frontend capsule API is shipped + bit-exact (`test_qwen36_agent_capsule.py`). **This is the actual coding-agent reuse lever** (survives EOS; see the measured finding). | Seam 3 + Seam 4 | **1 (first feature)** |
+| C | clean cancellation + KV-never-leads-transcript on abort | Seam 1 + Seam 2 | 1 (correctness) |
+| F | resource limits / reject-before-OOM (capsule budget needed by B) | Seam 4 | 1–2 |
+| G | observability (queued/tokenize/capture/spec) | Seam 2 + Seam 5 | 2 |
+| (thin worker) | move GPU work off the event loop; admission | Seam 1 + Seam 2 | 2 |
+| A | tool-call turn contiguous append. **Demoted to optional**: EOS invalidates the hot session before it matters, so it only helps `max_tokens`-capped turns; the frontend append is fine, the gap is serving-layer suffix extraction with a safe rebuild fallback. | Seam 3 | optional |
+| D | long-horizon resume: capsule → host RAM / disk | Seam 3 + the one exec addition (§6) | deferred, interface reserved |
+| E | branch / undo as agent ops (fork / time-travel) | Seam 3 | deferred, interface reserved |
+
+---
+
+## 4. Correctness gates (non-negotiable)
+
+- **A:** tool-call multi-turn (assistant `content=null` + `tool_calls`, then `tool`
+  result) resent as full history is **token-exact** vs a cold full prefill of the
+  same rendered transcript; the suffix tokenizer reproduces the committed token
+  prefix or honestly reports `rebuild`. New test alongside
+  `test_qwen36_agent_gpu_split.py`.
+- **C:** a cancelled / disconnected request leaves no session marked hot
+  (invariant 2); the next turn rebuilds/restores and is token-exact.
+- **B/E:** capsule restore / fork stays bit-exact (already gated by
+  `test_qwen36_agent_capsule.py`); the *server* path inherits the same assertion.
+- **no-regression:** default path byte-identical; existing policy + warmup +
+  gpu-split suites stay green. Additive, opt-in.
+
+---
+
+## 5. Staged implementation (behind the locked seams)
+
+Correctness first; the user-visible levers next; heavy work deferred but its
+interface reserved. Each stage has its own acceptance gate.
+
+Reordered after the EOS finding: capsule (B) is the coding-agent lever and goes
+first; the tool-call contiguous-append (A) is demoted to optional.
+
+- **Stage 1 — capsule in the server + the correctness it needs (gaps B, C, and the
+  F budget B depends on).** Wire the shipped frontend capsule API into the policy
+  layer: a `CapsuleStore` (pin + small LRU + a byte budget so an over-budget pin is
+  rejected, not OOM), a `restore` `PrefixPlan` action, and the `flashrt_pin_prefix`
+  request field; snapshot at a chunk-aligned boundary (`capsule_aligned_len`) for
+  the long route. Make cancel/abort a first-class transition reusing the existing
+  invalidation guard (C). Gate: pinned-prefix `restore + append(suffix) + decode`
+  is **token-exact vs a cold full prefill** of the same prompt (the
+  `test_qwen36_agent_capsule.py` contract, now at the server level); over-budget
+  pin rejected; abort leaves no hot session; default path byte-identical.
+- **Stage 2 — thin worker + admission + metrics (Seams 1, 2, 4, 5; gaps F, G).**
+  Move GPU work onto one worker thread; HTTP enqueues; bounded queue + admission
+  (reject, not crash); lifecycle FSM + metrics. Gate: `/health` responsive during a
+  long decode; queue-full → 429; metric record complete; single-stream latency
+  unchanged.
+- **Optional — A (tool-call contiguous append).** Only helps `max_tokens`-capped
+  turns; revisit if a non-EOS streaming pattern needs it.
+- **Deferred, interface reserved — D (capsule→host/disk resume), E (fork/undo as
+  agent ops), multi-GPU router.** No code now; Seam 1/3 and the §6 exec addition
+  leave room. Built when a workload needs them.
+
+---
+
+## 6. The single allowed execution-contract addition
+
+Only stage D needs it: **host-backed `Buffer` + device↔host async copy** (D2H/H2D),
+so a capsule can be parked off-GPU and a long-horizon session can resume after a
+restart. This is still "named memory + copy" — mechanism, not policy
+(serving_design §3, exec §9). No `session` / `cache` / `schedule` verb enters the
+contract. Until D, capsules stay GPU-resident and the contract is untouched.
+
+---
+
+## 7. Decisions (resolved)
+
+Resolved thinnest-first, coding-agent-first; every "later" option keeps its
+interface hook so it can land without a core rewrite.
+
+1. **Concurrency contract for multi-agent:** **(a) fair serial queue now.** N
+   concurrent requests (even on different sessions) serialize through the one
+   worker. Capsule-swap per request (b) is a stage-3+ policy once `CapsuleStore`
+   exists; Seam 1 leaves the hook.
+2. **Cancel granularity:** **accept-boundary cancel only** now. A hard decode
+   deadline (`max_decode_ms`) is a later worker policy; the `CancelToken` /
+   `Limits` interfaces reserve it.
+3. **Pin API surface:** **`flashrt_pin_prefix` request field** now (no new
+   endpoint — thinnest for a coding agent that pins its system+repo prefix once).
+   An explicit `/v1/sessions` capsule endpoint is a later addition.
+4. **Metrics:** **fold into the `/health` aggregate** now (plus the existing
+   per-completion log line). A separate `/metrics` (Prometheus-style) is later.
+5. **Relationship to serving_design:** this **extends** serving_design §6/§10 —
+   serving_design stays the capsule rationale; this is the production engineering
+   layer. No supersession.
+
+Guiding principle for all of the above: usability and experience for one coding
+agent first; thinnest core that is correct; hooks (not implementations) for the
+rest.

--- a/docs/serving_production.md
+++ b/docs/serving_production.md
@@ -75,12 +75,23 @@ tokens even when the message prefix is semantically identical. The serving layer
 now appends the newly added message suffix after a known-equivalent visible
 message prefix, instead of forcing a full render byte-prefix match.
 
+This is the R1 continuation contract: the hot journal may retain internal
+non-thinking control tokens, and continuation happens from that committed
+boundary. A naive cold canonical render that strips those internal tokens is not
+the reference for hot reuse.
+
 Verified end-to-end on realistic EOS-terminated long-sequence turns:
 `append(cold) → message_append → message_append`, with `new_prefill_tokens`
 dropping from thousands to tens and TTFT staying ~70-150 ms. Capsule restore is
 still the right primitive for shared-prefix reuse across fresh sessions,
 branches, restarts, or non-hot workers; it is no longer required for the normal
 single hot coding-agent loop.
+
+The frontend-level correctness gate is token-exact: decode with a stop token
+inside a speculative chunk, rollback to the stop boundary, append a suffix, and
+decode again must match prefill to the exact stopped boundary plus the same
+suffix. This is covered for short and long routes in
+`tests/test_qwen36_agent_gpu_split.py`.
 
 ### Measured finding (2026-05-31): session id is not an ecosystem contract
 

--- a/docs/serving_production.md
+++ b/docs/serving_production.md
@@ -82,6 +82,21 @@ still the right primitive for shared-prefix reuse across fresh sessions,
 branches, restarts, or non-hot workers; it is no longer required for the normal
 single hot coding-agent loop.
 
+### Measured finding (2026-05-31): session id is not an ecosystem contract
+
+OpenAI-compatible clients generally resend the full message/tool history and do
+not carry a backend-specific session id. A FlashRT session id is therefore only a
+native affinity hint. The production path must be automatic and content-addressed:
+tokenize the incoming OpenAI request, try to attach it to the current hot
+token/message prefix, then fall back to capsule restore or cold prefill. This
+matches the ecosystem expectation set by OpenAI prompt caching, vLLM Automatic
+Prefix Caching, and SGLang prefix caching: clients may provide namespace hints
+(`prompt_cache_key`, `cache_salt`), but they should not need FlashRT-specific
+fields for normal prefix reuse.
+
+The implemented v1 remains capsule/hot-state granular, not block-radix. It does
+not add a KV-block table or scheduler to the execution contract.
+
 ---
 
 ## 2. The five seams (the heart of this design)

--- a/docs/serving_production.md
+++ b/docs/serving_production.md
@@ -161,11 +161,14 @@ Every request carries a small state record with a timestamp per transition. This
 Transitions stamp: `enqueued_at, started_at, first_token_at, finished_at`, plus
 `terminal_state`. CANCELLED and ERROR both trip invariant 2.
 
-### Seam 3 — session / capsule policy interface
+### Seam 3 — automatic prefix / capsule policy interface
 
-Extend the existing `SessionRegistry` + `PrefixPlan` (do not replace). Add the
-`restore` and `fork` actions and a capsule store; this is serving_design §6
-steps 2–3 made into a locked interface.
+Extend the existing `SessionRegistry` + `PrefixPlan` (do not replace), but do
+not make a client session id the compatibility contract. The worker first asks
+an automatic prefix policy to match the incoming tokenized OpenAI request against
+the current hot state; explicit session ids are affinity hints. Add the `restore`
+and `fork` actions and a capsule store; this is serving_design §6 steps 2–3 made
+into a locked interface.
 
 ```python
 # PrefixPlan.action ∈ {exact, append, message_append, restore, rebuild, fork, truncate}
@@ -178,12 +181,13 @@ class CapsuleStore:
     def evict_lru(self) -> None: ...
     def footprint(self) -> int: ...        # for the budget (Seam 4)
 
-class SessionPolicy:                       # what the worker asks before each request
-    def plan(self, session, incoming_tokens, *, tools, salt) -> PrefixPlan: ...
+class AutoPrefixPolicy:                    # what the worker asks before each request
+    def plan(self, incoming_tokens, *, session_hint, tools, salt) -> PrefixPlan: ...
     def on_commit(self, session, tokens, *, lookahead: int) -> None: ...   # invariant 2
 ```
 
-Pin source: an OpenAI-side field (`flashrt_pin_prefix`) or a `/v1/sessions`
+Namespace source is `prompt_cache_key > cache_salt > native salt/default`.
+Pin source is an OpenAI-side field (`flashrt_pin_prefix`) or a `/v1/sessions`
 capsule option. Restore-vs-rebuild and which boundary to pin stay here (policy),
 never in the contract.
 

--- a/docs/serving_production.md
+++ b/docs/serving_production.md
@@ -64,20 +64,23 @@ taste):
    accept boundary, and prefix reuse on hybrid state is snapshot/restore, never
    block gather.
 
-### Measured finding (2026-05-30): contiguous append does not survive EOS
+### Measured finding (2026-05-31): EOS turns can stay hot if the boundary is committed
 
-A turn that ends on a stop token (the realistic agent case — every answer / tool
-call ends with `<|im_end|>`) commits the stop token + any spec-verified lookahead
-into the GPU KV but **not** into the visible journal, so the KV leads the journal
-and `_mark_reusable` correctly invalidates the hot session
-(`hot_session_id = None`). Verified end-to-end: a 3-turn session of EOS-terminated
-turns reports `append(cold) → rebuild → rebuild`, full re-prefill each turn, never
-hot. Contiguous append only stays hot for turns capped by `max_tokens` (no EOS),
-which is **not** the agent workload. Consequence: **the coding-agent flat-prefill
-win comes from capsule restore (a clean committed boundary), not contiguous
-append.** This reorders the stages below (B before A) and means the
-`serving_design.md` §7 "prefix reuse keeps prefill flat" table was measured on
-`max_tokens`-capped turns; the serving README should say so to stay honest.
+The production stream now stops at the visible stop-token boundary and does not
+leave speculative lookahead ahead of the client-visible transcript. A second
+issue was Qwen3.6's hidden non-thinking generation prompt
+(`<think>\n\n</think>\n\n`): OpenAI clients replay only visible assistant text,
+so the full rendered prompt can differ from the internal hot KV journal by a few
+tokens even when the message prefix is semantically identical. The serving layer
+now appends the newly added message suffix after a known-equivalent visible
+message prefix, instead of forcing a full render byte-prefix match.
+
+Verified end-to-end on realistic EOS-terminated long-sequence turns:
+`append(cold) → message_append → message_append`, with `new_prefill_tokens`
+dropping from thousands to tens and TTFT staying ~70-150 ms. Capsule restore is
+still the right primitive for shared-prefix reuse across fresh sessions,
+branches, restarts, or non-hot workers; it is no longer required for the normal
+single hot coding-agent loop.
 
 ---
 
@@ -206,12 +209,12 @@ Emitted as the existing one-line log and an aggregate on `/health` (optionally a
 
 | gap | what it is | seam(s) that make it safe | stage |
 | --- | --- | --- | --- |
-| **B** | capsule not wired into the server (pin/restore policy, VRAM budget). The frontend capsule API is shipped + bit-exact (`test_qwen36_agent_capsule.py`). **This is the actual coding-agent reuse lever** (survives EOS; see the measured finding). | Seam 3 + Seam 4 | **1 (first feature)** |
+| **B** | capsule not wired into the server (pin/restore policy, VRAM budget). The frontend capsule API is shipped + bit-exact (`test_qwen36_agent_capsule.py`). This is the shared-prefix reuse lever for fresh sessions, branches, restarts, and non-hot workers; the single hot EOS loop now uses `message_append`. | Seam 3 + Seam 4 | **1 (first feature)** |
 | C | clean cancellation + KV-never-leads-transcript on abort | Seam 1 + Seam 2 | 1 (correctness) |
 | F | resource limits / reject-before-OOM (capsule budget needed by B) | Seam 4 | 1–2 |
 | G | observability (queued/tokenize/capture/spec) | Seam 2 + Seam 5 | 2 |
 | (thin worker) | move GPU work off the event loop; admission | Seam 1 + Seam 2 | 2 |
-| A | tool-call turn contiguous append. **Demoted to optional**: EOS invalidates the hot session before it matters, so it only helps `max_tokens`-capped turns; the frontend append is fine, the gap is serving-layer suffix extraction with a safe rebuild fallback. | Seam 3 | optional |
+| A | tool-call / text turn contiguous append. The hot EOS loop is now viable: stop-aware committed stream + message-boundary suffix append keeps visible OpenAI history connected to the internal KV journal, with safe rebuild fallback on divergence. | Seam 3 | shipped, keep hardening |
 | D | long-horizon resume: capsule → host RAM / disk | Seam 3 + the one exec addition (§6) | deferred, interface reserved |
 | E | branch / undo as agent ops (fork / time-travel) | Seam 3 | deferred, interface reserved |
 

--- a/flash_rt/frontends/torch/qwen36_rtx.py
+++ b/flash_rt/frontends/torch/qwen36_rtx.py
@@ -4731,7 +4731,8 @@ class Qwen36TorchFrontendRtx:
         return self._agent_pending_tok_buf
 
     def decode_own_speculative_nvfp4_committed_stream(
-            self, *, max_new_tokens: int, K: int = 6):
+            self, *, max_new_tokens: int, K: int = 6,
+            stop_token_ids=None):
         """Decode from the current committed-stream boundary.
 
         Every yielded chunk has already been replayed through the main model.
@@ -4754,6 +4755,7 @@ class Qwen36TorchFrontendRtx:
         hidden = self._cfg['hidden_size']
         cur_pos = int(self._agent_stream_cur_pos)
         pending_tok = self._agent_stream_pending_tok
+        stop_ids = {int(t) for t in (stop_token_ids or ())}
         h = self._agent_stream_h
         ev_pf0 = self._agent_stream_pf0
         ev_pf1 = self._agent_stream_pf1
@@ -4878,6 +4880,7 @@ class Qwen36TorchFrontendRtx:
                 # Commit and yield only inputs that verify actually processed:
                 # pending token + accepted drafts.  The correction/bonus token
                 # becomes private lookahead for the next cycle.
+                step_start = cur_pos
                 committed = [int(pending_tok.item())]
                 if N > 0:
                     committed.extend(int(x) for x in all_argmax[:N].tolist())
@@ -4909,7 +4912,33 @@ class Qwen36TorchFrontendRtx:
                     raise RuntimeError(
                         'internal error: committed chunk exceeds remaining '
                         'budget')
-                commit_count = len(committed)
+                stop_i = next(
+                    (i for i, tok in enumerate(committed)
+                     if tok in stop_ids),
+                    None,
+                )
+                stop_after_yield = stop_i is not None
+                if stop_i is not None:
+                    committed = committed[:stop_i + 1]
+                    commit_count = len(committed)
+                    if stop_i != (cur_pos - step_start - 1):
+                        fvk.gpu_copy(
+                            self._lin_state.data_ptr(),
+                            self._K_lin_state_per_step[stop_i].data_ptr(),
+                            self._lin_state.numel() * 2, s,
+                        )
+                        fvk.gpu_copy(
+                            self._lin_conv_state.data_ptr(),
+                            self._K_lin_conv_state_per_step[stop_i].data_ptr(),
+                            self._lin_conv_state.numel() * 2, s,
+                        )
+                    pending_tok = self._agent_stable_pending_tok(
+                        all_argmax[stop_i:stop_i + 1].view(1, 1))
+                    h = self._K_last_hidden_buf[
+                        :, stop_i:stop_i + 1, :].contiguous()
+                    cur_pos = step_start + commit_count
+                else:
+                    commit_count = len(committed)
                 self._prefill_h_cache[
                     commit_start:commit_start + commit_count].copy_(
                         self._K_last_hidden_buf[
@@ -4919,6 +4948,8 @@ class Qwen36TorchFrontendRtx:
                 self._agent_stream_pending_tok = pending_tok
                 self._agent_stream_h = h
                 yield tuple(committed)
+                if stop_after_yield:
+                    break
 
             ev_dec1.record()
             torch.cuda.synchronize()
@@ -9119,7 +9150,8 @@ class Qwen36TorchFrontendRtx:
         self._agent_stream_pf1 = ev_pf1
 
     def decode_long_ctx_nvfp4_committed_stream(
-            self, *, max_new_tokens: int, K: int = 6):
+            self, *, max_new_tokens: int, K: int = 6,
+            stop_token_ids=None):
         """Yield committed chunks from the long FP8-KV/TQ agent boundary."""
         import torch
 
@@ -9137,6 +9169,7 @@ class Qwen36TorchFrontendRtx:
         cur_pos = int(self._agent_stream_cur_pos)
         prompt_len = int(self._agent_stream_prompt_len)
         pending_tok = self._agent_stream_pending_tok
+        stop_ids = {int(t) for t in (stop_token_ids or ())}
         h = self._agent_stream_h
         mtp_base = int(self._agent_stream_mtp_base)
         K = int(getattr(self, '_agent_stream_K', K))
@@ -9342,6 +9375,8 @@ class Qwen36TorchFrontendRtx:
                 self._spec_attempts += 1
                 self._spec_accepts += N
 
+                step_start = cur_pos
+                mtp_start = mtp_base
                 committed = [int(pending_tok.item())]
                 if N > 0:
                     committed.extend(int(x) for x in all_argmax[:N].tolist())
@@ -9369,12 +9404,38 @@ class Qwen36TorchFrontendRtx:
                         all_argmax[N:N + 1].view(1, 1))
                     cur_pos += N + 1
                     mtp_base += N + 1
+                stop_i = next(
+                    (i for i, tok in enumerate(committed)
+                     if tok in stop_ids),
+                    None,
+                )
+                stop_after_yield = stop_i is not None
+                if stop_i is not None:
+                    committed = committed[:stop_i + 1]
+                    commit_count = len(committed)
+                    if stop_i != (cur_pos - step_start - 1):
+                        fvk.gpu_copy(
+                            self._lin_state.data_ptr(),
+                            self._K_lin_state_per_step[stop_i].data_ptr(),
+                            self._lin_state.numel() * 2, s,
+                        )
+                        fvk.gpu_copy(
+                            self._lin_conv_state.data_ptr(),
+                            self._K_lin_conv_state_per_step[stop_i].data_ptr(),
+                            self._lin_conv_state.numel() * 2, s,
+                        )
+                    h = self._K_last_hidden_buf[:, stop_i:stop_i + 1, :]
+                    pending_tok = self._agent_stable_pending_tok(
+                        all_argmax[stop_i:stop_i + 1].view(1, 1))
+                    cur_pos = step_start + commit_count
+                    mtp_base = mtp_start + commit_count
+                else:
+                    commit_count = len(committed)
                 self._tq_mark_dequant_valid_end(cur_pos)
                 self._fp8_mark_dequant_valid_end(cur_pos)
 
-                commit_count = len(committed)
                 self._agent_long_h_tail_append(
-                    cur_pos - commit_count,
+                    step_start,
                     self._K_last_hidden_buf[:, :commit_count, :].view(
                         commit_count, hidden))
                 emitted += len(committed)
@@ -9383,6 +9444,8 @@ class Qwen36TorchFrontendRtx:
                 self._agent_stream_h = h
                 self._agent_stream_mtp_base = mtp_base
                 yield tuple(committed)
+                if stop_after_yield:
+                    break
 
                 if (adaptive_k and K > 3
                         and self._spec_attempts >= 8

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -115,6 +115,14 @@ assistant turn. Divergent prompts rebuild or restore at a future checkpoint
 boundary. Truncation also rebuilds in v1: the frontend cannot roll the hot GPU
 state back to a shorter prefix until checkpoint/rollback support lands.
 
+The hot journal is the source of truth for continuation. For Qwen3.6
+non-thinking mode it may include internal empty `<think></think>` control tokens
+that are not visible in the OpenAI assistant message. That R1 continuation
+contract is intentional: later turns append after the committed hot journal, not
+after a freshly rendered visible-only prompt. Tests compare against exact hot
+boundary continuation, not a naive canonical render with those internal tokens
+stripped.
+
 For OpenAI-style clients that resend the full message list every turn, prefix
 reuse requires the history to include the assistant content/tool call emitted by
 the previous response. If a client sends only the new user/tool message without
@@ -483,7 +491,8 @@ PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q \
 ```
 
 The GPU split test is skipped unless both checkpoint variables are present.  To
-validate real Qwen3.6 short/long split and long append equivalence:
+validate real Qwen3.6 short/long split, long append equivalence, and stop-token
+rollback at a speculative chunk boundary:
 
 ```bash
 FLASHRT_QWEN36_NVFP4_CKPT_DIR=CHECKPOINT_DIR \

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -34,6 +34,7 @@ python -m serving.qwen36_agent.server \
   --model-name qwen36-27b \
   --max-seq 32768 \
   --route-min-seq 0 \
+  --default-K 6 \
   --host 127.0.0.1 --port 8000
 # startup loads the model, then logs: Uvicorn running on http://127.0.0.1:8000
 ```
@@ -176,6 +177,7 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--warmup-preset` | `none` | startup warmup shapes: `none` / `agent` / `short` / `long` / `all`; production agent serving does not need graph warmup by default |
 | `--warmup` | `""` | extra warmup shapes, comma-separated `prompt_len:max_tokens` |
 | `--warmup-K` | `6` | speculative K used during warmup |
+| `--default-K` | `6` | default speculative decode K for live requests; OpenAI-compatible clients inherit this unless they pass `flashrt_K` |
 | `--warmup-committed-max-prompt` | `1024` | run real committed-stream warmup up to this prompt length; larger long-context shapes use graph-only warmup |
 | `--warm-long-prefill-graphs` | off | also capture long-context prefill chunk graphs at startup |
 | `--capsule-budget-mb` | `0` | GPU byte budget (MB) for pinned shared-prefix capsules; `0` disables pinning. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-for-non-hot-requests). |
@@ -219,6 +221,10 @@ decode graphs are keyed by the live `cur_pos` and hurt first-use latency in a
 continually growing session. Set those graph flags to `1` before startup only
 for fixed-shape warmed benchmark runs. `/health` reports the kernel flags.
 
+`--default-K` controls live serving, while `--warmup-K` controls startup warmup.
+Use `--default-K` when a standard OpenAI-compatible client cannot pass FlashRT
+extension fields. Native clients may hot-switch per request with `flashrt_K`.
+
 ## HTTP surface and request fields
 
 OpenAI-compatible: `GET /v1/models`, `GET /health`, `POST /v1/chat/completions`,
@@ -243,7 +249,8 @@ before streaming begins.
   `prompt_cache_key`.
 - `flashrt_session_id` (or `session_id`): optional native session-affinity hint.
 - `flashrt_cache_salt`: legacy FlashRT namespace separator.
-- `flashrt_K`: speculative decode K for this request (default 6).
+- `flashrt_K`: speculative decode K for this request; overrides server
+  `--default-K`.
 - `enable_thinking`: passed to the Qwen chat template (default false).
 - `flashrt_pin_prefix`: pin this request's shared prefix as a capsule for reuse —
   an integer (pin that many leading prompt tokens) or `true` (pin the whole

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -30,7 +30,7 @@ python -m serving.qwen36_agent.server \
   --checkpoint /path/to/qwen36_nvfp4 \
   --model-name qwen36-27b \
   --host 127.0.0.1 --port 8000
-# startup runs graph warmup, then logs: Uvicorn running on http://127.0.0.1:8000
+# startup loads the model, then logs: Uvicorn running on http://127.0.0.1:8000
 ```
 
 **2. Check it is up**
@@ -74,8 +74,10 @@ decode), so the visible transcript never runs ahead of the GPU state.
 - Latency-first, single-stream hot session by default.
 - Exact token-prefix reuse for coding-agent turns: cold prefill once, then only
   prefill appended user/tool/diff/log tokens.
-- Startup committed-stream warmup so the first real request does not pay
-  CUDA Graph capture for common agent prompt shapes.
+- Direct long-decode kernel launch by default for live agent sessions, so a
+  growing conversation does not pay exact-position CUDA Graph capture in the
+  first real request. Fixed-shape graph replay remains opt-in for demos and
+  benchmarks.
 - True SSE streaming at speculative-decode accept boundaries.
 - Streamed tokens are session-committed tokens only. The old stateless
   full-generate shortcut of over-verifying and trimming output is forbidden in
@@ -88,7 +90,7 @@ decode), so the visible transcript never runs ahead of the GPU state.
 ## v1 cache policy
 
 The first backend is contiguous and session-first because that matches the
-current fastest Qwen3.6 CUDA-graph replay path. A request can reuse the hot
+current fastest Qwen3.6 single-stream kernel path. A request can reuse the hot
 frontend state when its tokenized prompt exactly extends the cached session
 prefix.
 
@@ -148,8 +150,8 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--device` | `cuda` | torch device |
 | `--max-seq` | `262208` | max sequence length (prompt + generation) |
 | `--route-min-seq` | `0` | min prompt length sent to the chunked long-context FP8-KV path; `0` routes even short real prompts there to avoid request-time per-position graph capture |
-| `--graph-cache-max` | auto | per-cache CUDA-graph LRU bound; auto-scales with `--max-seq` (1024 at ≤32K, 256 at ≤128K, 128 at 256K) so small-context deployments keep warmed graphs across requests instead of evicting + re-capturing. Override to force a value. |
-| `--warmup-preset` | `agent` | startup warmup shapes: `agent` / `short` / `long` / `all` / `none` |
+| `--graph-cache-max` | auto | per-cache CUDA-graph LRU bound for opt-in exact graph replay; the production agent default uses direct long-decode kernels instead of exact-position decode graphs |
+| `--warmup-preset` | `none` | startup warmup shapes: `none` / `agent` / `short` / `long` / `all`; production agent serving does not need graph warmup by default |
 | `--warmup` | `""` | extra warmup shapes, comma-separated `prompt_len:max_tokens` |
 | `--warmup-K` | `6` | speculative K used during warmup |
 | `--warmup-committed-max-prompt` | `1024` | run real committed-stream warmup up to this prompt length; larger long-context shapes use graph-only warmup |
@@ -168,9 +170,10 @@ budget plus the long FP8-KV route (`--route-min-seq 0` and a long-context
 `--max-seq`). It fails fast instead of silently falling back to the legacy short
 prefill path.
 
-Startup warmup moves CUDA-graph capture out of the first request: it runs real
-committed-stream warmup for short/medium shapes and graph-only warmup for larger
-long-context shapes.
+Startup warmup is optional. The production agent default avoids exact-position
+decode graphs on the live path, so arbitrary coding-agent sessions do not need
+minutes of synthetic warmup. Use `--warmup-preset agent/all` only when you are
+intentionally preparing fixed-shape graph-replay demos or benchmarks.
 
 Startup logs print every queued warmup shape and then a `startup warmup done
 i/N` line as each shape finishes. Per-request logs use the same metric fields for
@@ -185,10 +188,14 @@ For streaming responses, `decode_tok/s` measures backend decode-active time;
 `stream_wall_tok/s` includes SSE/client backpressure and is the user-visible
 streaming wall-time rate.
 
-On SM120, the server defaults to the same optimized decode kernels used by the
+On SM120, the server defaults to the optimized decode kernels used by the
 benchmark path (`FLASHRT_QWEN36_DECODE_FASTGEMM=1` and
-`FLASHRT_QWEN36_VERIFY_WARPSPLIT=1`) unless the environment explicitly overrides
-them before startup. `/health` reports both flags.
+`FLASHRT_QWEN36_VERIFY_WARPSPLIT=1`). It also defaults
+`FLASHRT_QWEN36_TQ_VERIFY_GRAPH=0` and
+`FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH=0` for agent serving, because exact-position
+decode graphs are keyed by the live `cur_pos` and hurt first-use latency in a
+continually growing session. Set those graph flags to `1` before startup only
+for fixed-shape warmed benchmark runs. `/health` reports the kernel flags.
 
 ## HTTP surface and request fields
 
@@ -256,15 +263,11 @@ server without prefix reuse re-prefills the full prompt every turn (589 tokens o
 turn 4). This is the `append` / `message_append` path; correctness is gated
 token-exact by `tests/test_qwen36_agent_gpu_split.py`.
 
-> **Honest scope of contiguous append.** This flat-prefill table is measured on
-> turns capped by `max_tokens` (no stop token). A turn that ends on `<|im_end|>`
-> — the realistic agent case — commits the stop token plus spec lookahead into the
-> KV but not the visible journal, so the hot session is correctly invalidated and
-> the **next turn rebuilds**. Contiguous `append` / `message_append` therefore
-> only keeps prefill flat across non-EOS turns. For the realistic EOS-terminated
-> coding-agent loop, the reuse that survives is [capsule
-> pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos): a fresh turn
-> restores a clean committed boundary and re-prefills only the suffix.
+> **Honest scope of contiguous append.** The committed stream stops at the
+> visible stop-token boundary, so the hot session remains reusable when the next
+> OpenAI request resends the prior assistant/tool turn. If a client rewrites or
+> omits prior visible history, the token stream is no longer append-only and the
+> server rebuilds or restores from a capsule instead of reporting a fake hit.
 
 **2. Capsule restore replaces a shared-prefix cold prefill with a flat copy.**
 Snapshot a shared prefix once, then restore + append the new suffix instead of
@@ -321,10 +324,10 @@ reuse per se.
 only): warm steady-state matches the frontend's documented decode number; the
 serving policy adds no measurable decode overhead.
 
-**3. Warm decode is stable across task types** (real `/v1/chat/completions`,
-median of 3 warm runs, `--graph-cache-max` auto):
+**3. Decode is stable across task types** (real `/v1/chat/completions`,
+median of 3 runs in the fixed-shape warmed benchmark mode):
 
-| scenario | ctx | warm decode tok/s |
+| scenario | ctx | fixed-shape decode tok/s |
 | --- | ---: | ---: |
 | code (merge sort) | 20 | 159.0 |
 | reasoning (bat & ball) | 41 | 150.3 |
@@ -336,9 +339,9 @@ median of 3 warm runs, `--graph-cache-max` auto):
 
 Run-to-run variance < 2%. Decode tok/s varies with the task's speculative
 accept-length (predictable code/reasoning highest; long-context attention pulls
-the 3K-context RAG case down) — not with the serving path. These are warm
-numbers; the first request of a brand-new prompt length still pays one-time
-graph capture (see Cold start below).
+the 3K-context RAG case down) — not with the serving path. These rows are the
+fixed-shape warmed graph-replay benchmark mode, not the production agent
+default.
 
 To reproduce these rows, keep the same serving envelope and measurement
 discipline:
@@ -346,6 +349,8 @@ discipline:
 ```bash
 export FLASHRT_QWEN36_MTP_CKPT_DIR=/path/to/qwen36_mtp_ckpt
 export FLASHRT_QWEN36_LONG_KV_CACHE=fp8
+export FLASHRT_QWEN36_TQ_VERIFY_GRAPH=1
+export FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH=1
 python -m serving.qwen36_agent.server \
   --checkpoint /path/to/qwen36_nvfp4 \
   --max-seq 32768 \
@@ -354,24 +359,11 @@ python -m serving.qwen36_agent.server \
   --host 127.0.0.1 --port 8000
 ```
 
-Then run the same prompt shape at least once to warm exact decode graph keys and
-report the later `flashrt.decode_tok_per_s` values. Very short answers, early
-EOS, dense RAG summaries, or a first traversal of a new prompt length will not
-match the table; those are different accept-length / cold-capture regimes rather
-than serving overhead.
-
-**Cold start.** The first request of a not-yet-seen prompt length / accept
-trajectory pays CUDA-graph capture for the decode / verify / MTP-chain graphs it
-traverses (~one decode's worth, e.g. first call ~35 tok/s → warm ~138). Because
-these graphs are keyed by exact `(cur_pos, draft_k, mtp_cache_base)`, startup
-warmup cannot pre-cover every arbitrary prompt length, so this one-time capture
-is inherent to the exact-key fast-replay design. What `--graph-cache-max`
-(auto-scaled, above) fixes is the *repeated* cold start: at the old fixed cap of
-128 the warmed graphs were evicted between requests, so the server kept
-re-capturing; with the larger cap the warmed graphs survive and the server stays
-warm across requests and prompt lengths after the first traversal (measured: a
-short prompt re-hit after intervening medium/long requests stays at ~150 tok/s,
-no re-capture).
+The production agent path should be measured without those graph flags: it uses
+direct verify/MTP-chain kernel launch, so an arbitrary new prompt length no
+longer falls to cold graph-capture throughput. On RTX 5090, first-use live
+requests measured ~122 tok/s for a short text stream and ~130 tok/s for a
+tool-shaped stream with K=6.
 
 ## Session prefix reuse (walkthrough)
 

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -172,8 +172,11 @@ committed-stream warmup for short/medium shapes and graph-only warmup for larger
 long-context shapes.
 
 Startup logs print every queued warmup shape and then a `startup warmup done
-i/N` line as each shape finishes. Per-request logs use the same metric fields for
-both buffered and streaming responses:
+i/N` line as each shape finishes. Committed-stream warmup results include
+`completion_tokens`, `decode_ms`, and `decode_tok/s`; graph-only warmup results
+report graph counts instead because they do not execute a real decode stream.
+Per-request logs use the same metric fields for both buffered and streaming
+responses:
 
 ```text
 complete sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -146,9 +146,10 @@ short-context committed split:
   `decode_own_speculative_nvfp4_committed_stream` or
   `decode_long_ctx_nvfp4_committed_stream`
 
-Long-context append-prefill is limited to the currently hot contiguous session.
-Non-hot sessions still rebuild/restore at the policy layer rather than reporting
-a fake cache hit.
+Long-context append-prefill is limited to the currently hot contiguous frontend
+state. Requests without `flashrt_session_id` can still attach to that hot state
+when their tokenized OpenAI history is an exact extension. Non-hot prompts still
+rebuild/restore at the policy layer rather than reporting a fake cache hit.
 Exact same-length prompts continue from the current hot boundary; shorter
 prompts rebuild until rollback/checkpoint support lands.
 
@@ -169,10 +170,10 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--warmup-K` | `6` | speculative K used during warmup |
 | `--warmup-committed-max-prompt` | `1024` | run real committed-stream warmup up to this prompt length; larger long-context shapes use graph-only warmup |
 | `--warm-long-prefill-graphs` | off | also capture long-context prefill chunk graphs at startup |
-| `--capsule-budget-mb` | `0` | GPU byte budget (MB) for pinned shared-prefix capsules; `0` disables pinning. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos). |
+| `--capsule-budget-mb` | `0` | GPU byte budget (MB) for pinned shared-prefix capsules; `0` disables pinning. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-for-non-hot-requests). |
 | `--default-max-tokens` | `2048` | generated-token budget used when a request omits both `max_tokens` and `max_completion_tokens` |
 | `--max-output-tokens` | `8192` | hard generated-token cap; requests above this return HTTP 400 instead of being silently truncated |
-| `--default-session-id` | unset | fallback session id for requests that omit `flashrt_session_id` / `session_id`; intended only for single-client local agent demos or trusted one-user deployments |
+| `--default-session-id` | unset | legacy fallback session id for older single-client demos; normal OpenAI-compatible clients should rely on automatic hot-prefix reuse instead |
 | `--host` / `--port` | `127.0.0.1` / `8000` | bind address |
 | `--log-level` | `info` | uvicorn log level |
 | `--access-log` | off | enable uvicorn per-request access logs; off by default to avoid benchmark jitter |
@@ -239,7 +240,7 @@ before streaming begins.
 - `flashrt_pin_prefix`: pin this request's shared prefix as a capsule for reuse —
   an integer (pin that many leading prompt tokens) or `true` (pin the whole
   prompt's chunk-aligned head). Inert unless the server was started with
-  `--capsule-budget-mb > 0`. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos).
+  `--capsule-budget-mb > 0`. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-for-non-hot-requests).
 
 OpenAI-compatible clients do not need to pass FlashRT extension fields for the
 normal single hot conversation path. The server tokenizes the full resent
@@ -415,14 +416,15 @@ If a client sends only the new message without the prior assistant turn, or a
 shorter/divergent prompt, the token stream has diverged and the server rebuilds
 or restores at a checkpoint boundary (it reports `rebuild`, never a fake hit).
 
-## Capsule pinning (shared-prefix reuse that survives EOS)
+## Capsule pinning (shared-prefix reuse for non-hot requests)
 
-A coding agent resends a large stable prefix every turn — system prompt, tool
-schemas, repo index/summary — then a small new user/tool suffix, and each turn
-ends on a stop token. Because an EOS-terminated turn invalidates contiguous append
-(above), the way to reuse that prefix is to **pin it as an execution-state
-capsule** and *restore* a clean committed boundary on every later turn/session,
-re-prefilling only the suffix. This is FlashRT's graph-replay-native prefix reuse
+A coding agent often resends a large stable prefix — system prompt, tool
+schemas, repo index/summary — plus a small user/tool/diff suffix. The normal
+single hot conversation uses automatic `append` / `message_append`. Capsules are
+for the cases that hot-state append cannot cover: fresh sessions, branch/fork,
+restart/resume, non-hot workers, or a deliberately pinned shared prefix reused by
+multiple later requests. A capsule restores a clean committed boundary and
+re-prefills only the suffix. This is FlashRT's graph-replay-native prefix reuse
 (see [`capsules.md`](capsules.md) and [`../../docs/serving_design.md`](../../docs/serving_design.md)).
 
 Enable it at startup with a GPU byte budget, then pin per request:

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -177,8 +177,12 @@ both buffered and streaming responses:
 
 ```text
 complete sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...
-stream   sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...
+stream   sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=... stream_wall_tok/s=...
 ```
+
+For streaming responses, `decode_tok/s` measures backend decode-active time;
+`stream_wall_tok/s` includes SSE/client backpressure and is the user-visible
+streaming wall-time rate.
 
 On SM120, the server defaults to the same optimized decode kernels used by the
 benchmark path (`FLASHRT_QWEN36_DECODE_FASTGEMM=1` and

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -34,6 +34,7 @@ python -m serving.qwen36_agent.server \
   --model-name qwen36-27b \
   --max-seq 32768 \
   --route-min-seq 0 \
+  --default-session-id local-agent \
   --host 127.0.0.1 --port 8000
 # startup loads the model, then logs: Uvicorn running on http://127.0.0.1:8000
 ```
@@ -221,6 +222,13 @@ off by a chat-sized output cap. Production deployments should set
 `--default-max-tokens` for their client mix and keep `--max-output-tokens` as a
 hard safety bound; oversized requests fail with HTTP 400 instead of being
 silently shortened.
+
+If `prompt_tokens + max_tokens` would exceed `--max-seq`, the server clips the
+generated-token budget to the remaining context for that request. If the prompt
+itself leaves no room for at least one generated token, the request is rejected
+before streaming begins. For local clients that do not send `flashrt_session_id`,
+start with `--default-session-id` so repeated agent turns share one hot session
+instead of rebuilding under a new generated session id each request.
 
 - `flashrt_session_id` (or `session_id`): stable session key for prefix reuse.
 - `flashrt_cache_salt`: optional namespace separator for different prompt policies.

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -34,7 +34,7 @@ python -m serving.qwen36_agent.server \
   --model-name qwen36-27b \
   --max-seq 32768 \
   --route-min-seq 0 \
-  --default-K 6 \
+  --default-K 4 \
   --host 127.0.0.1 --port 8000
 # startup loads the model, then logs: Uvicorn running on http://127.0.0.1:8000
 ```
@@ -177,7 +177,7 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--warmup-preset` | `none` | startup warmup shapes: `none` / `agent` / `short` / `long` / `all`; production agent serving does not need graph warmup by default |
 | `--warmup` | `""` | extra warmup shapes, comma-separated `prompt_len:max_tokens` |
 | `--warmup-K` | `6` | speculative K used during warmup |
-| `--default-K` | `6` | default speculative decode K for live requests; OpenAI-compatible clients inherit this unless they pass `flashrt_K` |
+| `--default-K` | `4` | default speculative decode K for live requests; OpenAI-compatible clients inherit this unless they pass `flashrt_K`; production agent sweeps currently favor K=4 |
 | `--warmup-committed-max-prompt` | `1024` | run real committed-stream warmup up to this prompt length; larger long-context shapes use graph-only warmup |
 | `--warm-long-prefill-graphs` | off | also capture long-context prefill chunk graphs at startup |
 | `--capsule-budget-mb` | `0` | GPU byte budget (MB) for pinned shared-prefix capsules; `0` disables pinning. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-for-non-hot-requests). |
@@ -204,8 +204,8 @@ If startup warmup is enabled, logs print every queued warmup shape and then a
 same metric fields for both buffered and streaming responses:
 
 ```text
-complete | sid=... | act=message_append | tok p=  9251 cache=  9237 new=   22 out= 384 | ms prefill=   13.0 ttft=  146.0 decode= 3278.4 | speed decode= 117.1 tok/s | finish=stop | tools=0 | lookahead=0 | hot=... | K=6
-stream   | sid=... | act=message_append | tok p=  3110 cache=  3089 new=   31 out= 512 | ms prefill=   12.8 ttft=   72.7 decode= 4316.9 | speed decode= 118.6 tok/s | stream= 4418.5ms/ 115.9 tok/s | finish=stop | tools=0 | lookahead=0 | hot=... | K=6
+complete | sid=... | act=message_append | tok p=  9251 cache=  9237 new=   22 out= 384 | ms prefill=   13.0 ttft=  146.0 decode= 3278.4 | speed decode= 117.1 tok/s | finish=stop | tools=0 | lookahead=0 | hot=... | K=4
+stream   | sid=... | act=message_append | tok p=  3110 cache=  3089 new=   31 out= 512 | ms prefill=   12.8 ttft=   72.7 decode= 4316.9 | speed decode= 118.6 tok/s | stream= 4418.5ms/ 115.9 tok/s | finish=stop | tools=0 | lookahead=0 | hot=... | K=4
 ```
 
 For streaming responses, `decode_tok/s` measures backend decode-active time;
@@ -224,6 +224,10 @@ for fixed-shape warmed benchmark runs. `/health` reports the kernel flags.
 `--default-K` controls live serving, while `--warmup-K` controls startup warmup.
 Use `--default-K` when a standard OpenAI-compatible client cannot pass FlashRT
 extension fields. Native clients may hot-switch per request with `flashrt_K`.
+For production agent serving on RTX 5090, the measured default is K=4: K=3/4
+are the stable plateau for short coding prompts, and K=4 wins the tool-call
+coding-agent sweep. K=6 remains available for fixed-shape benchmark/demo
+prompts where its accept length is known to be favorable.
 
 ## HTTP surface and request fields
 
@@ -404,8 +408,44 @@ python -m serving.qwen36_agent.server \
 The production agent path should be measured without those graph flags: it uses
 direct verify/MTP-chain kernel launch, so an arbitrary new prompt length no
 longer falls to cold graph-capture throughput. On RTX 5090, first-use live
-requests measured ~122 tok/s for a short text stream and ~130 tok/s for a
-tool-shaped stream with K=6.
+requests measured ~120-130 tok/s for short text/tool-shaped streams.
+
+**4. Production agent K sweep.** The live server default is K=4, based on real
+OpenAI-compatible agent workloads with direct kernel launch (no exact-position
+decode graph flags). Native clients can still override per request with
+`flashrt_K`.
+
+RTX 5090, `--route-min-seq 0`, FP8-KV long route, hot-prefix reuse enabled:
+
+| K | plain multi-turn coding warm decode tok/s | CLI-tool-call style coding-agent warm decode tok/s | short algorithm prompt decode tok/s |
+|---:|---:|---:|---:|
+| 1 | 77.0 | 96.8 | 99.6 |
+| 2 | 97.4 | 119.1 | 121.5 |
+| 3 | **104.2** | 133.8 | 128.9 |
+| 4 | 97.6 | **140.7** | 128.9 |
+| 5 | 89.6 | 132.7 | 128.9 |
+| 6 | 93.0 | 135.2 | **129.0** |
+
+The default chooses K=4 because tool-call coding-agent turns are the main
+production target and K=4 is the measured winner there. K=3 is a good
+conservative override for long plain-text coding sessions. K=6 is still useful
+for known short benchmark prompts, but it is not the best default for mixed
+agent traffic.
+
+Short algorithm prompt detail (real HTTP production path, median of 3 runs per
+prompt; values are decode-active tok/s):
+
+| scenario | K=1 | K=2 | K=3 | K=4 | K=5 | K=6 |
+| --- | ---:| ---:| ---:| ---:| ---:| ---:|
+| merge-sort | 100.0 | 130.3 | 146.9 | 146.9 | 146.8 | 146.8 |
+| dijkstra | 99.4 | 116.3 | 122.6 | 122.6 | 122.6 | 122.7 |
+| lru-cache | 101.7 | 126.6 | 135.1 | 135.2 | 135.1 | 135.2 |
+| coin-change | 98.3 | 115.0 | 122.4 | 122.7 | 122.6 | 122.7 |
+
+For these short algorithm prompts, K=3-K=6 are effectively on the same plateau
+except for the merge-sort prompt, where K>=3 reaches ~147 tok/s. This is why the
+live default can be K=4 without giving up the short-prompt speed people expect
+from the benchmark table.
 
 ## Automatic prefix reuse (walkthrough)
 

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -181,6 +181,10 @@ OpenAI-compatible: `GET /v1/models`, `GET /health`, `POST /v1/chat/completions`,
 (`messages`, `max_tokens` / `max_completion_tokens`, `stream`, `tools`) plus
 FlashRT extensions:
 
+If neither `max_tokens` nor `max_completion_tokens` is supplied, the agent
+server defaults to 1024 generated tokens so coding-agent tool turns are not cut
+off by a chat-sized output cap.
+
 - `flashrt_session_id` (or `session_id`): stable session key for prefix reuse.
 - `flashrt_cache_salt`: optional namespace separator for different prompt policies.
 - `flashrt_K`: speculative decode K for this request (default 6).

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -191,8 +191,8 @@ If startup warmup is enabled, logs print every queued warmup shape and then a
 same metric fields for both buffered and streaming responses:
 
 ```text
-complete sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...
-stream   sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=... stream_wall_tok/s=...
+complete | sid=... | act=message_append | tok p=  9251 cache=  9237 new=   22 out= 384 | ms prefill=   13.0 ttft=  146.0 decode= 3278.4 | speed decode= 117.1 tok/s | finish=stop | tools=0 | lookahead=0 | hot=... | K=6
+stream   | sid=... | act=message_append | tok p=  3110 cache=  3089 new=   31 out= 512 | ms prefill=   12.8 ttft=   72.7 decode= 4316.9 | speed decode= 118.6 tok/s | stream= 4418.5ms/ 115.9 tok/s | finish=stop | tools=0 | lookahead=0 | hot=... | K=6
 ```
 
 For streaming responses, `decode_tok/s` measures backend decode-active time;

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -157,6 +157,7 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--capsule-budget-mb` | `0` | GPU byte budget (MB) for pinned shared-prefix capsules; `0` disables pinning. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos). |
 | `--default-max-tokens` | `2048` | generated-token budget used when a request omits both `max_tokens` and `max_completion_tokens` |
 | `--max-output-tokens` | `8192` | hard generated-token cap; requests above this return HTTP 400 instead of being silently truncated |
+| `--default-session-id` | unset | fallback session id for requests that omit `flashrt_session_id` / `session_id`; intended only for single-client local agent demos or trusted one-user deployments |
 | `--host` / `--port` | `127.0.0.1` / `8000` | bind address |
 | `--log-level` | `info` | uvicorn log level |
 | `--access-log` | off | enable uvicorn per-request access logs; off by default to avoid benchmark jitter |
@@ -211,6 +212,11 @@ silently shortened.
   an integer (pin that many leading prompt tokens) or `true` (pin the whole
   prompt's chunk-aligned head). Inert unless the server was started with
   `--capsule-budget-mb > 0`. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos).
+
+For OpenAI-compatible clients that cannot pass FlashRT extension fields, a
+single-client deployment may set `--default-session-id <id>` so omitted session
+ids still hit the local prefix/session cache. Leave it unset for multi-client
+serving.
 
 ## Response fields
 

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -155,6 +155,8 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--warmup-committed-max-prompt` | `1024` | run real committed-stream warmup up to this prompt length; larger long-context shapes use graph-only warmup |
 | `--warm-long-prefill-graphs` | off | also capture long-context prefill chunk graphs at startup |
 | `--capsule-budget-mb` | `0` | GPU byte budget (MB) for pinned shared-prefix capsules; `0` disables pinning. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos). |
+| `--default-max-tokens` | `2048` | generated-token budget used when a request omits both `max_tokens` and `max_completion_tokens` |
+| `--max-output-tokens` | `8192` | hard generated-token cap; requests above this return HTTP 400 instead of being silently truncated |
 | `--host` / `--port` | `127.0.0.1` / `8000` | bind address |
 | `--log-level` | `info` | uvicorn log level |
 | `--access-log` | off | enable uvicorn per-request access logs; off by default to avoid benchmark jitter |
@@ -183,7 +185,10 @@ FlashRT extensions:
 
 If neither `max_tokens` nor `max_completion_tokens` is supplied, the agent
 server defaults to 2048 generated tokens so coding-agent tool turns are not cut
-off by a chat-sized output cap.
+off by a chat-sized output cap. Production deployments should set
+`--default-max-tokens` for their client mix and keep `--max-output-tokens` as a
+hard safety bound; oversized requests fail with HTTP 400 instead of being
+silently shortened.
 
 - `flashrt_session_id` (or `session_id`): stable session key for prefix reuse.
 - `flashrt_cache_salt`: optional namespace separator for different prompt policies.

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -159,6 +159,12 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--log-level` | `info` | uvicorn log level |
 | `--access-log` | off | enable uvicorn per-request access logs; off by default to avoid benchmark jitter |
 
+Capsule pin/restore in this server is a production long-route feature. If a
+request supplies `flashrt_pin_prefix`, the server requires a positive capsule
+budget plus the long FP8-KV route (`--route-min-seq 0` and a long-context
+`--max-seq`). It fails fast instead of silently falling back to the legacy short
+prefill path.
+
 Startup warmup moves CUDA-graph capture out of the first request: it runs real
 committed-stream warmup for short/medium shapes and graph-only warmup for larger
 long-context shapes.

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -171,6 +171,15 @@ Startup warmup moves CUDA-graph capture out of the first request: it runs real
 committed-stream warmup for short/medium shapes and graph-only warmup for larger
 long-context shapes.
 
+Startup logs print every queued warmup shape and then a `startup warmup done
+i/N` line as each shape finishes. Per-request logs use the same metric fields for
+both buffered and streaming responses:
+
+```text
+complete sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...
+stream   sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...
+```
+
 On SM120, the server defaults to the same optimized decode kernels used by the
 benchmark path (`FLASHRT_QWEN36_DECODE_FASTGEMM=1` and
 `FLASHRT_QWEN36_VERIFY_WARPSPLIT=1`) unless the environment explicitly overrides

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -26,12 +26,23 @@ capsule API lives on the frontend.
 **1. Start the server**
 
 ```bash
+export FLASHRT_QWEN36_MTP_CKPT_DIR=/path/to/qwen36_mtp_ckpt
+export FLASHRT_QWEN36_LONG_KV_CACHE=fp8
+
 python -m serving.qwen36_agent.server \
   --checkpoint /path/to/qwen36_nvfp4 \
   --model-name qwen36-27b \
+  --max-seq 32768 \
+  --route-min-seq 0 \
   --host 127.0.0.1 --port 8000
 # startup loads the model, then logs: Uvicorn running on http://127.0.0.1:8000
 ```
+
+Do not set `FLASHRT_QWEN36_TQ_VERIFY_GRAPH=1` or
+`FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH=1` for normal agent serving. The server
+defaults those graph flags to `0` on SM120 so arbitrary growing sessions avoid
+request-time exact-position graph capture. Enable them only for fixed-shape
+graph-replay benchmarks.
 
 **2. Check it is up**
 
@@ -175,9 +186,9 @@ decode graphs on the live path, so arbitrary coding-agent sessions do not need
 minutes of synthetic warmup. Use `--warmup-preset agent/all` only when you are
 intentionally preparing fixed-shape graph-replay demos or benchmarks.
 
-Startup logs print every queued warmup shape and then a `startup warmup done
-i/N` line as each shape finishes. Per-request logs use the same metric fields for
-both buffered and streaming responses:
+If startup warmup is enabled, logs print every queued warmup shape and then a
+`startup warmup done i/N` line as each shape finishes. Per-request logs use the
+same metric fields for both buffered and streaming responses:
 
 ```text
 complete sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -154,6 +154,7 @@ prompts rebuild until rollback/checkpoint support lands.
 | `--warmup-K` | `6` | speculative K used during warmup |
 | `--warmup-committed-max-prompt` | `1024` | run real committed-stream warmup up to this prompt length; larger long-context shapes use graph-only warmup |
 | `--warm-long-prefill-graphs` | off | also capture long-context prefill chunk graphs at startup |
+| `--capsule-budget-mb` | `0` | GPU byte budget (MB) for pinned shared-prefix capsules; `0` disables pinning. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos). |
 | `--host` / `--port` | `127.0.0.1` / `8000` | bind address |
 | `--log-level` | `info` | uvicorn log level |
 | `--access-log` | off | enable uvicorn per-request access logs; off by default to avoid benchmark jitter |
@@ -178,6 +179,10 @@ FlashRT extensions:
 - `flashrt_cache_salt`: optional namespace separator for different prompt policies.
 - `flashrt_K`: speculative decode K for this request (default 6).
 - `enable_thinking`: passed to the Qwen chat template (default false).
+- `flashrt_pin_prefix`: pin this request's shared prefix as a capsule for reuse —
+  an integer (pin that many leading prompt tokens) or `true` (pin the whole
+  prompt's chunk-aligned head). Inert unless the server was started with
+  `--capsule-budget-mb > 0`. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos).
 
 ## Response fields
 
@@ -192,7 +197,7 @@ response carries a `flashrt` telemetry block:
 | `prefill_ms` | prefill / append time |
 | `first_delta_ms` | time to first emitted delta (TTFT-like) |
 | `decode_ms`, `decode_tok_per_s` | decode time and throughput |
-| `prefix_action` | how the session was reused: `exact` / `append` / `message_append` / `truncate` / `rebuild` / `activate_rebuild` |
+| `prefix_action` | how the session was reused: `exact` / `append` / `message_append` / `restore` / `pin` / `truncate` / `rebuild` / `activate_rebuild` |
 
 ## Measured (RTX 5090, in-container)
 
@@ -216,6 +221,16 @@ Each turn prefills only the ~20 new tokens and reuses the growing cached prefix
 server without prefix reuse re-prefills the full prompt every turn (589 tokens on
 turn 4). This is the `append` / `message_append` path; correctness is gated
 token-exact by `tests/test_qwen36_agent_gpu_split.py`.
+
+> **Honest scope of contiguous append.** This flat-prefill table is measured on
+> turns capped by `max_tokens` (no stop token). A turn that ends on `<|im_end|>`
+> — the realistic agent case — commits the stop token plus spec lookahead into the
+> KV but not the visible journal, so the hot session is correctly invalidated and
+> the **next turn rebuilds**. Contiguous `append` / `message_append` therefore
+> only keeps prefill flat across non-EOS turns. For the realistic EOS-terminated
+> coding-agent loop, the reuse that survives is [capsule
+> pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos): a fresh turn
+> restores a clean committed boundary and re-prefills only the suffix.
 
 **2. Capsule restore replaces a shared-prefix cold prefill with a flat copy.**
 Snapshot a shared prefix once, then restore + append the new suffix instead of
@@ -348,6 +363,60 @@ If a client sends only the new message without the prior assistant turn, or a
 shorter/divergent prompt, the token stream has diverged and the server rebuilds
 or restores at a checkpoint boundary (it reports `rebuild`, never a fake hit).
 
+## Capsule pinning (shared-prefix reuse that survives EOS)
+
+A coding agent resends a large stable prefix every turn — system prompt, tool
+schemas, repo index/summary — then a small new user/tool suffix, and each turn
+ends on a stop token. Because an EOS-terminated turn invalidates contiguous append
+(above), the way to reuse that prefix is to **pin it as an execution-state
+capsule** and *restore* a clean committed boundary on every later turn/session,
+re-prefilling only the suffix. This is FlashRT's graph-replay-native prefix reuse
+(see [`capsules.md`](capsules.md) and [`../../docs/serving_design.md`](../../docs/serving_design.md)).
+
+Enable it at startup with a GPU byte budget, then pin per request:
+
+```bash
+python -m serving.qwen36_agent.server --checkpoint /path/to/qwen36_nvfp4 \
+  --max-seq 32768 --route-min-seq 0 --capsule-budget-mb 4096
+```
+
+```bash
+# First turn: pin the stable prefix (e.g. its first 6000 tokens). The server
+# cold-prefills + snapshots a chunk-aligned capsule, then serves normally.
+curl -s :8000/v1/chat/completions -d '{"model":"qwen36-27b",
+ "messages":[{"role":"system","content":"<system + tool schemas + repo index>"},
+             {"role":"user","content":"First task"}],
+ "flashrt_pin_prefix": 6000, "max_tokens": 256}'
+# -> flashrt.prefix_action == "pin"
+
+# Later turns / fresh sessions that share that prefix: restore + suffix only.
+curl -s :8000/v1/chat/completions -d '{"model":"qwen36-27b",
+ "messages":[{"role":"system","content":"<same system + tools + repo index>"},
+             {"role":"user","content":"Second task"}],
+ "flashrt_pin_prefix": 6000, "max_tokens": 256}'
+# -> flashrt.prefix_action == "restore", cached_tokens == the chunk-aligned
+#    boundary, new_prefill_tokens == only the suffix after it
+```
+
+Semantics and bounds:
+
+- `flashrt_pin_prefix` is an int (pin that many leading prompt tokens) or `true`
+  (pin the whole prompt's aligned head). The pin boundary is floored to the long
+  prefill chunk size (2048), so a prefix shorter than one chunk is not pinned.
+- A capsule is keyed by the digest of its chunk-aligned prefix tokens, so any
+  later request — same session or not — whose prompt starts with that exact prefix
+  restores it. Restore is **token-identical to a cold full prefill** (gated by
+  `tests/test_qwen36_agent_capsule_serving.py`); tool conversations benefit too,
+  because the stable system+tools head is pinned and only the changing suffix is
+  re-prefilled.
+- `--capsule-budget-mb` bounds GPU footprint. Capsules are LRU-evicted to fit and
+  a single capsule larger than the whole budget is rejected (the request is served
+  cold — never an OOM, never a false hit). Each capsule's KV grows with the pin
+  length (≈230 MB for a 4096-token aligned prefix here), and competes with the
+  model + KV cache for VRAM, so size the budget to the headroom you have.
+- `/health` reports `capsules` (count, bytes, budget). Default budget is `0`
+  (pinning off, serving path byte-identical).
+
 ## Validation
 
 Fast policy and HTTP checks:
@@ -366,5 +435,10 @@ validate real Qwen3.6 short/long split and long append equivalence:
 FLASHRT_QWEN36_NVFP4_CKPT_DIR=CHECKPOINT_DIR \
 FLASHRT_QWEN36_MTP_CKPT_DIR=MTP_CHECKPOINT_DIR \
 PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
-pytest -q tests/test_qwen36_agent_gpu_split.py -s
+pytest -q tests/test_qwen36_agent_gpu_split.py \
+  tests/test_qwen36_agent_capsule.py \
+  tests/test_qwen36_agent_capsule_serving.py -s
 ```
+
+`test_qwen36_agent_capsule_serving.py` gates the serving-layer pin/restore policy:
+a restored pinned prefix produces the same tokens as a cold full prefill.

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -182,7 +182,7 @@ OpenAI-compatible: `GET /v1/models`, `GET /health`, `POST /v1/chat/completions`,
 FlashRT extensions:
 
 If neither `max_tokens` nor `max_completion_tokens` is supplied, the agent
-server defaults to 1024 generated tokens so coding-agent tool turns are not cut
+server defaults to 2048 generated tokens so coding-agent tool turns are not cut
 off by a chat-sized output cap.
 
 - `flashrt_session_id` (or `session_id`): stable session key for prefix reuse.

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -172,11 +172,8 @@ committed-stream warmup for short/medium shapes and graph-only warmup for larger
 long-context shapes.
 
 Startup logs print every queued warmup shape and then a `startup warmup done
-i/N` line as each shape finishes. Committed-stream warmup results include
-`completion_tokens`, `decode_ms`, and `decode_tok/s`; graph-only warmup results
-report graph counts instead because they do not execute a real decode stream.
-Per-request logs use the same metric fields for both buffered and streaming
-responses:
+i/N` line as each shape finishes. Per-request logs use the same metric fields for
+both buffered and streaming responses:
 
 ```text
 complete sid=... prompt=... completion=... prefill_ms=... first_delta_ms=... decode_ms=... decode_tok/s=...

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -4,14 +4,14 @@ Production-oriented Qwen3.6-27B NVFP4 serving example for long-running agent
 sessions.
 
 This directory is the **policy layer** above the FlashRT execution contract. It
-owns session cache, exact token-prefix reuse, OpenAI-compatible tool calling,
-streaming, and request scheduling. It must not add session or KV verbs to
+owns automatic exact-prefix reuse, OpenAI-compatible tool calling, streaming,
+and request scheduling. It must not add session or KV verbs to
 `exec/`; the contract remains Buffer / Graph / Plan / Event / ShapeKey.
 
 The execution-state **capsule** feature (cold-prefill a shared prefix once, then
 restore instead of re-prefill on later turns) is documented in
-[`capsules.md`](capsules.md); this server exposes session prefix reuse, and the
-capsule API lives on the frontend.
+[`capsules.md`](capsules.md); this server exposes hot-state prefix reuse, and
+the capsule API lives on the frontend.
 
 ## Quickstart (end-to-end, reproducible)
 
@@ -34,7 +34,6 @@ python -m serving.qwen36_agent.server \
   --model-name qwen36-27b \
   --max-seq 32768 \
   --route-min-seq 0 \
-  --default-session-id local-agent \
   --host 127.0.0.1 --port 8000
 # startup loads the model, then logs: Uvicorn running on http://127.0.0.1:8000
 ```
@@ -58,8 +57,7 @@ curl -s http://127.0.0.1:8000/health      # model, max_seq, live sessions
 curl -s http://127.0.0.1:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
   "model": "qwen36-27b",
   "messages": [{"role": "user", "content": "Write a Python one-liner to reverse a string."}],
-  "max_tokens": 128,
-  "flashrt_session_id": "demo"
+  "max_tokens": 128
 }'
 ```
 
@@ -72,7 +70,7 @@ telemetry (see [Response fields](#response-fields)).
 curl -N http://127.0.0.1:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
   "model": "qwen36-27b", "stream": true,
   "messages": [{"role": "user", "content": "Explain a hash map in two sentences."}],
-  "max_tokens": 128, "flashrt_session_id": "demo"
+  "max_tokens": 128
 }'
 # emits `data: {chat.completion.chunk}` lines, then `data: [DONE]`
 ```
@@ -84,8 +82,9 @@ decode), so the visible transcript never runs ahead of the GPU state.
 
 - 256K context on the existing Qwen3.6 long-context FP8-KV/TQ kernel path.
 - Latency-first, single-stream hot session by default.
-- Exact token-prefix reuse for coding-agent turns: cold prefill once, then only
-  prefill appended user/tool/diff/log tokens.
+- Automatic exact token-prefix reuse for OpenAI-compatible coding-agent turns:
+  cold prefill once, then only prefill appended user/tool/diff/log tokens. A
+  FlashRT session id is an optional native hint, not a protocol requirement.
 - Direct long-decode kernel launch by default for live agent sessions, so a
   growing conversation does not pay exact-position CUDA Graph capture in the
   first real request. Fixed-shape graph replay remains opt-in for demos and
@@ -101,10 +100,12 @@ decode), so the visible transcript never runs ahead of the GPU state.
 
 ## v1 cache policy
 
-The first backend is contiguous and session-first because that matches the
+The first backend is contiguous and hot-state-first because that matches the
 current fastest Qwen3.6 single-stream kernel path. A request can reuse the hot
-frontend state when its tokenized prompt exactly extends the cached session
-prefix.
+frontend state when its tokenized prompt exactly extends the cached prefix. This
+does not require a client-provided session id: OpenAI-compatible clients that
+resend full history are matched by token/content prefix. `flashrt_session_id`
+remains a native hint for explicit affinity, not the primary compatibility path.
 
 For OpenAI-style clients that resend full visible history, the service also
 tracks the visible message journal. If the token journal contains hidden
@@ -226,12 +227,13 @@ silently shortened.
 If `prompt_tokens + max_tokens` would exceed `--max-seq`, the server clips the
 generated-token budget to the remaining context for that request. If the prompt
 itself leaves no room for at least one generated token, the request is rejected
-before streaming begins. For local clients that do not send `flashrt_session_id`,
-start with `--default-session-id` so repeated agent turns share one hot session
-instead of rebuilding under a new generated session id each request.
+before streaming begins.
 
-- `flashrt_session_id` (or `session_id`): stable session key for prefix reuse.
-- `flashrt_cache_salt`: optional namespace separator for different prompt policies.
+- `prompt_cache_key`: OpenAI-style namespace hint for routing/reuse policy.
+- `cache_salt`: vLLM-style namespace separator; lower priority than
+  `prompt_cache_key`.
+- `flashrt_session_id` (or `session_id`): optional native session-affinity hint.
+- `flashrt_cache_salt`: legacy FlashRT namespace separator.
 - `flashrt_K`: speculative decode K for this request (default 6).
 - `enable_thinking`: passed to the Qwen chat template (default false).
 - `flashrt_pin_prefix`: pin this request's shared prefix as a capsule for reuse —
@@ -239,10 +241,11 @@ instead of rebuilding under a new generated session id each request.
   prompt's chunk-aligned head). Inert unless the server was started with
   `--capsule-budget-mb > 0`. See [Capsule pinning](#capsule-pinning-shared-prefix-reuse-that-survives-eos).
 
-For OpenAI-compatible clients that cannot pass FlashRT extension fields, a
-single-client deployment may set `--default-session-id <id>` so omitted session
-ids still hit the local prefix/session cache. Leave it unset for multi-client
-serving.
+OpenAI-compatible clients do not need to pass FlashRT extension fields for the
+normal single hot conversation path. The server tokenizes the full resent
+history and automatically attaches it to the hot prefix when it is an exact
+extension. `--default-session-id` is kept only as a single-client compatibility
+fallback for older local demos.
 
 ## Response fields
 
@@ -259,6 +262,10 @@ response carries a `flashrt` telemetry block:
 | `decode_ms`, `decode_tok_per_s` | decode time and throughput |
 | `prefix_action` | how the session was reused: `exact` / `append` / `message_append` / `restore` / `pin` / `truncate` / `rebuild` / `activate_rebuild` |
 
+The standard `usage.prompt_tokens_details.cached_tokens` mirrors the FlashRT
+cached-token count so OpenAI-compatible tools can observe prefix-cache hits
+without reading the `flashrt` extension block.
+
 ## Measured (RTX 5090, in-container)
 
 Single RTX 5090 (sm_120), `qwen36_nvfp4` (25 GB) + MTP, `--route-min-seq 0`,
@@ -266,8 +273,8 @@ FP8-KV. Numbers are the serving path (real `/v1/chat/completions`), measured to
 substantiate the two design claims below; this is not a throughput-serving
 benchmark (single stream, latency-first).
 
-**1. Session prefix reuse keeps prefill flat as a conversation grows.** A 4-turn
-coding-agent session (same `flashrt_session_id`, full history resent each turn):
+**1. Automatic hot-prefix reuse keeps prefill flat as a conversation grows.** A
+4-turn coding-agent session (full history resent each turn; session id optional):
 
 | turn | `prefix_action` | `cached_tokens` | `new_prefill_tokens` | `prefill_ms` |
 | --- | --- | ---: | ---: | ---: |
@@ -384,21 +391,21 @@ longer falls to cold graph-capture throughput. On RTX 5090, first-use live
 requests measured ~122 tok/s for a short text stream and ~130 tok/s for a
 tool-shaped stream with K=6.
 
-## Session prefix reuse (walkthrough)
+## Automatic prefix reuse (walkthrough)
 
-Reuse the same `flashrt_session_id` across turns and resend the full message list
-(including the previous assistant turn). The server tokenizes the new prompt,
-finds the longest exact token-prefix match against the hot session, and prefills
-only the appended suffix:
+Resend the full message list across turns, including the previous assistant
+turn. This is the normal OpenAI-compatible client pattern. The server tokenizes
+the new prompt, finds the longest exact token-prefix match against the hot
+state, and prefills only the appended suffix:
 
 ```bash
-# turn 1 (cold): flashrt.cached_tokens == 0, prefix_action == "rebuild"
-curl -s :8000/v1/chat/completions -d '{"model":"qwen36-27b","flashrt_session_id":"s1",
+# turn 1 (cold): flashrt.cached_tokens == 0
+curl -s :8000/v1/chat/completions -d '{"model":"qwen36-27b",
  "messages":[{"role":"user","content":"List three sorting algorithms."}],"max_tokens":128}'
 
 # turn 2 (warm): append the prior assistant reply + a new user message;
 # flashrt.cached_tokens > 0, prefix_action == "append" / "message_append"
-curl -s :8000/v1/chat/completions -d '{"model":"qwen36-27b","flashrt_session_id":"s1",
+curl -s :8000/v1/chat/completions -d '{"model":"qwen36-27b",
  "messages":[{"role":"user","content":"List three sorting algorithms."},
              {"role":"assistant","content":"<prior reply>"},
              {"role":"user","content":"Now give the time complexity of each."}],"max_tokens":128}'

--- a/serving/qwen36_agent/auto_prefix.py
+++ b/serving/qwen36_agent/auto_prefix.py
@@ -1,0 +1,59 @@
+"""Automatic prefix selection for OpenAI-compatible agent clients.
+
+OpenAI-compatible clients normally resend the full message history and do not
+carry a FlashRT session id.  This module keeps the session id as an optional
+native hint, but lets the serving layer first try the current hot execution
+state by token/content prefix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Sequence
+
+from .session import PrefixPlan, SessionRecord, SessionRegistry
+
+
+MessageAppendPredicate = Callable[[SessionRecord], bool]
+
+
+@dataclass(frozen=True)
+class AutoPrefixSelection:
+    session: SessionRecord
+    plan: PrefixPlan
+    source: str
+
+
+class AutoPrefixCacheManager:
+    """Session-less prefix planner over the existing hot execution state.
+
+    This is intentionally not a vLLM/SGLang block cache.  It only decides
+    whether an incoming request can attach to the single hot FlashRT frontend
+    state, or should fall back to a normal per-session/cold plan.  Capsule
+    restore/pinning remains a separate execution policy in the service.
+    """
+
+    def __init__(self, sessions: SessionRegistry):
+        self.sessions = sessions
+
+    def select(
+            self, session_id: Optional[str], incoming: Sequence[int], *,
+            cache_salt: str = "",
+            can_message_append: Optional[MessageAppendPredicate] = None
+    ) -> AutoPrefixSelection:
+        if session_id:
+            session, plan = self.sessions.plan_request(
+                session_id, incoming, cache_salt=cache_salt)
+            return AutoPrefixSelection(session, plan, "explicit_session")
+
+        hot = self.sessions.hot_record()
+        if hot is not None and hot.cache_salt == cache_salt:
+            plan = hot.plan(incoming)
+            if plan.action in ("exact", "append", "truncate"):
+                return AutoPrefixSelection(hot, plan, "hot_token_prefix")
+            if can_message_append is not None and can_message_append(hot):
+                return AutoPrefixSelection(hot, plan, "hot_message_prefix")
+
+        session, plan = self.sessions.plan_request(
+            None, incoming, cache_salt=cache_salt)
+        return AutoPrefixSelection(session, plan, "new_session")

--- a/serving/qwen36_agent/engine.py
+++ b/serving/qwen36_agent/engine.py
@@ -17,12 +17,12 @@ class DecodeChunk:
 
     ``token_ids`` are the visible tokens to commit to the session journal.
 
-    Qwen3.6 speculative decode verifies a whole chunk at once, so when a stop
-    token lands mid-chunk the frontend KV/recurrent state has already committed
-    the tokens *after* the stop. Those are not part of the transcript:
-    ``state_lookahead`` counts them. A nonzero ``state_lookahead`` means the GPU
-    state leads the visible journal, so the session must be rebuilt (not
-    hot-appended) until a rollback/checkpoint mechanism lands.
+    Qwen3.6 speculative decode verifies a whole chunk at once. A committed
+    frontend should roll KV/recurrent state back when a stop token lands
+    mid-chunk, so ``state_lookahead`` is normally zero. If a backend cannot
+    rollback and reports tokens after the visible stop boundary,
+    ``state_lookahead`` counts them; a nonzero value means the GPU state leads
+    the visible journal, so the session must be rebuilt rather than hot-appended.
     """
 
     token_ids: tuple[int, ...]

--- a/serving/qwen36_agent/prefix.py
+++ b/serving/qwen36_agent/prefix.py
@@ -1,9 +1,10 @@
-"""Token-prefix helpers for contiguous FlashRT session cache.
+"""Token-prefix helpers for contiguous FlashRT hot-state cache.
 
-The first Qwen3.6 agent-serving backend is session-first and contiguous: it
+The first Qwen3.6 agent-serving backend is hot-state-first and contiguous: it
 keeps one hot GPU KV/state region and reuses it when the next request extends
-the same exact token prefix.  More elaborate block/radix caches can implement
-the same policy interface later without changing the exec contract.
+the same exact token prefix.  A client-provided session id is only a native
+affinity hint.  More elaborate cache policies can implement the same policy
+interface later without changing the exec contract.
 """
 
 from __future__ import annotations

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -91,6 +91,16 @@ class Qwen36FrontendAgentEngine:
                     add_generation_prompt: bool = True,
                     enable_thinking: bool = False) -> str:
         self._last_enable_thinking = bool(enable_thinking)
+        return self._render_chat(
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            enable_thinking=enable_thinking,
+        )
+
+    def _render_chat(self, messages, tools=None, *,
+                     add_generation_prompt: bool = True,
+                     enable_thinking: bool = False) -> str:
         normalized: List[Dict[str, Any]] = []
         for msg in messages:
             if msg.get("content") is None:
@@ -147,6 +157,20 @@ class Qwen36FrontendAgentEngine:
     def tokenize_chat(self, messages, tools=None, *,
                       enable_thinking: bool = False) -> List[int]:
         prompt = self.render_chat(
+            messages,
+            tools=tools,
+            add_generation_prompt=True,
+            enable_thinking=enable_thinking,
+        )
+        return self.tokenize_text(prompt)
+
+    def tokenize_chat_for_validation(self, messages, tools=None, *,
+                                     enable_thinking: bool = False) -> List[int]:
+        """Tokenize a request for HTTP pre-validation without mutating hot
+        decode state. The normal ``tokenize_chat`` records ``enable_thinking``
+        for committed-stream filtering; this method is safe to call before a
+        StreamingResponse is returned while another stream owns the engine."""
+        prompt = self._render_chat(
             messages,
             tools=tools,
             add_generation_prompt=True,

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -442,24 +442,14 @@ class Qwen36FrontendAgentEngine:
 
             ids = self.dummy_token_ids(prompt_len)
             self.prefill(ids.view(-1).tolist(), max_tokens=max_tokens, K=K)
-            decode_t0 = time.perf_counter()
-            chunks = list(self.generate_stream(max_tokens=max_tokens, K=K))
+            _ = list(self.generate_stream(max_tokens=max_tokens, K=K))
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
-            decode_ms = max(0.0, (time.perf_counter() - decode_t0) * 1000.0)
-            completion_tokens = sum(len(chunk.token_ids) for chunk in chunks)
-            decode_tok_per_s = (
-                completion_tokens * 1000.0 / decode_ms
-                if decode_ms > 0 else 0.0
-            )
             item = {
                 "prompt_len": prompt_len,
                 "max_tokens": max_tokens,
                 "route": self._last_route,
                 "prefill_ms": self._last_prefill_ms,
-                "completion_tokens": completion_tokens,
-                "decode_ms": decode_ms,
-                "decode_tok/s": decode_tok_per_s,
                 "wall_ms": (time.perf_counter() - t0) * 1000.0,
             }
             out.append(item)

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -49,13 +49,7 @@ class Qwen36FrontendAgentEngine:
         import torch
 
         cap = torch.cuda.get_device_capability()
-        if cap[0] >= 12:
-            # The production Qwen3.6 server should use the same SM120 fast
-            # decode/verify kernels as the documented benchmark path unless a
-            # caller explicitly opts out before startup.
-            import os
-            os.environ.setdefault("FLASHRT_QWEN36_DECODE_FASTGEMM", "1")
-            os.environ.setdefault("FLASHRT_QWEN36_VERIFY_WARPSPLIT", "1")
+        cls._set_agent_runtime_env_defaults(cap[0])
         if cap == (11, 0):
             from flash_rt.frontends.torch.qwen36_thor import (
                 Qwen36TorchFrontendThor as Frontend,
@@ -72,6 +66,26 @@ class Qwen36FrontendAgentEngine:
         if graph_cache_max is not None:
             fe.GRAPH_CACHE_MAX = int(graph_cache_max)
         return cls(fe, model_name=model_name)
+
+    @staticmethod
+    def _set_agent_runtime_env_defaults(cap_major: int) -> None:
+        """Set agent-serving runtime defaults before frontend construction.
+
+        The fixed-shape benchmark path benefits from exact-position CUDA Graph
+        replay. A long-lived agent session does not: every new generated
+        position can be a never-seen graph key, so the first real coding-agent
+        turn pays capture on the hot path and drops to cold-capture throughput.
+        Keep the fast SM120 kernels on, but default the agent host to direct
+        long-decode kernel launch for verify/MTP-chain unless the caller opts
+        back into exact graph replay before startup.
+        """
+        import os
+
+        if int(cap_major) >= 12:
+            os.environ.setdefault("FLASHRT_QWEN36_DECODE_FASTGEMM", "1")
+            os.environ.setdefault("FLASHRT_QWEN36_VERIFY_WARPSPLIT", "1")
+            os.environ.setdefault("FLASHRT_QWEN36_TQ_VERIFY_GRAPH", "0")
+            os.environ.setdefault("FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH", "0")
 
     def render_chat(self, messages, tools=None, *,
                     add_generation_prompt: bool = True,

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -185,8 +185,28 @@ class Qwen36FrontendAgentEngine:
             enable_thinking=enable_thinking,
         )
         if not rendered.startswith(previous_rendered):
-            return None
-        suffix = rendered[len(previous_rendered):]
+            # Qwen3.6's non-thinking generation prompt still injects an
+            # internal ``<think>\n\n</think>\n\n`` control block before decode.
+            # That block is part of the hot KV state but is intentionally not
+            # replayed by OpenAI clients as visible assistant content. When the
+            # visible message prefix is already known-equivalent, append only
+            # the newly added messages after the committed stop-token boundary
+            # instead of requiring the full visible render to be a byte prefix
+            # of the internal prompt journal.
+            suffix_messages = incoming_messages[len(previous_messages):]
+            if not suffix_messages:
+                return None
+            suffix = self.fe._tokenizer.apply_chat_template(
+                suffix_messages,
+                tools=tools or None,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=enable_thinking,
+            )
+            if suffix:
+                suffix = "\n" + suffix
+        else:
+            suffix = rendered[len(previous_rendered):]
         if not suffix:
             return None
         return self.tokenize_text(suffix)

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -189,6 +189,80 @@ class Qwen36FrontendAgentEngine:
         self._last_prompt_tokens = prompt_len
         self._last_prefill_ms = (time.perf_counter() - t0) * 1000.0
 
+    def _to_input_ids(self, token_ids: Sequence[int]):
+        import torch
+
+        return torch.tensor(
+            [[int(t) for t in token_ids]],
+            device=getattr(self.fe, "device", "cuda"),
+            dtype=torch.long,
+        )
+
+    def _uses_long_route(self, prompt_len: int, max_tokens: int) -> bool:
+        return bool(
+            getattr(self.fe, "_long_ctx_mode", False)
+            and hasattr(self.fe, "_should_use_long_ctx_route")
+            and self.fe._should_use_long_ctx_route(int(prompt_len), int(max_tokens))
+        )
+
+    def supports_capsule(self) -> bool:
+        """True if the frontend exposes the capsule snapshot/restore API."""
+        return (
+            hasattr(self.fe, "snapshot_capsule")
+            and hasattr(self.fe, "restore_capsule")
+            and hasattr(self.fe, "capsule_aligned_len")
+        )
+
+    def capsule_aligned_len(self, prompt_len: int, max_tokens: int) -> int:
+        """Chunk-aligned boundary to pin a shared prefix at for this prompt's
+        route, or 0 if it cannot be pinned (short route, or shorter than one
+        prefill chunk). Snapshotting at this boundary makes restore + append
+        token-identical to a cold full prefill (see the frontend capsule API)."""
+        if not self.supports_capsule():
+            return 0
+        if not self._uses_long_route(prompt_len, max_tokens):
+            return 0
+        return int(self.fe.capsule_aligned_len(int(prompt_len)))
+
+    def prefill_and_pin(self, token_ids: Sequence[int], *, aligned_len: int,
+                        max_tokens: int = 1, K: int = 6):
+        """Cold-prefill the chunk-aligned head, snapshot it into a capsule, then
+        append the remainder so the stream is ready to decode. Returns the opaque
+        capsule. Long route only (``aligned_len`` > 0 comes from
+        ``capsule_aligned_len``)."""
+        if aligned_len <= 0:
+            raise ValueError("aligned_len must be > 0 to pin a capsule")
+        ids = self._to_input_ids(token_ids)
+        prompt_len = int(ids.shape[1])
+        if aligned_len > prompt_len:
+            raise ValueError("aligned_len exceeds prompt length")
+        self.fe.prefill_long_ctx_nvfp4_agent(
+            ids[:, :aligned_len], max_new_tokens=int(max_tokens), K=int(K))
+        cap = self.fe.snapshot_capsule()
+        if prompt_len > aligned_len:
+            self.fe.append_long_ctx_nvfp4_agent(
+                ids, start_pos=int(aligned_len),
+                max_new_tokens=int(max_tokens), K=int(K))
+        self._last_route = "long"
+        self._last_prompt_tokens = prompt_len
+        return cap
+
+    def prefill_from_capsule(self, capsule, token_ids: Sequence[int], *,
+                             max_tokens: int = 1, K: int = 6) -> None:
+        """Restore a pinned capsule and append the remainder of ``token_ids`` after
+        the snapshot boundary, leaving the stream ready to decode. Token-identical
+        to a cold full prefill of ``token_ids`` (capsule correctness contract)."""
+        aligned = int(capsule["cur_pos"])
+        ids = self._to_input_ids(token_ids)
+        prompt_len = int(ids.shape[1])
+        self.fe.restore_capsule(capsule)
+        if prompt_len > aligned:
+            self.fe.append_long_ctx_nvfp4_agent(
+                ids, start_pos=aligned,
+                max_new_tokens=int(max_tokens), K=int(K))
+        self._last_route = "long"
+        self._last_prompt_tokens = prompt_len
+
     def generate_stream(self, *, max_tokens: int,
                         K: int) -> Iterable[DecodeChunk]:
         if self._last_route == "long":

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -143,28 +143,36 @@ class Qwen36FrontendAgentEngine:
     def append_suffix_tokens_for_messages(
             self, previous_messages, incoming_messages, *,
             tools=None, enable_thinking: bool = False) -> List[int] | None:
-        """Tokenize only the message suffix after a completed assistant turn."""
-        if tools:
-            return None
+        """Tokenize only the message suffix after a completed assistant turn.
+
+        Agent clients replay tool-call history through their own OpenAI/SDK
+        adapters.  The replayed full prompt may not be byte-identical to the
+        exact tool-call text the model generated, but the continuation after
+        the completed assistant message is still appendable from the hot GPU
+        state.  Prefer a message-boundary suffix over full-prompt token prefix
+        matching whenever the previous visible messages are a strict prefix of
+        the incoming messages.
+        """
         if not previous_messages or len(incoming_messages) <= len(previous_messages):
             return None
         if incoming_messages[:len(previous_messages)] != previous_messages:
             return None
-        last = previous_messages[-1]
-        if last.get("role") != "assistant":
-            return None
-        content = last.get("content") or ""
-        rendered_content = content.rstrip()
+
+        previous_rendered = self.render_chat(
+            previous_messages,
+            tools=tools or None,
+            add_generation_prompt=False,
+            enable_thinking=enable_thinking,
+        )
         rendered = self.render_chat(
             incoming_messages,
-            tools=None,
+            tools=tools or None,
             add_generation_prompt=True,
             enable_thinking=enable_thinking,
         )
-        idx = rendered.rfind(rendered_content)
-        if idx < 0:
+        if not rendered.startswith(previous_rendered):
             return None
-        suffix = rendered[idx + len(rendered_content):]
+        suffix = rendered[len(previous_rendered):]
         if not suffix:
             return None
         return self.tokenize_text(suffix)
@@ -302,13 +310,15 @@ class Qwen36FrontendAgentEngine:
 
     def generate_stream(self, *, max_tokens: int,
                         K: int) -> Iterable[DecodeChunk]:
-        if self._last_route == "long":
-            chunks = self.fe.decode_long_ctx_nvfp4_committed_stream(
-                max_new_tokens=int(max_tokens), K=int(K))
-        else:
-            chunks = self.fe.decode_own_speculative_nvfp4_committed_stream(
-                max_new_tokens=int(max_tokens), K=int(K))
         stop_ids = self._visible_stop_token_ids()
+        if self._last_route == "long":
+            chunks = self._committed_stream(
+                self.fe.decode_long_ctx_nvfp4_committed_stream,
+                max_tokens=max_tokens, K=K, stop_ids=stop_ids)
+        else:
+            chunks = self._committed_stream(
+                self.fe.decode_own_speculative_nvfp4_committed_stream,
+                max_tokens=max_tokens, K=K, stop_ids=stop_ids)
         for token_chunk in chunks:
             ids = tuple(int(t) for t in token_chunk)
             stop_at = next(
@@ -334,6 +344,16 @@ class Qwen36FrontendAgentEngine:
                 token_ids=committed_ids, text=text, accepted=len(visible_ids),
                 stop=True, state_lookahead=len(ids) - len(committed_ids))
             break
+
+    @staticmethod
+    def _committed_stream(fn, *, max_tokens: int, K: int, stop_ids: set[int]):
+        try:
+            return fn(max_new_tokens=int(max_tokens), K=int(K),
+                      stop_token_ids=tuple(int(t) for t in stop_ids))
+        except TypeError as exc:
+            if "stop_token_ids" not in str(exc):
+                raise
+            return fn(max_new_tokens=int(max_tokens), K=int(K))
 
     def _visible_stop_token_ids(self) -> set[int]:
         tokenizer = self.fe._tokenizer

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from typing import Any, Dict, Iterable, List, Sequence
+from typing import Any, Callable, Dict, Iterable, List, Sequence
 
 from .engine import DecodeChunk
 
@@ -377,6 +377,7 @@ class Qwen36FrontendAgentEngine:
             committed_max_prompt: int = 1024,
             long_decode_graphs: bool = True,
             long_prefill_graphs: bool = False,
+            on_result: Callable[[int, int, Dict[str, Any]], None] | None = None,
     ) -> List[Dict[str, Any]]:
         """Move committed-stream graph capture out of the first request.
 
@@ -388,17 +389,21 @@ class Qwen36FrontendAgentEngine:
 
         out: List[Dict[str, Any]] = []
         for prompt_len, max_tokens in shapes:
+            index = len(out) + 1
             prompt_len = int(prompt_len)
             max_tokens = int(max_tokens)
             if prompt_len <= 0 or max_tokens <= 0:
                 continue
             if self.max_seq and prompt_len + max_tokens > self.max_seq:
-                out.append({
+                item = {
                     "prompt_len": prompt_len,
                     "max_tokens": max_tokens,
                     "route": "skip",
                     "reason": "exceeds max_seq",
-                })
+                }
+                out.append(item)
+                if on_result is not None:
+                    on_result(index, len(shapes), item)
                 continue
 
             use_long = (
@@ -422,14 +427,17 @@ class Qwen36FrontendAgentEngine:
                         [(prompt_len, max_tokens)], K=K)
                 if torch.cuda.is_available():
                     torch.cuda.synchronize()
-                out.append({
+                item = {
                     "prompt_len": prompt_len,
                     "max_tokens": max_tokens,
                     "route": "long_graphs",
                     "prefill_graphs": len(prefill_warmed),
                     "decode_graphs": len(decode_warmed),
                     "wall_ms": (time.perf_counter() - t0) * 1000.0,
-                })
+                }
+                out.append(item)
+                if on_result is not None:
+                    on_result(index, len(shapes), item)
                 continue
 
             ids = self.dummy_token_ids(prompt_len)
@@ -437,11 +445,14 @@ class Qwen36FrontendAgentEngine:
             _ = list(self.generate_stream(max_tokens=max_tokens, K=K))
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
-            out.append({
+            item = {
                 "prompt_len": prompt_len,
                 "max_tokens": max_tokens,
                 "route": self._last_route,
                 "prefill_ms": self._last_prefill_ms,
                 "wall_ms": (time.perf_counter() - t0) * 1000.0,
-            })
+            }
+            out.append(item)
+            if on_result is not None:
+                on_result(index, len(shapes), item)
         return out

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -324,14 +324,15 @@ class Qwen36FrontendAgentEngine:
                 yield DecodeChunk(
                     token_ids=ids, text=text, accepted=len(ids))
                 continue
-            # Stop token mid-chunk: the frontend committed `ids` to KV state, but
-            # only `visible_ids` belong to the transcript. Commit the visible
-            # tokens to the journal and report the post-stop tokens (the stop
-            # token itself + any verified tail) as state lookahead so the session
-            # is rebuilt rather than falsely hot-appended.
+            # Stop token mid-chunk: the token itself is the chat-template
+            # boundary that a later full-history prompt will contain, so keep it
+            # in the cache journal while hiding it from client-visible text. Any
+            # tokens verified after the stop are not part of the transcript and
+            # still force a rebuild.
+            committed_ids = ids[:stop_at + 1]
             yield DecodeChunk(
-                token_ids=visible_ids, text=text, accepted=len(visible_ids),
-                stop=True, state_lookahead=len(ids) - len(visible_ids))
+                token_ids=committed_ids, text=text, accepted=len(visible_ids),
+                stop=True, state_lookahead=len(ids) - len(committed_ids))
             break
 
     def _visible_stop_token_ids(self) -> set[int]:

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from typing import Any, Dict, Iterable, List, Sequence
@@ -80,6 +81,11 @@ class Qwen36FrontendAgentEngine:
         for msg in messages:
             if msg.get("content") is None:
                 msg = {**msg, "content": ""}
+            else:
+                msg = dict(msg)
+            if msg.get("tool_calls"):
+                msg["tool_calls"] = self._normalize_tool_calls(
+                    msg.get("tool_calls"))
             normalized.append(msg)
         return self.fe._tokenizer.apply_chat_template(
             normalized,
@@ -88,6 +94,37 @@ class Qwen36FrontendAgentEngine:
             add_generation_prompt=add_generation_prompt,
             enable_thinking=enable_thinking,
         )
+
+    @staticmethod
+    def _normalize_tool_calls(tool_calls: Any) -> Any:
+        """Qwen's chat template expects assistant tool-call arguments as a
+        mapping so it can emit one <parameter=...> block per key. OpenAI wire
+        format carries ``function.arguments`` as a JSON string; normalize it
+        before handing history back to the tokenizer."""
+        if not isinstance(tool_calls, list):
+            return tool_calls
+        out = []
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                out.append(tc)
+                continue
+            tc = dict(tc)
+            fn = tc.get("function")
+            if isinstance(fn, dict):
+                fn = dict(fn)
+                args = fn.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        parsed = json.loads(args) if args.strip() else {}
+                    except Exception:
+                        parsed = {"arguments": args}
+                    if isinstance(parsed, dict):
+                        fn["arguments"] = parsed
+                    else:
+                        fn["arguments"] = {"arguments": parsed}
+                tc["function"] = fn
+            out.append(tc)
+        return out
 
     def tokenize_text(self, text: str) -> List[int]:
         return list(self.fe._tokenizer(

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -442,14 +442,24 @@ class Qwen36FrontendAgentEngine:
 
             ids = self.dummy_token_ids(prompt_len)
             self.prefill(ids.view(-1).tolist(), max_tokens=max_tokens, K=K)
-            _ = list(self.generate_stream(max_tokens=max_tokens, K=K))
+            decode_t0 = time.perf_counter()
+            chunks = list(self.generate_stream(max_tokens=max_tokens, K=K))
             if torch.cuda.is_available():
                 torch.cuda.synchronize()
+            decode_ms = max(0.0, (time.perf_counter() - decode_t0) * 1000.0)
+            completion_tokens = sum(len(chunk.token_ids) for chunk in chunks)
+            decode_tok_per_s = (
+                completion_tokens * 1000.0 / decode_ms
+                if decode_ms > 0 else 0.0
+            )
             item = {
                 "prompt_len": prompt_len,
                 "max_tokens": max_tokens,
                 "route": self._last_route,
                 "prefill_ms": self._last_prefill_ms,
+                "completion_tokens": completion_tokens,
+                "decode_ms": decode_ms,
+                "decode_tok/s": decode_tok_per_s,
                 "wall_ms": (time.perf_counter() - t0) * 1000.0,
             }
             out.append(item)

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -11,7 +11,7 @@ import time
 from typing import Any, Dict
 
 from .qwen36_engine import Qwen36FrontendAgentEngine
-from .service import AgentService, request_from_openai, result_to_openai
+from .service import AgentService, result_to_openai
 
 log = logging.getLogger("qwen36_agent")
 
@@ -60,7 +60,7 @@ def build_app(service: AgentService):
     @app.post("/v1/chat/completions")
     async def chat_completions(raw: Dict[str, Any]):
         try:
-            req = request_from_openai(raw)
+            req = service.request_from_openai(raw)
             if req.stream:
                 return StreamingResponse(
                     service.stream_openai(req, model=service.engine.model_name),
@@ -119,7 +119,9 @@ def create_app_from_checkpoint(*, checkpoint: str,
                                warmup_k: int = 6,
                                warmup_committed_max_prompt: int = 1024,
                                warm_long_prefill_graphs: bool = False,
-                               capsule_budget_bytes: int = 0):
+                               capsule_budget_bytes: int = 0,
+                               default_max_tokens: int = 2048,
+                               max_output_tokens: int = 8192):
     if graph_cache_max is None:
         graph_cache_max = _auto_graph_cache_max(max_seq)
     engine = Qwen36FrontendAgentEngine.from_checkpoint(
@@ -162,7 +164,11 @@ def create_app_from_checkpoint(*, checkpoint: str,
         log.info("capsule pinning enabled, budget %.0f MB",
                  capsule_budget_bytes / (1 << 20))
     return build_app(AgentService(
-        engine, capsule_budget_bytes=capsule_budget_bytes))
+        engine,
+        capsule_budget_bytes=capsule_budget_bytes,
+        default_max_tokens=default_max_tokens,
+        max_output_tokens=max_output_tokens,
+    ))
 
 
 def _parse_warmup_shapes(spec_csv: str) -> list[tuple[int, int]]:
@@ -273,6 +279,14 @@ def main(argv: list[str] | None = None) -> None:
              "EOS, unlike contiguous append). Needs VRAM headroom beyond the "
              "model + KV; capsules are LRU-evicted to fit and an over-budget pin "
              "is rejected, not OOM.")
+    parser.add_argument(
+        "--default-max-tokens", type=int, default=2048,
+        help="Generated-token budget used when an OpenAI request omits both "
+             "max_tokens and max_completion_tokens.")
+    parser.add_argument(
+        "--max-output-tokens", type=int, default=8192,
+        help="Hard server-side generated-token cap. Requests above this cap "
+             "return HTTP 400 instead of being silently truncated.")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--log-level", default="info")
@@ -303,6 +317,8 @@ def main(argv: list[str] | None = None) -> None:
         warmup_committed_max_prompt=args.warmup_committed_max_prompt,
         warm_long_prefill_graphs=args.warm_long_prefill_graphs,
         capsule_budget_bytes=int(args.capsule_budget_mb) * (1 << 20),
+        default_max_tokens=args.default_max_tokens,
+        max_output_tokens=args.max_output_tokens,
     )
     uvicorn.run(app, host=args.host, port=args.port,
                 log_level=args.log_level, access_log=args.access_log)

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -53,6 +53,7 @@ def build_app(service: AgentService):
             "speculative": bool(getattr(engine, "spec_enabled", False)),
             "decode_fastgemm": bool(getattr(fe, "_decode_fastgemm", False)),
             "verify_warpsplit": bool(getattr(fe, "_verify_warpsplit", False)),
+            "capsules": service.capsules.snapshot(),
             "sessions": service.sessions.snapshot(),
         }
 
@@ -117,7 +118,8 @@ def create_app_from_checkpoint(*, checkpoint: str,
                                warmup_shapes=None,
                                warmup_k: int = 6,
                                warmup_committed_max_prompt: int = 1024,
-                               warm_long_prefill_graphs: bool = False):
+                               warm_long_prefill_graphs: bool = False,
+                               capsule_budget_bytes: int = 0):
     if graph_cache_max is None:
         graph_cache_max = _auto_graph_cache_max(max_seq)
     engine = Qwen36FrontendAgentEngine.from_checkpoint(
@@ -149,7 +151,11 @@ def create_app_from_checkpoint(*, checkpoint: str,
         )
         for item in warmed:
             log.info("startup warmup result: %s", item)
-    return build_app(AgentService(engine))
+    if capsule_budget_bytes > 0:
+        log.info("capsule pinning enabled, budget %.0f MB",
+                 capsule_budget_bytes / (1 << 20))
+    return build_app(AgentService(
+        engine, capsule_budget_bytes=capsule_budget_bytes))
 
 
 def _parse_warmup_shapes(spec_csv: str) -> list[tuple[int, int]]:
@@ -251,6 +257,15 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--warm-long-prefill-graphs", action="store_true",
         help="Also capture long-context prefill chunk graphs at startup.")
+    parser.add_argument(
+        "--capsule-budget-mb", type=int, default=0,
+        help="GPU byte budget (MB) for pinned shared-prefix capsules. 0 (default) "
+             "disables pinning. When >0, a request with flashrt_pin_prefix pins "
+             "its chunk-aligned shared prefix so later turns/sessions restore a "
+             "clean committed boundary instead of cold-prefilling it (survives "
+             "EOS, unlike contiguous append). Needs VRAM headroom beyond the "
+             "model + KV; capsules are LRU-evicted to fit and an over-budget pin "
+             "is rejected, not OOM.")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--log-level", default="info")
@@ -280,6 +295,7 @@ def main(argv: list[str] | None = None) -> None:
         warmup_k=args.warmup_K,
         warmup_committed_max_prompt=args.warmup_committed_max_prompt,
         warm_long_prefill_graphs=args.warm_long_prefill_graphs,
+        capsule_budget_bytes=int(args.capsule_budget_mb) * (1 << 20),
     )
     uvicorn.run(app, host=args.host, port=args.port,
                 log_level=args.log_level, access_log=args.access_log)

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -316,10 +316,10 @@ def main(argv: list[str] | None = None) -> None:
              "return HTTP 400 instead of being silently truncated.")
     parser.add_argument(
         "--default-session-id", default=None,
-        help="Optional fallback session id for requests that omit "
-             "flashrt_session_id/session_id. Use only for single-client local "
-             "agent demos or trusted one-user deployments; multi-client "
-             "servers should leave this unset.")
+        help="Legacy fallback session id for older single-client local demos. "
+             "Normal OpenAI-compatible clients should rely on automatic "
+             "hot-prefix reuse instead; multi-client servers should leave this "
+             "unset.")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--log-level", default="info")

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -63,6 +63,7 @@ def build_app(service: AgentService):
         try:
             req = service.request_from_openai(raw)
             if req.stream:
+                service.validate_request_bounds(req)
                 return StreamingResponse(
                     service.stream_openai(req, model=service.engine.model_name),
                     media_type="text/event-stream",

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -151,15 +151,33 @@ def create_app_from_checkpoint(*, checkpoint: str,
     if warmup_shapes:
         log.info("startup warmup: %d shape(s), K=%d", len(warmup_shapes),
                  warmup_k)
+        for idx, (prompt_len, max_tokens) in enumerate(warmup_shapes, start=1):
+            route_hint = (
+                "graph-only"
+                if int(prompt_len) > int(warmup_committed_max_prompt)
+                else "committed-stream"
+            )
+            log.info(
+                "startup warmup queued %d/%d: prompt_len=%d max_tokens=%d "
+                "mode=%s",
+                idx, len(warmup_shapes), int(prompt_len), int(max_tokens),
+                route_hint,
+            )
+
+        def _log_warmup_result(index: int, total: int, item: Dict[str, Any]):
+            log.info("startup warmup done %d/%d: %s", index, total, item)
+
         warmed = engine.warmup_committed_stream(
             warmup_shapes,
             K=warmup_k,
             committed_max_prompt=warmup_committed_max_prompt,
             long_decode_graphs=True,
             long_prefill_graphs=warm_long_prefill_graphs,
+            on_result=_log_warmup_result,
         )
-        for item in warmed:
-            log.info("startup warmup result: %s", item)
+        total_ms = sum(float(item.get("wall_ms", 0.0)) for item in warmed)
+        log.info("startup warmup complete: %d shape(s), total_wall_ms=%.1f",
+                 len(warmed), total_ms)
     if capsule_budget_bytes > 0:
         log.info("capsule pinning enabled, budget %.0f MB",
                  capsule_budget_bytes / (1 << 20))

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -7,6 +7,7 @@ The HTTP layer is intentionally thin: all cache and streaming policy lives in
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import Any, Dict
 
@@ -93,14 +94,13 @@ def build_app(service: AgentService):
 
 
 def _auto_graph_cache_max(max_seq: int) -> int:
-    """Default per-cache CUDA-graph LRU bound, scaled to the VRAM headroom that
-    ``max_seq`` leaves. Decode graphs are keyed by exact (cur_pos, K, ...), so a
-    request traverses ~one-per-position graphs; a cap below that working set
-    evicts warmed graphs and forces re-capture on the next request (a repeated
-    cold start). A bigger cap lets warmed graphs survive across requests/lengths
-    — but each graph holds pooled buffers, so it competes with the KV cache.
-    Small max_seq leaves plenty of VRAM (use a large cap, kill the eviction
-    thrash); a 256K-capable cache leaves almost none (stay conservative)."""
+    """Default per-cache CUDA-graph LRU bound for opt-in graph replay.
+
+    The agent host defaults long decode to direct kernels so arbitrary growing
+    sessions do not pay exact-position graph capture in the request path. This
+    cap still matters when a caller explicitly opts back into CUDA Graph replay
+    for fixed-shape demos or benchmarks.
+    """
     max_seq = int(max_seq)
     if max_seq <= 32768:
         return 1024
@@ -142,6 +142,11 @@ def create_app_from_checkpoint(*, checkpoint: str,
     else:
         log.info("MTP head loaded; speculative decode enabled (default K=%d)",
                  warmup_k)
+    log.info(
+        "agent decode graph mode: verify_graph=%s mtp_chain_graph=%s",
+        os.environ.get("FLASHRT_QWEN36_TQ_VERIFY_GRAPH", "<unset>"),
+        os.environ.get("FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH", "<unset>"),
+    )
     if capsule_budget_bytes > 0:
         fe = getattr(engine, "fe", None)
         if not bool(getattr(fe, "_long_ctx_mode", False)):
@@ -220,7 +225,7 @@ def _dedupe_shapes(shapes: list[tuple[int, int]]) -> list[tuple[int, int]]:
 
 
 def _warmup_preset_shapes(preset: str, max_seq: int) -> list[tuple[int, int]]:
-    preset = (preset or "agent").strip().lower()
+    preset = (preset or "none").strip().lower()
     if preset in ("none", "off", "false", "0"):
         return []
     if preset not in ("agent", "short", "long", "all"):
@@ -269,13 +274,14 @@ def main(argv: list[str] | None = None) -> None:
             "per-position short-route graph capture."))
     parser.add_argument(
         "--graph-cache-max", type=int, default=None,
-        help="Per-cache CUDA graph LRU bound for Qwen3.6 frontend graphs. "
-             "Default auto-scales with --max-seq (1024 at <=32K, 256 at "
-             "<=128K, 128 at 256K) so small-context deployments keep warmed "
-             "graphs across requests instead of evicting and re-capturing.")
+        help="Per-cache CUDA graph LRU bound for opt-in Qwen3.6 frontend "
+             "graphs. The agent host defaults long decode to direct kernels; "
+             "this only matters when exact graph replay is explicitly enabled.")
     parser.add_argument(
-        "--warmup-preset", default="agent",
-        help="Startup warmup preset: agent, short, long, all, or none.")
+        "--warmup-preset", default="none",
+        help="Startup warmup preset: none, agent, short, long, or all. The "
+             "production agent default is none because long decode uses direct "
+             "kernels by default; use agent/all for fixed-shape graph demos.")
     parser.add_argument(
         "--warmup", default="",
         help='Additional comma-separated "prompt_len:max_tokens" shapes.')

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -121,7 +121,7 @@ def create_app_from_checkpoint(*, checkpoint: str,
                                warmup_committed_max_prompt: int = 1024,
                                warm_long_prefill_graphs: bool = False,
                                capsule_budget_bytes: int = 0,
-                               default_k: int = 6,
+                               default_k: int = 4,
                                default_max_tokens: int = 2048,
                                max_output_tokens: int = 8192,
                                default_session_id: str | None = None):
@@ -292,7 +292,7 @@ def main(argv: list[str] | None = None) -> None:
         "--warmup-K", type=int, default=6,
         help="Speculative decode K used for startup warmup.")
     parser.add_argument(
-        "--default-K", dest="default_K", type=int, default=6,
+        "--default-K", dest="default_K", type=int, default=4,
         help="Default speculative decode K for live requests. Requests may "
              "override it with the FlashRT extension field flashrt_K.")
     parser.add_argument(

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -121,7 +121,8 @@ def create_app_from_checkpoint(*, checkpoint: str,
                                warm_long_prefill_graphs: bool = False,
                                capsule_budget_bytes: int = 0,
                                default_max_tokens: int = 2048,
-                               max_output_tokens: int = 8192):
+                               max_output_tokens: int = 8192,
+                               default_session_id: str | None = None):
     if graph_cache_max is None:
         graph_cache_max = _auto_graph_cache_max(max_seq)
     engine = Qwen36FrontendAgentEngine.from_checkpoint(
@@ -186,6 +187,7 @@ def create_app_from_checkpoint(*, checkpoint: str,
         capsule_budget_bytes=capsule_budget_bytes,
         default_max_tokens=default_max_tokens,
         max_output_tokens=max_output_tokens,
+        default_session_id=default_session_id,
     ))
 
 
@@ -305,6 +307,12 @@ def main(argv: list[str] | None = None) -> None:
         "--max-output-tokens", type=int, default=8192,
         help="Hard server-side generated-token cap. Requests above this cap "
              "return HTTP 400 instead of being silently truncated.")
+    parser.add_argument(
+        "--default-session-id", default=None,
+        help="Optional fallback session id for requests that omit "
+             "flashrt_session_id/session_id. Use only for single-client local "
+             "agent demos or trusted one-user deployments; multi-client "
+             "servers should leave this unset.")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--log-level", default="info")
@@ -337,6 +345,7 @@ def main(argv: list[str] | None = None) -> None:
         capsule_budget_bytes=int(args.capsule_budget_mb) * (1 << 20),
         default_max_tokens=args.default_max_tokens,
         max_output_tokens=args.max_output_tokens,
+        default_session_id=args.default_session_id,
     )
     uvicorn.run(app, host=args.host, port=args.port,
                 log_level=args.log_level, access_log=args.access_log)

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -139,6 +139,13 @@ def create_app_from_checkpoint(*, checkpoint: str,
     else:
         log.info("MTP head loaded; speculative decode enabled (default K=%d)",
                  warmup_k)
+    if capsule_budget_bytes > 0:
+        fe = getattr(engine, "fe", None)
+        if not bool(getattr(fe, "_long_ctx_mode", False)):
+            raise ValueError(
+                "--capsule-budget-mb requires the long FP8-KV route; use a "
+                "long-context --max-seq, --route-min-seq 0, and "
+                "FLASHRT_QWEN36_LONG_KV_CACHE=fp8")
     if warmup_shapes:
         log.info("startup warmup: %d shape(s), K=%d", len(warmup_shapes),
                  warmup_k)

--- a/serving/qwen36_agent/server.py
+++ b/serving/qwen36_agent/server.py
@@ -121,6 +121,7 @@ def create_app_from_checkpoint(*, checkpoint: str,
                                warmup_committed_max_prompt: int = 1024,
                                warm_long_prefill_graphs: bool = False,
                                capsule_budget_bytes: int = 0,
+                               default_k: int = 6,
                                default_max_tokens: int = 2048,
                                max_output_tokens: int = 8192,
                                default_session_id: str | None = None):
@@ -142,7 +143,7 @@ def create_app_from_checkpoint(*, checkpoint: str,
             "\"speculative\": false).")
     else:
         log.info("MTP head loaded; speculative decode enabled (default K=%d)",
-                 warmup_k)
+                 default_k)
     log.info(
         "agent decode graph mode: verify_graph=%s mtp_chain_graph=%s",
         os.environ.get("FLASHRT_QWEN36_TQ_VERIFY_GRAPH", "<unset>"),
@@ -191,6 +192,7 @@ def create_app_from_checkpoint(*, checkpoint: str,
     return build_app(AgentService(
         engine,
         capsule_budget_bytes=capsule_budget_bytes,
+        default_k=default_k,
         default_max_tokens=default_max_tokens,
         max_output_tokens=max_output_tokens,
         default_session_id=default_session_id,
@@ -290,6 +292,10 @@ def main(argv: list[str] | None = None) -> None:
         "--warmup-K", type=int, default=6,
         help="Speculative decode K used for startup warmup.")
     parser.add_argument(
+        "--default-K", dest="default_K", type=int, default=6,
+        help="Default speculative decode K for live requests. Requests may "
+             "override it with the FlashRT extension field flashrt_K.")
+    parser.add_argument(
         "--warmup-committed-max-prompt", type=int, default=1024,
         help=(
             "Run real committed-stream warmup up to this prompt length; "
@@ -350,6 +356,7 @@ def main(argv: list[str] | None = None) -> None:
         warmup_committed_max_prompt=args.warmup_committed_max_prompt,
         warm_long_prefill_graphs=args.warm_long_prefill_graphs,
         capsule_budget_bytes=int(args.capsule_budget_mb) * (1 << 20),
+        default_k=args.default_K,
         default_max_tokens=args.default_max_tokens,
         max_output_tokens=args.max_output_tokens,
         default_session_id=args.default_session_id,

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -86,6 +86,7 @@ class AgentService:
         # holds the lock for the whole turn; a streaming call holds it for the
         # life of the generator (released when it is exhausted or closed).
         self._lock = threading.Lock()
+        self._active_stream_committed = False
 
     def request_from_openai(self, req: Dict[str, Any]) -> AgentRequest:
         agent_req = request_from_openai(
@@ -114,6 +115,7 @@ class AgentService:
                       model: str) -> Iterable[str]:
         with self._lock:
             completed = False
+            self._active_stream_committed = False
             try:
                 yield from self._stream_openai(req, model=model)
                 completed = True
@@ -122,8 +124,9 @@ class AgentService:
                 # the final commit / mark, and an exception aborts it too. Either
                 # way the frontend state advanced past the journal, so clear the
                 # hot session and force the next turn to rebuild.
-                if not completed:
+                if not completed and not self._active_stream_committed:
                     self.sessions.hot_session_id = None
+                self._active_stream_committed = False
 
     def _effective_plan(
             self, session, plan: PrefixPlan) -> tuple[int, PrefixPlan]:
@@ -428,6 +431,7 @@ class AgentService:
         generated_ids: List[int] = []
         visible_parts: List[str] = []
         tool_calls: List[Dict[str, Any]] = []
+        deferred_tool_events: List[StreamEvent] = []
         seen_tool_call = False
         state_lookahead = False
         yield sse_data(role_chunk(completion_id, model))
@@ -456,9 +460,10 @@ class AgentService:
                     seen_tool_call = True
                     saw_tool_call = True
                     tool_calls.append(ev.payload)
+                    deferred_tool_events.append(ev)
                 else:
                     visible_parts.append(str(ev.payload))
-                yield sse_data(event_chunk(completion_id, model, ev))
+                    yield sse_data(event_chunk(completion_id, model, ev))
             if saw_tool_call:
                 break
         for ev in parser.finish():
@@ -468,9 +473,10 @@ class AgentService:
                 seen_tool_call = True
                 saw_tool_call = True
                 tool_calls.append(ev.payload)
+                deferred_tool_events.append(ev)
             else:
                 visible_parts.append(str(ev.payload))
-            yield sse_data(event_chunk(completion_id, model, ev))
+                yield sse_data(event_chunk(completion_id, model, ev))
         t_done = time.perf_counter()
 
         session.commit([*engine_prompt_tokens, *generated_ids])
@@ -479,6 +485,7 @@ class AgentService:
             "".join(visible_parts), tool_calls))
         session.visible_messages = visible_messages
         self._mark_reusable(session, state_lookahead)
+        self._active_stream_committed = True
         usage = {
             "prompt_tokens": len(prompt_tokens),
             "completion_tokens": len(generated_ids),
@@ -503,6 +510,8 @@ class AgentService:
             (t_prefill - t0) * 1000.0, first_delta_ms, decode_ms,
             decode_tok_per_s, stream_wall_ms, stream_wall_tok_per_s,
         )
+        for ev in deferred_tool_events:
+            yield sse_data(event_chunk(completion_id, model, ev))
         yield sse_data(done_chunk(
             completion_id,
             model,

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -310,7 +310,10 @@ class AgentService:
 
     @staticmethod
     def _effective_k(req: AgentRequest) -> int:
-        return int(req.K)
+        k = int(req.K)
+        if k < 1:
+            raise ValueError("flashrt_K must be >= 1")
+        return k
 
     def _log_reuse_miss(self, session, plan: PrefixPlan,
                         incoming_messages: List[Dict[str, Any]]) -> None:
@@ -417,7 +420,11 @@ class AgentService:
         begins SSE streaming, otherwise the client sees a broken stream and the
         server logs an ASGI traceback.
         """
-        prompt_tokens = self.engine.tokenize_chat(
+        tokenizer = getattr(
+            self.engine, "tokenize_chat_for_validation", None)
+        if not callable(tokenizer):
+            tokenizer = self.engine.tokenize_chat
+        prompt_tokens = tokenizer(
             req.messages,
             tools=req.tools,
             enable_thinking=req.enable_thinking,
@@ -844,6 +851,8 @@ def request_from_openai(req: Dict[str, Any], *, default_k: int = 4,
         raise ValueError(
             f"max_tokens must be <= {int(max_output_tokens)}")
     K = parse_int(req.get("flashrt_K"), name="flashrt_K", default=default_k)
+    if K < 1:
+        raise ValueError("flashrt_K must be >= 1")
     return AgentRequest(
         messages=messages,
         tools=tools,

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -18,7 +18,8 @@ from .openai_stream import (
     role_chunk,
     sse_data,
 )
-from .session import PrefixPlan, SessionRegistry
+from .prefix import token_digest
+from .session import CapsuleEntry, CapsuleStore, PrefixPlan, SessionRegistry
 from .tool_stream import StreamEvent, ToolCallStreamParser
 
 
@@ -32,6 +33,12 @@ class AgentRequest:
     cache_salt: str = ""
     enable_thinking: bool = False
     K: int = 6
+    # Pin the shared-prefix capsule: int = number of leading prompt tokens to pin
+    # as a reusable capsule; True = pin the whole current prompt's aligned head;
+    # None/0 = no pinning. Restore on a later request whose prompt starts with the
+    # same chunk-aligned prefix. Effective only when the service has a capsule
+    # budget and the prompt takes the long route.
+    pin_prefix: Optional[int] = None
 
 
 @dataclass
@@ -51,9 +58,15 @@ class AgentService:
     """Policy layer over a Qwen3.6 split prefill/decode engine."""
 
     def __init__(self, engine: AgentEngine, *,
-                 sessions: Optional[SessionRegistry] = None):
+                 sessions: Optional[SessionRegistry] = None,
+                 capsule_budget_bytes: int = 0):
         self.engine = engine
         self.sessions = sessions or SessionRegistry()
+        # Pinned shared-prefix capsules (off-by-default: budget 0 keeps the
+        # serving path byte-identical). A pinned capsule lets a fresh turn/session
+        # restore a clean committed boundary instead of cold-prefilling the shared
+        # prefix — the reuse path that survives EOS, unlike contiguous append.
+        self.capsules = CapsuleStore(budget_bytes=capsule_budget_bytes)
         # The backend is a single hot GPU frontend with mutable KV / linear /
         # session state. Serialize whole requests so concurrent HTTP calls cannot
         # interleave prefill/decode and corrupt that state. A non-streaming call
@@ -112,6 +125,64 @@ class AgentService:
             )
         return effective_cached, plan
 
+    def _capsule_prefill(
+            self, req: AgentRequest, prompt_tokens: List[int], session
+    ) -> Optional[PrefixPlan]:
+        """Restore-or-pin a shared-prefix capsule when ``pin_prefix`` is requested
+        and viable, performing the prefill on the engine and returning its
+        PrefixPlan. Returns None (caller uses the normal hot-append / rebuild path)
+        when pinning is disabled, unsupported, or the prefix is too short to pin.
+
+        A pinned capsule is keyed by the digest of its chunk-aligned prefix tokens,
+        so a later turn or a different session whose prompt starts with the same
+        prefix restores a clean committed boundary instead of cold-prefilling it.
+        Unlike contiguous append, this survives an EOS-terminated previous turn.
+        On a budget-rejected pin the request is already served cold; only a future
+        restore is lost (never an OOM, never a false hit — the restore key is an
+        exact aligned-prefix digest match).
+        """
+        pin = req.pin_prefix
+        if not pin or not self.capsules.enabled:
+            return None
+        supports = getattr(self.engine, "supports_capsule", None)
+        if not callable(supports) or not supports():
+            return None
+        prompt_len = len(prompt_tokens)
+        pin_len = prompt_len if pin is True else min(int(pin), prompt_len)
+        if pin_len <= 0:
+            return None
+        aligned = self.engine.capsule_aligned_len(pin_len, req.max_tokens)
+        if aligned <= 0 or aligned > prompt_len:
+            return None
+        key = token_digest(prompt_tokens[:aligned], salt=req.cache_salt)
+        entry = self.capsules.get(key)
+        if entry is not None:
+            self.engine.prefill_from_capsule(
+                entry.capsule, prompt_tokens,
+                max_tokens=req.max_tokens, K=req.K)
+            return PrefixPlan(
+                session_id=session.session_id,
+                cached_tokens=aligned,
+                new_prefill_tokens=max(0, prompt_len - aligned),
+                incoming_tokens=prompt_len,
+                matched_tokens=aligned,
+                action="restore",
+            )
+        cap = self.engine.prefill_and_pin(
+            prompt_tokens, aligned_len=aligned,
+            max_tokens=req.max_tokens, K=req.K)
+        nbytes = int(cap.get("nbytes", 0)) if isinstance(cap, dict) else 0
+        pinned = self.capsules.pin(CapsuleEntry(
+            key=key, aligned_len=aligned, nbytes=nbytes, capsule=cap))
+        return PrefixPlan(
+            session_id=session.session_id,
+            cached_tokens=0,
+            new_prefill_tokens=prompt_len,
+            incoming_tokens=prompt_len,
+            matched_tokens=0,
+            action="pin" if pinned else "rebuild",
+        )
+
     def _message_append_prompt_tokens(
             self, session, req: AgentRequest, plan: PrefixPlan
     ) -> tuple[Optional[List[int]], Optional[PrefixPlan]]:
@@ -168,24 +239,27 @@ class AgentService:
             cache_salt=req.cache_salt,
         )
 
-        engine_prompt_tokens = prompt_tokens
-        msg_prompt, msg_plan = self._message_append_prompt_tokens(
-            session, req, plan)
-        if msg_prompt is not None and msg_plan is not None:
-            engine_prompt_tokens = msg_prompt
-            plan = msg_plan
-            effective_cached = plan.cached_tokens
-        else:
-            effective_cached, plan = self._effective_plan(session, plan)
-
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+        engine_prompt_tokens = prompt_tokens
         t0 = time.perf_counter()
-        self.engine.prefill(
-            engine_prompt_tokens,
-            cached_tokens=effective_cached,
-            max_tokens=req.max_tokens,
-            K=req.K,
-        )
+        cap_plan = self._capsule_prefill(req, prompt_tokens, session)
+        if cap_plan is not None:
+            plan = cap_plan
+        else:
+            msg_prompt, msg_plan = self._message_append_prompt_tokens(
+                session, req, plan)
+            if msg_prompt is not None and msg_plan is not None:
+                engine_prompt_tokens = msg_prompt
+                plan = msg_plan
+                effective_cached = plan.cached_tokens
+            else:
+                effective_cached, plan = self._effective_plan(session, plan)
+            self.engine.prefill(
+                engine_prompt_tokens,
+                cached_tokens=effective_cached,
+                max_tokens=req.max_tokens,
+                K=req.K,
+            )
         t_prefill = time.perf_counter()
 
         parser = ToolCallStreamParser()
@@ -281,22 +355,26 @@ class AgentService:
             prompt_tokens,
             cache_salt=req.cache_salt,
         )
-        engine_prompt_tokens = prompt_tokens
-        msg_prompt, msg_plan = self._message_append_prompt_tokens(
-            session, req, plan)
-        if msg_prompt is not None and msg_plan is not None:
-            engine_prompt_tokens = msg_prompt
-            effective_cached = msg_plan.cached_tokens
-        else:
-            effective_cached, _ = self._effective_plan(session, plan)
-
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
-        self.engine.prefill(
-            engine_prompt_tokens,
-            cached_tokens=effective_cached,
-            max_tokens=req.max_tokens,
-            K=req.K,
-        )
+        engine_prompt_tokens = prompt_tokens
+        cap_plan = self._capsule_prefill(req, prompt_tokens, session)
+        if cap_plan is not None:
+            plan = cap_plan
+        else:
+            msg_prompt, msg_plan = self._message_append_prompt_tokens(
+                session, req, plan)
+            if msg_prompt is not None and msg_plan is not None:
+                engine_prompt_tokens = msg_prompt
+                plan = msg_plan
+                effective_cached = msg_plan.cached_tokens
+            else:
+                effective_cached, plan = self._effective_plan(session, plan)
+            self.engine.prefill(
+                engine_prompt_tokens,
+                cached_tokens=effective_cached,
+                max_tokens=req.max_tokens,
+                K=req.K,
+            )
 
         parser = ToolCallStreamParser()
         generated_ids: List[int] = []
@@ -406,6 +484,24 @@ def parse_int(value: Any, *, name: str, default: int) -> int:
         raise ValueError(f"{name} must be an integer, got {value!r}")
 
 
+def parse_pin_prefix(value: Any) -> Optional[int]:
+    """Parse ``flashrt_pin_prefix``: a positive int (pin that many leading prompt
+    tokens), ``true`` (pin the whole current prompt's aligned head), or
+    absent/false/0/null (no pinning)."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return True if value else None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"flashrt_pin_prefix must be an integer or boolean, got {value!r}")
+    return n if n > 0 else None
+
+
 def request_from_openai(req: Dict[str, Any], *, default_k: int = 6) -> AgentRequest:
     messages = validate_messages(req.get("messages"))
     tools = validate_tools(req.get("tools"))
@@ -429,6 +525,7 @@ def request_from_openai(req: Dict[str, Any], *, default_k: int = 6) -> AgentRequ
         cache_salt=str(req.get("flashrt_cache_salt", "")),
         enable_thinking=parse_bool(req.get("enable_thinking"), default=False),
         K=K,
+        pin_prefix=parse_pin_prefix(req.get("flashrt_pin_prefix")),
     )
 
 

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -27,7 +27,7 @@ from .tool_stream import StreamEvent, ToolCallStreamParser
 class AgentRequest:
     messages: List[Dict[str, Any]]
     tools: Optional[List[Dict[str, Any]]] = None
-    max_tokens: int = 256
+    max_tokens: int = 1024
     stream: bool = False
     session_id: Optional[str] = None
     cache_salt: str = ""
@@ -511,7 +511,8 @@ def parse_pin_prefix(value: Any) -> Optional[int]:
     return n if n > 0 else None
 
 
-def request_from_openai(req: Dict[str, Any], *, default_k: int = 6) -> AgentRequest:
+def request_from_openai(req: Dict[str, Any], *, default_k: int = 6,
+                        default_max_tokens: int = 1024) -> AgentRequest:
     messages = validate_messages(req.get("messages"))
     tools = validate_tools(req.get("tools"))
     # Fall back to max_completion_tokens only when max_tokens is absent *or*
@@ -521,7 +522,8 @@ def request_from_openai(req: Dict[str, Any], *, default_k: int = 6) -> AgentRequ
     raw_max_tokens = req.get("max_tokens")
     if raw_max_tokens is None:
         raw_max_tokens = req.get("max_completion_tokens")
-    max_tokens = parse_int(raw_max_tokens, name="max_tokens", default=256)
+    max_tokens = parse_int(
+        raw_max_tokens, name="max_tokens", default=default_max_tokens)
     if max_tokens < 1:
         raise ValueError("max_tokens must be >= 1")
     K = parse_int(req.get("flashrt_K"), name="flashrt_K", default=default_k)

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -27,7 +27,7 @@ from .tool_stream import StreamEvent, ToolCallStreamParser
 class AgentRequest:
     messages: List[Dict[str, Any]]
     tools: Optional[List[Dict[str, Any]]] = None
-    max_tokens: int = 1024
+    max_tokens: int = 2048
     stream: bool = False
     session_id: Optional[str] = None
     cache_salt: str = ""
@@ -512,7 +512,7 @@ def parse_pin_prefix(value: Any) -> Optional[int]:
 
 
 def request_from_openai(req: Dict[str, Any], *, default_k: int = 6,
-                        default_max_tokens: int = 1024) -> AgentRequest:
+                        default_max_tokens: int = 2048) -> AgentRequest:
     messages = validate_messages(req.get("messages"))
     tools = validate_tools(req.get("tools"))
     # Fall back to max_completion_tokens only when max_tokens is absent *or*

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -62,9 +62,12 @@ class AgentService:
     def __init__(self, engine: AgentEngine, *,
                  sessions: Optional[SessionRegistry] = None,
                  capsule_budget_bytes: int = 0,
+                 default_k: int = 6,
                  default_max_tokens: int = 2048,
                  max_output_tokens: int = 8192,
                  default_session_id: Optional[str] = None):
+        if default_k < 1:
+            raise ValueError("default_k must be >= 1")
         if default_max_tokens < 1:
             raise ValueError("default_max_tokens must be >= 1")
         if max_output_tokens < 1:
@@ -75,6 +78,7 @@ class AgentService:
         self.engine = engine
         self.sessions = sessions or SessionRegistry()
         self.auto_prefix = AutoPrefixCacheManager(self.sessions)
+        self.default_k = int(default_k)
         self.default_max_tokens = int(default_max_tokens)
         self.max_output_tokens = int(max_output_tokens)
         self.default_session_id = default_session_id or None
@@ -94,6 +98,7 @@ class AgentService:
     def request_from_openai(self, req: Dict[str, Any]) -> AgentRequest:
         agent_req = request_from_openai(
             req,
+            default_k=self.default_k,
             default_max_tokens=self.default_max_tokens,
             max_output_tokens=self.max_output_tokens,
         )

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -154,7 +154,7 @@ class AgentService:
 
     def _capsule_prefill(
             self, req: AgentRequest, prompt_tokens: List[int], session, *,
-            K: int
+            max_tokens: int, K: int
     ) -> Optional[PrefixPlan]:
         """Restore-or-pin a shared-prefix capsule when ``pin_prefix`` is requested
         and viable, performing the prefill on the engine and returning its
@@ -184,7 +184,7 @@ class AgentService:
         pin_len = prompt_len if pin is True else min(int(pin), prompt_len)
         if pin_len <= 0:
             return None
-        aligned = self.engine.capsule_aligned_len(pin_len, req.max_tokens)
+        aligned = self.engine.capsule_aligned_len(pin_len, max_tokens)
         if aligned <= 0 or aligned > prompt_len:
             raise ValueError(
                 "flashrt_pin_prefix requires the long FP8-KV route and a "
@@ -196,7 +196,7 @@ class AgentService:
         if entry is not None:
             self.engine.prefill_from_capsule(
                 entry.capsule, prompt_tokens,
-                max_tokens=req.max_tokens, K=K)
+                max_tokens=max_tokens, K=K)
             return PrefixPlan(
                 session_id=session.session_id,
                 cached_tokens=aligned,
@@ -207,7 +207,7 @@ class AgentService:
             )
         cap = self.engine.prefill_and_pin(
             prompt_tokens, aligned_len=aligned,
-            max_tokens=req.max_tokens, K=K)
+            max_tokens=max_tokens, K=K)
         nbytes = int(cap.get("nbytes", 0)) if isinstance(cap, dict) else 0
         pinned = self.capsules.pin(CapsuleEntry(
             key=key, aligned_len=aligned, nbytes=nbytes, capsule=cap))
@@ -363,6 +363,40 @@ class AgentService:
         else:
             self.sessions.mark_hot(session.session_id)
 
+    def _effective_max_tokens(self, req: AgentRequest,
+                              prompt_len: int) -> int:
+        max_tokens = int(req.max_tokens)
+        max_seq = int(getattr(self.engine, "max_seq", 0) or 0)
+        if max_seq <= 0:
+            return max_tokens
+        remaining = max_seq - int(prompt_len)
+        if remaining < 1:
+            raise ValueError(
+                f"prompt length {int(prompt_len)} leaves no room under "
+                f"max_seq {max_seq}; reduce context or start with a larger "
+                "server --max-seq")
+        if max_tokens > remaining:
+            log.warning(
+                "clipping max_tokens from %d to %d for prompt=%d max_seq=%d",
+                max_tokens, remaining, int(prompt_len), max_seq)
+            return remaining
+        return max_tokens
+
+    def validate_request_bounds(self, req: AgentRequest) -> None:
+        """Fail hard context-limit errors before a StreamingResponse starts.
+
+        Soft output-budget overflow is handled by clipping in the request path;
+        a prompt that already fills the context must be rejected before Starlette
+        begins SSE streaming, otherwise the client sees a broken stream and the
+        server logs an ASGI traceback.
+        """
+        prompt_tokens = self.engine.tokenize_chat(
+            req.messages,
+            tools=req.tools,
+            enable_thinking=req.enable_thinking,
+        )
+        self._effective_max_tokens(req, len(prompt_tokens))
+
     @staticmethod
     def _fmt_metric_line(
             kind: str, *, session_id: str, action: str,
@@ -409,6 +443,7 @@ class AgentService:
             tools=req.tools,
             enable_thinking=req.enable_thinking,
         )
+        max_tokens = self._effective_max_tokens(req, len(prompt_tokens))
         session, plan = self.sessions.plan_request(
             req.session_id,
             prompt_tokens,
@@ -420,7 +455,7 @@ class AgentService:
         decode_k = self._effective_k(req)
         t0 = time.perf_counter()
         cap_plan = self._capsule_prefill(
-            req, prompt_tokens, session, K=decode_k)
+            req, prompt_tokens, session, max_tokens=max_tokens, K=decode_k)
         if cap_plan is not None:
             plan = cap_plan
         else:
@@ -436,7 +471,7 @@ class AgentService:
             self.engine.prefill(
                 engine_prompt_tokens,
                 cached_tokens=effective_cached,
-                max_tokens=req.max_tokens,
+                max_tokens=max_tokens,
                 K=decode_k,
             )
         t_prefill = time.perf_counter()
@@ -449,7 +484,7 @@ class AgentService:
         state_lookahead = False
         saw_tool_call = False
         for chunk in self.engine.generate_stream(
-                max_tokens=req.max_tokens, K=decode_k):
+                max_tokens=max_tokens, K=decode_k):
             generated_ids.extend(int(t) for t in chunk.token_ids)
             if getattr(chunk, "state_lookahead", 0):
                 state_lookahead = True
@@ -542,6 +577,7 @@ class AgentService:
             tools=req.tools,
             enable_thinking=req.enable_thinking,
         )
+        max_tokens = self._effective_max_tokens(req, len(prompt_tokens))
         session, plan = self.sessions.plan_request(
             req.session_id,
             prompt_tokens,
@@ -552,7 +588,7 @@ class AgentService:
         decode_k = self._effective_k(req)
         t0 = time.perf_counter()
         cap_plan = self._capsule_prefill(
-            req, prompt_tokens, session, K=decode_k)
+            req, prompt_tokens, session, max_tokens=max_tokens, K=decode_k)
         if cap_plan is not None:
             plan = cap_plan
         else:
@@ -568,7 +604,7 @@ class AgentService:
             self.engine.prefill(
                 engine_prompt_tokens,
                 cached_tokens=effective_cached,
-                max_tokens=req.max_tokens,
+                max_tokens=max_tokens,
                 K=decode_k,
             )
         t_prefill = time.perf_counter()
@@ -585,7 +621,7 @@ class AgentService:
         stream_started = time.perf_counter()
         backend_decode_ms = 0.0
         saw_tool_call = False
-        chunks = iter(self.engine.generate_stream(max_tokens=req.max_tokens,
+        chunks = iter(self.engine.generate_stream(max_tokens=max_tokens,
                                                   K=decode_k))
         while True:
             next_t0 = time.perf_counter()

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -363,6 +363,44 @@ class AgentService:
         else:
             self.sessions.mark_hot(session.session_id)
 
+    @staticmethod
+    def _fmt_metric_line(
+            kind: str, *, session_id: str, action: str,
+            prompt_tokens: int, cached_tokens: int, new_prefill_tokens: int,
+            completion_tokens: int, prefill_ms: float,
+            first_delta_ms: float, decode_ms: float,
+            decode_tok_per_s: float, finish: str, tool_calls: int,
+            state_lookahead: bool, hot_after: Optional[str], K: int,
+            stream_wall_ms: Optional[float] = None,
+            stream_wall_tok_per_s: Optional[float] = None) -> str:
+        """Stable one-line serving metrics optimized for terminal scanning."""
+        parts = [
+            f"{kind:<8}",
+            f"sid={session_id}",
+            f"act={action:<14}",
+            (
+                f"tok p={prompt_tokens:>6} cache={cached_tokens:>6} "
+                f"new={new_prefill_tokens:>5} out={completion_tokens:>4}"
+            ),
+            (
+                f"ms prefill={prefill_ms:>7.1f} "
+                f"ttft={first_delta_ms:>7.1f} decode={decode_ms:>7.1f}"
+            ),
+            f"speed decode={decode_tok_per_s:>6.1f} tok/s",
+        ]
+        if stream_wall_ms is not None and stream_wall_tok_per_s is not None:
+            parts.append(
+                f"stream={stream_wall_ms:>7.1f}ms/"
+                f"{stream_wall_tok_per_s:>6.1f} tok/s")
+        parts.extend([
+            f"finish={finish}",
+            f"tools={tool_calls}",
+            f"lookahead={int(state_lookahead)}",
+            f"hot={hot_after}",
+            f"K={K}",
+        ])
+        return " | ".join(parts)
+
     def _complete(self, req: AgentRequest) -> AgentResult:
         if req.max_tokens < 1:
             raise ValueError("max_tokens must be >= 1")
@@ -464,17 +502,24 @@ class AgentService:
             "completion_tokens": completion_tokens,
             "total_tokens": len(prompt_tokens) + completion_tokens,
         }
-        log.info(
-            "complete sid=%s action=%s prompt=%d cached=%d new_prefill=%d "
-            "completion=%d prefill_ms=%.1f first_delta_ms=%.1f decode_ms=%.1f "
-            "decode_tok/s=%.1f finish=%s tool_calls=%d state_lookahead=%d "
-            "hot_after=%s K=%d",
-            session.session_id, plan.action, len(prompt_tokens),
-            stats.cached_tokens, stats.new_prefill_tokens, completion_tokens,
-            stats.prefill_ms, stats.first_delta_ms, stats.decode_ms,
-            stats.decode_tok_per_s, finish_reason, len(tool_calls),
-            int(state_lookahead), self.sessions.hot_session_id, decode_k,
-        )
+        log.info(self._fmt_metric_line(
+            "complete",
+            session_id=session.session_id,
+            action=plan.action,
+            prompt_tokens=len(prompt_tokens),
+            cached_tokens=stats.cached_tokens,
+            new_prefill_tokens=stats.new_prefill_tokens,
+            completion_tokens=completion_tokens,
+            prefill_ms=stats.prefill_ms,
+            first_delta_ms=stats.first_delta_ms,
+            decode_ms=stats.decode_ms,
+            decode_tok_per_s=stats.decode_tok_per_s,
+            finish=finish_reason,
+            tool_calls=len(tool_calls),
+            state_lookahead=state_lookahead,
+            hot_after=self.sessions.hot_session_id,
+            K=decode_k,
+        ))
         return AgentResult(
             completion_id=completion_id,
             session_id=session.session_id,
@@ -602,18 +647,26 @@ class AgentService:
             completion_tokens * 1000.0 / stream_wall_ms
             if stream_wall_ms > 0 else 0.0
         )
-        log.info(
-            "stream sid=%s action=%s prompt=%d cached=%d new_prefill=%d "
-            "completion=%d prefill_ms=%.1f first_delta_ms=%.1f decode_ms=%.1f "
-            "decode_tok/s=%.1f stream_wall_ms=%.1f stream_wall_tok/s=%.1f "
-            "finish=%s tool_calls=%d state_lookahead=%d hot_after=%s K=%d",
-            session.session_id, plan.action, len(prompt_tokens),
-            plan.cached_tokens, plan.new_prefill_tokens, completion_tokens,
-            (t_prefill - t0) * 1000.0, first_delta_ms, decode_ms,
-            decode_tok_per_s, stream_wall_ms, stream_wall_tok_per_s,
-            "tool_calls" if seen_tool_call else "stop", len(tool_calls),
-            int(state_lookahead), self.sessions.hot_session_id, decode_k,
-        )
+        log.info(self._fmt_metric_line(
+            "stream",
+            session_id=session.session_id,
+            action=plan.action,
+            prompt_tokens=len(prompt_tokens),
+            cached_tokens=plan.cached_tokens,
+            new_prefill_tokens=plan.new_prefill_tokens,
+            completion_tokens=completion_tokens,
+            prefill_ms=(t_prefill - t0) * 1000.0,
+            first_delta_ms=first_delta_ms,
+            decode_ms=decode_ms,
+            decode_tok_per_s=decode_tok_per_s,
+            stream_wall_ms=stream_wall_ms,
+            stream_wall_tok_per_s=stream_wall_tok_per_s,
+            finish="tool_calls" if seen_tool_call else "stop",
+            tool_calls=len(tool_calls),
+            state_lookahead=state_lookahead,
+            hot_after=self.sessions.hot_session_id,
+            K=decode_k,
+        ))
         for ev in deferred_tool_events:
             yield sse_data(event_chunk(completion_id, model, ev))
         yield sse_data(done_chunk(

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -59,9 +59,20 @@ class AgentService:
 
     def __init__(self, engine: AgentEngine, *,
                  sessions: Optional[SessionRegistry] = None,
-                 capsule_budget_bytes: int = 0):
+                 capsule_budget_bytes: int = 0,
+                 default_max_tokens: int = 2048,
+                 max_output_tokens: int = 8192):
+        if default_max_tokens < 1:
+            raise ValueError("default_max_tokens must be >= 1")
+        if max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
+        if default_max_tokens > max_output_tokens:
+            raise ValueError(
+                "default_max_tokens must be <= max_output_tokens")
         self.engine = engine
         self.sessions = sessions or SessionRegistry()
+        self.default_max_tokens = int(default_max_tokens)
+        self.max_output_tokens = int(max_output_tokens)
         # Pinned shared-prefix capsules (off-by-default: budget 0 keeps the
         # serving path byte-identical). A pinned capsule lets a fresh turn/session
         # restore a clean committed boundary instead of cold-prefilling the shared
@@ -73,6 +84,13 @@ class AgentService:
         # holds the lock for the whole turn; a streaming call holds it for the
         # life of the generator (released when it is exhausted or closed).
         self._lock = threading.Lock()
+
+    def request_from_openai(self, req: Dict[str, Any]) -> AgentRequest:
+        return request_from_openai(
+            req,
+            default_max_tokens=self.default_max_tokens,
+            max_output_tokens=self.max_output_tokens,
+        )
 
     def complete(self, req: AgentRequest) -> AgentResult:
         with self._lock:
@@ -512,7 +530,17 @@ def parse_pin_prefix(value: Any) -> Optional[int]:
 
 
 def request_from_openai(req: Dict[str, Any], *, default_k: int = 6,
-                        default_max_tokens: int = 2048) -> AgentRequest:
+                        default_max_tokens: int = 2048,
+                        max_output_tokens: Optional[int] = 8192
+                        ) -> AgentRequest:
+    if default_max_tokens < 1:
+        raise ValueError("default_max_tokens must be >= 1")
+    if max_output_tokens is not None:
+        if max_output_tokens < 1:
+            raise ValueError("max_output_tokens must be >= 1")
+        if default_max_tokens > max_output_tokens:
+            raise ValueError(
+                "default_max_tokens must be <= max_output_tokens")
     messages = validate_messages(req.get("messages"))
     tools = validate_tools(req.get("tools"))
     # Fall back to max_completion_tokens only when max_tokens is absent *or*
@@ -526,6 +554,9 @@ def request_from_openai(req: Dict[str, Any], *, default_k: int = 6,
         raw_max_tokens, name="max_tokens", default=default_max_tokens)
     if max_tokens < 1:
         raise ValueError("max_tokens must be >= 1")
+    if max_output_tokens is not None and max_tokens > int(max_output_tokens):
+        raise ValueError(
+            f"max_tokens must be <= {int(max_output_tokens)}")
     K = parse_int(req.get("flashrt_K"), name="flashrt_K", default=default_k)
     return AgentRequest(
         messages=messages,

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -412,8 +412,19 @@ class AgentService:
         state_lookahead = False
         yield sse_data(role_chunk(completion_id, model))
         first_delta_ms = 0.0
-        decode_started = time.perf_counter()
-        for chunk in self.engine.generate_stream(max_tokens=req.max_tokens, K=req.K):
+        stream_started = time.perf_counter()
+        backend_decode_ms = 0.0
+        chunks = iter(self.engine.generate_stream(max_tokens=req.max_tokens,
+                                                  K=req.K))
+        while True:
+            next_t0 = time.perf_counter()
+            try:
+                chunk = next(chunks)
+            except StopIteration:
+                backend_decode_ms += (
+                    time.perf_counter() - next_t0) * 1000.0
+                break
+            backend_decode_ms += (time.perf_counter() - next_t0) * 1000.0
             generated_ids.extend(int(t) for t in chunk.token_ids)
             if getattr(chunk, "state_lookahead", 0):
                 state_lookahead = True
@@ -449,18 +460,23 @@ class AgentService:
             "total_tokens": len(prompt_tokens) + len(generated_ids),
         }
         completion_tokens = len(generated_ids)
-        decode_ms = max(0.0, (t_done - decode_started) * 1000.0)
+        decode_ms = max(0.0, backend_decode_ms)
         decode_tok_per_s = (
             completion_tokens * 1000.0 / decode_ms if decode_ms > 0 else 0.0
+        )
+        stream_wall_ms = max(0.0, (t_done - stream_started) * 1000.0)
+        stream_wall_tok_per_s = (
+            completion_tokens * 1000.0 / stream_wall_ms
+            if stream_wall_ms > 0 else 0.0
         )
         log.info(
             "stream sid=%s action=%s prompt=%d cached=%d new_prefill=%d "
             "completion=%d prefill_ms=%.1f first_delta_ms=%.1f decode_ms=%.1f "
-            "decode_tok/s=%.1f",
+            "decode_tok/s=%.1f stream_wall_ms=%.1f stream_wall_tok/s=%.1f",
             session.session_id, plan.action, len(prompt_tokens),
             plan.cached_tokens, plan.new_prefill_tokens, completion_tokens,
             (t_prefill - t0) * 1000.0, first_delta_ms, decode_ms,
-            decode_tok_per_s,
+            decode_tok_per_s, stream_wall_ms, stream_wall_tok_per_s,
         )
         yield sse_data(done_chunk(
             completion_id,

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 log = logging.getLogger("qwen36_agent")
 
+from .auto_prefix import AutoPrefixCacheManager
 from .engine import AgentEngine, GenerationStats
 from .openai_stream import (
     done_chunk,
@@ -50,7 +51,7 @@ class AgentResult:
     tool_calls: List[Dict[str, Any]]
     finish_reason: str
     events: List[StreamEvent]
-    usage: Dict[str, int]
+    usage: Dict[str, Any]
     stats: GenerationStats
     prefix_plan: PrefixPlan
 
@@ -73,6 +74,7 @@ class AgentService:
                 "default_max_tokens must be <= max_output_tokens")
         self.engine = engine
         self.sessions = sessions or SessionRegistry()
+        self.auto_prefix = AutoPrefixCacheManager(self.sessions)
         self.default_max_tokens = int(default_max_tokens)
         self.max_output_tokens = int(max_output_tokens)
         self.default_session_id = default_session_id or None
@@ -363,6 +365,26 @@ class AgentService:
         else:
             self.sessions.mark_hot(session.session_id)
 
+    def _select_prefix_session(
+            self, req: AgentRequest, prompt_tokens: List[int]):
+        def can_message_append(session) -> bool:
+            previous = getattr(session, "visible_messages", None)
+            if not previous:
+                return False
+            incoming_prefix = req.messages[:len(previous)]
+            return (
+                incoming_prefix == previous
+                or self._messages_equivalent_prefix(previous, incoming_prefix)
+            )
+
+        selected = self.auto_prefix.select(
+            req.session_id,
+            prompt_tokens,
+            cache_salt=req.cache_salt,
+            can_message_append=can_message_append,
+        )
+        return selected.session, selected.plan
+
     def _effective_max_tokens(self, req: AgentRequest,
                               prompt_len: int) -> int:
         max_tokens = int(req.max_tokens)
@@ -444,11 +466,7 @@ class AgentService:
             enable_thinking=req.enable_thinking,
         )
         max_tokens = self._effective_max_tokens(req, len(prompt_tokens))
-        session, plan = self.sessions.plan_request(
-            req.session_id,
-            prompt_tokens,
-            cache_salt=req.cache_salt,
-        )
+        session, plan = self._select_prefix_session(req, prompt_tokens)
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
         engine_prompt_tokens = prompt_tokens
@@ -536,6 +554,9 @@ class AgentService:
             "prompt_tokens": len(prompt_tokens),
             "completion_tokens": completion_tokens,
             "total_tokens": len(prompt_tokens) + completion_tokens,
+            "prompt_tokens_details": {
+                "cached_tokens": int(plan.cached_tokens),
+            },
         }
         log.info(self._fmt_metric_line(
             "complete",
@@ -578,11 +599,7 @@ class AgentService:
             enable_thinking=req.enable_thinking,
         )
         max_tokens = self._effective_max_tokens(req, len(prompt_tokens))
-        session, plan = self.sessions.plan_request(
-            req.session_id,
-            prompt_tokens,
-            cache_salt=req.cache_salt,
-        )
+        session, plan = self._select_prefix_session(req, prompt_tokens)
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
         engine_prompt_tokens = prompt_tokens
         decode_k = self._effective_k(req)
@@ -672,6 +689,9 @@ class AgentService:
             "prompt_tokens": len(prompt_tokens),
             "completion_tokens": len(generated_ids),
             "total_tokens": len(prompt_tokens) + len(generated_ids),
+            "prompt_tokens_details": {
+                "cached_tokens": int(plan.cached_tokens),
+            },
         }
         completion_tokens = len(generated_ids)
         decode_ms = max(0.0, backend_decode_ms)
@@ -825,7 +845,11 @@ def request_from_openai(req: Dict[str, Any], *, default_k: int = 6,
         max_tokens=max_tokens,
         stream=parse_bool(req.get("stream"), default=False),
         session_id=req.get("flashrt_session_id") or req.get("session_id"),
-        cache_salt=str(req.get("flashrt_cache_salt", "")),
+        cache_salt=str(
+            req.get("prompt_cache_key")
+            or req.get("cache_salt")
+            or req.get("flashrt_cache_salt", "")
+        ),
         enable_thinking=parse_bool(req.get("enable_thinking"), default=False),
         K=K,
         pin_prefix=parse_pin_prefix(req.get("flashrt_pin_prefix")),

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -130,8 +130,9 @@ class AgentService:
     ) -> Optional[PrefixPlan]:
         """Restore-or-pin a shared-prefix capsule when ``pin_prefix`` is requested
         and viable, performing the prefill on the engine and returning its
-        PrefixPlan. Returns None (caller uses the normal hot-append / rebuild path)
-        when pinning is disabled, unsupported, or the prefix is too short to pin.
+        PrefixPlan. Returns None only when the request did not ask for capsule
+        pinning. If the request does ask for pinning, fail fast on unsupported
+        configs instead of silently falling back to a different prefill route.
 
         A pinned capsule is keyed by the digest of its chunk-aligned prefix tokens,
         so a later turn or a different session whose prompt starts with the same
@@ -142,18 +143,26 @@ class AgentService:
         exact aligned-prefix digest match).
         """
         pin = req.pin_prefix
-        if not pin or not self.capsules.enabled:
+        if not pin:
             return None
+        if not self.capsules.enabled:
+            raise ValueError(
+                "flashrt_pin_prefix requires --capsule-budget-mb > 0")
         supports = getattr(self.engine, "supports_capsule", None)
         if not callable(supports) or not supports():
-            return None
+            raise ValueError(
+                "flashrt_pin_prefix requires a capsule-capable Qwen3.6 engine")
         prompt_len = len(prompt_tokens)
         pin_len = prompt_len if pin is True else min(int(pin), prompt_len)
         if pin_len <= 0:
             return None
         aligned = self.engine.capsule_aligned_len(pin_len, req.max_tokens)
         if aligned <= 0 or aligned > prompt_len:
-            return None
+            raise ValueError(
+                "flashrt_pin_prefix requires the long FP8-KV route and a "
+                "chunk-aligned prefix; start the server with a long-context "
+                "max_seq, --route-min-seq 0, and "
+                "FLASHRT_QWEN36_LONG_KV_CACHE=fp8")
         key = token_digest(prompt_tokens[:aligned], salt=req.cache_salt)
         entry = self.capsules.get(key)
         if entry is not None:

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -384,6 +384,7 @@ class AgentService:
         )
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
         engine_prompt_tokens = prompt_tokens
+        t0 = time.perf_counter()
         cap_plan = self._capsule_prefill(req, prompt_tokens, session)
         if cap_plan is not None:
             plan = cap_plan
@@ -402,6 +403,7 @@ class AgentService:
                 max_tokens=req.max_tokens,
                 K=req.K,
             )
+        t_prefill = time.perf_counter()
 
         parser = ToolCallStreamParser()
         generated_ids: List[int] = []
@@ -409,22 +411,29 @@ class AgentService:
         seen_tool_call = False
         state_lookahead = False
         yield sse_data(role_chunk(completion_id, model))
+        first_delta_ms = 0.0
+        decode_started = time.perf_counter()
         for chunk in self.engine.generate_stream(max_tokens=req.max_tokens, K=req.K):
             generated_ids.extend(int(t) for t in chunk.token_ids)
             if getattr(chunk, "state_lookahead", 0):
                 state_lookahead = True
             for ev in parser.feed(chunk.text):
+                if first_delta_ms <= 0.0:
+                    first_delta_ms = (time.perf_counter() - t0) * 1000.0
                 if ev.kind == "tool_call":
                     seen_tool_call = True
                 else:
                     visible_parts.append(str(ev.payload))
                 yield sse_data(event_chunk(completion_id, model, ev))
         for ev in parser.finish():
+            if first_delta_ms <= 0.0:
+                first_delta_ms = (time.perf_counter() - t0) * 1000.0
             if ev.kind == "tool_call":
                 seen_tool_call = True
             else:
                 visible_parts.append(str(ev.payload))
             yield sse_data(event_chunk(completion_id, model, ev))
+        t_done = time.perf_counter()
 
         session.commit([*engine_prompt_tokens, *generated_ids])
         visible_messages = self._copy_messages(req.messages)
@@ -439,10 +448,19 @@ class AgentService:
             "completion_tokens": len(generated_ids),
             "total_tokens": len(prompt_tokens) + len(generated_ids),
         }
+        completion_tokens = len(generated_ids)
+        decode_ms = max(0.0, (t_done - decode_started) * 1000.0)
+        decode_tok_per_s = (
+            completion_tokens * 1000.0 / decode_ms if decode_ms > 0 else 0.0
+        )
         log.info(
-            "stream sid=%s action=%s prompt=%d completion=%d",
+            "stream sid=%s action=%s prompt=%d cached=%d new_prefill=%d "
+            "completion=%d prefill_ms=%.1f first_delta_ms=%.1f decode_ms=%.1f "
+            "decode_tok/s=%.1f",
             session.session_id, plan.action, len(prompt_tokens),
-            len(generated_ids),
+            plan.cached_tokens, plan.new_prefill_tokens, completion_tokens,
+            (t_prefill - t0) * 1000.0, first_delta_ms, decode_ms,
+            decode_tok_per_s,
         )
         yield sse_data(done_chunk(
             completion_id,

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import time
@@ -152,7 +153,8 @@ class AgentService:
         return effective_cached, plan
 
     def _capsule_prefill(
-            self, req: AgentRequest, prompt_tokens: List[int], session
+            self, req: AgentRequest, prompt_tokens: List[int], session, *,
+            K: int
     ) -> Optional[PrefixPlan]:
         """Restore-or-pin a shared-prefix capsule when ``pin_prefix`` is requested
         and viable, performing the prefill on the engine and returning its
@@ -194,7 +196,7 @@ class AgentService:
         if entry is not None:
             self.engine.prefill_from_capsule(
                 entry.capsule, prompt_tokens,
-                max_tokens=req.max_tokens, K=req.K)
+                max_tokens=req.max_tokens, K=K)
             return PrefixPlan(
                 session_id=session.session_id,
                 cached_tokens=aligned,
@@ -205,7 +207,7 @@ class AgentService:
             )
         cap = self.engine.prefill_and_pin(
             prompt_tokens, aligned_len=aligned,
-            max_tokens=req.max_tokens, K=req.K)
+            max_tokens=req.max_tokens, K=K)
         nbytes = int(cap.get("nbytes", 0)) if isinstance(cap, dict) else 0
         pinned = self.capsules.pin(CapsuleEntry(
             key=key, aligned_len=aligned, nbytes=nbytes, capsule=cap))
@@ -227,8 +229,14 @@ class AgentService:
         if not previous or not hasattr(
                 self.engine, "append_suffix_tokens_for_messages"):
             return None, None
+        previous_for_suffix = previous
+        incoming_prefix = req.messages[:len(previous)]
+        if incoming_prefix != previous:
+            if not self._messages_equivalent_prefix(previous, incoming_prefix):
+                return None, None
+            previous_for_suffix = incoming_prefix
         suffix = self.engine.append_suffix_tokens_for_messages(
-            previous,
+            previous_for_suffix,
             req.messages,
             tools=req.tools,
             enable_thinking=req.enable_thinking,
@@ -243,6 +251,90 @@ class AgentService:
             incoming_tokens=plan.incoming_tokens,
             matched_tokens=plan.matched_tokens,
             action="message_append",
+        )
+
+    @classmethod
+    def _messages_equivalent_prefix(
+            cls, previous: List[Dict[str, Any]],
+            incoming: List[Dict[str, Any]]) -> bool:
+        if len(incoming) != len(previous):
+            return False
+        return all(cls._messages_equivalent(a, b)
+                   for a, b in zip(previous, incoming))
+
+    @classmethod
+    def _messages_equivalent(cls, a: Dict[str, Any],
+                             b: Dict[str, Any]) -> bool:
+        if a.get("role") != b.get("role"):
+            return False
+        if (a.get("content") or "") != (b.get("content") or ""):
+            return False
+        return cls._tool_calls_equivalent(
+            a.get("tool_calls"), b.get("tool_calls"))
+
+    @staticmethod
+    def _tool_calls_equivalent(a: Any, b: Any) -> bool:
+        if not a and not b:
+            return True
+        if not isinstance(a, list) or not isinstance(b, list):
+            return False
+        if len(a) != len(b):
+            return False
+
+        def norm_call(tc: Any) -> Any:
+            if not isinstance(tc, dict):
+                return tc
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                return fn
+            args = fn.get("arguments")
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args) if args.strip() else {}
+                except Exception:
+                    pass
+            return {
+                "type": tc.get("type", "function"),
+                "name": fn.get("name"),
+                "arguments": args,
+            }
+
+        return [norm_call(x) for x in a] == [norm_call(x) for x in b]
+
+    @staticmethod
+    def _effective_k(req: AgentRequest) -> int:
+        return int(req.K)
+
+    def _log_reuse_miss(self, session, plan: PrefixPlan,
+                        incoming_messages: List[Dict[str, Any]]) -> None:
+        if plan.action in ("append", "exact", "restore", "message_append"):
+            return
+        previous = getattr(session, "visible_messages", None) or []
+
+        def msg_shape(msg: Dict[str, Any]) -> str:
+            role = str(msg.get("role", "?"))
+            has_tools = bool(msg.get("tool_calls"))
+            content = msg.get("content")
+            if content is None:
+                ckind = "none"
+            elif isinstance(content, str):
+                ckind = f"str:{len(content)}"
+            elif isinstance(content, list):
+                ckind = f"list:{len(content)}"
+            else:
+                ckind = type(content).__name__
+            return f"{role}/{ckind}/tools={int(has_tools)}"
+
+        log.info(
+            "reuse_miss sid=%s action=%s matched=%d cached_len=%d "
+            "prev_tokens=%d incoming_tokens=%d hot=%s prev_msgs=%d "
+            "incoming_msgs=%d prev_tail=%s incoming_tail=%s",
+            session.session_id, plan.action, plan.matched_tokens,
+            session.cached_len, len(session.token_ids),
+            plan.incoming_tokens, self.sessions.hot_session_id,
+            len(previous), len(incoming_messages),
+            [msg_shape(m) for m in previous[-4:]],
+            [msg_shape(m) for m in incoming_messages[-4:]],
         )
 
     @staticmethod
@@ -287,8 +379,10 @@ class AgentService:
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
         engine_prompt_tokens = prompt_tokens
+        decode_k = self._effective_k(req)
         t0 = time.perf_counter()
-        cap_plan = self._capsule_prefill(req, prompt_tokens, session)
+        cap_plan = self._capsule_prefill(
+            req, prompt_tokens, session, K=decode_k)
         if cap_plan is not None:
             plan = cap_plan
         else:
@@ -300,11 +394,12 @@ class AgentService:
                 effective_cached = plan.cached_tokens
             else:
                 effective_cached, plan = self._effective_plan(session, plan)
+                self._log_reuse_miss(session, plan, req.messages)
             self.engine.prefill(
                 engine_prompt_tokens,
                 cached_tokens=effective_cached,
                 max_tokens=req.max_tokens,
-                K=req.K,
+                K=decode_k,
             )
         t_prefill = time.perf_counter()
 
@@ -315,7 +410,8 @@ class AgentService:
         decode_started = time.perf_counter()
         state_lookahead = False
         saw_tool_call = False
-        for chunk in self.engine.generate_stream(max_tokens=req.max_tokens, K=req.K):
+        for chunk in self.engine.generate_stream(
+                max_tokens=req.max_tokens, K=decode_k):
             generated_ids.extend(int(t) for t in chunk.token_ids)
             if getattr(chunk, "state_lookahead", 0):
                 state_lookahead = True
@@ -371,11 +467,13 @@ class AgentService:
         log.info(
             "complete sid=%s action=%s prompt=%d cached=%d new_prefill=%d "
             "completion=%d prefill_ms=%.1f first_delta_ms=%.1f decode_ms=%.1f "
-            "decode_tok/s=%.1f",
+            "decode_tok/s=%.1f finish=%s tool_calls=%d state_lookahead=%d "
+            "hot_after=%s K=%d",
             session.session_id, plan.action, len(prompt_tokens),
             stats.cached_tokens, stats.new_prefill_tokens, completion_tokens,
             stats.prefill_ms, stats.first_delta_ms, stats.decode_ms,
-            stats.decode_tok_per_s,
+            stats.decode_tok_per_s, finish_reason, len(tool_calls),
+            int(state_lookahead), self.sessions.hot_session_id, decode_k,
         )
         return AgentResult(
             completion_id=completion_id,
@@ -406,8 +504,10 @@ class AgentService:
         )
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
         engine_prompt_tokens = prompt_tokens
+        decode_k = self._effective_k(req)
         t0 = time.perf_counter()
-        cap_plan = self._capsule_prefill(req, prompt_tokens, session)
+        cap_plan = self._capsule_prefill(
+            req, prompt_tokens, session, K=decode_k)
         if cap_plan is not None:
             plan = cap_plan
         else:
@@ -419,11 +519,12 @@ class AgentService:
                 effective_cached = msg_plan.cached_tokens
             else:
                 effective_cached, plan = self._effective_plan(session, plan)
+                self._log_reuse_miss(session, plan, req.messages)
             self.engine.prefill(
                 engine_prompt_tokens,
                 cached_tokens=effective_cached,
                 max_tokens=req.max_tokens,
-                K=req.K,
+                K=decode_k,
             )
         t_prefill = time.perf_counter()
 
@@ -438,9 +539,9 @@ class AgentService:
         first_delta_ms = 0.0
         stream_started = time.perf_counter()
         backend_decode_ms = 0.0
-        chunks = iter(self.engine.generate_stream(max_tokens=req.max_tokens,
-                                                  K=req.K))
         saw_tool_call = False
+        chunks = iter(self.engine.generate_stream(max_tokens=req.max_tokens,
+                                                  K=decode_k))
         while True:
             next_t0 = time.perf_counter()
             try:
@@ -504,11 +605,14 @@ class AgentService:
         log.info(
             "stream sid=%s action=%s prompt=%d cached=%d new_prefill=%d "
             "completion=%d prefill_ms=%.1f first_delta_ms=%.1f decode_ms=%.1f "
-            "decode_tok/s=%.1f stream_wall_ms=%.1f stream_wall_tok/s=%.1f",
+            "decode_tok/s=%.1f stream_wall_ms=%.1f stream_wall_tok/s=%.1f "
+            "finish=%s tool_calls=%d state_lookahead=%d hot_after=%s K=%d",
             session.session_id, plan.action, len(prompt_tokens),
             plan.cached_tokens, plan.new_prefill_tokens, completion_tokens,
             (t_prefill - t0) * 1000.0, first_delta_ms, decode_ms,
             decode_tok_per_s, stream_wall_ms, stream_wall_tok_per_s,
+            "tool_calls" if seen_tool_call else "stop", len(tool_calls),
+            int(state_lookahead), self.sessions.hot_session_id, decode_k,
         )
         for ev in deferred_tool_events:
             yield sse_data(event_chunk(completion_id, model, ev))

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -34,7 +34,7 @@ class AgentRequest:
     session_id: Optional[str] = None
     cache_salt: str = ""
     enable_thinking: bool = False
-    K: int = 6
+    K: int = 4
     # Pin the shared-prefix capsule: int = number of leading prompt tokens to pin
     # as a reusable capsule; True = pin the whole current prompt's aligned head;
     # None/0 = no pinning. Restore on a later request whose prompt starts with the
@@ -62,7 +62,7 @@ class AgentService:
     def __init__(self, engine: AgentEngine, *,
                  sessions: Optional[SessionRegistry] = None,
                  capsule_budget_bytes: int = 0,
-                 default_k: int = 6,
+                 default_k: int = 4,
                  default_max_tokens: int = 2048,
                  max_output_tokens: int = 8192,
                  default_session_id: Optional[str] = None):
@@ -815,7 +815,7 @@ def parse_pin_prefix(value: Any) -> Optional[int]:
     return n if n > 0 else None
 
 
-def request_from_openai(req: Dict[str, Any], *, default_k: int = 6,
+def request_from_openai(req: Dict[str, Any], *, default_k: int = 4,
                         default_max_tokens: int = 2048,
                         max_output_tokens: Optional[int] = 8192
                         ) -> AgentRequest:

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -61,7 +61,8 @@ class AgentService:
                  sessions: Optional[SessionRegistry] = None,
                  capsule_budget_bytes: int = 0,
                  default_max_tokens: int = 2048,
-                 max_output_tokens: int = 8192):
+                 max_output_tokens: int = 8192,
+                 default_session_id: Optional[str] = None):
         if default_max_tokens < 1:
             raise ValueError("default_max_tokens must be >= 1")
         if max_output_tokens < 1:
@@ -73,6 +74,7 @@ class AgentService:
         self.sessions = sessions or SessionRegistry()
         self.default_max_tokens = int(default_max_tokens)
         self.max_output_tokens = int(max_output_tokens)
+        self.default_session_id = default_session_id or None
         # Pinned shared-prefix capsules (off-by-default: budget 0 keeps the
         # serving path byte-identical). A pinned capsule lets a fresh turn/session
         # restore a clean committed boundary instead of cold-prefilling the shared
@@ -86,11 +88,14 @@ class AgentService:
         self._lock = threading.Lock()
 
     def request_from_openai(self, req: Dict[str, Any]) -> AgentRequest:
-        return request_from_openai(
+        agent_req = request_from_openai(
             req,
             default_max_tokens=self.default_max_tokens,
             max_output_tokens=self.max_output_tokens,
         )
+        if not agent_req.session_id and self.default_session_id:
+            agent_req.session_id = self.default_session_id
+        return agent_req
 
     def complete(self, req: AgentRequest) -> AgentResult:
         with self._lock:

--- a/serving/qwen36_agent/service.py
+++ b/serving/qwen36_agent/service.py
@@ -246,6 +246,17 @@ class AgentService:
     def _copy_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return [dict(m) for m in messages]
 
+    @staticmethod
+    def _assistant_message(text: str,
+                           tool_calls: List[Dict[str, Any]]) -> Dict[str, Any]:
+        msg: Dict[str, Any] = {
+            "role": "assistant",
+            "content": text if text or not tool_calls else None,
+        }
+        if tool_calls:
+            msg["tool_calls"] = tool_calls
+        return msg
+
     def _mark_reusable(self, session, state_lookahead: bool) -> None:
         """Mark the session hot (reusable for append) only if the GPU state ends
         exactly at the committed transcript. If a stop token left committed
@@ -300,6 +311,7 @@ class AgentService:
         first_delta_ms = 0.0
         decode_started = time.perf_counter()
         state_lookahead = False
+        saw_tool_call = False
         for chunk in self.engine.generate_stream(max_tokens=req.max_tokens, K=req.K):
             generated_ids.extend(int(t) for t in chunk.token_ids)
             if getattr(chunk, "state_lookahead", 0):
@@ -308,10 +320,15 @@ class AgentService:
             if evs and first_delta_ms <= 0.0:
                 first_delta_ms = (time.perf_counter() - t0) * 1000.0
             events.extend(evs)
+            if any(ev.kind == "tool_call" for ev in evs):
+                saw_tool_call = True
+                break
         tail = parser.finish()
         if tail and first_delta_ms <= 0.0:
             first_delta_ms = (time.perf_counter() - t0) * 1000.0
         events.extend(tail)
+        if any(ev.kind == "tool_call" for ev in tail):
+            saw_tool_call = True
         t_done = time.perf_counter()
 
         text_parts: List[str] = []
@@ -325,10 +342,7 @@ class AgentService:
         finish_reason = "tool_calls" if tool_calls else "stop"
         session.commit([*engine_prompt_tokens, *generated_ids])
         visible_messages = self._copy_messages(req.messages)
-        visible_messages.append({
-            "role": "assistant",
-            "content": text,
-        })
+        visible_messages.append(self._assistant_message(text, tool_calls))
         session.visible_messages = visible_messages
         self._mark_reusable(session, state_lookahead)
 
@@ -413,6 +427,7 @@ class AgentService:
         parser = ToolCallStreamParser()
         generated_ids: List[int] = []
         visible_parts: List[str] = []
+        tool_calls: List[Dict[str, Any]] = []
         seen_tool_call = False
         state_lookahead = False
         yield sse_data(role_chunk(completion_id, model))
@@ -421,6 +436,7 @@ class AgentService:
         backend_decode_ms = 0.0
         chunks = iter(self.engine.generate_stream(max_tokens=req.max_tokens,
                                                   K=req.K))
+        saw_tool_call = False
         while True:
             next_t0 = time.perf_counter()
             try:
@@ -438,14 +454,20 @@ class AgentService:
                     first_delta_ms = (time.perf_counter() - t0) * 1000.0
                 if ev.kind == "tool_call":
                     seen_tool_call = True
+                    saw_tool_call = True
+                    tool_calls.append(ev.payload)
                 else:
                     visible_parts.append(str(ev.payload))
                 yield sse_data(event_chunk(completion_id, model, ev))
+            if saw_tool_call:
+                break
         for ev in parser.finish():
             if first_delta_ms <= 0.0:
                 first_delta_ms = (time.perf_counter() - t0) * 1000.0
             if ev.kind == "tool_call":
                 seen_tool_call = True
+                saw_tool_call = True
+                tool_calls.append(ev.payload)
             else:
                 visible_parts.append(str(ev.payload))
             yield sse_data(event_chunk(completion_id, model, ev))
@@ -453,10 +475,8 @@ class AgentService:
 
         session.commit([*engine_prompt_tokens, *generated_ids])
         visible_messages = self._copy_messages(req.messages)
-        visible_messages.append({
-            "role": "assistant",
-            "content": "".join(visible_parts),
-        })
+        visible_messages.append(self._assistant_message(
+            "".join(visible_parts), tool_calls))
         session.visible_messages = visible_messages
         self._mark_reusable(session, state_lookahead)
         usage = {

--- a/serving/qwen36_agent/session.py
+++ b/serving/qwen36_agent/session.py
@@ -28,6 +28,7 @@ class PrefixPlan:
             "exact",
             "append",
             "truncate",
+            "restore",
         }
 
 
@@ -169,3 +170,78 @@ class SessionRegistry:
             if victim_id is None:
                 break
             self._sessions.pop(victim_id, None)
+
+
+@dataclass
+class CapsuleEntry:
+    """A pinned execution-state capsule plus the metadata to match and bound it.
+
+    ``capsule`` is the opaque frontend capsule object (from
+    ``snapshot_capsule``); the store never inspects it beyond ``nbytes``.
+    ``aligned_len`` is the chunk-aligned prefix length the capsule was snapshotted
+    at, so a restore appends from there.
+    """
+
+    key: str
+    aligned_len: int
+    nbytes: int
+    capsule: object
+
+
+class CapsuleStore:
+    """Serving-layer LRU of pinned shared-prefix capsules, bounded by a byte
+    budget.
+
+    Keyed by the token digest of the chunk-aligned shared prefix, so a capsule
+    pinned by one session can be restored by any later request (or session) whose
+    prompt starts with the same prefix. The budget bounds GPU footprint: pinning
+    evicts least-recently-used capsules to fit, and a single capsule larger than
+    the whole budget is rejected (the caller then serves a plain cold prefill —
+    never an OOM). ``budget_bytes <= 0`` disables pinning entirely, keeping the
+    default serving path byte-identical.
+    """
+
+    def __init__(self, *, budget_bytes: int = 0):
+        self.budget_bytes = max(0, int(budget_bytes))
+        self._entries: "OrderedDict[str, CapsuleEntry]" = OrderedDict()
+        self._bytes = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.budget_bytes > 0
+
+    def get(self, key: str) -> Optional[CapsuleEntry]:
+        entry = self._entries.get(key)
+        if entry is not None:
+            self._entries.move_to_end(key)
+        return entry
+
+    def pin(self, entry: CapsuleEntry) -> bool:
+        """Store ``entry``, evicting LRU capsules to stay within the byte budget.
+
+        Returns False (and stores nothing) when pinning is disabled or the single
+        capsule alone exceeds the budget; the caller has already served a cold
+        prefill, so a rejected pin just means no future restore.
+        """
+        if not self.enabled or entry.nbytes <= 0 or entry.nbytes > self.budget_bytes:
+            return False
+        existing = self._entries.pop(entry.key, None)
+        if existing is not None:
+            self._bytes -= existing.nbytes
+        while self._bytes + entry.nbytes > self.budget_bytes and self._entries:
+            _, victim = self._entries.popitem(last=False)
+            self._bytes -= victim.nbytes
+        self._entries[entry.key] = entry
+        self._bytes += entry.nbytes
+        return True
+
+    def footprint(self) -> int:
+        return self._bytes
+
+    def snapshot(self) -> Dict[str, object]:
+        return {
+            "enabled": self.enabled,
+            "count": len(self._entries),
+            "bytes": self._bytes,
+            "budget_bytes": self.budget_bytes,
+        }

--- a/serving/qwen36_agent/session.py
+++ b/serving/qwen36_agent/session.py
@@ -116,6 +116,11 @@ class SessionRegistry:
             self._sessions.move_to_end(session_id)
         return rec
 
+    def hot_record(self) -> Optional[SessionRecord]:
+        if not self.hot_session_id:
+            return None
+        return self.get(self.hot_session_id)
+
     def get_or_create(self, session_id: Optional[str],
                       *, cache_salt: str = "") -> SessionRecord:
         if session_id:

--- a/serving/qwen36_agent/tool_stream.py
+++ b/serving/qwen36_agent/tool_stream.py
@@ -96,12 +96,12 @@ class ToolCallStreamParser:
             if s.endswith("```"):
                 s = s[:-3]
             s = s.strip()
-        try:
-            obj = json.loads(s)
-        except Exception:
+        parsed = self._parse_json_tool_call(s)
+        if parsed is None:
+            parsed = self._parse_qwen_xml_tool_call(s)
+        if parsed is None:
             return None
-        name = obj.get("name")
-        args = obj.get("arguments", obj.get("parameters", {}))
+        name, args = parsed
         if not isinstance(args, str):
             args = json.dumps(args, ensure_ascii=False, separators=(",", ":"))
         idx = self._tool_idx
@@ -115,3 +115,48 @@ class ToolCallStreamParser:
                 "arguments": args,
             },
         }
+
+    @staticmethod
+    def _parse_json_tool_call(s: str) -> Optional[tuple[str, Any]]:
+        try:
+            obj = json.loads(s)
+        except Exception:
+            return None
+        name = obj.get("name")
+        if not isinstance(name, str) or not name:
+            return None
+        args = obj.get("arguments", obj.get("parameters", {}))
+        return name, args
+
+    @staticmethod
+    def _parse_qwen_xml_tool_call(s: str) -> Optional[tuple[str, Dict[str, str]]]:
+        """Parse Qwen's native tool-call format from its chat template:
+
+        <function=name>
+        <parameter=arg>
+        value
+        </parameter>
+        </function>
+        """
+        m = re.fullmatch(
+            r"\s*<function=([^>\n]+)>\s*(.*?)\s*</function>\s*",
+            s,
+            flags=re.DOTALL,
+        )
+        if m is None:
+            return None
+        name = m.group(1).strip()
+        body = m.group(2)
+        if not name:
+            return None
+        args: Dict[str, str] = {}
+        for pm in re.finditer(
+                r"<parameter=([^>\n]+)>\s*(.*?)\s*</parameter>",
+                body,
+                flags=re.DOTALL):
+            key = pm.group(1).strip()
+            if key:
+                args[key] = pm.group(2).strip()
+        if not args and body.strip():
+            return None
+        return name, args

--- a/tests/test_qwen36_agent_capsule_serving.py
+++ b/tests/test_qwen36_agent_capsule_serving.py
@@ -100,8 +100,9 @@ def test_serving_capsule_restore_matches_cold_full_prefill(monkeypatch):
             == r_cold.usage["completion_tokens"])
 
 
-def test_serving_capsule_disabled_by_default(monkeypatch):
-    """With no budget, flashrt_pin_prefix is inert and the path is unchanged."""
+def test_serving_capsule_requires_budget(monkeypatch):
+    """With no budget, an explicit flashrt_pin_prefix fails fast instead of
+    silently falling back to the normal prefill path."""
     fe, _, _ = _service(monkeypatch)
     from serving.qwen36_agent.qwen36_engine import Qwen36FrontendAgentEngine
     from serving.qwen36_agent.service import AgentService, AgentRequest
@@ -110,8 +111,7 @@ def test_serving_capsule_disabled_by_default(monkeypatch):
     eng = Qwen36FrontendAgentEngine(fe)
     svc = AgentService(eng, sessions=SessionRegistry())  # budget 0
     assert not svc.capsules.enabled
-    res = svc.complete(AgentRequest(
-        messages=[{"role": "user", "content": "Hello."}],
-        max_tokens=8, session_id="t", K=6, pin_prefix=4096))
-    assert res.prefix_plan.action != "restore"
-    assert res.prefix_plan.action != "pin"
+    with pytest.raises(ValueError, match="capsule-budget"):
+        svc.complete(AgentRequest(
+            messages=[{"role": "user", "content": "Hello."}],
+            max_tokens=8, session_id="t", K=6, pin_prefix=4096))

--- a/tests/test_qwen36_agent_capsule_serving.py
+++ b/tests/test_qwen36_agent_capsule_serving.py
@@ -1,0 +1,117 @@
+"""Optional GPU test for the serving-layer capsule pin/restore policy.
+
+The frontend capsule API is gated bit-exact in test_qwen36_agent_capsule.py; this
+gates the *serving wiring* (CapsuleStore + flashrt_pin_prefix + the "restore"
+PrefixPlan action): a request that restores a pinned shared-prefix capsule must
+produce the same tokens as a cold full prefill of the same prompt, while
+re-prefilling only the suffix after the chunk-aligned pin boundary.
+
+Run manually with:
+
+    FLASHRT_QWEN36_NVFP4_CKPT_DIR=... \
+    FLASHRT_QWEN36_MTP_CKPT_DIR=... \
+    pytest -q tests/test_qwen36_agent_capsule_serving.py -s
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+CKPT = os.environ.get("FLASHRT_QWEN36_NVFP4_CKPT_DIR", "")
+MTP = os.environ.get("FLASHRT_QWEN36_MTP_CKPT_DIR", "")
+
+
+pytestmark = pytest.mark.skipif(
+    not CKPT or not MTP,
+    reason=(
+        "set FLASHRT_QWEN36_NVFP4_CKPT_DIR and "
+        "FLASHRT_QWEN36_MTP_CKPT_DIR to run Qwen3.6 capsule-serving tests"
+    ),
+)
+
+
+def _service(monkeypatch):
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    monkeypatch.setenv("FLASHRT_QWEN36_LONG_KV_CACHE", "fp8")
+    from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+    from serving.qwen36_agent.qwen36_engine import Qwen36FrontendAgentEngine
+    from serving.qwen36_agent.service import AgentService
+    from serving.qwen36_agent.session import SessionRegistry, CapsuleStore
+
+    fe = Qwen36TorchFrontendRtx(CKPT, quant="nvfp4", device="cuda", max_seq=32768)
+    if getattr(fe, "_long_ctx_mode", False):
+        fe._long_ctx_route_min_seq = 0
+    if not fe._long_ctx_mode or getattr(fe, "_long_kv_cache_mode", "") != "fp8":
+        pytest.skip("long fp8-KV route required for capsule serving")
+    eng = Qwen36FrontendAgentEngine(fe)
+    if not eng.supports_capsule():
+        pytest.skip("frontend has no capsule API")
+    store = CapsuleStore(budget_bytes=8 << 30)
+
+    def serve(messages, *, pin):
+        svc = AgentService(eng, sessions=SessionRegistry())
+        svc.capsules = store
+        from serving.qwen36_agent.service import AgentRequest
+        return svc.complete(AgentRequest(
+            messages=messages, max_tokens=32, session_id="t", K=6,
+            pin_prefix=pin))
+
+    return fe, serve, store
+
+
+def _shared_system(fe, approx_tokens: int = 6000) -> str:
+    unit = ("FlashRT is a latency-first inference runtime. Capsules freeze a "
+            "committed execution boundary so a shared prefix is restored, not "
+            "re-prefilled. ")
+    ids = fe._tokenizer(unit * 200, add_special_tokens=False).input_ids
+    return fe._tokenizer.decode(ids[:approx_tokens])
+
+
+def test_serving_capsule_restore_matches_cold_full_prefill(monkeypatch):
+    fe, serve, store = _service(monkeypatch)
+    sys_text = _shared_system(fe, 6000)
+    pin_n = 6000  # aligned down to a chunk multiple (>= one 2048 chunk)
+
+    msgs_a = [{"role": "system", "content": sys_text},
+              {"role": "user", "content": "Summarize the text in one sentence."}]
+    msgs_b = [{"role": "system", "content": sys_text},
+              {"role": "user", "content": "List two ideas from the text."}]
+
+    r_pin = serve(msgs_a, pin=pin_n)          # cold + pin the aligned prefix
+    assert r_pin.prefix_plan.action == "pin"
+    assert store.footprint() > 0
+
+    r_restore = serve(msgs_b, pin=pin_n)      # restore + append only the suffix
+    assert r_restore.prefix_plan.action == "restore"
+    assert r_restore.stats.cached_tokens > 0
+    assert r_restore.stats.cached_tokens % fe.long_prefill_chunk_size() == 0
+    # only the suffix after the pin boundary is re-prefilled
+    assert r_restore.stats.new_prefill_tokens < r_pin.stats.new_prefill_tokens
+
+    r_cold = serve(msgs_b, pin=None)          # cold full prefill of the same prompt
+    assert r_restore.text == r_cold.text
+    assert (r_restore.usage["completion_tokens"]
+            == r_cold.usage["completion_tokens"])
+
+
+def test_serving_capsule_disabled_by_default(monkeypatch):
+    """With no budget, flashrt_pin_prefix is inert and the path is unchanged."""
+    fe, _, _ = _service(monkeypatch)
+    from serving.qwen36_agent.qwen36_engine import Qwen36FrontendAgentEngine
+    from serving.qwen36_agent.service import AgentService, AgentRequest
+    from serving.qwen36_agent.session import SessionRegistry
+
+    eng = Qwen36FrontendAgentEngine(fe)
+    svc = AgentService(eng, sessions=SessionRegistry())  # budget 0
+    assert not svc.capsules.enabled
+    res = svc.complete(AgentRequest(
+        messages=[{"role": "user", "content": "Hello."}],
+        max_tokens=8, session_id="t", K=6, pin_prefix=4096))
+    assert res.prefix_plan.action != "restore"
+    assert res.prefix_plan.action != "pin"

--- a/tests/test_qwen36_agent_gpu_split.py
+++ b/tests/test_qwen36_agent_gpu_split.py
@@ -29,6 +29,21 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _release_cuda_between_gpu_split_tests():
+    yield
+    try:
+        import gc
+        import torch
+
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
+    except Exception:
+        pass
+
+
 def _load_frontend(max_seq: int):
     import torch
 
@@ -115,6 +130,89 @@ def _assert_long_text_split_matches_full(fe, text: str, *,
     assert actual == expected
 
 
+def _first_chunk_with_internal_stop(fe, ids, *, max_new: int, K: int,
+                                    use_long: bool):
+    """Return committed tokens from a chunk where a stop token can land before
+    the chunk end. This lets the rollback test force a real mid-chunk stop
+    without depending on a specific natural EOS sample."""
+    if use_long:
+        fe.prefill_long_ctx_nvfp4_agent(ids, max_new_tokens=max_new, K=K)
+        chunks = list(fe.decode_long_ctx_nvfp4_committed_stream(
+            max_new_tokens=max_new, K=K))
+    else:
+        fe.prefill_own_speculative_nvfp4_agent(
+            ids, max_new_tokens=max_new, K=K)
+        chunks = list(fe.decode_own_speculative_nvfp4_committed_stream(
+            max_new_tokens=max_new, K=K))
+    for chunk in chunks:
+        toks = [int(t) for t in chunk]
+        if len(toks) >= 2:
+            return toks
+    pytest.skip("no multi-token committed chunk available for stop rollback")
+
+
+def _assert_stop_rollback_append_matches_boundary_prefill(
+        fe, ids, suffix, *, max_new: int = 32, next_new: int = 8, K: int = 6,
+        use_long: bool = False):
+    import torch
+
+    prompt_len = int(ids.shape[1])
+    chunk = _first_chunk_with_internal_stop(
+        fe, ids, max_new=max_new, K=K, use_long=use_long)
+    stop_candidates = tuple(int(t) for t in chunk[:-1])
+
+    # Path A: decode stops inside a speculative chunk, frontend rolls recurrent
+    # state back to the visible stop boundary, then appends the suffix.
+    if use_long:
+        fe.prefill_long_ctx_nvfp4_agent(ids, max_new_tokens=max_new, K=K)
+        stopped_chunks = list(fe.decode_long_ctx_nvfp4_committed_stream(
+            max_new_tokens=max_new, K=K, stop_token_ids=stop_candidates))
+    else:
+        fe.prefill_own_speculative_nvfp4_agent(
+            ids, max_new_tokens=max_new, K=K)
+        stopped_chunks = list(fe.decode_own_speculative_nvfp4_committed_stream(
+            max_new_tokens=max_new, K=K, stop_token_ids=stop_candidates))
+    actual_stopped = [int(tok) for c in stopped_chunks for tok in c]
+    assert actual_stopped
+    assert actual_stopped[-1] in stop_candidates
+    stopped = actual_stopped
+
+    suffix = suffix.to(device=ids.device, dtype=torch.long)
+    prompt2 = torch.cat([
+        ids,
+        torch.tensor([stopped], device=ids.device, dtype=torch.long),
+        suffix,
+    ], dim=1)
+    start_pos = prompt_len + len(stopped)
+    if use_long:
+        fe.append_long_ctx_nvfp4_agent(
+            prompt2, start_pos=start_pos, max_new_tokens=next_new, K=K)
+        chunks = list(fe.decode_long_ctx_nvfp4_committed_stream(
+            max_new_tokens=next_new, K=K))
+    else:
+        fe.append_own_speculative_nvfp4_agent(
+            prompt2, start_pos=start_pos, max_new_tokens=next_new, K=K)
+        chunks = list(fe.decode_own_speculative_nvfp4_committed_stream(
+            max_new_tokens=next_new, K=K))
+    actual = [int(tok) for c in chunks for tok in c]
+
+    # Path B: exact boundary prefill to prompt + stopped token(s), append the
+    # same suffix, then decode.  This is the state Path A must match.
+    if use_long:
+        fe.prefill_long_ctx_nvfp4_agent(prompt2, max_new_tokens=next_new, K=K)
+        chunks = list(fe.decode_long_ctx_nvfp4_committed_stream(
+            max_new_tokens=next_new, K=K))
+    else:
+        fe.prefill_own_speculative_nvfp4_agent(
+            prompt2, max_new_tokens=next_new, K=K)
+        chunks = list(fe.decode_own_speculative_nvfp4_committed_stream(
+            max_new_tokens=next_new, K=K))
+    expected = [int(tok) for c in chunks for tok in c]
+
+    torch.cuda.synchronize()
+    assert actual == expected
+
+
 def test_qwen36_short_agent_split_matches_full_generate():
     fe = _load_frontend(max_seq=4096)
     _assert_split_matches_full(fe, 64)
@@ -166,6 +264,38 @@ def test_qwen36_long_agent_append_matches_full_generate(monkeypatch):
         max_new_tokens=next_new, K=K))
     actual = [tok for chunk in chunks for tok in chunk]
     assert actual == expected
+
+
+def test_qwen36_short_stop_rollback_append_matches_boundary_prefill():
+    import torch
+
+    fe = _load_frontend(max_seq=4096)
+    ids = _chat_ids(fe, "Explain why hash maps are usually fast.")
+    suffix_ids = fe._tokenizer(
+        "\nNow continue with one caveat.", add_special_tokens=False).input_ids
+    suffix = torch.tensor([suffix_ids], device="cuda", dtype=torch.long)
+    _assert_stop_rollback_append_matches_boundary_prefill(
+        fe, ids, suffix, max_new=32, next_new=8, K=6, use_long=False)
+
+
+def test_qwen36_long_stop_rollback_append_matches_boundary_prefill(monkeypatch):
+    import torch
+
+    monkeypatch.setenv("FLASHRT_QWEN36_LONG_KV_CACHE", "fp8")
+    fe = _load_frontend(max_seq=32768)
+    context = (
+        "File: cache_policy.py\n"
+        "- automatic prefix reuse\n"
+        "- stop boundary rollback\n"
+        "- committed stream append\n"
+    ) * 80
+    ids = _chat_ids(fe, context + "\nSummarize the implementation risk.")
+    assert fe._should_use_long_ctx_route(int(ids.shape[1]), 32)
+    suffix_ids = fe._tokenizer(
+        "\nNow list one validation test.", add_special_tokens=False).input_ids
+    suffix = torch.tensor([suffix_ids], device="cuda", dtype=torch.long)
+    _assert_stop_rollback_append_matches_boundary_prefill(
+        fe, ids, suffix, max_new=32, next_new=8, K=6, use_long=True)
 
 
 def test_qwen36_long_agent_text_split_matches_full_generate(monkeypatch):

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -195,6 +195,37 @@ def test_agent_service_clips_output_budget_to_remaining_context():
     assert engine.generate_calls[-1] == (2, 4)
 
 
+def test_agent_service_validation_uses_stateless_tokenizer_path():
+    class ValidationEngine(FakeAgentEngine):
+        def __init__(self):
+            super().__init__()
+            self.mutating_tokenize_calls = 0
+            self.validation_tokenize_calls = 0
+
+        def tokenize_chat(self, messages, tools=None, *,
+                          enable_thinking=False):
+            del messages, tools, enable_thinking
+            self.mutating_tokenize_calls += 1
+            raise AssertionError("stateful tokenizer should not validate")
+
+        def tokenize_chat_for_validation(self, messages, tools=None, *,
+                                         enable_thinking=False):
+            del tools, enable_thinking
+            self.validation_tokenize_calls += 1
+            return [1] * sum(len(m.get("content") or "") for m in messages)
+
+    engine = ValidationEngine()
+    svc = AgentService(engine)
+
+    svc.validate_request_bounds(AgentRequest(
+        messages=[{"role": "user", "content": "abc"}],
+        max_tokens=1,
+    ))
+
+    assert engine.validation_tokenize_calls == 1
+    assert engine.mutating_tokenize_calls == 0
+
+
 def test_agent_service_uses_message_append_when_visible_history_hides_tokens():
     class HiddenEngine(FakeAgentEngine):
         def __init__(self):
@@ -687,6 +718,27 @@ def test_agent_service_applies_default_k_and_request_override():
     }))
     assert engine.generate_calls[-1] == (1, 5)
     assert engine.prefills[-1][3] == 5
+
+
+def test_openai_request_rejects_invalid_flashrt_k():
+    for value in (0, -1):
+        with pytest.raises(ValueError, match="flashrt_K must be >= 1"):
+            request_from_openai({
+                "messages": [{"role": "user", "content": "abc"}],
+                "max_tokens": 1,
+                "flashrt_K": value,
+            })
+
+
+def test_agent_service_rejects_direct_invalid_k():
+    svc = AgentService(FakeAgentEngine())
+
+    with pytest.raises(ValueError, match="flashrt_K must be >= 1"):
+        svc.complete(AgentRequest(
+            messages=[{"role": "user", "content": "abc"}],
+            max_tokens=1,
+            K=0,
+        ))
 
 
 def test_openai_request_and_response_include_flashrt_cache_metrics():

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -314,6 +314,29 @@ def test_agent_service_stream_stops_decode_after_tool_call_to_keep_session_hot()
     assert svc.sessions.hot_session_id == "agent-tools-stream-hot"
 
 
+def test_agent_service_stream_tool_call_close_after_delta_keeps_hot_session():
+    engine = FakeAgentEngine()
+    engine.outputs = [
+        DecodeChunk((1001,),
+                    '<tool_call>{"name":"lookup","arguments":{"x":1}}</tool_call>',
+                    1),
+        DecodeChunk((999, ord("x")), "", 0, stop=True, state_lookahead=2),
+    ]
+    svc = AgentService(engine)
+
+    gen = svc.stream_openai(AgentRequest(
+        session_id="agent-tools-close-hot",
+        messages=[{"role": "user", "content": "abc"}],
+        max_tokens=8,
+    ), model=engine.model_name)
+    next(gen)                 # role chunk
+    tool_delta = next(gen)    # tool_call delta, emitted after commit/mark hot
+    assert '"tool_calls"' in tool_delta
+    assert svc.sessions.hot_session_id == "agent-tools-close-hot"
+    gen.close()
+    assert svc.sessions.hot_session_id == "agent-tools-close-hot"
+
+
 def test_agent_service_stream_openai_yields_live_sse_chunks():
     engine = FakeAgentEngine()
     svc = AgentService(engine)

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -700,6 +700,42 @@ def test_qwen36_frontend_agent_engine_appends_tool_suffix_from_message_boundary(
     assert suffix == [ord(ch) for ch in "<tool>done</m><assistant>"]
 
 
+def test_qwen36_frontend_agent_engine_appends_suffix_when_internal_think_breaks_render_prefix():
+    class ThinkBoundaryTokenizer(FakeTokenizer):
+        def apply_chat_template(self, messages, **kwargs):
+            rendered = ""
+            for msg in messages:
+                rendered += f"<{msg.get('role')}>"
+                if len(messages) > 2 and msg.get("role") == "assistant":
+                    rendered += "<hidden>"
+                rendered += msg.get("content") or ""
+                rendered += "</m>\n"
+            if kwargs.get("add_generation_prompt"):
+                rendered += "<assistant>\n<think>\n\n</think>\n\n"
+            return rendered
+
+    class ThinkBoundaryFrontend(FakeFrontend):
+        def __init__(self):
+            super().__init__()
+            self._tokenizer = ThinkBoundaryTokenizer()
+
+    engine = Qwen36FrontendAgentEngine(
+        ThinkBoundaryFrontend(), model_name="fake")
+    previous = [
+        {"role": "user", "content": "write code"},
+        {"role": "assistant", "content": "done"},
+    ]
+    incoming = [
+        *previous,
+        {"role": "user", "content": "add tests"},
+    ]
+
+    suffix = engine.append_suffix_tokens_for_messages(previous, incoming)
+
+    expected = "\n<user>add tests</m>\n<assistant>\n<think>\n\n</think>\n\n"
+    assert suffix == [ord(ch) for ch in expected]
+
+
 def test_qwen36_frontend_agent_engine_hides_think_tags_by_default():
     class ThinkTokenizer(FakeTokenizer):
         def decode(self, ids, skip_special_tokens=False):

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -397,6 +397,93 @@ def test_agent_service_stream_openai_reuses_hot_session_prefix():
     assert engine.prefills[-1][1:] == (6, 1, 6)
 
 
+def test_agent_service_auto_reuses_hot_prefix_without_session_id():
+    engine = FakeAgentEngine()
+    svc = AgentService(engine)
+
+    res0 = svc.complete(AgentRequest(
+        messages=[{"role": "user", "content": "abc"}],
+        max_tokens=2,
+    ))
+    assert res0.session_id.startswith("frt-")
+
+    res1 = svc.complete(AgentRequest(
+        messages=[
+            {"role": "user", "content": "abc"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "z"},
+        ],
+        max_tokens=1,
+    ))
+
+    assert res1.session_id == res0.session_id
+    assert res1.prefix_plan.action == "append"
+    assert res1.stats.cached_tokens == 6
+    assert res1.stats.new_prefill_tokens == 2
+    assert engine.prefills[-1][1:] == (6, 1, 6)
+
+
+def test_agent_service_auto_message_append_without_session_id():
+    class HiddenEngine(FakeAgentEngine):
+        def __init__(self):
+            super().__init__()
+            self.outputs = [DecodeChunk((999, ord("h")), "h", 2)]
+
+        def append_suffix_tokens_for_messages(
+                self, previous, incoming, *, tools=None,
+                enable_thinking=False):
+            del tools, enable_thinking
+            if previous != incoming[:len(previous)]:
+                return None
+            return [42, 43]
+
+    engine = HiddenEngine()
+    svc = AgentService(engine)
+    res0 = svc.complete(AgentRequest(
+        messages=[{"role": "user", "content": "abc"}],
+        max_tokens=1,
+    ))
+
+    res1 = svc.complete(AgentRequest(
+        messages=[
+            {"role": "user", "content": "abc"},
+            {"role": "assistant", "content": "h"},
+            {"role": "user", "content": "next"},
+        ],
+        max_tokens=1,
+    ))
+
+    assert res1.session_id == res0.session_id
+    assert res1.prefix_plan.action == "message_append"
+    assert res1.stats.cached_tokens == 6
+    assert res1.stats.new_prefill_tokens == 2
+    assert engine.prefills[-1][1:] == (6, 1, 6)
+
+
+def test_agent_service_auto_prefix_respects_cache_namespace():
+    engine = FakeAgentEngine()
+    svc = AgentService(engine)
+    svc.complete(AgentRequest(
+        messages=[{"role": "user", "content": "abc"}],
+        cache_salt="tenant-a",
+        max_tokens=2,
+    ))
+
+    res = svc.complete(AgentRequest(
+        messages=[
+            {"role": "user", "content": "abc"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "z"},
+        ],
+        cache_salt="tenant-b",
+        max_tokens=1,
+    ))
+
+    assert res.prefix_plan.action == "append"
+    assert res.stats.cached_tokens == 0
+    assert engine.prefills[-1][1:] == (0, 1, 6)
+
+
 def test_agent_service_message_append_ignores_tool_call_wire_ids():
     class SuffixEngine(FakeAgentEngine):
         def append_suffix_tokens_for_messages(
@@ -595,6 +682,24 @@ def test_openai_request_and_response_include_flashrt_cache_metrics():
     assert body["model"] == "fake-qwen36"
     assert body["flashrt"]["session_id"] == "s"
     assert body["flashrt"]["new_prefill_tokens"] == 2
+    assert body["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
+
+
+def test_openai_request_accepts_standard_prompt_cache_namespace():
+    req = request_from_openai({
+        "messages": [{"role": "user", "content": "a"}],
+        "prompt_cache_key": "repo-a",
+        "cache_salt": "tenant-b",
+        "flashrt_cache_salt": "legacy",
+    })
+    assert req.cache_salt == "repo-a"
+
+    req = request_from_openai({
+        "messages": [{"role": "user", "content": "a"}],
+        "cache_salt": "tenant-b",
+        "flashrt_cache_salt": "legacy",
+    })
+    assert req.cache_salt == "tenant-b"
 
 
 def test_openai_request_uses_configured_default_and_output_cap():

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -268,6 +268,52 @@ def test_agent_service_parses_tool_calls_from_generated_stream():
     assert res.tool_calls[0]["function"]["name"] == "lookup"
 
 
+def test_agent_service_stops_decode_after_tool_call_to_keep_session_hot():
+    engine = FakeAgentEngine()
+    engine.outputs = [
+        DecodeChunk((1001,),
+                    '<tool_call>{"name":"lookup","arguments":{"x":1}}</tool_call>',
+                    1),
+        DecodeChunk((999, ord("x")), "", 0, stop=True, state_lookahead=2),
+    ]
+    svc = AgentService(engine)
+
+    res = svc.complete(AgentRequest(
+        session_id="agent-tools-hot",
+        messages=[{"role": "user", "content": "abc"}],
+        max_tokens=8,
+    ))
+
+    assert res.finish_reason == "tool_calls"
+    assert res.usage["completion_tokens"] == 1
+    assert svc.sessions.hot_session_id == "agent-tools-hot"
+    msg = svc.sessions.get("agent-tools-hot").visible_messages[-1]
+    assert msg["content"] is None
+    assert msg["tool_calls"][0]["function"]["name"] == "lookup"
+
+
+def test_agent_service_stream_stops_decode_after_tool_call_to_keep_session_hot():
+    engine = FakeAgentEngine()
+    engine.outputs = [
+        DecodeChunk((1001,),
+                    '<tool_call>{"name":"lookup","arguments":{"x":1}}</tool_call>',
+                    1),
+        DecodeChunk((999, ord("x")), "", 0, stop=True, state_lookahead=2),
+    ]
+    svc = AgentService(engine)
+
+    chunks = list(svc.stream_openai(AgentRequest(
+        session_id="agent-tools-stream-hot",
+        messages=[{"role": "user", "content": "abc"}],
+        max_tokens=8,
+    ), model=engine.model_name))
+
+    joined = "".join(chunks)
+    assert '"tool_calls"' in joined
+    assert '"completion_tokens":1' in joined
+    assert svc.sessions.hot_session_id == "agent-tools-stream-hot"
+
+
 def test_agent_service_stream_openai_yields_live_sse_chunks():
     engine = FakeAgentEngine()
     svc = AgentService(engine)

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -121,6 +121,7 @@ class FakeAgentEngine:
 
     def __init__(self):
         self.prefills = []
+        self.generate_calls = []
         self.outputs = [
             DecodeChunk((ord("h"),), "h", 1),
             DecodeChunk((ord("i"),), "i", 1),
@@ -139,7 +140,7 @@ class FakeAgentEngine:
         self.prefills.append((list(token_ids), cached_tokens, max_tokens, K))
 
     def generate_stream(self, *, max_tokens, K):
-        del K
+        self.generate_calls.append((max_tokens, K))
         yield from self.outputs[:max_tokens]
 
 
@@ -376,6 +377,53 @@ def test_agent_service_stream_openai_reuses_hot_session_prefix():
     assert engine.prefills[-1][1:] == (6, 1, 6)
 
 
+def test_agent_service_message_append_ignores_tool_call_wire_ids():
+    class SuffixEngine(FakeAgentEngine):
+        def append_suffix_tokens_for_messages(
+                self, previous_messages, incoming_messages, *,
+                tools=None, enable_thinking=False):
+            del tools, enable_thinking
+            if previous_messages != incoming_messages[:len(previous_messages)]:
+                return None
+            return [7, 8]
+
+    engine = SuffixEngine()
+    svc = AgentService(engine)
+    session = svc.sessions.get_or_create("s")
+    session.commit([1, 2, 3])
+    svc.sessions.mark_hot("s")
+    session.visible_messages = [
+        {"role": "user", "content": "make"},
+        {"role": "assistant", "content": None, "tool_calls": [{
+            "id": "call_server",
+            "index": 0,
+            "type": "function",
+            "function": {"name": "write", "arguments": "{\"x\":1}"},
+        }]},
+    ]
+    req = AgentRequest(
+        session_id="s",
+        messages=[
+            {"role": "user", "content": "make"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call_client",
+                "type": "function",
+                "function": {"name": "write", "arguments": {"x": 1}},
+            }]},
+            {"role": "tool", "content": "ok"},
+        ],
+        tools=[{"type": "function"}],
+        max_tokens=1,
+    )
+    plan = session.plan([9, 9, 9, 9])
+
+    prompt, msg_plan = svc._message_append_prompt_tokens(session, req, plan)
+
+    assert prompt == [1, 2, 3, 7, 8]
+    assert msg_plan.action == "message_append"
+    assert msg_plan.cached_tokens == 3
+
+
 def test_agent_service_pin_prefix_fails_without_capsule_budget():
     engine = FakeAgentEngine()
     svc = AgentService(engine)
@@ -610,6 +658,44 @@ def test_qwen36_frontend_agent_engine_wires_short_committed_split():
     chunks = list(engine.generate_stream(max_tokens=2, K=4))
     assert [c.token_ids for c in chunks] == [(ord("a"),), (ord("b"),)]
     assert "".join(c.text for c in chunks) == "ab"
+
+
+def test_qwen36_frontend_agent_engine_appends_tool_suffix_from_message_boundary():
+    class BoundaryTokenizer(FakeTokenizer):
+        def apply_chat_template(self, messages, **kwargs):
+            rendered = ""
+            for msg in messages:
+                rendered += f"<{msg.get('role')}>"
+                rendered += msg.get("content") or ""
+                if msg.get("tool_calls"):
+                    rendered += "<tool_call/>"
+                rendered += "</m>"
+            if kwargs.get("add_generation_prompt"):
+                rendered += "<assistant>"
+            return rendered
+
+    class BoundaryFrontend(FakeFrontend):
+        def __init__(self):
+            super().__init__()
+            self._tokenizer = BoundaryTokenizer()
+
+    engine = Qwen36FrontendAgentEngine(BoundaryFrontend(), model_name="fake")
+    previous = [
+        {"role": "user", "content": "make file"},
+        {"role": "assistant", "content": "ok", "tool_calls": [{
+            "type": "function",
+            "function": {"name": "write", "arguments": "{}"},
+        }]},
+    ]
+    incoming = [
+        *previous,
+        {"role": "tool", "content": "done"},
+    ]
+
+    suffix = engine.append_suffix_tokens_for_messages(
+        previous, incoming, tools=[{"type": "function"}])
+
+    assert suffix == [ord(ch) for ch in "<tool>done</m><assistant>"]
 
 
 def test_qwen36_frontend_agent_engine_hides_think_tags_by_default():

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -284,6 +284,40 @@ def test_agent_service_stream_openai_reuses_hot_session_prefix():
     assert engine.prefills[-1][1:] == (6, 1, 6)
 
 
+def test_agent_service_pin_prefix_fails_without_capsule_budget():
+    engine = FakeAgentEngine()
+    svc = AgentService(engine)
+
+    with pytest.raises(ValueError, match="capsule-budget"):
+        svc.complete(AgentRequest(
+            session_id="pin-no-budget",
+            messages=[{"role": "user", "content": "abc"}],
+            max_tokens=1,
+            pin_prefix=1,
+        ))
+
+
+def test_agent_service_pin_prefix_fails_when_long_route_unavailable():
+    class CapsuleButNoLongRouteEngine(FakeAgentEngine):
+        def supports_capsule(self):
+            return True
+
+        def capsule_aligned_len(self, prompt_len, max_tokens):
+            del prompt_len, max_tokens
+            return 0
+
+    engine = CapsuleButNoLongRouteEngine()
+    svc = AgentService(engine, capsule_budget_bytes=1024)
+
+    with pytest.raises(ValueError, match="long FP8-KV route"):
+        svc.complete(AgentRequest(
+            session_id="pin-no-long-route",
+            messages=[{"role": "user", "content": "abc"}],
+            max_tokens=1,
+            pin_prefix=1,
+        ))
+
+
 def test_qwen36_agent_fastapi_non_stream_and_stream_endpoints():
     pytest.importorskip("fastapi")
     from fastapi.testclient import TestClient

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -689,12 +689,12 @@ def test_qwen36_frontend_agent_engine_stops_visible_text_at_im_end():
     chunks = list(engine.generate_stream(max_tokens=8, K=4))
 
     assert len(chunks) == 1
-    # Only the visible tokens are committed to the journal; the stop token (999)
-    # and the post-stop tail ('u') are reported as state lookahead, not journaled.
-    assert chunks[0].token_ids == (ord("o"), ord("k"))
+    # The stop token is a chat-template boundary: it is cached but not rendered.
+    # Only the verified post-stop tail ('u') is reported as lookahead.
+    assert chunks[0].token_ids == (ord("o"), ord("k"), 999)
     assert chunks[0].text == "ok"
     assert chunks[0].stop is True
-    assert chunks[0].state_lookahead == 2
+    assert chunks[0].state_lookahead == 1
 
 
 def test_qwen36_frontend_agent_engine_wires_short_append_split():
@@ -785,8 +785,8 @@ def test_qwen36_frontend_agent_engine_warmup_uses_long_graph_hooks():
 
 
 def test_qwen36_engine_trims_visible_tokens_and_flags_state_lookahead():
-    """A stop token mid-chunk: commit only visible tokens, report the post-stop
-    tokens (eos + verified tail) as state lookahead."""
+    """A stop token mid-chunk: cache the stop boundary but report any verified
+    post-stop tail as lookahead."""
     class StopTokenizer(FakeTokenizer):
         eos_token_id = 7
 
@@ -809,10 +809,10 @@ def test_qwen36_engine_trims_visible_tokens_and_flags_state_lookahead():
 
     assert len(chunks) == 1
     chunk = chunks[0]
-    assert chunk.token_ids == (ord("a"), ord("b"))   # visible only
+    assert chunk.token_ids == (ord("a"), ord("b"), 7)
     assert chunk.text == "ab"
     assert chunk.stop is True
-    assert chunk.state_lookahead == 2                # eos + 'c' committed to KV
+    assert chunk.state_lookahead == 1                # only 'c' leads transcript
 
 
 def test_agent_service_stop_lookahead_trims_journal_and_forces_rebuild():

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -177,6 +177,24 @@ def test_agent_service_reuses_exact_session_prefix_when_history_is_returned():
     assert engine.prefills[-1][1:] == (6, 1, 6)
 
 
+def test_agent_service_clips_output_budget_to_remaining_context():
+    class SmallContextEngine(FakeAgentEngine):
+        max_seq = 6
+
+    engine = SmallContextEngine()
+    svc = AgentService(engine)
+
+    res = svc.complete(AgentRequest(
+        session_id="small-context",
+        messages=[{"role": "user", "content": "abc"}],  # 4 prompt tokens
+        max_tokens=8,
+    ))
+
+    assert res.usage["completion_tokens"] == 2
+    assert engine.prefills[-1][2] == 2
+    assert engine.generate_calls[-1] == (2, 6)
+
+
 def test_agent_service_uses_message_append_when_visible_history_hides_tokens():
     class HiddenEngine(FakeAgentEngine):
         def __init__(self):
@@ -513,6 +531,27 @@ def test_qwen36_agent_fastapi_rejects_output_above_service_cap():
 
     assert resp.status_code == 400
     assert "max_tokens must be <= 8" in resp.text
+
+
+def test_qwen36_agent_fastapi_rejects_full_prompt_before_streaming():
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+    from serving.qwen36_agent.server import build_app
+
+    class TinyContextEngine(FakeAgentEngine):
+        max_seq = 3
+
+    app = build_app(AgentService(TinyContextEngine()))
+    client = TestClient(app)
+
+    resp = client.post("/v1/chat/completions", json={
+        "messages": [{"role": "user", "content": "abc"}],  # 4 prompt tokens
+        "max_tokens": 2,
+        "stream": True,
+    })
+
+    assert resp.status_code == 400
+    assert "leaves no room under max_seq" in resp.text
 
 
 def test_agent_service_applies_default_session_id_for_openai_clients():

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -664,6 +664,31 @@ def test_agent_service_keeps_explicit_session_over_default_session_id():
     assert req.session_id == "explicit"
 
 
+def test_agent_service_applies_default_k_and_request_override():
+    engine = FakeAgentEngine()
+    svc = AgentService(engine, default_k=4)
+
+    res = svc.complete(svc.request_from_openai({
+        "messages": [{"role": "user", "content": "abc"}],
+        "max_tokens": 1,
+    }))
+    assert res.prefix_plan.action == "append"
+    assert engine.generate_calls[-1] == (1, 4)
+    assert engine.prefills[-1][3] == 4
+
+    res = svc.complete(svc.request_from_openai({
+        "messages": [
+            {"role": "user", "content": "abc"},
+            {"role": "assistant", "content": res.text},
+            {"role": "user", "content": "next"},
+        ],
+        "max_tokens": 1,
+        "flashrt_K": 5,
+    }))
+    assert engine.generate_calls[-1] == (1, 5)
+    assert engine.prefills[-1][3] == 5
+
+
 def test_openai_request_and_response_include_flashrt_cache_metrics():
     engine = FakeAgentEngine()
     svc = AgentService(engine)

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -157,7 +157,7 @@ def test_agent_service_reuses_exact_session_prefix_when_history_is_returned():
     res0 = svc.complete(req0)
     assert res0.stats.cached_tokens == 0
     assert res0.stats.new_prefill_tokens == 4
-    assert engine.prefills[-1][1:] == (0, 2, 6)
+    assert engine.prefills[-1][1:] == (0, 2, 4)
     assert res0.text == "hi"
     assert res0.finish_reason == "stop"
 
@@ -174,7 +174,7 @@ def test_agent_service_reuses_exact_session_prefix_when_history_is_returned():
     assert res1.prefix_plan.action == "append"
     assert res1.stats.cached_tokens == 6
     assert res1.stats.new_prefill_tokens == 3
-    assert engine.prefills[-1][1:] == (6, 1, 6)
+    assert engine.prefills[-1][1:] == (6, 1, 4)
 
 
 def test_agent_service_clips_output_budget_to_remaining_context():
@@ -192,7 +192,7 @@ def test_agent_service_clips_output_budget_to_remaining_context():
 
     assert res.usage["completion_tokens"] == 2
     assert engine.prefills[-1][2] == 2
-    assert engine.generate_calls[-1] == (2, 6)
+    assert engine.generate_calls[-1] == (2, 4)
 
 
 def test_agent_service_uses_message_append_when_visible_history_hides_tokens():
@@ -236,7 +236,7 @@ def test_agent_service_uses_message_append_when_visible_history_hides_tokens():
     assert res1.stats.new_prefill_tokens == 2
     assert engine.prefills[-1][0][:6] == [ord("a"), ord("b"), ord("c"), 0, 999, ord("h")]
     assert engine.prefills[-1][0][6:] == [42, 43]
-    assert engine.prefills[-1][1:] == (6, 1, 6)
+    assert engine.prefills[-1][1:] == (6, 1, 4)
 
 
 def test_agent_service_rebuilds_token_journal_without_hot_state():
@@ -252,7 +252,7 @@ def test_agent_service_rebuilds_token_journal_without_hot_state():
     ))
     assert res.prefix_plan.action == "activate_rebuild"
     assert res.stats.cached_tokens == 0
-    assert engine.prefills[-1][1:] == (0, 1, 6)
+    assert engine.prefills[-1][1:] == (0, 1, 4)
 
 
 def test_agent_service_rebuilds_truncate_without_rollback():
@@ -269,7 +269,7 @@ def test_agent_service_rebuilds_truncate_without_rollback():
     ))
     assert res.prefix_plan.action == "activate_rebuild"
     assert res.stats.cached_tokens == 0
-    assert engine.prefills[-1][1:] == (0, 1, 6)
+    assert engine.prefills[-1][1:] == (0, 1, 4)
 
 
 def test_agent_service_parses_tool_calls_from_generated_stream():
@@ -394,7 +394,7 @@ def test_agent_service_stream_openai_reuses_hot_session_prefix():
         max_tokens=1,
     ), model=engine.model_name))
 
-    assert engine.prefills[-1][1:] == (6, 1, 6)
+    assert engine.prefills[-1][1:] == (6, 1, 4)
 
 
 def test_agent_service_auto_reuses_hot_prefix_without_session_id():
@@ -420,7 +420,7 @@ def test_agent_service_auto_reuses_hot_prefix_without_session_id():
     assert res1.prefix_plan.action == "append"
     assert res1.stats.cached_tokens == 6
     assert res1.stats.new_prefill_tokens == 2
-    assert engine.prefills[-1][1:] == (6, 1, 6)
+    assert engine.prefills[-1][1:] == (6, 1, 4)
 
 
 def test_agent_service_auto_message_append_without_session_id():
@@ -457,7 +457,7 @@ def test_agent_service_auto_message_append_without_session_id():
     assert res1.prefix_plan.action == "message_append"
     assert res1.stats.cached_tokens == 6
     assert res1.stats.new_prefill_tokens == 2
-    assert engine.prefills[-1][1:] == (6, 1, 6)
+    assert engine.prefills[-1][1:] == (6, 1, 4)
 
 
 def test_agent_service_auto_prefix_respects_cache_namespace():
@@ -481,7 +481,7 @@ def test_agent_service_auto_prefix_respects_cache_namespace():
 
     assert res.prefix_plan.action == "append"
     assert res.stats.cached_tokens == 0
-    assert engine.prefills[-1][1:] == (0, 1, 6)
+    assert engine.prefills[-1][1:] == (0, 1, 4)
 
 
 def test_agent_service_message_append_ignores_tool_call_wire_ids():

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -378,6 +378,24 @@ def test_qwen36_agent_fastapi_non_stream_and_stream_endpoints():
     assert "data: [DONE]" in text
 
 
+def test_qwen36_agent_fastapi_rejects_output_above_service_cap():
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+    from serving.qwen36_agent.server import build_app
+
+    app = build_app(AgentService(
+        FakeAgentEngine(), default_max_tokens=4, max_output_tokens=8))
+    client = TestClient(app)
+
+    resp = client.post("/v1/chat/completions", json={
+        "messages": [{"role": "user", "content": "abc"}],
+        "max_tokens": 9,
+    })
+
+    assert resp.status_code == 400
+    assert "max_tokens must be <= 8" in resp.text
+
+
 def test_openai_request_and_response_include_flashrt_cache_metrics():
     engine = FakeAgentEngine()
     svc = AgentService(engine)
@@ -396,6 +414,25 @@ def test_openai_request_and_response_include_flashrt_cache_metrics():
     assert body["model"] == "fake-qwen36"
     assert body["flashrt"]["session_id"] == "s"
     assert body["flashrt"]["new_prefill_tokens"] == 2
+
+
+def test_openai_request_uses_configured_default_and_output_cap():
+    req = request_from_openai({
+        "messages": [{"role": "user", "content": "a"}],
+    }, default_max_tokens=123, max_output_tokens=256)
+    assert req.max_tokens == 123
+
+    req = request_from_openai({
+        "messages": [{"role": "user", "content": "a"}],
+        "max_completion_tokens": 77,
+    }, default_max_tokens=123, max_output_tokens=256)
+    assert req.max_tokens == 77
+
+    with pytest.raises(ValueError, match="max_tokens must be <= 256"):
+        request_from_openai({
+            "messages": [{"role": "user", "content": "a"}],
+            "max_tokens": 257,
+        }, default_max_tokens=123, max_output_tokens=256)
 
 
 class FakeTokenizer:

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -396,6 +396,29 @@ def test_qwen36_agent_fastapi_rejects_output_above_service_cap():
     assert "max_tokens must be <= 8" in resp.text
 
 
+def test_agent_service_applies_default_session_id_for_openai_clients():
+    svc = AgentService(FakeAgentEngine(), default_session_id="local-agent")
+
+    req = svc.request_from_openai({
+        "messages": [{"role": "user", "content": "abc"}],
+        "max_tokens": 1,
+    })
+
+    assert req.session_id == "local-agent"
+
+
+def test_agent_service_keeps_explicit_session_over_default_session_id():
+    svc = AgentService(FakeAgentEngine(), default_session_id="local-agent")
+
+    req = svc.request_from_openai({
+        "messages": [{"role": "user", "content": "abc"}],
+        "max_tokens": 1,
+        "flashrt_session_id": "explicit",
+    })
+
+    assert req.session_id == "explicit"
+
+
 def test_openai_request_and_response_include_flashrt_cache_metrics():
     engine = FakeAgentEngine()
     svc = AgentService(engine)

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -78,6 +78,29 @@ def test_tool_stream_parser_holds_partial_tags_and_json():
     assert tail == []
 
 
+def test_tool_stream_parser_accepts_qwen_xml_function_calls():
+    p = ToolCallStreamParser()
+
+    out = p.feed(
+        "<tool_call>\n"
+        "<function=write>\n"
+        "<parameter=path>\n"
+        "merge_sort.py\n"
+        "</parameter>\n"
+        "<parameter=content>\n"
+        "print('ok')\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>")
+
+    assert len(out) == 1
+    assert out[0].kind == "tool_call"
+    tc = out[0].payload
+    assert tc["function"]["name"] == "write"
+    assert tc["function"]["arguments"] == (
+        "{\"path\":\"merge_sort.py\",\"content\":\"print('ok')\"}")
+
+
 def test_sse_stream_contains_role_tool_call_and_done():
     p = ToolCallStreamParser()
     events = []
@@ -378,9 +401,11 @@ def test_openai_request_and_response_include_flashrt_cache_metrics():
 class FakeTokenizer:
     def __init__(self):
         self.template_kwargs = None
+        self.messages = None
 
     def apply_chat_template(self, messages, **kwargs):
         self.template_kwargs = kwargs
+        self.messages = messages
         return "|".join((m.get("content") or "") for m in messages)
 
     def __call__(self, prompt, add_special_tokens=False):
@@ -480,6 +505,30 @@ def test_qwen36_frontend_agent_engine_hides_think_tags_by_default():
     chunks = list(engine.generate_stream(max_tokens=1, K=4))
 
     assert chunks[0].text == "answer"
+
+
+def test_qwen36_frontend_agent_engine_normalizes_openai_tool_call_history():
+    fe = FakeFrontend()
+    engine = Qwen36FrontendAgentEngine(fe)
+
+    engine.render_chat([{
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "write",
+                "arguments": "{\"path\":\"x.txt\",\"content\":\"ok\"}",
+            },
+        }],
+    }])
+
+    tool_call = fe._tokenizer.messages[0]["tool_calls"][0]
+    assert tool_call["function"]["arguments"] == {
+        "path": "x.txt",
+        "content": "ok",
+    }
 
 
 def test_qwen36_frontend_agent_engine_stops_visible_text_at_im_end():

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from serving.qwen36_agent.openai_stream import sse_from_events
@@ -818,6 +820,34 @@ def test_qwen36_frontend_agent_engine_wires_long_append_split():
     engine = Qwen36FrontendAgentEngine(fe)
     engine.prefill([1, 2, 3], cached_tokens=2, max_tokens=1, K=4)
     assert fe.long_append_args == ([[1, 2, 3]], 2, 1, 4)
+
+
+def test_qwen36_agent_sm120_defaults_disable_exact_position_decode_graphs(monkeypatch):
+    keys = (
+        "FLASHRT_QWEN36_DECODE_FASTGEMM",
+        "FLASHRT_QWEN36_VERIFY_WARPSPLIT",
+        "FLASHRT_QWEN36_TQ_VERIFY_GRAPH",
+        "FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH",
+    )
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+    Qwen36FrontendAgentEngine._set_agent_runtime_env_defaults(12)
+
+    assert os.environ["FLASHRT_QWEN36_DECODE_FASTGEMM"] == "1"
+    assert os.environ["FLASHRT_QWEN36_VERIFY_WARPSPLIT"] == "1"
+    assert os.environ["FLASHRT_QWEN36_TQ_VERIFY_GRAPH"] == "0"
+    assert os.environ["FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH"] == "0"
+
+
+def test_qwen36_agent_runtime_defaults_respect_overrides(monkeypatch):
+    monkeypatch.setenv("FLASHRT_QWEN36_TQ_VERIFY_GRAPH", "1")
+    monkeypatch.setenv("FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH", "1")
+
+    Qwen36FrontendAgentEngine._set_agent_runtime_env_defaults(12)
+
+    assert os.environ["FLASHRT_QWEN36_TQ_VERIFY_GRAPH"] == "1"
+    assert os.environ["FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH"] == "1"
 
 
 def test_qwen36_frontend_agent_engine_warmup_runs_committed_stream():


### PR DESCRIPTION
## Summary

This PR hardens the Qwen3.6 agent-serving path for OpenAI-compatible coding-agent workloads.

Key changes:
- Add automatic hot-prefix reuse without requiring a FlashRT-specific session id.
- Preserve appendability across tool-call and EOS-terminated streaming turns.
- Keep committed-stream state aligned with the visible transcript, including stop-token rollback gates.
- Add capsule pin/restore policy wiring for explicit shared-prefix reuse.
- Avoid request-time exact-position decode graph capture on the default live agent path.
- Add configurable output budgets, cleaner request metrics, and default live speculative `K=4` based on production agent sweeps.
- Update Qwen3.6 agent serving docs with startup guidance, cache semantics, K-sweep data, and operational notes.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_qwen36_agent_serving_policy.py tests/test_qwen36_server_warmup.py tests/test_qwen36_agent_capsule_serving.py -q`
  - `68 passed, 2 skipped`
- GPU split / rollback gate on RTX 5090 with Qwen3.6 NVFP4 + MTP checkpoints:
  - `python3 -m pytest tests/test_qwen36_agent_gpu_split.py -q`
  - `6 passed`
- `git diff --check`
- Reviewed branch diff for local paths, temporary demo artifacts, private IPs, and internal-only references.