### PR TITLE
Track prompt state removal

### DIFF
--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -94,7 +94,7 @@ class VLAModel:
             import inspect
             sig = inspect.signature(self._pipe.set_prompt)
             prompt_accepts_state = 'state' in sig.parameters
-            if prompt_accepts_state and state is not None:
+            if prompt_accepts_state:
                 prompt_state_changed = not self._prompt_state_equal(
                     self._current_prompt_state, state)
         else:
@@ -187,6 +187,21 @@ class VLAModel:
             self._current_prompt = kwargs["prompt"]
         elif args and isinstance(args[0], str):
             self._current_prompt = args[0]
+        try:
+            import inspect
+            sig = inspect.signature(self._pipe.set_prompt)
+            params = list(sig.parameters)
+            if "state" in sig.parameters:
+                state_pos = params.index("state")
+                if "state" in kwargs:
+                    state = kwargs["state"]
+                elif len(args) > state_pos:
+                    state = args[state_pos]
+                else:
+                    state = None
+                self._current_prompt_state = self._snapshot_prompt_state(state)
+        except (TypeError, ValueError):
+            pass
         return result
 
     def infer(self, *args, **kwargs):

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -63,6 +63,54 @@ def test_predict_refreshes_prompt_when_prompt_state_changes():
     assert TokenStateFrontend.prompt_states == [state0, state1]
 
 
+def test_predict_refreshes_prompt_when_prompt_state_is_removed():
+    from flash_rt.api import VLAModel
+
+    image = object()
+    state0 = [0.0, 1.0]
+
+    class TokenStateFrontend:
+        prompt_states = []
+
+        def set_prompt(self, prompt, state=None):
+            type(self).prompt_states.append(
+                None if state is None else list(state))
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    TokenStateFrontend.prompt_states = []
+    model = VLAModel(TokenStateFrontend(), framework="torch")
+    model.predict(images=[image], prompt="pick", state=state0)
+    model.predict(images=[image], state=None)
+
+    assert TokenStateFrontend.prompt_states == [state0, None]
+
+
+def test_manual_set_prompt_tracks_prompt_state():
+    from flash_rt.api import VLAModel
+
+    image = object()
+    state0 = [0.0, 1.0]
+
+    class TokenStateFrontend:
+        prompt_states = []
+
+        def set_prompt(self, prompt, state=None):
+            type(self).prompt_states.append(
+                None if state is None else list(state))
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    TokenStateFrontend.prompt_states = []
+    model = VLAModel(TokenStateFrontend(), framework="torch")
+    model.set_prompt("pick", state=state0)
+    model.predict(images=[image], state=None)
+
+    assert TokenStateFrontend.prompt_states == [state0, None]
+
+
 def test_predict_preserves_state_from_observation_dict():
     from flash_rt.api import VLAModel
 


### PR DESCRIPTION
## Summary

Fix Pi0.5 JAX Thor state-prompt handling and tighten prompt-state lifecycle tracking.

## Changes

- Add Pi0.5 JAX Thor `set_prompt(..., state=...)` support.
- Align JAX state prompt tokenization with OpenPI:
  - use `Encode(full_prompt, add_bos=True)` for state prompts
  - avoid appending the extra newline token used by non-state prompts
- Align Pi0.5 state binning with OpenPI:
  - `np.digitize(state, np.linspace(-1, 1, 257)[:-1]) - 1`
  - in-range normalized values are usually `0..255`
  - values below `-1` can become `-1`
- Reset JAX Thor real-data calibration after prompt/state graph rebuilds, so FP8 scales match the current prompt-state input.
- Track prompt-state removal in the stable API, so switching from `state != None` to `state=None` refreshes prompt embeddings instead of reusing stale state prompts.
- Update docs for Pi0.5 state prompt bins and JAX Thor support.

## Validation

- Pi0.5 state prompt token IDs match OpenPI exactly.
- Real LIBERO smoke with fixed noise:
  - same-state repeat max abs: `0.0`
  - same-state reset max abs: `0.0`
  - different-state max abs: about `0.0214`
  - different-state cosine: about `0.99994`
- State prompt unit tests pass.
- API prompt-state lifecycle tests pass.
- Python compile and `git diff --check` pass.