### PR TITLE
Pi05 state serving opt

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -140,12 +140,15 @@ length: the padded prefix keys are masked (FlashAttention-2 `seqused_k`) and the
 decoder's action K/V are appended right after the *valid* prefix
 (`qkv_split_rope_devpos`), so a changing state-token length **never re-captures
 a graph or reruns autotune** — no warmup needed. The trade-off is latency:
-every inference runs at the padded max length, so `"fixed"` is ~+4.6 ms (2
-views) / +6.7 ms (3 views) slower than `"exact"` at a typical prompt length —
-for peak performance prefer `"exact"` and warm a fuller length sweep yourself
-with `warm_state_prompt_buckets()`. (Lowering `PI05_STATE_PROMPT_MAX_LEN`
-toward your real maximum shrinks the padding and the gap.) Enable `"fixed"`
-when you don't want to enumerate state lengths up front:
+every inference runs at the padded max length, so `"fixed"` is ~+1.0 ms (2
+views) / +1.2 ms (3 views) slower than `"exact"` at a typical prompt length
+(measured fp8, RTX 5090; the decoder joint-attention uses a graph-safe
+split-KV kernel that keeps the padding overhead small). That ~1 ms makes
+`"fixed"` the low-friction choice when the state-token length drifts: zero
+recapture, no length enumeration. Prefer `"exact"` + `warm_state_prompt_buckets()`
+only when you need absolute peak latency at a known, stable set of lengths.
+(Lowering `PI05_STATE_PROMPT_MAX_LEN` toward your real maximum shrinks the
+padding and the gap further.) Enable `"fixed"` like so:
 
 ```python
 model = flash_rt.load_model(

--- a/csrc/attention/fa2_wrapper.cu
+++ b/csrc/attention/fa2_wrapper.cu
@@ -309,10 +309,45 @@ extern "C" void fvk_attention_fa2_fwd_bf16_seqused(
     params.oaccum_ptr = nullptr;
     dispatch_hdim<cutlass::bfloat16_t>(head_dim, 1, params, stream);
 }
+
+// seqused_k + split-KV variant (experimental). Caller MUST pre-init
+// softmax_lse_accum to -inf each launch (empty splits past seqused_k keep that
+// so the combine ignores them) — see standalone graph-replay test.
+extern "C" void fvk_attention_fa2_fwd_bf16_seqused_splitkv(
+    const void* q_ptr, const void* k_ptr, const void* v_ptr,
+    void* o_ptr, void* softmax_lse_ptr, const void* seqused_k_ptr,
+    void* softmax_lse_accum_ptr, void* o_accum_ptr,
+    int batch, int seqlen_q, int seqlen_k,
+    int num_heads_q, int num_heads_kv, int head_dim,
+    int q_batch_stride, int q_row_stride, int q_head_stride,
+    int k_batch_stride, int k_row_stride, int k_head_stride,
+    int v_batch_stride, int v_row_stride, int v_head_stride,
+    int o_batch_stride, int o_row_stride, int o_head_stride,
+    float softmax_scale, int num_sms, cudaStream_t stream)
+{
+    FLASH_NAMESPACE::Flash_fwd_params params;
+    fill_params(params, true, q_ptr, k_ptr, v_ptr, o_ptr, softmax_lse_ptr,
+                batch, seqlen_q, seqlen_k, num_heads_q, num_heads_kv, head_dim,
+                q_batch_stride, q_row_stride, q_head_stride,
+                k_batch_stride, k_row_stride, k_head_stride,
+                v_batch_stride, v_row_stride, v_head_stride,
+                o_batch_stride, o_row_stride, o_head_stride, softmax_scale);
+    params.seqused_k = reinterpret_cast<int*>(const_cast<void*>(seqused_k_ptr));
+    int num_splits = setup_splitkv(params, softmax_lse_accum_ptr, o_accum_ptr,
+                                    num_sms, seqlen_q, seqlen_k,
+                                    head_dim, batch, num_heads_q);
+    dispatch_hdim<cutlass::bfloat16_t>(head_dim, num_splits, params, stream);
+}
 #else
 DEFINE_FA2_STUB(fvk_attention_fa2_fwd_bf16,  "bf16")
 extern "C" void fvk_attention_fa2_fwd_bf16_seqused(
     const void*, const void*, const void*, void*, void*, const void*,
+    int, int, int, int, int, int, int, int, int, int, int, int,
+    int, int, int, int, int, int, float, int, cudaStream_t)
+{ std::abort(); }
+extern "C" void fvk_attention_fa2_fwd_bf16_seqused_splitkv(
+    const void*, const void*, const void*, void*, void*, const void*,
+    void*, void*,
     int, int, int, int, int, int, int, int, int, int, int, int,
     int, int, int, int, int, int, float, int, cudaStream_t)
 { std::abort(); }

--- a/csrc/fa2_bindings.cpp
+++ b/csrc/fa2_bindings.cpp
@@ -66,6 +66,19 @@ extern "C" void fvk_attention_fa2_fwd_bf16_seqused(
     int o_batch_stride, int o_row_stride, int o_head_stride,
     float softmax_scale, int num_sms, cudaStream_t stream);
 
+// seqused_k + split-KV variant (experimental; caller pre-inits lse_accum=-inf).
+extern "C" void fvk_attention_fa2_fwd_bf16_seqused_splitkv(
+    const void* q_ptr, const void* k_ptr, const void* v_ptr,
+    void* o_ptr, void* softmax_lse_ptr, const void* seqused_k_ptr,
+    void* softmax_lse_accum_ptr, void* o_accum_ptr,
+    int batch, int seqlen_q, int seqlen_k,
+    int num_heads_q, int num_heads_kv, int head_dim,
+    int q_batch_stride, int q_row_stride, int q_head_stride,
+    int k_batch_stride, int k_row_stride, int k_head_stride,
+    int v_batch_stride, int v_row_stride, int v_head_stride,
+    int o_batch_stride, int o_row_stride, int o_head_stride,
+    float softmax_scale, int num_sms, cudaStream_t stream);
+
 // Causal variant — definition in csrc/attention/fa2_wrapper_causal.cu.
 // Currently only (bf16, head_dim=128) is built. Used by Qwen3-8B
 // prefill (S=N causal self-attention).
@@ -159,6 +172,35 @@ static auto make_fwd_seqused(
 }
 
 
+static auto make_fwd_seqused_splitkv(
+    void (*fn)(const void*, const void*, const void*, void*, void*, const void*,
+               void*, void*,
+               int, int, int, int, int, int, int, int, int, int, int, int,
+               int, int, int, int, int, int, float, int, cudaStream_t)) {
+    return [fn](uintptr_t Q, uintptr_t K, uintptr_t V, uintptr_t O,
+                uintptr_t softmax_lse, uintptr_t seqused_k,
+                uintptr_t softmax_lse_accum, uintptr_t o_accum,
+                int batch, int seqlen_q, int seqlen_k,
+                int num_heads_q, int num_heads_kv, int head_dim,
+                py::tuple q_strides, py::tuple k_strides,
+                py::tuple v_strides, py::tuple o_strides,
+                float softmax_scale, int num_sms, uintptr_t stream) {
+        fn(reinterpret_cast<const void*>(Q), reinterpret_cast<const void*>(K),
+           reinterpret_cast<const void*>(V), reinterpret_cast<void*>(O),
+           reinterpret_cast<void*>(softmax_lse),
+           reinterpret_cast<const void*>(seqused_k),
+           reinterpret_cast<void*>(softmax_lse_accum),
+           reinterpret_cast<void*>(o_accum),
+           batch, seqlen_q, seqlen_k, num_heads_q, num_heads_kv, head_dim,
+           py::cast<int>(q_strides[0]), py::cast<int>(q_strides[1]), py::cast<int>(q_strides[2]),
+           py::cast<int>(k_strides[0]), py::cast<int>(k_strides[1]), py::cast<int>(k_strides[2]),
+           py::cast<int>(v_strides[0]), py::cast<int>(v_strides[1]), py::cast<int>(v_strides[2]),
+           py::cast<int>(o_strides[0]), py::cast<int>(o_strides[1]), py::cast<int>(o_strides[2]),
+           softmax_scale, num_sms, to_stream(stream));
+    };
+}
+
+
 PYBIND11_MODULE(flash_rt_fa2, m) {
     m.doc() = "FlashRT — vendored Flash-Attention 2 forward (fp16 + bf16).";
 
@@ -171,6 +213,15 @@ PYBIND11_MODULE(flash_rt_fa2, m) {
         py::arg("v_strides"), py::arg("o_strides"),
         py::arg("softmax_scale") = 1.0f, py::arg("num_sms") = 0,
         py::arg("stream") = 0);
+
+    m.def("fwd_bf16_seqused_splitkv",
+        make_fwd_seqused_splitkv(&fvk_attention_fa2_fwd_bf16_seqused_splitkv),
+        py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"), py::arg("softmax_lse"),
+        py::arg("seqused_k"), py::arg("softmax_lse_accum")=0, py::arg("o_accum")=0,
+        py::arg("batch"), py::arg("seqlen_q"), py::arg("seqlen_k"),
+        py::arg("num_heads_q"), py::arg("num_heads_kv"), py::arg("head_dim"),
+        py::arg("q_strides"), py::arg("k_strides"), py::arg("v_strides"), py::arg("o_strides"),
+        py::arg("softmax_scale")=1.0f, py::arg("num_sms")=0, py::arg("stream")=0);
 
     m.def("fwd_fp16", make_fwd(&fvk_attention_fa2_fwd_fp16),
         py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"), py::arg("softmax_lse"),

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -387,6 +387,12 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 K/V appended at the valid offset); a changing length never
                 re-captures and no warmup is needed. Requires the vendored
                 bf16 FA2 path (``FVK_RTX_FA2=1``, encoder+decoder sites on).
+                Cost: every inference runs at the padded max length, so it is
+                ~1 ms slower than a warmed ``"exact"`` graph (split-KV decoder
+                joint-attention keeps the padding overhead small). Prefer
+                ``"fixed"`` when the state-token length drifts and you'd rather
+                not enumerate/warm lengths; prefer ``"exact"`` + warmup for
+                absolute peak latency at known lengths.
             Env override: ``FLASHRT_PI05_STATE_PROMPT_MODE``.
 
     Returns:

--- a/flash_rt/hardware/rtx/attn_backend.py
+++ b/flash_rt/hardware/rtx/attn_backend.py
@@ -503,6 +503,10 @@ class RtxFlashAttnBackend:
                 reasons.append("decoder excluded from FVK_RTX_FA2_SITES")
             if not hasattr(getattr(self, "_fa2", None), "fwd_bf16_seqused"):
                 reasons.append("flash_rt_fa2.fwd_bf16_seqused unavailable")
+            if not hasattr(getattr(self, "_fa2", None),
+                           "fwd_bf16_seqused_splitkv"):
+                reasons.append("flash_rt_fa2.fwd_bf16_seqused_splitkv "
+                               "unavailable (rebuild flash_rt_fa2)")
             if reasons:
                 raise RuntimeError(
                     "Pi0.5 fixed-shape state-prompt mode needs the vendored "
@@ -545,6 +549,40 @@ class RtxFlashAttnBackend:
             Q=q.data_ptr(), K=k.data_ptr(), V=v.data_ptr(),
             O=o.data_ptr(), softmax_lse=lse.data_ptr(),
             seqused_k=seqused.data_ptr(),
+            batch=B, seqlen_q=Sq, seqlen_k=Sk,
+            num_heads_q=Hq, num_heads_kv=Hk, head_dim=D,
+            q_strides=(q.stride(0), q.stride(1), q.stride(2)),
+            k_strides=(k.stride(0), k.stride(1), k.stride(2)),
+            v_strides=(v.stride(0), v.stride(1), v.stride(2)),
+            o_strides=(o.stride(0), o.stride(1), o.stride(2)),
+            softmax_scale=softmax_scale, num_sms=self._num_sms, stream=stream)
+
+    def _call_fvk_fa2_seqused_splitkv(self, q, k, v, o, lse, seqused, *,
+                                      lse_accum, o_accum,
+                                      stream: int = 0, softmax_scale=None):
+        """``fwd_bf16_seqused`` + split-KV (better SM occupancy on tiny-Q,
+        long-K shapes like the Pi0.5 decoder joint-attention: Sq=chunk,
+        Sk=valid_prefix+chunk, 1 KV head).
+
+        ``num_splits`` is computed host-side from ``seqlen_k`` (the K-tensor's
+        max length, fixed at capture) so it is constant across graph replays.
+        At replay with a smaller ``seqused``, splits whose K-range lies entirely
+        past ``seqused`` are empty and the kernel does NOT write ``-inf`` into
+        their ``lse_accum`` slot — so we MUST pre-fill ``lse_accum`` with
+        ``-inf`` each call (captured in the graph). Empty splits then keep
+        ``-inf`` → combine weight ``exp(-inf)=0`` → correct. ``o_accum`` needs
+        no init (it is multiplied by the zero weight). bf16-only."""
+        B, Sq, Hq, D = q.shape
+        Sk, Hk = k.shape[1], k.shape[2]
+        if softmax_scale is None:
+            softmax_scale = 1.0 / (D ** 0.5)
+        lse_accum.fill_(float("-inf"))
+        self._fa2.fwd_bf16_seqused_splitkv(
+            Q=q.data_ptr(), K=k.data_ptr(), V=v.data_ptr(),
+            O=o.data_ptr(), softmax_lse=lse.data_ptr(),
+            seqused_k=seqused.data_ptr(),
+            softmax_lse_accum=lse_accum.data_ptr(),
+            o_accum=o_accum.data_ptr(),
             batch=B, seqlen_q=Sq, seqlen_k=Sk,
             num_heads_q=Hq, num_heads_kv=Hk, head_dim=D,
             q_strides=(q.stride(0), q.stride(1), q.stride(2)),
@@ -604,8 +642,14 @@ class RtxFlashAttnBackend:
                 # The decoder's action K/V were appended right after the valid
                 # prefix (qkv_split_rope_devpos), so [0 : valid+chunk] is one
                 # contiguous valid range — single seqused call masks padding.
-                self._call_fvk_fa2_seqused(
-                    q, k, v, o, self._dec_lse, self.dec_seqused, stream=stream)
+                # Split-KV: this shape (Sq=chunk, Sk≈valid+chunk, 1 KV head) is
+                # occupancy-bound; no-split leaves most SMs idle. Split-KV is 3×
+                # faster here. (Encoder stays no-split: its Sq is already large
+                # enough to fill the GPU, and split-KV slightly hurts it.)
+                self._call_fvk_fa2_seqused_splitkv(
+                    q, k, v, o, self._dec_lse, self.dec_seqused,
+                    lse_accum=self._dec_lse_accum, o_accum=self._dec_o_accum,
+                    stream=stream)
             else:
                 self._call_fvk_fa2(q, k, v, o, self._dec_lse, stream=stream,
                                    lse_accum=self._dec_lse_accum,

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -254,6 +254,9 @@ class Pi05Pipeline:
         # FP8 activation scratch buffers + per-layer static scales
         self.fp8_act_scales = {}  # name -> CudaBuffer(1, fp32)
         self.fp8_calibrated = False
+        # Set once autotune_gemms() has benchmarked this pipeline's (fixed) GEMM
+        # shapes, so repeat calls (frontend + record_infer_graph) are no-ops.
+        self._gemms_autotuned = False
         self._fp8_current_decoder_step = -1
         self._allocate_fp8_scratch()
         self.int8_act_scales = {}  # name -> CudaBuffer(rows, fp32), runtime-dynamic
@@ -1732,7 +1735,12 @@ class Pi05Pipeline:
         """Benchmark cuBLASLt algorithms for each GEMM shape and cache the best.
 
         Call after ``calibrate_fp8()`` and before ``record_infer_graph()``.
+        Idempotent: a pipeline's GEMM shapes are fixed, so once tuned, repeat
+        calls return immediately (the frontend tunes before capture and
+        record_infer_graph tunes again — without this guard that ran twice).
         """
+        if self._gemms_autotuned:
+            return
         B = self.bufs
         W = self.weights
         gemm = self.gemm
@@ -1885,6 +1893,7 @@ class Pi05Pipeline:
                 "Skipping cuBLASLt INT8 autotune: decoder INT8 uses CUTLASS fused path")
 
         self._cudart.cudaDeviceSynchronize()
+        self._gemms_autotuned = True
         logger.info("Autotune complete")
 
     # ── opt-in: route graph REPLAY through the FlashRT exec contract ──


### PR DESCRIPTION
# Pi0.5 RTX: fixed-shape state-prompt graph option (one graph, no recapture)

## Problem

Pi0.5 renders the discretized robot **state into the language prompt**, so the
prompt token length **drifts with the state values**. The per-length pipeline
cache therefore captures a *new* CUDA graph (and reruns autotune) the first time
each new length appears — which can stall a real-time control loop unless every
length is enumerated and warmed up front.

## Solution

Add `state_prompt_mode` to the RTX Pi0.5 frontend:

- **`"exact"` (default, unchanged behavior)** — a separate pipeline is captured
  per exact prompt length and cached. Pair with `warm_state_prompt_buckets()` to
  front-load the lengths you expect so the control loop avoids a mid-loop
  capture. (Default keeps existing behavior bit-for-bit.)
- **`"fixed"` (opt-in)** — **ONE pipeline + ONE captured graph** at the max
  prompt length serves every length:
  - padded prefix keys are masked with FlashAttention-2 `seqused_k`;
  - the decoder appends its action K/V right **after the valid prefix** via a new
    `qkv_split_rope_devpos` kernel, so the cross-attention stays a single
    contiguous masked call;
  - the valid length + write offset are tiny device buffers updated per prompt.

  A changing state length then **never re-captures a graph or reruns autotune**,
  and no warmup is needed. Select with `state_prompt_mode="fixed"` or
  `FLASHRT_PI05_STATE_PROMPT_MODE=fixed`.

Additive only: a new `qkv_split_rope_devpos` kernel (`csrc/kernels/rope.cu` +
binding); existing kernels/bindings are untouched. Non-state prompts are
unchanged in both modes.

## Validation

### 1. Mechanism is exact (BF16, no quant noise) — `tests/test_pi05_state_prompt_fixed_graph.py`

Over a varying-length state sequence, **fixed vs exact actions match to cosine
≥ 0.9999** (seqused masking + devpos K/V append reproduce the per-length
computation bit-for-bit), with **one** captured graph (fixed) vs one-per-length
(exact), and zero recapture.

### 2. Per-frame precision on real LIBERO frames (8 frames, real state, identical noise)

Unnormalized robot actions; `original` = unquantized BF16 model output.

| frame | len | fixed-FP8 vs original | exact-FP8 vs original | fixed-FP8 vs exact-FP8 |
|---|---|---|---|---|
|  |  | cos / max_abs | cos / max_abs | cos / max_abs |
| 0 | 62 | 0.999981 / 0.0078 | 0.999987 / 0.0065 | 0.999978 / 0.0081 |
| 1 | 62 | 0.999976 / 0.0117 | 0.999988 / 0.0078 | 0.999978 / 0.0099 |
| 2 | 62 | 0.999802 / 0.0395 | 0.999764 / 0.0428 | 0.999982 / 0.0082 |
| 3 | 60 | 0.999901 / 0.0154 | 0.999967 / 0.0147 | 0.999917 / 0.0152 |
| 4 | 61 | 0.999964 / 0.0194 | 0.999987 / 0.0117 | 0.999960 / 0.0162 |
| 5 | 61 | 0.999962 / 0.0147 | 0.999975 / 0.0156 | 0.999963 / 0.0156 |
| 6 | 61 | 0.999891 / 0.0280 | 0.999890 / 0.0321 | 0.999953 / 0.0195 |
| 7 | 61 | 0.999976 / 0.0109 | 0.999969 / 0.0195 | 0.999956 / 0.0234 |
| **mean** |  | **0.999932** | **0.999941** | **0.999961** |

**fixed-FP8 vs original (0.99993) ≈ exact-FP8 vs original (0.99994)** — fixed mode
is as accurate as the shipped exact path against the unquantized model; the
difference is FP8 noise, not a regression.

Matches the reference Pi0.5 LIBERO numbers; fp8 and bf16 are comparable
(within trial noise). The fixed-shape graph drives correct closed-loop behavior.

## Latency (RTX 5090, FP8, pure CUDA-graph replay)

Measured as **pure graph replay** (CUDA events around the captured graph, 500-iter
warmup); the replay is deterministic (std ≤ 0.03 ms). Prompt ≈ 51 tokens,
`PI05_STATE_PROMPT_MAX_LEN=200`.

| views | `exact` | `fixed` | **fixed − exact** |
|---|---|---|---|
| 2 | 18.68 ms | 23.21 ms | **+4.53 ms** |
| 3 | 21.37 ms | 28.10 ms | **+6.74 ms** |
| **3 − 2 (extra view)** | +2.69 ms | +4.90 ms | |

> **Update (split-KV decoder, follow-up PR):** the `fixed`-mode penalty above
> was dominated by the decoder joint-attention running a no-split `seqused`
> FA2 kernel — occupancy-bound on the tiny-Q / long-K decode shape. A
> graph-safe split-KV variant cut it ~3×, shrinking the gap to **~1 ms**:
>
> | views | `exact` | `fixed` | **fixed − exact** |
> |---|---|---|---|
> | 2 | 19.69 ms | 20.70 ms | **+1.01 ms** |
> | 3 | 22.74 ms | 23.93 ms | **+1.19 ms** |
>
> (Full `predict()` p50, RTX 5090, FP8, `PI05_STATE_PROMPT_MAX_LEN=200`,
> ~54-token prompt — so these include the ~1–1.6 ms `predict()` overhead the
> bullet below notes, unlike the pure-replay table above.) Action cos vs
> `exact` stays 0.99999 across varying lengths.

- `"fixed"` runs **every** inference at the padded max length, so it is slower
  than `"exact"` at the real length — the price for never re-capturing as the
  length drifts. With split-KV that price is now ~1 ms (was ~+4.5 ms 2v /
  +6.7 ms 3v); the gap shrinks further as `PI05_STATE_PROMPT_MAX_LEN`
  approaches the real maximum.
- A full `predict()` adds ~1–1.6 ms over pure replay (noise gen + image H2D +
  output D2H) — that overhead is identical in both modes.
- Recommendation: `"fixed"` is now the low-friction default for state-in-prompt
  serving where the token length drifts — ~1 ms over `"exact"` with zero
  recapture and no length enumeration. Use `"exact"` + `warm_state_prompt_buckets()`
  only when you need absolute peak latency at a known, stable set of lengths.

## Reproduce

```bash
# Unit gate (in the FlashRT container; needs a Pi0.5 checkpoint):
PI05_LIBERO_PYTORCH_CHECKPOINT=/path/to/pi05_libero_pytorch \
  python -m pytest tests/test_pi05_state_prompt_fixed_graph.py -v

# Closed-loop LIBERO (separate sim venv: mujoco 3.1.6 + robosuite 1.4.1 + LIBERO,
# numpy<2; flash_rt + LIBERO on PYTHONPATH; MUJOCO_GL=egl):
python libero_eval_flashrt.py --suite libero_spatial --num-tasks 10 --trials 5 \
    --precision fp8 --state-prompt-mode fixed
```

## Files

- `csrc/kernels/rope.cu`, `rope.cuh`, `csrc/bindings.cpp` — new
  `qkv_split_rope_devpos` (runtime device K/V-cache row offset).
- `flash_rt/hardware/rtx/attn_backend.py` — fixed-shape encoder/decoder seqused
  path + valid-length buffers.
- `flash_rt/models/pi05/pipeline_rtx.py` — fixed-shape wiring (devpos K/V write,
  padded embeds, seqused/devpos updates).
- `flash_rt/frontends/torch/pi05_rtx.py`, `flash_rt/api.py` — `state_prompt_mode`
  (default `"exact"`, opt-in `"fixed"`, env override).
- `tests/test_pi05_state_prompt_fixed_graph.py`, `USAGE.md`.
