### PR TITLE
Pi05 frontend jax state issue

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -100,8 +100,10 @@ loaded from either source as long as you point
 ### Pi0.5 State Prompts
 
 Pi0.5 follows openpi's discrete-state prompt format. Passing `state`
-through the stable API discretizes normalized state values into 0..255 bins
-and embeds:
+through the stable API discretizes normalized state values with OpenPI's
+`np.digitize(state, np.linspace(-1, 1, 257)[:-1]) - 1` bins and embeds:
+values in the normalized range usually become 0..255, while values below
+-1 become -1.
 
 ```python
 actions = model.predict(
@@ -187,10 +189,11 @@ model = flash_rt.load_model(
 ### Pi0.5 state prompt bucket warmup
 
 Pi0.5 follows the OpenPI contract where robot state is discretized into
-the language prefix:
+the language prefix with `np.digitize(state, np.linspace(-1, 1, 257)[:-1]) - 1`.
+Normalized in-range values usually become 0..255; values below -1 become -1.
 
 ```text
-Task: <prompt>, State: <0..255 bins>;
+Task: <prompt>, State: <openpi state bins>;
 Action:
 ```
 

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -130,8 +130,11 @@ class VLAModel:
   its own reference contract:
   - Pi0 uses a continuous state token in the action-expert suffix.
   - Pi0.5 encodes state as openpi-compatible discretized prompt tokens:
-    `Task: <prompt>, State: <0..255 bins>;\nAction: `. RTX/Thor torch
-    frontends accept `state` in `set_prompt()` and through `predict()`.
+    `Task: <prompt>, State: <openpi state bins>;\nAction: `. The bins use
+    OpenPI's `np.digitize(state, np.linspace(-1, 1, 257)[:-1]) - 1`
+    convention: normalized in-range values usually become 0..255, while
+    values below -1 become -1. RTX/Thor torch frontends and the JAX Thor
+    Pi0.5 frontend accept `state` in `set_prompt()` and through `predict()`.
     Same-length state prompt updates reuse the captured graph; recurring
     RTX prompt lengths reuse the cached pipeline instead of rebuilding.
   - Pi0-FAST encodes state in the FAST token prefix.

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -94,7 +94,7 @@ class VLAModel:
             import inspect
             sig = inspect.signature(self._pipe.set_prompt)
             prompt_accepts_state = 'state' in sig.parameters
-            if prompt_accepts_state and state is not None:
+            if prompt_accepts_state:
                 prompt_state_changed = not self._prompt_state_equal(
                     self._current_prompt_state, state)
         else:
@@ -187,6 +187,21 @@ class VLAModel:
             self._current_prompt = kwargs["prompt"]
         elif args and isinstance(args[0], str):
             self._current_prompt = args[0]
+        try:
+            import inspect
+            sig = inspect.signature(self._pipe.set_prompt)
+            params = list(sig.parameters)
+            if "state" in sig.parameters:
+                state_pos = params.index("state")
+                if "state" in kwargs:
+                    state = kwargs["state"]
+                elif len(args) > state_pos:
+                    state = args[state_pos]
+                else:
+                    state = None
+                self._current_prompt_state = self._snapshot_prompt_state(state)
+        except (TypeError, ValueError):
+            pass
         return result
 
     def infer(self, *args, **kwargs):

--- a/flash_rt/core/thor_frontend_utils.py
+++ b/flash_rt/core/thor_frontend_utils.py
@@ -131,8 +131,14 @@ def embed_prompt_numpy(prompt_text, embedding_weight_np, max_len: int = 48,
     No torch dependency. Returns (embeds_fp16_np, prompt_len).
     """
     if state is not None:
-        prompt_text = format_pi05_prompt(prompt_text, state)
-    tokens = _tokenize_sentencepiece(prompt_text)
+        from flash_rt.utils.paligemma_tokenizer import (
+            load_paligemma_sentencepiece,
+        )
+        sp = load_paligemma_sentencepiece()
+        tokens = sp.Encode(format_pi05_prompt(prompt_text, state),
+                           add_bos=True)
+    else:
+        tokens = _tokenize_sentencepiece(prompt_text)
     token_ids = np.array(tokens, dtype=np.int32)
     prompt_len = len(token_ids)
     embeds = embedding_weight_np[token_ids]

--- a/flash_rt/core/thor_frontend_utils.py
+++ b/flash_rt/core/thor_frontend_utils.py
@@ -16,14 +16,8 @@ from __future__ import annotations
 import os
 
 import numpy as np
-import torch
-import torch.nn.functional as F
 
 from flash_rt.core.utils.pi05_prompt import format_pi05_prompt
-
-
-# Resolved once at import time; all Thor frontends use the same FP8 dtype.
-_FP8 = torch.float8_e4m3fn
 
 
 def interleave_qk(w, num_heads):
@@ -58,10 +52,12 @@ def quant_fp8(w):
     CUTLASS reads by raw data pointer assuming row-major contiguous
     storage; non-contiguous inputs would silently produce wrong outputs.
     """
+    import torch
+
     w = w.contiguous()
     a = w.float().abs().max().item()
     s = max(a / 448.0, 1e-12)
-    return (w.float() / s).clamp(-448, 448).to(_FP8), s
+    return (w.float() / s).clamp(-448, 448).to(torch.float8_e4m3fn), s
 
 
 # ════════════════════════════════════════════════════════════════════
@@ -98,6 +94,9 @@ def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48,
     fp16 CUDA tensor, already multiplied by sqrt(hidden_dim) per Gemma
     convention.
     """
+    import torch
+    import torch.nn.functional as F
+
     try:
         from openpi.models.tokenizer import PaligemmaTokenizer
         tokenizer = PaligemmaTokenizer(max_len=max_len)
@@ -125,11 +124,14 @@ def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48,
     return embeds, prompt_len
 
 
-def embed_prompt_numpy(prompt_text, embedding_weight_np, max_len: int = 48):
+def embed_prompt_numpy(prompt_text, embedding_weight_np, max_len: int = 48,
+                       state=None):
     """Numpy-side tokenize + embed (used by JAX frontends).
 
     No torch dependency. Returns (embeds_fp16_np, prompt_len).
     """
+    if state is not None:
+        prompt_text = format_pi05_prompt(prompt_text, state)
     tokens = _tokenize_sentencepiece(prompt_text)
     token_ids = np.array(tokens, dtype=np.int32)
     prompt_len = len(token_ids)

--- a/flash_rt/core/utils/pi05_prompt.py
+++ b/flash_rt/core/utils/pi05_prompt.py
@@ -22,7 +22,7 @@ def discretize_pi05_state(state) -> np.ndarray:
     arr = np.asarray(state, dtype=np.float32).reshape(-1)
     bins = np.linspace(-1, 1, 256 + 1, dtype=np.float32)[:-1]
     tokens = np.digitize(arr, bins=bins) - 1
-    return np.clip(tokens, 0, 255).astype(np.int64)
+    return tokens.astype(np.int64)
 
 
 def format_pi05_prompt(prompt: str, state=None) -> str:

--- a/flash_rt/frontends/jax/pi05_thor.py
+++ b/flash_rt/frontends/jax/pi05_thor.py
@@ -814,6 +814,8 @@ class Pi05JaxFrontendThor:
         else:
             self._capture_enc_ae_graph()
 
+        if self.use_fp8:
+            self._real_data_calibrated = False
         self.current_prompt = prompt_text
         logger.info(f"Set prompt: '{prompt_text}' (Se={Se})")
 

--- a/flash_rt/frontends/jax/pi05_thor.py
+++ b/flash_rt/frontends/jax/pi05_thor.py
@@ -55,6 +55,7 @@ import jax.numpy as jnp
 
 
 from flash_rt.core.thor_frontend_utils import embed_prompt_numpy as _embed_prompt  # noqa: E402
+from flash_rt.core.utils.pi05_prompt import PI05_STATE_PROMPT_MAX_LEN  # noqa: E402
 
 
 class Pi05JaxFrontendThor:
@@ -647,7 +648,7 @@ class Pi05JaxFrontendThor:
 
         logger.info("Weights restored from cache")
 
-    def set_prompt(self, prompt_text):
+    def set_prompt(self, prompt_text, state=None):
         """Set prompt: tokenize, time conditioning (numpy), RoPE, calibrate, capture graph.
 
         When :meth:`set_rl_mode` has activated CFG inference and a text
@@ -660,6 +661,9 @@ class Pi05JaxFrontendThor:
         if (self._rl_config is not None
                 and not getattr(self, "_in_rl_set_prompt", False)
                 and isinstance(prompt_text, str)):
+            if state is not None:
+                raise ValueError(
+                    "Pi0.5 RL CFG mode does not support state-in-prompt yet")
             self._in_rl_set_prompt = True
             try:
                 self._set_prompt_rl(prompt_text)
@@ -678,7 +682,9 @@ class Pi05JaxFrontendThor:
             embeds_np = self._embedding_np[token_ids]
             embeds_np = (embeds_np * float(embeds_np.shape[-1] ** 0.5)).astype(np.float16)
         else:
-            embeds_np, prompt_len = _embed_prompt(prompt_text, self._embedding_np, max_len=48)
+            max_len = PI05_STATE_PROMPT_MAX_LEN if state is not None else 48
+            embeds_np, prompt_len = _embed_prompt(
+                prompt_text, self._embedding_np, max_len=max_len, state=state)
         Se = S + prompt_len
         if Se % 2 != 0:
             Se += 1

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -63,6 +63,54 @@ def test_predict_refreshes_prompt_when_prompt_state_changes():
     assert TokenStateFrontend.prompt_states == [state0, state1]
 
 
+def test_predict_refreshes_prompt_when_prompt_state_is_removed():
+    from flash_rt.api import VLAModel
+
+    image = object()
+    state0 = [0.0, 1.0]
+
+    class TokenStateFrontend:
+        prompt_states = []
+
+        def set_prompt(self, prompt, state=None):
+            type(self).prompt_states.append(
+                None if state is None else list(state))
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    TokenStateFrontend.prompt_states = []
+    model = VLAModel(TokenStateFrontend(), framework="torch")
+    model.predict(images=[image], prompt="pick", state=state0)
+    model.predict(images=[image], state=None)
+
+    assert TokenStateFrontend.prompt_states == [state0, None]
+
+
+def test_manual_set_prompt_tracks_prompt_state():
+    from flash_rt.api import VLAModel
+
+    image = object()
+    state0 = [0.0, 1.0]
+
+    class TokenStateFrontend:
+        prompt_states = []
+
+        def set_prompt(self, prompt, state=None):
+            type(self).prompt_states.append(
+                None if state is None else list(state))
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    TokenStateFrontend.prompt_states = []
+    model = VLAModel(TokenStateFrontend(), framework="torch")
+    model.set_prompt("pick", state=state0)
+    model.predict(images=[image], state=None)
+
+    assert TokenStateFrontend.prompt_states == [state0, None]
+
+
 def test_predict_preserves_state_from_observation_dict():
     from flash_rt.api import VLAModel
 

--- a/tests/test_pi05_state_prompt.py
+++ b/tests/test_pi05_state_prompt.py
@@ -9,9 +9,9 @@ def test_pi05_state_prompt_matches_openpi_format():
 
     state = np.array([-1.0, 0.0, 1.0, 2.0, -2.0], dtype=np.float32)
 
-    assert discretize_pi05_state(state).tolist() == [0, 128, 255, 255, 0]
+    assert discretize_pi05_state(state).tolist() == [0, 128, 255, 255, -1]
     assert format_pi05_prompt("pick_up\nred", state) == (
-        "Task: pick up red, State: 0 128 255 255 0;\nAction: "
+        "Task: pick up red, State: 0 128 255 255 -1;\nAction: "
     )
 
 
@@ -26,12 +26,15 @@ def test_jax_prompt_embedding_formats_state(monkeypatch):
 
     seen = {}
 
-    def fake_tokenize(text):
-        seen["text"] = text
-        return [0, 1, 2]
+    class FakeSentencePiece:
+        def Encode(self, text, add_bos=False):
+            seen["text"] = text
+            seen["add_bos"] = add_bos
+            return [0, 1, 2]
 
     monkeypatch.setattr(
-        thor_frontend_utils, "_tokenize_sentencepiece", fake_tokenize)
+        "flash_rt.utils.paligemma_tokenizer.load_paligemma_sentencepiece",
+        lambda: FakeSentencePiece())
     embedding = np.ones((3, 4), dtype=np.float16)
 
     embeds, prompt_len = thor_frontend_utils.embed_prompt_numpy(
@@ -42,3 +45,4 @@ def test_jax_prompt_embedding_formats_state(monkeypatch):
     assert seen["text"] == (
         "Task: pick up red, State: 0 128 255;\nAction: "
     )
+    assert seen["add_bos"] is True

--- a/tests/test_pi05_state_prompt.py
+++ b/tests/test_pi05_state_prompt.py
@@ -19,3 +19,26 @@ def test_pi05_state_prompt_without_state_keeps_text_only_format():
     from flash_rt.core.utils.pi05_prompt import format_pi05_prompt
 
     assert format_pi05_prompt(" pick_up\nred ") == "pick up red"
+
+
+def test_jax_prompt_embedding_formats_state(monkeypatch):
+    from flash_rt.core import thor_frontend_utils
+
+    seen = {}
+
+    def fake_tokenize(text):
+        seen["text"] = text
+        return [0, 1, 2]
+
+    monkeypatch.setattr(
+        thor_frontend_utils, "_tokenize_sentencepiece", fake_tokenize)
+    embedding = np.ones((3, 4), dtype=np.float16)
+
+    embeds, prompt_len = thor_frontend_utils.embed_prompt_numpy(
+        "pick_up\nred", embedding, state=np.array([-1.0, 0.0, 1.0]))
+
+    assert prompt_len == 3
+    assert embeds.shape == (3, 4)
+    assert seen["text"] == (
+        "Task: pick up red, State: 0 128 255;\nAction: "
+    )


### PR DESCRIPTION
## Summary

Fix Pi0.5 JAX Thor state-prompt handling and tighten prompt-state lifecycle tracking.

## Changes

- Add Pi0.5 JAX Thor `set_prompt(..., state=...)` support.
- Align JAX state prompt tokenization with OpenPI:
  - use `Encode(full_prompt, add_bos=True)` for state prompts
  - avoid appending the extra newline token used by non-state prompts
- Align Pi0.5 state binning with OpenPI:
  - `np.digitize(state, np.linspace(-1, 1, 257)[:-1]) - 1`
  - in-range normalized values are usually `0..255`
  - values below `-1` can become `-1`
- Reset JAX Thor real-data calibration after prompt/state graph rebuilds, so FP8 scales match the current prompt-state input.
- Track prompt-state removal in the stable API, so switching from `state != None` to `state=None` refreshes prompt embeddings instead of reusing stale state prompts.
- Update docs for Pi0.5 state prompt bins and JAX Thor support.

## Validation

- Pi0.5 state prompt token IDs match OpenPI exactly.
- Real LIBERO smoke with fixed noise:
  - same-state repeat max abs: `0.0`
  - same-state reset max abs: `0.0`
  - different-state max abs: about `0.0214`
  - different-state cosine: about `0.99994`
- State prompt unit tests pass.
- API prompt-state lifecycle tests pass.
- Python compile and `git diff --check` pass.