### PR TITLE
Add Qwen3.6 Spark support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,13 @@ option(FLASHRT_BUILD_SM100_ENCODER_MLP
        "Build the WIP Path C encoder MLP megakernel scaffold" OFF)
 
 # SM120+ (Blackwell): NVFP4/W4A8 block-scaled GEMM
-if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "120a")
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "120a" OR
+   GPU_ARCH STREQUAL "121" OR GPU_ARCH STREQUAL "121a")
   set(ENABLE_NVFP4 ON)
-  message(STATUS "NVFP4/W4A8 support: ENABLED (sm_120a)")
+  message(STATUS "NVFP4/W4A8 support: ENABLED (sm_${GPU_ARCH}a)")
 else()
   set(ENABLE_NVFP4 OFF)
-  message(STATUS "NVFP4/W4A8 support: DISABLED (requires sm_120a, current: sm_${GPU_ARCH})")
+  message(STATUS "NVFP4/W4A8 support: DISABLED (requires Blackwell sm_120a/sm_121a, current: sm_${GPU_ARCH})")
 endif()
 
 # Only sm_90/100/110/120 ship an 'a' (architecture-accelerated) variant.
@@ -68,7 +69,8 @@ endif()
 # arch=compute_89a,code=sm_89a breaks nvcc on 4090. Pick the right
 # gencode flag once here and reuse it for every target below.
 if(GPU_ARCH STREQUAL "90"  OR GPU_ARCH STREQUAL "100" OR
-   GPU_ARCH STREQUAL "110" OR GPU_ARCH STREQUAL "120")
+   GPU_ARCH STREQUAL "110" OR GPU_ARCH STREQUAL "120" OR
+   GPU_ARCH STREQUAL "121")
   set(GPU_GENCODE "-gencode=arch=compute_${GPU_ARCH}a,code=sm_${GPU_ARCH}a")
 else()
   set(GPU_GENCODE "-gencode=arch=compute_${GPU_ARCH},code=sm_${GPU_ARCH}")
@@ -85,7 +87,8 @@ message(STATUS "Using gencode flag: ${GPU_GENCODE}")
 # FA2 there would add ~10 MB to the .so and unused compile time.
 if(GPU_ARCH STREQUAL "80"  OR GPU_ARCH STREQUAL "86" OR
    GPU_ARCH STREQUAL "87"  OR
-   GPU_ARCH STREQUAL "89"  OR GPU_ARCH STREQUAL "120")
+   GPU_ARCH STREQUAL "89"  OR GPU_ARCH STREQUAL "120" OR
+   GPU_ARCH STREQUAL "121")
   set(ENABLE_FA2 ON)
   message(STATUS "FA2 in-SO attention: ENABLED (sm_${GPU_ARCH})")
 else()
@@ -431,7 +434,7 @@ endif()
 # Block-scaled FP4 e2m1 weights × FP4 e2m1 act (post quant) × FP8 ue4m3
 # group scales × BF16 output. Ported from NVIDIA unit test
 # sm120_bs_gemm_nvf4_nvf4_f32_bf16.cu — sm_120a / sm_121a.
-if(GPU_ARCH STREQUAL "120")
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121")
   add_library(cutlass_nvfp4_w4a16_sm120_obj OBJECT
     csrc/gemm/fp4/cutlass_nvfp4_w4a16_gemm_sm120.cu)
   set_target_properties(cutlass_nvfp4_w4a16_sm120_obj PROPERTIES
@@ -489,7 +492,8 @@ endif()
 # link whenever it is built — otherwise the binding would reference an unlinked
 # symbol when MOTUS is OFF. (FP8 still needs the SM120 prefill GEMM in MOTUS, so
 # the FP8 path is SM120-only; the BF16 path runs wherever this object is built.)
-if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121" OR
+   GPU_ARCH STREQUAL "89")
   add_library(decode_gemv_m1_obj OBJECT
     csrc/gemm/fp8_gemv_m1_sm120.cu
     csrc/gemm/bf16_gemv_m1_sm120.cu)
@@ -648,7 +652,7 @@ if(ENABLE_NVFP4)
   target_compile_options(gemm_kernels_obj PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:
       --expt-relaxed-constexpr -O3
-      -gencode arch=compute_120a,code=sm_120a
+      ${GPU_GENCODE}
     >
   )
 endif()
@@ -764,14 +768,16 @@ if(ENABLE_FA2)
   # ──────────────────────────────────────────────────────────────
   # gencode selection — default ships multi-arch AOT so one build
   # covers every RTX card (sm_80 SASS runs SM80/86/89 natively; sm_120
-  # SASS for 5090; compute_120 PTX fallback for future consumer archs).
+  # / sm_121 SASS for Blackwell; compute_121 PTX fallback for future
+  # consumer archs).
   # FA2_ARCH_NATIVE_ONLY=ON skips the non-native AOT passes, saving
   # ~66% compile time on single-card developer boxes.
   # ──────────────────────────────────────────────────────────────
   if(FA2_ARCH_NATIVE_ONLY)
     # Just emit native SASS for the detected GPU. Use the real arch
     # (compute_80 for SM80/86/89 since they share Ampere ISA; direct
-    # compute_120 for SM120). Matches upstream FA2 setup.py behaviour.
+    # Blackwell arch for SM120/121). Matches upstream FA2 setup.py
+    # behaviour where applicable.
     if(GPU_ARCH STREQUAL "80" OR GPU_ARCH STREQUAL "86" OR
        GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "89")
       target_compile_options(fa2_vendor_obj PRIVATE
@@ -787,6 +793,13 @@ if(ENABLE_FA2)
         >
       )
       message(STATUS "FA2 vendor arch: sm_120 AOT only (FA2_ARCH_NATIVE_ONLY=ON)")
+    elseif(GPU_ARCH STREQUAL "121")
+      target_compile_options(fa2_vendor_obj PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:
+          "SHELL:-gencode arch=compute_121,code=sm_121"
+        >
+      )
+      message(STATUS "FA2 vendor arch: sm_121 AOT only (FA2_ARCH_NATIVE_ONLY=ON)")
     endif()
   else()
     # Default multi-arch AOT (original behaviour; distributable across
@@ -799,9 +812,11 @@ if(ENABLE_FA2)
         "SHELL:-gencode arch=compute_80,code=sm_80"
         "SHELL:-gencode arch=compute_120,code=sm_120"
         "SHELL:-gencode arch=compute_120,code=compute_120"
+        "SHELL:-gencode arch=compute_121,code=sm_121"
+        "SHELL:-gencode arch=compute_121,code=compute_121"
       >
     )
-    message(STATUS "FA2 vendor arch: sm_80 + sm_120 AOT + compute_120 PTX fallback (default)")
+    message(STATUS "FA2 vendor arch: sm_80 + sm_120/sm_121 AOT + Blackwell PTX fallback (default)")
   endif()
 
   # Macros the wrapper reads to #ifdef-guard optional hdim/dtype
@@ -839,12 +854,12 @@ if(ENABLE_FA2)
   message(STATUS "FA2 pybind module: flash_rt_fa2 (separate .so)")
 endif()
 
-# ── Qwen3.6 FlashInfer XQA FP8-KV (SM120 + SM110/Thor) ──
-# Vendored FlashInfer XQA mha.cu has explicit `__CUDA_ARCH__ == 1100`
-# branches alongside the SM120 ones, so the same translation unit
-# compiles for both GPU_ARCH values; the differentiation is purely the
-# -gencode flag forwarded via GPU_GENCODE.
-if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "110")
+# ── Qwen3.6 FlashInfer XQA FP8-KV (SM120/SM121 + SM110/Thor) ──
+# Vendored FlashInfer XQA mha.cu handles Blackwell SM120/SM121 and
+# Thor SM110 in the same translation unit; the differentiation is
+# purely the -gencode flag forwarded via GPU_GENCODE.
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121" OR
+   GPU_ARCH STREQUAL "110")
   add_library(qwen36_flashinfer_xqa_obj OBJECT
     csrc/attention/flashinfer_xqa_src/mha.cu
     csrc/kernels/qwen36_flashinfer_xqa.cu)
@@ -982,7 +997,8 @@ endif()
 # Dedicated M=1 decode GEMV (FP8 + BF16); linked + macro defined wherever the
 # object is built (sm89 / sm120) so the ENABLE_DECODE_GEMV_M1 bindings always
 # resolve, independent of FLASHRT_ENABLE_MOTUS.
-if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121" OR
+   GPU_ARCH STREQUAL "89")
   target_sources(flash_rt_kernels PRIVATE
     $<TARGET_OBJECTS:decode_gemv_m1_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE
@@ -990,9 +1006,12 @@ if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
 endif()
 
 # SM120a CUTLASS NVFP4 W4A16 GEMM (Qwen3.6 NVFP4 ckpt path).
-if(GPU_ARCH STREQUAL "120")
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121")
   target_sources(flash_rt_kernels PRIVATE
     $<TARGET_OBJECTS:cutlass_nvfp4_w4a16_sm120_obj>
+    csrc/gemm/fp4/cutlass_nvfp4_gemm_bias_gelu_bf16out_sm120.cu
+    csrc/gemm/fp4/cutlass_nvfp4_gemm_bias_gelu_fp4out_sm120.cu
+    csrc/gemm/fp4/cutlass_nvfp4_gemm_dn_streamk_bias_sm120.cu
     csrc/quantize/nvfp4_sf_reshape_sm120.cu)
   target_compile_definitions(flash_rt_kernels PRIVATE
     ENABLE_CUTLASS_SM120_NVFP4_W4A16=1)
@@ -1010,7 +1029,8 @@ if(GPU_ARCH STREQUAL "110")
     ENABLE_CUTLASS_SM100_NVFP4_W4A16=1)
 endif()
 
-if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "110")
+if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121" OR
+   GPU_ARCH STREQUAL "110")
   target_sources(flash_rt_kernels PRIVATE
     $<TARGET_OBJECTS:qwen36_flashinfer_xqa_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE

--- a/README.md
+++ b/README.md
@@ -651,7 +651,7 @@ System requirements:
 
 | Component | Minimum | Notes |
 |---|---|---|
-| GPU | SM80+ (A100, 30xx+, Thor, 4090, 5090) | |
+| GPU | SM80+ (A100, 30xx+, Thor, 4090, 5090, DGX Spark) | |
 | NVIDIA driver | 545+ for CUDA 13, 525+ for CUDA 12.4 | 5090 needs 550+ |
 | CUDA Toolkit | 12.4+ (Thor/Hopper) or 12.8+ (Blackwell) | CUDA 13 recommended on 5090 |
 | Python | 3.10 / 3.11 / 3.12 | 3.12 on the default NGC image |
@@ -724,13 +724,14 @@ arch. Override for cross-compilation or when auto-detect fails:
 
 ```bash
 cmake -B build -S . -DGPU_ARCH=110   # Jetson AGX Thor   (FA2 skipped, CUTLASS SM100 path ON)
-cmake -B build -S . -DGPU_ARCH=120   # RTX 5090           (FA2 sm_80+sm_120 AOT, NVFP4 ON)
+cmake -B build -S . -DGPU_ARCH=121   # DGX Spark / GB10   (FA2 sm_121 AOT, NVFP4 ON)
+cmake -B build -S . -DGPU_ARCH=120   # RTX 5090           (FA2 sm_120 AOT, NVFP4 ON)
 cmake -B build -S . -DGPU_ARCH=89    # RTX 4090           (FA2 sm_80 AOT natively runs on Ada)
 cmake -B build -S . -DGPU_ARCH=86    # RTX 3090 / A10     (FA2 sm_80 AOT)
 cmake -B build -S . -DGPU_ARCH=80    # A100               (FA2 sm_80 AOT)
 ```
 
-FA2 is enabled by CMake when `GPU_ARCH ∈ {80, 86, 89, 120}`. Other
+FA2 is enabled by CMake when `GPU_ARCH ∈ {80, 86, 89, 120, 121}`. Other
 arches (notably Thor SM110 and SM90 Hopper) route attention through
 the cuBLAS-decomposed `fvk.attention_qkv_fp16` path instead of FA2 —
 `flash_rt_fa2.so` simply isn't built, and no runtime error results.
@@ -742,7 +743,7 @@ On a 5090 with CUDA 13 in a warm container, `make -j$(nproc)`:
 | Target | Time |
 |---|---|
 | `flash_rt_kernels` (main kernels) | ~2 min |
-| `flash_rt_fa2` (FA2 vendor, default — 12 kernel .cu files × 3 arches) | **~4.5 min** (267 s) |
+| `flash_rt_fa2` (FA2 vendor, default — 12 kernel .cu files × sm_80 + sm_120/sm_121 + Blackwell PTX fallback) | **~4.5 min** (267 s) |
 | Full `make -j$(nproc)` | ~6.5 min |
 
 Subsequent rebuilds of only the hand-written kernels take ~2 min —
@@ -759,7 +760,7 @@ opt-in CMake flags trade binary coverage for iteration speed:
 
 | Flag | Default | What it does | `fa2` cold build on 5090 |
 |---|---|---|---|
-| — | (none) | 12 .cu × sm_80 + sm_120 + PTX fallback | **267 s (4.5 min)** |
+| — | (none) | 12 .cu × sm_80 + sm_120/sm_121 + Blackwell PTX fallback | **267 s (4.5 min)** |
 | `-DFA2_ARCH_NATIVE_ONLY=ON` | OFF | Only emit SASS for the detected GPU; skip sm_80 + PTX passes | **110 s** (−59%) |
 | `-DFA2_HDIMS="96;256"` | `"96;128;256"` | Drop `head_dim=128` (shipped models don't use it; reserved for future DiT variants) | **210 s** (−21%) |
 | `-DFA2_DTYPES="fp16"` | `"fp16;bf16"` | Drop bf16 (Pi0 is fp16-only; Pi0.5 / GROOT need bf16) | **179 s** (−33%) |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ Jetson AGX Thor:
 | NVFP4, 128 | **268 ms** | **42.8 tok/s** | [Qwen3.6 Thor](docs/qwen36_nvfp4.md#jetson-agx-thor-numbers) |
 | NVFP4, 16 K | **19.23 s** | **52.9 tok/s** | [Qwen3.6 Thor](docs/qwen36_nvfp4.md#jetson-agx-thor-numbers) |
 
+DGX Spark / GB10:
+
+| Mode | Prefill | Decode | Source |
+|---|---:|---:|---|
+| NVFP4, 128 | **170.1 ms** | **40.42 tok/s** | [Qwen3.6 Spark](docs/qwen36_spark.md#performance) |
+| NVFP4, 16 K | **8.545 s** | **54.94 tok/s** | [Qwen3.6 Spark](docs/qwen36_spark.md#performance) |
+
 #### Qwen3-8B
 
 | Hardware | Mode | Prefill | Decode | Source |
@@ -154,7 +161,7 @@ Jetson AGX Thor:
 - [API snippets — Pi0 / Pi0.5 / GROOT / Pi0-FAST / Qwen3.6](#api-snippets)
 - [Supported Models](#supported-models) · [Hardware Support](#hardware-support) · [Benchmark](#benchmark)
 - [Serving](serving/README.md) · [Architecture](docs/architecture.md)
-- [Qwen3.6-27B NVFP4 LLM path — quickstart, K selection, measured throughput](docs/qwen36_nvfp4.md) · [parameter reference](docs/qwen36_usage.md) · [OpenAI-compatible server example](serving/qwen36_agent/README.md)
+- [Qwen3.6-27B NVFP4 LLM path — quickstart, K selection, measured throughput](docs/qwen36_nvfp4.md) · [Spark usage](docs/qwen36_spark.md) · [parameter reference](docs/qwen36_usage.md) · [OpenAI-compatible server example](serving/qwen36_agent/README.md)
 - [Adding a new model](docs/adding_new_model.md)
 - [Contributing](CONTRIBUTING.md)
 - [Architecture](docs/architecture.md)
@@ -189,7 +196,7 @@ First call: ~3 s (calibration + CUDA Graph capture). Every subsequent call: 44 m
 |---|---|
 | **Run your first inference** | [Build & install](#build--install) — Docker and native Linux paths |
 | **See API examples for all 4 VLA models + the Qwen3.6 LLM** | [API snippets](#api-snippets) |
-| **Run Qwen3.6-27B NVFP4 (LLM, 256 K on RTX 5090)** | [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) — quickstart, K selection, measured throughput · [`docs/qwen36_usage.md`](docs/qwen36_usage.md) — full parameter reference · [`serving/qwen36_agent/`](serving/qwen36_agent/README.md) — OpenAI-compatible HTTP server |
+| **Run Qwen3.6-27B NVFP4 (LLM, 256 K on RTX 5090; Spark/GB10 supported)** | [`docs/qwen36_nvfp4.md`](docs/qwen36_nvfp4.md) — quickstart, K selection, measured throughput · [`docs/qwen36_spark.md`](docs/qwen36_spark.md) — DGX Spark usage and performance · [`docs/qwen36_usage.md`](docs/qwen36_usage.md) — full parameter reference · [`serving/qwen36_agent/`](serving/qwen36_agent/README.md) — OpenAI-compatible HTTP server |
 | **Run Qwen3-8B NVFP4 text serving** | [`docs/qwen3_8b_nvfp4.md`](docs/qwen3_8b_nvfp4.md) · [`examples/qwen3_openai_server.py`](examples/qwen3_openai_server.py) |
 | **Run Higgs Audio v3 TTS** | [`docs/higgs_audio_v3.md`](docs/higgs_audio_v3.md) — usage + performance · [`serving/higgs_audio_agent/`](serving/higgs_audio_agent/README.md) — HTTP serving |
 | **Run Motus RTX beta, TeaCache, or RTC-lite** | [`docs/motus_usage_beta.md`](docs/motus_usage_beta.md) · [`docs/rtc_lite_design.md`](docs/rtc_lite_design.md) |

--- a/benchmarks/qwen36_spark_al_sweep.py
+++ b/benchmarks/qwen36_spark_al_sweep.py
@@ -1,0 +1,349 @@
+"""Spark AL/K sweep for Qwen3.6 NVFP4 speculative decode.
+
+The script keeps one frontend/model loaded and varies only runtime policy
+knobs between generations. It is intended for Spark/SM121 acceptance-length
+tuning before changing kernels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from dataclasses import dataclass
+
+import torch
+
+
+GRAPH_CACHE_ATTRS = (
+    "_captured_graphs",
+    "_captured_verify_graphs",
+    "_captured_mtp_graphs",
+    "_captured_chain_graphs",
+    "_captured_graphs_tq",
+    "_captured_verify_graphs_tq",
+    "_captured_prefill_graphs_tq",
+    "_captured_verify_graphs_fp8kv",
+    "_captured_prefill_graphs_fp8kv",
+    "_captured_verify_graphs_dflash",
+    "_captured_drafter_graphs_dflash",
+)
+
+
+PROMPTS = {
+    "repeat": (
+        "Qwen Spark benchmark prompt. Keep the answer concise and factual. "
+        "This text is repeated only to create a deterministic context."
+    ),
+    "explain": (
+        "Explain CUDA graphs and speculative decoding to an engineer. "
+        "Use a direct, technical style and continue the explanation "
+        "without changing topics."
+    ),
+    "code": (
+        "Write a clean, commented Python implementation of topological sort. "
+        "Continue with edge cases, tests, and complexity analysis."
+    ),
+    "json": (
+        "Extract the following deployment notes into compact JSON records "
+        "with fields name, value, and reason. Keep the schema stable."
+    ),
+    "math": (
+        "Solve the optimization problem step by step, show intermediate "
+        "equations, and keep the derivation consistent."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Case:
+    prompt_name: str
+    ctx: int
+    k_label: str
+    tail: str
+    tail_kv_only: str
+
+
+def _parse_csv(value: str) -> list[str]:
+    out = [part.strip() for part in value.split(",") if part.strip()]
+    if not out:
+        raise argparse.ArgumentTypeError("expected at least one value")
+    return out
+
+
+def _parse_csv_ints(value: str) -> list[int]:
+    out: list[int] = []
+    for part in value.split(","):
+        part = part.strip()
+        if part:
+            out.append(int(part))
+    if not out:
+        raise argparse.ArgumentTypeError("expected at least one integer")
+    return out
+
+
+def _prompt_text(name: str) -> str:
+    if "=" in name:
+        label, text = name.split("=", 1)
+        if not label.strip() or not text.strip():
+            raise argparse.ArgumentTypeError(
+                "custom prompt format is label=text")
+        return text.strip()
+    try:
+        return PROMPTS[name]
+    except KeyError as exc:
+        choices = ", ".join(sorted(PROMPTS))
+        raise argparse.ArgumentTypeError(
+            f"unknown prompt {name!r}; choose one of {choices}, "
+            "or pass label=text") from exc
+
+
+def _prompt_label(name: str) -> str:
+    return name.split("=", 1)[0].strip() if "=" in name else name
+
+
+def _build_prompt_ids(tokenizer, device: torch.device, ctx: int,
+                      seed_text: str) -> torch.Tensor:
+    text = seed_text
+    ids = tokenizer(text, return_tensors="pt").input_ids
+    while int(ids.shape[1]) < ctx:
+        text = f"{text}\n{seed_text}"
+        ids = tokenizer(text, return_tensors="pt").input_ids
+    return ids[:, :ctx].contiguous().to(device)
+
+
+def _tokens(obj) -> list[int]:
+    if isinstance(obj, torch.Tensor):
+        return obj.detach().cpu().view(-1).tolist()
+    if isinstance(obj, tuple):
+        for item in obj:
+            if isinstance(item, torch.Tensor):
+                return item.detach().cpu().view(-1).tolist()
+    return list(obj)
+
+
+def _clear_graph_caches(fe) -> int:
+    if hasattr(fe, "clear_graphs"):
+        try:
+            fe.clear_graphs()
+        except TypeError:
+            pass
+    cleared = 0
+    for name in GRAPH_CACHE_ATTRS:
+        cache = getattr(fe, name, None)
+        if hasattr(cache, "clear"):
+            cache.clear()
+            cleared += 1
+    return cleared
+
+
+def _set_case_env(case: Case, *, direct: bool) -> int:
+    old_k = os.environ.pop("FLASHRT_QWEN36_TQ_SPEC_K", None)
+    if case.k_label != "auto":
+        os.environ["FLASHRT_QWEN36_TQ_SPEC_K"] = case.k_label
+    os.environ["FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL"] = case.tail
+    os.environ["FLASHRT_QWEN36_LONG_MTP_TAIL_KV_ONLY"] = case.tail_kv_only
+    if direct:
+        os.environ["FLASHRT_QWEN36_TQ_VERIFY_GRAPH"] = "0"
+        os.environ["FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH"] = "0"
+    else:
+        os.environ["FLASHRT_QWEN36_TQ_VERIFY_GRAPH"] = "1"
+        os.environ["FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH"] = "1"
+    return 0 if old_k is None else 1
+
+
+def _effective_k(fe, ctx: int, k_label: str, caller_k: int,
+                 max_new: int) -> int:
+    if k_label != "auto":
+        return int(k_label)
+    if hasattr(fe, "_long_tq_effective_k"):
+        return int(fe._long_tq_effective_k(ctx, caller_k, max_new))
+    return int(caller_k)
+
+
+def _caller_k_for_case(k_label: str, caller_k: int) -> int:
+    if k_label != "auto":
+        return int(k_label)
+    return int(caller_k)
+
+
+def _run_once(fe, ids: torch.Tensor, *, max_new: int,
+              caller_k: int) -> tuple[list[int], dict]:
+    torch.cuda.synchronize()
+    out = fe.generate_own_speculative_KN_nvfp4(
+        ids, max_new_tokens=max_new, K=caller_k)
+    torch.cuda.synchronize()
+    toks = _tokens(out)
+    prefill_ms = float(getattr(fe, "_long_ctx_prefill_ms", 0.0) or 0.0)
+    decode_ms = float(getattr(fe, "_long_ctx_decode_ms", 0.0) or 0.0)
+    attempts = int(getattr(fe, "_spec_attempts", 0) or 0)
+    accepts = int(getattr(fe, "_spec_accepts", 0) or 0)
+    full = int(getattr(fe, "_spec_full", 0) or 0)
+    route = str(getattr(fe, "_long_ctx_route", ""))
+    generated = max(0, len(toks) - int(ids.shape[1]))
+    return toks, {
+        "generated": generated,
+        "prefill_ms": prefill_ms,
+        "decode_ms": decode_ms,
+        "tok_s": (generated * 1000.0 / decode_ms) if decode_ms > 0 else 0.0,
+        "spec_attempts": attempts,
+        "spec_accepts": accepts,
+        "accept_per_attempt": (accepts / attempts) if attempts > 0 else 0.0,
+        "full_accept_rate": (full / attempts) if attempts > 0 else 0.0,
+        "spec_full": full,
+        "route": route,
+    }
+
+
+def _writer(path: str):
+    fields = (
+        "prompt",
+        "ctx",
+        "K",
+        "effective_K",
+        "tail",
+        "tail_kv_only",
+        "direct",
+        "rep",
+        "generated",
+        "prefill_ms",
+        "decode_ms",
+        "tok_s",
+        "spec_attempts",
+        "spec_accepts",
+        "accept_per_attempt",
+        "full_accept_rate",
+        "spec_full",
+        "same_as_warmup",
+        "route",
+    )
+    if path == "-":
+        return sys.stdout, csv.DictWriter(sys.stdout, fieldnames=fields)
+    fh = open(path, "w", newline="", encoding="utf-8")
+    return fh, csv.DictWriter(fh, fieldnames=fields)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--mtp-dir", default="")
+    parser.add_argument("--ctx", type=_parse_csv_ints, default=[128])
+    parser.add_argument("--K", type=_parse_csv, default=["auto", "3", "5", "6"])
+    parser.add_argument("--tails", type=_parse_csv, default=["auto", "0", "128"])
+    parser.add_argument("--tail-kv-only", type=_parse_csv, default=["1"])
+    parser.add_argument("--prompts", type=_parse_csv,
+                        default=["repeat", "explain", "code", "json"])
+    parser.add_argument("--max-new", type=int, default=64)
+    parser.add_argument("--max-seq", type=int, default=32768)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--reps", type=int, default=1)
+    parser.add_argument("--caller-k", type=int, default=6)
+    parser.add_argument("--long-route-min", type=int, default=None)
+    parser.add_argument("--long-kv-cache", choices=("fp8", "tq"), default=None)
+    parser.add_argument("--frontend", choices=("auto", "rtx", "spark"),
+                        default="auto")
+    parser.add_argument("--direct", action="store_true")
+    parser.add_argument("--out", default="-")
+    parser.add_argument("--use-exec", action="store_true",
+                        help="Leave FLASHRT_QWEN36_USE_EXEC enabled.")
+    args = parser.parse_args()
+
+    if args.mtp_dir:
+        os.environ["FLASHRT_QWEN36_MTP_CKPT_DIR"] = args.mtp_dir
+    if not args.use_exec:
+        os.environ["FLASHRT_QWEN36_USE_EXEC"] = "0"
+    if args.long_route_min is not None:
+        os.environ["FLASHRT_QWEN36_LONG_CTX_ROUTE_MIN_SEQ"] = str(
+            args.long_route_min)
+    if args.long_kv_cache is not None:
+        os.environ["FLASHRT_QWEN36_LONG_KV_CACHE"] = args.long_kv_cache
+
+    frontend_name = args.frontend
+    if frontend_name == "auto":
+        cap = tuple(int(x) for x in torch.cuda.get_device_capability())
+        frontend_name = "spark" if cap == (12, 1) else "rtx"
+    if frontend_name == "spark":
+        from flash_rt.frontends.torch.qwen36_spark import (
+            Qwen36TorchFrontendSpark as Frontend,
+        )
+    else:
+        from flash_rt.frontends.torch.qwen36_rtx import (
+            Qwen36TorchFrontendRtx as Frontend,
+        )
+
+    fe = Frontend(args.model, quant="nvfp4", max_seq=args.max_seq)
+    tokenizer = getattr(fe, "tokenizer", getattr(fe, "_tokenizer"))
+
+    prompt_texts = {name: _prompt_text(name) for name in args.prompts}
+    prompt_labels = {name: _prompt_label(name) for name in args.prompts}
+    prompt_ids: dict[tuple[str, int], torch.Tensor] = {}
+    for raw_name, seed in prompt_texts.items():
+        for ctx in args.ctx:
+            prompt_ids[(raw_name, ctx)] = _build_prompt_ids(
+                tokenizer, fe.device, ctx, seed)
+
+    fh, writer = _writer(args.out)
+    try:
+        writer.writeheader()
+        if fh is not sys.stdout:
+            fh.flush()
+        for raw_prompt in args.prompts:
+            for ctx in args.ctx:
+                ids = prompt_ids[(raw_prompt, ctx)]
+                for k_label in args.K:
+                    if k_label != "auto":
+                        int(k_label)
+                    for tail in args.tails:
+                        if tail != "auto":
+                            int(tail)
+                        for tail_kv_only in args.tail_kv_only:
+                            if tail_kv_only not in ("0", "1"):
+                                raise ValueError(
+                                    "--tail-kv-only values must be 0 or 1")
+                            case = Case(
+                                prompt_labels[raw_prompt], ctx, k_label,
+                                tail, tail_kv_only)
+                            _set_case_env(case, direct=args.direct)
+                            _clear_graph_caches(fe)
+                            case_caller_k = _caller_k_for_case(
+                                k_label, args.caller_k)
+                            warm_toks: list[int] | None = None
+                            for _ in range(args.warmup):
+                                warm_toks, _ = _run_once(
+                                    fe, ids, max_new=args.max_new,
+                                    caller_k=case_caller_k)
+                            effective_k = _effective_k(
+                                fe, ctx, k_label, case_caller_k,
+                                args.max_new)
+                            for rep in range(args.reps):
+                                toks, metrics = _run_once(
+                                    fe, ids, max_new=args.max_new,
+                                    caller_k=case_caller_k)
+                                row = {
+                                    "prompt": case.prompt_name,
+                                    "ctx": case.ctx,
+                                    "K": case.k_label,
+                                    "effective_K": effective_k,
+                                    "tail": case.tail,
+                                    "tail_kv_only": case.tail_kv_only,
+                                    "direct": int(args.direct),
+                                    "rep": rep,
+                                    "same_as_warmup": int(
+                                        warm_toks == toks
+                                        if warm_toks is not None else True),
+                                    **metrics,
+                                }
+                                writer.writerow(row)
+                                if fh is not sys.stdout:
+                                    fh.flush()
+                                else:
+                                    sys.stdout.flush()
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,7 +28,7 @@ flash_rt.__version__` returns the installed version, and
 
 | Component | Minimum | Notes |
 |---|---|---|
-| GPU | SM80+ | A100 / RTX 30-series / 40-series / Thor / 5090. Pre-SM80 (V100, 20-series) is unsupported — FA2 vendored code requires Ampere. |
+| GPU | SM80+ | A100 / RTX 30-series / 40-series / Thor / 5090 / DGX Spark. Pre-SM80 (V100, 20-series) is unsupported — FA2 vendored code requires Ampere. |
 | NVIDIA driver | 525+ (CUDA 12.4) / 545+ (CUDA 13) | 5090 needs 550+ |
 | CUDA Toolkit | 12.4+ on Thor/Ada/Hopper, 12.8+ on Blackwell | CUDA 13 is the NGC-image default |
 | Python | 3.10 / 3.11 / 3.12 | One venv; the interpreter that runs `cmake` MUST match the interpreter that later imports `flash_rt` |
@@ -83,7 +83,7 @@ built, and `import flash_rt` later would fail with a missing
 
 ```bash
 cmake -B build -S .                  # auto-detects GPU arch via nvidia-smi
-# Or override: cmake -B build -S . -DGPU_ARCH=110   (110=Thor, 120=5090, 89=4090, 80=A100)
+# Or override: cmake -B build -S . -DGPU_ARCH=121   (121=Spark, 120=5090, 110=Thor, 89=4090, 80=A100)
 cmake --build build -j$(nproc)       # equivalent to: ninja -C build, or make -C build
 ```
 
@@ -100,17 +100,19 @@ Per-arch produced shared libraries:
 |---------|:----------------------:|:------------------:|:------------------:|:-------------------------:|
 | Thor (SM110) | ✅ | ✅ | — | ✅ (SigLIP fast path) |
 | Hopper (SM100) | ✅ | ✅ | — | ✅ |
+| DGX Spark / GB10 (SM121) | ✅ | ✅ | ✅ (in-SO FA2) | — |
 | RTX 5090 (SM120) | ✅ | ✅ | ✅ (in-SO FA2) | — |
 | RTX 4090 (SM89) | ✅ | — | ✅ (in-SO FA2) | — |
 
 ### 6.1 Building on CUDA < 12.8
 
-The default vendor build of Flash-Attention 2 emits a ``compute_120``
-PTX fallback alongside the per-arch SASS so a single ``.so`` covers
-all listed gencodes — including Blackwell (SM120) targets that need
+The default vendor build of Flash-Attention 2 emits Blackwell PTX
+fallbacks alongside the per-arch SASS so a single ``.so`` covers all
+listed gencodes — including Blackwell SM120/SM121 targets that need
 CUDA 12.8+. On older toolchains (e.g. an L40S running a CUDA-12.4
-image) ``nvcc`` rejects the ``compute_120`` PTX target with a
-``Value 'compute_120' is not defined`` error and the build aborts.
+image) ``nvcc`` rejects the Blackwell PTX target with a
+``Value 'compute_120' is not defined`` or
+``Value 'compute_121' is not defined`` error and the build aborts.
 
 If you only need a binary for the GPU detected on the build host
 (typical for cloud / self-hosted users that aren't shipping the

--- a/docs/qwen36_nvfp4.md
+++ b/docs/qwen36_nvfp4.md
@@ -9,6 +9,8 @@ For the full per-parameter API reference (constructor, generate args,
 env vars), see [`qwen36_usage.md`](qwen36_usage.md). For an OpenAI-API
 compatible HTTP server, see
 [`serving/qwen36_agent/`](../serving/qwen36_agent/README.md).
+For DGX Spark / GB10 (SM121), see
+[`qwen36_spark.md`](qwen36_spark.md).
 
 ## 0. Quickstart
 

--- a/docs/qwen36_spark.md
+++ b/docs/qwen36_spark.md
@@ -1,0 +1,165 @@
+# Qwen3.6-27B NVFP4 on DGX Spark
+
+This document covers the FlashRT Spark path for Qwen3.6-27B NVFP4 on
+NVIDIA GB10 / SM121. It is an additive frontend over the RTX Qwen3.6
+path: existing RTX and Thor frontends keep their own dispatch and kernel
+defaults.
+
+For the general Qwen3.6 NVFP4 model contract, K selection background,
+and parameter reference, see [`qwen36_nvfp4.md`](qwen36_nvfp4.md) and
+[`qwen36_usage.md`](qwen36_usage.md).
+
+## Requirements
+
+- DGX Spark / GB10 GPU, compute capability SM121.
+- FlashRT built with `GPU_ARCH=121`.
+- Qwen3.6-27B NVFP4 main checkpoint.
+- Paired Qwen3.6 FP8 MTP checkpoint containing `mtp.safetensors`.
+- Single-GPU inference. Batch size is still 1.
+
+The measured path uses the public NVFP4 main checkpoint plus a paired
+FP8 MTP checkpoint converted to NVFP4 at load time. The Spark frontend
+adds the NVFP4 MTP prompt-tail K/V prefill needed by this checkpoint
+layout; it does not require BF16 shadow MTP projection weights.
+
+## Build
+
+```bash
+cmake -B build-spark-sm121 -S . -DGPU_ARCH=121
+cmake --build build-spark-sm121 -j
+pip install -e ".[torch]"
+```
+
+The SM121 build enables the same NVFP4/CUTLASS, FA2, FP8-KV XQA, and
+decode GEMV objects used by the Qwen3.6 path, compiled for Spark.
+
+## Direct Frontend
+
+```python
+import os
+import torch
+
+from flash_rt.frontends.torch.qwen36_spark import Qwen36TorchFrontendSpark
+
+os.environ["FLASHRT_QWEN36_MTP_CKPT_DIR"] = "/models/Qwen3.6-27B-FP8-MTP"
+os.environ["FLASHRT_QWEN36_LONG_KV_CACHE"] = "fp8"
+
+fe = Qwen36TorchFrontendSpark(
+    "/models/Qwen3.6-27B-NVFP4",
+    quant="nvfp4",
+    max_seq=32768,
+)
+
+prompt = "Explain CUDA graphs and speculative decoding briefly."
+ids = fe._tokenizer(prompt, return_tensors="pt").input_ids.to(fe.device)
+
+out = fe.generate_own_speculative_KN_nvfp4(
+    ids,
+    max_new_tokens=64,
+    K=6,
+)
+print(fe._tokenizer.decode(out[0, ids.shape[1]:].tolist()))
+```
+
+## Agent Server
+
+The OpenAI-compatible agent server auto-selects the Spark frontend on
+SM121:
+
+```bash
+pip install -e ".[torch,server]"
+
+export FLASHRT_QWEN36_MTP_CKPT_DIR=/models/Qwen3.6-27B-FP8-MTP
+export FLASHRT_QWEN36_LONG_KV_CACHE=fp8
+
+python -m serving.qwen36_agent.server \
+  --checkpoint /models/Qwen3.6-27B-NVFP4 \
+  --model-name qwen36-27b \
+  --max-seq 32768 \
+  --port 8000
+```
+
+On SM121 the server leaves the SM120 hand-tuned fastgemm/warpsplit
+decode kernels opt-in by default, because Spark profiling favored the
+default CUTLASS NVFP4 path. Exact-position long-decode graphs are also
+disabled by default for agent serving, matching the existing agent
+latency policy.
+
+## Tuned Spark Policy
+
+Spark uses a measured policy for the long-context speculative route:
+
+| prompt ctx | effective K | MTP tail | FP8-KV XQA |
+|---:|---:|---:|:---:|
+| 128 | 6 | 128 | on |
+| 2 K | 6 | 2048 | on |
+| 8 K | 7 | 4096 | off |
+| 16 K | 6 | 4096 | on |
+| 24 K | 7 | 2048 | on |
+| 32 K | 7 | 2048 | on |
+
+The policy is encoded in `Qwen36TorchFrontendSpark`; callers can still
+override `FLASHRT_QWEN36_TQ_SPEC_K`,
+`FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL`, or FP8-XQA env vars for
+experiments.
+
+## Performance
+
+Measured on a single DGX Spark / GB10 (SM121), Qwen3.6-27B NVFP4 main
+checkpoint plus FP8 MTP checkpoint, `max_new_tokens=64`, repeated text
+prompt, warm-state decode, long KV cache in FP8. Decode tok/s excludes
+prefill.
+
+| prompt ctx | effective K | MTP tail | TTFT / prefill | decode tok/s | AL |
+|---:|---:|---:|---:|---:|---:|
+| 128 | 6 | 128 | 170.1 ms | 40.42 | 3.57 |
+| 2 K | 6 | 2048 | 1.784 s | 40.11 | 3.64 |
+| 8 K | 7 | 4096 | 5.160 s | 36.14 | 3.50 |
+| 16 K | 6 | 4096 | 8.545 s | 54.94 | 5.30 |
+| 24 K | 7 | 2048 | 11.077 s | 57.73 | 6.22 |
+| 32 K | 7 | 2048 | 15.110 s | 57.32 | 6.67 |
+
+The 8 K bucket is acceptance-length limited on this prompt distribution:
+changing only XQA or the MTP tail does not recover the 16 K / 24 K AL.
+The checked-in Spark policy keeps the best measured 8 K setting while
+preserving the stronger long-context buckets.
+
+## Reproducing the Table
+
+```bash
+PYTHONPATH=. python benchmarks/qwen36_spark_al_sweep.py \
+  --frontend spark \
+  --model /models/Qwen3.6-27B-NVFP4 \
+  --mtp-dir /models/Qwen3.6-27B-FP8-MTP \
+  --ctx 128,2048,8192,16384 \
+  --max-new 64 \
+  --K auto \
+  --tails auto \
+  --tail-kv-only 1 \
+  --prompts repeat \
+  --warmup 1 \
+  --reps 2 \
+  --max-seq 32768 \
+  --long-kv-cache fp8 \
+  --out qwen36_spark_al_repeat_128_16k_auto_policy.csv
+```
+
+For 24 K / 32 K:
+
+```bash
+PYTHONPATH=. python benchmarks/qwen36_spark_al_sweep.py \
+  --frontend spark \
+  --model /models/Qwen3.6-27B-NVFP4 \
+  --mtp-dir /models/Qwen3.6-27B-FP8-MTP \
+  --ctx 24576,32768 \
+  --max-new 64 \
+  --K auto \
+  --tails auto \
+  --tail-kv-only 1 \
+  --prompts repeat \
+  --warmup 1 \
+  --reps 1 \
+  --max-seq 65536 \
+  --long-kv-cache fp8 \
+  --out qwen36_spark_al_24k_32k_auto_policy.csv
+```

--- a/docs/qwen36_usage.md
+++ b/docs/qwen36_usage.md
@@ -51,12 +51,29 @@ fe = Qwen36TorchFrontendThor(
 )
 ```
 
+On DGX Spark / GB10 (SM121), use the Spark subclass. It keeps the RTX
+compute path but applies Spark-measured long-context K / MTP-tail /
+FP8-XQA policy and supports NVFP4 MTP tail K/V prefill for paired FP8
+MTP checkpoints:
+
+```python
+from flash_rt.frontends.torch.qwen36_spark import Qwen36TorchFrontendSpark
+
+fe = Qwen36TorchFrontendSpark(
+    checkpoint_path,
+    device='cuda:0',
+    max_seq=32768,
+    quant='nvfp4',
+)
+```
+
 The bundled OpenAI server
 ([`serving/qwen36_agent/`](../serving/qwen36_agent/README.md))
 detects the compute capability at startup and dispatches automatically:
-SM110 (Jetson AGX Thor) loads `Qwen36TorchFrontendThor`; everything else
-loads `Qwen36TorchFrontendRtx`. The CLI / config surface is identical
-across both.
+SM110 (Jetson AGX Thor) loads `Qwen36TorchFrontendThor`, SM121
+(DGX Spark / GB10) loads `Qwen36TorchFrontendSpark`, and other
+supported Blackwell/Ada GPUs load `Qwen36TorchFrontendRtx`. The CLI /
+config surface is identical across these frontends.
 
 | Argument | Type | Default | Meaning |
 |---|---|---|---|

--- a/flash_rt/frontends/torch/_qwen36_rtx_nvfp4_weights.py
+++ b/flash_rt/frontends/torch/_qwen36_rtx_nvfp4_weights.py
@@ -407,13 +407,11 @@ def extract_weights_nvfp4(
 
             if t == 'linear_attention':
                 la = base + 'linear_attn.'
-                # G7: ckpt leaves the three large lin projections as
-                # BF16. We quantize them to NVFP4 at load time (with
-                # per-tensor global_scale) so the verify-path GEMMs
-                # read FP4 weights instead of BF16 — cuts BW by 2× on
-                # 48 lin layers (the dominant FP8/NVFP4 verify-forward
-                # delta). in_proj_a / in_proj_b are tiny (N=48) so we
-                # keep them BF16; the matvec/matmul cost is negligible.
+                # G7: some ckpts leave the three large lin projections
+                # as BF16, while others pre-pack out_proj as NVFP4.
+                # Normalize both forms to the same NVFP4 handle fields.
+                # in_proj_a / in_proj_b are tiny (N=48), so keep them
+                # BF16; the matvec/matmul cost is negligible.
                 _quant_bf16_lin_proj(
                     handles, ld, 'in_proj_qkv',
                     f.get_tensor(la + 'in_proj_qkv.weight'),
@@ -435,10 +433,15 @@ def extract_weights_nvfp4(
                 ab_w = torch.cat([a_w, b_w], dim=0).contiguous()
                 ld['in_proj_ab_w'] = _ensure_anchored(handles, ab_w)
                 ld['in_proj_ab_w_t'] = ab_w
-                _quant_bf16_lin_proj(
-                    handles, ld, 'out_proj',
-                    f.get_tensor(la + 'out_proj.weight'),
-                    fvk, device)
+                if la + 'out_proj.weight_packed' in f.keys():
+                    _load_quantized_proj(
+                        handles, ld, 'out_proj',
+                        f, la + 'out_proj', fvk, device)
+                else:
+                    _quant_bf16_lin_proj(
+                        handles, ld, 'out_proj',
+                        f.get_tensor(la + 'out_proj.weight'),
+                        fvk, device)
                 conv = f.get_tensor(la + 'conv1d.weight').to(
                     torch.bfloat16).squeeze(1).contiguous().to(device)
                 ld['conv1d_w'] = _ensure_anchored(handles, conv)

--- a/flash_rt/frontends/torch/qwen36_rtx.py
+++ b/flash_rt/frontends/torch/qwen36_rtx.py
@@ -19,6 +19,7 @@ in Phase 2) that quantizes weights into fvk-compatible layouts.
 from __future__ import annotations
 
 import collections
+import json
 import os
 from typing import Any
 
@@ -48,6 +49,48 @@ def _qwen36_tq_prefill_gdn_backend() -> str:
             'FLASHRT_QWEN36_TQ_PREFILL_GDN_BACKEND no longer supports '
             f'{backend!r}; use wy_lt or native for FlashRT CUDA kernels')
     return backend
+
+
+def _load_qwen36_tokenizer(checkpoint_path: str):
+    """Load Qwen3.6 tokenizer with a local fast-tokenizer fallback."""
+    from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+    try:
+        return AutoTokenizer.from_pretrained(checkpoint_path)
+    except (KeyError, ValueError):
+        tokenizer_file = os.path.join(checkpoint_path, 'tokenizer.json')
+        if not os.path.isfile(tokenizer_file):
+            raise
+
+        cfg_path = os.path.join(checkpoint_path, 'tokenizer_config.json')
+        cfg = {}
+        if os.path.isfile(cfg_path):
+            with open(cfg_path, 'r', encoding='utf-8') as f:
+                cfg = json.load(f)
+        kwargs = {
+            key: cfg[key]
+            for key in (
+                'bos_token',
+                'eos_token',
+                'unk_token',
+                'pad_token',
+                'additional_special_tokens',
+            )
+            if key in cfg
+        }
+        tok = PreTrainedTokenizerFast(
+            tokenizer_file=tokenizer_file,
+            **kwargs,
+        )
+        chat_template = cfg.get('chat_template')
+        if chat_template is None:
+            template_path = os.path.join(checkpoint_path, 'chat_template.jinja')
+            if os.path.isfile(template_path):
+                with open(template_path, 'r', encoding='utf-8') as f:
+                    chat_template = f.read()
+        if chat_template is not None:
+            tok.chat_template = chat_template
+        return tok
 
 
 class Qwen36TorchFrontendRtx:
@@ -195,7 +238,7 @@ class Qwen36TorchFrontendRtx:
         Phase 1 only. Phase 2 will replace with a WEIGHT_SPEC-driven
         loader.
         """
-        from transformers import AutoModelForCausalLM, AutoTokenizer
+        from transformers import AutoModelForCausalLM
 
         # attn_implementation='flash_attention_2' routes the attention
         # path through the vendored FA2 (flash_rt_fa2.so) instead of
@@ -208,7 +251,7 @@ class Qwen36TorchFrontendRtx:
             low_cpu_mem_usage=True,
             attn_implementation='flash_attention_2',
         ).eval()
-        self._tokenizer = AutoTokenizer.from_pretrained(self.checkpoint_path)
+        self._tokenizer = _load_qwen36_tokenizer(self.checkpoint_path)
         self._pipeline = Qwen36Pipeline(mdl)
 
     # ---------- Phase 6 MTP head loader ----------
@@ -898,8 +941,7 @@ class Qwen36TorchFrontendRtx:
 
         # Tokenizer — NVFP4 ckpts ship tokenizer.json + chat_template
         # at the ckpt path (verified prithivMLmods/Qwen3.6-27B-NVFP4).
-        from transformers import AutoTokenizer
-        self._tokenizer = AutoTokenizer.from_pretrained(self.checkpoint_path)
+        self._tokenizer = _load_qwen36_tokenizer(self.checkpoint_path)
 
         # Raw NVFP4 weights → handles (compatible schema with FP8 path
         # but with *_packed/_sf/_alpha keys for quantized linears).
@@ -1030,6 +1072,17 @@ class Qwen36TorchFrontendRtx:
             return n_row_super * n_col_super * 512
 
         layers = self._weights.ptrs['layers']
+        try:
+            cap = tuple(int(x) for x in torch.cuda.get_device_capability(
+                device))
+        except Exception:
+            cap = ()
+        is_sm121 = cap == (12, 1)
+        pingpong_default = '0' if is_sm121 else '1'
+        def _flag_enabled(name: str, default: str) -> bool:
+            return os.environ.get(name, default).strip().lower() not in (
+                '0', 'false', 'off')
+
         gate_up_default = '1' if self._long_ctx_mode else '0'
         self._enable_mlp_gate_up_fusion = (
             bool(int(os.environ.get(
@@ -1040,15 +1093,15 @@ class Qwen36TorchFrontendRtx:
         self._enable_mlp_gate_up_pingpong = (
             self._enable_mlp_gate_up_fusion
             and hasattr(fvk, 'fp4_w4a16_gemm_sm120_bf16out_pingpong')
-            and os.environ.get(
+            and _flag_enabled(
                 'FLASHRT_QWEN36_MLP_GATE_UP_PINGPONG',
-                '1').strip().lower() not in ('0', 'false', 'off')
+                pingpong_default)
         )
         self._enable_prefill_proj_pingpong = (
             hasattr(fvk, 'fp4_w4a16_gemm_sm120_bf16out_pingpong')
-            and os.environ.get(
+            and _flag_enabled(
                 'FLASHRT_QWEN36_PREFILL_PROJ_PINGPONG',
-                '1').strip().lower() not in ('0', 'false', 'off')
+                pingpong_default)
         )
         self._enable_silu_mul_quant_fusion = bool(int(os.environ.get(
             'FLASHRT_QWEN36_FUSE_SILU_MUL_QUANT', '0') or '0'))
@@ -1098,7 +1151,6 @@ class Qwen36TorchFrontendRtx:
             'FLASHRT_QWEN36_VERIFY_WS_SPLIT', '2') or '2')
         self._verify_ws_stages = int(os.environ.get(
             'FLASHRT_QWEN36_VERIFY_WS_STAGES', '6') or '6')
-
         self._nvfp4_scratch: dict[tuple[int, int],
                                   tuple[torch.Tensor, ...]] = {}
         for N, K in self._NVFP4_SHAPES:
@@ -12037,10 +12089,16 @@ class Qwen36TorchFrontendRtx:
         _add('logits', self._logits_buf)
         _add('lin_state', self._lin_state)
         _add('lin_conv_state', self._lin_conv_state)
-        for (N, K), (qinp, sc, out) in self._fp8_scratch.items():
+        for (N, K), (qinp, sc, out) in getattr(
+                self, '_fp8_scratch', {}).items():
             _add(f'fp8_{N}x{K}_qinp', qinp)
             _add(f'fp8_{N}x{K}_scale', sc)
             _add(f'fp8_{N}x{K}_out', out)
+        for (N, K), (qinp, sc, out) in getattr(
+                self, '_nvfp4_scratch', {}).items():
+            _add(f'nvfp4_{N}x{K}_qinp', qinp)
+            _add(f'nvfp4_{N}x{K}_scale', sc)
+            _add(f'nvfp4_{N}x{K}_out', out)
         # attn backend buffers
         _add('attn_K_cache', self._attn.K_cache)
         _add('attn_V_cache', self._attn.V_cache)

--- a/flash_rt/frontends/torch/qwen36_spark.py
+++ b/flash_rt/frontends/torch/qwen36_spark.py
@@ -1,0 +1,200 @@
+"""FlashRT - Qwen3.6-27B NVFP4 Spark frontend (SM121).
+
+Spark reuses the RTX Qwen3.6 compute path, but needs the NVFP4 MTP
+prompt-tail K/V prefill that Thor already uses. The RTX parent only
+enables the K/V-only tail helper when BF16 shadow MTP weights exist;
+the paired public FP8 MTP checkpoint is converted to NVFP4 at load time
+and therefore lacks those shadow pointers. Without this override,
+``FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL=auto`` collapses to zero and the
+long FP8-KV route starts the drafter with an unseeded MTP cache.
+"""
+
+from __future__ import annotations
+
+import os
+
+from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
+
+
+class Qwen36TorchFrontendSpark(Qwen36TorchFrontendRtx):
+    """Qwen3.6 NVFP4 frontend for DGX Spark / GB10 (SM121).
+
+    This class is intentionally narrow: it keeps the RTX attention backend
+    and all SM120/SM121 GEMM dispatch, while adding the NVFP4 MTP tail
+    prefill path needed for high speculative acceptance length.
+    """
+
+    def _long_mtp_prefill_tail_for_prompt(self, prompt_len: int) -> int:
+        raw = os.environ.get(
+            'FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL', 'auto') or 'auto'
+        if raw.lower() != 'auto':
+            return max(0, int(raw))
+        mtp = self._weights.ptrs.get('mtp') if self._weights else None
+        if not isinstance(mtp, dict):
+            return 0
+        prompt_len = int(prompt_len)
+        if prompt_len >= 128 and prompt_len < 512:
+            return min(128, prompt_len)
+        if prompt_len < 512:
+            return 0
+        if prompt_len < 768:
+            return 512
+        if prompt_len < 3072:
+            return 2048
+        if prompt_len < 6144:
+            return 512
+        if prompt_len < 24576:
+            return 4096
+        return 2048
+
+    def _long_tq_effective_k(
+            self, prompt_len: int, K: int,
+            max_new_tokens: int | None = None) -> int:
+        target_k = super()._long_tq_effective_k(
+            prompt_len, K, max_new_tokens)
+        if os.environ.get('FLASHRT_QWEN36_TQ_SPEC_K', ''):
+            return target_k
+        prompt_len = int(prompt_len)
+        if 6144 <= prompt_len < 12288:
+            target_k = 7
+        elif 12288 <= prompt_len < 24576:
+            target_k = 6
+        elif 24576 <= prompt_len < 49152:
+            target_k = 7
+        caller_k = int(K)
+        if caller_k < 6:
+            return min(caller_k, target_k)
+        return target_k
+
+    def _fp8_xqa_auto_bucket_enabled(
+            self, q_seq: int | None, end_pos: int) -> bool:
+        """Spark-measured FP8-KV XQA bucket policy.
+
+        GB10/SM121 differs from the RTX 5090 policy inherited by the parent:
+        XQA is faster for the 2K and 16K buckets, while the staged BF16 path is
+        faster around 8K for the measured K/tail policy.
+        """
+        end_pos = int(end_pos)
+        if end_pos < 256 and q_seq is not None and int(q_seq) <= 7:
+            return True
+        if end_pos < 6144:
+            return True
+        if end_pos < 12288:
+            return False
+        return True
+
+    def _prefill_mtp_tail_kv_nvfp4(
+            self, prev_h_rows, token_ids, pos_start: int,
+            cache_base_pos: int) -> bool:
+        """Populate MTP prompt-tail K/V cache without full MTP decode.
+
+        The parent implementation supports BF16-shadow MTP projection
+        weights. Spark's normal public path uses the official FP8 MTP
+        checkpoint converted to NVFP4, so compute K/V with the packed
+        NVFP4 k/v projections in one batched tail pass.
+        """
+        import torch
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        mtp = self._weights.ptrs.get('mtp')
+        if mtp is None:
+            return False
+        if 'k_proj_w_bf16' in mtp:
+            return super()._prefill_mtp_tail_kv_nvfp4(
+                prev_h_rows, token_ids, pos_start, cache_base_pos)
+
+        rows = int(token_ids.numel())
+        if rows <= 0:
+            return True
+
+        hidden = self._cfg['hidden_size']
+        eps = float(self._cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        self._ensure_mtp_tail_kv_buffers(rows)
+
+        embed = self._mtp_tail_embed_buf[:rows]
+        h_norm = self._mtp_tail_h_norm_buf[:rows]
+        e_norm = self._mtp_tail_e_norm_buf[:rows]
+        cat_buf = self._mtp_tail_cat_buf[:rows]
+        fc_out = self._mtp_tail_fc_out_buf[:rows]
+        x_norm = self._mtp_tail_x_norm_buf[:rows]
+        k_proj = self._mtp_tail_k_proj_buf[:rows]
+        v_proj = self._mtp_tail_v_proj_buf[:rows]
+        k_norm = self._mtp_tail_k_norm_buf[:rows * 4]
+
+        fvk.qwen36_embedding_lookup_bf16(
+            token_ids.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            embed.data_ptr(), rows, hidden, s,
+        )
+        fvk.rms_norm(
+            prev_h_rows.view(rows, hidden).data_ptr(),
+            int(mtp['pre_fc_norm_hidden_eff_w']),
+            h_norm.data_ptr(), rows, hidden, eps, s,
+        )
+        fvk.rms_norm(
+            embed.data_ptr(), int(mtp['pre_fc_norm_embedding_eff_w']),
+            e_norm.data_ptr(), rows, hidden, eps, s,
+        )
+        fvk.concat2_bf16(
+            e_norm.data_ptr(), h_norm.data_ptr(),
+            cat_buf.data_ptr(), rows, hidden, hidden, s,
+        )
+        self._mtp_tail_fc_matmul(
+            cat_buf.data_ptr(), int(mtp['fc_w']),
+            fc_out.data_ptr(), rows, hidden, s,
+        )
+        fvk.rms_norm(
+            fc_out.data_ptr(), int(mtp['input_norm_eff_w']),
+            x_norm.data_ptr(), rows, hidden, eps, s,
+        )
+
+        ap_5120, sf_5120, _ = self._nvfp4_scratch[(1024, 5120)]
+        fvk.quantize_bf16_to_nvfp4_swizzled(
+            x_norm.data_ptr(), ap_5120.data_ptr(),
+            sf_5120.data_ptr(), rows, hidden, s,
+        )
+        fvk.fp4_w4a16_gemm_sm120_bf16out(
+            ap_5120.data_ptr(), int(mtp['k_proj_packed']),
+            k_proj.data_ptr(),
+            rows, 4 * 256, hidden,
+            sf_5120.data_ptr(), int(mtp['k_proj_sf']),
+            float(mtp['k_proj_alpha']),
+            s,
+        )
+        fvk.fp4_w4a16_gemm_sm120_bf16out(
+            ap_5120.data_ptr(), int(mtp['v_proj_packed']),
+            v_proj.data_ptr(),
+            rows, 4 * 256, hidden,
+            sf_5120.data_ptr(), int(mtp['v_proj_sf']),
+            float(mtp['v_proj_alpha']),
+            s,
+        )
+        fvk.rms_norm(
+            k_proj.view(rows * 4, 256).data_ptr(),
+            int(mtp['k_norm_eff_w']),
+            k_norm.data_ptr(), rows * 4, 256, eps, s,
+        )
+
+        cache_base = int(cache_base_pos)
+        cos = self._rope_cos_table[
+            pos_start:pos_start + rows].view(rows, self._rope_dim)
+        sin = self._rope_sin_table[
+            pos_start:pos_start + rows].view(rows, self._rope_dim)
+        q_dummy = self._mtp_tail_dummy_q_in[:rows]
+        q_dummy_out = self._mtp_tail_dummy_q_out[:rows]
+        fvk.qwen36_partial_rope_qk_bf16(
+            q_dummy.data_ptr(), k_norm.data_ptr(),
+            cos.data_ptr(), sin.data_ptr(),
+            q_dummy_out.data_ptr(),
+            self._mtp_K_cache[
+                cache_base:cache_base + rows].data_ptr(),
+            rows, 1, 4, 256, self._rope_dim, s,
+        )
+        fvk.gpu_copy(
+            self._mtp_V_cache[
+                cache_base:cache_base + rows].data_ptr(),
+            v_proj.data_ptr(), rows * 4 * 256 * 2, s,
+        )
+        return True

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -34,7 +34,7 @@ def detect_arch() -> str:
 
     Supported:
         ``"thor"``      — Jetson AGX Thor, SM110 (cc 11.0)
-        ``"rtx_sm120"`` — RTX 5090 / Blackwell consumer, SM120 (cc 12.0)
+        ``"rtx_sm120"`` — RTX 5090 / DGX Spark GB10 Blackwell, SM120/SM121
         ``"rtx_sm89"``  — RTX 4090 / Ada, SM89 (cc 8.9)
         ``"rtx_sm87"``  — Jetson Orin via RTX consumer backend, SM87 (cc 8.7)
 
@@ -54,7 +54,7 @@ def detect_arch() -> str:
     major, minor = torch.cuda.get_device_capability()
     if (major, minor) == (11, 0):
         return "thor"
-    if (major, minor) == (12, 0):
+    if (major, minor) in ((12, 0), (12, 1)):
         return "rtx_sm120"
     if (major, minor) == (8, 7):
         return "rtx_sm87"
@@ -62,7 +62,7 @@ def detect_arch() -> str:
         return "rtx_sm89"
     raise RuntimeError(
         f"FlashRT: unsupported GPU SM {major}.{minor}. "
-        f"Supported architectures: SM110 (Thor), SM120 (RTX 5090), "
+        f"Supported architectures: SM110 (Thor), SM120/SM121 (Blackwell), "
         f"SM89 (RTX 4090), SM87 (Jetson Orin experimental)."
     )
 

--- a/serving/qwen36_agent/README.md
+++ b/serving/qwen36_agent/README.md
@@ -214,7 +214,11 @@ streaming wall-time rate.
 
 On SM120, the server defaults to the optimized decode kernels used by the
 benchmark path (`FLASHRT_QWEN36_DECODE_FASTGEMM=1` and
-`FLASHRT_QWEN36_VERIFY_WARPSPLIT=1`). It also defaults
+`FLASHRT_QWEN36_VERIFY_WARPSPLIT=1`). On GB10/SM121 Spark these SM120
+hand-tuned small-M kernels are left opt-in because profiling shows the default
+CUTLASS NVFP4 path is faster; the frontend also defaults the SM120 ping-pong
+CUTLASS NVFP4 variants off on SM121 unless explicitly re-enabled. The server
+also defaults
 `FLASHRT_QWEN36_TQ_VERIFY_GRAPH=0` and
 `FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH=0` for agent serving, because exact-position
 decode graphs are keyed by the live `cur_pos` and hurt first-use latency in a

--- a/serving/qwen36_agent/qwen36_engine.py
+++ b/serving/qwen36_agent/qwen36_engine.py
@@ -49,10 +49,14 @@ class Qwen36FrontendAgentEngine:
         import torch
 
         cap = torch.cuda.get_device_capability()
-        cls._set_agent_runtime_env_defaults(cap[0])
+        cls._set_agent_runtime_env_defaults(cap)
         if cap == (11, 0):
             from flash_rt.frontends.torch.qwen36_thor import (
                 Qwen36TorchFrontendThor as Frontend,
+            )
+        elif cap == (12, 1):
+            from flash_rt.frontends.torch.qwen36_spark import (
+                Qwen36TorchFrontendSpark as Frontend,
             )
         else:
             from flash_rt.frontends.torch.qwen36_rtx import (
@@ -68,22 +72,31 @@ class Qwen36FrontendAgentEngine:
         return cls(fe, model_name=model_name)
 
     @staticmethod
-    def _set_agent_runtime_env_defaults(cap_major: int) -> None:
+    def _set_agent_runtime_env_defaults(capability) -> None:
         """Set agent-serving runtime defaults before frontend construction.
 
         The fixed-shape benchmark path benefits from exact-position CUDA Graph
         replay. A long-lived agent session does not: every new generated
         position can be a never-seen graph key, so the first real coding-agent
         turn pays capture on the hot path and drops to cold-capture throughput.
-        Keep the fast SM120 kernels on, but default the agent host to direct
+        Keep the fast SM120 kernels on for RTX 5090, but do not enable them by
+        default on GB10/SM121: Spark profiling shows those SM120 hand-tuned
+        small-M kernels are slower there. Default the agent host to direct
         long-decode kernel launch for verify/MTP-chain unless the caller opts
         back into exact graph replay before startup.
         """
         import os
 
-        if int(cap_major) >= 12:
-            os.environ.setdefault("FLASHRT_QWEN36_DECODE_FASTGEMM", "1")
-            os.environ.setdefault("FLASHRT_QWEN36_VERIFY_WARPSPLIT", "1")
+        if isinstance(capability, tuple):
+            cap_major = int(capability[0])
+            cap_minor = int(capability[1]) if len(capability) > 1 else 0
+        else:
+            cap_major = int(capability)
+            cap_minor = 0
+        if cap_major >= 12:
+            if (cap_major, cap_minor) == (12, 0):
+                os.environ.setdefault("FLASHRT_QWEN36_DECODE_FASTGEMM", "1")
+                os.environ.setdefault("FLASHRT_QWEN36_VERIFY_WARPSPLIT", "1")
             os.environ.setdefault("FLASHRT_QWEN36_TQ_VERIFY_GRAPH", "0")
             os.environ.setdefault("FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH", "0")
 

--- a/tests/test_qwen36_agent_serving_policy.py
+++ b/tests/test_qwen36_agent_serving_policy.py
@@ -1097,6 +1097,24 @@ def test_qwen36_agent_sm120_defaults_disable_exact_position_decode_graphs(monkey
     assert os.environ["FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH"] == "0"
 
 
+def test_qwen36_agent_sm121_defaults_do_not_enable_sm120_fastgemm(monkeypatch):
+    keys = (
+        "FLASHRT_QWEN36_DECODE_FASTGEMM",
+        "FLASHRT_QWEN36_VERIFY_WARPSPLIT",
+        "FLASHRT_QWEN36_TQ_VERIFY_GRAPH",
+        "FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH",
+    )
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+    Qwen36FrontendAgentEngine._set_agent_runtime_env_defaults((12, 1))
+
+    assert "FLASHRT_QWEN36_DECODE_FASTGEMM" not in os.environ
+    assert "FLASHRT_QWEN36_VERIFY_WARPSPLIT" not in os.environ
+    assert os.environ["FLASHRT_QWEN36_TQ_VERIFY_GRAPH"] == "0"
+    assert os.environ["FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH"] == "0"
+
+
 def test_qwen36_agent_runtime_defaults_respect_overrides(monkeypatch):
     monkeypatch.setenv("FLASHRT_QWEN36_TQ_VERIFY_GRAPH", "1")
     monkeypatch.setenv("FLASHRT_QWEN36_TQ_MTP_CHAIN_GRAPH", "1")

--- a/tests/test_qwen36_server_warmup.py
+++ b/tests/test_qwen36_server_warmup.py
@@ -155,6 +155,24 @@ def test_long_mtp_tail_auto_policy(monkeypatch):
     assert fe._long_mtp_prefill_tail_for_prompt(204800) == 512
 
 
+def test_spark_long_k_and_xqa_buckets(monkeypatch):
+    from flash_rt.frontends.torch.qwen36_spark import Qwen36TorchFrontendSpark
+
+    monkeypatch.delenv('FLASHRT_QWEN36_TQ_SPEC_K', raising=False)
+    fe = Qwen36TorchFrontendSpark.__new__(Qwen36TorchFrontendSpark)
+
+    assert fe._long_tq_effective_k(2048, 6, 64) == 6
+    assert fe._long_tq_effective_k(8192, 6, 64) == 7
+    assert fe._long_tq_effective_k(16384, 6, 64) == 6
+    assert fe._long_tq_effective_k(24576, 6, 64) == 7
+    assert fe._long_tq_effective_k(32768, 6, 64) == 7
+
+    assert fe._fp8_xqa_auto_bucket_enabled(7, 2048)
+    assert not fe._fp8_xqa_auto_bucket_enabled(8, 8192)
+    assert fe._fp8_xqa_auto_bucket_enabled(7, 16384)
+    assert fe._fp8_xqa_auto_bucket_enabled(7, 32768)
+
+
 def test_long_mtp_tail_auto_disables_without_bf16_kv(monkeypatch):
     from flash_rt.frontends.torch.qwen36_rtx import Qwen36TorchFrontendRtx
 
@@ -170,6 +188,25 @@ def test_long_mtp_tail_auto_disables_without_bf16_kv(monkeypatch):
 
     monkeypatch.setenv('FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL', '512')
     assert fe._long_mtp_prefill_tail_for_prompt(204800) == 512
+
+
+def test_spark_long_mtp_tail_auto_supports_nvfp4_mtp(monkeypatch):
+    from flash_rt.frontends.torch.qwen36_spark import Qwen36TorchFrontendSpark
+
+    monkeypatch.delenv('FLASHRT_QWEN36_LONG_MTP_PREFILL_TAIL',
+                       raising=False)
+    fe = Qwen36TorchFrontendSpark.__new__(Qwen36TorchFrontendSpark)
+    fe._weights = type('Weights', (), {
+        'ptrs': {'mtp': {'k_proj_packed': 1}},
+    })()
+
+    assert fe._long_mtp_prefill_tail_for_prompt(128) == 128
+    assert fe._long_mtp_prefill_tail_for_prompt(512) == 512
+    assert fe._long_mtp_prefill_tail_for_prompt(1024) == 2048
+    assert fe._long_mtp_prefill_tail_for_prompt(4096) == 512
+    assert fe._long_mtp_prefill_tail_for_prompt(8192) == 4096
+    assert fe._long_mtp_prefill_tail_for_prompt(16384) == 4096
+    assert fe._long_mtp_prefill_tail_for_prompt(204800) == 2048
 
 
 def test_long_tq_effective_k_uses_measured_context_buckets(monkeypatch):


### PR DESCRIPTION
## Summary

Add Qwen3.6-27B NVFP4 support for DGX Spark / GB10 (SM121).

This PR keeps Spark support additive and isolated:
- adds a dedicated `Qwen36TorchFrontendSpark`
- enables SM121 build support for the existing Qwen3.6 NVFP4/FA2/XQA path
- wires SM121 agent serving to the Spark frontend
- documents Spark usage and measured performance
- adds a reproducible Spark AL benchmark script and policy tests

No experimental SM121 small-M kernel path is included in this PR.

## Spark Policy

Measured Spark long-context policy:

| ctx | effective K | MTP tail | XQA |
|---:|---:|---:|:---:|
| 128 | 6 | 128 | on |
| 2K | 6 | 2048 | on |
| 8K | 7 | 4096 | off |
| 16K | 6 | 4096 | on |
| 24K | 7 | 2048 | on |
| 32K | 7 | 2048 | on |

## Performance

Measured on single DGX Spark / GB10, Qwen3.6-27B NVFP4 + FP8 MTP, `max_new_tokens=64`, FP8 long KV cache:

| ctx | TTFT / prefill | decode tok/s | AL |
|---:|---:|---:|---:|
| 128 | 170.1 ms | 40.42 | 3.57 |
| 2K | 1.784 s | 40.11 | 3.64 |
| 8K | 5.160 s | 36.14 | 3.50 |
| 16K | 8.545 s | 54.94 | 5.30 |
| 24K | 11.077 s | 57.73 | 6.22 |
| 32K | 15.110 s | 57.32 | 6.67 |

README includes the 128 and 16K Spark numbers next to the Thor Qwen3.6 benchmark table.

## Docs

Added:
- `docs/qwen36_spark.md`

Updated:
- `README.md`
- `docs/qwen36_usage.md`
- `docs/qwen36_nvfp4.md`
- `serving/qwen36_agent/README.md`

## Validation

- `git diff --check`
- `py_compile` for Spark frontend, benchmark, agent engine, tests
- `pytest -q tests/test_qwen36_server_warmup.py -k 'spark_long_mtp_tail_auto or spark_long_k_and_xqa or long_mtp_tail_auto'`
  - 4 passed
- `pytest -q tests/test_qwen36_agent_serving_policy.py -k 'sm121_defaults or sm120_defaults or runtime_defaults'`
  - 3 passed