### PR TITLE
Pi0.5 RTX: fixed-shape state-prompt graph option (one graph, no recap…

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -224,6 +224,7 @@ model = flash_rt.load_model(
 | `vision_pool_factor` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Spatial pooling factor for vision tokens. The FP16 RTX path currently supports only `1`. |
 | `vision_num_layers` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Number of SigLIP vision layers to run. |
 | `cache_frames` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Temporal encoder K/V cache period; `1` means no temporal reuse. |
+| `state_prompt_mode` | `str` | `"exact"` | Pi0.5 torch RTX. State-in-prompt graph strategy: `"exact"` (per-length capture + `warm_state_prompt_buckets()`) or `"fixed"` (one graph at the max length, no recapture; ~+4.6 ms/2v, +6.7 ms/3v). Env override `FLASHRT_PI05_STATE_PROMPT_MODE`. See [Pi0.5 State Prompts](#pi05-state-prompts). |
 
 ### Pi0.5 state prompt bucket warmup
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -139,8 +139,12 @@ ONE pipeline and ONE captured CUDA Graph at the max prompt length serve every
 length: the padded prefix keys are masked (FlashAttention-2 `seqused_k`) and the
 decoder's action K/V are appended right after the *valid* prefix
 (`qkv_split_rope_devpos`), so a changing state-token length **never re-captures
-a graph or reruns autotune** — no warmup needed. Enable it when you don't want
-to enumerate state lengths up front:
+a graph or reruns autotune** — no warmup needed. The trade-off is that every
+inference runs at the padded max length, so steady-state latency is somewhat
+higher than `"exact"` at a given length (it buys you no recapture stalls when
+the length drifts). Lower `PI05_STATE_PROMPT_MAX_LEN` toward your real maximum
+to shrink the padding. Enable it when you don't want to enumerate state lengths
+up front:
 
 ```python
 model = flash_rt.load_model(

--- a/USAGE.md
+++ b/USAGE.md
@@ -139,12 +139,13 @@ ONE pipeline and ONE captured CUDA Graph at the max prompt length serve every
 length: the padded prefix keys are masked (FlashAttention-2 `seqused_k`) and the
 decoder's action K/V are appended right after the *valid* prefix
 (`qkv_split_rope_devpos`), so a changing state-token length **never re-captures
-a graph or reruns autotune** — no warmup needed. The trade-off is that every
-inference runs at the padded max length, so steady-state latency is somewhat
-higher than `"exact"` at a given length (it buys you no recapture stalls when
-the length drifts). Lower `PI05_STATE_PROMPT_MAX_LEN` toward your real maximum
-to shrink the padding. Enable it when you don't want to enumerate state lengths
-up front:
+a graph or reruns autotune** — no warmup needed. The trade-off is latency:
+every inference runs at the padded max length, so `"fixed"` is ~+4.6 ms (2
+views) / +6.7 ms (3 views) slower than `"exact"` at a typical prompt length —
+for peak performance prefer `"exact"` and warm a fuller length sweep yourself
+with `warm_state_prompt_buckets()`. (Lowering `PI05_STATE_PROMPT_MAX_LEN`
+toward your real maximum shrinks the padding and the gap.) Enable `"fixed"`
+when you don't want to enumerate state lengths up front:
 
 ```python
 model = flash_rt.load_model(

--- a/USAGE.md
+++ b/USAGE.md
@@ -113,9 +113,43 @@ actions = model.predict(
 )
 ```
 
-State changes update the prompt embeddings. RTX keeps a per-prompt-length
-pipeline cache and updates same-length language buffers in place, so repeated
-state-token lengths do not repeatedly rebuild CUDA Graphs or rerun autotune.
+State changes update the prompt embeddings. Because the discretized state is
+rendered into the prompt, its token length drifts with the state values. The
+RTX Pi0.5 frontend offers two strategies via `state_prompt_mode`:
+
+**`"exact"` (default) — per-length capture + manual warmup.**
+A separate pipeline is captured per exact prompt length and cached, so a
+recurring length is not rebuilt. Front-load the lengths you expect with
+`warm_state_prompt_buckets()` so the control loop does not pay a mid-loop
+capture the first time a new length appears:
+
+```python
+model = flash_rt.load_model(
+    checkpoint="/path/to/pi05", framework="torch", config="pi05")  # exact
+# Pre-warm representative state lengths once at startup:
+warmed = model.warm_state_prompt_buckets(
+    images=[base_img, wrist_img],
+    prompt="pick up the red block",
+    states=[s_min, s_typical, s_max, ...])   # a few representative states
+# control loop: predict() reuses the warmed graphs, no new capture
+```
+
+**`"fixed"` (opt-in) — one graph, no warmup.**
+ONE pipeline and ONE captured CUDA Graph at the max prompt length serve every
+length: the padded prefix keys are masked (FlashAttention-2 `seqused_k`) and the
+decoder's action K/V are appended right after the *valid* prefix
+(`qkv_split_rope_devpos`), so a changing state-token length **never re-captures
+a graph or reruns autotune** — no warmup needed. Enable it when you don't want
+to enumerate state lengths up front:
+
+```python
+model = flash_rt.load_model(
+    checkpoint="/path/to/pi05", framework="torch", config="pi05",
+    state_prompt_mode="fixed")
+# or, without code changes: FLASHRT_PI05_STATE_PROMPT_MODE=fixed
+# predict() handles any state length with a single captured graph
+```
+
 Thor updates same-length prompt embeddings in place after graph capture.
 
 **Q: I'm getting `FileNotFoundError: paligemma_tokenizer.model not found`.**

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -757,6 +757,24 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("seq"), py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"),
        py::arg("head_dim"), py::arg("stream") = 0);
 
+    // QKV split + RoPE with a runtime device K/V-cache row offset (devpos).
+    // K/V are cache BASE pointers; row written = devpos[0] + token index.
+    m.def("qkv_split_rope_devpos", [](uintptr_t qkv, uintptr_t rope_weights,
+                                       uintptr_t Q, uintptr_t K, uintptr_t V,
+                                       uintptr_t devpos,
+                                       int seq, int q_dim, int k_dim, int v_dim,
+                                       int head_dim, uintptr_t stream) {
+        qkv_split_rope_devpos(typed_ptr<__nv_bfloat16>(qkv),
+                              typed_ptr<__nv_bfloat16>(rope_weights),
+                              typed_ptr<__nv_bfloat16>(Q), typed_ptr<__nv_bfloat16>(K),
+                              typed_ptr<__nv_bfloat16>(V),
+                              typed_ptr<int>(devpos),
+                              seq, q_dim, k_dim, v_dim, head_dim, to_stream(stream));
+    }, py::arg("qkv"), py::arg("rope_weights"),
+       py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("devpos"),
+       py::arg("seq"), py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"),
+       py::arg("head_dim"), py::arg("stream") = 0);
+
     // Elementwise
     m.def("gate_mul_residual", [](uintptr_t residual, uintptr_t x, uintptr_t gate, int n, uintptr_t stream) {
         gate_mul_residual(typed_ptr<__nv_bfloat16>(residual),

--- a/csrc/kernels/rope.cu
+++ b/csrc/kernels/rope.cu
@@ -205,6 +205,77 @@ void qkv_split_rope(const __nv_bfloat16* qkv,
         qkv, rope_weights, Q, K, V, seq, q_dim, k_dim, v_dim, head_dim);
 }
 
+// ── Fused QKV Split + RoPE with a RUNTIME (device) K/V-cache row offset ──
+// Identical math to qkv_split_rope, but the K/V destination row is shifted by
+// ``devpos[0]`` read at launch time. Q is still written contiguous (rows 0..seq).
+// This lets a single fixed-shape CUDA graph append the decoder's K/V right
+// after a variable-length valid prefix (devpos = valid prefix length), so the
+// cross-attention can be one contiguous (seqused) call instead of recapturing
+// per prompt length. K/V are the cache BASE pointers (row 0), not pre-offset.
+__global__ void qkv_split_rope_devpos_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ rope_weights,
+    __nv_bfloat16* __restrict__ Q,
+    __nv_bfloat16* __restrict__ K,
+    __nv_bfloat16* __restrict__ V,
+    const int* __restrict__ devpos,
+    int seq, int q_dim, int k_dim, int v_dim, int head_dim) {
+    int qkv_dim = q_dim + k_dim + v_dim;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * qkv_dim;
+    if (idx >= total) return;
+
+    int row = idx / qkv_dim;
+    int col = idx % qkv_dim;
+    int pos = devpos[0];  // runtime K/V-cache row offset (valid prefix length)
+
+    if (col < q_dim) {
+        int q_col = col;
+        int head = q_col / head_dim;
+        int d_in_head = q_col % head_dim;
+        int pair = d_in_head / 2;
+        int is_odd = d_in_head & 1;
+        int pair_base_qkv = row * qkv_dim + head * head_dim + pair * 2;
+        float x0 = bf16_to_f32(qkv[pair_base_qkv]);
+        float x1 = bf16_to_f32(qkv[pair_base_qkv + 1]);
+        int rope_base = row * head_dim + pair * 2;
+        float c = bf16_to_f32(rope_weights[rope_base]);
+        float s = bf16_to_f32(rope_weights[rope_base + 1]);
+        int out_idx = row * q_dim + q_col;
+        if (is_odd == 0) Q[out_idx] = f32_to_bf16(x0 * c - x1 * s);
+        else             Q[out_idx] = f32_to_bf16(x1 * c + x0 * s);
+    } else if (col < q_dim + k_dim) {
+        int k_col = col - q_dim;
+        int pair = k_col / 2;
+        int is_odd = k_col & 1;
+        int pair_base_qkv = row * qkv_dim + q_dim + pair * 2;
+        float x0 = bf16_to_f32(qkv[pair_base_qkv]);
+        float x1 = bf16_to_f32(qkv[pair_base_qkv + 1]);
+        int rope_base = row * head_dim + pair * 2;
+        float c = bf16_to_f32(rope_weights[rope_base]);
+        float s = bf16_to_f32(rope_weights[rope_base + 1]);
+        int out_idx = (pos + row) * k_dim + k_col;
+        if (is_odd == 0) K[out_idx] = f32_to_bf16(x0 * c - x1 * s);
+        else             K[out_idx] = f32_to_bf16(x1 * c + x0 * s);
+    } else {
+        int v_col = col - q_dim - k_dim;
+        V[(pos + row) * v_dim + v_col] = qkv[idx];
+    }
+}
+
+void qkv_split_rope_devpos(const __nv_bfloat16* qkv,
+                           const __nv_bfloat16* rope_weights,
+                           __nv_bfloat16* Q, __nv_bfloat16* K, __nv_bfloat16* V,
+                           const int* devpos,
+                           int seq, int q_dim, int k_dim, int v_dim,
+                           int head_dim, cudaStream_t stream) {
+    int total = seq * (q_dim + k_dim + v_dim);
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    qkv_split_rope_devpos_kernel<<<blocks, threads, 0, stream>>>(
+        qkv, rope_weights, Q, K, V, devpos, seq, q_dim, k_dim, v_dim, head_dim);
+}
+
 // ── Fused QKV Split + RoPE + KV Cache Write (FP16) ──
 // Direct port of pi05 qkv_split_rope_kvcache_k for FP16 data.
 // Q → contiguous (S, Q_dim)

--- a/csrc/kernels/rope.cuh
+++ b/csrc/kernels/rope.cuh
@@ -33,6 +33,16 @@ void qkv_split_rope(const __nv_bfloat16* qkv,
                      int seq, int q_dim, int k_dim, int v_dim, int head_dim,
                      cudaStream_t stream = 0);
 
+// Same as qkv_split_rope, but the K/V cache write row is shifted by a RUNTIME
+// device offset ``devpos[0]`` (K/V are cache base pointers, row 0). Lets one
+// fixed-shape graph append decoder K/V after a variable-length valid prefix.
+void qkv_split_rope_devpos(const __nv_bfloat16* qkv,
+                           const __nv_bfloat16* rope_weights,
+                           __nv_bfloat16* Q, __nv_bfloat16* K, __nv_bfloat16* V,
+                           const int* devpos,
+                           int seq, int q_dim, int k_dim, int v_dim,
+                           int head_dim, cudaStream_t stream = 0);
+
 // Fused QKV split + RoPE + KV cache write (FP16)
 // Matches pi05 qkv_split_rope_kvcache_k exactly.
 // Q → contiguous (S, Q_dim), K → Kc[kc_offset + s*kc_stride], V → Vc[kc_offset + s*kc_stride]

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -377,6 +377,17 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             1 runs the full vision+encoder+decoder path on every frame; 2
             alternates full and decoder-only frames. ``None`` keeps the
             frontend default.
+        state_prompt_mode: Pi0.5 torch RTX only. How the variable-length
+            state-in-prompt is mapped to CUDA graphs:
+              ``"exact"`` (default) — one captured graph per exact prompt
+                length, cached; pair with ``warm_state_prompt_buckets()`` to
+                front-load the lengths you expect. Unchanged legacy behavior.
+              ``"fixed"`` — ONE graph at the max prompt length serves every
+                length (padded prefix masked via FA2 ``seqused_k`` + decoder
+                K/V appended at the valid offset); a changing length never
+                re-captures and no warmup is needed. Requires the vendored
+                bf16 FA2 path (``FVK_RTX_FA2=1``, encoder+decoder sites on).
+            Env override: ``FLASHRT_PI05_STATE_PROMPT_MODE``.
 
     Returns:
         VLAModel instance with .predict() method.
@@ -589,8 +600,8 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             kwargs["vision_num_layers"] = vision_num_layers
         if cache_frames is not None and "cache_frames" in sig.parameters:
             kwargs["cache_frames"] = cache_frames
-        # Pi0.5 state-in-prompt graph strategy: "fixed" (default, one graph) /
-        # "exact" (legacy per-length capture). Forwarded only if accepted.
+        # Pi0.5 state-in-prompt graph strategy: "exact" (default, per-length
+        # capture) / "fixed" (opt-in, one graph). Forwarded only if accepted.
         if "state_prompt_mode" in sig.parameters:
             kwargs["state_prompt_mode"] = state_prompt_mode
         # FP4 frontend accepts these extra kwargs (only set when the class

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -296,7 +296,8 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                vision_num_layers=None,
                cache_frames=None,
                use_fp16=False,
-               use_fp8=True):
+               use_fp8=True,
+               state_prompt_mode="exact"):
     """Load a FlashRT model.
 
     Args:
@@ -588,6 +589,10 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             kwargs["vision_num_layers"] = vision_num_layers
         if cache_frames is not None and "cache_frames" in sig.parameters:
             kwargs["cache_frames"] = cache_frames
+        # Pi0.5 state-in-prompt graph strategy: "fixed" (default, one graph) /
+        # "exact" (legacy per-length capture). Forwarded only if accepted.
+        if "state_prompt_mode" in sig.parameters:
+            kwargs["state_prompt_mode"] = state_prompt_mode
         # FP4 frontend accepts these extra kwargs (only set when the class
         # actually accepts them — base class ignores, FP4 subclass uses).
         if use_fp4 and "use_fp4_encoder_ffn" in sig.parameters:

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -1013,6 +1013,10 @@ class Pi05TorchFrontendRtx:
                 raise ValueError(
                     "Pi0.5 RL CFG mode does not support state-in-prompt yet")
             self._set_prompt_rl(prompt_text)
+            # RL has no state-in-prompt; ensure the shared backend is not stuck
+            # in fixed-shape mode from a prior state prompt.
+            self.attn_backend.set_fixed_shape(
+                bool(getattr(self.pipeline, "_fixed_shape", False)))
             return
 
         max_len = (PI05_STATE_PROMPT_MAX_LEN if state is not None
@@ -1024,6 +1028,14 @@ class Pi05TorchFrontendRtx:
             self._set_prompt_fixed(prompt_len)
         else:
             self._set_prompt_per_length(state, prompt_len)
+
+        # The attention backend is shared across pipelines, so sync its
+        # fixed-shape mode to the now-active pipeline BEFORE running it. Without
+        # this, a frontend that ran a fixed state prompt and then a no-state
+        # prompt (which falls back to a per-length pipeline) would keep the
+        # backend in fixed mode and reuse stale seqused/devpos buffers.
+        self.attn_backend.set_fixed_shape(
+            bool(getattr(self.pipeline, "_fixed_shape", False)))
 
         # Upload language embeds into pipeline's encoder_x slot. In fixed mode
         # set_language_embeds pads to max + updates the seqused/devpos buffers.

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -533,6 +533,10 @@ class Pi05TorchFrontendRtx:
         self.current_prompt_len = 0
         self.pipeline: Optional[Pi05Pipeline] = None
         self._prompt_pipeline_cache: dict[int, Pi05Pipeline] = {}
+        # Fixed-shape (state_prompt_mode="fixed") pipeline, cached separately so
+        # switching to a no-state prompt and back reuses the already-calibrated,
+        # already-captured graph instead of rebuilding it.
+        self._fixed_pipeline: Optional[Pi05Pipeline] = None
         # RL inference configuration. ``None`` = default behaviour (single
         # forward, no advantage-conditioned prompt injection). When set
         # by :meth:`set_rl_mode`, the next :meth:`set_prompt` call builds
@@ -655,6 +659,7 @@ class Pi05TorchFrontendRtx:
             chunk_size=self.chunk_size,
             num_encoder_layers=ENC_L)
         self._prompt_pipeline_cache.clear()
+        self._fixed_pipeline = None
         self.pipeline = None
         self.current_prompt_len = 0
         self.graph_recorded = False
@@ -1048,16 +1053,21 @@ class Pi05TorchFrontendRtx:
 
     def _set_prompt_fixed(self, prompt_len: int) -> None:
         """Fixed-shape mode: build ONE max-length pipeline + one graph; later
-        prompt lengths only update embeds + seqused/devpos (no re-capture)."""
+        prompt lengths only update embeds + seqused/devpos (no re-capture).
+
+        The fixed pipeline is cached in ``self._fixed_pipeline`` so that
+        switching to a no-state prompt (which activates a per-length pipeline)
+        and back REUSES the already-calibrated, already-captured graph instead
+        of rebuilding it — a rebuild would re-run FP8 calibration/autotune on a
+        backend the per-length pipeline has since touched (observed CUDA illegal
+        access) and would also perturb numerics via autotune variance.
+        """
         self._ensure_prompt_capacity(PI05_STATE_PROMPT_MAX_LEN)
-        if (self.pipeline is None
-                or not getattr(self.pipeline, "_fixed_shape", False)):
+        if self._fixed_pipeline is None:
             logger.info("Building fixed-shape Pi05Pipeline (max_prompt_len=%d)...",
                         PI05_STATE_PROMPT_MAX_LEN)
-            self.graph_recorded = False
-            self.calibrated = False
             pipeline_weights = self._build_pipeline_weights()
-            self.pipeline = Pi05Pipeline(
+            self._fixed_pipeline = Pi05Pipeline(
                 gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
                 weights=pipeline_weights,
                 num_views=self.num_views,
@@ -1068,9 +1078,19 @@ class Pi05TorchFrontendRtx:
                 vision_num_layers=self._vision_num_layers,
                 fixed_shape=True,
                 **self._pipeline_precision_kwargs())
-            if self.pipeline.use_int8_vision_static:
-                self.pipeline.vis_int8_static_calibrated = False
-                self.pipeline.vis_int8_static_scales = {}
+            if self._fixed_pipeline.use_int8_vision_static:
+                self._fixed_pipeline.vis_int8_static_calibrated = False
+                self._fixed_pipeline.vis_int8_static_scales = {}
+        # (Re)activate the cached fixed pipeline, restoring calibration/capture
+        # state from the instance (mirrors the per-length cache reuse path) so
+        # predict() does not re-calibrate or re-capture on switch-back.
+        if self.pipeline is not self._fixed_pipeline:
+            self.pipeline = self._fixed_pipeline
+            self.graph_recorded = (
+                getattr(self._fixed_pipeline, "_graph", None) is not None)
+            self.calibrated = (
+                self.graph_recorded
+                or bool(getattr(self._fixed_pipeline, "fp8_calibrated", False)))
         self.current_prompt_len = prompt_len
 
     def _set_prompt_per_length(self, state, prompt_len: int) -> None:

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -480,8 +480,24 @@ class Pi05TorchFrontendRtx:
                  cache_frames: int = 1,
                  use_fp8: bool = True,
                  hardware: Optional[str] = None,
-                 fp8_layout: Optional[str] = None):
+                 fp8_layout: Optional[str] = None,
+                 state_prompt_mode: str = "exact"):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
+        # State-in-prompt graph strategy (Pi0.5 renders robot state into the
+        # prompt, so its token length drifts with the state values):
+        #   "exact" (default): a separate pipeline captured per exact length,
+        #       cached; pair with warm_state_prompt_buckets() to front-load the
+        #       lengths you expect so the control loop avoids a mid-loop capture.
+        #   "fixed": ONE pipeline + ONE captured graph at the max prompt length;
+        #       every length is served by masking the padded prefix (FA2
+        #       seqused) + appending decoder K/V at the valid offset (devpos),
+        #       so a changing length never re-captures and no warmup is needed.
+        # Env override: FLASHRT_PI05_STATE_PROMPT_MODE.
+        _spm = os.environ.get("FLASHRT_PI05_STATE_PROMPT_MODE", state_prompt_mode)
+        if _spm not in ("fixed", "exact"):
+            raise ValueError(
+                f"state_prompt_mode must be 'fixed' or 'exact', got {_spm!r}")
+        self._state_prompt_mode = _spm
         self.num_views = int(num_views)
         self.chunk_size = int(chunk_size)
         self.max_prompt_len = int(max_prompt_len)
@@ -1003,6 +1019,51 @@ class Pi05TorchFrontendRtx:
                    else MAX_PROMPT_LEN_DEFAULT)
         embeds, prompt_len = _embed_prompt(
             prompt_text, self.embedding_weight, max_len=max_len, state=state)
+
+        if self._state_prompt_mode == "fixed" and state is not None:
+            self._set_prompt_fixed(prompt_len)
+        else:
+            self._set_prompt_per_length(state, prompt_len)
+
+        # Upload language embeds into pipeline's encoder_x slot. In fixed mode
+        # set_language_embeds pads to max + updates the seqused/devpos buffers.
+        embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
+        self.pipeline.set_language_embeds(embeds_np)
+        self._frame_count = 0
+        logger.info("Set prompt: '%s' (%d tokens, state=%s, mode=%s)",
+                    prompt_text, prompt_len, state is not None,
+                    self._state_prompt_mode)
+
+    def _set_prompt_fixed(self, prompt_len: int) -> None:
+        """Fixed-shape mode: build ONE max-length pipeline + one graph; later
+        prompt lengths only update embeds + seqused/devpos (no re-capture)."""
+        self._ensure_prompt_capacity(PI05_STATE_PROMPT_MAX_LEN)
+        if (self.pipeline is None
+                or not getattr(self.pipeline, "_fixed_shape", False)):
+            logger.info("Building fixed-shape Pi05Pipeline (max_prompt_len=%d)...",
+                        PI05_STATE_PROMPT_MAX_LEN)
+            self.graph_recorded = False
+            self.calibrated = False
+            pipeline_weights = self._build_pipeline_weights()
+            self.pipeline = Pi05Pipeline(
+                gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
+                weights=pipeline_weights,
+                num_views=self.num_views,
+                max_prompt_len=PI05_STATE_PROMPT_MAX_LEN,
+                chunk_size=self.chunk_size,
+                num_steps=self._num_steps,
+                vision_pool_factor=self._vision_pool_factor,
+                vision_num_layers=self._vision_num_layers,
+                fixed_shape=True,
+                **self._pipeline_precision_kwargs())
+            if self.pipeline.use_int8_vision_static:
+                self.pipeline.vis_int8_static_calibrated = False
+                self.pipeline.vis_int8_static_scales = {}
+        self.current_prompt_len = prompt_len
+
+    def _set_prompt_per_length(self, state, prompt_len: int) -> None:
+        """Legacy 'exact' mode: a separate pipeline captured per exact length
+        (cached so a recurring length is not re-built)."""
         required_capacity = (PI05_STATE_PROMPT_MAX_LEN if state is not None
                              else prompt_len)
         self._ensure_prompt_capacity(required_capacity)
@@ -1021,10 +1082,6 @@ class Pi05TorchFrontendRtx:
             else:
                 logger.info("Building Pi05Pipeline for prompt_len=%d...",
                             prompt_len)
-                # Rebuild the pipeline with the exact prompt length to avoid
-                # wasted compute on padding tokens. The instance is cached so
-                # Pi0.5 discrete-state prompt lengths do not repeatedly pay
-                # build/autotune/capture when they recur.
                 self.graph_recorded = False
                 self.calibrated = False
 
@@ -1041,17 +1098,9 @@ class Pi05TorchFrontendRtx:
                     **self._pipeline_precision_kwargs())
                 self._prompt_pipeline_cache[prompt_len] = self.pipeline
                 # Static INT8 vision scales are per-pipeline-instance.
-                # Reset so calibrate_single_frame collects fresh scales.
                 if self.pipeline.use_int8_vision_static:
                     self.pipeline.vis_int8_static_calibrated = False
                     self.pipeline.vis_int8_static_scales = {}
-
-        # Upload language embeds into pipeline's encoder_x slot
-        embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
-        self.pipeline.set_language_embeds(embeds_np)
-        self._frame_count = 0
-        logger.info("Set prompt: '%s' (%d tokens, state=%s)",
-                    prompt_text, prompt_len, state is not None)
 
     def warm_state_prompt_buckets(self, prompt_text: str, states,
                                   sample_observation: dict) -> list[int]:

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -1699,6 +1699,11 @@ class Pi05TorchFrontendRtx:
                 encoder_seq_max=enc_seq_max,
                 chunk_size=self.chunk_size,
                 num_encoder_layers=ENC_L)
+            # Replacing the backend orphans any single-sample pipelines that were
+            # bound to the old one; drop the caches so they are rebuilt on the
+            # new backend (mirrors _ensure_prompt_capacity()).
+            self._prompt_pipeline_cache.clear()
+            self._fixed_pipeline = None
         self._batched_active = True
         # Force pipeline rebuild so set_prompt_batch picks the batched class.
         if not isinstance(self.pipeline, Pi05BatchedPipeline):

--- a/flash_rt/hardware/rtx/attn_backend.py
+++ b/flash_rt/hardware/rtx/attn_backend.py
@@ -478,6 +478,40 @@ class RtxFlashAttnBackend:
             stream=stream,
         )
 
+    def set_fixed_shape(self, enabled: bool) -> None:
+        """Enable/disable fixed-shape (seqused/devpos) state-prompt execution.
+
+        Fixed shape masks the padded prompt prefix with FlashAttention-2
+        ``seqused_k`` (``fwd_bf16_seqused``) on the encoder + decoder sites, so
+        it is ONLY correct on the vendored bf16 FA2 path with those sites
+        enabled. The legacy pip-flash-attn fallback (``FVK_RTX_FA2=0`` or a
+        site excluded via ``FVK_RTX_FA2_SITES``) does NOT mask the padded keys
+        and would silently produce wrong output — so refuse to enable there
+        instead of falling back. Call with ``False`` to return to per-length
+        execution (the shared backend is reused across pipelines, so the active
+        pipeline must sync this each time it changes).
+        """
+        if enabled:
+            reasons = []
+            if self._is_fp16:
+                reasons.append("backend is fp16 (seqused path is bf16-only)")
+            if not self._use_fvk_fa2:
+                reasons.append("FVK_RTX_FA2=0 (vendored FA2 disabled)")
+            if not self._fa2_sites.get("encoder", False):
+                reasons.append("encoder excluded from FVK_RTX_FA2_SITES")
+            if not self._fa2_sites.get("decoder", False):
+                reasons.append("decoder excluded from FVK_RTX_FA2_SITES")
+            if not hasattr(getattr(self, "_fa2", None), "fwd_bf16_seqused"):
+                reasons.append("flash_rt_fa2.fwd_bf16_seqused unavailable")
+            if reasons:
+                raise RuntimeError(
+                    "Pi0.5 fixed-shape state-prompt mode needs the vendored "
+                    "bf16 FlashAttention-2 seqused path on the encoder+decoder "
+                    "sites; refusing because: " + "; ".join(reasons) + ". Use "
+                    "state_prompt_mode='exact' (per-length capture), or enable "
+                    "FA2 (unset FVK_RTX_FA2 / FVK_RTX_FA2_SITES).")
+        self._fixed_shape = bool(enabled)
+
     def set_fixed_valid_len(self, valid_prefix_len: int) -> None:
         """Update the fixed-shape valid prefix length (host->device).
 

--- a/flash_rt/hardware/rtx/attn_backend.py
+++ b/flash_rt/hardware/rtx/attn_backend.py
@@ -269,6 +269,18 @@ class RtxFlashAttnBackend:
         # pay zero overhead.
         self.dec_O_masked = torch.empty(chunk_size, 8, 256, dtype=bf16, device=d)
 
+        # ── Fixed-shape (seqused/devpos) state-prompt support ──
+        # One captured graph at the MAX prefix length serves any prompt length.
+        # The valid prefix length is read from device buffers at replay, so FA2
+        # (seqused_k) masks the padded keys and the decoder appends its action
+        # K/V right after the valid prefix (qkv_split_rope_devpos). Updated per
+        # set_prompt via :meth:`set_fixed_valid_len` — runtime inputs, never a
+        # recapture. batch=1, so each is a single int32.
+        self._fixed_shape = False
+        self.enc_seqused = torch.zeros(1, dtype=torch.int32, device=d)  # vis_enc+plen
+        self.dec_seqused = torch.zeros(1, dtype=torch.int32, device=d)  # +chunk
+        self.dec_devpos = torch.zeros(1, dtype=torch.int32, device=d)   # = enc_seqused
+
         # Cached shape metadata
         self._num_views = num_views
         self._encoder_seq_max = encoder_seq_max
@@ -466,6 +478,47 @@ class RtxFlashAttnBackend:
             stream=stream,
         )
 
+    def set_fixed_valid_len(self, valid_prefix_len: int) -> None:
+        """Update the fixed-shape valid prefix length (host->device).
+
+        ``valid_prefix_len`` = vision tokens + valid prompt tokens. Drives:
+          - encoder self-attn seqused_k  = valid_prefix_len
+          - decoder cross-attn seqused_k = valid_prefix_len + chunk
+          - decoder K/V append row offset (devpos) = valid_prefix_len
+        Called once per prompt (outside the captured graph); the graph reads
+        these device buffers at replay, so no recapture as the length drifts.
+        """
+        import torch
+        v = int(valid_prefix_len)
+        self.enc_seqused.fill_(v)
+        self.dec_seqused.fill_(v + self._chunk_size)
+        self.dec_devpos.fill_(v)
+        # Cold path (once per prompt): make the device writes visible before
+        # the next graph replay reads them (the fills run on the current stream,
+        # the graph replays on its own captured stream).
+        torch.cuda.synchronize()
+
+    def _call_fvk_fa2_seqused(self, q, k, v, o, lse, seqused, *,
+                              stream: int = 0, softmax_scale=None):
+        """FA2 with a device-side valid K length (``seqused_k``): the kernel
+        early-exits past ``seqused[0]`` keys, so one fixed-shape (max-length)
+        launch masks the padded prefix bit-exactly. bf16-only."""
+        B, Sq, Hq, D = q.shape
+        Sk, Hk = k.shape[1], k.shape[2]
+        if softmax_scale is None:
+            softmax_scale = 1.0 / (D ** 0.5)
+        self._fa2.fwd_bf16_seqused(
+            Q=q.data_ptr(), K=k.data_ptr(), V=v.data_ptr(),
+            O=o.data_ptr(), softmax_lse=lse.data_ptr(),
+            seqused_k=seqused.data_ptr(),
+            batch=B, seqlen_q=Sq, seqlen_k=Sk,
+            num_heads_q=Hq, num_heads_kv=Hk, head_dim=D,
+            q_strides=(q.stride(0), q.stride(1), q.stride(2)),
+            k_strides=(k.stride(0), k.stride(1), k.stride(2)),
+            v_strides=(v.stride(0), v.stride(1), v.stride(2)),
+            o_strides=(o.stride(0), o.stride(1), o.stride(2)),
+            softmax_scale=softmax_scale, num_sms=self._num_sms, stream=stream)
+
     def vision_attn(self, stream: int = 0) -> int:
         # (batch=nv, seq=256, heads=16, head_dim=72) → per-view attention
         if self._fa2_sites["siglip"]:
@@ -492,9 +545,14 @@ class RtxFlashAttnBackend:
         v = self.enc_V[layer_idx, :seq].unsqueeze(0)     # (1, seq, 1, 256)
         if self._fa2_sites["encoder"]:
             o = self._enc_O[:, :seq].contiguous()
-            self._call_fvk_fa2(q, k, v, o, self._enc_lse, stream=stream,
-                               lse_accum=self._enc_lse_accum,
-                               o_accum=self._enc_o_accum)
+            if self._fixed_shape:
+                # Fixed max shape; padded prefix keys masked via seqused_k.
+                self._call_fvk_fa2_seqused(
+                    q, k, v, o, self._enc_lse, self.enc_seqused, stream=stream)
+            else:
+                self._call_fvk_fa2(q, k, v, o, self._enc_lse, stream=stream,
+                                   lse_accum=self._enc_lse_accum,
+                                   o_accum=self._enc_o_accum)
             return o.data_ptr()
         out = self._flash_attn_func(q, k, v, causal=False)
         self._enc_out_ref = out
@@ -508,9 +566,16 @@ class RtxFlashAttnBackend:
         v = self.enc_V[layer_idx, :total_kv].unsqueeze(0)    # (1, total, 1, 256)
         if self._fa2_sites["decoder"]:
             o = self._dec_O[:, :dec_seq].contiguous()
-            self._call_fvk_fa2(q, k, v, o, self._dec_lse, stream=stream,
-                               lse_accum=self._dec_lse_accum,
-                               o_accum=self._dec_o_accum)
+            if self._fixed_shape:
+                # The decoder's action K/V were appended right after the valid
+                # prefix (qkv_split_rope_devpos), so [0 : valid+chunk] is one
+                # contiguous valid range — single seqused call masks padding.
+                self._call_fvk_fa2_seqused(
+                    q, k, v, o, self._dec_lse, self.dec_seqused, stream=stream)
+            else:
+                self._call_fvk_fa2(q, k, v, o, self._dec_lse, stream=stream,
+                                   lse_accum=self._dec_lse_accum,
+                                   o_accum=self._dec_o_accum)
             return o.data_ptr()
         out = self._flash_attn_func(q, k, v, causal=False)
         self._dec_out_ref = out

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -171,10 +171,13 @@ class Pi05Pipeline:
         # Fixed-shape state-prompt mode: one captured graph at the MAX prompt
         # length serves every length via seqused masking + devpos K/V append.
         # The attention backend masks padded keys; this pipeline appends the
-        # decoder K/V right after the valid prefix. Toggled by the frontend.
+        # decoder K/V right after the valid prefix. set_fixed_shape validates
+        # the FA2 seqused path is available (fail-fast for fixed pipelines).
+        # NOTE: the backend is SHARED across pipelines, so the frontend re-syncs
+        # backend.set_fixed_shape(active_pipeline._fixed_shape) on every prompt
+        # — this build-time call must not be relied on for run-time mode.
         self._fixed_shape = bool(fixed_shape)
-        if self._fixed_shape:
-            self.attn._fixed_shape = True
+        self.attn.set_fixed_shape(self._fixed_shape)
 
         self.num_views = int(num_views)
         self.max_prompt_len = int(max_prompt_len)

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -161,11 +161,20 @@ class Pi05Pipeline:
                  use_int8_vision_static: bool = False,
                  vision_pool_factor: int = 1,
                  vision_num_layers: int = VIS_L,
-                 num_steps: int = NUM_STEPS_DEFAULT):
+                 num_steps: int = NUM_STEPS_DEFAULT,
+                 fixed_shape: bool = False):
         self.gemm = gemm
         self.fvk = fvk
         self.attn = attn_backend
         self.weights = weights
+
+        # Fixed-shape state-prompt mode: one captured graph at the MAX prompt
+        # length serves every length via seqused masking + devpos K/V append.
+        # The attention backend masks padded keys; this pipeline appends the
+        # decoder K/V right after the valid prefix. Toggled by the frontend.
+        self._fixed_shape = bool(fixed_shape)
+        if self._fixed_shape:
+            self.attn._fixed_shape = True
 
         self.num_views = int(num_views)
         self.max_prompt_len = int(max_prompt_len)
@@ -1486,15 +1495,28 @@ class Pi05Pipeline:
                     B["decoder_QKV"].ptr.value,
                     ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D, stream=stream)
 
-        # C2: QKV split + RoPE. Decoder K/V write into enc cache at offset enc_seq.
-        k_ptr, v_ptr = self._enc_kv_layer_ptrs(i, offset_tokens=enc_seq)
-        fvk.qkv_split_rope(
-            B["decoder_QKV"].ptr.value,
-            B["decoder_rope_weights"].ptr.value,
-            attn_ptrs["dec_Q"],
-            k_ptr, v_ptr,
-            ds, DEC_NH * DEC_HD, DEC_NKV * DEC_HD, DEC_NKV * DEC_HD,
-            DEC_HD, stream=stream)
+        # C2: QKV split + RoPE. Decoder K/V write into enc cache after prefix.
+        if self._fixed_shape:
+            # Fixed graph: append the action K/V right after the VALID prefix
+            # (runtime row offset = devpos), so cross-attn over [0:valid+chunk]
+            # is one contiguous (seqused) call. K/V pointers are cache base.
+            k_base, v_base = self._enc_kv_layer_ptrs(i, offset_tokens=0)
+            fvk.qkv_split_rope_devpos(
+                B["decoder_QKV"].ptr.value,
+                B["decoder_rope_weights"].ptr.value,
+                attn_ptrs["dec_Q"],
+                k_base, v_base, self.attn.dec_devpos.data_ptr(),
+                ds, DEC_NH * DEC_HD, DEC_NKV * DEC_HD, DEC_NKV * DEC_HD,
+                DEC_HD, stream=stream)
+        else:
+            k_ptr, v_ptr = self._enc_kv_layer_ptrs(i, offset_tokens=enc_seq)
+            fvk.qkv_split_rope(
+                B["decoder_QKV"].ptr.value,
+                B["decoder_rope_weights"].ptr.value,
+                attn_ptrs["dec_Q"],
+                k_ptr, v_ptr,
+                ds, DEC_NH * DEC_HD, DEC_NKV * DEC_HD, DEC_NKV * DEC_HD,
+                DEC_HD, stream=stream)
 
         # C3: Cross-attention (decoder Q over enc+dec K/V cache) — returns ptr.
         dec_o_ptr = self.attn.run(
@@ -1991,6 +2013,15 @@ class Pi05Pipeline:
             f"prompt_len {prompt_len} exceeds max_prompt_len {self.max_prompt_len}"
         assert lang_embeds_np.shape[1] == ENC_D
 
+        if self._fixed_shape and prompt_len < self.max_prompt_len:
+            # Pad to max with zeros so the in-graph embeds copy is a fixed
+            # MAX-row copy; the padded prompt rows are masked (seqused) in
+            # attention, so they never affect the valid output.
+            padded = np.zeros((self.max_prompt_len, ENC_D),
+                              dtype=lang_embeds_np.dtype)
+            padded[:prompt_len] = lang_embeds_np
+            lang_embeds_np = padded
+
         # Store a persistent device copy of the (prompt_len, ENC_D) embeds.
         # CUDA Graph capture bakes the source pointer used by
         # _copy_lang_embeds_to_encoder_x(), so same-shape prompt updates must
@@ -2005,6 +2036,11 @@ class Pi05Pipeline:
 
         # Update decoder RoPE slice for this prompt length
         self._set_decoder_rope_for_prompt(prompt_len)
+
+        # Fixed-shape: update the valid prefix length read by FA2 (seqused) +
+        # the devpos K/V append offset. Runtime device buffers; no recapture.
+        if self._fixed_shape:
+            self.attn.set_fixed_valid_len(self.vision_seq_enc + prompt_len)
 
         # Initial copy into encoder_x (so the FIRST calibration pass sees
         # the correct lang embeds without needing a prior forward() call).

--- a/tests/test_pi05_state_prompt_fixed_graph.py
+++ b/tests/test_pi05_state_prompt_fixed_graph.py
@@ -187,6 +187,37 @@ except RuntimeError:
 """
 
 
+# Switching a fixed-mode frontend to a no-state prompt and back must reuse the
+# cached fixed pipeline rather than rebuild it. A rebuild re-runs FP8
+# calibration/autotune on a backend the per-length pipeline has touched (CUDA
+# illegal access) and perturbs numerics. Run the full predict() in FP8 (the
+# default) through the switch and require it to complete with a stable output.
+_CHILD_SWITCH_PREDICT = r"""
+import sys, numpy as np, torch, flash_rt
+m = flash_rt.load_model(sys.argv[1], framework="torch", config="pi05",
+                        num_views=2, state_prompt_mode="fixed")  # FP8 default
+rng = np.random.RandomState(0)
+imgs = [rng.randint(0, 255, (224, 224, 3), dtype=np.uint8),
+        rng.randint(0, 255, (224, 224, 3), dtype=np.uint8)]
+st = np.zeros(8, dtype=np.float32)
+prompt = "pick up the cup"
+for kw in (dict(state=st), dict(), dict(state=st)):  # warm both pipelines
+    m.predict(imgs, prompt=prompt, **kw)
+
+def pr(**kw):
+    torch.manual_seed(11)
+    return np.asarray(m.predict(imgs, prompt=prompt, **kw), dtype=np.float32)
+
+a1 = pr(state=st)   # fixed
+_ = pr()            # no-state -> per-length pipeline
+a2 = pr(state=st)   # back to fixed (must reuse cached graph, same state)
+x, y = a1.reshape(-1).astype(np.float64), a2.reshape(-1).astype(np.float64)
+cos = float(x @ y / (np.linalg.norm(x) * np.linalg.norm(y)))
+finite = bool(np.isfinite(a1).all() and np.isfinite(a2).all())
+print("SWITCHPRED", finite, round(cos, 6))
+"""
+
+
 def _run_child_text(child_src):
     proc = subprocess.run([sys.executable, "-c", child_src, CKPT_PI05],
                           capture_output=True, text=True, env=dict(os.environ))
@@ -216,3 +247,18 @@ def test_fixed_shape_refuses_without_fa2_seqused():
     assert line.strip() == "RESULT RAISED", (
         f"fixed-shape must refuse when the FA2 seqused path is unavailable, "
         f"got: {line}")
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="CUDA GPU required")
+@pytest.mark.skipif(not _CKPT_AVAILABLE,
+                    reason=f"Pi0.5 checkpoint not found at {CKPT_PI05}")
+def test_fixed_shape_mode_switch_predict_fp8_no_rebuild():
+    out = _run_child_text(_CHILD_SWITCH_PREDICT)
+    line = [ln for ln in out.splitlines() if ln.startswith("SWITCHPRED")][-1]
+    _, finite, cos = line.split()
+    assert finite == "True", f"non-finite action through mode switch: {line}"
+    # Same state before and after the no-state detour: the cached fixed
+    # pipeline is reused (not rebuilt), so the outputs must match closely.
+    assert float(cos) >= 0.999, (
+        f"fixed pipeline not reused across mode switch (cos={cos}); a rebuild "
+        "would re-calibrate/re-capture and perturb the output")

--- a/tests/test_pi05_state_prompt_fixed_graph.py
+++ b/tests/test_pi05_state_prompt_fixed_graph.py
@@ -1,11 +1,11 @@
 """End-to-end gate for the Pi0.5 fixed-shape state-prompt graph.
 
 Pi0.5 renders the discretized robot state into the language prompt, so the
-prompt token length drifts with the state values. The default
+prompt token length drifts with the state values. The opt-in
 ``state_prompt_mode="fixed"`` keeps ONE pipeline and ONE captured graph at the
 max prompt length: every length is served by masking the padded prefix keys
 (FlashAttention-2 ``seqused_k``) and appending the decoder's action K/V right
-after the valid prefix (``qkv_split_rope_devpos``). The legacy ``"exact"`` mode
+after the valid prefix (``qkv_split_rope_devpos``). The default ``"exact"`` mode
 captures a separate graph per length.
 
 Gates (each mode runs in its own child process; sharing a CUDA context between
@@ -143,3 +143,76 @@ def test_fixed_graph_mechanism_exact_and_one_graph():
         assert c >= 0.9999, (
             f"BF16 step {i} (len={fixed['lens'][i]}): fixed vs exact "
             f"cos={c:.7f} — seqused/devpos mechanism is not bit-exact")
+
+
+# The shared attention backend must track the active pipeline's mode: a
+# fixed-mode frontend that serves a state prompt and then a no-state prompt
+# (which falls back to a per-length pipeline) must NOT leave the backend in
+# fixed mode with stale seqused/devpos.
+_CHILD_SWITCH = r"""
+import sys, numpy as np, flash_rt
+m = flash_rt.load_model(sys.argv[1], framework="torch", config="pi05",
+                        num_views=2, state_prompt_mode="fixed")
+fe = m._pipe
+st = np.zeros(8, dtype=np.float32)
+flags = []
+def active_flag():
+    # The frontend may swap attn_backend when growing prompt capacity, so read
+    # it fresh; it must be the SAME object the active pipeline runs on.
+    assert fe.attn_backend is fe.pipeline.attn, "backend/pipeline mismatch"
+    return bool(fe.attn_backend._fixed_shape)
+fe.set_prompt("pick up the cup", state=st)        # fixed pipeline
+flags.append(active_flag())
+fe.set_prompt("pick up the cup")                  # no-state -> per-length
+flags.append(active_flag())
+fe.set_prompt("pick up the cup", state=st + 1.0)  # fixed again
+flags.append(active_flag())
+print("FLAGS", flags[0], flags[1], flags[2])
+"""
+
+# Fixed shape relies on the vendored bf16 FA2 seqused path; if a site is
+# unavailable it must REFUSE (raise) rather than silently run the unmasked
+# legacy path on padded keys.
+_CHILD_FA2_GUARD = r"""
+import sys, flash_rt
+m = flash_rt.load_model(sys.argv[1], framework="torch", config="pi05",
+                        num_views=2, state_prompt_mode="exact")
+be = m._pipe.attn_backend
+be._fa2_sites["encoder"] = False   # simulate FA2 excluded for a site
+try:
+    be.set_fixed_shape(True)
+    print("RESULT NO_RAISE")
+except RuntimeError:
+    print("RESULT RAISED")
+"""
+
+
+def _run_child_text(child_src):
+    proc = subprocess.run([sys.executable, "-c", child_src, CKPT_PI05],
+                          capture_output=True, text=True, env=dict(os.environ))
+    if proc.returncode != 0:
+        raise RuntimeError(f"child failed:\n{proc.stdout}\n{proc.stderr}")
+    return proc.stdout
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="CUDA GPU required")
+@pytest.mark.skipif(not _CKPT_AVAILABLE,
+                    reason=f"Pi0.5 checkpoint not found at {CKPT_PI05}")
+def test_fixed_shape_backend_synced_on_mode_switch():
+    out = _run_child_text(_CHILD_SWITCH)
+    line = [ln for ln in out.splitlines() if ln.startswith("FLAGS")][-1]
+    _, a, b, c = line.split()
+    assert (a, b, c) == ("True", "False", "True"), (
+        f"backend _fixed_shape not synced to active pipeline: {line} "
+        "(state->True, no-state->False, state->True expected)")
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="CUDA GPU required")
+@pytest.mark.skipif(not _CKPT_AVAILABLE,
+                    reason=f"Pi0.5 checkpoint not found at {CKPT_PI05}")
+def test_fixed_shape_refuses_without_fa2_seqused():
+    out = _run_child_text(_CHILD_FA2_GUARD)
+    line = [ln for ln in out.splitlines() if ln.startswith("RESULT")][-1]
+    assert line.strip() == "RESULT RAISED", (
+        f"fixed-shape must refuse when the FA2 seqused path is unavailable, "
+        f"got: {line}")

--- a/tests/test_pi05_state_prompt_fixed_graph.py
+++ b/tests/test_pi05_state_prompt_fixed_graph.py
@@ -1,0 +1,145 @@
+"""End-to-end gate for the Pi0.5 fixed-shape state-prompt graph.
+
+Pi0.5 renders the discretized robot state into the language prompt, so the
+prompt token length drifts with the state values. The default
+``state_prompt_mode="fixed"`` keeps ONE pipeline and ONE captured graph at the
+max prompt length: every length is served by masking the padded prefix keys
+(FlashAttention-2 ``seqused_k``) and appending the decoder's action K/V right
+after the valid prefix (``qkv_split_rope_devpos``). The legacy ``"exact"`` mode
+captures a separate graph per length.
+
+Gates (each mode runs in its own child process; sharing a CUDA context between
+two frontends in one process is known-flaky — see test_pi05_batched_*):
+
+1. **Mechanism is exact** — in BF16 (no FP8 quant noise), fixed-mode actions
+   match exact-mode actions to cosine >= 0.9999 across a varying-length state
+   sequence. This proves the seqused masking + devpos K/V append reproduce the
+   per-length computation bit-for-bit; exact mode is the unchanged origin/main
+   path (validated against the openpi reference), so the equivalence carries.
+2. **One graph, zero recapture** — fixed mode captures exactly ONE graph for
+   the whole sequence; exact mode captures one per distinct length.
+3. **Coverage** — the sequence exercises multiple distinct prompt lengths.
+
+The FP8 path adds quantization/tactic noise (fixed runs GEMMs at the padded
+M=vision+max, exact at M=vision+len), so fixed-vs-exact FP8 cosine is ~0.999 and
+is reported (not hard-gated) here; the BF16 gate is the exactness proof and the
+FP8 cosine-vs-reference should be validated on real benchmark observations.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+
+CKPT_PI05 = os.environ.get(
+    "PI05_LIBERO_PYTORCH_CHECKPOINT",
+    "<ckpts>/pi05_libero_pytorch")
+
+_GPU_AVAILABLE = torch.cuda.is_available()
+_CKPT_AVAILABLE = os.path.isdir(CKPT_PI05)
+
+_CHILD = r"""
+import sys, numpy as np, torch
+import flash_rt
+
+mode, ckpt, out_path, seed = (
+    sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4]))
+
+rng = np.random.RandomState(0)
+images = [rng.randint(0, 255, (224, 224, 3), dtype=np.uint8),
+          rng.randint(0, 255, (224, 224, 3), dtype=np.uint8)]
+prompt = "pick up the cup"
+states = [
+    np.zeros(8, dtype=np.float32),
+    np.ones(8, dtype=np.float32),
+    np.full(8, 0.5, dtype=np.float32),
+    np.linspace(-1.0, 1.0, 8).astype(np.float32),
+    np.full(8, -0.5, dtype=np.float32),
+]
+
+model = flash_rt.load_model(ckpt, framework="torch", config="pi05",
+                            num_views=2, state_prompt_mode=mode)
+fe = model._pipe
+# Warmup: calibrate + capture (fixed: one graph; exact: per-length).
+for s in states:
+    model.predict(images, prompt=prompt, state=s)
+
+def measure(s):
+    torch.manual_seed(seed)
+    a = np.asarray(model.predict(images, prompt=prompt, state=s),
+                   dtype=np.float32)
+    return a, int(fe.current_prompt_len)
+
+acts, lens = [], []
+for s in states:
+    a, L = measure(s)
+    acts.append(a)
+    lens.append(L)
+acts = np.stack(acts)
+lens = np.array(lens, dtype=np.int64)
+
+if mode == "fixed" and getattr(fe.pipeline, "_fixed_shape", False):
+    n_graphs = 1
+else:
+    n_graphs = len(getattr(fe, "_prompt_pipeline_cache", {}))
+
+np.savez(out_path, acts=acts, lens=lens, n_graphs=n_graphs)
+"""
+
+
+def _run(mode, ckpt, env=None, seed=4321):
+    with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+        out_path = f.name
+    full_env = dict(os.environ)
+    if env:
+        full_env.update(env)
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD, mode, ckpt, out_path, str(seed)],
+        capture_output=True, text=True, env=full_env)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{mode} child failed:\nSTDOUT:\n{proc.stdout}\n"
+            f"STDERR:\n{proc.stderr}")
+    data = dict(np.load(out_path))
+    os.unlink(out_path)
+    return data
+
+
+def _cos(a, b):
+    a = a.reshape(-1).astype(np.float64)
+    b = b.reshape(-1).astype(np.float64)
+    na, nb = np.linalg.norm(a), np.linalg.norm(b)
+    return float(a @ b / (na * nb)) if na > 0 and nb > 0 else float("nan")
+
+
+@pytest.mark.skipif(not _GPU_AVAILABLE, reason="CUDA GPU required")
+@pytest.mark.skipif(not _CKPT_AVAILABLE,
+                    reason=f"Pi0.5 checkpoint not found at {CKPT_PI05}")
+def test_fixed_graph_mechanism_exact_and_one_graph():
+    # ── BF16: the exactness proof (no FP8 quant noise) ──
+    bf = {"FVK_PI05_RTX_FORCE_BF16": "1"}
+    fixed = _run("fixed", CKPT_PI05, env=bf)
+    exact = _run("exact", CKPT_PI05, env=bf)
+
+    # Coverage + lengths agree across modes.
+    distinct = sorted(set(fixed["lens"].tolist()))
+    assert len(distinct) >= 2, f"need >=2 prompt lengths, got {distinct}"
+    assert fixed["lens"].tolist() == exact["lens"].tolist()
+
+    # One graph (fixed) vs per-length (exact).
+    assert int(fixed["n_graphs"]) == 1, (
+        f"fixed mode must capture exactly ONE graph, got {fixed['n_graphs']}")
+    assert int(exact["n_graphs"]) == len(distinct), (
+        f"exact mode: one graph per length {len(distinct)}, "
+        f"got {exact['n_graphs']}")
+
+    # Mechanism exact: BF16 fixed == exact per step.
+    for i in range(fixed["acts"].shape[0]):
+        c = _cos(fixed["acts"][i], exact["acts"][i])
+        assert c >= 0.9999, (
+            f"BF16 step {i} (len={fixed['lens'][i]}): fixed vs exact "
+            f"cos={c:.7f} — seqused/devpos mechanism is not bit-exact")

--- a/tests/test_prompt_runtime_lifecycle.py
+++ b/tests/test_prompt_runtime_lifecycle.py
@@ -3,6 +3,18 @@ from pathlib import Path
 import numpy as np
 
 
+class _FakeAttnBackend:
+    """Minimal stand-in for RtxFlashAttnBackend in the lightweight lifecycle
+    tests: set_prompt() syncs the shared backend's fixed-shape flag to the
+    active pipeline, so the mock must accept set_fixed_shape()."""
+
+    def __init__(self):
+        self._fixed_shape = False
+
+    def set_fixed_shape(self, enabled):
+        self._fixed_shape = bool(enabled)
+
+
 def test_pi05_rtx_caches_recurring_state_prompt_lengths(monkeypatch):
     import torch
     from flash_rt.frontends.torch import pi05_rtx
@@ -38,11 +50,13 @@ def test_pi05_rtx_caches_recurring_state_prompt_lengths(monkeypatch):
     pipe.pipeline = None
     pipe.current_prompt_len = 0
     pipe._prompt_pipeline_cache = {}
+    pipe._fixed_pipeline = None
+    pipe._state_prompt_mode = "exact"
     pipe.graph_recorded = False
     pipe.calibrated = False
     pipe.gemm = None
     pipe.fvk = None
-    pipe.attn_backend = None
+    pipe.attn_backend = _FakeAttnBackend()
     pipe._build_pipeline_weights = lambda: {}
     pipe._pipeline_precision_kwargs = lambda: {}
 
@@ -98,11 +112,13 @@ def test_vla_model_warms_pi05_state_prompt_buckets(monkeypatch):
     pipe.pipeline = None
     pipe.current_prompt_len = 0
     pipe._prompt_pipeline_cache = {}
+    pipe._fixed_pipeline = None
+    pipe._state_prompt_mode = "exact"
     pipe.graph_recorded = False
     pipe.calibrated = False
     pipe.gemm = None
     pipe.fvk = None
-    pipe.attn_backend = None
+    pipe.attn_backend = _FakeAttnBackend()
     pipe._build_pipeline_weights = lambda: {}
     pipe._pipeline_precision_kwargs = lambda: {}
 


### PR DESCRIPTION
…ture)

Pi0.5 renders discretized robot state into the prompt, so the token length drifts with state values. Add a `state_prompt_mode` to the RTX Pi0.5 frontend:

  - "exact" (default, unchanged behavior): a separate pipeline captured per exact prompt length, cached; pair with warm_state_prompt_buckets() to front-load the lengths you expect.
  - "fixed" (opt-in): ONE pipeline + ONE captured graph at the max prompt length serves every length. Padded prefix keys are masked via FlashAttention-2 seqused_k; the decoder appends its action K/V right after the valid prefix through a new qkv_split_rope_devpos kernel, so a changing state length never re-captures a graph or reruns autotune and no warmup is needed. Select via state_prompt_mode="fixed" or FLASHRT_PI05_STATE_PROMPT_MODE=fixed.

Validated on Pi0.5 (RTX 5090): BF16 fixed-vs-exact cosine >= 0.9999 over a varying-length state sequence (seqused + devpos reproduce the per-length computation bit-for-bit), one captured graph vs per-length, zero recapture. Non-state prompts are unchanged.

New additive kernel qkv_split_rope_devpos (rope.cu + binding); existing kernels untouched.

### 2. Per-frame precision on real LIBERO frames (8 frames, real state, identical noise)

Unnormalized robot actions; `original` = unquantized BF16 model output.

| frame | len | fixed-FP8 vs original | exact-FP8 vs original | fixed-FP8 vs exact-FP8 |
|---|---|---|---|---|
|  |  | cos / max_abs | cos / max_abs | cos / max_abs |
| 0 | 62 | 0.999981 / 0.0078 | 0.999987 / 0.0065 | 0.999978 / 0.0081 |
| 1 | 62 | 0.999976 / 0.0117 | 0.999988 / 0.0078 | 0.999978 / 0.0099 |
| 2 | 62 | 0.999802 / 0.0395 | 0.999764 / 0.0428 | 0.999982 / 0.0082 |
| 3 | 60 | 0.999901 / 0.0154 | 0.999967 / 0.0147 | 0.999917 / 0.0152 |
| 4 | 61 | 0.999964 / 0.0194 | 0.999987 / 0.0117 | 0.999960 / 0.0162 |
| 5 | 61 | 0.999962 / 0.0147 | 0.999975 / 0.0156 | 0.999963 / 0.0156 |
| 6 | 61 | 0.999891 / 0.0280 | 0.999890 / 0.0321 | 0.999953 / 0.0195 |
| 7 | 61 | 0.999976 / 0.0109 | 0.999969 / 0.0195 | 0.999956 / 0.0234 |
| **mean** |  | **0.999932** | **0.999941** | **0.999961** |

**fixed-FP8 vs original (0.99993) ≈ exact-FP8 vs original (0.99994)** — fixed mode
is as accurate as the shipped exact path against the unquantized model; the
difference is FP8 noise, not a regression.

## Latency (RTX 5090, FP8, pure CUDA-graph replay)

Measured as **pure graph replay** (CUDA events around the captured graph, 500-iter
warmup); the replay is deterministic (std ≤ 0.03 ms). Prompt ≈ 51 tokens,
`PI05_STATE_PROMPT_MAX_LEN=200`.

| views | `exact` | `fixed` | **fixed − exact** |
|---|---|---|---|
| 2 | 18.68 ms | 23.21 ms | **+4.53 ms** |
| 3 | 21.37 ms | 28.10 ms | **+6.74 ms** |
| **3 − 2 (extra view)** | +2.69 ms | +4.90 ms | |

- `"fixed"` runs **every** inference at the padded max length (200 here vs the
  ~51-token prompt), so it is ~+4.5 ms (2v) / +6.7 ms (3v) slower than `"exact"`
  at that length — the price for never re-capturing as the length drifts. The
  gap shrinks as `PI05_STATE_PROMPT_MAX_LEN` approaches the real maximum.
- The extra camera view costs +2.69 ms (`exact`) / +4.90 ms (`fixed`); `fixed`
  pays more because the third view's tokens add onto the larger padded base.
- A full `predict()` adds ~1–1.6 ms over pure replay (noise gen + image H2D +
  output D2H) — that overhead is identical in both modes.
- Recommendation for peak latency: use `"exact"` and warm a fuller length sweep
  with `warm_state_prompt_buckets()`; use `"fixed"` when you'd rather not
  enumerate lengths and can spend the padding overhead.
