### PR TITLE
Higgs Audio v3 TTS-4B on RTX SM120 — FP8 + BF16, fully-kernelised decode + streaming server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,7 +519,8 @@ if(FLASHRT_ENABLE_MOTUS AND GPU_ARCH STREQUAL "120")
     csrc/gemm/fp8_smallM_handtuned_sm120.cu
     csrc/gemm/fp8_smallM_handtuned_splitk_sm120.cu
     csrc/gemm/fp8_smallM_handtuned_ldmatrix_sm120.cu
-    csrc/gemm/fp8_gemv_m1_sm120.cu)
+    csrc/gemm/fp8_gemv_m1_sm120.cu
+    csrc/gemm/bf16_gemv_m1_sm120.cu)
   set_target_properties(motus_fp8_smallm_sm120_obj PROPERTIES
     CUDA_STANDARD 17
     POSITION_INDEPENDENT_CODE ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,18 +490,18 @@ endif()
 # symbol when MOTUS is OFF. (FP8 still needs the SM120 prefill GEMM in MOTUS, so
 # the FP8 path is SM120-only; the BF16 path runs wherever this object is built.)
 if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
-  add_library(sm120_gemv_m1_obj OBJECT
+  add_library(decode_gemv_m1_obj OBJECT
     csrc/gemm/fp8_gemv_m1_sm120.cu
     csrc/gemm/bf16_gemv_m1_sm120.cu)
-  set_target_properties(sm120_gemv_m1_obj PROPERTIES
+  set_target_properties(decode_gemv_m1_obj PROPERTIES
     CUDA_STANDARD 17
     POSITION_INDEPENDENT_CODE ON
   )
-  target_include_directories(sm120_gemv_m1_obj PRIVATE
+  target_include_directories(decode_gemv_m1_obj PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels
   )
-  target_compile_options(sm120_gemv_m1_obj PRIVATE
+  target_compile_options(decode_gemv_m1_obj PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:
       --expt-relaxed-constexpr -O3 --use_fast_math
       ${GPU_GENCODE}
@@ -984,7 +984,7 @@ endif()
 # resolve, independent of FLASHRT_ENABLE_MOTUS.
 if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
   target_sources(flash_rt_kernels PRIVATE
-    $<TARGET_OBJECTS:sm120_gemv_m1_obj>)
+    $<TARGET_OBJECTS:decode_gemv_m1_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE
     ENABLE_DECODE_GEMV_M1=1)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,12 +481,15 @@ if(GPU_ARCH STREQUAL "110")
   message(STATUS "SM100 CUTLASS NVFP4 W4A16 GEMM (Thor): ENABLED")
 endif()
 
-# ── Dedicated M=1 GEMV (FP8 + BF16) for sm_120a decode ──
-# Independent of FLASHRT_ENABLE_MOTUS: the bindings are gated by
-# ENABLE_SM120_GEMV_M1 (set for every GPU_ARCH=120 build below), so the object
-# must link whenever GPU_ARCH=120 — otherwise the binding would reference an
-# unlinked symbol when MOTUS is OFF.
-if(GPU_ARCH STREQUAL "120")
+# ── Dedicated M=1 decode GEMV (FP8 + BF16) ──
+# Origin sm_120a, but neither kernel uses an SM120-specific instruction, so both
+# compile for Ada (sm89) too — built for the FP8-capable consumer RTX arches
+# (sm89 / sm120). Independent of FLASHRT_ENABLE_MOTUS: the bindings are gated by
+# ENABLE_DECODE_GEMV_M1 (set alongside this object below), so the object must
+# link whenever it is built — otherwise the binding would reference an unlinked
+# symbol when MOTUS is OFF. (FP8 still needs the SM120 prefill GEMM in MOTUS, so
+# the FP8 path is SM120-only; the BF16 path runs wherever this object is built.)
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
   add_library(sm120_gemv_m1_obj OBJECT
     csrc/gemm/fp8_gemv_m1_sm120.cu
     csrc/gemm/bf16_gemv_m1_sm120.cu)
@@ -976,13 +979,14 @@ if(GPU_ARCH STREQUAL "120")
     ENABLE_CUTLASS_SM120_BLOCK_FP8=1)
 endif()
 
-# Dedicated M=1 GEMV (FP8 + BF16); linked for every GPU_ARCH=120 build so the
-# ENABLE_SM120_GEMV_M1 bindings always resolve, independent of FLASHRT_ENABLE_MOTUS.
-if(GPU_ARCH STREQUAL "120")
+# Dedicated M=1 decode GEMV (FP8 + BF16); linked + macro defined wherever the
+# object is built (sm89 / sm120) so the ENABLE_DECODE_GEMV_M1 bindings always
+# resolve, independent of FLASHRT_ENABLE_MOTUS.
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
   target_sources(flash_rt_kernels PRIVATE
     $<TARGET_OBJECTS:sm120_gemv_m1_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE
-    ENABLE_SM120_GEMV_M1=1)
+    ENABLE_DECODE_GEMV_M1=1)
 endif()
 
 # SM120a CUTLASS NVFP4 W4A16 GEMM (Qwen3.6 NVFP4 ckpt path).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,6 +481,31 @@ if(GPU_ARCH STREQUAL "110")
   message(STATUS "SM100 CUTLASS NVFP4 W4A16 GEMM (Thor): ENABLED")
 endif()
 
+# ── Dedicated M=1 GEMV (FP8 + BF16) for sm_120a decode ──
+# Independent of FLASHRT_ENABLE_MOTUS: the bindings are gated by
+# ENABLE_SM120_GEMV_M1 (set for every GPU_ARCH=120 build below), so the object
+# must link whenever GPU_ARCH=120 — otherwise the binding would reference an
+# unlinked symbol when MOTUS is OFF.
+if(GPU_ARCH STREQUAL "120")
+  add_library(sm120_gemv_m1_obj OBJECT
+    csrc/gemm/fp8_gemv_m1_sm120.cu
+    csrc/gemm/bf16_gemv_m1_sm120.cu)
+  set_target_properties(sm120_gemv_m1_obj PROPERTIES
+    CUDA_STANDARD 17
+    POSITION_INDEPENDENT_CODE ON
+  )
+  target_include_directories(sm120_gemv_m1_obj PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gemm
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels
+  )
+  target_compile_options(sm120_gemv_m1_obj PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3 --use_fast_math
+      ${GPU_GENCODE}
+    >
+  )
+endif()
+
 # ── Motus beta SM120 kernels ──
 # These are model-specific RTX kernels and must remain additive. They are
 # compiled into flash_rt_kernels so Motus does not depend on separate
@@ -518,9 +543,7 @@ if(FLASHRT_ENABLE_MOTUS AND GPU_ARCH STREQUAL "120")
   add_library(motus_fp8_smallm_sm120_obj OBJECT
     csrc/gemm/fp8_smallM_handtuned_sm120.cu
     csrc/gemm/fp8_smallM_handtuned_splitk_sm120.cu
-    csrc/gemm/fp8_smallM_handtuned_ldmatrix_sm120.cu
-    csrc/gemm/fp8_gemv_m1_sm120.cu
-    csrc/gemm/bf16_gemv_m1_sm120.cu)
+    csrc/gemm/fp8_smallM_handtuned_ldmatrix_sm120.cu)
   set_target_properties(motus_fp8_smallm_sm120_obj PROPERTIES
     CUDA_STANDARD 17
     POSITION_INDEPENDENT_CODE ON
@@ -951,6 +974,15 @@ if(GPU_ARCH STREQUAL "120")
     $<TARGET_OBJECTS:cutlass_sm120_block_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE
     ENABLE_CUTLASS_SM120_BLOCK_FP8=1)
+endif()
+
+# Dedicated M=1 GEMV (FP8 + BF16); linked for every GPU_ARCH=120 build so the
+# ENABLE_SM120_GEMV_M1 bindings always resolve, independent of FLASHRT_ENABLE_MOTUS.
+if(GPU_ARCH STREQUAL "120")
+  target_sources(flash_rt_kernels PRIVATE
+    $<TARGET_OBJECTS:sm120_gemv_m1_obj>)
+  target_compile_definitions(flash_rt_kernels PRIVATE
+    ENABLE_SM120_GEMV_M1=1)
 endif()
 
 # SM120a CUTLASS NVFP4 W4A16 GEMM (Qwen3.6 NVFP4 ckpt path).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,7 +518,8 @@ if(FLASHRT_ENABLE_MOTUS AND GPU_ARCH STREQUAL "120")
   add_library(motus_fp8_smallm_sm120_obj OBJECT
     csrc/gemm/fp8_smallM_handtuned_sm120.cu
     csrc/gemm/fp8_smallM_handtuned_splitk_sm120.cu
-    csrc/gemm/fp8_smallM_handtuned_ldmatrix_sm120.cu)
+    csrc/gemm/fp8_smallM_handtuned_ldmatrix_sm120.cu
+    csrc/gemm/fp8_gemv_m1_sm120.cu)
   set_target_properties(motus_fp8_smallm_sm120_obj PROPERTIES
     CUDA_STANDARD 17
     POSITION_INDEPENDENT_CODE ON

--- a/csrc/attention/fa2_wrapper.cu
+++ b/csrc/attention/fa2_wrapper.cu
@@ -279,6 +279,41 @@ DEFINE_FA2_STUB(fvk_attention_fa2_fwd_fp16,  "fp16")
 
 #ifdef FA2_HAS_BF16
 DEFINE_FA2_ENTRY(fvk_attention_fa2_fwd_bf16, cutlass::bfloat16_t, true)
+
+// seqused_k variant: K/V length is read per-batch from device memory
+// (seqused_k[b]); the kernel clamps n_block_max to that length and early-exits.
+// Forces num_splits=1 (no reduction scratch, CUDA-graph-safe). Lets one captured
+// decode graph serve every position — the host writes the current length into
+// the seqused_k buffer before each replay (paired with the devpos KV-write).
+extern "C" void fvk_attention_fa2_fwd_bf16_seqused(
+    const void* q_ptr, const void* k_ptr, const void* v_ptr,
+    void* o_ptr, void* softmax_lse_ptr, const void* seqused_k_ptr,
+    int batch, int seqlen_q, int seqlen_k,
+    int num_heads_q, int num_heads_kv, int head_dim,
+    int q_batch_stride, int q_row_stride, int q_head_stride,
+    int k_batch_stride, int k_row_stride, int k_head_stride,
+    int v_batch_stride, int v_row_stride, int v_head_stride,
+    int o_batch_stride, int o_row_stride, int o_head_stride,
+    float softmax_scale, int /*num_sms*/, cudaStream_t stream)
+{
+    FLASH_NAMESPACE::Flash_fwd_params params;
+    fill_params(params, true, q_ptr, k_ptr, v_ptr, o_ptr, softmax_lse_ptr,
+                batch, seqlen_q, seqlen_k, num_heads_q, num_heads_kv, head_dim,
+                q_batch_stride, q_row_stride, q_head_stride,
+                k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride,
+                o_batch_stride, o_row_stride, o_head_stride, softmax_scale);
+    params.seqused_k = reinterpret_cast<int*>(const_cast<void*>(seqused_k_ptr));
+    params.num_splits = 1;
+    params.softmax_lseaccum_ptr = nullptr;
+    params.oaccum_ptr = nullptr;
+    dispatch_hdim<cutlass::bfloat16_t>(head_dim, 1, params, stream);
+}
 #else
 DEFINE_FA2_STUB(fvk_attention_fa2_fwd_bf16,  "bf16")
+extern "C" void fvk_attention_fa2_fwd_bf16_seqused(
+    const void*, const void*, const void*, void*, void*, const void*,
+    int, int, int, int, int, int, int, int, int, int, int, int,
+    int, int, int, int, int, int, float, int, cudaStream_t)
+{ std::abort(); }
 #endif

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -6049,6 +6049,26 @@ graph-replay safe) to fill the SMs on long K. M in 1..16; N%8==0; K%64==0;
         py::arg("n_kv_heads"), py::arg("eps") = 1e-6f,
         py::arg("stream") = 0);
 
+    m.def("qwen3_k_norm_rope_kvwrite_devpos_bf16",
+        [](uintptr_t k_pre, uintptr_t v_pre, uintptr_t k_norm_w,
+           uintptr_t cos, uintptr_t sin,
+           uintptr_t k_cache_base, uintptr_t v_cache_base,
+           uintptr_t cur_pos, int row_elems,
+           int n_kv_heads, float eps, uintptr_t stream) -> int {
+            return flash_rt::kernels::qwen3_k_norm_rope_kvwrite_devpos_bf16(
+                to_ptr(k_pre), to_ptr(v_pre), to_ptr(k_norm_w),
+                to_ptr(cos), to_ptr(sin),
+                to_ptr(k_cache_base), to_ptr(v_cache_base),
+                to_ptr(cur_pos), row_elems,
+                n_kv_heads, eps, to_stream(stream));
+        },
+        py::arg("k_pre"), py::arg("v_pre"), py::arg("k_norm_w"),
+        py::arg("cos"), py::arg("sin"),
+        py::arg("k_cache_base"), py::arg("v_cache_base"),
+        py::arg("cur_pos"), py::arg("row_elems"),
+        py::arg("n_kv_heads"), py::arg("eps") = 1e-6f,
+        py::arg("stream") = 0);
+
     m.def("ada_rms_norm_style_int8", [](uintptr_t x, uintptr_t weight, uintptr_t style,
                                          uintptr_t out, uintptr_t gate_out,
                                          int seq_len, int dim, float eps,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -15,6 +15,7 @@
 #include "gemm/fp8_smallM_handtuned_sm120.cuh"
 #include "gemm/fp8_smallM_handtuned_splitk_sm120.cuh"
 #include "gemm/fp8_smallM_handtuned_ldmatrix_sm120.cuh"
+#include "gemm/fp8_gemv_m1_sm120.cuh"
 #endif
 #ifdef ENABLE_CUTLASS_SM120_NVFP4_W4A16
 #include "gemm/fp4/cutlass_nvfp4_w4a16_gemm_sm120.cuh"
@@ -5241,6 +5242,25 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_SPLITK(splitk_fp8_gemm_32x64x128_w4);
 
 #undef BIND_SPLITK
+
+    // Dedicated M=1 FP8 GEMV (warp-per-output-row, no MMA padding tax).
+#define BIND_GEMV_M1(NAME)                                                   \
+    m.def("ht_" #NAME,                                                       \
+        [](uintptr_t A, uintptr_t B, uintptr_t D,                            \
+           int M, int N, int K, float alpha, uintptr_t stream) {             \
+            return flash_rt::gemm::gemv_m1::NAME(                            \
+                to_ptr(A), to_ptr(B), to_ptr(D),                             \
+                M, N, K, alpha, to_stream(stream));                          \
+        },                                                                   \
+        py::arg("A"), py::arg("B"), py::arg("D"),                            \
+        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("alpha"),          \
+        py::arg("stream") = 0)
+
+    BIND_GEMV_M1(gemv_fp8_m1_w4);
+    BIND_GEMV_M1(gemv_fp8_m1_w8);
+    BIND_GEMV_M1(gemv_fp8_m1_w16);
+
+#undef BIND_GEMV_M1
 #endif
 
 #ifdef ENABLE_FP8_CONV3D_V17

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -16,6 +16,7 @@
 #include "gemm/fp8_smallM_handtuned_splitk_sm120.cuh"
 #include "gemm/fp8_smallM_handtuned_ldmatrix_sm120.cuh"
 #include "gemm/fp8_gemv_m1_sm120.cuh"
+#include "gemm/bf16_gemv_m1_sm120.cuh"
 #endif
 #ifdef ENABLE_CUTLASS_SM120_NVFP4_W4A16
 #include "gemm/fp4/cutlass_nvfp4_w4a16_gemm_sm120.cuh"
@@ -5261,6 +5262,11 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_GEMV_M1(gemv_fp8_m1_w16);
     BIND_GEMV_M1(gemv_fp8_m1_resadd_w4);
     BIND_GEMV_M1(gemv_fp8_m1_resadd_w8);
+
+    // Dedicated M=1 BF16 GEMV (all-BF16 decode; no smem A-stage -> full occ).
+    BIND_GEMV_M1(gemv_bf16_m1_w4);
+    BIND_GEMV_M1(gemv_bf16_m1_w8);
+    BIND_GEMV_M1(gemv_bf16_m1_w16);
 
 #undef BIND_GEMV_M1
 #endif

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -15,6 +15,8 @@
 #include "gemm/fp8_smallM_handtuned_sm120.cuh"
 #include "gemm/fp8_smallM_handtuned_splitk_sm120.cuh"
 #include "gemm/fp8_smallM_handtuned_ldmatrix_sm120.cuh"
+#endif
+#ifdef ENABLE_SM120_GEMV_M1
 #include "gemm/fp8_gemv_m1_sm120.cuh"
 #include "gemm/bf16_gemv_m1_sm120.cuh"
 #endif
@@ -5243,8 +5245,13 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_SPLITK(splitk_fp8_gemm_32x64x128_w4);
 
 #undef BIND_SPLITK
+#endif  // ENABLE_CUTLASS_SM120_BLOCK_FP8
 
-    // Dedicated M=1 FP8 GEMV (warp-per-output-row, no MMA padding tax).
+#ifdef ENABLE_SM120_GEMV_M1
+    // Dedicated M=1 GEMV (FP8 + BF16), warp-per-output-row, no MMA padding tax.
+    // Internal decode kernels: callers must pass M=1 and K aligned (FP8 K%16,
+    // BF16 K%8). These hold for the fixed Higgs/Qwen decode shapes; the kernels
+    // do not validate, so do not expose these to arbitrary external shapes.
 #define BIND_GEMV_M1(NAME)                                                   \
     m.def("ht_" #NAME,                                                       \
         [](uintptr_t A, uintptr_t B, uintptr_t D,                            \
@@ -5269,7 +5276,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_GEMV_M1(gemv_bf16_m1_w16);
 
 #undef BIND_GEMV_M1
-#endif
+#endif  // ENABLE_SM120_GEMV_M1
 
 #ifdef ENABLE_FP8_CONV3D_V17
     m.def("fp8_conv3d_v17_ndhwc_bf16out",

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -16,7 +16,7 @@
 #include "gemm/fp8_smallM_handtuned_splitk_sm120.cuh"
 #include "gemm/fp8_smallM_handtuned_ldmatrix_sm120.cuh"
 #endif
-#ifdef ENABLE_SM120_GEMV_M1
+#ifdef ENABLE_DECODE_GEMV_M1
 #include "gemm/fp8_gemv_m1_sm120.cuh"
 #include "gemm/bf16_gemv_m1_sm120.cuh"
 #endif
@@ -5247,7 +5247,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
 #undef BIND_SPLITK
 #endif  // ENABLE_CUTLASS_SM120_BLOCK_FP8
 
-#ifdef ENABLE_SM120_GEMV_M1
+#ifdef ENABLE_DECODE_GEMV_M1
     // Dedicated M=1 GEMV (FP8 + BF16), warp-per-output-row, no MMA padding tax.
     // Internal decode kernels: callers must pass M=1 and K aligned (FP8 K%16,
     // BF16 K%8). These hold for the fixed Higgs/Qwen decode shapes; the kernels
@@ -5276,7 +5276,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_GEMV_M1(gemv_bf16_m1_w16);
 
 #undef BIND_GEMV_M1
-#endif  // ENABLE_SM120_GEMV_M1
+#endif  // ENABLE_DECODE_GEMV_M1
 
 #ifdef ENABLE_FP8_CONV3D_V17
     m.def("fp8_conv3d_v17_ndhwc_bf16out",

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -5259,6 +5259,8 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_GEMV_M1(gemv_fp8_m1_w4);
     BIND_GEMV_M1(gemv_fp8_m1_w8);
     BIND_GEMV_M1(gemv_fp8_m1_w16);
+    BIND_GEMV_M1(gemv_fp8_m1_resadd_w4);
+    BIND_GEMV_M1(gemv_fp8_m1_resadd_w8);
 
 #undef BIND_GEMV_M1
 #endif

--- a/csrc/fa2_bindings.cpp
+++ b/csrc/fa2_bindings.cpp
@@ -53,6 +53,19 @@ extern "C" void fvk_attention_fa2_fwd_bf16(
     int o_batch_stride, int o_row_stride, int o_head_stride,
     float softmax_scale, int num_sms, cudaStream_t stream);
 
+// seqused_k variant — definition in csrc/attention/fa2_wrapper.cu. Reads the
+// per-batch K length from device memory so one captured graph serves any pos.
+extern "C" void fvk_attention_fa2_fwd_bf16_seqused(
+    const void* q_ptr, const void* k_ptr, const void* v_ptr,
+    void* o_ptr, void* softmax_lse_ptr, const void* seqused_k_ptr,
+    int batch, int seqlen_q, int seqlen_k,
+    int num_heads_q, int num_heads_kv, int head_dim,
+    int q_batch_stride, int q_row_stride, int q_head_stride,
+    int k_batch_stride, int k_row_stride, int k_head_stride,
+    int v_batch_stride, int v_row_stride, int v_head_stride,
+    int o_batch_stride, int o_row_stride, int o_head_stride,
+    float softmax_scale, int num_sms, cudaStream_t stream);
+
 // Causal variant — definition in csrc/attention/fa2_wrapper_causal.cu.
 // Currently only (bf16, head_dim=128) is built. Used by Qwen3-8B
 // prefill (S=N causal self-attention).
@@ -119,8 +132,45 @@ static auto make_fwd(Fn fn) {
 }
 
 
+// seqused variant: same as make_fwd but with a device seqused_k pointer and no
+// splitkv accum args (num_splits is forced to 1 inside the entry).
+static auto make_fwd_seqused(
+    void (*fn)(const void*, const void*, const void*, void*, void*, const void*,
+               int, int, int, int, int, int, int, int, int, int, int, int,
+               int, int, int, int, int, int, float, int, cudaStream_t)) {
+    return [fn](uintptr_t Q, uintptr_t K, uintptr_t V, uintptr_t O,
+                uintptr_t softmax_lse, uintptr_t seqused_k,
+                int batch, int seqlen_q, int seqlen_k,
+                int num_heads_q, int num_heads_kv, int head_dim,
+                py::tuple q_strides, py::tuple k_strides,
+                py::tuple v_strides, py::tuple o_strides,
+                float softmax_scale, int num_sms, uintptr_t stream) {
+        fn(reinterpret_cast<const void*>(Q), reinterpret_cast<const void*>(K),
+           reinterpret_cast<const void*>(V), reinterpret_cast<void*>(O),
+           reinterpret_cast<void*>(softmax_lse),
+           reinterpret_cast<const void*>(seqused_k),
+           batch, seqlen_q, seqlen_k, num_heads_q, num_heads_kv, head_dim,
+           py::cast<int>(q_strides[0]), py::cast<int>(q_strides[1]), py::cast<int>(q_strides[2]),
+           py::cast<int>(k_strides[0]), py::cast<int>(k_strides[1]), py::cast<int>(k_strides[2]),
+           py::cast<int>(v_strides[0]), py::cast<int>(v_strides[1]), py::cast<int>(v_strides[2]),
+           py::cast<int>(o_strides[0]), py::cast<int>(o_strides[1]), py::cast<int>(o_strides[2]),
+           softmax_scale, num_sms, to_stream(stream));
+    };
+}
+
+
 PYBIND11_MODULE(flash_rt_fa2, m) {
     m.doc() = "FlashRT — vendored Flash-Attention 2 forward (fp16 + bf16).";
+
+    m.def("fwd_bf16_seqused", make_fwd_seqused(&fvk_attention_fa2_fwd_bf16_seqused),
+        py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"), py::arg("softmax_lse"),
+        py::arg("seqused_k"),
+        py::arg("batch"), py::arg("seqlen_q"), py::arg("seqlen_k"),
+        py::arg("num_heads_q"), py::arg("num_heads_kv"), py::arg("head_dim"),
+        py::arg("q_strides"), py::arg("k_strides"),
+        py::arg("v_strides"), py::arg("o_strides"),
+        py::arg("softmax_scale") = 1.0f, py::arg("num_sms") = 0,
+        py::arg("stream") = 0);
 
     m.def("fwd_fp16", make_fwd(&fvk_attention_fa2_fwd_fp16),
         py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"), py::arg("softmax_lse"),

--- a/csrc/gemm/bf16_gemv_m1_sm120.cu
+++ b/csrc/gemm/bf16_gemv_m1_sm120.cu
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Dedicated M=1 BF16 GEMV for sm_120a decode (batch=1 token) — the all-BF16
+// sibling of fp8_gemv_m1_sm120.cu, for hosts that cannot run FP8.
+//
+// One warp per output row n: each warp reduces B[n] against A and writes D[n].
+// B is read in 16-byte coalesced uint4 (8 bf16) chunks, stride 32 across the
+// warp; the partial sums are folded by a warp-shuffle reduction. A is read from
+// global (no smem staging): at BF16 the FP8 variant's smem stage would be 2x
+// the bytes (K=9728 -> 19.5 KB/block) and cap blocks/SM under
+// launch_bounds(.,8); A is tiny (<=19 KB) and stays hot in L2 across blocks, so
+// reading it from global keeps smem=0 and occupancy maximal — the all-BF16
+// decode is HBM-bound on the weight read, which this saturates.
+
+#include "bf16_gemv_m1_sm120.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt {
+namespace gemm {
+namespace gemv_m1 {
+
+namespace {
+
+template <int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+void gemv_bf16_m1_kernel(
+    const __nv_bfloat16* __restrict__ A,   // [K]
+    const __nv_bfloat16* __restrict__ B,   // [N, K]
+    __nv_bfloat16* __restrict__ D,         // [N]
+    int N, int K, float alpha)
+{
+    const int tid  = threadIdx.x;
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    const int K8   = K >> 3;                // # of 16-byte (uint4 = 8 bf16) groups
+
+    const int n = blockIdx.x * WARPS_PER_BLOCK + warp;
+    if (n >= N) return;
+
+    const uint4* A8   = reinterpret_cast<const uint4*>(A);
+    const uint4* Brow = reinterpret_cast<const uint4*>(B) + (size_t)n * K8;
+    float acc = 0.0f;
+    for (int i = lane; i < K8; i += 32) {
+        uint4 bpack = Brow[i];
+        uint4 apack = A8[i];
+        const __nv_bfloat16* bp = reinterpret_cast<const __nv_bfloat16*>(&bpack);
+        const __nv_bfloat16* ap = reinterpret_cast<const __nv_bfloat16*>(&apack);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            acc += __bfloat162float(ap[j]) * __bfloat162float(bp[j]);
+        }
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    }
+    if (lane == 0) D[n] = __float2bfloat16(acc * alpha);
+}
+
+template <int W>
+int launch_(const void* A, const void* B, void* D,
+            int /*M*/, int N, int K, float alpha, cudaStream_t stream) {
+    dim3 grid((N + W - 1) / W);
+    gemv_bf16_m1_kernel<W><<<grid, W * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(A),
+        reinterpret_cast<const __nv_bfloat16*>(B),
+        reinterpret_cast<__nv_bfloat16*>(D), N, K, alpha);
+    return 0;
+}
+
+}  // namespace
+
+#define DEFINE(NAME, W)                                                         \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,          \
+           float alpha, cudaStream_t stream) {                                  \
+    return launch_<W>(A, B, D, M, N, K, alpha, stream);                         \
+  }
+
+DEFINE(gemv_bf16_m1_w4,  4)
+DEFINE(gemv_bf16_m1_w8,  8)
+DEFINE(gemv_bf16_m1_w16, 16)
+
+#undef DEFINE
+
+}  // namespace gemv_m1
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/bf16_gemv_m1_sm120.cuh
+++ b/csrc/gemm/bf16_gemv_m1_sm120.cuh
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace gemm {
+namespace gemv_m1 {
+
+// Dedicated M=1 BF16 -> BF16 GEMV for sm_120a decode shapes (the all-BF16
+// sibling of the FP8 gemv_fp8_m1_*). Inputs: BF16 A [1,K] row-major, BF16
+// B [N,K] row-major (= W.T), BF16 D [1,N]. alpha is applied to the output
+// (1.0 for BF16; kept for ABI symmetry with the FP8 GEMV + BIND_GEMV_M1).
+// M is ignored (M=1 assumed). Warp-per-output-row; B read in 16-byte coalesced
+// uint4 (8 bf16) chunks; warp-shuffle reduction. Unlike the FP8 variant it does
+// NOT stage A in shared memory: at BF16 that stage is 2x the bytes and caps
+// blocks/SM on K=9728; A is tiny and stays hot in L2, so reading it from global
+// keeps smem=0 and occupancy maximal. K assumed a multiple of 8.
+
+#define DECL_BF16_GEMV(NAME) \
+  int NAME(const void* A, const void* B, void* D, \
+           int M, int N, int K, float alpha, cudaStream_t stream)
+
+DECL_BF16_GEMV(gemv_bf16_m1_w4);
+DECL_BF16_GEMV(gemv_bf16_m1_w8);
+DECL_BF16_GEMV(gemv_bf16_m1_w16);
+
+#undef DECL_BF16_GEMV
+
+}  // namespace gemv_m1
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_gemv_m1_sm120.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cu
@@ -69,6 +69,53 @@ void gemv_fp8_m1_kernel(
     if (lane == 0) D[n] = __float2bfloat16(acc * alpha);
 }
 
+// GEMV with fused residual accumulate: D[n] += acc * alpha (in-place into the
+// residual stream). The residual is per-element local — no cross-block
+// dependency like the norm — so it folds into the epilogue for free, removing
+// the separate residual_add launch. Each output n is written by one warp lane.
+template <int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+void gemv_fp8_m1_resadd_kernel(
+    const __nv_fp8_e4m3* __restrict__ A,
+    const __nv_fp8_e4m3* __restrict__ B,
+    __nv_bfloat16* __restrict__ D,   // residual stream, accumulated in place
+    int N, int K, float alpha)
+{
+    extern __shared__ __nv_fp8_e4m3 sA[];
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int threads = WARPS_PER_BLOCK * 32, K16 = K >> 4;
+    uint4* sA16 = reinterpret_cast<uint4*>(sA);
+    const uint4* A16 = reinterpret_cast<const uint4*>(A);
+    for (int i = tid; i < K16; i += threads) sA16[i] = A16[i];
+    __syncthreads();
+    const int n = blockIdx.x * WARPS_PER_BLOCK + warp;
+    if (n >= N) return;
+    const uint4* Brow = reinterpret_cast<const uint4*>(B) + (size_t)n * K16;
+    float acc = 0.0f;
+    for (int i = lane; i < K16; i += 32) {
+        uint4 bpack = Brow[i];
+        const __nv_fp8_e4m3* bp = reinterpret_cast<const __nv_fp8_e4m3*>(&bpack);
+        const __nv_fp8_e4m3* ap = sA + (i << 4);
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) acc += float(ap[j]) * float(bp[j]);
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) acc += __shfl_down_sync(0xffffffffu, acc, off);
+    if (lane == 0) D[n] = __float2bfloat16(__bfloat162float(D[n]) + acc * alpha);
+}
+
+template <int W>
+int launch_resadd_(const void* A, const void* B, void* D,
+                   int N, int K, float alpha, cudaStream_t stream) {
+    dim3 grid((N + W - 1) / W);
+    size_t smem = (size_t)K * sizeof(__nv_fp8_e4m3);
+    gemv_fp8_m1_resadd_kernel<W><<<grid, W * 32, smem, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        reinterpret_cast<__nv_bfloat16*>(D), N, K, alpha);
+    return 0;
+}
+
 template <int W>
 int launch_(const void* A, const void* B, void* D,
             int /*M*/, int N, int K, float alpha, cudaStream_t stream) {
@@ -95,7 +142,17 @@ DEFINE(gemv_fp8_m1_w4,  4)
 DEFINE(gemv_fp8_m1_w8,  8)
 DEFINE(gemv_fp8_m1_w16, 16)
 
+#define DEFINE_RA(NAME, W)                                                      \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,          \
+           float alpha, cudaStream_t stream) {                                  \
+    return launch_resadd_<W>(A, B, D, N, K, alpha, stream);                     \
+  }
+
+DEFINE_RA(gemv_fp8_m1_resadd_w4, 4)
+DEFINE_RA(gemv_fp8_m1_resadd_w8, 8)
+
 #undef DEFINE
+#undef DEFINE_RA
 
 }  // namespace gemv_m1
 }  // namespace gemm

--- a/csrc/gemm/fp8_gemv_m1_sm120.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cu
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Dedicated M=1 FP8 e4m3 -> BF16 GEMV for sm_120a decode (batch=1 token).
+//
+// The hand-tuned MMA GEMMs pad M=1 to BLOCK_M=16 (m16n8k32), computing 16
+// rows to use 1 — fine for compute (memory-bound) but the N=2560 shapes only
+// spawn N/BLOCK_N blocks and starve the SMs. This GEMV assigns one warp per
+// output row: A[1,K] is staged once into smem (hot in L2 across blocks), each
+// warp streams its B row in 16-byte coalesced chunks and warp-reduces the dot
+// product. BLOCK_N effectively 1-per-warp => N/WARPS_PER_BLOCK blocks (e.g.
+// N=2560, W=8 -> 320 blocks) saturates occupancy without a split-K reduction.
+
+#include "fp8_gemv_m1_sm120.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt {
+namespace gemm {
+namespace gemv_m1 {
+
+namespace {
+
+// One warp per output row n. A staged in smem as raw fp8 (K bytes). B row read
+// in uint4 (16 fp8) coalesced chunks, stride 32 across the warp. K assumed a
+// multiple of 16 (all Higgs/Qwen3 GEMM K: 2560/4096/9728).
+template <int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+void gemv_fp8_m1_kernel(
+    const __nv_fp8_e4m3* __restrict__ A,   // [K]
+    const __nv_fp8_e4m3* __restrict__ B,   // [N, K]
+    __nv_bfloat16* __restrict__ D,         // [N]
+    int N, int K, float alpha)
+{
+    extern __shared__ __nv_fp8_e4m3 sA[];   // [K]
+    const int tid     = threadIdx.x;
+    const int lane    = tid & 31;
+    const int warp    = tid >> 5;
+    const int threads = WARPS_PER_BLOCK * 32;
+    const int K16     = K >> 4;             // # of 16-byte (uint4) groups
+
+    // Cooperatively stage A into smem, 16 bytes per thread.
+    uint4* sA16 = reinterpret_cast<uint4*>(sA);
+    const uint4* A16 = reinterpret_cast<const uint4*>(A);
+    for (int i = tid; i < K16; i += threads) sA16[i] = A16[i];
+    __syncthreads();
+
+    const int n = blockIdx.x * WARPS_PER_BLOCK + warp;
+    if (n >= N) return;
+
+    const uint4* Brow = reinterpret_cast<const uint4*>(B) + (size_t)n * K16;
+    const __nv_fp8_e4m3* sAf = sA;
+    float acc = 0.0f;
+    for (int i = lane; i < K16; i += 32) {
+        uint4 bpack = Brow[i];
+        const __nv_fp8_e4m3* bp = reinterpret_cast<const __nv_fp8_e4m3*>(&bpack);
+        const __nv_fp8_e4m3* ap = sAf + (i << 4);
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            acc += float(ap[j]) * float(bp[j]);
+        }
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    }
+    if (lane == 0) D[n] = __float2bfloat16(acc * alpha);
+}
+
+template <int W>
+int launch_(const void* A, const void* B, void* D,
+            int /*M*/, int N, int K, float alpha, cudaStream_t stream) {
+    dim3 grid((N + W - 1) / W);
+    dim3 block(W * 32);
+    size_t smem = (size_t)K * sizeof(__nv_fp8_e4m3);
+    gemv_fp8_m1_kernel<W><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        reinterpret_cast<__nv_bfloat16*>(D),
+        N, K, alpha);
+    return 0;
+}
+
+}  // namespace
+
+#define DEFINE(NAME, W)                                                         \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,          \
+           float alpha, cudaStream_t stream) {                                  \
+    return launch_<W>(A, B, D, M, N, K, alpha, stream);                         \
+  }
+
+DEFINE(gemv_fp8_m1_w4,  4)
+DEFINE(gemv_fp8_m1_w8,  8)
+DEFINE(gemv_fp8_m1_w16, 16)
+
+#undef DEFINE
+
+}  // namespace gemv_m1
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_gemv_m1_sm120.cuh
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cuh
@@ -21,6 +21,8 @@ namespace gemv_m1 {
 DECL(gemv_fp8_m1_w4);
 DECL(gemv_fp8_m1_w8);
 DECL(gemv_fp8_m1_w16);
+DECL(gemv_fp8_m1_resadd_w4);  // D[n] += acc*alpha (fused residual)
+DECL(gemv_fp8_m1_resadd_w8);
 
 #undef DECL
 

--- a/csrc/gemm/fp8_gemv_m1_sm120.cuh
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cuh
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace gemm {
+namespace gemv_m1 {
+
+// Dedicated M=1 FP8 e4m3 -> BF16 GEMV for sm_120a decode shapes.
+// Inputs: FP8 A [1,K] row-major, FP8 B [N,K] row-major (= W.T), BF16 D [1,N].
+// alpha = a_scale * w_scale (per-tensor). M is ignored (M=1 assumed).
+// Warp-per-output-row: each warp reduces one B row against A (held in smem),
+// 16-byte vectorized coalesced B loads. No MMA / no BLOCK_M padding tax.
+// Returns 0 on success.
+
+#define DECL(NAME) \
+  int NAME(const void* A, const void* B, void* D, \
+           int M, int N, int K, float alpha, cudaStream_t stream)
+
+DECL(gemv_fp8_m1_w4);
+DECL(gemv_fp8_m1_w8);
+DECL(gemv_fp8_m1_w16);
+
+#undef DECL
+
+}  // namespace gemv_m1
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/kernels/qwen3_qkv_post_proc.cu
+++ b/csrc/kernels/qwen3_qkv_post_proc.cu
@@ -152,7 +152,80 @@ __global__ void k_norm_rope_kvwrite_kernel(
   v_cache_dst[head * HEAD_DIM + tid] = v_pre[head * HEAD_DIM + tid];
 }
 
+// Device-position variant: writes K/V into K_cache[*cur_pos] / V_cache[*cur_pos]
+// where cur_pos is read from device memory, so a single captured graph serves
+// every decode position (the host bumps *cur_pos before each replay). row_elems
+// = elements between consecutive position slots (n_kv * HEAD_DIM). Same rope/norm
+// math as k_norm_rope_kvwrite_kernel.
+__global__ void k_norm_rope_kvwrite_devpos_kernel(
+    const __nv_bfloat16* __restrict__ k_pre,
+    const __nv_bfloat16* __restrict__ v_pre,
+    const __nv_bfloat16* __restrict__ k_norm_w,
+    const __nv_bfloat16* __restrict__ cos_v,
+    const __nv_bfloat16* __restrict__ sin_v,
+    __nv_bfloat16* __restrict__ k_cache_base,
+    __nv_bfloat16* __restrict__ v_cache_base,
+    const int* __restrict__ cur_pos,
+    int row_elems,
+    int n_kv,
+    float eps) {
+  int head = blockIdx.x;
+  if (head >= n_kv) return;
+  int tid = threadIdx.x;
+  const size_t slot = (size_t)(*cur_pos) * row_elems;
+  __nv_bfloat16* k_cache_dst = k_cache_base + slot;
+  __nv_bfloat16* v_cache_dst = v_cache_base + slot;
+
+  __shared__ float s_normed[HEAD_DIM];
+  __shared__ float s_smem4[N_WARPS];
+
+  const __nv_bfloat16* k_row = k_pre + head * HEAD_DIM;
+  float v = __bfloat162float(k_row[tid]);
+  float w = __bfloat162float(k_norm_w[tid]);
+  float sum_sq = block_sum_4warp(v * v, s_smem4);
+  float rstd = rsqrtf(sum_sq / float(HEAD_DIM) + eps);
+  float normed = v * rstd * w;
+  s_normed[tid] = normed;
+  __syncthreads();
+
+  float partner, c, sn;
+  if (tid < HALF) {
+    partner = s_normed[tid + HALF];
+    c = __bfloat162float(cos_v[tid]);
+    sn = __bfloat162float(sin_v[tid]);
+    k_cache_dst[head * HEAD_DIM + tid] = __float2bfloat16(normed * c - partner * sn);
+  } else {
+    partner = s_normed[tid - HALF];
+    int half_idx = tid - HALF;
+    c = __bfloat162float(cos_v[half_idx]);
+    sn = __bfloat162float(sin_v[half_idx]);
+    k_cache_dst[head * HEAD_DIM + tid] = __float2bfloat16(normed * c + partner * sn);
+  }
+  v_cache_dst[head * HEAD_DIM + tid] = v_pre[head * HEAD_DIM + tid];
+}
+
 }  // namespace
+
+int qwen3_k_norm_rope_kvwrite_devpos_bf16(
+    const void* k_pre, const void* v_pre, const void* k_norm_w,
+    const void* cos, const void* sin, void* k_cache_base, void* v_cache_base,
+    const void* cur_pos, int row_elems, int n_kv_heads, float eps,
+    cudaStream_t stream) {
+  if (!k_pre || !v_pre || !k_norm_w || !cos || !sin
+      || !k_cache_base || !v_cache_base || !cur_pos) return 1;
+  if (n_kv_heads <= 0) return 2;
+  k_norm_rope_kvwrite_devpos_kernel<<<dim3(n_kv_heads), dim3(THREADS), 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(k_pre),
+      reinterpret_cast<const __nv_bfloat16*>(v_pre),
+      reinterpret_cast<const __nv_bfloat16*>(k_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(cos),
+      reinterpret_cast<const __nv_bfloat16*>(sin),
+      reinterpret_cast<__nv_bfloat16*>(k_cache_base),
+      reinterpret_cast<__nv_bfloat16*>(v_cache_base),
+      reinterpret_cast<const int*>(cur_pos),
+      row_elems, n_kv_heads, eps);
+  return 0;
+}
 
 int qwen3_q_norm_rope_qstage_bf16(
     const void* q_pre,

--- a/csrc/kernels/qwen3_qkv_post_proc.cuh
+++ b/csrc/kernels/qwen3_qkv_post_proc.cuh
@@ -76,5 +76,22 @@ int qwen3_k_norm_rope_kvwrite_bf16(
     float       eps,
     cudaStream_t stream);
 
+// Device-position variant: cache slot = K_cache_base + (*cur_pos) * row_elems,
+// so one captured graph serves every decode position (host bumps *cur_pos
+// before each replay). row_elems = n_kv * 128. Returns 0 on success.
+int qwen3_k_norm_rope_kvwrite_devpos_bf16(
+    const void* k_pre,
+    const void* v_pre,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       k_cache_base,
+    void*       v_cache_base,
+    const void* cur_pos,
+    int         row_elems,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream);
+
 }  // namespace kernels
 }  // namespace flash_rt

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -34,12 +34,15 @@ unquantised precision path for the same hardware (see below):
 Both precisions run the **same** fully-kernelised, zero-torch decode path
 (position-agnostic CUDA graph, batched prefill, prefix reuse). BF16 reads 2× the
 weight bytes of FP8, so its per-frame is ~1.7× — the bandwidth floor, not
-overhead. **Want unquantised BF16 numerics (e.g. FP8 disabled in your build, or
-to skip quantisation)? construct with `fp8=False` or pass `--bf16`** —
-everything else is identical. Both paths still require **SM120** (the BF16 path
-also uses an `sm_120a` GEMV); it is *not* a pre-Blackwell (e.g. 4090 / Thor /
-Orin) fallback — those would need separate kernels, which this frontend does
-not provide.
+overhead. **Want unquantised BF16 numerics (e.g. to skip quantisation)?
+construct with `fp8=False` or pass `--bf16`** — everything else is identical.
+
+**Architecture**: as shipped both paths are built for **SM120** (`-gencode
+sm_120a`), so a default build runs on SM120 only. The BF16 decode kernels use no
+SM120-specific instruction (the M=1 GEMV is plain CUDA, the rest is shared
+kernels) and compile for Ada (sm89) — a 4090 BF16 build is a CMake-gating change
+away, but is not built or validated here. The FP8 path additionally needs the
+SM120 FP8 GEMM, so it stays SM120-only. See [§8](#8-notes--limitations).
 
 **Speedup over the unoptimised PyTorch reference** (same model + GPU, transformers
 eager backbone):
@@ -229,6 +232,15 @@ Headline numbers are in [Performance](#performance) above. Methodology:
   ranges are stable across prompts; re-instantiate the frontend to recalibrate.
 - The BF16 projection weights are freed after calibration (the FP8 backbone is
   the active path); pass `fp8=False` for the BF16 backbone, which keeps them.
+- **GPU support.** A default build targets **SM120** (`GPU_ARCH=120`,
+  `-gencode sm_120a`), so the frontend's decode kernels are only compiled there;
+  a non-SM120 build (e.g. `GPU_ARCH=89` for a 4090) builds the rest of FlashRT
+  but **not** these kernels, so the frontend raises at runtime (the `ht_gemv_*`
+  symbols are absent). The BF16 GEMV itself is plain CUDA (no SM120 intrinsics)
+  and *compiles* for Ada (sm89) — and all the support kernels (RMSNorm, SwiGLU,
+  q/k-norm+RoPE, FlashAttention-2) are arch-generic — so a 4090 **BF16** build is
+  a build-gating change away, but it is not enabled or hardware-validated here.
+  The FP8 path additionally needs the SM120 FP8 GEMM and stays SM120-only.
 - Synthesis here is **non-streaming** (the codec decodes the whole clip at the
   end). Streaming / chunked synthesis is not yet wired.
 - Codec source: the `bosonai/higgs-audio` v2 tokenizer (decode path only),

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -45,11 +45,12 @@ in one batched M=P pass; a shared `system` preamble's KV is reused across
 requests (only the new text is prefilled — see [§4](#4-python-api)).
 
 **BF16 fallback (`fp8=False`)** — for hosts without FP8 — runs the same
-fully-kernelised, zero-torch path (dedicated M=1 BF16 GEMV at **86 % HBM BW**,
-residual folded into the following RMSNorm, position-agnostic graph, batched
-prefill, prefix reuse): **≈ 6.4 ms/frame, RTF ≈ 0.16, ~7.3 GB**, bit-exact vs
-the eager reference. BF16 reads 2× the weight bytes of FP8, so it is ~1.7×
-slower; everything else is identical.
+fully-kernelised decode path (dedicated M=1 BF16 GEMV at **86 % HBM BW**,
+residual folded into the following RMSNorm, position-agnostic graph, prefix
+reuse): **≈ 6.1 ms/frame, RTF ≈ 0.15, TTFA ≈ 138 ms, ~9.6 GB**, bit-exact vs
+the eager reference. BF16 reads 2× the weight bytes of FP8, so per-frame is at
+its bandwidth wall (~1.7× FP8); the one-time prompt prefill uses cuBLAS
+(weight-once, 66–82 % HBM) since it is eager setup, not the decode graph.
 
 ---
 

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -44,6 +44,13 @@ and replayed from a single position-agnostic CUDA graph. The prompt is prefilled
 in one batched M=P pass; a shared `system` preamble's KV is reused across
 requests (only the new text is prefilled — see [§4](#4-python-api)).
 
+**BF16 fallback (`fp8=False`)** — for hosts without FP8 — runs the same
+fully-kernelised, zero-torch path (dedicated M=1 BF16 GEMV at **86 % HBM BW**,
+residual folded into the following RMSNorm, position-agnostic graph, batched
+prefill, prefix reuse): **≈ 6.4 ms/frame, RTF ≈ 0.16, ~7.3 GB**, bit-exact vs
+the eager reference. BF16 reads 2× the weight bytes of FP8, so it is ~1.7×
+slower; everything else is identical.
+
 ---
 
 ## 1. Requirements

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -16,18 +16,25 @@ non-commercial license — check the model card.
 
 ## Performance
 
-Measured on a single **RTX 5090** (SM120), single stream, FP8 W8A8, warm
-(numbers vary with text and clocks):
+Measured on a single **RTX 5090** (SM120), single stream, warm (numbers vary
+with text and clocks). Two precisions: **FP8 W8A8** (default) and **BF16
+W16A16** — the fallback for hosts without FP8 (`fp8=False`, see below):
 
-| Metric | Value |
-|---|---|
-| Real-time factor (RTF) | **0.095 – 0.11** (≈ 9–10× faster than real time) |
-| Time to first audio (TTFA) | **≈ 94 ms** |
-| Prompt prefill | **≈ 1.0 ms/token** (batched single-pass; ~0.8 on longer prompts) |
-| Autoregressive decode | **≈ 3.2 ms/frame** steady (≈ 3.7–4.3 ms/frame full-pipeline incl. prefill amortisation + codec) |
-| Peak VRAM | **6.6 GB** (FP8 backbone ≈ 3.6 GB + bf16 embed/head + fp32 codec) |
-| Fidelity | teacher-forced logits **cos 1.0** vs the reference backbone; codec **cos 0.99993** vs canonical; streamed == one-shot **cos 1.0** |
-| Prefix reuse | a shared `system` preamble cuts prefill by **~64 %**, output bit-identical |
+| Metric | **FP8** (default) | **BF16** (`fp8=False`) |
+|---|---|---|
+| Real-time factor (RTF) | **0.095 – 0.11** (≈ 9–10× real time) | **0.15** (≈ 6.5× real time) |
+| Time to first audio (TTFA) | **≈ 94 ms** | **≈ 138 ms** |
+| Autoregressive decode | **≈ 3.2 ms/frame** | **≈ 6.1 ms/frame** (at the BF16 bandwidth wall) |
+| Prompt prefill | **≈ 1.0 ms/token** | **≈ 0.9 ms/token** (cuBLAS, weight-once) |
+| Peak VRAM | **6.6 GB** | **9.6 GB** |
+| Fidelity | teacher-forced logits **cos 1.0**; codec **cos 0.99993**; streamed == one-shot **cos 1.0** | same (bit-exact vs eager) |
+| Prefix reuse | shared `system` preamble cuts prefill **~64 %**, output bit-identical | same |
+
+Both precisions run the **same** fully-kernelised, zero-torch decode path
+(position-agnostic CUDA graph, batched prefill, prefix reuse). BF16 reads 2× the
+weight bytes of FP8, so its per-frame is ~1.7× — the bandwidth floor, not
+overhead. **No FP8 (pre-Blackwell, or FP8 disabled)? construct with `fp8=False`
+or pass `--bf16` to the quickstart/server** — everything else is identical.
 
 **Speedup over the unoptimised PyTorch reference** (same model + GPU, transformers
 eager backbone):
@@ -38,19 +45,13 @@ eager backbone):
 | Prompt prefill | 3.7 ms/token | **1.0 ms/token** | **3.7× faster** |
 | Backbone weight VRAM | 7.3 GB (bf16) | **3.6 GB (FP8)** | **2× smaller** |
 
-The decode math path is fully kernelised (RMSNorm→FP8 quant, dedicated M=1 FP8
-GEMV with fused residual epilogue, fused q/k-norm+RoPE+KV-write, FlashAttention-2)
-and replayed from a single position-agnostic CUDA graph. The prompt is prefilled
-in one batched M=P pass; a shared `system` preamble's KV is reused across
-requests (only the new text is prefilled — see [§4](#4-python-api)).
-
-**BF16 fallback (`fp8=False`)** — for hosts without FP8 — runs the same
-fully-kernelised decode path (dedicated M=1 BF16 GEMV at **86 % HBM BW**,
-residual folded into the following RMSNorm, position-agnostic graph, prefix
-reuse): **≈ 6.1 ms/frame, RTF ≈ 0.15, TTFA ≈ 138 ms, ~9.6 GB**, bit-exact vs
-the eager reference. BF16 reads 2× the weight bytes of FP8, so per-frame is at
-its bandwidth wall (~1.7× FP8); the one-time prompt prefill uses cuBLAS
-(weight-once, 66–82 % HBM) since it is eager setup, not the decode graph.
+The decode math path is fully kernelised (RMSNorm + quant, dedicated M=1 GEMV
+with fused residual, fused q/k-norm+RoPE+KV-write, FlashAttention-2) and replayed
+from a single position-agnostic CUDA graph. The prompt is prefilled in one
+batched M=P pass; a shared `system` preamble's KV is reused across requests (only
+the new text is prefilled — see [§4](#4-python-api)). The dedicated M=1 GEMV runs
+at **86 % HBM bandwidth** in both precisions; per-frame is bandwidth-bound, so
+the only lever below the BF16 floor is the FP8 quantisation (half the bytes).
 
 ---
 

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -17,9 +17,9 @@ non-commercial license — check the model card.
 ## Performance
 
 Measured on a single **RTX 5090** (SM120), single stream, warm (numbers vary
-with text and clocks). Two precisions, **both SM120-only** (the GEMV kernels are
-`sm_120a`): **FP8 W8A8** (default) and **BF16 W16A16** (`fp8=False`) — the
-unquantised precision path for the same hardware (see below):
+with text and clocks). Two precisions, auto-selected by GPU (see *Hardware-
+adaptive* below): **FP8 W8A8** (SM120) and **BF16 W16A16** (the unquantised path,
+also the auto-selection on non-FP8 builds):
 
 | Metric | **FP8** (default) | **BF16** (`fp8=False`) |
 |---|---|---|
@@ -34,15 +34,17 @@ unquantised precision path for the same hardware (see below):
 Both precisions run the **same** fully-kernelised, zero-torch decode path
 (position-agnostic CUDA graph, batched prefill, prefix reuse). BF16 reads 2× the
 weight bytes of FP8, so its per-frame is ~1.7× — the bandwidth floor, not
-overhead. **Want unquantised BF16 numerics (e.g. to skip quantisation)?
-construct with `fp8=False` or pass `--bf16`** — everything else is identical.
+overhead.
 
-**Architecture**: as shipped both paths are built for **SM120** (`-gencode
-sm_120a`), so a default build runs on SM120 only. The BF16 decode kernels use no
-SM120-specific instruction (the M=1 GEMV is plain CUDA, the rest is shared
-kernels) and compile for Ada (sm89) — a 4090 BF16 build is a CMake-gating change
-away, but is not built or validated here. The FP8 path additionally needs the
-SM120 FP8 GEMM, so it stays SM120-only. See [§8](#8-notes--limitations).
+**Hardware-adaptive**: the precision is auto-selected from the GPU
+(`fp8=None`, the default) — FP8 where its kernels are compiled in, else BF16;
+pass `fp8=True` / `fp8=False` (or `--bf16`) to force, and forced FP8 falls back
+to BF16 with a warning if its kernels are absent. The decode GEMV (FP8 + BF16)
+is built for **sm89 and sm120** (the build auto-detects the GPU arch), so a 4090
+build compiles the BF16 path and the frontend runs it automatically. The FP8
+path additionally needs the SM120 FP8 prefill GEMM, so **FP8 is SM120-only**.
+Validated on SM120 (5090); the sm89/4090 BF16 path compiles and configures but
+is not hardware-validated here. See [§8](#8-notes--limitations).
 
 **Speedup over the unoptimised PyTorch reference** (same model + GPU, transformers
 eager backbone):
@@ -125,7 +127,8 @@ run the BF16 backbone instead of FP8.
 ```python
 from flash_rt.frontends.torch.higgs_audio_v3_rtx import HiggsAudioV3TorchFrontendRtx
 
-fe = HiggsAudioV3TorchFrontendRtx(CHECKPOINT_DIR, fp8=True)   # fp8=False -> BF16 backbone
+fe = HiggsAudioV3TorchFrontendRtx(CHECKPOINT_DIR)   # fp8=None (default): auto FP8/BF16 by GPU
+# fe = HiggsAudioV3TorchFrontendRtx(CHECKPOINT_DIR, fp8=False)   # force BF16
 
 wav = fe.generate("Hello from FlashRT.")     # text -> 24 kHz mono waveform [L] (cpu f32)
 
@@ -232,15 +235,19 @@ Headline numbers are in [Performance](#performance) above. Methodology:
   ranges are stable across prompts; re-instantiate the frontend to recalibrate.
 - The BF16 projection weights are freed after calibration (the FP8 backbone is
   the active path); pass `fp8=False` for the BF16 backbone, which keeps them.
-- **GPU support.** A default build targets **SM120** (`GPU_ARCH=120`,
-  `-gencode sm_120a`), so the frontend's decode kernels are only compiled there;
-  a non-SM120 build (e.g. `GPU_ARCH=89` for a 4090) builds the rest of FlashRT
-  but **not** these kernels, so the frontend raises at runtime (the `ht_gemv_*`
-  symbols are absent). The BF16 GEMV itself is plain CUDA (no SM120 intrinsics)
-  and *compiles* for Ada (sm89) — and all the support kernels (RMSNorm, SwiGLU,
-  q/k-norm+RoPE, FlashAttention-2) are arch-generic — so a 4090 **BF16** build is
-  a build-gating change away, but it is not enabled or hardware-validated here.
-  The FP8 path additionally needs the SM120 FP8 GEMM and stays SM120-only.
+- **GPU support / precision auto-selection.** The build auto-detects the GPU
+  arch (CMake reads `nvidia-smi`), and the decode GEMV (FP8 + BF16) is compiled
+  for **sm89 and sm120**. At construction the frontend follows FlashRT's
+  hardware-detection convention — it probes the compiled kernels + the SM version
+  and auto-selects (`fp8=None`): **FP8 W8A8** when its kernels are present
+  (SM120, where the FP8 prefill GEMM is built) else **BF16 W16A16**. So a 5090
+  runs FP8 by default and a 4090 runs BF16 automatically; `fp8=True`/`False`
+  force, and forced FP8 falls back to BF16 (with a warning) when its kernels are
+  absent. FP8 stays SM120-only (its prefill GEMM is SM120). The BF16 path is
+  validated on SM120 here; it compiles and configures for sm89 (4090) but is not
+  hardware-validated on that part. A build for an arch outside {sm89, sm120}
+  (e.g. Orin/Thor) does not compile these kernels, and the frontend raises a
+  clear error at construction.
 - Synthesis here is **non-streaming** (the codec decodes the whole clip at the
   end). Streaming / chunked synthesis is not yet wired.
 - Codec source: the `bosonai/higgs-audio` v2 tokenizer (decode path only),

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -17,8 +17,9 @@ non-commercial license — check the model card.
 ## Performance
 
 Measured on a single **RTX 5090** (SM120), single stream, warm (numbers vary
-with text and clocks). Two precisions: **FP8 W8A8** (default) and **BF16
-W16A16** — the fallback for hosts without FP8 (`fp8=False`, see below):
+with text and clocks). Two precisions, **both SM120-only** (the GEMV kernels are
+`sm_120a`): **FP8 W8A8** (default) and **BF16 W16A16** (`fp8=False`) — the
+unquantised precision path for the same hardware (see below):
 
 | Metric | **FP8** (default) | **BF16** (`fp8=False`) |
 |---|---|---|
@@ -33,8 +34,12 @@ W16A16** — the fallback for hosts without FP8 (`fp8=False`, see below):
 Both precisions run the **same** fully-kernelised, zero-torch decode path
 (position-agnostic CUDA graph, batched prefill, prefix reuse). BF16 reads 2× the
 weight bytes of FP8, so its per-frame is ~1.7× — the bandwidth floor, not
-overhead. **No FP8 (pre-Blackwell, or FP8 disabled)? construct with `fp8=False`
-or pass `--bf16` to the quickstart/server** — everything else is identical.
+overhead. **Want unquantised BF16 numerics (e.g. FP8 disabled in your build, or
+to skip quantisation)? construct with `fp8=False` or pass `--bf16`** —
+everything else is identical. Both paths still require **SM120** (the BF16 path
+also uses an `sm_120a` GEMV); it is *not* a pre-Blackwell (e.g. 4090 / Thor /
+Orin) fallback — those would need separate kernels, which this frontend does
+not provide.
 
 **Speedup over the unoptimised PyTorch reference** (same model + GPU, transformers
 eager backbone):

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -1,0 +1,173 @@
+# Higgs Audio v3 TTS-4B on FlashRT (RTX 5090 / SM120)
+
+> Single-stream, zero-shot text-to-speech: an **FP8 W8A8 Qwen3-4B** backbone
+> drives a fused 8-codebook head under a delay pattern, decoded autoregressively
+> and synthesised by the bundled neural codec — **text → 24 kHz waveform in one
+> process, no server required.** Per-frame decode is fully kernelised (no torch
+> in the math path) behind a clean `generate(text) -> waveform` API.
+
+Model: [`bosonai/higgs-audio-v3-tts-4b`](https://huggingface.co/bosonai/higgs-audio-v3-tts-4b)
+— a dense Qwen3-4B backbone (36 layers, hidden 2560, GQA 32q/8kv, head_dim 128,
+SwiGLU, RoPE θ=1e6) + a fused multi-codebook acoustic head (8 codebooks × 1026)
++ a DAC-style convolutional codec (25 Hz / 24 kHz, delay pattern). Research /
+non-commercial license — check the model card.
+
+---
+
+## 1. Requirements
+
+| | |
+|---|---|
+| **GPU** | RTX 5090 (SM120). Other SM120 Blackwell parts should work; the FP8 GEMV/GEMM kernels are `sm_120a`. |
+| **FlashRT** | Built with `GPU_ARCH=120` — see [Build & install](../README.md#build--install) (`cmake .. && make -j` produces `flash_rt/flash_rt_kernels*.so` and `flash_rt/flash_rt_fa2.so`). |
+| **Python** | 3.12, CUDA 13, torch ≥ 2.9. |
+| **Packages** | `transformers` (≥ 4.53; tokenizer + codec config classes), `safetensors`, `numpy`. `torchaudio` is **optional** (only the codec *encode* path uses it; decode does not — it is auto-stubbed if absent). |
+
+> **The `kernels` package.** Some `transformers` installs pull the optional
+> `kernels` accelerator, whose `huggingface_hub` strict-dataclass usage can
+> raise on import. The codec never needs it; FlashRT neutralises it at import
+> time (`flash_rt/models/higgs_audio_v3/_codec/env_guard.py`), so **no manual
+> step is required**. If you prefer, `pip uninstall kernels` has the same effect.
+
+---
+
+## 2. Get the checkpoint
+
+Download the checkpoint to a directory of your choice and point an environment
+variable at it (used by the quickstart and the examples below):
+
+```bash
+huggingface-cli download bosonai/higgs-audio-v3-tts-4b --local-dir /path/to/higgs-audio-v3-tts-4b
+export HIGGS_CHECKPOINT=/path/to/higgs-audio-v3-tts-4b
+```
+
+The directory must contain `config.json`, `model.safetensors`, and
+`tokenizer.json`. The codec weights are bundled inside `model.safetensors`
+(prefix `tied.embedding.modality_embeddings.0.model.`) — no separate download.
+
+---
+
+## 3. Quickstart
+
+```bash
+python examples/higgs_audio_v3_quickstart.py \
+    --text "The quick brown fox jumps over the lazy dog." \
+    --out fox.wav --benchmark 3
+```
+
+Expected output on a 5090 (numbers vary with text length and clocks):
+
+```
+[FP8 W8A8] 'The quick brown fox jumps over the lazy dog.'
+  -> fox.wav  (2.76s audio, ~4.5s wall incl 1st-call setup)
+  bench 1: AR decode ~334 ms (~4.8 ms/frame)
+  bench 2: AR decode ~333 ms (~4.8 ms/frame)
+  ...
+```
+
+First call pays a one-time cost: FP8 activation-scale **calibration** (a short
+BF16 free-run) and **codec load**. Subsequent calls are warm. Add `--bf16` to
+run the BF16 backbone instead of FP8.
+
+---
+
+## 4. Python API
+
+```python
+from flash_rt.frontends.torch.higgs_audio_v3_rtx import HiggsAudioV3TorchFrontendRtx
+
+fe = HiggsAudioV3TorchFrontendRtx(CHECKPOINT_DIR, fp8=True)   # fp8=False -> BF16 backbone
+
+wav = fe.generate("Hello from FlashRT.")     # text -> 24 kHz mono waveform [L] (cpu f32)
+
+# or split the stages:
+codes = fe.predict("Hello from FlashRT.")    # [T, 8] acoustic codes (int64, cpu)
+wav   = fe.synthesize(codes)                 # codes -> waveform
+```
+
+Save with any WAV writer (the quickstart uses the stdlib `wave` module at 24 kHz).
+
+---
+
+## 5. What runs under the hood
+
+Per acoustic frame, the FP8 decode step is fully kernelised — **no torch in the
+math path**:
+
+```
+rms_norm_fp8 (norm + quant)
+  -> M=1 FP8 GEMV  (qkv)                    # warp-per-output-row, no MMA padding tax
+  -> fused q/k-norm + RoPE  -> FA2
+  -> quantize_fp8_static (attn-out)
+  -> M=1 FP8 GEMV  (o_proj, fused residual epilogue: h += o)
+  -> rms_norm_fp8  -> GEMV (gate/up) -> silu_mul -> quantize_fp8_static
+  -> M=1 FP8 GEMV  (down_proj, fused residual epilogue: h += down)
+  -> rms_norm + quantize_fp8_static -> GEMV (fused 8-codebook head)
+```
+
+The M=1 GEMV (`csrc/gemm/fp8_gemv_m1_sm120.cu`) is the key kernel: the hand-tuned
+MMA GEMMs pad M=1 to BLOCK_M=16 and starve the SMs on the N=2560 projections;
+the GEMV assigns one warp per output row and folds the residual add into the
+epilogue. Greedy generation applies the delay pattern (BOC/EOC) and un-delays
+the codes before the codec.
+
+---
+
+## 6. Faithfulness & validation
+
+| check | metric | result |
+|---|---|---|
+| FP8 backbone vs eager BF16 | teacher-forced logits cosine | **1.0** |
+| codec (authoritative codes → wave) vs reference | waveform cosine | **0.99993** |
+
+**On free-run vs other implementations.** Greedy decoding over discrete audio
+codes is numerically chaotic: even teacher-forced, two faithful BF16
+implementations agree on only ~84–92 % of tokens (codebook logits ≈ 86, bf16
+ULP ≈ 0.5 — near-ties resolve differently). In free-run, the first near-tie
+difference feeds back and compounds, so FlashRT, the BF16 reference, and the
+upstream engine each produce a **different but valid** realisation of the same
+text (frame 0 agrees; full divergence by frame ~2). This is intrinsic to the
+task, **not** a quantisation error — faithfulness is established by the
+teacher-forced cosine above, and the codec is bit-faithful on identical codes.
+
+---
+
+## 7. Measured comparison (RTX 5090, single stream, greedy)
+
+Full text→waveform pipeline. FlashRT numbers are the standardized frontend
+(`generate`), warm, FP8 backbone:
+
+| | per-frame | RTF | first-token / TTFA | VRAM | precision |
+|---|---|---|---|---|---|
+| PyTorch eager (transformers Qwen3, AR backbone only) | 10.8 ms | 0.27 | — | 9.0 GB | bf16 |
+| sglang-omni (full pipeline) | ~6.4 ms | 0.16–0.19 | 0.36–0.63 s | 28.3 GB¹ | bf16 |
+| **FlashRT (this frontend, FP8 + codec)** | **4.6–5.1 ms** | **0.12** | **~40 ms²** | **6.3 GB** | FP8 W8A8 |
+
+¹ sglang reserves ~85 % of the GPU for its KV pool (`mem_fraction_static`); its
+  actual working set is ≈ 10 GB. FlashRT does not over-reserve.
+² FlashRT prefill latency (time to first frame logits) for a short prompt; the
+  codec adds 3–49 ms once for the whole clip (3–40 s of audio).
+
+Notes:
+- **RTF 0.12 across short/medium/long** (≈ 8× real time), ~1.4× faster than
+  sglang's full pipeline; **VRAM ~4.5× smaller** than sglang's reservation.
+- The kernel-level decode floor is **3.2 ms/frame** (clean CUDA-graph replay at
+  a single position, short KV). The frontend's eager per-frame is higher because
+  it includes Python dispatch and the attention cost growing with KV length over
+  a full generation; a per-position CUDA-graph capture closes most of that gap.
+- The codec runs in fp32 (ConvTranspose is unstable in low precision) and costs
+  a small one-shot pass at the end (≤ 50 ms for 40 s of audio).
+
+---
+
+## 8. Notes & limitations
+
+- **FP8 calibration** is per-tensor static (activation `amax/448`), measured
+  once from a short BF16 free-run of the first prompt and reused. Activation
+  ranges are stable across prompts; re-instantiate the frontend to recalibrate.
+- The BF16 projection weights are freed after calibration (the FP8 backbone is
+  the active path); pass `fp8=False` for the BF16 backbone, which keeps them.
+- Synthesis here is **non-streaming** (the codec decodes the whole clip at the
+  end). Streaming / chunked synthesis is not yet wired.
+- Codec source: the `bosonai/higgs-audio` v2 tokenizer (decode path only),
+  vendored under `flash_rt/models/higgs_audio_v3/_codec/`.

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -14,6 +14,38 @@ non-commercial license — check the model card.
 
 ---
 
+## Performance
+
+Measured on a single **RTX 5090** (SM120), single stream, FP8 W8A8, warm
+(numbers vary with text and clocks):
+
+| Metric | Value |
+|---|---|
+| Real-time factor (RTF) | **0.095 – 0.11** (≈ 9–10× faster than real time) |
+| Time to first audio (TTFA) | **≈ 94 ms** |
+| Prompt prefill | **≈ 1.0 ms/token** (batched single-pass; ~0.8 on longer prompts) |
+| Autoregressive decode | **≈ 3.2 ms/frame** steady (≈ 3.7–4.3 ms/frame full-pipeline incl. prefill amortisation + codec) |
+| Peak VRAM | **6.6 GB** (FP8 backbone ≈ 3.6 GB + bf16 embed/head + fp32 codec) |
+| Fidelity | teacher-forced logits **cos 1.0** vs the reference backbone; codec **cos 0.99993** vs canonical; streamed == one-shot **cos 1.0** |
+| Prefix reuse | a shared `system` preamble cuts prefill by **~64 %**, output bit-identical |
+
+**Speedup over the unoptimised PyTorch reference** (same model + GPU, transformers
+eager backbone):
+
+| Stage | PyTorch eager | FlashRT FP8 | |
+|---|---|---|---|
+| Autoregressive decode (no codec) | 10.8 ms/frame | **3.2 ms/frame** | **3.3× faster** |
+| Prompt prefill | 3.7 ms/token | **1.0 ms/token** | **3.7× faster** |
+| Backbone weight VRAM | 7.3 GB (bf16) | **3.6 GB (FP8)** | **2× smaller** |
+
+The decode math path is fully kernelised (RMSNorm→FP8 quant, dedicated M=1 FP8
+GEMV with fused residual epilogue, fused q/k-norm+RoPE+KV-write, FlashAttention-2)
+and replayed from a single position-agnostic CUDA graph. The prompt is prefilled
+in one batched M=P pass; a shared `system` preamble's KV is reused across
+requests (only the new text is prefilled — see [§4](#4-python-api)).
+
+---
+
 ## 1. Requirements
 
 | | |
@@ -59,9 +91,9 @@ Expected output on a 5090 (numbers vary with text length and clocks):
 
 ```
 [FP8 W8A8] 'The quick brown fox jumps over the lazy dog.'
-  -> fox.wav  (2.76s audio, ~4.5s wall incl 1st-call setup)
-  bench 1: AR decode ~334 ms (~4.8 ms/frame)
-  bench 2: AR decode ~333 ms (~4.8 ms/frame)
+  -> fox.wav  (~3.0s audio, ~4.5s wall incl 1st-call setup)
+  bench 1: AR decode ~290 ms (~3.8 ms/frame)
+  bench 2: AR decode ~290 ms (~3.8 ms/frame)
   ...
 ```
 
@@ -83,9 +115,29 @@ wav = fe.generate("Hello from FlashRT.")     # text -> 24 kHz mono waveform [L] 
 # or split the stages:
 codes = fe.predict("Hello from FlashRT.")    # [T, 8] acoustic codes (int64, cpu)
 wav   = fe.synthesize(codes)                 # codes -> waveform
+
+# streaming (low TTFA): yields 24 kHz chunks as frames decode
+for chunk in fe.generate_stream("A longer sentence to speak aloud."):
+    ...                                      # chunk: waveform [n] (cpu f32)
 ```
 
 Save with any WAV writer (the quickstart uses the stdlib `wave` module at 24 kHz).
+
+**Shared preamble + prefix reuse.** Pass a `system` preamble (a fixed
+voice/style instruction) to reuse its KV across requests — when successive calls
+share the same preamble, only the new text is prefilled, cutting prefill cost
+while producing bit-identical audio:
+
+```python
+SYSTEM = "Narrate in a calm, warm storyteller voice with clear diction."
+for line in lines:                           # same voice, many utterances
+    for chunk in fe.generate_stream(line, system=SYSTEM):
+        ...                                  # preamble KV reused after the 1st call
+```
+
+The reuse is a frontend mechanism (the KV cache is owned by the frontend); the
+caching/eviction policy belongs in the serving layer
+(`serving/higgs_audio_agent` forwards the request `instructions` as `system`).
 
 ---
 
@@ -132,31 +184,27 @@ teacher-forced cosine above, and the codec is bit-faithful on identical codes.
 
 ---
 
-## 7. Measured comparison (RTX 5090, single stream, greedy)
+## 7. Measurement notes
 
-Full text→waveform pipeline. FlashRT numbers are the standardized frontend
-(`generate`), warm, FP8 backbone:
+Headline numbers are in [Performance](#performance) above. Methodology:
 
-| | per-frame | RTF | first-token / TTFA | VRAM | precision |
-|---|---|---|---|---|---|
-| PyTorch eager (transformers Qwen3, AR backbone only) | 10.8 ms | 0.27 | — | 9.0 GB | bf16 |
-| sglang-omni (full pipeline) | ~6.4 ms | 0.16–0.19 | 0.36–0.63 s | 28.3 GB¹ | bf16 |
-| **FlashRT (this frontend, FP8 + codec)** | **4.6–5.1 ms** | **0.12** | **~40 ms²** | **6.3 GB** | FP8 W8A8 |
-
-¹ sglang reserves ~85 % of the GPU for its KV pool (`mem_fraction_static`); its
-  actual working set is ≈ 10 GB. FlashRT does not over-reserve.
-² FlashRT prefill latency (time to first frame logits) for a short prompt; the
-  codec adds 3–49 ms once for the whole clip (3–40 s of audio).
-
-Notes:
-- **RTF 0.12 across short/medium/long** (≈ 8× real time), ~1.4× faster than
-  sglang's full pipeline; **VRAM ~4.5× smaller** than sglang's reservation.
-- The kernel-level decode floor is **3.2 ms/frame** (clean CUDA-graph replay at
-  a single position, short KV). The frontend's eager per-frame is higher because
-  it includes Python dispatch and the attention cost growing with KV length over
-  a full generation; a per-position CUDA-graph capture closes most of that gap.
-- The codec runs in fp32 (ConvTranspose is unstable in low precision) and costs
-  a small one-shot pass at the end (≤ 50 ms for 40 s of audio).
+- **Full pipeline, warm.** RTF / TTFA are end-to-end text→waveform through the
+  standardized `generate` / `generate_stream` frontend, FP8 backbone, after a
+  warm-up call (lazy FP8 calibration + codec load + CUDA-graph capture happen
+  once on the first call and are excluded).
+- **Decode floor 3.2 ms/frame** is the clean single-position CUDA-graph replay;
+  the per-token GEMMs read 3.6 GB of distinct FP8 weights, so this is genuinely
+  HBM-bound (micro-benchmarks that reuse weights report L2-cached fiction). The
+  full-pipeline per-frame is slightly higher because attention cost grows with KV
+  length over a long generation.
+- **Prefill** is one batched M=P forward (≈ 1 ms/token); a shared `system`
+  preamble reuses its resident KV across requests (only the new text suffix is
+  prefilled — bit-identical to a cold prefill).
+- **Codec** runs in fp32 (ConvTranspose is unstable in low precision) as one
+  small pass at the end (≤ 50 ms for 40 s of audio); in streaming it is decoded
+  in overlapping windows so the streamed waveform matches the one-shot output.
+- **VRAM** is the peak process working set, not a reservation: FP8 backbone
+  weights ≈ 3.6 GB (bf16 would be 7.3 GB) + bf16 embed/head + fp32 codec.
 
 ---
 

--- a/docs/higgs_audio_v3.md
+++ b/docs/higgs_audio_v3.md
@@ -69,8 +69,8 @@ the only lever below the BF16 floor is the FP8 quantisation (half the bytes).
 
 | | |
 |---|---|
-| **GPU** | RTX 5090 (SM120). Other SM120 Blackwell parts should work; the FP8 GEMV/GEMM kernels are `sm_120a`. |
-| **FlashRT** | Built with `GPU_ARCH=120` — see [Build & install](../README.md#build--install) (`cmake .. && make -j` produces `flash_rt/flash_rt_kernels*.so` and `flash_rt/flash_rt_fa2.so`). |
+| **GPU** | **FP8** path: SM120 (RTX 5090 / Blackwell consumer) — the FP8 prefill GEMM is `sm_120a`. **BF16** path: SM89 (RTX 4090 / Ada) **or** SM120 — its GEMV compiles for both (sm89 BF16 is build/configure-validated but not yet hardware accuracy/perf-validated). The frontend auto-selects the precision for the GPU. |
+| **FlashRT** | Built with `GPU_ARCH=120` (FP8 + BF16) or `GPU_ARCH=89` (BF16 only) — auto-detected from the GPU if unset. See [Build & install](../README.md#build--install) (`cmake .. && make -j` produces `flash_rt/flash_rt_kernels*.so` and `flash_rt/flash_rt_fa2.so`). |
 | **Python** | 3.12, CUDA 13, torch ≥ 2.9. |
 | **Packages** | `transformers` (≥ 4.53; tokenizer + codec config classes), `safetensors`, `numpy`. `torchaudio` is **optional** (only the codec *encode* path uses it; decode does not — it is auto-stubbed if absent). |
 

--- a/examples/higgs_audio_v3_quickstart.py
+++ b/examples/higgs_audio_v3_quickstart.py
@@ -70,8 +70,8 @@ def main() -> None:
 
     fe = HiggsAudioV3TorchFrontendRtx(
         args.checkpoint, device=args.device, max_seq=args.max_seq,
-        fp8=not args.bf16)
-    backbone = "BF16" if args.bf16 else "FP8 W8A8"
+        fp8=False if args.bf16 else None)   # None: auto-select by GPU
+    backbone = "BF16" if not fe.fp8 else "FP8 W8A8"
 
     t0 = time.perf_counter()
     wav = fe.generate(args.text)                  # 1st call: lazy calibrate + codec

--- a/examples/higgs_audio_v3_quickstart.py
+++ b/examples/higgs_audio_v3_quickstart.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Higgs Audio v3 TTS-4B FlashRT quickstart — text -> 24 kHz waveform.
+
+Single-stream zero-shot TTS on RTX SM120 (5090): an FP8 W8A8 Qwen3-4B backbone
+drives a fused 8-codebook head under a delay pattern, decoded autoregressively
+and synthesised by the bundled neural codec — all in one process.
+
+Set HIGGS_CHECKPOINT to the checkpoint directory (the local snapshot of
+``bosonai/higgs-audio-v3-tts-4b``: config.json + model.safetensors +
+tokenizer.json), or pass it as --checkpoint.
+
+Examples:
+    export HIGGS_CHECKPOINT=/path/to/higgs-audio-v3-tts-4b
+    python examples/higgs_audio_v3_quickstart.py \
+        --text "The quick brown fox jumps over the lazy dog." --out hello.wav
+
+    # BF16 backbone instead of FP8:
+    python examples/higgs_audio_v3_quickstart.py --text "..." --bf16
+
+    # Per-frame decode latency (excludes one-time calibration / codec load):
+    python examples/higgs_audio_v3_quickstart.py --text "..." --benchmark 3
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+import time
+import wave
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _save_wav(path: str, wav, sample_rate: int = 24_000) -> None:
+    import numpy as np
+
+    x = (np.clip(wav.numpy() if hasattr(wav, "numpy") else wav, -1.0, 1.0)
+         * 32767.0).astype(np.int16)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(x.tobytes())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--checkpoint", default=os.environ.get("HIGGS_CHECKPOINT"),
+                    help="checkpoint dir (or set HIGGS_CHECKPOINT)")
+    ap.add_argument("--text", default="The quick brown fox jumps over the lazy dog.",
+                    help="text to synthesise")
+    ap.add_argument("--out", default="higgs_quickstart.wav", help="output wav path")
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--max-seq", type=int, default=2048)
+    ap.add_argument("--bf16", action="store_true", help="use the BF16 backbone")
+    ap.add_argument("--benchmark", type=int, default=0,
+                    help="re-generate N times and report per-frame decode latency")
+    args = ap.parse_args()
+
+    if not args.checkpoint:
+        ap.error("set --checkpoint or the HIGGS_CHECKPOINT environment variable")
+
+    from flash_rt.frontends.torch.higgs_audio_v3_rtx import (
+        HiggsAudioV3TorchFrontendRtx,
+    )
+
+    fe = HiggsAudioV3TorchFrontendRtx(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        fp8=not args.bf16)
+    backbone = "BF16" if args.bf16 else "FP8 W8A8"
+
+    t0 = time.perf_counter()
+    wav = fe.generate(args.text)                  # 1st call: lazy calibrate + codec
+    dt = time.perf_counter() - t0
+    _save_wav(args.out, wav)
+    dur = len(wav) / 24_000
+    frames = fe.latency_records[-1] if fe.latency_records else 0.0
+    print(f"[{backbone}] '{args.text}'")
+    print(f"  -> {args.out}  ({dur:.2f}s audio, {dt:.2f}s wall incl 1st-call setup)")
+
+    for i in range(args.benchmark):
+        fe.predict(args.text)                     # warm: no calibration/codec load
+        ms = fe.latency_records[-1]
+        n = max(1, int(round(dur * 25)))          # 25 Hz acoustic frames
+        print(f"  bench {i + 1}: AR decode {ms:.0f} ms ({ms / n:.2f} ms/frame)")
+    print("done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_rt/frontends/torch/_higgs_audio_v3_bf16.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_bf16.py
@@ -177,7 +177,12 @@ class HiggsAudioV3Bf16Decoder:
         H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
         NQK, KV, EPS = self.NQK, self.KV, self.EPS
         s = torch.cuda.current_stream().cuda_stream
-        mm = fvk.bf16_matmul_qwen36_bf16
+        # One-time eager prefill GEMM: cuBLAS (torch.matmul) reads each weight
+        # ONCE across the P prompt rows (5-14x the warp-per-row bf16_matmul,
+        # which re-reads W per row -> 11%/5% effective BW at P=13/33). This is
+        # the one-time setup path, not the per-frame decode graph (which stays
+        # the hand-written bf16 GEMV); the norms/qk-norm+RoPE/silu/attention all
+        # stay kernelised. mv is the M=1 head GEMV.
         mv = fvk.bf16_matvec_qwen36_bf16
         rc, rs = fe._rope_cos, fe._rope_sin
 
@@ -194,8 +199,7 @@ class HiggsAudioV3Bf16Decoder:
                      xn.data_ptr(), S, H, EPS, s)
         for L in range(self.NL):
             w = self.WL[L]
-            mm(xn.data_ptr(), w["qkv"].data_ptr(), Dq.data_ptr(),
-               S, NQK + 2 * KV, H, s)
+            torch.matmul(xn, w["qkv"].t(), out=Dq)
             for j in range(S):
                 pos = start_pos + j
                 qj = Dq[j, :NQK].contiguous()
@@ -217,18 +221,16 @@ class HiggsAudioV3Bf16Decoder:
             be.run("full", L, S, kv_seq=P, causal=True, stream=s,
                    softmax_scale=HD ** -0.5)
             ao = be.O_buf[:, :S].reshape(S, NQK).contiguous()
-            mm(ao.data_ptr(), w["o"].data_ptr(), tmp.data_ptr(), S, H, NQK, s)
+            torch.matmul(ao, w["o"].t(), out=tmp)
             fvk.residual_add_rms_norm(h.data_ptr(), tmp.data_ptr(),
                                       w["post_norm"].data_ptr(), xn2.data_ptr(),
                                       S, H, EPS, s)
-            mm(xn2.data_ptr(), w["gu"].data_ptr(), Dg.data_ptr(),
-               S, 2 * INTER, H, s)
+            torch.matmul(xn2, w["gu"].t(), out=Dg)
             g = Dg[:, :INTER].contiguous()
             u = Dg[:, INTER:].contiguous()
             fvk.silu_mul_qwen36_bf16(g.data_ptr(), u.data_ptr(), act.data_ptr(),
                                      S * INTER, s)
-            mm(act.data_ptr(), w["down"].data_ptr(), tmp.data_ptr(),
-               S, H, INTER, s)
+            torch.matmul(act, w["down"].t(), out=tmp)
             if L < self.NL - 1:
                 fvk.residual_add_rms_norm(
                     h.data_ptr(), tmp.data_ptr(),

--- a/flash_rt/frontends/torch/_higgs_audio_v3_bf16.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_bf16.py
@@ -1,0 +1,367 @@
+"""BF16 (W16A16) decode engine for the Higgs Audio v3 TTS-4B backbone.
+
+The all-BF16 sibling of :class:`HiggsAudioV3Fp8Decoder` for hosts that cannot run
+FP8 — same fully-kernelised, zero-torch math path and the same position-agnostic
+CUDA graph + batched prefill + prefix-reuse surface, at BF16 weight bandwidth (no
+quantisation). Extreme fusion: the residual add folds into the *following*
+RMSNorm via the single ``residual_add_rms_norm`` kernel (in-place ``h += x`` in
+fp32, then ``out = rmsnorm(h)·w``) at both the attention-out and FFN-out
+boundaries, including the cross-layer boundary (down-proj residual folds into the
+next layer's input norm). Per layer: 4 GEMVs (qkv, o, gate/up, down) + 2 fused
+residual-norms + fused q/k-norm+RoPE+KV-write + FA2 + silu_mul; nothing else.
+
+GEMV kernel is the dedicated M=1 ``bf16_matvec_qwen36_bf16`` (warp-per-output-row,
+no MMA BLOCK_M padding tax), selected over the tiled ``bf16_matmul`` by measured
+full-decode latency. Prefill uses the tiled ``bf16_matmul_qwen36_bf16`` at M=P.
+
+Used by :class:`HiggsAudioV3TorchFrontendRtx` when ``fp8=False``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+BF16 = torch.bfloat16
+
+
+class HiggsAudioV3Bf16Decoder:
+    """Holds concatenated BF16 weights + scratch; runs the BF16 decode."""
+
+    def __init__(self, frontend: Any) -> None:
+        self.fe = frontend
+        self.dev = frontend.device
+        c = frontend._cfg
+        self.H, self.NQ, self.NKV, self.HD = (
+            c["hidden"], c["num_q_heads"], c["num_kv_heads"], c["head_dim"])
+        self.INTER, self.EPS = c["intermediate"], c["rms_norm_eps"]
+        self.NL = c["num_layers"]
+        self.NC, self.CV = c["num_codebooks"], c["codebook_vocab"]
+        self.NQK = self.NQ * self.HD
+        self.KV = self.NKV * self.HD
+        self._prepare_weights()
+        self._alloc()
+
+    # ── one-time setup ──
+
+    def _prepare_weights(self) -> None:
+        """Concatenate q/k/v and gate/up into single GEMV weights (one launch,
+        better N-tiling), keep o/down/norms, and free the separate projections."""
+        w = self.fe._weights
+        self.WL = []
+        for L in w["layers"]:
+            qkv = torch.cat([L["q"], L["k"], L["v"]], 0).contiguous()
+            gu = torch.cat([L["gate"], L["up"]], 0).contiguous()
+            self.WL.append(dict(
+                qkv=qkv, gu=gu, o=L["o"], down=L["down"],
+                in_norm=L["in_norm"], post_norm=L["post_norm"],
+                qn=L["qn"], kn=L["kn"]))
+        for L in w["layers"]:           # reclaim the separate projections
+            for k in ("q", "k", "v", "gate", "up"):
+                L.pop(k, None)
+        self.CB = w["codebook"]
+        self.final_norm = w["final_norm"]
+        torch.cuda.empty_cache()
+
+    # Dedicated M=1 BF16 GEMV — 86% HBM BW (2.1x the generic bf16_matvec/matmul
+    # at 40%; the generic kernels stage x in smem, 2x the bytes of FP8, capping
+    # blocks/SM on K=9728). Warp count w4 measured fastest on the decode shapes.
+    _GEMV = "ht_gemv_bf16_m1_w4"
+
+    def _alloc(self) -> None:
+        d = self.dev
+        self.Dq = torch.empty(1, self.NQK + 2 * self.KV, device=d, dtype=BF16)
+        self.Dg = torch.empty(1, 2 * self.INTER, device=d, dtype=BF16)
+        self.Dh = torch.empty(1, self.NC * self.CV, device=d, dtype=BF16)
+        self.act = torch.empty(1, self.INTER, device=d, dtype=BF16)
+        self.h = torch.empty(1, self.H, device=d, dtype=BF16)
+        self.xn = torch.empty(1, self.H, device=d, dtype=BF16)
+        self.xn2 = torch.empty(1, self.H, device=d, dtype=BF16)
+        self.otmp = torch.empty(1, self.H, device=d, dtype=BF16)
+        self.dtmp = torch.empty(1, self.H, device=d, dtype=BF16)
+        self.hn = torch.empty(1, self.H, device=d, dtype=BF16)
+
+    # ── BF16 decode step (eager, fully kernelised, extreme fusion) ──
+
+    @torch.no_grad()
+    def step(self, t: int) -> torch.Tensor:
+        from flash_rt import flash_rt_kernels as fvk
+        fe, be = self.fe, self.fe._attn
+        H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
+        NQK, KV, EPS = self.NQK, self.KV, self.EPS
+        gv = getattr(fvk, self._GEMV)
+
+        def mv(xp, wp, op, N, K, st):
+            gv(xp, wp, op, 1, N, K, 1.0, st)
+        s = torch.cuda.current_stream().cuda_stream
+        h, xn, xn2 = self.h, self.xn, self.xn2
+        otmp, dtmp = self.otmp, self.dtmp
+        fvk.rms_norm(h.data_ptr(), self.WL[0]["in_norm"].data_ptr(),
+                     xn.data_ptr(), 1, H, EPS, s)
+        for L in range(self.NL):
+            w = self.WL[L]
+            mv(xn.data_ptr(), w["qkv"].data_ptr(), self.Dq.data_ptr(),
+               NQK + 2 * KV, H, s)
+            q = self.Dq[:, :NQK].view(NQ, HD)
+            k = self.Dq[:, NQK:NQK + KV].view(NKV, HD)
+            v = self.Dq[:, NQK + KV:].view(NKV, HD)
+            cos_t, sin_t = fe._rope_cos[t], fe._rope_sin[t]
+            fvk.qwen3_q_norm_rope_qstage_bf16(
+                q_pre=q.data_ptr(), q_norm_w=w["qn"].data_ptr(),
+                cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
+                q_buf_dst=be.Q_buf[:, :1].data_ptr(), n_q_heads=NQ, eps=EPS,
+                stream=s)
+            fvk.qwen3_k_norm_rope_kvwrite_bf16(
+                k_pre=k.data_ptr(), v_pre=v.data_ptr(),
+                k_norm_w=w["kn"].data_ptr(),
+                cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
+                k_cache_dst=be.K_cache[L, t:t + 1].data_ptr(),
+                v_cache_dst=be.V_cache[L, t:t + 1].data_ptr(),
+                n_kv_heads=NKV, eps=EPS, stream=s)
+            kv = t + 1
+            qb, kc = be.Q_buf[:, :1], be.K_cache[L:L + 1, :kv]
+            vc, ob = be.V_cache[L:L + 1, :kv], be.O_buf[:, :1]
+            be._fa2_fwd(
+                Q=qb.data_ptr(), K=kc.data_ptr(), V=vc.data_ptr(), O=ob.data_ptr(),
+                softmax_lse=be.lse_buf.data_ptr(), softmax_lse_accum=0, o_accum=0,
+                batch=1, seqlen_q=1, seqlen_k=kv, num_heads_q=NQ, num_heads_kv=NKV,
+                head_dim=HD, q_strides=(qb.stride(0), qb.stride(1), qb.stride(2)),
+                k_strides=(kc.stride(0), kc.stride(1), kc.stride(2)),
+                v_strides=(vc.stride(0), vc.stride(1), vc.stride(2)),
+                o_strides=(ob.stride(0), ob.stride(1), ob.stride(2)),
+                softmax_scale=HD ** -0.5, num_sms=be._num_sms, stream=s)
+            ao = be.O_buf[:, :1].reshape(1, NQK)
+            mv(ao.data_ptr(), w["o"].data_ptr(), otmp.data_ptr(), H, NQK, s)
+            # fused: h += o  (fp32 accum, in-place), xn2 = rmsnorm(h)·post_norm
+            fvk.residual_add_rms_norm(h.data_ptr(), otmp.data_ptr(),
+                                      w["post_norm"].data_ptr(), xn2.data_ptr(),
+                                      1, H, EPS, s)
+            mv(xn2.data_ptr(), w["gu"].data_ptr(), self.Dg.data_ptr(),
+               2 * INTER, H, s)
+            fvk.silu_mul_qwen36_bf16(self.Dg[:, :INTER].contiguous().data_ptr(),
+                                     self.Dg[:, INTER:].contiguous().data_ptr(),
+                                     self.act.data_ptr(), INTER, s)
+            mv(self.act.data_ptr(), w["down"].data_ptr(), dtmp.data_ptr(),
+               H, INTER, s)
+            if L < self.NL - 1:
+                # fused: h += down, xn = rmsnorm(h)·next-layer in_norm
+                fvk.residual_add_rms_norm(
+                    h.data_ptr(), dtmp.data_ptr(),
+                    self.WL[L + 1]["in_norm"].data_ptr(), xn.data_ptr(),
+                    1, H, EPS, s)
+            else:
+                fvk.residual_add(h.data_ptr(), dtmp.data_ptr(), H, s)
+                fvk.rms_norm(h.data_ptr(), self.final_norm.data_ptr(),
+                             self.hn.data_ptr(), 1, H, EPS, s)
+        mv(self.hn.data_ptr(), self.CB.data_ptr(), self.Dh.data_ptr(),
+           self.NC * self.CV, H, s)
+        return self.Dh.view(1, self.NC, self.CV)
+
+    def set_input(self, embed_row: torch.Tensor) -> None:
+        self.h.copy_(embed_row)
+
+    # ── batched prompt prefill (single M=S forward, optional cached prefix) ──
+    # Mirrors the FP8 path: one M=S pass over ids[start_pos:] (tiled BF16 GEMM),
+    # per-position fused q/k-norm+RoPE+KV-write, one causal FA2, residual+norm
+    # fused via residual_add_rms_norm. ``start_pos`` reuses a resident prefix's
+    # KV (serving prefix caching) — bit-identical to a full prefill.
+
+    @torch.no_grad()
+    def prefill_batched(self, ids: list[int], start_pos: int = 0) -> torch.Tensor:
+        from flash_rt import flash_rt_kernels as fvk
+        fe, be = self.fe, self.fe._attn
+        dev = self.dev
+        P = len(ids)
+        S = P - start_pos
+        H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
+        NQK, KV, EPS = self.NQK, self.KV, self.EPS
+        s = torch.cuda.current_stream().cuda_stream
+        mm = fvk.bf16_matmul_qwen36_bf16
+        mv = fvk.bf16_matvec_qwen36_bf16
+        rc, rs = fe._rope_cos, fe._rope_sin
+
+        ids_t = torch.tensor(ids[start_pos:], device=dev)
+        h = F.embedding(ids_t, fe._weights["text_embed"]).contiguous()  # [S,H]
+        xn = torch.empty(S, H, device=dev, dtype=BF16)
+        xn2 = torch.empty(S, H, device=dev, dtype=BF16)
+        Dq = torch.empty(S, NQK + 2 * KV, device=dev, dtype=BF16)
+        Dg = torch.empty(S, 2 * INTER, device=dev, dtype=BF16)
+        act = torch.empty(S, INTER, device=dev, dtype=BF16)
+        tmp = torch.empty(S, H, device=dev, dtype=BF16)
+
+        fvk.rms_norm(h.data_ptr(), self.WL[0]["in_norm"].data_ptr(),
+                     xn.data_ptr(), S, H, EPS, s)
+        for L in range(self.NL):
+            w = self.WL[L]
+            mm(xn.data_ptr(), w["qkv"].data_ptr(), Dq.data_ptr(),
+               S, NQK + 2 * KV, H, s)
+            for j in range(S):
+                pos = start_pos + j
+                qj = Dq[j, :NQK].contiguous()
+                kj = Dq[j, NQK:NQK + KV].contiguous()
+                vj = Dq[j, NQK + KV:].contiguous()
+                fvk.qwen3_q_norm_rope_qstage_bf16(
+                    q_pre=qj.data_ptr(), q_norm_w=w["qn"].data_ptr(),
+                    cos=rc[pos].data_ptr(), sin=rs[pos].data_ptr(),
+                    q_buf_dst=be.Q_buf[:, j].data_ptr(), n_q_heads=NQ, eps=EPS,
+                    stream=s)
+                fvk.qwen3_k_norm_rope_kvwrite_bf16(
+                    k_pre=kj.data_ptr(), v_pre=vj.data_ptr(),
+                    k_norm_w=w["kn"].data_ptr(),
+                    cos=rc[pos].data_ptr(), sin=rs[pos].data_ptr(),
+                    k_cache_dst=be.K_cache[L, pos].data_ptr(),
+                    v_cache_dst=be.V_cache[L, pos].data_ptr(),
+                    n_kv_heads=NKV, eps=EPS, stream=s)
+            be.O_buf[:, :S].zero_()
+            be.run("full", L, S, kv_seq=P, causal=True, stream=s,
+                   softmax_scale=HD ** -0.5)
+            ao = be.O_buf[:, :S].reshape(S, NQK).contiguous()
+            mm(ao.data_ptr(), w["o"].data_ptr(), tmp.data_ptr(), S, H, NQK, s)
+            fvk.residual_add_rms_norm(h.data_ptr(), tmp.data_ptr(),
+                                      w["post_norm"].data_ptr(), xn2.data_ptr(),
+                                      S, H, EPS, s)
+            mm(xn2.data_ptr(), w["gu"].data_ptr(), Dg.data_ptr(),
+               S, 2 * INTER, H, s)
+            g = Dg[:, :INTER].contiguous()
+            u = Dg[:, INTER:].contiguous()
+            fvk.silu_mul_qwen36_bf16(g.data_ptr(), u.data_ptr(), act.data_ptr(),
+                                     S * INTER, s)
+            mm(act.data_ptr(), w["down"].data_ptr(), tmp.data_ptr(),
+               S, H, INTER, s)
+            if L < self.NL - 1:
+                fvk.residual_add_rms_norm(
+                    h.data_ptr(), tmp.data_ptr(),
+                    self.WL[L + 1]["in_norm"].data_ptr(), xn.data_ptr(),
+                    S, H, EPS, s)
+            else:
+                fvk.residual_add(h.data_ptr(), tmp.data_ptr(), S * H, s)
+
+        hlast = h[S - 1:S].contiguous()
+        fvk.rms_norm(hlast.data_ptr(), self.final_norm.data_ptr(),
+                     self.hn.data_ptr(), 1, H, EPS, s)
+        mv(self.hn.data_ptr(), self.CB.data_ptr(), self.Dh.data_ptr(),
+           self.NC * self.CV, H, s)
+        return self.Dh.view(1, self.NC, self.CV)
+
+    # ── position-agnostic single decode graph ──
+
+    def _alloc_graph(self) -> None:
+        d, HALF = self.dev, self.HD // 2
+        self.rope_cos_buf = torch.empty(HALF, device=d, dtype=BF16)
+        self.rope_sin_buf = torch.empty(HALF, device=d, dtype=BF16)
+        self.cur_pos_dev = torch.zeros(1, device=d, dtype=torch.int32)
+        self.seqused_dev = torch.zeros(1, device=d, dtype=torch.int32)
+        self._graph = None
+        self._gs = torch.cuda.Stream(device=d)
+
+    @torch.no_grad()
+    def _step_graphable(self):
+        from flash_rt import flash_rt_kernels as fvk
+        from flash_rt import flash_rt_fa2 as fa2
+        fe, be = self.fe, self.fe._attn
+        H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
+        NQK, KV, EPS = self.NQK, self.KV, self.EPS
+        MAXS = be._max_seq
+        gv = getattr(fvk, self._GEMV)
+
+        def mv(xp, wp, op, N, K, st):
+            gv(xp, wp, op, 1, N, K, 1.0, st)
+        s = torch.cuda.current_stream().cuda_stream
+        rc, rs = self.rope_cos_buf, self.rope_sin_buf
+        cp, su = self.cur_pos_dev, self.seqused_dev
+        h, xn, xn2 = self.h, self.xn, self.xn2
+        otmp, dtmp = self.otmp, self.dtmp
+        qb, ob = be.Q_buf[:, :1], be.O_buf[:, :1]
+        qst = (qb.stride(0), qb.stride(1), qb.stride(2))
+        ost = (ob.stride(0), ob.stride(1), ob.stride(2))
+        fvk.rms_norm(h.data_ptr(), self.WL[0]["in_norm"].data_ptr(),
+                     xn.data_ptr(), 1, H, EPS, s)
+        for L in range(self.NL):
+            w = self.WL[L]
+            mv(xn.data_ptr(), w["qkv"].data_ptr(), self.Dq.data_ptr(),
+               NQK + 2 * KV, H, s)
+            q = self.Dq[:, :NQK].view(NQ, HD)
+            k = self.Dq[:, NQK:NQK + KV].view(NKV, HD)
+            v = self.Dq[:, NQK + KV:].view(NKV, HD)
+            fvk.qwen3_q_norm_rope_qstage_bf16(
+                q_pre=q.data_ptr(), q_norm_w=w["qn"].data_ptr(),
+                cos=rc.data_ptr(), sin=rs.data_ptr(),
+                q_buf_dst=qb.data_ptr(), n_q_heads=NQ, eps=EPS, stream=s)
+            fvk.qwen3_k_norm_rope_kvwrite_devpos_bf16(
+                k.data_ptr(), v.data_ptr(), w["kn"].data_ptr(),
+                rc.data_ptr(), rs.data_ptr(),
+                be.K_cache[L, 0].data_ptr(), be.V_cache[L, 0].data_ptr(),
+                cp.data_ptr(), NKV * HD, NKV, EPS, s)
+            kf, vf = be.K_cache[L:L + 1, :MAXS], be.V_cache[L:L + 1, :MAXS]
+            fa2.fwd_bf16_seqused(
+                Q=qb.data_ptr(), K=kf.data_ptr(), V=vf.data_ptr(), O=ob.data_ptr(),
+                softmax_lse=be.lse_buf.data_ptr(), seqused_k=su.data_ptr(),
+                batch=1, seqlen_q=1, seqlen_k=MAXS, num_heads_q=NQ,
+                num_heads_kv=NKV, head_dim=HD, q_strides=qst,
+                k_strides=(kf.stride(0), kf.stride(1), kf.stride(2)),
+                v_strides=(vf.stride(0), vf.stride(1), vf.stride(2)),
+                o_strides=ost, softmax_scale=HD ** -0.5, num_sms=0, stream=s)
+            ao = be.O_buf[:, :1].reshape(1, NQK)
+            mv(ao.data_ptr(), w["o"].data_ptr(), otmp.data_ptr(), H, NQK, s)
+            fvk.residual_add_rms_norm(h.data_ptr(), otmp.data_ptr(),
+                                      w["post_norm"].data_ptr(), xn2.data_ptr(),
+                                      1, H, EPS, s)
+            mv(xn2.data_ptr(), w["gu"].data_ptr(), self.Dg.data_ptr(),
+               2 * INTER, H, s)
+            fvk.silu_mul_qwen36_bf16(self.Dg[:, :INTER].contiguous().data_ptr(),
+                                     self.Dg[:, INTER:].contiguous().data_ptr(),
+                                     self.act.data_ptr(), INTER, s)
+            mv(self.act.data_ptr(), w["down"].data_ptr(), dtmp.data_ptr(),
+               H, INTER, s)
+            if L < self.NL - 1:
+                fvk.residual_add_rms_norm(
+                    h.data_ptr(), dtmp.data_ptr(),
+                    self.WL[L + 1]["in_norm"].data_ptr(), xn.data_ptr(),
+                    1, H, EPS, s)
+            else:
+                fvk.residual_add(h.data_ptr(), dtmp.data_ptr(), H, s)
+                fvk.rms_norm(h.data_ptr(), self.final_norm.data_ptr(),
+                             self.hn.data_ptr(), 1, H, EPS, s)
+        mv(self.hn.data_ptr(), self.CB.data_ptr(), self.Dh.data_ptr(),
+           self.NC * self.CV, H, s)
+        return self.Dh.view(1, self.NC, self.CV)
+
+    @torch.no_grad()
+    def _set_pos(self, t: int) -> None:
+        self.rope_cos_buf.copy_(self.fe._rope_cos[t])
+        self.rope_sin_buf.copy_(self.fe._rope_sin[t])
+        self.cur_pos_dev.fill_(t)
+        self.seqused_dev.fill_(t + 1)
+
+    @torch.no_grad()
+    def capture_graph(self, embed_row: torch.Tensor, warm_pos: int) -> None:
+        if getattr(self, "_graph", None) is not None:
+            return
+        if not hasattr(self, "rope_cos_buf"):
+            self._alloc_graph()
+        gs = self._gs
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs):
+            for _ in range(3):
+                self.h.copy_(embed_row)
+                self._set_pos(warm_pos)
+                self._step_graphable()
+            self.h.copy_(embed_row)
+            self._set_pos(warm_pos)
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g, stream=gs):
+                self._step_graphable()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._graph = g
+
+    @torch.no_grad()
+    def decode_graph(self, embed_row: torch.Tensor, t: int) -> torch.Tensor:
+        gs = self._gs
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs):
+            self.h.copy_(embed_row)
+            self._set_pos(t)
+            self._graph.replay()
+        torch.cuda.current_stream().wait_stream(gs)
+        return self.Dh.view(1, self.NC, self.CV)

--- a/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
@@ -1,0 +1,223 @@
+"""FP8 (W8A8) decode engine for the Higgs Audio v3 TTS-4B backbone.
+
+Per-tensor FP8 e4m3 weights (amax/448) with static per-tensor activation scales
+calibrated from a short BF16 free-run; the math path is fully kernelised:
+
+  rms_norm_fp8 (norm+quant) -> dedicated M=1 FP8 GEMV (warp-per-row, with fused
+  residual epilogue on o_proj / down_proj) -> quantize_fp8_static for the
+  attention-out / SwiGLU-out points -> silu_mul -> fused q/k-norm+RoPE -> FA2.
+
+Teacher-forced logits reproduce the eager BF16 backbone (cos 1.0); free-run
+greedy diverges from any other implementation by bf16 near-tie noise (an
+intrinsic property of greedy discrete-code AR, not a quantisation error).
+
+Used by :class:`HiggsAudioV3TorchFrontendRtx` when ``fp8=True``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+BF16, F8 = torch.bfloat16, torch.float8_e4m3fn
+
+# Per-shape M=1 GEMV kernel selection (warp count tuned per shape; o/down use
+# the fused-residual epilogue so the residual add folds into the GEMV).
+_GEMV = {
+    "qkv": "ht_gemv_fp8_m1_w8", "o": "ht_gemv_fp8_m1_resadd_w8",
+    "gu": "ht_gemv_fp8_m1_w4", "dn": "ht_gemv_fp8_m1_resadd_w4",
+    "head": "ht_gemv_fp8_m1_w4",
+}
+
+
+def _qw(w: torch.Tensor) -> tuple[torch.Tensor, float]:
+    """bf16 weight -> (fp8 e4m3 [N,K], per-tensor scale = amax/448)."""
+    sc = (w.float().abs().amax() / 448).item()
+    return (w.float() / sc).clamp(-448, 448).to(F8).contiguous(), sc
+
+
+class HiggsAudioV3Fp8Decoder:
+    """Holds FP8 weights + calibrated scales + scratch; runs the FP8 decode."""
+
+    def __init__(self, frontend: Any) -> None:
+        self.fe = frontend
+        self.dev = frontend.device
+        c = frontend._cfg
+        self.H, self.NQ, self.NKV, self.HD = (
+            c["hidden"], c["num_q_heads"], c["num_kv_heads"], c["head_dim"])
+        self.INTER, self.EPS = c["intermediate"], c["rms_norm_eps"]
+        self.NL = c["num_layers"]
+        self.NC, self.CV = c["num_codebooks"], c["codebook_vocab"]
+        self.NQK = self.NQ * self.HD
+        self.KV = self.NKV * self.HD
+        self._quantize_weights()
+        self._calibrated = False
+
+    # ── one-time setup ──
+
+    def _quantize_weights(self) -> None:
+        w = self.fe._weights
+        self.WL = []
+        for L in w["layers"]:
+            qkvq, qkvs = _qw(torch.cat([L["q"], L["k"], L["v"]], 0))
+            guq, gus = _qw(torch.cat([L["gate"], L["up"]], 0))
+            oq, os_ = _qw(L["o"])
+            dnq, dns = _qw(L["down"])
+            self.WL.append(dict(
+                qkvq=qkvq, qkvs=qkvs, oq=oq, os=os_, guq=guq, gus=gus,
+                dnq=dnq, dns=dns, in_norm=L["in_norm"], post_norm=L["post_norm"],
+                qn=L["qn"], kn=L["kn"]))
+        self.CBq, self.CBs = _qw(w["codebook"])
+
+    def _alloc(self) -> None:
+        d = self.dev
+        self.fp8a = torch.empty(1, self.H, device=d, dtype=F8)
+        self.fp8o = torch.empty(1, self.NQK, device=d, dtype=F8)
+        self.fp8d = torch.empty(1, self.INTER, device=d, dtype=F8)
+        self.Dq = torch.empty(1, self.NQK + 2 * self.KV, device=d, dtype=BF16)
+        self.Dg = torch.empty(1, 2 * self.INTER, device=d, dtype=BF16)
+        self.Dh = torch.empty(1, self.NC * self.CV, device=d, dtype=BF16)
+        self.act = torch.empty(1, self.INTER, device=d, dtype=BF16)
+        self.h = torch.empty(1, self.H, device=d, dtype=BF16)
+        self.hn = torch.empty(1, self.H, device=d, dtype=BF16)
+
+    # ── calibration: amax of the 4 quant points/layer + final, from a short
+    #    BF16 free-run of a built-in sentence (activation ranges are stable). ──
+
+    @torch.no_grad()
+    def calibrate(self, prompt_ids: list[int], n_frames: int = 24) -> None:
+        fe = self.fe
+        c = fe._cfg
+        H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
+        NQK, KV = self.NQK, self.KV
+        be = fe._attn
+        be.reset_cache()
+        am = torch.zeros(self.NL, 4, device=self.dev)
+        amf = torch.zeros(1, device=self.dev)
+        te = fe._weights["text_embed"]
+        layers = fe._weights["layers"]
+        import math
+
+        def rms(x, w):
+            o = torch.empty(1, H, device=self.dev, dtype=BF16)
+            from flash_rt import flash_rt_kernels as fvk
+            fvk.rms_norm(x.contiguous().data_ptr(), w.data_ptr(), o.data_ptr(),
+                         1, H, self.EPS, torch.cuda.current_stream().cuda_stream)
+            return o
+
+        def step(h, t):
+            for L in range(self.NL):
+                w = layers[L]
+                xn = rms(h, w["in_norm"])
+                am[L, 0] = torch.maximum(am[L, 0], xn.float().abs().amax())
+                qkv = xn.float() @ torch.cat([w["q"], w["k"], w["v"]], 0).float().t()
+                q = qkv[:, :NQK].view(NQ, HD)
+                k = qkv[:, NQK:NQK + KV].view(NKV, HD)
+                v = qkv[:, NQK + KV:].view(NKV, HD)
+                be.K_cache[L, t:t + 1].copy_(k.to(BF16).view(1, NKV, HD))
+                be.V_cache[L, t:t + 1].copy_(v.to(BF16).view(1, NKV, HD))
+                Kc = be.K_cache[L, :t + 1].float()
+                Vc = be.V_cache[L, :t + 1].float()
+                krep = Kc.repeat_interleave(NQ // NKV, 1).view(t + 1, NQ, HD)
+                vrep = Vc.repeat_interleave(NQ // NKV, 1).view(t + 1, NQ, HD)
+                sc = (q.float().unsqueeze(0) * krep).sum(-1) / math.sqrt(HD)
+                ao = (torch.softmax(sc, 0).unsqueeze(-1) * vrep).sum(0).reshape(1, NQK)
+                am[L, 1] = torch.maximum(am[L, 1], ao.abs().amax())
+                h = h.float() + ao @ w["o"].float().t()
+                xn2 = rms(h.to(BF16), w["post_norm"])
+                am[L, 2] = torch.maximum(am[L, 2], xn2.float().abs().amax())
+                gu = xn2.float() @ torch.cat([w["gate"], w["up"]], 0).float().t()
+                act = F.silu(gu[:, :INTER]) * gu[:, INTER:]
+                am[L, 3] = torch.maximum(am[L, 3], act.abs().amax())
+                h = (h + act @ w["down"].float().t()).to(BF16)
+            amf[0] = torch.maximum(amf[0], rms(h, fe._weights["final_norm"]).float().abs().amax())
+            return h
+
+        for t, tok in enumerate(prompt_ids):
+            h = step(F.embedding(torch.tensor([tok], device=self.dev), te), t)
+        P = len(prompt_ids)
+        for j in range(n_frames):
+            logits = (rms(h, fe._weights["final_norm"]).float()
+                      @ fe._weights["codebook"].float().t()).view(self.NC, self.CV)
+            codes = logits.argmax(-1)
+            emb = F.embedding(codes.long() + fe._cb_offsets,
+                              fe._weights["codebook"]).sum(0, keepdim=True)
+            h = step(emb, P + j)
+
+        self.asc = (am / 448)
+        self.asc_f = (amf / 448).item()
+        self.DS = [[torch.tensor([max(self.asc[L, i].item(), 1e-9)], device=self.dev,
+                    dtype=torch.float32) for i in range(4)] for L in range(self.NL)]
+        self.DSF = torch.tensor([max(self.asc_f, 1e-9)], device=self.dev, dtype=torch.float32)
+        self.ALP = [[self.asc[L, i].item() for i in range(4)] for L in range(self.NL)]
+        self._alloc()
+        self._calibrated = True
+
+    # ── FP8 decode step (eager, fully kernelised) ──
+
+    @torch.no_grad()
+    def step(self, t: int) -> torch.Tensor:
+        from flash_rt import flash_rt_kernels as fvk
+        fe = self.fe
+        be = fe._attn
+        H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
+        NQK, KV, EPS = self.NQK, self.KV, self.EPS
+        gv = {k: getattr(fvk, v) for k, v in _GEMV.items()}
+        s = torch.cuda.current_stream().cuda_stream
+        h, fp8a, fp8o, fp8d = self.h, self.fp8a, self.fp8o, self.fp8d
+        for L in range(self.NL):
+            w = self.WL[L]
+            fvk.rms_norm_fp8(h.data_ptr(), w["in_norm"].data_ptr(), fp8a.data_ptr(),
+                             1, H, EPS, self.DS[L][0].data_ptr(), s)
+            gv["qkv"](fp8a.data_ptr(), w["qkvq"].data_ptr(), self.Dq.data_ptr(),
+                      1, NQK + 2 * KV, H, self.ALP[L][0] * w["qkvs"], s)
+            q = self.Dq[:, :NQK].view(NQ, HD).contiguous()
+            k = self.Dq[:, NQK:NQK + KV].view(NKV, HD).contiguous()
+            v = self.Dq[:, NQK + KV:].view(NKV, HD).contiguous()
+            cos_t, sin_t = fe._rope_cos[t], fe._rope_sin[t]
+            fvk.qwen3_q_norm_rope_qstage_bf16(
+                q_pre=q.data_ptr(), q_norm_w=w["qn"].data_ptr(),
+                cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
+                q_buf_dst=be.Q_buf[:, :1].data_ptr(), n_q_heads=NQ, eps=EPS, stream=s)
+            fvk.qwen3_k_norm_rope_kvwrite_bf16(
+                k_pre=k.data_ptr(), v_pre=v.data_ptr(), k_norm_w=w["kn"].data_ptr(),
+                cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
+                k_cache_dst=be.K_cache[L, t:t + 1].data_ptr(),
+                v_cache_dst=be.V_cache[L, t:t + 1].data_ptr(),
+                n_kv_heads=NKV, eps=EPS, stream=s)
+            kv = t + 1
+            qb, kc = be.Q_buf[:, :1], be.K_cache[L:L + 1, :kv]
+            vc, ob = be.V_cache[L:L + 1, :kv], be.O_buf[:, :1]
+            be._fa2_fwd(
+                Q=qb.data_ptr(), K=kc.data_ptr(), V=vc.data_ptr(), O=ob.data_ptr(),
+                softmax_lse=be.lse_buf.data_ptr(), softmax_lse_accum=0, o_accum=0,
+                batch=1, seqlen_q=1, seqlen_k=kv, num_heads_q=NQ, num_heads_kv=NKV,
+                head_dim=HD, q_strides=(qb.stride(0), qb.stride(1), qb.stride(2)),
+                k_strides=(kc.stride(0), kc.stride(1), kc.stride(2)),
+                v_strides=(vc.stride(0), vc.stride(1), vc.stride(2)),
+                o_strides=(ob.stride(0), ob.stride(1), ob.stride(2)),
+                softmax_scale=HD ** -0.5, num_sms=be._num_sms, stream=s)
+            ao = be.O_buf[:, :1].reshape(1, NQK).contiguous()
+            fvk.quantize_fp8_static(ao.data_ptr(), fp8o.data_ptr(), self.DS[L][1].data_ptr(), NQK, s)
+            gv["o"](fp8o.data_ptr(), w["oq"].data_ptr(), h.data_ptr(),
+                    1, H, NQK, self.ALP[L][1] * w["os"], s)
+            fvk.rms_norm_fp8(h.data_ptr(), w["post_norm"].data_ptr(), fp8a.data_ptr(),
+                             1, H, EPS, self.DS[L][2].data_ptr(), s)
+            gv["gu"](fp8a.data_ptr(), w["guq"].data_ptr(), self.Dg.data_ptr(),
+                     1, 2 * INTER, H, self.ALP[L][2] * w["gus"], s)
+            fvk.silu_mul_qwen36_bf16(self.Dg[:, :INTER].contiguous().data_ptr(),
+                                     self.Dg[:, INTER:].contiguous().data_ptr(),
+                                     self.act.data_ptr(), INTER, s)
+            fvk.quantize_fp8_static(self.act.data_ptr(), fp8d.data_ptr(), self.DS[L][3].data_ptr(), INTER, s)
+            gv["dn"](fp8d.data_ptr(), w["dnq"].data_ptr(), h.data_ptr(),
+                     1, H, INTER, self.ALP[L][3] * w["dns"], s)
+        fvk.rms_norm(h.data_ptr(), fe._weights["final_norm"].data_ptr(),
+                     self.hn.data_ptr(), 1, H, EPS, s)
+        fvk.quantize_fp8_static(self.hn.data_ptr(), fp8a.data_ptr(), self.DSF.data_ptr(), H, s)
+        gv["head"](fp8a.data_ptr(), self.CBq.data_ptr(), self.Dh.data_ptr(),
+                   1, self.NC * self.CV, H, self.asc_f * self.CBs, s)
+        return self.Dh.view(1, self.NC, self.CV)
+
+    def set_input(self, embed_row: torch.Tensor) -> None:
+        self.h.copy_(embed_row)

--- a/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
@@ -232,25 +232,34 @@ class HiggsAudioV3Fp8Decoder:
     def set_input(self, embed_row: torch.Tensor) -> None:
         self.h.copy_(embed_row)
 
-    # ── batched prompt prefill (single M=P forward) ──
-    # Prefill the whole prompt in one M=P pass instead of P separate M=1 decode
-    # steps. At small M the FP8 GEMM is weight-bandwidth-bound, so an M=P pass
-    # costs ~one M=1 pass — all P tokens for roughly one step. Reuses the tiled
-    # ht_fp8_gemm kernels (M=P), a per-position loop of the same fused
+    # ── batched prompt prefill (single M=S forward, optional cached prefix) ──
+    # Prefill the prompt in one M=S pass instead of S separate M=1 decode steps.
+    # At small M the FP8 GEMM is weight-bandwidth-bound, so an M=S pass costs
+    # ~one M=1 pass — all S tokens for roughly one step. Reuses the tiled
+    # ht_fp8_gemm kernels (M=S), a per-position loop of the same fused
     # q/k-norm+RoPE+KV-write kernels the decode step uses (identical convention,
-    # writing Q_buf[:, j] / K_cache[L, j]), and one causal FA2 over the prompt.
-    # The head runs on the last position only — that is the first-frame logits.
+    # writing Q_buf[:, j] / K_cache[L, start_pos+j]), and one causal FA2.
+    #
+    # ``start_pos`` enables prefix-KV reuse (serving prefix caching): when the
+    # leading ``start_pos`` tokens of ``ids`` already have valid KV resident in
+    # K_cache[:, :start_pos] (from a prior prefill of the same prefix), only the
+    # suffix ids[start_pos:] is prefilled (S = P-start_pos). Causal attention
+    # over the full [0:P] reuses the prefix KV; FA2's q_seq<kv_seq causal aligns
+    # the S queries to the trailing positions. Prefix KV is independent of the
+    # suffix (causal), so the result is bit-identical to a full prefill. The
+    # head runs on the last position only — that is the first-frame logits.
 
     # 16x64/128 tiles race at large N (non-deterministic KV); 16x192x128_w8 is
     # bit-deterministic across all prefill shapes (M up to 512) and fastest.
     _PREFILL_GEMM = "ht_fp8_gemm_16x192x128_w8"
 
     @torch.no_grad()
-    def prefill_batched(self, ids: list[int]) -> torch.Tensor:
+    def prefill_batched(self, ids: list[int], start_pos: int = 0) -> torch.Tensor:
         from flash_rt import flash_rt_kernels as fvk
         fe, be = self.fe, self.fe._attn
         dev = self.dev
         P = len(ids)
+        S = P - start_pos
         H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
         NQK, KV, EPS = self.NQK, self.KV, self.EPS
         s = torch.cuda.current_stream().cuda_stream
@@ -258,68 +267,70 @@ class HiggsAudioV3Fp8Decoder:
         head = getattr(fvk, _GEMV["head"])
         rc, rs = fe._rope_cos, fe._rope_sin
 
-        ids_t = torch.tensor(ids, device=dev)
-        h = F.embedding(ids_t, fe._weights["text_embed"]).contiguous()  # [P,H]
-        fp8a = torch.empty(P, H, device=dev, dtype=F8)
-        Dq = torch.empty(P, NQK + 2 * KV, device=dev, dtype=BF16)
-        Dg = torch.empty(P, 2 * INTER, device=dev, dtype=BF16)
-        fp8o = torch.empty(P, NQK, device=dev, dtype=F8)
-        fp8d = torch.empty(P, INTER, device=dev, dtype=F8)
-        tmp = torch.empty(P, H, device=dev, dtype=BF16)
-        act = torch.empty(P, INTER, device=dev, dtype=BF16)
+        ids_t = torch.tensor(ids[start_pos:], device=dev)
+        h = F.embedding(ids_t, fe._weights["text_embed"]).contiguous()  # [S,H]
+        fp8a = torch.empty(S, H, device=dev, dtype=F8)
+        Dq = torch.empty(S, NQK + 2 * KV, device=dev, dtype=BF16)
+        Dg = torch.empty(S, 2 * INTER, device=dev, dtype=BF16)
+        fp8o = torch.empty(S, NQK, device=dev, dtype=F8)
+        fp8d = torch.empty(S, INTER, device=dev, dtype=F8)
+        tmp = torch.empty(S, H, device=dev, dtype=BF16)
+        act = torch.empty(S, INTER, device=dev, dtype=BF16)
 
         for L in range(self.NL):
             w = self.WL[L]
             fvk.rms_norm_fp8(h.data_ptr(), w["in_norm"].data_ptr(),
-                             fp8a.data_ptr(), P, H, EPS,
+                             fp8a.data_ptr(), S, H, EPS,
                              self.DS[L][0].data_ptr(), s)
             gemm(fp8a.data_ptr(), w["qkvq"].data_ptr(), Dq.data_ptr(),
-                 P, NQK + 2 * KV, H, self.ALP[L][0] * w["qkvs"], s)
-            for j in range(P):
+                 S, NQK + 2 * KV, H, self.ALP[L][0] * w["qkvs"], s)
+            for j in range(S):
+                pos = start_pos + j
                 qj = Dq[j, :NQK].contiguous()
                 kj = Dq[j, NQK:NQK + KV].contiguous()
                 vj = Dq[j, NQK + KV:].contiguous()
                 fvk.qwen3_q_norm_rope_qstage_bf16(
                     q_pre=qj.data_ptr(), q_norm_w=w["qn"].data_ptr(),
-                    cos=rc[j].data_ptr(), sin=rs[j].data_ptr(),
+                    cos=rc[pos].data_ptr(), sin=rs[pos].data_ptr(),
                     q_buf_dst=be.Q_buf[:, j].data_ptr(), n_q_heads=NQ,
                     eps=EPS, stream=s)
                 fvk.qwen3_k_norm_rope_kvwrite_bf16(
                     k_pre=kj.data_ptr(), v_pre=vj.data_ptr(),
                     k_norm_w=w["kn"].data_ptr(),
-                    cos=rc[j].data_ptr(), sin=rs[j].data_ptr(),
-                    k_cache_dst=be.K_cache[L, j].data_ptr(),
-                    v_cache_dst=be.V_cache[L, j].data_ptr(),
+                    cos=rc[pos].data_ptr(), sin=rs[pos].data_ptr(),
+                    k_cache_dst=be.K_cache[L, pos].data_ptr(),
+                    v_cache_dst=be.V_cache[L, pos].data_ptr(),
                     n_kv_heads=NKV, eps=EPS, stream=s)
             # Pre-zero the query slots: the causal FA2 path can leave a partial
             # query-tile slot unwritten, and reading stale O_buf makes the
             # prefill non-deterministic run-to-run (frame-0 near-tie argmax
             # flips). Zeroing fixes determinism with cos vs eager preserved.
-            be.O_buf[:, :P].zero_()
-            be.run("full", L, P, kv_seq=P, causal=True, stream=s,
+            be.O_buf[:, :S].zero_()
+            # queries are the trailing S positions of kv_seq=P (causal align).
+            be.run("full", L, S, kv_seq=P, causal=True, stream=s,
                    softmax_scale=HD ** -0.5)
-            ao = be.O_buf[:, :P].reshape(P, NQK).contiguous()
+            ao = be.O_buf[:, :S].reshape(S, NQK).contiguous()
             fvk.quantize_fp8_static(ao.data_ptr(), fp8o.data_ptr(),
-                                    self.DS[L][1].data_ptr(), P * NQK, s)
+                                    self.DS[L][1].data_ptr(), S * NQK, s)
             gemm(fp8o.data_ptr(), w["oq"].data_ptr(), tmp.data_ptr(),
-                 P, H, NQK, self.ALP[L][1] * w["os"], s)
+                 S, H, NQK, self.ALP[L][1] * w["os"], s)
             h = (h.float() + tmp.float()).to(BF16)
             fvk.rms_norm_fp8(h.data_ptr(), w["post_norm"].data_ptr(),
-                             fp8a.data_ptr(), P, H, EPS,
+                             fp8a.data_ptr(), S, H, EPS,
                              self.DS[L][2].data_ptr(), s)
             gemm(fp8a.data_ptr(), w["guq"].data_ptr(), Dg.data_ptr(),
-                 P, 2 * INTER, H, self.ALP[L][2] * w["gus"], s)
+                 S, 2 * INTER, H, self.ALP[L][2] * w["gus"], s)
             g = Dg[:, :INTER].contiguous()
             u = Dg[:, INTER:].contiguous()
             fvk.silu_mul_qwen36_bf16(g.data_ptr(), u.data_ptr(),
-                                     act.data_ptr(), P * INTER, s)
+                                     act.data_ptr(), S * INTER, s)
             fvk.quantize_fp8_static(act.data_ptr(), fp8d.data_ptr(),
-                                    self.DS[L][3].data_ptr(), P * INTER, s)
+                                    self.DS[L][3].data_ptr(), S * INTER, s)
             gemm(fp8d.data_ptr(), w["dnq"].data_ptr(), tmp.data_ptr(),
-                 P, H, INTER, self.ALP[L][3] * w["dns"], s)
+                 S, H, INTER, self.ALP[L][3] * w["dns"], s)
             h = (h.float() + tmp.float()).to(BF16)
 
-        hlast = h[P - 1:P].contiguous()
+        hlast = h[S - 1:S].contiguous()
         fvk.rms_norm(hlast.data_ptr(), fe._weights["final_norm"].data_ptr(),
                      self.hn.data_ptr(), 1, H, EPS, s)
         fvk.quantize_fp8_static(self.hn.data_ptr(), self.fp8a.data_ptr(),

--- a/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
@@ -232,6 +232,102 @@ class HiggsAudioV3Fp8Decoder:
     def set_input(self, embed_row: torch.Tensor) -> None:
         self.h.copy_(embed_row)
 
+    # ── batched prompt prefill (single M=P forward) ──
+    # Prefill the whole prompt in one M=P pass instead of P separate M=1 decode
+    # steps. At small M the FP8 GEMM is weight-bandwidth-bound, so an M=P pass
+    # costs ~one M=1 pass — all P tokens for roughly one step. Reuses the tiled
+    # ht_fp8_gemm kernels (M=P), a per-position loop of the same fused
+    # q/k-norm+RoPE+KV-write kernels the decode step uses (identical convention,
+    # writing Q_buf[:, j] / K_cache[L, j]), and one causal FA2 over the prompt.
+    # The head runs on the last position only — that is the first-frame logits.
+
+    # 16x64/128 tiles race at large N (non-deterministic KV); 16x192x128_w8 is
+    # bit-deterministic across all prefill shapes (M up to 512) and fastest.
+    _PREFILL_GEMM = "ht_fp8_gemm_16x192x128_w8"
+
+    @torch.no_grad()
+    def prefill_batched(self, ids: list[int]) -> torch.Tensor:
+        from flash_rt import flash_rt_kernels as fvk
+        fe, be = self.fe, self.fe._attn
+        dev = self.dev
+        P = len(ids)
+        H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
+        NQK, KV, EPS = self.NQK, self.KV, self.EPS
+        s = torch.cuda.current_stream().cuda_stream
+        gemm = getattr(fvk, self._PREFILL_GEMM)
+        head = getattr(fvk, _GEMV["head"])
+        rc, rs = fe._rope_cos, fe._rope_sin
+
+        ids_t = torch.tensor(ids, device=dev)
+        h = F.embedding(ids_t, fe._weights["text_embed"]).contiguous()  # [P,H]
+        fp8a = torch.empty(P, H, device=dev, dtype=F8)
+        Dq = torch.empty(P, NQK + 2 * KV, device=dev, dtype=BF16)
+        Dg = torch.empty(P, 2 * INTER, device=dev, dtype=BF16)
+        fp8o = torch.empty(P, NQK, device=dev, dtype=F8)
+        fp8d = torch.empty(P, INTER, device=dev, dtype=F8)
+        tmp = torch.empty(P, H, device=dev, dtype=BF16)
+        act = torch.empty(P, INTER, device=dev, dtype=BF16)
+
+        for L in range(self.NL):
+            w = self.WL[L]
+            fvk.rms_norm_fp8(h.data_ptr(), w["in_norm"].data_ptr(),
+                             fp8a.data_ptr(), P, H, EPS,
+                             self.DS[L][0].data_ptr(), s)
+            gemm(fp8a.data_ptr(), w["qkvq"].data_ptr(), Dq.data_ptr(),
+                 P, NQK + 2 * KV, H, self.ALP[L][0] * w["qkvs"], s)
+            for j in range(P):
+                qj = Dq[j, :NQK].contiguous()
+                kj = Dq[j, NQK:NQK + KV].contiguous()
+                vj = Dq[j, NQK + KV:].contiguous()
+                fvk.qwen3_q_norm_rope_qstage_bf16(
+                    q_pre=qj.data_ptr(), q_norm_w=w["qn"].data_ptr(),
+                    cos=rc[j].data_ptr(), sin=rs[j].data_ptr(),
+                    q_buf_dst=be.Q_buf[:, j].data_ptr(), n_q_heads=NQ,
+                    eps=EPS, stream=s)
+                fvk.qwen3_k_norm_rope_kvwrite_bf16(
+                    k_pre=kj.data_ptr(), v_pre=vj.data_ptr(),
+                    k_norm_w=w["kn"].data_ptr(),
+                    cos=rc[j].data_ptr(), sin=rs[j].data_ptr(),
+                    k_cache_dst=be.K_cache[L, j].data_ptr(),
+                    v_cache_dst=be.V_cache[L, j].data_ptr(),
+                    n_kv_heads=NKV, eps=EPS, stream=s)
+            # Pre-zero the query slots: the causal FA2 path can leave a partial
+            # query-tile slot unwritten, and reading stale O_buf makes the
+            # prefill non-deterministic run-to-run (frame-0 near-tie argmax
+            # flips). Zeroing fixes determinism with cos vs eager preserved.
+            be.O_buf[:, :P].zero_()
+            be.run("full", L, P, kv_seq=P, causal=True, stream=s,
+                   softmax_scale=HD ** -0.5)
+            ao = be.O_buf[:, :P].reshape(P, NQK).contiguous()
+            fvk.quantize_fp8_static(ao.data_ptr(), fp8o.data_ptr(),
+                                    self.DS[L][1].data_ptr(), P * NQK, s)
+            gemm(fp8o.data_ptr(), w["oq"].data_ptr(), tmp.data_ptr(),
+                 P, H, NQK, self.ALP[L][1] * w["os"], s)
+            h = (h.float() + tmp.float()).to(BF16)
+            fvk.rms_norm_fp8(h.data_ptr(), w["post_norm"].data_ptr(),
+                             fp8a.data_ptr(), P, H, EPS,
+                             self.DS[L][2].data_ptr(), s)
+            gemm(fp8a.data_ptr(), w["guq"].data_ptr(), Dg.data_ptr(),
+                 P, 2 * INTER, H, self.ALP[L][2] * w["gus"], s)
+            g = Dg[:, :INTER].contiguous()
+            u = Dg[:, INTER:].contiguous()
+            fvk.silu_mul_qwen36_bf16(g.data_ptr(), u.data_ptr(),
+                                     act.data_ptr(), P * INTER, s)
+            fvk.quantize_fp8_static(act.data_ptr(), fp8d.data_ptr(),
+                                    self.DS[L][3].data_ptr(), P * INTER, s)
+            gemm(fp8d.data_ptr(), w["dnq"].data_ptr(), tmp.data_ptr(),
+                 P, H, INTER, self.ALP[L][3] * w["dns"], s)
+            h = (h.float() + tmp.float()).to(BF16)
+
+        hlast = h[P - 1:P].contiguous()
+        fvk.rms_norm(hlast.data_ptr(), fe._weights["final_norm"].data_ptr(),
+                     self.hn.data_ptr(), 1, H, EPS, s)
+        fvk.quantize_fp8_static(self.hn.data_ptr(), self.fp8a.data_ptr(),
+                                self.DSF.data_ptr(), H, s)
+        head(self.fp8a.data_ptr(), self.CBq.data_ptr(), self.Dh.data_ptr(),
+             1, self.NC * self.CV, H, self.asc_f * self.CBs, s)
+        return self.Dh.view(1, self.NC, self.CV)
+
     # ── position-agnostic single decode graph ──
     # One captured graph serves every decode position: the RoPE row is pre-copied
     # into a fixed buffer, the KV write targets K_cache[*cur_pos] via the devpos

--- a/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
@@ -152,7 +152,17 @@ class HiggsAudioV3Fp8Decoder:
         self.DSF = torch.tensor([max(self.asc_f, 1e-9)], device=self.dev, dtype=torch.float32)
         self.ALP = [[self.asc[L, i].item() for i in range(4)] for L in range(self.NL)]
         self._alloc()
+        self._free_bf16_backbone()
         self._calibrated = True
+
+    def _free_bf16_backbone(self) -> None:
+        """Release the bf16 projection weights — quantised into WL and no longer
+        needed (norm weights are tiny and kept; this drops ~half the VRAM). The
+        bf16 fallback backbone is unavailable once FP8 is calibrated."""
+        for L in self.fe._weights["layers"]:
+            for k in ("q", "k", "v", "o", "gate", "up", "down"):
+                L.pop(k, None)
+        torch.cuda.empty_cache()
 
     # ── FP8 decode step (eager, fully kernelised) ──
 

--- a/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_fp8.py
@@ -231,3 +231,123 @@ class HiggsAudioV3Fp8Decoder:
 
     def set_input(self, embed_row: torch.Tensor) -> None:
         self.h.copy_(embed_row)
+
+    # ── position-agnostic single decode graph ──
+    # One captured graph serves every decode position: the RoPE row is pre-copied
+    # into a fixed buffer, the KV write targets K_cache[*cur_pos] via the devpos
+    # kernel, and attention reads the device KV length via FA2 seqused_k. The host
+    # updates three small buffers (rope row, cur_pos, seqused) before each replay.
+
+    def _alloc_graph(self) -> None:
+        d, HALF = self.dev, self.HD // 2
+        self.rope_cos_buf = torch.empty(HALF, device=d, dtype=BF16)
+        self.rope_sin_buf = torch.empty(HALF, device=d, dtype=BF16)
+        self.cur_pos_dev = torch.zeros(1, device=d, dtype=torch.int32)
+        self.seqused_dev = torch.zeros(1, device=d, dtype=torch.int32)
+        self._graph = None
+        self._gs = torch.cuda.Stream(device=d)
+
+    @torch.no_grad()
+    def _step_graphable(self):
+        from flash_rt import flash_rt_kernels as fvk
+        from flash_rt import flash_rt_fa2 as fa2
+        fe, be = self.fe, self.fe._attn
+        H, NQ, NKV, HD, INTER = self.H, self.NQ, self.NKV, self.HD, self.INTER
+        NQK, KV, EPS = self.NQK, self.KV, self.EPS
+        MAXS = be._max_seq
+        gv = {k: getattr(fvk, v) for k, v in _GEMV.items()}
+        s = torch.cuda.current_stream().cuda_stream
+        rc, rs = self.rope_cos_buf, self.rope_sin_buf
+        cp, su = self.cur_pos_dev, self.seqused_dev
+        h, fp8a, fp8o, fp8d = self.h, self.fp8a, self.fp8o, self.fp8d
+        qb, ob = be.Q_buf[:, :1], be.O_buf[:, :1]
+        qst = (qb.stride(0), qb.stride(1), qb.stride(2))
+        ost = (ob.stride(0), ob.stride(1), ob.stride(2))
+        for L in range(self.NL):
+            w = self.WL[L]
+            fvk.rms_norm_fp8(h.data_ptr(), w["in_norm"].data_ptr(), fp8a.data_ptr(),
+                             1, H, EPS, self.DS[L][0].data_ptr(), s)
+            gv["qkv"](fp8a.data_ptr(), w["qkvq"].data_ptr(), self.Dq.data_ptr(),
+                      1, NQK + 2 * KV, H, self.ALP[L][0] * w["qkvs"], s)
+            q = self.Dq[:, :NQK].view(NQ, HD).contiguous()
+            k = self.Dq[:, NQK:NQK + KV].view(NKV, HD).contiguous()
+            v = self.Dq[:, NQK + KV:].view(NKV, HD).contiguous()
+            fvk.qwen3_q_norm_rope_qstage_bf16(
+                q_pre=q.data_ptr(), q_norm_w=w["qn"].data_ptr(),
+                cos=rc.data_ptr(), sin=rs.data_ptr(),
+                q_buf_dst=qb.data_ptr(), n_q_heads=NQ, eps=EPS, stream=s)
+            fvk.qwen3_k_norm_rope_kvwrite_devpos_bf16(
+                k.data_ptr(), v.data_ptr(), w["kn"].data_ptr(),
+                rc.data_ptr(), rs.data_ptr(),
+                be.K_cache[L, 0].data_ptr(), be.V_cache[L, 0].data_ptr(),
+                cp.data_ptr(), NKV * HD, NKV, EPS, s)
+            kf, vf = be.K_cache[L:L + 1, :MAXS], be.V_cache[L:L + 1, :MAXS]
+            fa2.fwd_bf16_seqused(
+                Q=qb.data_ptr(), K=kf.data_ptr(), V=vf.data_ptr(), O=ob.data_ptr(),
+                softmax_lse=be.lse_buf.data_ptr(), seqused_k=su.data_ptr(),
+                batch=1, seqlen_q=1, seqlen_k=MAXS, num_heads_q=NQ,
+                num_heads_kv=NKV, head_dim=HD, q_strides=qst,
+                k_strides=(kf.stride(0), kf.stride(1), kf.stride(2)),
+                v_strides=(vf.stride(0), vf.stride(1), vf.stride(2)),
+                o_strides=ost, softmax_scale=HD ** -0.5, num_sms=0, stream=s)
+            ao = be.O_buf[:, :1].reshape(1, NQK).contiguous()
+            fvk.quantize_fp8_static(ao.data_ptr(), fp8o.data_ptr(), self.DS[L][1].data_ptr(), NQK, s)
+            gv["o"](fp8o.data_ptr(), w["oq"].data_ptr(), h.data_ptr(),
+                    1, H, NQK, self.ALP[L][1] * w["os"], s)
+            fvk.rms_norm_fp8(h.data_ptr(), w["post_norm"].data_ptr(), fp8a.data_ptr(),
+                             1, H, EPS, self.DS[L][2].data_ptr(), s)
+            gv["gu"](fp8a.data_ptr(), w["guq"].data_ptr(), self.Dg.data_ptr(),
+                     1, 2 * INTER, H, self.ALP[L][2] * w["gus"], s)
+            fvk.silu_mul_qwen36_bf16(self.Dg[:, :INTER].contiguous().data_ptr(),
+                                     self.Dg[:, INTER:].contiguous().data_ptr(),
+                                     self.act.data_ptr(), INTER, s)
+            fvk.quantize_fp8_static(self.act.data_ptr(), fp8d.data_ptr(), self.DS[L][3].data_ptr(), INTER, s)
+            gv["dn"](fp8d.data_ptr(), w["dnq"].data_ptr(), h.data_ptr(),
+                     1, H, INTER, self.ALP[L][3] * w["dns"], s)
+        fvk.rms_norm(h.data_ptr(), fe._weights["final_norm"].data_ptr(),
+                     self.hn.data_ptr(), 1, H, EPS, s)
+        fvk.quantize_fp8_static(self.hn.data_ptr(), fp8a.data_ptr(), self.DSF.data_ptr(), H, s)
+        gv["head"](fp8a.data_ptr(), self.CBq.data_ptr(), self.Dh.data_ptr(),
+                   1, self.NC * self.CV, H, self.asc_f * self.CBs, s)
+        return self.Dh.view(1, self.NC, self.CV)
+
+    @torch.no_grad()
+    def _set_pos(self, t: int) -> None:
+        self.rope_cos_buf.copy_(self.fe._rope_cos[t])
+        self.rope_sin_buf.copy_(self.fe._rope_sin[t])
+        self.cur_pos_dev.fill_(t)
+        self.seqused_dev.fill_(t + 1)
+
+    @torch.no_grad()
+    def capture_graph(self, embed_row: torch.Tensor, warm_pos: int) -> None:
+        """Capture the single decode graph once (any warm position works)."""
+        if getattr(self, "_graph", None) is not None:
+            return
+        if not hasattr(self, "rope_cos_buf"):
+            self._alloc_graph()
+        gs = self._gs
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs):
+            for _ in range(3):
+                self.h.copy_(embed_row)
+                self._set_pos(warm_pos)
+                self._step_graphable()
+            self.h.copy_(embed_row)
+            self._set_pos(warm_pos)
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(g, stream=gs):
+                self._step_graphable()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._graph = g
+
+    @torch.no_grad()
+    def decode_graph(self, embed_row: torch.Tensor, t: int) -> torch.Tensor:
+        """Replay the decode graph at position t with input embed_row."""
+        gs = self._gs
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs):
+            self.h.copy_(embed_row)
+            self._set_pos(t)
+            self._graph.replay()
+        torch.cuda.current_stream().wait_stream(gs)
+        return self.Dh.view(1, self.NC, self.CV)

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -36,6 +36,7 @@ class HiggsAudioV3TorchFrontendRtx:
                  device: str = "cuda:0",
                  max_seq: int = 2048,
                  max_new_frames: int = 1024,
+                 fp8: bool = True,
                  alloc_own_forward_buffers: bool = True) -> None:
         """Load the BF16 backbone + fused codebook table and build scratch.
 
@@ -44,6 +45,9 @@ class HiggsAudioV3TorchFrontendRtx:
           device: CUDA device string.
           max_seq: KV-cache length (prompt + generated frames).
           max_new_frames: cap on generated acoustic frames per call.
+          fp8: run the decode backbone in FP8 W8A8 (the dedicated M=1 GEMV
+            path); falls back to the BF16 backbone when False. FP8 weights are
+            quantised and activation scales calibrated lazily on first use.
           alloc_own_forward_buffers: pre-allocate the attention backend and
             RoPE table at construction.
         """
@@ -51,6 +55,7 @@ class HiggsAudioV3TorchFrontendRtx:
         self.device = device
         self.max_seq = int(max_seq)
         self.max_new_frames = int(max_new_frames)
+        self.fp8 = bool(fp8)
 
         self._tokenizer: Any = None
         self._special_ids: dict[str, int] = {}
@@ -60,6 +65,8 @@ class HiggsAudioV3TorchFrontendRtx:
         self._rope_cos = None
         self._rope_sin = None
         self._prompt_ids: list[int] | None = None
+        self._fp8_decoder: Any = None
+        self._codec: Any = None
         self.latency_records: list[float] = []
 
         self._load_weights()
@@ -270,12 +277,38 @@ class HiggsAudioV3TorchFrontendRtx:
         self._prompt_ids = self.build_prompt(text)
         self._attn.reset_cache()
 
+    # ── FP8 / codec lazy init ──
+
+    def _ensure_fp8(self) -> None:
+        if self._fp8_decoder is not None:
+            return
+        from flash_rt.frontends.torch._higgs_audio_v3_fp8 import (
+            HiggsAudioV3Fp8Decoder,
+        )
+        dec = HiggsAudioV3Fp8Decoder(self)
+        dec.calibrate(self._prompt_ids)   # static activation scales (one-time)
+        self._fp8_decoder = dec
+
+    def _ensure_codec(self) -> None:
+        if self._codec is not None:
+            return
+        from flash_rt.models.higgs_audio_v3.codec import HiggsAudioV3Codec
+        self._codec = HiggsAudioV3Codec.from_checkpoint(
+            self.checkpoint_path, device=self.device)
+
+    def _frame_logits(self, fvk, embed_row, t):
+        """[num_codebooks, codebook_vocab] logits for one frame at position t."""
+        if self.fp8:
+            self._fp8_decoder.set_input(embed_row)
+            return self._fp8_decoder.step(t)[0]
+        return self._logits(self._step(fvk, embed_row, t))
+
     @torch.no_grad()
     def predict(self, text: str | None = None) -> torch.Tensor:
         """Generate acoustic codes for ``text`` (greedy, delay/EOC).
 
         Returns raw codes of shape ``[T, num_codebooks]`` (int64, CPU);
-        feed them to the Higgs codec to synthesise a 24 kHz waveform.
+        feed them to :meth:`synthesize` (or the Higgs codec) for a 24 kHz wave.
         """
         import time
 
@@ -285,6 +318,8 @@ class HiggsAudioV3TorchFrontendRtx:
             self.set_prompt(text)
         if self._prompt_ids is None:
             raise RuntimeError("no prompt set; call set_prompt() or pass text")
+        if self.fp8:
+            self._ensure_fp8()
 
         c = self._cfg
         nc = c["num_codebooks"]
@@ -296,15 +331,14 @@ class HiggsAudioV3TorchFrontendRtx:
         self._attn.reset_cache()
         ids = self._prompt_ids
         for t, tok in enumerate(ids):
-            row = F.embedding(
-                torch.tensor([tok], device=self.device), te)
-            hn = self._step(fvk, row, t)
+            row = F.embedding(torch.tensor([tok], device=self.device), te)
+            logits = self._frame_logits(fvk, row, t)
         P = len(ids)
 
         delay, eoc_countdown, done = 0, None, False
         delayed = []
         for j in range(self.max_new_frames):
-            codes = self._logits(hn).argmax(-1).clone()
+            codes = logits.argmax(-1).clone()
             if delay < nc:
                 if delay + 1 < nc:
                     codes[delay + 1:] = boc
@@ -318,7 +352,7 @@ class HiggsAudioV3TorchFrontendRtx:
             if done:
                 break
             delayed.append(codes.clone())
-            hn = self._step(fvk, self._embed_codes(codes), P + j)
+            logits = self._frame_logits(fvk, self._embed_codes(codes), P + j)
 
         torch.cuda.synchronize()
         self.latency_records.append((time.perf_counter() - t0) * 1000.0)
@@ -329,3 +363,16 @@ class HiggsAudioV3TorchFrontendRtx:
         if T <= 0:
             return torch.empty(0, nc, dtype=torch.long)
         return torch.stack([grid[i:i + T, i] for i in range(nc)], dim=1).cpu()
+
+    @torch.no_grad()
+    def synthesize(self, codes: torch.Tensor) -> torch.Tensor:
+        """``[T, num_codebooks]`` codes -> mono 24 kHz waveform ``[L]`` (cpu)."""
+        self._ensure_codec()
+        if codes.numel() == 0:
+            return torch.zeros(0)
+        return self._codec.decode(codes)
+
+    @torch.no_grad()
+    def generate(self, text: str) -> torch.Tensor:
+        """Full pipeline: text -> acoustic codes -> 24 kHz waveform ``[L]``."""
+        return self.synthesize(self.predict(text))

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -79,6 +79,7 @@ class HiggsAudioV3TorchFrontendRtx:
         self._rope_cos = None
         self._rope_sin = None
         self._prompt_ids: list[int] | None = None
+        self._resident_ids: list[int] | None = None   # KV currently on GPU
         self._fp8_decoder: Any = None
         self._codec: Any = None
         self.latency_records: list[float] = []
@@ -283,9 +284,17 @@ class HiggsAudioV3TorchFrontendRtx:
 
     # ── Public API ──
 
-    def build_prompt(self, text: str) -> list[int]:
-        """Zero-shot TTS prompt: <|tts|> <|text|> tok(text) <|audio|>."""
+    def build_prompt(self, text: str, system: str | None = None) -> list[int]:
+        """Zero-shot TTS prompt: <|tts|> <|text|> [enc(system)] tok(text) <|audio|>.
+
+        An optional ``system`` preamble (voice/style instruction) is prepended
+        as a clean reusable token prefix: requests that share the same ``system``
+        share that leading run, so its KV can be reused across requests (serving
+        prefix caching) — only the varying ``text`` suffix is re-prefilled.
+        """
         ids = [self._special_ids["<|tts|>"], self._special_ids["<|text|>"]]
+        if system:
+            ids += self._tokenizer.encode(system, add_special_tokens=False)
         ids += self._tokenizer.encode(text, add_special_tokens=False)
         ids.append(self._special_ids["<|audio|>"])
         return ids
@@ -293,6 +302,7 @@ class HiggsAudioV3TorchFrontendRtx:
     def set_prompt(self, text: str) -> None:
         self._prompt_ids = self.build_prompt(text)
         self._attn.reset_cache()
+        self._resident_ids = None      # KV zeroed; nothing reusable resident
 
     # ── FP8 / codec lazy init ──
 
@@ -335,9 +345,33 @@ class HiggsAudioV3TorchFrontendRtx:
     # after nc-1 further frames decode, so the stream carries a fixed nc-1
     # holdback; every yielded frame is already committed to the KV state.
 
+    def resident_prefix_len(self, prompt_ids: list[int]) -> int:
+        """Longest prefix of ``prompt_ids`` whose KV is already resident on GPU
+        (from the previous prefill). The serving layer passes this back as
+        ``cached_tokens`` to skip re-prefilling a shared prefix (system/voice
+        preamble) — prefix-KV reuse. Mechanism only; the cache/eviction policy
+        lives in the serving layer. Always keeps >=1 token to prefill fresh."""
+        resident = self._resident_ids
+        if not resident:
+            return 0
+        n = 0
+        for a, b in zip(prompt_ids, resident):
+            if a != b:
+                break
+            n += 1
+        return max(0, min(n, len(prompt_ids) - 1))
+
     @torch.no_grad()
-    def prefill(self, prompt_ids: list[int] | None = None) -> int:
-        """Run the prompt prefill; returns cur_pos (= prompt length)."""
+    def prefill(self, prompt_ids: list[int] | None = None,
+                cached_tokens: int = 0) -> int:
+        """Run the prompt prefill; returns cur_pos (= prompt length).
+
+        ``cached_tokens`` > 0 reuses the KV of the leading ``cached_tokens``
+        tokens (already resident from a prior prefill of the same prefix) and
+        prefills only the suffix — serving prefix caching. The claim is verified
+        against the resident tokens; on mismatch it safely falls back to a full
+        prefill. Reuse requires the batched FP8 prefill path.
+        """
         from flash_rt import flash_rt_kernels as fvk
         if prompt_ids is not None:
             self._prompt_ids = list(prompt_ids)
@@ -345,19 +379,28 @@ class HiggsAudioV3TorchFrontendRtx:
             raise RuntimeError("no prompt set; call set_prompt()/pass prompt_ids")
         if self.fp8:
             self._ensure_fp8()
-        self._attn.reset_cache()
         P = len(self._prompt_ids)
-        if (self._batched_prefill
-                and P <= self._attn._max_q_seq):
-            # one M=P forward over the whole prompt
+        batched = self._batched_prefill and P <= self._attn._max_q_seq
+        # Validate the cached-prefix claim against the resident KV (safety: never
+        # reuse stale/mismatched KV); reuse only on the batched path.
+        reuse = (batched and 0 < cached_tokens < P
+                 and self._resident_ids is not None
+                 and len(self._resident_ids) >= cached_tokens
+                 and self._prompt_ids[:cached_tokens]
+                 == self._resident_ids[:cached_tokens])
+        if not reuse:
+            self._attn.reset_cache()      # cold prefill writes KV from pos 0
+            cached_tokens = 0
+        if batched:
             self._gen_logits = self._fp8_decoder.prefill_batched(
-                self._prompt_ids)[0]
+                self._prompt_ids, start_pos=cached_tokens)[0]
         else:
             te = self._weights["text_embed"]
             for t, tok in enumerate(self._prompt_ids):
                 row = F.embedding(torch.tensor([tok], device=self.device), te)
                 self._gen_logits = self._frame_logits(fvk, row, t)
         self._gen_pos = P
+        self._resident_ids = list(self._prompt_ids)
         return self._gen_pos
 
     @torch.no_grad()
@@ -429,8 +472,9 @@ class HiggsAudioV3TorchFrontendRtx:
     SAMPLES_PER_FRAME = 960   # 24000 Hz / 25 Hz acoustic frame rate
 
     @torch.no_grad()
-    def generate_stream(self, text: str, *, first_chunk: int = 8,
-                        chunk: int = 25, ctx: int = 8, holdback: int = 8):
+    def generate_stream(self, text: str, *, system: str | None = None,
+                        first_chunk: int = 8, chunk: int = 25, ctx: int = 8,
+                        holdback: int = 8):
         """Stream 24 kHz audio chunks as frames decode (low TTFA).
 
         Yields mono waveform chunks (cpu f32). ``first_chunk`` frames are emitted
@@ -440,10 +484,20 @@ class HiggsAudioV3TorchFrontendRtx:
         emitted left context and ``holdback`` frames of not-yet-emitted right
         context; only the centre frames' samples are released, so the streamed
         waveform matches the one-shot ``synthesize`` (no boundary seams).
+
+        ``system`` is an optional shared preamble (voice/style instruction). When
+        successive requests carry the same ``system``, its KV is reused across
+        requests (only the new ``text`` suffix is prefilled) — serving prefix
+        caching, bit-identical to a cold prefill.
         """
         self._ensure_codec()
-        self.set_prompt(text)
-        self.prefill()
+        if system is None:
+            self.set_prompt(text)
+            self.prefill()
+        else:
+            ids = self.build_prompt(text, system=system)
+            # reuse the resident shared-preamble KV; only prefill the new suffix
+            self.prefill(ids, cached_tokens=self.resident_prefix_len(ids))
         spf = self.SAMPLES_PER_FRAME
         frames: list[torch.Tensor] = []
         emitted = 0

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -36,6 +36,7 @@ class HiggsAudioV3TorchFrontendRtx:
                  device: str = "cuda:0",
                  max_seq: int = 2048,
                  max_new_frames: int = 1024,
+                 max_prefill_tokens: int = 512,
                  fp8: bool = True,
                  alloc_own_forward_buffers: bool = True) -> None:
         """Load the BF16 backbone + fused codebook table and build scratch.
@@ -45,6 +46,9 @@ class HiggsAudioV3TorchFrontendRtx:
           device: CUDA device string.
           max_seq: KV-cache length (prompt + generated frames).
           max_new_frames: cap on generated acoustic frames per call.
+          max_prefill_tokens: max prompt length served by the batched single-
+            pass FP8 prefill; longer prompts fall back to the eager per-token
+            prefill. Sizes the attention Q/O buffers.
           fp8: run the decode backbone in FP8 W8A8 (the dedicated M=1 GEMV
             path); falls back to the BF16 backbone when False. FP8 weights are
             quantised and activation scales calibrated lazily on first use.
@@ -55,7 +59,12 @@ class HiggsAudioV3TorchFrontendRtx:
         self.device = device
         self.max_seq = int(max_seq)
         self.max_new_frames = int(max_new_frames)
+        self.max_prefill_tokens = int(max_prefill_tokens)
         self.fp8 = bool(fp8)
+        # Batched single-pass prompt prefill (M=P) instead of P eager M=1 steps.
+        # On by default for FP8; set FLASHRT_HIGGS_BATCHED_PREFILL=0 for eager.
+        self._batched_prefill = self.fp8 and os.environ.get(
+            "FLASHRT_HIGGS_BATCHED_PREFILL", "1") != "0"
         # Single position-agnostic decode CUDA graph (devpos KV-write + FA2
         # seqused_k). On by default for FP8; set FLASHRT_HIGGS_GRAPH=0 to force
         # the eager decode path.
@@ -175,8 +184,11 @@ class HiggsAudioV3TorchFrontendRtx:
             RtxFlashAttnBackendQwen3,
         )
 
+        # max_q_seq sizes the Q/O/lse buffers; batched prefill needs room for
+        # the whole prompt (q_seq=P), decode only ever uses q_seq=1.
+        mqs = max(1, self.max_prefill_tokens) if self._batched_prefill else 1
         self._attn = RtxFlashAttnBackendQwen3(
-            max_seq=self.max_seq, max_q_seq=1, dtype=torch.bfloat16)
+            max_seq=self.max_seq, max_q_seq=mqs, dtype=torch.bfloat16)
         nc = self._cfg["num_codebooks"]
         self._cb_offsets = (
             torch.arange(nc, device=self.device) * self._cfg["codebook_vocab"])
@@ -334,11 +346,18 @@ class HiggsAudioV3TorchFrontendRtx:
         if self.fp8:
             self._ensure_fp8()
         self._attn.reset_cache()
-        te = self._weights["text_embed"]
-        for t, tok in enumerate(self._prompt_ids):
-            row = F.embedding(torch.tensor([tok], device=self.device), te)
-            self._gen_logits = self._frame_logits(fvk, row, t)
-        self._gen_pos = len(self._prompt_ids)
+        P = len(self._prompt_ids)
+        if (self._batched_prefill
+                and P <= self._attn._max_q_seq):
+            # one M=P forward over the whole prompt
+            self._gen_logits = self._fp8_decoder.prefill_batched(
+                self._prompt_ids)[0]
+        else:
+            te = self._weights["text_embed"]
+            for t, tok in enumerate(self._prompt_ids):
+                row = F.embedding(torch.tensor([tok], device=self.device), te)
+                self._gen_logits = self._frame_logits(fvk, row, t)
+        self._gen_pos = P
         return self._gen_pos
 
     @torch.no_grad()

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -37,7 +37,7 @@ class HiggsAudioV3TorchFrontendRtx:
                  max_seq: int = 2048,
                  max_new_frames: int = 1024,
                  max_prefill_tokens: int = 512,
-                 fp8: bool = True,
+                 fp8: bool | None = None,
                  alloc_own_forward_buffers: bool = True) -> None:
         """Load the BF16 backbone + fused codebook table and build scratch.
 
@@ -47,11 +47,14 @@ class HiggsAudioV3TorchFrontendRtx:
           max_seq: KV-cache length (prompt + generated frames).
           max_new_frames: cap on generated acoustic frames per call.
           max_prefill_tokens: max prompt length served by the batched single-
-            pass FP8 prefill; longer prompts fall back to the eager per-token
+            pass prefill; longer prompts fall back to the eager per-token
             prefill. Sizes the attention Q/O buffers.
-          fp8: run the decode backbone in FP8 W8A8 (the dedicated M=1 GEMV
-            path); falls back to the BF16 backbone when False. FP8 weights are
-            quantised and activation scales calibrated lazily on first use.
+          fp8: decode precision. ``None`` (default) auto-selects by hardware —
+            FP8 W8A8 when the FP8 decode kernels are compiled in (SM120 build),
+            else BF16 W16A16. ``True`` forces FP8 (falls back to BF16 with a
+            warning if its kernels are absent); ``False`` forces BF16. Both run
+            the same kernelised graph; selection follows the FlashRT
+            hardware-detection convention (compiled-symbol probe + SM version).
           alloc_own_forward_buffers: pre-allocate the attention backend and
             RoPE table at construction.
         """
@@ -60,7 +63,7 @@ class HiggsAudioV3TorchFrontendRtx:
         self.max_seq = int(max_seq)
         self.max_new_frames = int(max_new_frames)
         self.max_prefill_tokens = int(max_prefill_tokens)
-        self.fp8 = bool(fp8)
+        self.fp8 = self._resolve_precision(fp8)
         # Batched single-pass prompt prefill (M=P) instead of P eager M=1 steps
         # (both FP8 and BF16 paths). Set FLASHRT_HIGGS_BATCHED_PREFILL=0 for eager.
         self._batched_prefill = os.environ.get(
@@ -87,6 +90,53 @@ class HiggsAudioV3TorchFrontendRtx:
         if alloc_own_forward_buffers:
             self._alloc_buffers()
             self._build_rope_table()
+
+    @staticmethod
+    def _resolve_precision(fp8: bool | None) -> bool:
+        """Pick the decode precision from the hardware, FlashRT-style: probe the
+        compiled kernel module (the FP8 path needs both its M=1 GEMV and the
+        SM120 FP8 prefill GEMM; BF16 needs its M=1 GEMV) and read the SM version
+        for the log. ``None`` auto-selects FP8 if available else BF16; ``True``
+        forces FP8 but falls back to BF16 (with a warning) when its kernels were
+        not compiled into this build; ``False`` forces BF16."""
+        import logging
+
+        from flash_rt import flash_rt_kernels as fvk
+        from flash_rt.core.utils.hardware import (
+            get_gpu_name,
+            get_gpu_sm_version,
+        )
+        log = logging.getLogger(__name__)
+        fp8_ok = (hasattr(fvk, "ht_gemv_fp8_m1_w8")
+                  and hasattr(fvk, "ht_fp8_gemm_16x192x128_w8"))
+        bf16_ok = hasattr(fvk, "ht_gemv_bf16_m1_w4")
+        sm, name = get_gpu_sm_version(), get_gpu_name()
+
+        if fp8 is None:
+            use_fp8 = fp8_ok
+        elif fp8:
+            use_fp8 = True
+            if not fp8_ok:
+                if not bf16_ok:
+                    raise RuntimeError(
+                        f"Higgs Audio v3: no decode kernels in this build "
+                        f"(SM{sm} {name}); rebuild FlashRT with GPU_ARCH "
+                        f"matching the GPU.")
+                log.warning(
+                    "Higgs Audio v3: FP8 requested but the FP8 decode kernels "
+                    "are not in this build (SM%s %s); using BF16.", sm, name)
+                use_fp8 = False
+        else:
+            use_fp8 = False
+
+        if not use_fp8 and not bf16_ok:
+            raise RuntimeError(
+                f"Higgs Audio v3: the BF16 decode GEMV is not in this build "
+                f"(SM{sm} {name}); rebuild FlashRT with GPU_ARCH matching the "
+                f"GPU.")
+        log.info("Higgs Audio v3 on SM%s (%s): %s decode", sm, name,
+                 "FP8 W8A8" if use_fp8 else "BF16 W16A16")
+        return use_fp8
 
     # ── Load ──
 

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -1,0 +1,331 @@
+"""Higgs Audio v3 TTS-4B — RTX SM120 PyTorch frontend (BF16 acoustic path).
+
+Hand-written forward over flash_rt_kernels + flash_rt_fa2: a dense Qwen3-4B
+backbone drives a fused multi-codebook head that emits 8 codec tokens per
+acoustic frame under a delay pattern, decoded autoregressively with greedy
+sampling. ``predict`` returns raw ``[T, num_codebooks]`` codes; waveform
+synthesis is the codec's responsibility.
+
+Kernels used: ``rms_norm``, ``bf16_matmul_qwen36_bf16``, ``silu_mul_qwen36_bf16``,
+``qwen3_q_norm_rope_qstage_bf16`` / ``qwen3_k_norm_rope_kvwrite_bf16`` (fused
+q/k-norm + full RoPE), and vendored FlashAttention-2 via
+``RtxFlashAttnBackendQwen3`` (head config 36 / 32q / 8kv / 128 is shared with
+Qwen3-8B). Plain RMSNorm weight convention (multiplies by ``w``, not ``1+w``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from flash_rt.models.higgs_audio_v3.pipeline_rtx import HiggsAudioV3Dims
+
+_SPECIALS = ("<|tts|>", "<|text|>", "<|audio|>")
+
+
+class HiggsAudioV3TorchFrontendRtx:
+    """Single-stream Higgs Audio v3 TTS inference on RTX SM120 (BF16 backbone)."""
+
+    DIMS = HiggsAudioV3Dims()
+
+    def __init__(self, checkpoint_path: str, *,
+                 device: str = "cuda:0",
+                 max_seq: int = 2048,
+                 max_new_frames: int = 1024,
+                 alloc_own_forward_buffers: bool = True) -> None:
+        """Load the BF16 backbone + fused codebook table and build scratch.
+
+        Args:
+          checkpoint_path: dir holding config.json + model.safetensors.
+          device: CUDA device string.
+          max_seq: KV-cache length (prompt + generated frames).
+          max_new_frames: cap on generated acoustic frames per call.
+          alloc_own_forward_buffers: pre-allocate the attention backend and
+            RoPE table at construction.
+        """
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+        self.max_new_frames = int(max_new_frames)
+
+        self._tokenizer: Any = None
+        self._special_ids: dict[str, int] = {}
+        self._weights: dict[str, Any] | None = None
+        self._cfg: dict[str, Any] | None = None
+        self._attn = None
+        self._rope_cos = None
+        self._rope_sin = None
+        self._prompt_ids: list[int] | None = None
+        self.latency_records: list[float] = []
+
+        self._load_weights()
+        if alloc_own_forward_buffers:
+            self._alloc_buffers()
+            self._build_rope_table()
+
+    # ── Load ──
+
+    def _load_weights(self) -> None:
+        from safetensors.torch import load_file
+
+        cfg = json.load(open(os.path.join(self.checkpoint_path, "config.json")))
+        tc = cfg["text_config"]
+        enc = cfg["audio_encoder_config"]
+        rope_theta = float(tc.get("rope_parameters", {}).get(
+            "rope_theta", tc.get("rope_theta", self.DIMS.rope_theta)))
+        self._cfg = {
+            "hidden": int(tc["hidden_size"]),
+            "num_layers": int(tc["num_hidden_layers"]),
+            "num_q_heads": int(tc["num_attention_heads"]),
+            "num_kv_heads": int(tc["num_key_value_heads"]),
+            "head_dim": int(tc["head_dim"]),
+            "intermediate": int(tc["intermediate_size"]),
+            "rms_norm_eps": float(tc["rms_norm_eps"]),
+            "rope_theta": rope_theta,
+            "num_codebooks": int(enc["num_codebooks"]),
+            "codebook_vocab": int(enc["vocab_size"]),
+        }
+        self._assert_dims()
+
+        dev, bf16 = self.device, torch.bfloat16
+        sd = load_file(os.path.join(self.checkpoint_path, "model.safetensors"))
+
+        def g(k):
+            return sd[k].to(dev, bf16)
+
+        nl = self._cfg["num_layers"]
+        layers = []
+        for i in range(nl):
+            p = f"body.layers.{i}"
+            layers.append({
+                "in_norm": g(f"{p}.input_layernorm.weight"),
+                "q": g(f"{p}.self_attn.q_proj.weight"),
+                "k": g(f"{p}.self_attn.k_proj.weight"),
+                "v": g(f"{p}.self_attn.v_proj.weight"),
+                "o": g(f"{p}.self_attn.o_proj.weight"),
+                "qn": g(f"{p}.self_attn.q_norm.weight"),
+                "kn": g(f"{p}.self_attn.k_norm.weight"),
+                "post_norm": g(f"{p}.post_attention_layernorm.weight"),
+                "gate": g(f"{p}.mlp.gate_proj.weight"),
+                "up": g(f"{p}.mlp.up_proj.weight"),
+                "down": g(f"{p}.mlp.down_proj.weight"),
+            })
+        self._weights = {
+            "layers": layers,
+            "text_embed": g("tied.embedding.text_embedding.weight"),
+            "final_norm": g("body.norm.weight"),
+            # fused [num_codebooks * codebook_vocab, hidden]; head ties to embed.
+            "codebook": g(
+                "tied.embedding.modality_embeddings.0.embedding.weight"),
+        }
+        self._load_tokenizer()
+
+    def _assert_dims(self) -> None:
+        d, c = self.DIMS, self._cfg
+        for name, want, got in (
+            ("hidden", d.hidden, c["hidden"]),
+            ("num_layers", d.num_layers, c["num_layers"]),
+            ("num_q_heads", d.num_q_heads, c["num_q_heads"]),
+            ("num_kv_heads", d.num_kv_heads, c["num_kv_heads"]),
+            ("head_dim", d.head_dim, c["head_dim"]),
+            ("intermediate", d.intermediate, c["intermediate"]),
+            ("num_codebooks", d.num_codebooks, c["num_codebooks"]),
+            ("codebook_vocab", d.codebook_vocab, c["codebook_vocab"]),
+        ):
+            if want != got:
+                raise ValueError(
+                    f"checkpoint dim {name}={got} != expected {want}; "
+                    f"this frontend targets Higgs Audio v3 TTS-4B.")
+
+    def _load_tokenizer(self) -> None:
+        # Load tokenizer.json directly: transformers<5 mishandles the
+        # list-form extra_special_tokens in this checkpoint's config.
+        from tokenizers import Tokenizer
+        from transformers import PreTrainedTokenizerFast
+
+        raw = Tokenizer.from_file(
+            os.path.join(self.checkpoint_path, "tokenizer.json"))
+        self._tokenizer = PreTrainedTokenizerFast(tokenizer_object=raw)
+        vocab = dict(self._tokenizer.get_added_vocab())
+        missing = [t for t in _SPECIALS if t not in vocab]
+        if missing:
+            raise ValueError(f"tokenizer missing Higgs TTS specials: {missing}")
+        self._special_ids = {t: vocab[t] for t in _SPECIALS}
+
+    # ── Buffers / RoPE ──
+
+    def _alloc_buffers(self) -> None:
+        from flash_rt.hardware.rtx.attn_backend_qwen3 import (
+            RtxFlashAttnBackendQwen3,
+        )
+
+        self._attn = RtxFlashAttnBackendQwen3(
+            max_seq=self.max_seq, max_q_seq=1, dtype=torch.bfloat16)
+        nc = self._cfg["num_codebooks"]
+        self._cb_offsets = (
+            torch.arange(nc, device=self.device) * self._cfg["codebook_vocab"])
+
+    def _build_rope_table(self) -> None:
+        hd = self._cfg["head_dim"]
+        theta = self._cfg["rope_theta"]
+        inv = 1.0 / (theta ** (
+            torch.arange(0, hd, 2, device=self.device, dtype=torch.float32) / hd))
+        pos = torch.arange(self.max_seq, device=self.device, dtype=torch.float32)
+        f = torch.outer(pos, inv)  # [max_seq, hd/2]
+        self._rope_cos = f.cos().to(torch.bfloat16).contiguous()
+        self._rope_sin = f.sin().to(torch.bfloat16).contiguous()
+
+    # ── Forward ──
+
+    def _layer(self, fvk, L, h, t):
+        c = self._cfg
+        H, NQ, NKV, HD = (c["hidden"], c["num_q_heads"],
+                          c["num_kv_heads"], c["head_dim"])
+        INTER, eps = c["intermediate"], c["rms_norm_eps"]
+        w = self._weights["layers"][L]
+        s = torch.cuda.current_stream().cuda_stream
+        bf16 = torch.bfloat16
+
+        def rms(x, weight, M, K):
+            out = torch.empty(M, K, device=self.device, dtype=bf16)
+            fvk.rms_norm(x.contiguous().data_ptr(), weight.data_ptr(),
+                         out.data_ptr(), M, K, eps, s)
+            return out
+
+        def mm(x, weight, M, N, K):
+            out = torch.empty(M, N, device=self.device, dtype=bf16)
+            fvk.bf16_matmul_qwen36_bf16(x.contiguous().data_ptr(),
+                                        weight.data_ptr(), out.data_ptr(),
+                                        M, N, K, s)
+            return out
+
+        xn = rms(h, w["in_norm"], 1, H)
+        q = mm(xn, w["q"], 1, NQ * HD, H).view(NQ, HD).contiguous()
+        k = mm(xn, w["k"], 1, NKV * HD, H).view(NKV, HD).contiguous()
+        v = mm(xn, w["v"], 1, NKV * HD, H).view(NKV, HD).contiguous()
+        cos_t = self._rope_cos[t]
+        sin_t = self._rope_sin[t]
+        fvk.qwen3_q_norm_rope_qstage_bf16(
+            q_pre=q.data_ptr(), q_norm_w=w["qn"].data_ptr(),
+            cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
+            q_buf_dst=self._attn.Q_buf[:, :1].data_ptr(),
+            n_q_heads=NQ, eps=eps, stream=s)
+        fvk.qwen3_k_norm_rope_kvwrite_bf16(
+            k_pre=k.data_ptr(), v_pre=v.data_ptr(), k_norm_w=w["kn"].data_ptr(),
+            cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
+            k_cache_dst=self._attn.K_cache[L, t:t + 1].data_ptr(),
+            v_cache_dst=self._attn.V_cache[L, t:t + 1].data_ptr(),
+            n_kv_heads=NKV, eps=eps, stream=s)
+        self._attn.run("full", L, 1, kv_seq=t + 1, causal=True,
+                       softmax_scale=HD ** -0.5)
+        ao = self._attn.O_buf[:, :1].reshape(1, NQ * HD).to(bf16)
+        h = (h.float() + mm(ao, w["o"], 1, H, NQ * HD).float()).to(bf16)
+        xn2 = rms(h, w["post_norm"], 1, H)
+        gate = mm(xn2, w["gate"], 1, INTER, H)
+        up = mm(xn2, w["up"], 1, INTER, H)
+        act = torch.empty(1, INTER, device=self.device, dtype=bf16)
+        fvk.silu_mul_qwen36_bf16(gate.contiguous().data_ptr(),
+                                 up.contiguous().data_ptr(),
+                                 act.data_ptr(), INTER, s)
+        h = (h.float() + mm(act, w["down"], 1, H, INTER).float()).to(bf16)
+        return h
+
+    def _step(self, fvk, embed_row, t):
+        c = self._cfg
+        H = c["hidden"]
+        h = embed_row
+        for L in range(c["num_layers"]):
+            h = self._layer(fvk, L, h, t)
+        s = torch.cuda.current_stream().cuda_stream
+        hn = torch.empty(1, H, device=self.device, dtype=torch.bfloat16)
+        fvk.rms_norm(h.contiguous().data_ptr(),
+                     self._weights["final_norm"].data_ptr(),
+                     hn.data_ptr(), 1, H, c["rms_norm_eps"], s)
+        return hn
+
+    def _logits(self, hn):
+        cb = self._weights["codebook"]
+        nc, cv = self._cfg["num_codebooks"], self._cfg["codebook_vocab"]
+        return (hn.float() @ cb.float().t()).view(nc, cv)
+
+    def _embed_codes(self, codes):
+        cb = self._weights["codebook"]
+        ids = codes.to(self.device).long() + self._cb_offsets
+        return F.embedding(ids, cb).sum(0, keepdim=True)
+
+    # ── Public API ──
+
+    def build_prompt(self, text: str) -> list[int]:
+        """Zero-shot TTS prompt: <|tts|> <|text|> tok(text) <|audio|>."""
+        ids = [self._special_ids["<|tts|>"], self._special_ids["<|text|>"]]
+        ids += self._tokenizer.encode(text, add_special_tokens=False)
+        ids.append(self._special_ids["<|audio|>"])
+        return ids
+
+    def set_prompt(self, text: str) -> None:
+        self._prompt_ids = self.build_prompt(text)
+        self._attn.reset_cache()
+
+    @torch.no_grad()
+    def predict(self, text: str | None = None) -> torch.Tensor:
+        """Generate acoustic codes for ``text`` (greedy, delay/EOC).
+
+        Returns raw codes of shape ``[T, num_codebooks]`` (int64, CPU);
+        feed them to the Higgs codec to synthesise a 24 kHz waveform.
+        """
+        import time
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        if text is not None:
+            self.set_prompt(text)
+        if self._prompt_ids is None:
+            raise RuntimeError("no prompt set; call set_prompt() or pass text")
+
+        c = self._cfg
+        nc = c["num_codebooks"]
+        boc, eoc = self.DIMS.boc_id, self.DIMS.eoc_id
+        te = self._weights["text_embed"]
+
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        self._attn.reset_cache()
+        ids = self._prompt_ids
+        for t, tok in enumerate(ids):
+            row = F.embedding(
+                torch.tensor([tok], device=self.device), te)
+            hn = self._step(fvk, row, t)
+        P = len(ids)
+
+        delay, eoc_countdown, done = 0, None, False
+        delayed = []
+        for j in range(self.max_new_frames):
+            codes = self._logits(hn).argmax(-1).clone()
+            if delay < nc:
+                if delay + 1 < nc:
+                    codes[delay + 1:] = boc
+                delay += 1
+            elif eoc_countdown is not None:
+                eoc_countdown -= 1
+                if eoc_countdown <= 0:
+                    done = True
+            elif int(codes[0]) == eoc:
+                eoc_countdown = nc - 2
+            if done:
+                break
+            delayed.append(codes.clone())
+            hn = self._step(fvk, self._embed_codes(codes), P + j)
+
+        torch.cuda.synchronize()
+        self.latency_records.append((time.perf_counter() - t0) * 1000.0)
+        if not delayed:
+            return torch.empty(0, nc, dtype=torch.long)
+        grid = torch.stack(delayed)            # [L, nc] delayed
+        T = grid.shape[0] - (nc - 1)
+        if T <= 0:
+            return torch.empty(0, nc, dtype=torch.long)
+        return torch.stack([grid[i:i + T, i] for i in range(nc)], dim=1).cpu()

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -303,40 +303,39 @@ class HiggsAudioV3TorchFrontendRtx:
             return self._fp8_decoder.step(t)[0]
         return self._logits(self._step(fvk, embed_row, t))
 
+    # ── split surface (committed streaming seam for the serving layer) ──
+    # prefill once -> decode_stream yields un-delayed [nc] frames as they
+    # complete. The delay pattern means an un-delayed frame t is only complete
+    # after nc-1 further frames decode, so the stream carries a fixed nc-1
+    # holdback; every yielded frame is already committed to the KV state.
+
     @torch.no_grad()
-    def predict(self, text: str | None = None) -> torch.Tensor:
-        """Generate acoustic codes for ``text`` (greedy, delay/EOC).
-
-        Returns raw codes of shape ``[T, num_codebooks]`` (int64, CPU);
-        feed them to :meth:`synthesize` (or the Higgs codec) for a 24 kHz wave.
-        """
-        import time
-
+    def prefill(self, prompt_ids: list[int] | None = None) -> int:
+        """Run the prompt prefill; returns cur_pos (= prompt length)."""
         from flash_rt import flash_rt_kernels as fvk
-
-        if text is not None:
-            self.set_prompt(text)
+        if prompt_ids is not None:
+            self._prompt_ids = list(prompt_ids)
         if self._prompt_ids is None:
-            raise RuntimeError("no prompt set; call set_prompt() or pass text")
+            raise RuntimeError("no prompt set; call set_prompt()/pass prompt_ids")
         if self.fp8:
             self._ensure_fp8()
-
-        c = self._cfg
-        nc = c["num_codebooks"]
-        boc, eoc = self.DIMS.boc_id, self.DIMS.eoc_id
-        te = self._weights["text_embed"]
-
-        torch.cuda.synchronize()
-        t0 = time.perf_counter()
         self._attn.reset_cache()
-        ids = self._prompt_ids
-        for t, tok in enumerate(ids):
+        te = self._weights["text_embed"]
+        for t, tok in enumerate(self._prompt_ids):
             row = F.embedding(torch.tensor([tok], device=self.device), te)
-            logits = self._frame_logits(fvk, row, t)
-        P = len(ids)
+            self._gen_logits = self._frame_logits(fvk, row, t)
+        self._gen_pos = len(self._prompt_ids)
+        return self._gen_pos
 
+    @torch.no_grad()
+    def decode_stream(self):
+        """Yield committed un-delayed ``[nc]`` int code frames (cpu) as ready."""
+        from flash_rt import flash_rt_kernels as fvk
+        nc = self._cfg["num_codebooks"]
+        boc, eoc = self.DIMS.boc_id, self.DIMS.eoc_id
+        P, logits = self._gen_pos, self._gen_logits
         delay, eoc_countdown, done = 0, None, False
-        delayed = []
+        window: list[torch.Tensor] = []
         for j in range(self.max_new_frames):
             codes = logits.argmax(-1).clone()
             if delay < nc:
@@ -351,18 +350,35 @@ class HiggsAudioV3TorchFrontendRtx:
                 eoc_countdown = nc - 2
             if done:
                 break
-            delayed.append(codes.clone())
+            window.append(codes.clone())
+            if len(window) >= nc:                       # frame (len-nc) complete
+                base = len(window) - nc
+                yield torch.stack(
+                    [window[base + i][i] for i in range(nc)]).cpu()
             logits = self._frame_logits(fvk, self._embed_codes(codes), P + j)
 
+    @torch.no_grad()
+    def predict(self, text: str | None = None) -> torch.Tensor:
+        """Generate acoustic codes for ``text`` (greedy, delay/EOC).
+
+        Returns raw codes of shape ``[T, num_codebooks]`` (int64, CPU);
+        feed them to :meth:`synthesize` (or the Higgs codec) for a 24 kHz wave.
+        """
+        import time
+
+        if text is not None:
+            self.set_prompt(text)
+        nc = self._cfg["num_codebooks"]
+
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        self.prefill()
+        frames = list(self.decode_stream())
         torch.cuda.synchronize()
         self.latency_records.append((time.perf_counter() - t0) * 1000.0)
-        if not delayed:
+        if not frames:
             return torch.empty(0, nc, dtype=torch.long)
-        grid = torch.stack(delayed)            # [L, nc] delayed
-        T = grid.shape[0] - (nc - 1)
-        if T <= 0:
-            return torch.empty(0, nc, dtype=torch.long)
-        return torch.stack([grid[i:i + T, i] for i in range(nc)], dim=1).cpu()
+        return torch.stack(frames)             # [T, nc] un-delayed
 
     @torch.no_grad()
     def synthesize(self, codes: torch.Tensor) -> torch.Tensor:

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -56,6 +56,11 @@ class HiggsAudioV3TorchFrontendRtx:
         self.max_seq = int(max_seq)
         self.max_new_frames = int(max_new_frames)
         self.fp8 = bool(fp8)
+        # Single position-agnostic decode CUDA graph (devpos KV-write + FA2
+        # seqused_k). On by default for FP8; set FLASHRT_HIGGS_GRAPH=0 to force
+        # the eager decode path.
+        self._use_graph = self.fp8 and os.environ.get(
+            "FLASHRT_HIGGS_GRAPH", "1") != "0"
 
         self._tokenizer: Any = None
         self._special_ids: dict[str, int] = {}
@@ -303,6 +308,15 @@ class HiggsAudioV3TorchFrontendRtx:
             return self._fp8_decoder.step(t)[0]
         return self._logits(self._step(fvk, embed_row, t))
 
+    def _decode_logits(self, fvk, embed_row, t):
+        """Decode-position logits; uses the position-agnostic graph when on."""
+        if self._use_graph:
+            dec = self._fp8_decoder
+            if getattr(dec, "_graph", None) is None:
+                dec.capture_graph(embed_row, t)   # one-time, any position
+            return dec.decode_graph(embed_row, t)[0]
+        return self._frame_logits(fvk, embed_row, t)
+
     # ── split surface (committed streaming seam for the serving layer) ──
     # prefill once -> decode_stream yields un-delayed [nc] frames as they
     # complete. The delay pattern means an un-delayed frame t is only complete
@@ -355,7 +369,7 @@ class HiggsAudioV3TorchFrontendRtx:
                 base = len(window) - nc
                 yield torch.stack(
                     [window[base + i][i] for i in range(nc)]).cpu()
-            logits = self._frame_logits(fvk, self._embed_codes(codes), P + j)
+            logits = self._decode_logits(fvk, self._embed_codes(codes), P + j)
 
     @torch.no_grad()
     def predict(self, text: str | None = None) -> torch.Tensor:

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -61,15 +61,13 @@ class HiggsAudioV3TorchFrontendRtx:
         self.max_new_frames = int(max_new_frames)
         self.max_prefill_tokens = int(max_prefill_tokens)
         self.fp8 = bool(fp8)
-        # Batched single-pass prompt prefill (M=P) instead of P eager M=1 steps.
-        # On by default for FP8; set FLASHRT_HIGGS_BATCHED_PREFILL=0 for eager.
-        self._batched_prefill = self.fp8 and os.environ.get(
+        # Batched single-pass prompt prefill (M=P) instead of P eager M=1 steps
+        # (both FP8 and BF16 paths). Set FLASHRT_HIGGS_BATCHED_PREFILL=0 for eager.
+        self._batched_prefill = os.environ.get(
             "FLASHRT_HIGGS_BATCHED_PREFILL", "1") != "0"
         # Single position-agnostic decode CUDA graph (devpos KV-write + FA2
-        # seqused_k). On by default for FP8; set FLASHRT_HIGGS_GRAPH=0 to force
-        # the eager decode path.
-        self._use_graph = self.fp8 and os.environ.get(
-            "FLASHRT_HIGGS_GRAPH", "1") != "0"
+        # seqused_k), both paths. Set FLASHRT_HIGGS_GRAPH=0 to force eager decode.
+        self._use_graph = os.environ.get("FLASHRT_HIGGS_GRAPH", "1") != "0"
 
         self._tokenizer: Any = None
         self._special_ids: dict[str, int] = {}
@@ -80,7 +78,8 @@ class HiggsAudioV3TorchFrontendRtx:
         self._rope_sin = None
         self._prompt_ids: list[int] | None = None
         self._resident_ids: list[int] | None = None   # KV currently on GPU
-        self._fp8_decoder: Any = None
+        self._dec: Any = None                          # active decode engine
+        self._fp8_decoder: Any = None                  # back-compat alias
         self._codec: Any = None
         self.latency_records: list[float] = []
 
@@ -204,79 +203,6 @@ class HiggsAudioV3TorchFrontendRtx:
         self._rope_cos = f.cos().to(torch.bfloat16).contiguous()
         self._rope_sin = f.sin().to(torch.bfloat16).contiguous()
 
-    # ── Forward ──
-
-    def _layer(self, fvk, L, h, t):
-        c = self._cfg
-        H, NQ, NKV, HD = (c["hidden"], c["num_q_heads"],
-                          c["num_kv_heads"], c["head_dim"])
-        INTER, eps = c["intermediate"], c["rms_norm_eps"]
-        w = self._weights["layers"][L]
-        s = torch.cuda.current_stream().cuda_stream
-        bf16 = torch.bfloat16
-
-        def rms(x, weight, M, K):
-            out = torch.empty(M, K, device=self.device, dtype=bf16)
-            fvk.rms_norm(x.contiguous().data_ptr(), weight.data_ptr(),
-                         out.data_ptr(), M, K, eps, s)
-            return out
-
-        def mm(x, weight, M, N, K):
-            out = torch.empty(M, N, device=self.device, dtype=bf16)
-            fvk.bf16_matmul_qwen36_bf16(x.contiguous().data_ptr(),
-                                        weight.data_ptr(), out.data_ptr(),
-                                        M, N, K, s)
-            return out
-
-        xn = rms(h, w["in_norm"], 1, H)
-        q = mm(xn, w["q"], 1, NQ * HD, H).view(NQ, HD).contiguous()
-        k = mm(xn, w["k"], 1, NKV * HD, H).view(NKV, HD).contiguous()
-        v = mm(xn, w["v"], 1, NKV * HD, H).view(NKV, HD).contiguous()
-        cos_t = self._rope_cos[t]
-        sin_t = self._rope_sin[t]
-        fvk.qwen3_q_norm_rope_qstage_bf16(
-            q_pre=q.data_ptr(), q_norm_w=w["qn"].data_ptr(),
-            cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
-            q_buf_dst=self._attn.Q_buf[:, :1].data_ptr(),
-            n_q_heads=NQ, eps=eps, stream=s)
-        fvk.qwen3_k_norm_rope_kvwrite_bf16(
-            k_pre=k.data_ptr(), v_pre=v.data_ptr(), k_norm_w=w["kn"].data_ptr(),
-            cos=cos_t.data_ptr(), sin=sin_t.data_ptr(),
-            k_cache_dst=self._attn.K_cache[L, t:t + 1].data_ptr(),
-            v_cache_dst=self._attn.V_cache[L, t:t + 1].data_ptr(),
-            n_kv_heads=NKV, eps=eps, stream=s)
-        self._attn.run("full", L, 1, kv_seq=t + 1, causal=True,
-                       softmax_scale=HD ** -0.5)
-        ao = self._attn.O_buf[:, :1].reshape(1, NQ * HD).to(bf16)
-        h = (h.float() + mm(ao, w["o"], 1, H, NQ * HD).float()).to(bf16)
-        xn2 = rms(h, w["post_norm"], 1, H)
-        gate = mm(xn2, w["gate"], 1, INTER, H)
-        up = mm(xn2, w["up"], 1, INTER, H)
-        act = torch.empty(1, INTER, device=self.device, dtype=bf16)
-        fvk.silu_mul_qwen36_bf16(gate.contiguous().data_ptr(),
-                                 up.contiguous().data_ptr(),
-                                 act.data_ptr(), INTER, s)
-        h = (h.float() + mm(act, w["down"], 1, H, INTER).float()).to(bf16)
-        return h
-
-    def _step(self, fvk, embed_row, t):
-        c = self._cfg
-        H = c["hidden"]
-        h = embed_row
-        for L in range(c["num_layers"]):
-            h = self._layer(fvk, L, h, t)
-        s = torch.cuda.current_stream().cuda_stream
-        hn = torch.empty(1, H, device=self.device, dtype=torch.bfloat16)
-        fvk.rms_norm(h.contiguous().data_ptr(),
-                     self._weights["final_norm"].data_ptr(),
-                     hn.data_ptr(), 1, H, c["rms_norm_eps"], s)
-        return hn
-
-    def _logits(self, hn):
-        cb = self._weights["codebook"]
-        nc, cv = self._cfg["num_codebooks"], self._cfg["codebook_vocab"]
-        return (hn.float() @ cb.float().t()).view(nc, cv)
-
     def _embed_codes(self, codes):
         cb = self._weights["codebook"]
         ids = codes.to(self.device).long() + self._cb_offsets
@@ -304,17 +230,31 @@ class HiggsAudioV3TorchFrontendRtx:
         self._attn.reset_cache()
         self._resident_ids = None      # KV zeroed; nothing reusable resident
 
-    # ── FP8 / codec lazy init ──
+    # ── decoder / codec lazy init ──
 
-    def _ensure_fp8(self) -> None:
-        if self._fp8_decoder is not None:
+    def _ensure_decoder(self) -> None:
+        """Build the active decode engine: FP8 (W8A8, static-calibrated) when
+        ``fp8`` else BF16 (W16A16). Both expose the same surface — step /
+        prefill_batched(start_pos) / capture_graph / decode_graph — so the
+        frontend drives them identically (kernelised step + position-agnostic
+        graph + batched prefill + prefix reuse)."""
+        if self._dec is not None:
             return
-        from flash_rt.frontends.torch._higgs_audio_v3_fp8 import (
-            HiggsAudioV3Fp8Decoder,
-        )
-        dec = HiggsAudioV3Fp8Decoder(self)
-        dec.calibrate(self._prompt_ids)   # static activation scales (one-time)
-        self._fp8_decoder = dec
+        if self.fp8:
+            from flash_rt.frontends.torch._higgs_audio_v3_fp8 import (
+                HiggsAudioV3Fp8Decoder,
+            )
+            dec = HiggsAudioV3Fp8Decoder(self)
+            dec.calibrate(self._prompt_ids)   # static activation scales (once)
+        else:
+            from flash_rt.frontends.torch._higgs_audio_v3_bf16 import (
+                HiggsAudioV3Bf16Decoder,
+            )
+            dec = HiggsAudioV3Bf16Decoder(self)
+        self._dec = dec
+        self._fp8_decoder = dec if self.fp8 else None   # back-compat alias
+
+    _ensure_fp8 = _ensure_decoder        # back-compat alias
 
     def _ensure_codec(self) -> None:
         if self._codec is not None:
@@ -325,15 +265,13 @@ class HiggsAudioV3TorchFrontendRtx:
 
     def _frame_logits(self, fvk, embed_row, t):
         """[num_codebooks, codebook_vocab] logits for one frame at position t."""
-        if self.fp8:
-            self._fp8_decoder.set_input(embed_row)
-            return self._fp8_decoder.step(t)[0]
-        return self._logits(self._step(fvk, embed_row, t))
+        self._dec.set_input(embed_row)
+        return self._dec.step(t)[0]
 
     def _decode_logits(self, fvk, embed_row, t):
         """Decode-position logits; uses the position-agnostic graph when on."""
         if self._use_graph:
-            dec = self._fp8_decoder
+            dec = self._dec
             if getattr(dec, "_graph", None) is None:
                 dec.capture_graph(embed_row, t)   # one-time, any position
             return dec.decode_graph(embed_row, t)[0]
@@ -377,8 +315,7 @@ class HiggsAudioV3TorchFrontendRtx:
             self._prompt_ids = list(prompt_ids)
         if self._prompt_ids is None:
             raise RuntimeError("no prompt set; call set_prompt()/pass prompt_ids")
-        if self.fp8:
-            self._ensure_fp8()
+        self._ensure_decoder()
         P = len(self._prompt_ids)
         batched = self._batched_prefill and P <= self._attn._max_q_seq
         # Validate the cached-prefix claim against the resident KV (safety: never
@@ -392,7 +329,7 @@ class HiggsAudioV3TorchFrontendRtx:
             self._attn.reset_cache()      # cold prefill writes KV from pos 0
             cached_tokens = 0
         if batched:
-            self._gen_logits = self._fp8_decoder.prefill_batched(
+            self._gen_logits = self._dec.prefill_batched(
                 self._prompt_ids, start_pos=cached_tokens)[0]
         else:
             te = self._weights["text_embed"]

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -392,3 +392,50 @@ class HiggsAudioV3TorchFrontendRtx:
     def generate(self, text: str) -> torch.Tensor:
         """Full pipeline: text -> acoustic codes -> 24 kHz waveform ``[L]``."""
         return self.synthesize(self.predict(text))
+
+    SAMPLES_PER_FRAME = 960   # 24000 Hz / 25 Hz acoustic frame rate
+
+    @torch.no_grad()
+    def generate_stream(self, text: str, *, first_chunk: int = 8,
+                        chunk: int = 25, ctx: int = 8, holdback: int = 8):
+        """Stream 24 kHz audio chunks as frames decode (low TTFA).
+
+        Yields mono waveform chunks (cpu f32). ``first_chunk`` frames are emitted
+        as soon as they are committed (minimises time-to-first-audio), then
+        ``chunk`` frames at a time. The codec conv has a receptive field, so each
+        emitted frame is decoded inside a window with ``ctx`` frames of already-
+        emitted left context and ``holdback`` frames of not-yet-emitted right
+        context; only the centre frames' samples are released, so the streamed
+        waveform matches the one-shot ``synthesize`` (no boundary seams).
+        """
+        self._ensure_codec()
+        self.set_prompt(text)
+        self.prefill()
+        spf = self.SAMPLES_PER_FRAME
+        frames: list[torch.Tensor] = []
+        emitted = 0
+
+        def flush(ready: int):
+            nonlocal emitted
+            if ready <= emitted:
+                return None
+            left = min(ctx, emitted)
+            right = min(holdback, len(frames) - ready)
+            wav = self._codec.decode(torch.stack(frames[emitted - left:ready + right]))
+            n = ready - emitted
+            out = wav[left * spf:(left + n) * spf].clone()
+            emitted = ready
+            return out
+
+        target = first_chunk
+        for frame in self.decode_stream():
+            frames.append(frame)
+            ready = len(frames) - holdback           # frames with full right ctx
+            if ready - emitted >= target:
+                out = flush(ready)
+                if out is not None:
+                    yield out
+                    target = chunk
+        out = flush(len(frames))                     # tail (no right context)
+        if out is not None:
+            yield out

--- a/flash_rt/models/higgs_audio_v3/__init__.py
+++ b/flash_rt/models/higgs_audio_v3/__init__.py
@@ -1,0 +1,14 @@
+"""Higgs Audio v3 TTS (discrete multi-codebook path) on RTX SM120.
+
+The acoustic backbone is a standard dense Qwen3-4B; audio is produced by a
+fused multi-codebook embedding/head over an 8-codebook neural codec at 25 Hz.
+The hand-written forward path lives in
+``flash_rt.frontends.torch.higgs_audio_v3_rtx``.
+"""
+
+from flash_rt.models.higgs_audio_v3.pipeline_rtx import (
+    HiggsAudioV3Dims,
+    HiggsAudioV3Pipeline,
+)
+
+__all__ = ["HiggsAudioV3Dims", "HiggsAudioV3Pipeline"]

--- a/flash_rt/models/higgs_audio_v3/_codec/env_guard.py
+++ b/flash_rt/models/higgs_audio_v3/_codec/env_guard.py
@@ -1,0 +1,42 @@
+"""Import-time guards so the vendored Higgs codec loads on a stock install.
+
+Two upstream pitfalls, both unrelated to the codec's decode path:
+
+* ``kernels`` (an optional transformers acceleration package) constructs a
+  ``huggingface_hub`` strict dataclass with a ``str | None`` field that some
+  ``huggingface_hub`` versions reject at import, raising — not an ImportError —
+  when transformers touches ``PreTrainedAudioTokenizerBase``. Neutralising the
+  module makes transformers treat it as absent and degrade gracefully. The
+  codec decoder is pure conv/transpose and never needs it.
+* ``torchaudio`` is imported at the top of the tokenizer module but is only
+  exercised by the *encode* path (resampling). Decode never calls it, so a stub
+  with a valid ``__spec__`` (so transformers' ``find_spec`` probe succeeds)
+  lets the module import without the dependency.
+
+Call :func:`apply` before importing anything from ``transformers``.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+
+_applied = False
+
+
+def apply() -> None:
+    global _applied
+    if _applied:
+        return
+    # Neutralise the optional `kernels` package (broken-or-absent both fine).
+    if sys.modules.get("kernels") is None or "kernels" not in sys.modules:
+        sys.modules["kernels"] = None  # type: ignore[assignment]
+    # Stub torchaudio only if it is genuinely not installed.
+    if "torchaudio" not in sys.modules and importlib.util.find_spec("torchaudio") is None:
+        ta = types.ModuleType("torchaudio")
+        ta.__spec__ = importlib.machinery.ModuleSpec("torchaudio", loader=None)
+        ta.functional = types.ModuleType("torchaudio.functional")
+        sys.modules["torchaudio"] = ta
+        sys.modules["torchaudio.functional"] = ta.functional
+    _applied = True

--- a/flash_rt/models/higgs_audio_v3/_codec/tokenizer_config.json
+++ b/flash_rt/models/higgs_audio_v3/_codec/tokenizer_config.json
@@ -1,0 +1,129 @@
+{
+  "acoustic_model_config": {
+    "codebook_dim": 8,
+    "codebook_loss_weight": 1.0,
+    "codebook_size": 1024,
+    "commitment_loss_weight": 0.25,
+    "decoder_hidden_size": 1024,
+    "downsampling_ratios": [
+      8,
+      5,
+      4,
+      2,
+      3
+    ],
+    "encoder_hidden_size": 64,
+    "hidden_size": 256,
+    "hop_length": 960,
+    "model_type": "dac",
+    "n_codebooks": 9,
+    "quantizer_dropout": 0,
+    "sampling_rate": 16000,
+    "upsampling_ratios": [
+      8,
+      5,
+      4,
+      2,
+      3
+    ]
+  },
+  "architectures": [
+    "HiggsAudioV2TokenizerModel"
+  ],
+  "block_dilations": [
+    1,
+    1
+  ],
+  "channel_ratios": [
+    1,
+    1
+  ],
+  "codebook_dim": 64,
+  "codebook_size": 1024,
+  "downsample_factor": 320,
+  "dtype": "float32",
+  "initializer_range": 0.02,
+  "kernel_size": 3,
+  "model_type": "higgs_audio_v2_tokenizer",
+  "sample_rate": 24000,
+  "semantic_model_config": {
+    "activation_dropout": 0.1,
+    "apply_spec_augment": true,
+    "attention_dropout": 0.1,
+    "bos_token_id": 1,
+    "classifier_proj_size": 256,
+    "conv_bias": false,
+    "conv_dim": [
+      512,
+      512,
+      512,
+      512,
+      512,
+      512,
+      512
+    ],
+    "conv_kernel": [
+      10,
+      3,
+      3,
+      3,
+      3,
+      2,
+      2
+    ],
+    "conv_pos_batch_norm": false,
+    "conv_stride": [
+      5,
+      2,
+      2,
+      2,
+      2,
+      2,
+      2
+    ],
+    "ctc_loss_reduction": "sum",
+    "ctc_zero_infinity": false,
+    "do_stable_layer_norm": false,
+    "eos_token_id": 2,
+    "feat_extract_activation": "gelu",
+    "feat_extract_norm": "group",
+    "feat_proj_dropout": 0.0,
+    "feat_proj_layer_norm": true,
+    "final_dropout": 0.1,
+    "hidden_act": "gelu",
+    "hidden_dropout": 0.1,
+    "hidden_size": 768,
+    "initializer_range": 0.02,
+    "intermediate_size": 3072,
+    "layer_norm_eps": 1e-05,
+    "layerdrop": 0.1,
+    "mask_feature_length": 10,
+    "mask_feature_min_masks": 0,
+    "mask_feature_prob": 0.0,
+    "mask_time_length": 10,
+    "mask_time_min_masks": 2,
+    "mask_time_prob": 0.0,
+    "model_type": "hubert",
+    "num_attention_heads": 12,
+    "num_conv_pos_embedding_groups": 16,
+    "num_conv_pos_embeddings": 128,
+    "num_feat_extract_layers": 7,
+    "num_hidden_layers": 12,
+    "pad_token_id": 0,
+    "use_weighted_layer_sum": false,
+    "vocab_size": 32
+  },
+  "semantic_sample_rate": 16000,
+  "strides": [
+    1,
+    1
+  ],
+  "target_bandwidths": [
+    0.5,
+    1,
+    1.5,
+    2
+  ],
+  "transformers_version": "5.3.0.dev0",
+  "unit_kernel_size": 3
+}

--- a/flash_rt/models/higgs_audio_v3/_codec/tokenizer_model.py
+++ b/flash_rt/models/higgs_audio_v3/_codec/tokenizer_model.py
@@ -1,0 +1,940 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vendored ``HiggsAudioV2TokenizerConfig`` / ``HiggsAudioV2TokenizerModel``.
+
+Upstream reference: https://github.com/huggingface/transformers/pull/40294
+"""
+
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchaudio
+from transformers import AutoConfig, DacConfig, HubertConfig, WavLMConfig
+from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import ModelOutput, logging
+
+# Patch vs. upstream: ``transformers<5`` doesn't ship the ``initialization``
+# module. Route everything to ``torch.nn.init`` and add ``copy_`` (the only
+# call in this file that isn't already in torch's namespace).
+try:  # pragma: no cover - only true on transformers>=5
+    from transformers import initialization as init  # type: ignore[attr-defined]
+except ImportError:
+    import torch.nn.init as _torch_init
+
+    class _InitShim:
+        @staticmethod
+        def copy_(dst: torch.Tensor, src: torch.Tensor) -> None:
+            dst.copy_(src)
+
+        def __getattr__(self, name: str):
+            return getattr(_torch_init, name)
+
+    init = _InitShim()
+
+from transformers.modeling_utils import PreTrainedAudioTokenizerBase
+from transformers.models.auto import AutoModel
+
+logger = logging.get_logger(__name__)
+
+
+def conv1d_output_length(module: "torch.nn.Conv1d", input_length: int) -> int:
+    """
+    Computes the output length of a 1D convolution layer according to torch's documentation:
+    https://docs.pytorch.org/docs/stable/generated/torch.nn.Conv1d.html
+    """
+    return int(
+        (
+            input_length
+            + 2 * module.padding[0]
+            - module.dilation[0] * (module.kernel_size[0] - 1)
+            - 1
+        )
+        / module.stride[0]
+        + 1
+    )
+
+
+class HiggsAudioV2TokenizerConfig(PretrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of an [`HiggsAudioV2TokenizerModel`]. It is used to instantiate a
+    HiggsAudioV2Tokenizer model according to the specified arguments, defining the model architecture. Instantiating a configuration
+    with the defaults will yield a similar configuration to that of the [`Higgs Audio v2 Tokenizer`](https://huggingface.co/bosonai/higgs-audio-v2-tokenizer).
+    e.g. [bosonai/higgs-audio-v2-tokenizer](https://huggingface.co/bosonai/higgs-audio-v2-tokenizer)
+
+    Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PreTrainedConfig`] for more information.
+
+    Args:
+            target_bandwidths (`List[float]`, *optional*, defaults to `[0.5, 1, 1.5, 2, 4]`):
+                The range of different bandwidths (in kbps) the model can encode audio with.
+            sample_rate (`int`, *optional*, defaults to 16000):
+                The sampling rate at which the audio waveform should be digitalized, in hertz (Hz).
+            kernel_size (`int`, *optional*, defaults to 3):
+                Kernel size for the initial semantic convolution.
+            channel_ratios (`List[float]`, *optional*, defaults to `[1, 1]`):
+                Expansion factors for the number of output channels in each semantic block.
+            strides (`List[int]`, *optional*, defaults to `[1, 1]`):
+                Strides for each semantic encoder block.
+            block_dilations (`List[int]`, *optional*, defaults to `[1, 1]`):
+                Dilation factors for the residual units in semantic blocks.
+            unit_kernel_size (`int`, *optional*, defaults to 3):
+                Kernel size inside each ResidualUnit in semantic blocks.
+            codebook_size (`int`, *optional*, defaults to 1024):
+                Number of entries in each residual quantizer's codebook.
+            codebook_dim (`int`, *optional*):
+                Dimensionality of each codebook vector. Defaults to sum of hidden size of acoustic and semantic models.
+            initializer_range (`float`, *optional*, defaults to 0.02):
+                Standard deviation of the truncated normal initializer for all weight matrices.
+            acoustic_model_config (`Union[Dict, DacConfig]`, *optional*):
+                An instance of the configuration for the acoustic (DAC) model.
+            semantic_model_config (`Union[Dict, HubertConfig, WavLMConfig]`, *optional*):
+                An instance of the configuration object for the semantic (HuBERT) model.
+
+    Example:
+
+    ```python
+    >>> from transformers import HiggsAudioV2TokenizerModel, HiggsAudioV2TokenizerConfig
+
+    >>> # Initializing configuration
+    >>> configuration = HiggsAudioV2TokenizerConfig()
+
+    >>> # Initializing a model (with random weights) from the configuration
+    >>> model = HiggsAudioV2TokenizerModel(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```"""
+
+    model_type = "higgs_audio_v2_tokenizer"
+
+    sub_configs = {
+        "acoustic_model_config": DacConfig,
+        "semantic_model_config": AutoConfig,
+    }
+
+    def __init__(
+        self,
+        target_bandwidths=None,
+        sample_rate=24000,
+        kernel_size=3,
+        channel_ratios=[1, 1],
+        strides=[1, 1],
+        block_dilations=[1, 1],
+        unit_kernel_size=3,
+        codebook_size=1024,
+        codebook_dim=None,
+        initializer_range=0.02,
+        acoustic_model_config=None,
+        semantic_model_config=None,
+        semantic_sample_rate=16000,
+        downsample_factor=320,
+        **kwargs,
+    ):
+        if acoustic_model_config is None:
+            self.acoustic_model_config = DacConfig(
+                encoder_hidden_size=64,
+                # NOTE: original DAC uses [2, 4, 8, 8] `downsampling ratios`, namely reverse of `upsampling_ratios`
+                # (not sure if intentional by HiggsAudioV2Tokenizer but we keep it)
+                downsampling_ratios=[8, 5, 4, 2],
+                decoder_hidden_size=1024,
+                upsampling_ratios=[8, 5, 4, 2],
+                hidden_size=256,
+            )
+        elif isinstance(acoustic_model_config, dict):
+            self.acoustic_model_config = DacConfig(**acoustic_model_config)
+        elif isinstance(acoustic_model_config, DacConfig):
+            self.acoustic_model_config = acoustic_model_config
+        else:
+            raise ValueError(
+                f"acoustic_model_config must be a dict or DacConfig instance, but got {type(acoustic_model_config)}"
+            )
+
+        if semantic_model_config is None:
+            self.semantic_model_config = HubertConfig()
+        elif isinstance(semantic_model_config, dict):
+            if "_name_or_path" in semantic_model_config:
+                # If the config is a path, load it using AutoConfig
+                self.semantic_model_config = AutoConfig.from_pretrained(
+                    semantic_model_config["_name_or_path"]
+                )
+            else:
+                # assume HubertConfig as probably created from scratch
+                logger.warning(
+                    "Could not determine semantic model type from config architecture. Defaulting to `HubertConfig`."
+                )
+                self.semantic_model_config = HubertConfig(**semantic_model_config)
+        elif isinstance(semantic_model_config, WavLMConfig) or isinstance(
+            semantic_model_config, HubertConfig
+        ):
+            self.semantic_model_config = semantic_model_config
+        else:
+            raise ValueError(
+                f"semantic_model_config must be a dict, HubertConfig, or WavLMConfig instance, but got {type(semantic_model_config)}"
+            )
+
+        if target_bandwidths is None:
+            target_bandwidths = [0.5, 1, 1.5, 2, 4]
+
+        self.target_bandwidths = target_bandwidths
+        self.sample_rate = sample_rate
+        self.kernel_size = kernel_size
+        self.channel_ratios = channel_ratios
+        self.strides = strides
+        self.block_dilations = block_dilations
+        self.unit_kernel_size = unit_kernel_size
+        self.codebook_size = codebook_size
+        self.initializer_range = initializer_range
+        if codebook_dim is None:
+            codebook_dim = (
+                self.acoustic_model_config.hidden_size
+                + self.semantic_model_config.hidden_size
+            )
+        self.codebook_dim = codebook_dim
+
+        super().__init__(**kwargs)
+
+        self.semantic_sample_rate = semantic_sample_rate
+        self.downsample_factor = downsample_factor
+
+    @property
+    def frame_rate(self) -> float:
+        return self.sample_rate / self.hop_length
+
+    @property
+    def semantic_hidden_size(self) -> int:
+        return self.semantic_model_config.hidden_size
+
+    @property
+    def hop_length(self) -> int:
+        return int(np.prod(self.acoustic_model_config.downsampling_ratios))
+
+    @property
+    def codebook_nbits(self) -> int:
+        return math.ceil(math.log2(self.codebook_size))
+
+    @property
+    def hidden_size(self) -> int:
+        return (
+            self.acoustic_model_config.hidden_size
+            + self.semantic_model_config.hidden_size
+        )
+
+    @property
+    def num_quantizers(self) -> int:
+        return int(
+            1000 * self.target_bandwidths[-1] // (self.frame_rate * self.codebook_nbits)
+        )
+
+    @property
+    def semantic_downsample_factor(self):
+        return int(
+            self.hop_length
+            / (self.sample_rate / self.semantic_sample_rate)
+            / self.downsample_factor
+        )
+
+
+class HiggsAudioV2TokenizerPreTrainedModel(PreTrainedAudioTokenizerBase):
+    """
+    An abstract class to handle weights initialization and a simple interface for downloading and loading pretrained
+    models.
+    """
+
+    config_class = HiggsAudioV2TokenizerConfig
+    base_model_prefix = "higgs_audio_v2_tokenizer"
+    main_input_name = "input_values"
+    input_modalities = "audio"
+    _no_split_modules = ["HiggsAudioV2TokenizerResidualVectorQuantization"]
+
+    @torch.no_grad()
+    def _init_weights(self, module):
+        """Initialize the weights"""
+        if isinstance(module, nn.Linear):
+            init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None:
+                init.zeros_(module.bias)
+        elif isinstance(module, (nn.LayerNorm, nn.GroupNorm)):
+            init.zeros_(module.bias)
+            init.ones_(module.weight)
+        elif isinstance(module, nn.Conv1d):
+            init.kaiming_normal_(module.weight)
+            if module.bias is not None:
+                k = math.sqrt(
+                    module.groups / (module.in_channels * module.kernel_size[0])
+                )
+                init.uniform_(module.bias, a=-k, b=k)
+        elif module.__class__.__name__ == "Snake1d":
+            init.ones_(module.alpha)
+        elif isinstance(module, nn.ConvTranspose1d):
+            module.reset_parameters()
+        elif isinstance(module, nn.Embedding):
+            init.normal_(module.weight, mean=0.0, std=0.02)
+        elif isinstance(module, HiggsAudioV2TokenizerModel):
+            # The conv1d are not handled correctly, as `self.acoustic_encoder/decoder` are initialized from a PreTrainedModel,
+            # but then only the submodules are used (which are not PreTrainedModels...) -> here we reinit them as in DacModel
+            for submodule in module.acoustic_encoder.modules():
+                if isinstance(submodule, nn.Conv1d):
+                    init.trunc_normal_(submodule.weight, std=0.02)
+                    init.constant_(submodule.bias, 0)
+            for submodule in module.acoustic_decoder.modules():
+                if isinstance(submodule, nn.Conv1d):
+                    init.trunc_normal_(submodule.weight, std=0.02)
+                    init.constant_(submodule.bias, 0)
+        elif isinstance(module, HiggsAudioV2TokenizerEuclideanCodebook):
+            init.copy_(module.inited, torch.Tensor([True]))
+            init.zeros_(module.cluster_size)
+            init.zeros_(module.embed)
+            init.zeros_(module.embed_avg)
+
+    def apply_weight_norm(self):
+        """Apply weight norm in the acoustic encoder and decoder because the original checkpoint has weight norm applied."""
+        weight_norm = torch.nn.utils.weight_norm
+        if hasattr(torch.nn.utils.parametrizations, "weight_norm"):
+            weight_norm = torch.nn.utils.parametrizations.weight_norm
+
+        weight_norm(self.acoustic_encoder.conv1)
+        weight_norm(self.acoustic_encoder.conv2)
+
+        for block in self.acoustic_encoder.block:
+            weight_norm(block.conv1)
+            for res_unit in (block.res_unit1, block.res_unit2, block.res_unit3):
+                weight_norm(res_unit.conv1)
+                weight_norm(res_unit.conv2)
+
+        weight_norm(self.acoustic_decoder.conv1, name="weight")
+        weight_norm(self.acoustic_decoder.conv2, name="weight")
+
+        for block in self.acoustic_decoder.block:
+            weight_norm(block.conv_t1, name="weight")
+            for res_unit in (block.res_unit1, block.res_unit2, block.res_unit3):
+                weight_norm(res_unit.conv1, name="weight")
+                weight_norm(res_unit.conv2, name="weight")
+
+    def remove_weight_norm(self):
+        """Remove the weight norm from the acoustic encoder and decoder."""
+        for module in (self.acoustic_encoder, self.acoustic_decoder):
+            for m in module.modules():
+                try:
+                    torch.nn.utils.remove_weight_norm(m, name="weight")
+                except (ValueError, AttributeError):
+                    pass
+                if hasattr(m, "parametrizations") and "weight" in m.parametrizations:
+                    torch.nn.utils.parametrize.remove_parametrizations(
+                        m, "weight", leave_parametrized=True
+                    )
+
+    @lru_cache
+    def _get_conv1d_layers(self, module):
+        """
+        Recursively iterate to fetch all Conv1d layers.
+        """
+
+        def get_conv1d_layers_recursive(module: nn.Module):
+            params_list = []
+
+            if isinstance(module, nn.Conv1d):
+                params_list.append(module)
+
+            # Recursively check all child modules
+            for child in module.children():
+                params_list.extend(get_conv1d_layers_recursive(child))
+
+            return params_list
+
+        return tuple(get_conv1d_layers_recursive(module))
+
+    def _get_conv1d_output_lengths(self, input_length, module=None):
+        """
+        For a given module, compute the output length that would be obtained after all Conv1d layers.
+        """
+        if module is None:
+            module = self
+
+        conv1d_layers = self._get_conv1d_layers(module)
+
+        for layer in conv1d_layers:
+            input_length = conv1d_output_length(layer, input_length)
+
+        return input_length
+
+
+class HiggsAudioV2TokenizerEuclideanCodebook(nn.Module):
+    """Codebook with Euclidean distance."""
+
+    def __init__(self, config):
+        super().__init__()
+        embed = torch.zeros(config.codebook_size, config.codebook_dim)
+        self.codebook_size = config.codebook_size
+        self.register_buffer("inited", torch.Tensor([True]))
+        self.register_buffer("cluster_size", torch.zeros(config.codebook_size))
+        self.register_buffer("embed", embed)
+        self.register_buffer("embed_avg", embed.clone())
+
+    def quantize(self, hidden_states):
+        embed = self.embed.t()
+        scaled_states = hidden_states.pow(2).sum(1, keepdim=True)
+        dist = -(
+            scaled_states
+            - 2 * hidden_states @ embed
+            + embed.pow(2).sum(0, keepdim=True)
+        )
+        embed_ind = dist.max(dim=-1).indices
+        return embed_ind
+
+    def encode(self, hidden_states):
+        shape = hidden_states.shape
+        hidden_states = hidden_states.reshape((-1, shape[-1]))
+        embed_ind = self.quantize(hidden_states)
+        embed_ind = embed_ind.view(*shape[:-1])
+        return embed_ind
+
+    def decode(self, embed_ind):
+        quantized = F.embedding(embed_ind.to(self.embed.device), self.embed)
+        return quantized
+
+
+class HiggsAudioV2TokenizerVectorQuantization(nn.Module):
+    def __init__(self, config: HiggsAudioV2TokenizerConfig):
+        super().__init__()
+        self.codebook = HiggsAudioV2TokenizerEuclideanCodebook(config)
+        self.project_in = nn.Linear(config.hidden_size, config.codebook_dim)
+        self.project_out = nn.Linear(config.codebook_dim, config.hidden_size)
+
+    def encode(self, hidden_states):
+        hidden_states = hidden_states.permute(0, 2, 1)
+        hidden_states = self.project_in(hidden_states)
+        embed_in = self.codebook.encode(hidden_states)
+        return embed_in
+
+    def decode(self, embed_ind):
+        quantize = self.codebook.decode(embed_ind)
+        quantize = self.project_out(quantize)
+        quantize = quantize.permute(0, 2, 1)
+        return quantize
+
+
+@dataclass
+class HiggsAudioV2TokenizerOutput(ModelOutput):
+    """
+    Args:
+        audio_codes (`torch.LongTensor`  of shape `(batch_size, num_quantizers, codes_length)`, *optional*):
+            Discrete code indices computed using `model.encode`.
+        audio_values (`torch.FloatTensor` of shape `(batch_size, channels, num_samples)`, *optional*)
+            Decoded audio values obtained using the decoder part of HiggsAudioV2Tokenizer.
+    """
+
+    audio_codes: torch.LongTensor | None = None
+    audio_values: torch.FloatTensor | None = None
+
+
+@dataclass
+class HiggsAudioV2TokenizerEncoderOutput(ModelOutput):
+    """
+    Args:
+        audio_codes (`torch.LongTensor`  of shape `(batch_size, num_quantizers, codes_length)`, *optional*):
+            Discrete code indices computed using `model.encode`.
+    """
+
+    audio_codes: torch.LongTensor | None = None
+
+
+@dataclass
+class HiggsAudioV2TokenizerDecoderOutput(ModelOutput):
+    """
+    Args:
+        audio_values (`torch.FloatTensor`  of shape `(batch_size, channels, num_samples)`, *optional*):
+            Decoded audio values obtained using the decoder part of HiggsAudioV2Tokenizer.
+    """
+
+    audio_values: torch.FloatTensor | None = None
+
+
+class HiggsAudioV2TokenizerResidualUnit(nn.Module):
+    """Residual block for SemanticEncoder and SemanticDecoder used in HiggsAudioV2Tokenizer."""
+
+    def __init__(
+        self,
+        config: HiggsAudioV2TokenizerConfig,
+        in_channels: int,
+        out_channels: int,
+        dilation: int,
+    ):
+        super().__init__()
+        self.activation = nn.ELU()
+        padding = ((config.unit_kernel_size - 1) // 2) * dilation
+        self.conv1 = nn.Conv1d(
+            in_channels,
+            out_channels,
+            config.unit_kernel_size,
+            stride=1,
+            padding=padding,
+            dilation=dilation,
+            groups=1,
+            bias=False,
+        )
+        self.conv2 = nn.Conv1d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=1,
+            bias=False,
+        )
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        output_tensor = self.activation(hidden_state)
+        output_tensor = self.conv1(output_tensor)
+        output_tensor = self.activation(output_tensor)
+        output_tensor = self.conv2(output_tensor)
+        return hidden_state + output_tensor
+
+
+class HiggsAudioV2TokenizerSemanticEncoderBlock(nn.Module):
+    def __init__(
+        self,
+        config: HiggsAudioV2TokenizerConfig,
+        in_channels: int,
+        out_channels: int,
+        stride: int,
+    ):
+        super().__init__()
+        self.res_units = nn.ModuleList(
+            [
+                HiggsAudioV2TokenizerResidualUnit(
+                    config, in_channels, in_channels, dilation
+                )
+                for dilation in config.block_dilations
+            ]
+        )
+
+        # special case: stride=1, do not use kernel=2
+        kernel = 3 if stride == 1 else (2 * stride)
+        padding = (kernel - 1) // 2
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel,
+            stride=stride,
+            padding=padding,
+            bias=True,
+        )
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        for unit in self.res_units:
+            hidden_state = unit(hidden_state)
+        hidden_state = self.conv(hidden_state)
+        return hidden_state
+
+
+class SemanticEncoder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        if len(config.strides) != len(config.channel_ratios):
+            raise ValueError(
+                "Number of strides must match the number of channel_ratios."
+            )
+        self.conv = nn.Conv1d(
+            config.semantic_hidden_size,
+            config.semantic_hidden_size,
+            config.kernel_size,
+            1,
+            config.kernel_size // 2,
+            bias=False,
+        )
+
+        in_channels = config.semantic_hidden_size
+        conv_blocks = []
+        for i, stride in enumerate(config.strides):
+            out_channels = int(config.semantic_hidden_size * config.channel_ratios[i])
+            conv_blocks += [
+                HiggsAudioV2TokenizerSemanticEncoderBlock(
+                    config, in_channels, out_channels, stride
+                )
+            ]
+            in_channels = out_channels
+
+        self.conv_blocks = nn.ModuleList(conv_blocks)
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        hidden_state = self.conv(hidden_state)
+        for block in self.conv_blocks:
+            hidden_state = block(hidden_state)
+        return hidden_state
+
+
+class SemanticDecoderBlock(nn.Module):
+    def __init__(
+        self,
+        config: HiggsAudioV2TokenizerConfig,
+        in_channels: int,
+        out_channels: int,
+        stride: int,
+    ):
+        super().__init__()
+        if stride == 1:
+            self.conv = nn.Conv1d(
+                in_channels,
+                out_channels,
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                bias=True,
+            )
+        else:
+            kernel_size = 2 * stride
+            padding = (stride + 1) // 2
+            output_padding = 1 if stride % 2 == 1 else 0
+            self.conv = nn.ConvTranspose1d(
+                in_channels,
+                out_channels,
+                kernel_size,
+                stride,
+                padding,
+                output_padding,
+                bias=False,
+            )
+
+        self.res_units = nn.ModuleList(
+            [
+                HiggsAudioV2TokenizerResidualUnit(
+                    config, out_channels, out_channels, dilation
+                )
+                for dilation in config.block_dilations
+            ]
+        )
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        hidden_state = self.conv(hidden_state)
+        for unit in self.res_units:
+            hidden_state = unit(hidden_state)
+        return hidden_state
+
+
+class SemanticDecoder(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.conv1 = nn.Conv1d(
+            in_channels=config.semantic_hidden_size,
+            out_channels=int(config.semantic_hidden_size * config.channel_ratios[0]),
+            kernel_size=config.kernel_size,
+            stride=1,
+            padding=config.kernel_size // 2,
+            bias=False,
+        )
+        conv_blocks = []
+        for i, stride in enumerate(config.strides):
+            in_channels = int(config.semantic_hidden_size * config.channel_ratios[i])
+
+            if i < (len(config.channel_ratios) - 1):
+                out_channels = int(
+                    config.semantic_hidden_size * config.channel_ratios[i + 1]
+                )
+            else:
+                out_channels = config.semantic_hidden_size
+
+            conv_blocks += [
+                SemanticDecoderBlock(config, in_channels, out_channels, stride)
+            ]
+
+        self.conv_blocks = nn.ModuleList(conv_blocks)
+        self.conv2 = nn.Conv1d(
+            config.semantic_hidden_size,
+            config.semantic_hidden_size,
+            config.kernel_size,
+            stride=1,
+            padding=config.kernel_size // 2,
+            bias=False,
+        )
+
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        hidden_state = self.conv1(hidden_state)
+        for block in self.conv_blocks:
+            hidden_state = block(hidden_state)
+        hidden_state = self.conv2(hidden_state)
+        return hidden_state
+
+
+class HiggsAudioV2TokenizerResidualVectorQuantization(nn.Module):
+    """
+    Residual vector quantization implementation. Follows Algorithm 1 in https://huggingface.co/papers/2107.03312
+    """
+
+    def __init__(self, config: HiggsAudioV2TokenizerConfig):
+        super().__init__()
+        self.quantizers = nn.ModuleList(
+            [
+                HiggsAudioV2TokenizerVectorQuantization(config)
+                for _ in range(config.num_quantizers)
+            ]
+        )
+        self.frame_rate = config.frame_rate
+        self.codebook_size = config.codebook_size
+        self.num_quantizers = config.num_quantizers
+
+    def get_bandwidth_per_quantizer(self):
+        """Return bandwidth per quantizer."""
+        return math.log2(self.codebook_size) * self.frame_rate / 1000
+
+    def get_num_quantizers_for_bandwidth(self, bandwidth=None) -> int:
+        """Return num_quantizers based on specified target bandwidth."""
+        bw_per_q = self.get_bandwidth_per_quantizer()
+        num_quantizers = self.num_quantizers
+        if bandwidth is not None and bandwidth > 0.0:
+            num_quantizers = int(max(1, math.floor(bandwidth / bw_per_q)))
+        return num_quantizers
+
+    def encode(self, embeddings: torch.Tensor, bandwidth=None) -> torch.Tensor:
+        """
+        Encode the input tensor into discrete indices using RVQ, with the number of quantizers selected based on the given bandwidth.
+        Each quantizer /codebook residually quantizes the input and returns the nearest indices in terms of Euclidian distance.
+        """
+        num_quantizers = self.get_num_quantizers_for_bandwidth(bandwidth)
+        residual = embeddings
+        all_indices = []
+        for quantizer in self.quantizers[:num_quantizers]:
+            indices = quantizer.encode(residual)
+            quantized = quantizer.decode(indices)
+            residual = residual - quantized
+            all_indices.append(indices)
+        out_indices = torch.stack(all_indices)
+        return out_indices
+
+    def decode(self, codes: torch.Tensor) -> torch.Tensor:
+        """Decode the given codes to their quantized representation."""
+        quantized_out = torch.tensor(0.0, device=codes.device)
+        for i, indices in enumerate(codes):
+            quantizer = self.quantizers[i]
+            quantized = quantizer.decode(indices)
+            quantized_out = quantized_out + quantized.to(codes.device)
+        return quantized_out
+
+
+class HiggsAudioV2TokenizerModel(HiggsAudioV2TokenizerPreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.config = config
+        self.pad = config.hop_length // 2
+        acoustic_model = AutoModel.from_config(config.acoustic_model_config)
+        self.acoustic_encoder = acoustic_model.encoder
+        self.acoustic_decoder = acoustic_model.decoder
+        self._adjust_dac_decoder(self.acoustic_decoder)
+        self.encoder_semantic = SemanticEncoder(config)
+        self.decoder_semantic = SemanticDecoder(config)
+        self.semantic_model = AutoModel.from_config(config.semantic_model_config).eval()
+        self.fc = nn.Linear(config.hidden_size, config.hidden_size)
+        self.fc1 = nn.Linear(
+            config.hidden_size, config.semantic_model_config.hidden_size
+        )
+        self.fc2 = nn.Linear(
+            config.hidden_size, config.acoustic_model_config.hidden_size
+        )
+        self.quantizer = HiggsAudioV2TokenizerResidualVectorQuantization(config)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    @staticmethod
+    def _adjust_dac_decoder(decoder: nn.Module):
+        r"""
+        DAC implemented in HiggsAudioV2Tokenizer is slightly different from the HF version.
+        DAC in HiggsAudioV2Tokenizer adjusts the output padding in every ConvTranspose1d in the decoder and removes
+        the final `nn.Tanh` activation function.
+        """
+        for module in decoder.modules():
+            if isinstance(module, nn.ConvTranspose1d):
+                stride = (
+                    module.stride[0]
+                    if isinstance(module.stride, tuple)
+                    else module.stride
+                )
+                module.output_padding = (stride % 2,)
+        if hasattr(decoder, "tanh") and isinstance(decoder.tanh, nn.Tanh):
+            decoder.tanh = nn.Identity()
+
+    def _extract_semantic_features(
+        self, input_values: torch.FloatTensor
+    ) -> torch.FloatTensor:
+        if self.config.sample_rate != self.config.semantic_sample_rate:
+            input_values = torchaudio.functional.resample(
+                input_values, self.config.sample_rate, self.config.semantic_sample_rate
+            )
+
+        input_values = input_values[:, 0, :]
+        # TODO: there is a diff here with original codebase https://github.com/boson-ai/higgs-audio/blob/f644b62b855ba2b938896436221e01efadcc76ca/boson_multimodal/audio_processing/higgs_audio_v2_tokenizer.py#L173-L174
+        # input_values = F.pad(input_values, (self.pad, self.pad))
+        input_values = F.pad(input_values, (160, 160))
+        with torch.no_grad():
+            outputs = self.semantic_model(input_values, output_hidden_states=True)
+            hidden_states = outputs.hidden_states
+
+        stacked = torch.stack([h.to(input_values.device) for h in hidden_states], dim=1)
+        semantic_features = stacked.mean(dim=1)
+
+        if self.config.semantic_downsample_factor > 1:
+            semantic_features = semantic_features[
+                :, :: self.config.semantic_downsample_factor, :
+            ]
+
+        return semantic_features
+
+    def encode(
+        self,
+        input_values: torch.Tensor,
+        bandwidth: float | None = None,
+        return_dict: bool | None = None,
+    ) -> torch.Tensor | HiggsAudioV2TokenizerEncoderOutput:
+        r"""
+        input_values (`torch.FloatTensor` of shape `(batch_size, channels, num_samples)`):
+            Float values of the input audio waveform.
+        bandwidth (`float`, *optional*):
+            The target bandwidth in (kbps) supports only values in `config.target_bandwidths`.
+            Defaults to the highest available bandwidth `4.0` kbps.
+        return_dict (`bool`, *optional*):
+            Whether or not to return a [`~utils.ModelOutput`].
+
+        Returns:
+            `torch.LongTensor` of shape `(batch_size, num_quantizers, codes_length)` containing the discrete encoded audio codes.
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.return_dict
+        )
+
+        channels = input_values.shape[1]
+        if channels != 1:
+            raise ValueError(f"Audio must be mono, but got {channels}")
+
+        if bandwidth is None:
+            bandwidth = self.config.target_bandwidths[-1]
+        elif bandwidth not in self.config.target_bandwidths:
+            raise ValueError(
+                f"This model doesn't support the bandwidth {bandwidth}. Select one of {self.config.target_bandwidths}."
+            )
+
+        e_semantic_input = self._extract_semantic_features(input_values).detach()
+        e_semantic = self.encoder_semantic(e_semantic_input.transpose(1, 2))
+
+        # original codebase infer to get the output length, but we can directly infer it
+        # from the model and know whether we should pad
+        if (
+            self._get_conv1d_output_lengths(
+                input_values.shape[2], self.acoustic_encoder
+            )
+            != e_semantic.shape[2]
+        ):
+            e_acoustic = self.acoustic_encoder(
+                F.pad(input_values, (self.pad, self.pad))
+            )
+        else:
+            e_acoustic = self.acoustic_encoder(input_values)
+
+        embeddings = torch.cat([e_acoustic.to(e_semantic.device), e_semantic], dim=1)
+        embeddings = self.fc(embeddings.transpose(1, 2)).transpose(1, 2)
+        audio_codes = self.quantizer.encode(embeddings, bandwidth)
+        audio_codes = audio_codes.transpose(0, 1)
+
+        if not return_dict:
+            return audio_codes
+
+        return HiggsAudioV2TokenizerEncoderOutput(audio_codes)
+
+    def decode(
+        self,
+        audio_codes: torch.Tensor,
+        return_dict: bool | None = None,
+    ) -> torch.Tensor | HiggsAudioV2TokenizerDecoderOutput:
+        r"""
+        audio_codes (`torch.LongTensor`  of shape `(batch_size, num_quantizers, codes_length)`):
+            Discrete code indices computed using `model.encode`.
+        return_dict (`bool`, *optional*):
+            Whether or not to return a [`~utils.ModelOutput`]
+
+        Returns:
+            Decoded audio values of shape `(batch_size, channels, num_samples)` obtained using the decoder part of
+            HiggsAudioV2Tokenizer.
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.return_dict
+        )
+
+        audio_codes = audio_codes.transpose(0, 1)
+        quantized = self.quantizer.decode(audio_codes)
+        quantized_acoustic = self.fc2(quantized.transpose(1, 2)).transpose(1, 2)
+        audio_values = self.acoustic_decoder(quantized_acoustic)
+
+        if not return_dict:
+            return audio_values
+
+        return HiggsAudioV2TokenizerDecoderOutput(audio_values)
+
+    def forward(
+        self,
+        input_values: torch.Tensor,
+        audio_codes: torch.Tensor | None = None,
+        bandwidth: float | None = None,
+        return_dict: bool | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor] | HiggsAudioV2TokenizerOutput:
+        r"""
+        input_values (`torch.FloatTensor` of shape `(batch_size, channels, num_samples)`):
+            The raw float values of the input audio waveform.
+        audio_codes (`torch.LongTensor`  of shape `(batch_size, num_quantizers, codes_length)`:
+            Discrete code indices computed using `model.encode`.
+        bandwidth (`float`, *optional*):
+            Target bandwidth in kbps. Must be one of `config.target_bandwidths`. Defaults to the highest available bandwidth.
+        bandwidth (`float`, *optional*):
+            Target bandwidth in kbps. Must be one of `config.target_bandwidths`. Defaults to the highest available bandwidth.
+        return_dict (`bool`, *optional*):
+            Whether to return a [`HiggsAudioV2TokenizerOutput`] instead of a plain tuple.
+
+        Returns:
+            `HiggsAudioV2TokenizerOutput` or tuple `(audio_codes, audio_values)`:
+            - `audio_codes` of shape `(batch_size, num_quantizers, codes_length)`: the quantized discrete codes.
+            - `audio_values` of shape `(batch_size, channels, num_samples)`: the reconstructed audio waveform given the codes.
+
+        Example:
+
+        ```python
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoFeatureExtractor, HiggsAudioV2TokenizerModel
+
+        >>> model_id = "hf-audio/higgs_audio_v2_tokenizer-hubert-librispeech"
+        >>> model = HiggsAudioV2TokenizerModel.from_pretrained(model_id)
+        >>> feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)
+
+        >>> dataset = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
+        >>> dataset = dataset.cast_column("audio", Audio(sampling_rate=feature_extractor.sampling_rate))
+        >>> audio_sample = dataset[0]['audio']['array']
+
+        >>> inputs = feature_extractor(raw_audio=audio_sample, return_tensors="pt")
+
+        >>> outputs = model(**inputs)
+        >>> audio_codes = outputs.audio_codes
+        >>> audio_values = outputs.audio_values
+        ```
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.return_dict
+        )
+        length = input_values.shape[-1]
+
+        if audio_codes is None:
+            audio_codes = self.encode(input_values, bandwidth, return_dict=False)
+
+        audio_values = self.decode(audio_codes, return_dict=return_dict)[0][
+            ..., :length
+        ]
+
+        if not return_dict:
+            return (audio_codes, audio_values)
+
+        return HiggsAudioV2TokenizerOutput(
+            audio_codes=audio_codes, audio_values=audio_values
+        )
+
+
+__all__ = [
+    "HiggsAudioV2TokenizerPreTrainedModel",
+    "HiggsAudioV2TokenizerModel",
+    "HiggsAudioV2TokenizerConfig",
+]

--- a/flash_rt/models/higgs_audio_v3/codec.py
+++ b/flash_rt/models/higgs_audio_v3/codec.py
@@ -1,0 +1,81 @@
+"""Higgs Audio v3 neural codec — decode (codes -> 24 kHz waveform).
+
+The codec is a DAC-style convolutional decoder bundled inside the TTS
+checkpoint's ``model.safetensors`` under the
+``tied.embedding.modality_embeddings.0.model.`` prefix. The model definition is
+vendored under ``_codec/tokenizer_model.py`` (upstream:
+``bosonai/higgs-audio`` v2 tokenizer). Only the decode path is used here;
+synthesis runs in fp32 (ConvTranspose is unstable in low precision).
+
+Acoustic codes are produced by :class:`HiggsAudioV3TorchFrontendRtx.predict`.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+from typing import Any
+
+import torch
+
+from ._codec.env_guard import apply as _apply_env_guard
+
+_apply_env_guard()
+
+from ._codec.tokenizer_model import (  # noqa: E402
+    HiggsAudioV2TokenizerConfig, HiggsAudioV2TokenizerModel,
+)
+
+_CODEC_PREFIX = "tied.embedding.modality_embeddings.0.model."
+_CONFIG_PATH = os.path.join(
+    os.path.dirname(__file__), "_codec", "tokenizer_config.json")
+
+
+class HiggsAudioV3Codec:
+    """Frozen decode-only wrapper around the bundled Higgs audio tokenizer."""
+
+    SAMPLE_RATE = 24_000
+
+    def __init__(self, model: Any, device: str) -> None:
+        self.model = model
+        self.device = device
+
+    @classmethod
+    def from_checkpoint(cls, checkpoint_path: str, *,
+                        device: str = "cuda:0",
+                        dtype: torch.dtype = torch.float32) -> "HiggsAudioV3Codec":
+        """Build the codec from a TTS checkpoint dir (config.json + shards)."""
+        with open(_CONFIG_PATH) as f:
+            cfg = json.load(f)
+        for k in ("architectures", "torch_dtype", "transformers_version"):
+            cfg.pop(k, None)
+        model = HiggsAudioV2TokenizerModel(
+            HiggsAudioV2TokenizerConfig(**cfg)).to(dtype=dtype).eval()
+
+        state: dict[str, torch.Tensor] = {}
+        for shard in sorted(glob.glob(os.path.join(checkpoint_path, "*.safetensors"))):
+            from safetensors import safe_open
+            with safe_open(shard, framework="pt") as f:
+                for key in f.keys():
+                    if key.startswith(_CODEC_PREFIX):
+                        state[key[len(_CODEC_PREFIX):]] = f.get_tensor(key)
+        if not state:
+            raise FileNotFoundError(
+                f"no codec weights under {_CODEC_PREFIX!r} in {checkpoint_path}")
+        missing, _ = model.load_state_dict(state, strict=False)
+        if len(missing) > len(state) // 2:
+            raise RuntimeError(
+                f"codec load too sparse: {len(missing)} missing / {len(state)}")
+        for p in model.parameters():
+            p.requires_grad_(False)
+        return cls(model.to(device), device)
+
+    @torch.no_grad()
+    def decode(self, codes_TN: torch.Tensor) -> torch.Tensor:
+        """``[T, num_codebooks]`` int codes -> mono waveform ``[L]`` (cpu f32)."""
+        if codes_TN.ndim != 2:
+            raise ValueError(
+                f"codes must be 2-D [T, num_codebooks], got {tuple(codes_TN.shape)}")
+        codes_BNT = codes_TN.transpose(0, 1).unsqueeze(0).to(
+            device=self.device, dtype=torch.long)
+        return self.model.decode(codes_BNT).audio_values.squeeze(0).squeeze(0).float().cpu()

--- a/flash_rt/models/higgs_audio_v3/pipeline_rtx.py
+++ b/flash_rt/models/higgs_audio_v3/pipeline_rtx.py
@@ -1,0 +1,64 @@
+"""Static dim contract for Higgs Audio v3 TTS-4B on RTX SM120.
+
+The backbone is dense Qwen3-4B (all full-attention). The audio head/embedding
+is a fused multi-codebook table tied to the embedding weight: ``num_codebooks``
+codebooks of ``codebook_vocab`` entries each, predicted per acoustic frame.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HiggsAudioV3Dims:
+    """Authoritative record of the dims the frontend hard-codes.
+
+    Constants are read from the checkpoint's ``config.json`` at load time and
+    asserted against these values.
+    """
+
+    # Backbone (text_config of HiggsMultimodalQwen3)
+    hidden: int = 2560
+    num_layers: int = 36
+    text_vocab: int = 151_936
+    intermediate: int = 9728
+
+    # Attention
+    num_q_heads: int = 32
+    num_kv_heads: int = 8           # GQA 4:1
+    head_dim: int = 128
+    rotary_dim: int = 128           # full RoPE (rotary_dim == head_dim)
+    rope_theta: float = 1_000_000.0
+    max_pos: int = 32_768
+
+    # Norm
+    rms_norm_eps: float = 1e-6
+
+    # Audio codec head/embedding
+    num_codebooks: int = 8
+    codebook_vocab: int = 1026      # includes BOC=1024 / EOC=1025
+    sample_rate: int = 24_000
+    frame_rate: int = 25            # acoustic frames per second
+    boc_id: int = 1024
+    eoc_id: int = 1025
+
+
+class HiggsAudioV3Pipeline:
+    """Framework-agnostic placeholder holding the frontend's WeightHandles.
+
+    The actual forward path is hand-written in
+    ``flash_rt.frontends.torch.higgs_audio_v3_rtx`` against the
+    flash_rt_kernels / flash_rt_fa2 entry points.
+    """
+
+    DIMS = HiggsAudioV3Dims()
+
+    def __init__(self, weights) -> None:
+        self.weights = weights
+
+    @property
+    def num_layers(self) -> int:
+        return int(self.weights.ptrs.get("num_layers", self.DIMS.num_layers))
+
+    @property
+    def hidden(self) -> int:
+        return int(self.weights.ptrs.get("hidden", self.DIMS.hidden))

--- a/serving/higgs_audio_agent/README.md
+++ b/serving/higgs_audio_agent/README.md
@@ -1,0 +1,72 @@
+# serving/higgs_audio_agent
+
+Streaming text-to-speech server for Higgs Audio v3 TTS-4B on FlashRT.
+
+This directory is the **policy layer** above the FlashRT execution contract. It
+owns the OpenAI-compatible HTTP surface, audio container framing (PCM / WAV),
+and request serialisation. It must not add session / KV / graph verbs to
+`exec/` — the contract stays Buffer / Graph / Plan / Event / ShapeKey, and all
+GPU state (the FP8 backbone, the position-agnostic decode graph, the KV cache,
+the codec) is owned by the frontend. The model is driven only through the
+frontend's committed `generate_stream`.
+
+## What runs where
+
+```
+serving/higgs_audio_agent/server.py        policy: HTTP, audio framing, serialisation
+  └─ frontend.generate_stream(text)        frontend: prefill -> committed decode_stream
+       ├─ decode_stream()                    one position-agnostic decode graph / frame
+       └─ codec (ctx + holdback windows)     streamed chunks == one-shot audio (cos 1.0)
+exec/                                       UNTOUCHED (no serving verb added)
+```
+
+Single stream: TTS requests serialise behind one lock (one decode graph + KV
+buffers). Concurrency/batching would be added here as policy, never in the
+contract.
+
+## Quickstart
+
+```bash
+export HIGGS_CHECKPOINT=/path/to/higgs-audio-v3-tts-4b
+pip install fastapi uvicorn
+python -m serving.higgs_audio_agent.server \
+    --checkpoint "$HIGGS_CHECKPOINT" --host 127.0.0.1 --port 8000
+# startup loads the model, warms the decode graph + codec, then serves.
+```
+
+Synthesize (OpenAI `audio/speech`-compatible):
+
+```bash
+# WAV
+curl -s http://127.0.0.1:8000/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"higgs-audio-v3-tts-4b","input":"Hello from FlashRT.","response_format":"wav"}' \
+  -o hello.wav
+
+# raw 24 kHz mono PCM16, streamed as it is generated
+curl -N http://127.0.0.1:8000/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"input":"Streaming low-latency speech.","response_format":"pcm"}' > out.pcm
+```
+
+`GET /health` and `GET /v1/models` report status and the served model.
+
+## Measured (RTX 5090, single stream, FP8 backbone)
+
+- Full pipeline RTF ≈ 0.12 (≈ 8× real time) across short/medium/long.
+- Time-to-first-audio ≈ 0.14 s (first committed chunk), vs an upstream
+  server's 0.36–0.63 s first-audio.
+- Peak VRAM ≈ 6.3 GB.
+
+See `docs/higgs_audio_v3.md` for the frontend, the decode kernels, and
+faithfulness validation.
+
+## Notes
+
+- `response_format`: `pcm` (raw 24 kHz mono int16, lowest latency) or `wav`.
+- The frontend's greedy decode is deterministic but, like any reimplementation
+  of greedy discrete-code TTS, produces a different valid realisation than other
+  engines (see the doc); faithfulness is established by teacher-forced cosine 1.0
+  and codec cosine 0.99993, not by matching another engine's samples.
+- `pip install fastapi uvicorn` is a server-only dependency; the frontend and
+  kernels do not require it.

--- a/serving/higgs_audio_agent/server.py
+++ b/serving/higgs_audio_agent/server.py
@@ -51,6 +51,7 @@ def build_app(frontend, model_name: str):
         model: str | None = None
         input: str
         voice: str | None = None
+        instructions: str | None = None       # shared voice/style preamble
         response_format: str = "pcm"          # pcm | wav
         stream: bool = True
 
@@ -78,7 +79,12 @@ def build_app(frontend, model_name: str):
                     # Unknown total length up front; stream with a max-size
                     # header (clients that read incrementally accept this).
                     yield _wav_header(0xFFFFFFFF - 44)
-                for chunk in frontend.generate_stream(req.input):
+                # ``instructions`` is a shared voice/style preamble: when many
+                # requests carry the same one, the frontend reuses its prefix KV
+                # (only the new input is prefilled). Policy lives here; the
+                # frontend owns the reuse mechanism.
+                for chunk in frontend.generate_stream(
+                        req.input, system=req.instructions):
                     yield _pcm16(chunk)
 
         media = "audio/wav" if fmt == "wav" else "audio/pcm"

--- a/serving/higgs_audio_agent/server.py
+++ b/serving/higgs_audio_agent/server.py
@@ -115,7 +115,7 @@ def main():
     )
     fe = HiggsAudioV3TorchFrontendRtx(
         args.checkpoint, device=args.device, max_seq=args.max_seq,
-        fp8=not args.bf16)
+        fp8=False if args.bf16 else None)   # None: auto-select by GPU
     if args.warmup:                            # capture graph + load codec once
         for _ in fe.generate_stream(args.warmup):
             pass

--- a/serving/higgs_audio_agent/server.py
+++ b/serving/higgs_audio_agent/server.py
@@ -1,0 +1,123 @@
+"""serving/higgs_audio_agent — streaming TTS server (policy layer).
+
+OpenAI-compatible ``POST /v1/audio/speech`` over the FlashRT Higgs Audio v3
+frontend. This is the **policy layer** above the execution contract: it owns the
+HTTP surface, audio container framing, and request serialisation. It must not
+add session/KV/graph verbs — those live in the frontend (which owns all GPU
+state) and the exec contract (Buffer/Graph/Plan). The model is driven only
+through the frontend's committed ``generate_stream``.
+
+Single stream: TTS requests are serialised behind one lock (the frontend holds
+one decode graph + KV buffers). Concurrency/batching would be added here as
+policy, never in the contract.
+
+Run:
+    export HIGGS_CHECKPOINT=/path/to/higgs-audio-v3-tts-4b
+    pip install fastapi uvicorn
+    python -m serving.higgs_audio_agent.server --checkpoint "$HIGGS_CHECKPOINT" \
+        --host 127.0.0.1 --port 8000
+"""
+import argparse
+import os
+import struct
+import threading
+
+SAMPLE_RATE = 24_000
+
+
+def _pcm16(wav) -> bytes:
+    import numpy as np
+    x = np.clip(wav.numpy() if hasattr(wav, "numpy") else wav, -1.0, 1.0)
+    return (x * 32767.0).astype("<i2").tobytes()
+
+
+def _wav_header(data_bytes: int) -> bytes:
+    # Minimal 44-byte PCM WAV header (mono, 16-bit, 24 kHz).
+    byte_rate = SAMPLE_RATE * 2
+    return (b"RIFF" + struct.pack("<I", 36 + data_bytes) + b"WAVE"
+            + b"fmt " + struct.pack("<IHHIIHH", 16, 1, 1, SAMPLE_RATE, byte_rate, 2, 16)
+            + b"data" + struct.pack("<I", data_bytes))
+
+
+def build_app(frontend, model_name: str):
+    from fastapi import FastAPI, HTTPException
+    from fastapi.responses import StreamingResponse
+    from pydantic import BaseModel
+
+    app = FastAPI(title="FlashRT Higgs Audio v3 TTS")
+    lock = threading.Lock()
+
+    class SpeechRequest(BaseModel):
+        model: str | None = None
+        input: str
+        voice: str | None = None
+        response_format: str = "pcm"          # pcm | wav
+        stream: bool = True
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok", "model": model_name,
+                "sample_rate": SAMPLE_RATE, "max_new_frames": frontend.max_new_frames}
+
+    @app.get("/v1/models")
+    def models():
+        return {"object": "list",
+                "data": [{"id": model_name, "object": "model"}]}
+
+    @app.post("/v1/audio/speech")
+    def speech(req: SpeechRequest):
+        if not req.input.strip():
+            raise HTTPException(status_code=400, detail="empty input")
+        fmt = req.response_format.lower()
+        if fmt not in ("pcm", "wav"):
+            raise HTTPException(status_code=400, detail="response_format must be pcm|wav")
+
+        def gen():
+            with lock:                         # one decode stream at a time
+                if fmt == "wav":
+                    # Unknown total length up front; stream with a max-size
+                    # header (clients that read incrementally accept this).
+                    yield _wav_header(0xFFFFFFFF - 44)
+                for chunk in frontend.generate_stream(req.input):
+                    yield _pcm16(chunk)
+
+        media = "audio/wav" if fmt == "wav" else "audio/pcm"
+        return StreamingResponse(gen(), media_type=media)
+
+    return app
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--checkpoint", default=os.environ.get("HIGGS_CHECKPOINT"))
+    ap.add_argument("--model-name", default="higgs-audio-v3-tts-4b")
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--max-seq", type=int, default=4096)
+    ap.add_argument("--bf16", action="store_true", help="BF16 backbone instead of FP8")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--warmup", default="Warm up the decode graph and codec.")
+    args = ap.parse_args()
+    if not args.checkpoint:
+        ap.error("set --checkpoint or HIGGS_CHECKPOINT")
+
+    import uvicorn
+
+    from flash_rt.frontends.torch.higgs_audio_v3_rtx import (
+        HiggsAudioV3TorchFrontendRtx,
+    )
+    fe = HiggsAudioV3TorchFrontendRtx(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        fp8=not args.bf16)
+    if args.warmup:                            # capture graph + load codec once
+        for _ in fe.generate_stream(args.warmup):
+            pass
+    app = build_app(fe, args.model_name)
+    print(f"FlashRT Higgs TTS ready: http://{args.host}:{args.port}  "
+          f"backbone={'BF16' if args.bf16 else 'FP8'}")
+    uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/serving/higgs_audio_agent/server.py
+++ b/serving/higgs_audio_agent/server.py
@@ -121,7 +121,7 @@ def main():
             pass
     app = build_app(fe, args.model_name)
     print(f"FlashRT Higgs TTS ready: http://{args.host}:{args.port}  "
-          f"backbone={'BF16' if args.bf16 else 'FP8'}")
+          f"backbone={'FP8' if fe.fp8 else 'BF16'}")   # actual selection
     uvicorn.run(app, host=args.host, port=args.port, log_level="warning")
 
 


### PR DESCRIPTION
## Summary

Adds end-to-end **`bosonai/higgs-audio-v3-tts-4b`** text-to-speech on FlashRT for
RTX 5090 / SM120: a dense Qwen3-4B backbone drives a fused 8-codebook acoustic
head under a delay pattern, decoded autoregressively and synthesised by the
bundled neural codec — **text → 24 kHz waveform in one process**. The decode
math path is fully kernelised (no torch in the hot path) and replayed from a
single position-agnostic CUDA graph, in **FP8 W8A8** (default) or **BF16 W16A16**
(fallback for hosts without FP8). Ships a standardized frontend, a prompt
prefix-KV reuse mechanism, and an OpenAI-compatible streaming server.

## Performance (RTX 5090, single stream, warm)

| Metric | FP8 (default) | BF16 (`fp8=False`) |
|---|---|---|
| RTF | 0.095–0.11 | 0.15 |
| Time to first audio | ~94 ms | ~138 ms |
| Decode | ~3.2 ms/frame | ~6.1 ms/frame |
| Prompt prefill | ~1.0 ms/token | ~0.9 ms/token |
| Peak VRAM | 6.6 GB | 9.6 GB |
| Prefix reuse | shared preamble cuts prefill ~64 %, bit-identical | same |

Versus the unoptimised PyTorch reference (same model + GPU): **3.3× faster
decode, 3.7× faster prefill, 2× smaller weights** (FP8). The dedicated M=1 GEMV
runs at **86 % HBM bandwidth**; per-frame is bandwidth-bound, so BF16 is ~1.7×
FP8 (the byte ratio), and FP8 is the only lever below the BF16 floor.

## What's included

**Kernels (additive — new `.cu` + new bindings; existing kernels unchanged):**
- Dedicated M=1 FP8 GEMV (`fp8_gemv_m1_sm120.cu`) with a fused-residual epilogue.
- Dedicated M=1 BF16 GEMV (`bf16_gemv_m1_sm120.cu`) — reads `x` from L2 (no smem
  stage) for full occupancy → 86 % HBM, ~2× the generic `bf16_matvec`.
- Device-position q/k-norm+RoPE+KV-write variant + FA2 `seqused_k` entry — let a
  single captured graph serve any decode position.

**Frontend** (`higgs_audio_v3_rtx.py` + `_higgs_audio_v3_{fp8,bf16}.py`): one
unified surface for both precisions — kernelised step, position-agnostic CUDA
graph, batched single-pass prefill, and `system`-preamble prefix-KV reuse.

**Codec** (`models/higgs_audio_v3/`): vendored DAC-style decoder
(SPDX + upstream attribution), with an import-time guard so it runs without the
optional `kernels`/`torchaudio` packages.

**Serving** (`serving/higgs_audio_agent/`): OpenAI-compatible streaming
`POST /v1/audio/speech` (PCM/WAV). Mechanism (KV/graph) stays in the frontend;
the server is policy only — it forwards a shared `instructions` preamble for
prefix reuse.

**Docs + example**: `docs/higgs_audio_v3.md` (requirements, quickstart, API,
performance, validation) and `examples/higgs_audio_v3_quickstart.py`.

## Fidelity & validation

Teacher-forced logits **cos 1.0** vs the eager BF16 reference; codec **cos
0.99993** vs canonical; streamed == one-shot **cos 1.0**; prefix reuse and the
BF16 graph/prefill are bit-exact. Free-run greedy divergence between faithful
implementations is intrinsic to discrete-code AR (documented), not a
quantisation error.

## Notes for reviewers

- **Build**: this adds CUDA kernels — run `cmake .. && make -j` to rebuild
  `flash_rt/flash_rt_kernels*.so` before importing.
- **Additive-only**: existing kernels, bindings, CMake targets, and the exec
  contract are untouched; new functionality is new files / new symbols.
- The one-time eager prefill uses cuBLAS for its GEMM (weight-once); the
  per-frame decode graph is entirely hand-written kernels.