### PR TITLE
cosmos3_video: Cosmos3-Nano text2video FP8 denoise (RTX SM120)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -213,7 +213,7 @@ model = flash_rt.load_model(
 | `autotune` | `int\|bool` | `3` | CUDA Graph autotune intensity. See [Autotune](#autotune). |
 | `recalibrate` | `bool` | `False` | Force fresh FP8 calibration (and weight cache for JAX), ignoring cache. See [Calibration](#calibration). |
 | `weight_cache` | `bool` | `True` | Cache FP8-quantized weights to disk. **JAX only** — reduces cold start from ~42s to ~6s. Torch loads in ~3s and ignores this. See [Weight Cache](#weight-cache-jax-only). |
-| `config` | `str` | `"pi05"` | Model architecture config: `"pi05"`, `"pi0"`, `"groot"`, `"groot_n17"`, `"pi0fast"`, `"motus"`, `"wan22_ti2v_5b"`. |
+| `config` | `str` | `"pi05"` | Model architecture config: `"pi05"`, `"pi0"`, `"groot"`, `"groot_n17"`, `"pi0fast"`, `"motus"`, `"wan22_ti2v_5b"`, `"cosmos3_video"`. `"cosmos3_video"` is a non-VLA text2video denoise model — drive it with `set_prompt(ref=...)` + `infer(...)`, not `predict()`. |
 | `decode_cuda_graph` | `bool` | `False` | **Pi0-FAST only.** Capture action-phase decode as CUDA Graph. Trades startup time for per-token speed. See [Pi0-FAST](#pi0-fast). |
 | `decode_graph_steps` | `int` | `80` | **Pi0-FAST only.** Number of action tokens to capture in the decode graph. Should cover your longest expected action sequence. |
 | `use_fp4` | `bool` | `False` | **Pi0.5 torch + jax on Thor.** Enable NVFP4 quantization on the encoder FFN stack. When `True`, resolves to the production preset (`fp4_layers=tuple(range(18))` + `use_awq=True` + `use_p1_split_gu=True`). Requires SM100+ GPU. Other configs emit a warning and fall back to FP8. See [NVFP4](#nvfp4-pi05-only). |
@@ -621,6 +621,37 @@ This route uses the official Wan Python pipeline and original ModelScope
 checkpoint layout. It is separate from ComfyUI; ComfyUI integration should
 be provided by an external custom-node package. See
 [`docs/wan22_usage.md`](docs/wan22_usage.md).
+
+### Cosmos3-Nano text2video
+
+Cosmos3-Nano text2video is a self-contained, kernelized FP8 denoise model
+(non-VLA) on RTX SM120. Conditioning enters via `set_prompt(ref=...)` and the
+denoise runs through `infer(...)`; `predict()` is not part of this API.
+
+```python
+import flash_rt
+
+model = flash_rt.load_model(
+    "/path/to/cosmos3_video_weights.safetensors",
+    framework="torch",
+    config="cosmos3_video",
+    hardware="rtx_sm120",
+    use_fp8=True,                       # default; use_fp8=False -> bf16 reference
+)
+
+model.set_prompt(ref="/path/to/tensors.safetensors")   # official reference dump
+out = model.infer(
+    teacache_skip="3,5,7",             # training-free step caching ("" = off)
+    shift=10.0,
+    compare_ref=True,
+    return_metadata=True,
+)
+# out["latent"] -> [1,48,T,H,W] denoised vision latent (VAE decode is downstream)
+```
+
+The model-local kernel is built once on the target GPU (`cd
+flash_rt/models/cosmos3_video/kernels && python3 setup.py build_ext --inplace`).
+See [`docs/cosmos3_video_usage.md`](docs/cosmos3_video_usage.md).
 
 ### `model.predict()`
 

--- a/docs/cosmos3_video_usage.md
+++ b/docs/cosmos3_video_usage.md
@@ -1,0 +1,129 @@
+# Cosmos3-Nano text2video (FP8) — Usage & Benchmark
+
+Kernelized, CUDA-graphed Cosmos3-Nano **text2video** denoise, packaged as a
+first-class FlashRT model (`config="cosmos3_video"`). Run it through the standard
+`flash_rt.load_model(...)` API.
+
+This is a self-contained two-tower MoT denoise backbone driven for the video
+path: the gen tower is the all-noisy vision latent, the head is `llm2vae`,
+and the output is unpatchified to a `[1, 48, T, H, W]` vision latent. Conditioning
+(text / VAE encode) is upstream and consumed from the official reference dump; VAE
+decode to pixels is the downstream step.
+
+---
+
+## 1. Precision & speed (RTX 5090 / sm120)
+
+Quantization choice matters: the **video latent is far more quant-sensitive than the
+AV action head**, so only **FP8 (E4M3) is near-lossless**; NVFP4 GEMM and int8-sage
+attention degrade it and are off by default.
+
+**480p / 49 frames / 10-step UniPC** (denoise loop; VAE decode listed separately):
+
+| path | denoise | VAE decode | E2E | latent cos | notes |
+|---|---|---|---|---|---|
+| official Cosmos3-Nano | ~53.5 s | ~2.3 s | **~55.8 s** | — (ref) | eager, uncached |
+| FlashRT **bf16** | 4.4 s | 2.3 s | 6.7 s | 0.9989 | CUDA graph + static text-KV cache |
+| FlashRT **fp8** | 2.5 s | 2.3 s | 4.8 s | 0.986 | near-lossless |
+| FlashRT **fp8 + TeaCache(3,5,7) + fp4-VAE** | ~1.8 s | 1.26 s | **~3.0 s** | 0.981 | default-recommended |
+
+→ **~18× faster end-to-end than the official pipeline**, near-lossless.
+
+**Decoded-frame quality** (256p, PSNR of decoded frames vs the official video):
+
+| denoise precision | frame PSNR |
+|---|---|
+| bf16 | 41.4 dB |
+| **fp8** | 34.2 dB |
+| fp4 | 22.8 dB (lossy — not recommended) |
+
+**How to read these numbers.** The official baseline runs eager (no CUDA graph) and
+recomputes the static text tower every step, so most of the ~18× is FlashRT's CUDA
+graph + static text-KV cache (same precision); the **quantization + TeaCache** kernels
+contribute ~2.2× on top of a graphed bf16 baseline. Both are real; the ~18× is the
+end-user speedup switching from the official pipeline.
+
+How it gets there: FP8 weights/activations (`fp8_gemm_descale_bf16out`) · static text
+K/V cache (text tower computed once) · fused qk-norm+rope · TeaCache training-free
+step caching · one CUDA graph per compute step · near-lossless fp4 Wan-VAE conv decode.
+
+---
+
+## 2. Prerequisites
+
+- **GPU**: RTX 5090 (sm120). FlashRT sm120 image (`flash_rt_kernels.so` + `flash_rt_fa2.so`).
+- Build the model-local kernels once on the target GPU (isolated; does not rebuild
+  `flash_rt_kernels.so`):
+
+```bash
+cd flash_rt/models/cosmos3_video/kernels && python3 setup.py build_ext --inplace
+```
+
+- Required files (paths are env/arg-driven — no host paths baked in):
+  - Cosmos3 flat-format weights `.safetensors` (the base text2video model, converted
+    from the public diffusers transformer).
+  - The official reference dump `tensors.safetensors` (conditioning: text/VAE-encode
+    tokens, rope tables, initial latent, timestep embeds).
+
+---
+
+## 3. Quickstart
+
+```bash
+python3 examples/cosmos3_video_quickstart.py \
+    --checkpoint <cosmos3 flat weights .safetensors> \
+    --ref <.../tensors.safetensors> \
+    --teacache-skip 3,5,7
+```
+
+Expected (RTX 5090, 480p/49f/10-step):
+
+```text
+[cosmos3_video] denoise 1809.1 ms  quant=fp8  teacache_skip=[3,5,7]
+[cosmos3_video] latent (1, 48, 13, 30, 52)
+[cosmos3_video] latent cos 0.98125  rel_l2 19.408%  (vs official reference)
+```
+
+Programmatic (all config via typed parameters — no environment knobs):
+
+```python
+import flash_rt
+model = flash_rt.load_model("<weights>", config="cosmos3_video",
+                            hardware="rtx_sm120", use_fp8=True)
+model.set_prompt(ref="<.../tensors.safetensors>")   # conditioning
+out = model.infer(teacache_skip="3,5,7", shift=10.0,
+                  compare_ref=True, return_metadata=True)
+# out["latent"]     -> [1,48,T,H,W] denoised vision latent
+# out["latency_ms"] -> denoise loop wall time
+# out["cos"]        -> latent cosine vs official once/final_vision_latent
+#
+# model.infer() with no return_metadata returns the latent tensor directly.
+```
+
+---
+
+## 4. Configuration (typed parameters, default-safe)
+
+| where | parameter | default | effect |
+|---|---|---|---|
+| `load_model(...)` | `use_fp8` | `True` | `True` → FP8 (near-lossless) · `False` → bf16 (reference) |
+| `set_prompt(...)` | `ref` | — | official reference dump (conditioning); required |
+| `infer(...)` | `teacache_skip` | `""` | step-cache skip steps, e.g. `"3,5,7"` (cos 0.99) or `"2,4,6,8"` (faster) |
+| `infer(...)` | `shift` | `10.0` | UniPC shift |
+| `infer(...)` | `compare_ref` | `False` | also return cos / rel_l2 vs the official latent |
+
+The fp4 path and per-projection bf16 overrides remain available as constructor
+arguments on the pipeline class for experiments (lossy for video; not exposed via
+`load_model`). TeaCache is **training-free step caching** (it reuses the cached
+velocity on skip steps), not step distillation.
+
+---
+
+## 5. Scope
+
+- The denoise policy is packaged here; **VAE decode to frames is downstream** (the
+  Wan2.2 VAE + its fp4/fp8 conv acceleration are applied to the user's VAE).
+- Conditioning (text encode, VAE encode) is upstream, consumed from the reference
+  dump passed to `set_prompt(ref=...)`.
+- **Additive & isolated**: the production `flash_rt_kernels.so` and its CMake are
+  untouched; the model-local kernels are an isolated extension.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -29,7 +29,7 @@ def load_model(
     autotune: int = 3,              # 0=off, 3=default, 5+=thorough
     recalibrate: bool = False,
     weight_cache: bool = True,      # JAX only
-    config: str = "pi05",           # "pi05" | "pi0" | "groot" | "groot_n17" | "pi0fast" | "motus" | "wan22_ti2v_5b"
+    config: str = "pi05",           # "pi05" | "pi0" | "groot" | "groot_n17" | "pi0fast" | "motus" | "wan22_ti2v_5b" | "cosmos3_video"
     device=None,                    # reserved
     # Pi0-FAST-specific:
     decode_cuda_graph: bool = False,
@@ -85,6 +85,12 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   teacache_threshold=..., teacache_start_step=...,
   teacache_end_step=..., teacache_cache_device=...)`; `predict()` is not
   part of this video-generation API. See `docs/wan22_usage.md`.
+- `config="cosmos3_video"` is an RTX SM120 Cosmos3-Nano text2video FP8
+  denoise model (non-VLA). It exposes `set_prompt(ref=<reference dump>)`
+  for conditioning and `infer(teacache_skip=..., shift=...,
+  compare_ref=..., return_metadata=...)`, returning the denoised vision
+  latent; `predict()` is not part of this API. Precision is selected with
+  `load_model(..., use_fp8=True|False)`. See `docs/cosmos3_video_usage.md`.
 - `config="groot_n17"` is registered for `framework="torch"` and
   `hardware="rtx_sm120"`. This route validates the N1.7 DiT
   self/cross-attention path on the vendored FA2 backend.

--- a/examples/cosmos3_video_quickstart.py
+++ b/examples/cosmos3_video_quickstart.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Cosmos3-Nano text2video FP8 denoise quickstart.
+
+Runs the kernelized UniPC denoise (FP8 GEMMs, static text-KV cache, optional
+TeaCache step caching) through the standard FlashRT API and reports the denoise
+latency + the latent cosine vs the official reference.
+
+Conditioning (text / VAE encode) is consumed from the official reference dump;
+this is the denoise policy, so infer() returns the denoised vision latent (Wan
+VAE decode to frames is the downstream step).
+
+Build the model-local kernels once on the target GPU:
+  cd flash_rt/models/cosmos3_video/kernels && python3 setup.py build_ext --inplace
+
+Run (all config via typed parameters; no environment knobs):
+  python3 examples/cosmos3_video_quickstart.py \
+      --checkpoint <cosmos3 flat weights .safetensors> \
+      --ref <.../tensors.safetensors> [--teacache-skip 3,5,7] [--shift 10.0]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import flash_rt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", required=True,
+                        help="Cosmos3 flat-format weights (.safetensors)")
+    parser.add_argument("--ref", required=True,
+                        help="Official reference dump tensors.safetensors")
+    parser.add_argument("--bf16", action="store_true",
+                        help="reference-accuracy bf16 path (default: fp8)")
+    parser.add_argument("--teacache-skip", default="",
+                        help="TeaCache skip steps, e.g. 3,5,7 (safe) or 2,4,6,8")
+    parser.add_argument("--shift", type=float, default=10.0)
+    args = parser.parse_args()
+
+    t0 = time.perf_counter()
+    model = flash_rt.load_model(
+        args.checkpoint,
+        framework="torch",
+        config="cosmos3_video",
+        hardware="rtx_sm120",
+        use_fp8=not args.bf16,
+    )
+    model.set_prompt(ref=args.ref)
+    print(f"[cosmos3_video] load_model + set_prompt "
+          f"wall={time.perf_counter() - t0:.2f}s")
+
+    out = model.infer(
+        teacache_skip=args.teacache_skip,
+        shift=args.shift,
+        compare_ref=True,
+        return_metadata=True,
+    )
+    quant = "bf16" if args.bf16 else "fp8"
+    print(f"[cosmos3_video] denoise {out['latency_ms']:.1f} ms  quant={quant}"
+          f"  teacache_skip=[{args.teacache_skip}]")
+    print(f"[cosmos3_video] latent {tuple(out['latent'].shape)}")
+    print(f"[cosmos3_video] latent cos {out['cos']:.5f}  "
+          f"rel_l2 {out['rel_l2'] * 100:.3f}%  (vs official reference)")
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -316,7 +316,9 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         weight_cache: if True (default), cache FP8-quantized weights to disk
             after first load. Only affects JAX.
         config: model config name: "pi05", "pi0", "groot", "groot_n17",
-            "pi0fast", "motus", "wan22_ti2v_5b"
+            "pi0fast", "motus", "wan22_ti2v_5b", "cosmos3_video".
+            "cosmos3_video" is a non-VLA text2video denoise model: drive it with
+            set_prompt(ref=<reference dump>) + infer(...), not predict().
         device: ignored (auto-detects GPU). Reserved for future multi-GPU.
         decode_cuda_graph: Pi0-FAST only. Capture action-phase decode as CUDA
             Graph for max throughput (trades startup time for per-token speed).
@@ -399,11 +401,11 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         VLAModel instance with .predict() method.
     """
     if config not in ("pi05", "groot", "groot_n17", "pi0", "pi0fast",
-                      "motus", "wan22_ti2v_5b"):
+                      "motus", "wan22_ti2v_5b", "cosmos3_video"):
         raise ValueError(
             f"Unknown config: {config}. "
             f"Supported: pi05, groot, groot_n17, pi0, pi0fast, motus, "
-            f"wan22_ti2v_5b")
+            f"wan22_ti2v_5b, cosmos3_video")
     if framework not in ("torch", "jax"):
         raise ValueError(
             f"Unknown framework: {framework}. Supported: torch, jax")

--- a/flash_rt/configs/cosmos3_video.yaml
+++ b/flash_rt/configs/cosmos3_video.yaml
@@ -1,0 +1,24 @@
+# Cosmos3-Nano text2video FP8 denoise (RTX SM120).
+# Metadata only — runtime dims are inferred from the reference dump in the model.
+name: cosmos3_video
+description: Cosmos3-Nano text2video FP8 denoise (two-tower MoT, UniPC, TeaCache)
+arch: two_tower_mot_denoise
+hidden_dim: 4096
+ffn_hidden_dim: 12288
+num_layers: 36
+num_heads: 32
+num_kv_heads: 8
+head_dim: 128
+patch_latent_dim: 192
+latent_channels: 48
+# denoise (runtime knobs are infer() parameters; precision is load_model use_fp8)
+num_steps: 10
+guidance: 1.0
+shift: 10.0                       # infer(shift=...) default
+scheduler: unipc
+# quantization
+weight_quant: fp8_e4m3           # near-lossless for the video latent; fp4 is lossy here
+attention: fa2_bf16              # int8-sage degrades the video latent
+teacache_skip: ""               # infer(teacache_skip="3,5,7") step caching; "" = off
+vae_decode: wan2.2_fp4           # near-lossless Wan VAE conv acceleration (downstream)
+# reference baseline (RTX 5090, 480p/49f/10-step): denoise ~2.6 s, e2e latent cos ~0.986

--- a/flash_rt/frontends/torch/cosmos3_video_rtx.py
+++ b/flash_rt/frontends/torch/cosmos3_video_rtx.py
@@ -1,0 +1,130 @@
+"""Cosmos3-Nano text2video FP8 denoise — RTX SM120 torch frontend.
+
+class Cosmos3VideoTorchFrontendRtx (docs/adding_new_model.md §0 rule 2).
+
+Cosmos is a novel architecture (two-tower MoT denoise), so it self-loads +
+quantizes its weights (the guide permits a hand-written loader for novel
+backbones). The compute path is models/cosmos3_video/pipeline_rtx.py, a
+fully self-contained two-tower MoT denoise with its own model-local kernels.
+
+Lifecycle (mirrors wan22_rtx / motus_rtx — typed parameters, no env knobs):
+  __init__(checkpoint, use_fp8=...)  select precision, defer load to set_prompt
+  set_prompt(ref=...)                load conditioning from the official ref
+                                     dump, build + calibrate the towers, cache
+                                     the static text K/V, capture the gen graph
+  infer(teacache_skip=, shift=)      run the UniPC denoise; return the latent
+
+Conditioning (text / VAE encode, rope tables, initial latent, timestep embeds)
+comes from the official reference dump passed to set_prompt(); VAE decode to
+frames is the downstream step.
+"""
+import time
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+from ...models.cosmos3_video.pipeline_rtx import (
+    CosmosVideo, patchify, unpatchify, BF, DEV)
+from ...models.cosmos3_video.fm_solvers_unipc import (
+    FlowUniPCMultistepScheduler)
+
+
+class Cosmos3VideoTorchFrontendRtx:
+    DEFAULT_SHIFT = 10.0
+    DEFAULT_TEACACHE_SKIP = ""
+
+    def __init__(self, checkpoint, num_views=2, autotune=3, use_fp8=True, **_):
+        self.checkpoint = checkpoint
+        self.num_views = num_views
+        self.autotune = autotune
+        self.quant = "fp8" if use_fp8 else "bf16"
+        self.m = None
+        self._rf = None
+        self._last_latency_ms = None
+
+    def set_prompt(self, ref=None):
+        """Load conditioning from the official reference dump, build + calibrate the
+        towers, and capture the per-step gen graph.
+
+        ``ref`` is the official reference dump (tensors.safetensors): und/gen inputs,
+        rope tables, per-step timestep embeds, and the initial vision latent.
+        """
+        if not ref:
+            raise ValueError(
+                "Cosmos3-video needs the official reference dump: "
+                "set_prompt(ref=<.../tensors.safetensors>).")
+        self._rf = safe_open(ref, "pt", device=DEV)
+        r = self._rf.get_tensor
+
+        und = r("once/und_in")
+        nu, ng = und.shape[0], r("s00/gen_in").shape[0]
+        self.m = CosmosVideo(self.checkpoint, nu, ng, quant=self.quant)
+        self.m.set_rope(r("once/rope_und_cos"), r("once/rope_gen_cos"),
+                        r("once/rope_und_sin"), r("once/rope_gen_sin"))
+        self.m.precompute_und(und)
+
+        self._n_steps = sum(1 for k in self._rf.keys()
+                            if k.endswith("/timestep_emb"))
+        fl = r("once/final_vision_latent__0")
+        _, self._C, self._T, Hh, Ww = fl.shape
+        self._p = 2
+        self._h, self._w = Hh // self._p, Ww // self._p
+        self._final_ref = fl
+
+        # capture the per-step gen graph (text K/V already cached)
+        self.m.embed_gen(r("s00/vae2llm_in"), r("s00/timestep_emb"))
+        self.m.capture()
+        torch.cuda.synchronize()
+
+    def _parse_skip(self, teacache_skip):
+        return {int(t) for t in str(teacache_skip).split(",")
+                if t.strip().isdigit() and 0 < int(t) < self._n_steps - 1}
+
+    def _denoise(self, *, teacache_skip, shift):
+        r = self._rf.get_tensor
+        C, T, h, w, p = self._C, self._T, self._h, self._w, self._p
+        skip = self._parse_skip(teacache_skip)
+        sched = FlowUniPCMultistepScheduler(num_train_timesteps=1000, shift=1.0,
+                                            use_dynamic_shifting=False)
+        sched.set_timesteps(self._n_steps, device=DEV, shift=shift)
+        lat = unpatchify(r("s00/vae2llm_in"), C, T, h, w, p).float()
+        cached = None
+        t0 = time.perf_counter()
+        for i, t in enumerate(sched.timesteps):
+            if i in skip and cached is not None:
+                vel_lat = cached
+            else:
+                pe = patchify(lat.to(BF), C, p)
+                self.m.embed_gen(pe, r(f"s{i:02d}/timestep_emb"))
+                vel = self.m.replay().clone()
+                vel_lat = unpatchify(vel, C, T, h, w, p).float()
+                cached = vel_lat
+            lat = sched.step(vel_lat, t, lat, return_dict=True).prev_sample
+        torch.cuda.synchronize()
+        self._last_latency_ms = (time.perf_counter() - t0) * 1000.0
+        return lat
+
+    def infer(self, *, teacache_skip=DEFAULT_TEACACHE_SKIP, shift=DEFAULT_SHIFT,
+              compare_ref=False, return_metadata=False):
+        """Run the UniPC denoise on the reference conditioning.
+
+        Returns the denoised ``[1,C,T,H,W]`` vision latent tensor. With
+        ``return_metadata=True`` returns a dict with the tensor, denoise latency,
+        and (if ``compare_ref``) cos / rel_l2 vs the official reference latent.
+        """
+        if self.m is None:
+            raise ValueError("set_prompt(ref=...) must be called before infer()")
+        lat = self._denoise(teacache_skip=teacache_skip, shift=shift)
+        if not return_metadata:
+            return lat
+        out = {"latent": lat, "latency_ms": self._last_latency_ms}
+        if compare_ref:
+            a = lat.flatten()
+            b = self._final_ref.flatten().float().to(lat.device)
+            out["rel_l2"] = ((a - b).norm() / b.norm()).item()
+            out["cos"] = F.cosine_similarity(a, b, 0).item()
+        return out
+
+    def get_latency_stats(self):
+        return {"denoise_loop_ms": self._last_latency_ms}

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -126,6 +126,10 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     ("wan22_ti2v_5b", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.wan22_rtx", "Wan22TorchFrontendRtx"),
 
+    # ── Cosmos3-Nano text2video FP8 denoise (RTX SM120 only) ──
+    ("cosmos3_video", "torch", "rtx_sm120"):
+        ("flash_rt.frontends.torch.cosmos3_video_rtx", "Cosmos3VideoTorchFrontendRtx"),
+
     # ── Pi0-FAST ── (SM120 runtime fork inside pipeline, no AttentionBackend protocol.)
     ("pi0fast", "torch", "thor"):
         ("flash_rt.frontends.torch.pi0fast", "Pi0FastTorchFrontend"),

--- a/flash_rt/models/cosmos3_video/__init__.py
+++ b/flash_rt/models/cosmos3_video/__init__.py
@@ -1,0 +1,6 @@
+"""Cosmos3-Nano text2video denoise model (RTX SM120).
+
+Fully self-contained (docs/adding_new_model.md §0): the two-tower MoT compute
+path is pipeline_rtx.py, the UniPC scheduler is fm_solvers_unipc.py, and the
+model-local CUDA kernels live in kernels/. No dependency on any other model.
+"""

--- a/flash_rt/models/cosmos3_video/fm_solvers_unipc.py
+++ b/flash_rt/models/cosmos3_video/fm_solvers_unipc.py
@@ -1,0 +1,808 @@
+# Copyright 2024 TSAIL Team and The HuggingFace Team. All rights reserved.
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+#
+# Copied from https://github.com/huggingface/diffusers/blob/v0.31.0/src/diffusers/schedulers/scheduling_unipc_multistep.py
+# Converted UniPC for flow matching.
+
+import math
+from typing import List, Optional, Tuple, Union
+
+import functools
+import inspect
+import types
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+
+# --- self-contained scheduler infrastructure (no diffusers dependency) ---
+def register_to_config(init):
+    """Capture an __init__'s bound arguments into ``self.config``. Drop-in for
+    diffusers.configuration_utils.register_to_config, stdlib-only."""
+    @functools.wraps(init)
+    def wrapper(self, *args, **kwargs):
+        bound = inspect.signature(init).bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        cfg = {k: v for k, v in bound.arguments.items() if k != "self"}
+        object.__setattr__(self, "config", types.SimpleNamespace(**cfg))
+        init(self, *args, **kwargs)
+    return wrapper
+
+
+class ConfigMixin:
+    """Minimal config holder (no diffusers / hub plumbing)."""
+
+    def register_to_config(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self.config, k, v)
+
+
+@dataclass
+class SchedulerOutput:
+    """Scheduler step output (replaces diffusers SchedulerOutput)."""
+
+    prev_sample: torch.Tensor
+
+
+def deprecate(name, version, message, **kwargs):
+    warnings.warn(f"{name} (since {version}): {message}",
+                  FutureWarning, stacklevel=2)
+
+
+class FlowUniPCMultistepScheduler(ConfigMixin):
+    """
+    `UniPCMultistepScheduler` is a training-free framework designed for the fast sampling of diffusion models.
+
+    This model inherits from [`SchedulerMixin`] and [`ConfigMixin`]. Check the superclass documentation for the generic
+    methods the library implements for all schedulers such as loading and saving.
+
+    Args:
+        num_train_timesteps (`int`, defaults to 1000):
+            The number of diffusion steps to train the model.
+        solver_order (`int`, default `2`):
+            The UniPC order which can be any positive integer. The effective order of accuracy is `solver_order + 1`
+            due to the UniC. It is recommended to use `solver_order=2` for guided sampling, and `solver_order=3` for
+            unconditional sampling.
+        prediction_type (`str`, defaults to "flow_prediction"):
+            Prediction type of the scheduler function; must be `flow_prediction` for this scheduler, which predicts
+            the flow of the diffusion process.
+        thresholding (`bool`, defaults to `False`):
+            Whether to use the "dynamic thresholding" method. This is unsuitable for latent-space diffusion models such
+            as Stable Diffusion.
+        dynamic_thresholding_ratio (`float`, defaults to 0.995):
+            The ratio for the dynamic thresholding method. Valid only when `thresholding=True`.
+        sample_max_value (`float`, defaults to 1.0):
+            The threshold value for dynamic thresholding. Valid only when `thresholding=True` and `predict_x0=True`.
+        predict_x0 (`bool`, defaults to `True`):
+            Whether to use the updating algorithm on the predicted x0.
+        solver_type (`str`, default `bh2`):
+            Solver type for UniPC. It is recommended to use `bh1` for unconditional sampling when steps < 10, and `bh2`
+            otherwise.
+        lower_order_final (`bool`, default `True`):
+            Whether to use lower-order solvers in the final steps. Only valid for < 15 inference steps. This can
+            stabilize the sampling of DPMSolver for steps < 15, especially for steps <= 10.
+        disable_corrector (`list`, default `[]`):
+            Decides which step to disable the corrector to mitigate the misalignment between `epsilon_theta(x_t, c)`
+            and `epsilon_theta(x_t^c, c)` which can influence convergence for a large guidance scale. Corrector is
+            usually disabled during the first few steps.
+        solver_p (`SchedulerMixin`, default `None`):
+            Any other scheduler that if specified, the algorithm becomes `solver_p + UniC`.
+        use_karras_sigmas (`bool`, *optional*, defaults to `False`):
+            Whether to use Karras sigmas for step sizes in the noise schedule during the sampling process. If `True`,
+            the sigmas are determined according to a sequence of noise levels {σi}.
+        use_exponential_sigmas (`bool`, *optional*, defaults to `False`):
+            Whether to use exponential sigmas for step sizes in the noise schedule during the sampling process.
+        timestep_spacing (`str`, defaults to `"linspace"`):
+            The way the timesteps should be scaled. Refer to Table 2 of the [Common Diffusion Noise Schedules and
+            Sample Steps are Flawed](https://huggingface.co/papers/2305.08891) for more information.
+        steps_offset (`int`, defaults to 0):
+            An offset added to the inference steps, as required by some model families.
+        final_sigmas_type (`str`, defaults to `"zero"`):
+            The final `sigma` value for the noise schedule during the sampling process. If `"sigma_min"`, the final
+            sigma is the same as the last sigma in the training schedule. If `zero`, the final sigma is set to 0.
+    """
+
+    order = 1
+
+    @register_to_config
+    def __init__(
+        self,
+        num_train_timesteps: int = 1000,
+        solver_order: int = 2,
+        prediction_type: str = "flow_prediction",
+        shift: Optional[float] = 1.0,
+        use_dynamic_shifting=False,
+        thresholding: bool = False,
+        dynamic_thresholding_ratio: float = 0.995,
+        sample_max_value: float = 1.0,
+        predict_x0: bool = True,
+        solver_type: str = "bh2",
+        lower_order_final: bool = True,
+        disable_corrector: List[int] = [],
+        solver_p=None,
+        timestep_spacing: str = "linspace",
+        steps_offset: int = 0,
+        final_sigmas_type: Optional[str] = "zero",  # "zero", "sigma_min"
+    ):
+        if solver_type not in ["bh1", "bh2"]:
+            if solver_type in ["midpoint", "heun", "logrho"]:
+                self.register_to_config(solver_type="bh2")
+            else:
+                raise NotImplementedError(f"{solver_type} is not implemented for {self.__class__}")
+
+        self.predict_x0 = predict_x0
+        # setable values
+        self.num_inference_steps = None
+        alphas = np.linspace(1, 1 / num_train_timesteps, num_train_timesteps)[::-1].copy()
+        sigmas = 1.0 - alphas
+        sigmas = torch.from_numpy(sigmas).to(dtype=torch.float32)  # [num_train_timesteps]
+
+        if not use_dynamic_shifting:
+            # when use_dynamic_shifting is True, we apply the timestep shifting on the fly based on the image resolution
+            sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # [num_train_timesteps]  # pyright: ignore
+
+        self.sigmas = sigmas  # [num_train_timesteps]
+        self.timesteps = sigmas * num_train_timesteps  # [num_train_timesteps]
+
+        self.model_outputs = [None] * solver_order
+        self.timestep_list = [None] * solver_order
+        self.lower_order_nums = 0
+        self.disable_corrector = disable_corrector
+        self.solver_p = solver_p
+        self.last_sample = None
+        self._step_index = None
+        self._begin_index = None
+
+        self.sigmas = self.sigmas.to("cpu")  # to avoid too much CPU/GPU communication
+        self.sigma_min = self.sigmas[-1].item()
+        self.sigma_max = self.sigmas[0].item()
+
+    @property
+    def step_index(self):
+        """
+        The index counter for current timestep. It will increase 1 after each scheduler step.
+        """
+        return self._step_index
+
+    @property
+    def begin_index(self):
+        """
+        The index for the first timestep. It should be set from pipeline with `set_begin_index` method.
+        """
+        return self._begin_index
+
+    # Copied from diffusers.schedulers.scheduling_dpmsolver_multistep.DPMSolverMultistepScheduler.set_begin_index
+    def set_begin_index(self, begin_index: int = 0):
+        """
+        Sets the begin index for the scheduler. This function should be run from pipeline before the inference.
+
+        Args:
+            begin_index (`int`):
+                The begin index for the scheduler.
+        """
+        self._begin_index = begin_index
+
+    # Modified from diffusers.schedulers.scheduling_flow_match_euler_discrete.FlowMatchEulerDiscreteScheduler.set_timesteps
+    def set_timesteps(
+        self,
+        num_inference_steps: Union[int, None] = None,
+        device: Union[str, torch.device] = None,
+        sigmas: Optional[List[float]] = None,
+        mu: Optional[Union[float, None]] = None,
+        shift: Optional[Union[float, None]] = None,
+        use_kerras_sigma: bool = False,
+    ):
+        """
+        Sets the discrete timesteps used for the diffusion chain (to be run before inference).
+        Args:
+            num_inference_steps (`int`):
+                Total number of the spacing of the time steps.
+            device (`str` or `torch.device`, *optional*):
+                The device to which the timesteps should be moved to. If `None`, the timesteps are not moved.
+        """
+        if self.config.use_dynamic_shifting and mu is None:
+            raise ValueError(" you have to pass a value for `mu` when `use_dynamic_shifting` is set to be `True`")
+
+        if use_kerras_sigma:
+            # force to use the exact sigma used in edm sampler
+            sigma_max = 200
+            sigma_min = 0.01
+            rho = 7
+            sigmas = np.arange(num_inference_steps + 1) / num_inference_steps
+            min_inv_rho = sigma_min ** (1 / rho)
+            max_inv_rho = sigma_max ** (1 / rho)
+            sigmas = (max_inv_rho + sigmas * (min_inv_rho - max_inv_rho)) ** rho
+            sigmas = sigmas / (1 + sigmas)
+        else:
+            if sigmas is None:
+                sigmas = np.linspace(self.sigma_max, self.sigma_min, num_inference_steps + 1).copy()[:-1]  # pyright: ignore
+
+            if self.config.use_dynamic_shifting:
+                sigmas = self.time_shift(mu, 1.0, sigmas)  # pyright: ignore
+            else:
+                if shift is None:
+                    shift = self.config.shift
+                sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # pyright: ignore
+
+        if self.config.final_sigmas_type == "sigma_min":
+            sigma_last = ((1 - self.alphas_cumprod[0]) / self.alphas_cumprod[0]) ** 0.5
+        elif self.config.final_sigmas_type == "zero":
+            sigma_last = 0
+        else:
+            raise ValueError(
+                f"`final_sigmas_type` must be one of 'zero', or 'sigma_min', but got {self.config.final_sigmas_type}"
+            )
+
+        timesteps = sigmas * self.config.num_train_timesteps
+        sigmas = np.concatenate([sigmas, [sigma_last]]).astype(np.float32)  # pyright: ignore
+
+        self.sigmas = torch.from_numpy(sigmas)  # [num_inference_steps+1]
+        self.timesteps = torch.from_numpy(timesteps).to(device=device, dtype=torch.int64)  # [num_inference_steps]
+
+        self.num_inference_steps = len(timesteps)
+
+        self.model_outputs = [
+            None,
+        ] * self.config.solver_order
+        self.lower_order_nums = 0
+        self.last_sample = None
+        if self.solver_p:
+            self.solver_p.set_timesteps(self.num_inference_steps, device=device)
+
+        # add an index counter for schedulers that allow duplicated timesteps
+        self._step_index = None
+        self._begin_index = None
+        self.sigmas = self.sigmas.to("cpu")  # to avoid too much CPU/GPU communication
+
+    # Copied from diffusers.schedulers.scheduling_ddpm.DDPMScheduler._threshold_sample
+    def _threshold_sample(self, sample: torch.Tensor) -> torch.Tensor:
+        """
+        "Dynamic thresholding: At each sampling step we set s to a certain percentile absolute pixel value in xt0 (the
+        prediction of x_0 at timestep t), and if s > 1, then we threshold xt0 to the range [-s, s] and then divide by
+        s. Dynamic thresholding pushes saturated pixels (those near -1 and 1) inwards, thereby actively preventing
+        pixels from saturation at each step. We find that dynamic thresholding results in significantly better
+        photorealism as well as better image-text alignment, especially when using very large guidance weights."
+
+        https://arxiv.org/abs/2205.11487
+        """
+        dtype = sample.dtype
+        batch_size, channels, *remaining_dims = sample.shape
+
+        if dtype not in (torch.float32, torch.float64):
+            sample = sample.float()  # upcast for quantile calculation, and clamp not implemented for cpu half
+
+        # Flatten sample for doing quantile calculation along each image
+        sample = sample.reshape(batch_size, channels * np.prod(remaining_dims))  # [B,C*spatial]
+
+        abs_sample = sample.abs()  # "a certain percentile absolute pixel value"  # [B,C*spatial]
+
+        s = torch.quantile(abs_sample, self.config.dynamic_thresholding_ratio, dim=1)  # [B]
+        s = torch.clamp(
+            s, min=1, max=self.config.sample_max_value
+        )  # When clamped to min=1, equivalent to standard clipping to [-1, 1]  # [B]
+        s = s.unsqueeze(1)  # [B,1]
+        sample = (
+            torch.clamp(sample, -s, s) / s
+        )  # "we threshold xt0 to the range [-s, s] and then divide by s"  # [B,C*spatial]
+
+        sample = sample.reshape(batch_size, channels, *remaining_dims)  # [B,C,...]
+        sample = sample.to(dtype)
+
+        return sample
+
+    # Copied from diffusers.schedulers.scheduling_flow_match_euler_discrete.FlowMatchEulerDiscreteScheduler._sigma_to_t
+    def _sigma_to_t(self, sigma):
+        return sigma * self.config.num_train_timesteps
+
+    def _sigma_to_alpha_sigma_t(self, sigma):
+        return 1 - sigma, sigma
+
+    # Copied from diffusers.schedulers.scheduling_flow_match_euler_discrete.set_timesteps
+    def time_shift(self, mu: float, sigma: float, t: torch.Tensor):
+        return math.exp(mu) / (math.exp(mu) + (1 / t - 1) ** sigma)
+
+    def convert_model_output(
+        self,
+        model_output: torch.Tensor,
+        *args,
+        sample: torch.Tensor = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""
+        Convert the model output to the corresponding type the UniPC algorithm needs.
+
+        Args:
+            model_output (`torch.Tensor`):
+                The direct output from the learned diffusion model.
+            timestep (`int`):
+                The current discrete timestep in the diffusion chain.
+            sample (`torch.Tensor`):
+                A current instance of a sample created by the diffusion process.
+
+        Returns:
+            `torch.Tensor`:
+                The converted model output.
+        """
+        timestep = args[0] if len(args) > 0 else kwargs.pop("timestep", None)
+        if sample is None:
+            if len(args) > 1:
+                sample = args[1]
+            else:
+                raise ValueError("missing `sample` as a required keyward argument")
+        if timestep is not None:
+            deprecate(
+                "timesteps",
+                "1.0.0",
+                "Passing `timesteps` is deprecated and has no effect as model output conversion is now handled via an internal counter `self.step_index`",
+            )
+
+        sigma = self.sigmas[self.step_index]
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma)
+
+        # print("sigma_t ==>", self.step_index, sigma, sigma_t, alpha_t, sample.shape, model_output.shape)
+        if self.predict_x0:
+            if self.config.prediction_type == "flow_prediction":
+                sigma_t = self.sigmas[self.step_index]
+                x0_pred = sample - sigma_t * model_output
+            else:
+                raise ValueError(
+                    f"prediction_type given as {self.config.prediction_type} must be one of `epsilon`, `sample`,"
+                    " `v_prediction` or `flow_prediction` for the UniPCMultistepScheduler."
+                )
+
+            if self.config.thresholding:
+                x0_pred = self._threshold_sample(x0_pred)
+            # print("self.config.thresholding", self.config.thresholding)
+            return x0_pred
+        else:
+            if self.config.prediction_type == "flow_prediction":
+                sigma_t = self.sigmas[self.step_index]
+                epsilon = sample - (1 - sigma_t) * model_output
+            else:
+                raise ValueError(
+                    f"prediction_type given as {self.config.prediction_type} must be one of `epsilon`, `sample`,"
+                    " `v_prediction` or `flow_prediction` for the UniPCMultistepScheduler."
+                )
+
+            if self.config.thresholding:
+                sigma_t = self.sigmas[self.step_index]
+                x0_pred = sample - sigma_t * model_output
+                x0_pred = self._threshold_sample(x0_pred)
+                epsilon = model_output + x0_pred
+
+            return epsilon
+
+    def multistep_uni_p_bh_update(
+        self,
+        model_output: torch.Tensor,
+        *args,
+        sample: torch.Tensor = None,
+        order: int = None,  # pyright: ignore
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        One step for the UniP (B(h) version). Alternatively, `self.solver_p` is used if is specified.
+
+        Args:
+            model_output (`torch.Tensor`):
+                The direct output from the learned diffusion model at the current timestep.
+            prev_timestep (`int`):
+                The previous discrete timestep in the diffusion chain.
+            sample (`torch.Tensor`):
+                A current instance of a sample created by the diffusion process.
+            order (`int`):
+                The order of UniP at this timestep (corresponds to the *p* in UniPC-p).
+
+        Returns:
+            `torch.Tensor`:
+                The sample tensor at the previous timestep.
+        """
+        prev_timestep = args[0] if len(args) > 0 else kwargs.pop("prev_timestep", None)
+        if sample is None:
+            if len(args) > 1:
+                sample = args[1]
+            else:
+                raise ValueError(" missing `sample` as a required keyward argument")
+        if order is None:
+            if len(args) > 2:
+                order = args[2]
+            else:
+                raise ValueError(" missing `order` as a required keyward argument")
+        if prev_timestep is not None:
+            deprecate(
+                "prev_timestep",
+                "1.0.0",
+                "Passing `prev_timestep` is deprecated and has no effect as model output conversion is now handled via an internal counter `self.step_index`",
+            )
+        model_output_list = self.model_outputs
+
+        s0 = self.timestep_list[-1]
+        m0 = model_output_list[-1]
+        x = sample
+
+        if self.solver_p:
+            x_t = self.solver_p.step(model_output, s0, x).prev_sample
+            return x_t
+
+        sigma_t, sigma_s0 = self.sigmas[self.step_index + 1], self.sigmas[self.step_index]  # pyright: ignore
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t)
+        alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0)
+
+        lambda_t = torch.log(alpha_t) - torch.log(sigma_t)
+        lambda_s0 = torch.log(alpha_s0) - torch.log(sigma_s0)
+
+        h = lambda_t - lambda_s0
+        device = sample.device
+
+        rks = []
+        D1s = []
+        for i in range(1, order):
+            si = self.step_index - i  # pyright: ignore
+            mi = model_output_list[-(i + 1)]
+            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si])
+            lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
+            rk = (lambda_si - lambda_s0) / h
+            rks.append(rk)
+            D1s.append((mi - m0) / rk)  # pyright: ignore
+
+        rks.append(1.0)
+        rks = torch.tensor(rks, device=device)  # [order]
+
+        R = []
+        b = []
+
+        hh = -h if self.predict_x0 else h
+        h_phi_1 = torch.expm1(hh)  # h\phi_1(h) = e^h - 1
+        h_phi_k = h_phi_1 / hh - 1
+
+        factorial_i = 1
+
+        if self.config.solver_type == "bh1":
+            B_h = hh
+        elif self.config.solver_type == "bh2":
+            B_h = torch.expm1(hh)
+        else:
+            raise NotImplementedError()
+
+        for i in range(1, order + 1):
+            R.append(torch.pow(rks, i - 1))  # [order]
+            b.append(h_phi_k * factorial_i / B_h)
+            factorial_i *= i + 1
+            h_phi_k = h_phi_k / hh - 1 / factorial_i
+
+        R = torch.stack(R)  # [order,order]
+        b = torch.tensor(b, device=device)  # [order]
+
+        if len(D1s) > 0:
+            D1s = torch.stack(D1s, dim=1)  # [B,order-1,C,T,H,W]
+            # for order 2, we use a simplified version
+            if order == 2:
+                rhos_p = torch.tensor([0.5], dtype=x.dtype, device=device)  # [1]
+            else:
+                rhos_p = torch.linalg.solve(R[:-1, :-1], b[:-1]).to(device).to(x.dtype)  # [order-1]
+        else:
+            D1s = None
+
+        if self.predict_x0:
+            x_t_ = sigma_t / sigma_s0 * x - alpha_t * h_phi_1 * m0  # [B,C,T,H,W]
+            if D1s is not None:
+                pred_res = torch.einsum("k,bkc...->bc...", rhos_p, D1s)  # [B,C,T,H,W]  # pyright: ignore
+            else:
+                pred_res = 0
+            x_t = x_t_ - alpha_t * B_h * pred_res  # [B,C,T,H,W]
+        else:
+            x_t_ = alpha_t / alpha_s0 * x - sigma_t * h_phi_1 * m0  # [B,C,T,H,W]
+            if D1s is not None:
+                pred_res = torch.einsum("k,bkc...->bc...", rhos_p, D1s)  # [B,C,T,H,W]  # pyright: ignore
+            else:
+                pred_res = 0
+            x_t = x_t_ - sigma_t * B_h * pred_res  # [B,C,T,H,W]
+
+        x_t = x_t.to(x.dtype)  # [B,C,T,H,W]
+        return x_t  # [B,C,T,H,W]
+
+    def multistep_uni_c_bh_update(
+        self,
+        this_model_output: torch.Tensor,
+        *args,
+        last_sample: torch.Tensor = None,
+        this_sample: torch.Tensor = None,
+        order: int = None,  # pyright: ignore
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        One step for the UniC (B(h) version).
+
+        Args:
+            this_model_output (`torch.Tensor`):
+                The model outputs at `x_t`.
+            this_timestep (`int`):
+                The current timestep `t`.
+            last_sample (`torch.Tensor`):
+                The generated sample before the last predictor `x_{t-1}`.
+            this_sample (`torch.Tensor`):
+                The generated sample after the last predictor `x_{t}`.
+            order (`int`):
+                The `p` of UniC-p at this step. The effective order of accuracy should be `order + 1`.
+
+        Returns:
+            `torch.Tensor`:
+                The corrected sample tensor at the current timestep.
+        """
+        this_timestep = args[0] if len(args) > 0 else kwargs.pop("this_timestep", None)
+        if last_sample is None:
+            if len(args) > 1:
+                last_sample = args[1]
+            else:
+                raise ValueError(" missing`last_sample` as a required keyward argument")
+        if this_sample is None:
+            if len(args) > 2:
+                this_sample = args[2]
+            else:
+                raise ValueError(" missing`this_sample` as a required keyward argument")
+        if order is None:
+            if len(args) > 3:
+                order = args[3]
+            else:
+                raise ValueError(" missing`order` as a required keyward argument")
+        if this_timestep is not None:
+            deprecate(
+                "this_timestep",
+                "1.0.0",
+                "Passing `this_timestep` is deprecated and has no effect as model output conversion is now handled via an internal counter `self.step_index`",
+            )
+
+        model_output_list = self.model_outputs
+
+        m0 = model_output_list[-1]
+        x = last_sample
+        x_t = this_sample
+        model_t = this_model_output
+
+        sigma_t, sigma_s0 = self.sigmas[self.step_index], self.sigmas[self.step_index - 1]  # pyright: ignore
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma_t)
+        alpha_s0, sigma_s0 = self._sigma_to_alpha_sigma_t(sigma_s0)
+
+        lambda_t = torch.log(alpha_t) - torch.log(sigma_t)
+        lambda_s0 = torch.log(alpha_s0) - torch.log(sigma_s0)
+
+        h = lambda_t - lambda_s0
+        device = this_sample.device
+
+        rks = []
+        D1s = []
+        for i in range(1, order):
+            si = self.step_index - (i + 1)  # pyright: ignore
+            mi = model_output_list[-(i + 1)]
+            alpha_si, sigma_si = self._sigma_to_alpha_sigma_t(self.sigmas[si])
+            lambda_si = torch.log(alpha_si) - torch.log(sigma_si)
+            rk = (lambda_si - lambda_s0) / h
+            rks.append(rk)
+            D1s.append((mi - m0) / rk)  # pyright: ignore
+
+        rks.append(1.0)
+        rks = torch.tensor(rks, device=device)  # [order]
+
+        R = []
+        b = []
+
+        hh = -h if self.predict_x0 else h
+        h_phi_1 = torch.expm1(hh)  # h\phi_1(h) = e^h - 1
+        h_phi_k = h_phi_1 / hh - 1
+
+        factorial_i = 1
+
+        if self.config.solver_type == "bh1":
+            B_h = hh
+        elif self.config.solver_type == "bh2":
+            B_h = torch.expm1(hh)
+        else:
+            raise NotImplementedError()
+
+        for i in range(1, order + 1):
+            R.append(torch.pow(rks, i - 1))  # [order]
+            b.append(h_phi_k * factorial_i / B_h)
+            factorial_i *= i + 1
+            h_phi_k = h_phi_k / hh - 1 / factorial_i
+
+        R = torch.stack(R)  # [order,order]
+        b = torch.tensor(b, device=device)  # [order]
+
+        if len(D1s) > 0:
+            D1s = torch.stack(D1s, dim=1)  # [B,order-1,C,T,H,W]
+        else:
+            D1s = None
+
+        # for order 1, we use a simplified version
+        if order == 1:
+            rhos_c = torch.tensor([0.5], dtype=x.dtype, device=device)  # [1]
+        else:
+            rhos_c = torch.linalg.solve(R, b).to(device).to(x.dtype)  # [order]
+
+        if self.predict_x0:
+            x_t_ = sigma_t / sigma_s0 * x - alpha_t * h_phi_1 * m0  # [B,C,T,H,W]
+            if D1s is not None:
+                corr_res = torch.einsum("k,bkc...->bc...", rhos_c[:-1], D1s)  # [B,C,T,H,W]
+            else:
+                corr_res = 0
+            D1_t = model_t - m0  # [B,C,T,H,W]
+            x_t = x_t_ - alpha_t * B_h * (corr_res + rhos_c[-1] * D1_t)  # [B,C,T,H,W]
+        else:
+            x_t_ = alpha_t / alpha_s0 * x - sigma_t * h_phi_1 * m0  # [B,C,T,H,W]
+            if D1s is not None:
+                corr_res = torch.einsum("k,bkc...->bc...", rhos_c[:-1], D1s)  # [B,C,T,H,W]
+            else:
+                corr_res = 0
+            D1_t = model_t - m0  # [B,C,T,H,W]
+            x_t = x_t_ - sigma_t * B_h * (corr_res + rhos_c[-1] * D1_t)  # [B,C,T,H,W]
+        x_t = x_t.to(x.dtype)  # [B,C,T,H,W]
+        return x_t  # [B,C,T,H,W]
+
+    def index_for_timestep(self, timestep, schedule_timesteps=None):
+        if schedule_timesteps is None:
+            schedule_timesteps = self.timesteps
+
+        indices = (schedule_timesteps == timestep).nonzero()
+
+        # The sigma index that is taken for the **very** first `step`
+        # is always the second index (or the last index if there is only 1)
+        # This way we can ensure we don't accidentally skip a sigma in
+        # case we start in the middle of the denoising schedule (e.g. for image-to-image)
+        pos = 1 if len(indices) > 1 else 0
+
+        return indices[pos].item()
+
+    # Copied from diffusers.schedulers.scheduling_dpmsolver_multistep.DPMSolverMultistepScheduler._init_step_index
+    def _init_step_index(self, timestep):
+        """
+        Initialize the step_index counter for the scheduler.
+        """
+
+        if self.begin_index is None:
+            if isinstance(timestep, torch.Tensor):
+                timestep = timestep.to(self.timesteps.device)
+            self._step_index = self.index_for_timestep(timestep)
+        else:
+            self._step_index = self._begin_index
+
+    def step(
+        self,
+        model_output: torch.Tensor,
+        timestep: Union[int, torch.Tensor],
+        sample: torch.Tensor,
+        return_dict: bool = True,
+        generator=None,
+    ) -> Union[SchedulerOutput, Tuple]:
+        """
+        Predict the sample from the previous timestep by reversing the SDE. This function propagates the sample with
+        the multistep UniPC.
+
+        Args:
+            model_output (`torch.Tensor`):
+                The direct output from learned diffusion model.
+            timestep (`int`):
+                The current discrete timestep in the diffusion chain.
+            sample (`torch.Tensor`):
+                A current instance of a sample created by the diffusion process.
+            return_dict (`bool`):
+                Whether or not to return a [`~schedulers.scheduling_utils.SchedulerOutput`] or `tuple`.
+
+        Returns:
+            [`~schedulers.scheduling_utils.SchedulerOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_utils.SchedulerOutput`] is returned, otherwise a
+                tuple is returned where the first element is the sample tensor.
+
+        """
+        if self.num_inference_steps is None:
+            raise ValueError(
+                "Number of inference steps is 'None', you need to run 'set_timesteps' after creating the scheduler"
+            )
+
+        if self.step_index is None:
+            self._init_step_index(timestep)
+
+        # print("self.step_index ==> ", self.step_index)
+
+        use_corrector = (
+            self.step_index > 0 and self.step_index - 1 not in self.disable_corrector and self.last_sample is not None  # pyright: ignore
+        )
+
+        model_output_convert = self.convert_model_output(model_output, sample=sample)
+
+        if use_corrector:
+            sample = self.multistep_uni_c_bh_update(
+                this_model_output=model_output_convert,
+                last_sample=self.last_sample,
+                this_sample=sample,
+                order=self.this_order,
+            )
+
+        for i in range(self.config.solver_order - 1):
+            self.model_outputs[i] = self.model_outputs[i + 1]
+            self.timestep_list[i] = self.timestep_list[i + 1]
+
+        self.model_outputs[-1] = model_output_convert
+        self.timestep_list[-1] = timestep  # pyright: ignore
+
+        if self.config.lower_order_final:
+            this_order = min(self.config.solver_order, len(self.timesteps) - self.step_index)  # pyright: ignore
+        else:
+            this_order = self.config.solver_order
+
+        self.this_order = min(this_order, self.lower_order_nums + 1)  # warmup for multistep
+        assert self.this_order > 0
+
+        self.last_sample = sample
+        prev_sample = self.multistep_uni_p_bh_update(
+            model_output=model_output,  # pass the original non-converted model output, in case solver-p is used
+            sample=sample,
+            order=self.this_order,
+        )
+
+        if self.lower_order_nums < self.config.solver_order:
+            self.lower_order_nums += 1
+
+        # upon completion increase step index by one
+        self._step_index += 1  # pyright: ignore
+
+        if not return_dict:
+            return (prev_sample, model_output_convert)
+
+        return SchedulerOutput(prev_sample=prev_sample)
+
+    def scale_model_input(self, sample: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        """
+        Ensures interchangeability with schedulers that need to scale the denoising model input depending on the
+        current timestep.
+
+        Args:
+            sample (`torch.Tensor`):
+                The input sample.
+
+        Returns:
+            `torch.Tensor`:
+                A scaled input sample.
+        """
+        return sample
+
+    # Copied from diffusers.schedulers.scheduling_dpmsolver_multistep.DPMSolverMultistepScheduler.add_noise
+    def add_noise(
+        self,
+        original_samples: torch.Tensor,
+        noise: torch.Tensor,
+        timesteps: torch.IntTensor,
+    ) -> torch.Tensor:
+        # Make sure sigmas and timesteps have the same device and dtype as original_samples
+        sigmas = self.sigmas.to(device=original_samples.device, dtype=original_samples.dtype)
+        if original_samples.device.type == "mps" and torch.is_floating_point(timesteps):
+            # mps does not support float64
+            schedule_timesteps = self.timesteps.to(original_samples.device, dtype=torch.float32)
+            timesteps = timesteps.to(original_samples.device, dtype=torch.float32)
+        else:
+            schedule_timesteps = self.timesteps.to(original_samples.device)
+            timesteps = timesteps.to(original_samples.device)
+
+        # begin_index is None when the scheduler is used for training or pipeline does not implement set_begin_index
+        if self.begin_index is None:
+            step_indices = [self.index_for_timestep(t, schedule_timesteps) for t in timesteps]
+        elif self.step_index is not None:
+            # add_noise is called after first denoising step (for inpainting)
+            step_indices = [self.step_index] * timesteps.shape[0]
+        else:
+            # add noise is called before first denoising step to create initial latent(img2img)
+            step_indices = [self.begin_index] * timesteps.shape[0]
+
+        sigma = sigmas[step_indices].flatten()  # [B]
+        while len(sigma.shape) < len(original_samples.shape):
+            sigma = sigma.unsqueeze(-1)  # [B,1,...] broadcast-ready
+
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma)
+        noisy_samples = alpha_t * original_samples + sigma_t * noise  # [B,C,T,H,W]
+        return noisy_samples
+
+    def __len__(self):
+        return self.config.num_train_timesteps

--- a/flash_rt/models/cosmos3_video/kernels/__init__.py
+++ b/flash_rt/models/cosmos3_video/kernels/__init__.py
@@ -1,0 +1,22 @@
+"""Loader for the Cosmos3-video model-local kernel extension.
+
+Imports the precompiled `cosmos3_video_kernels` .so built by setup.py (build_ext
+--inplace). This kernel is model-specific and intentionally NOT in the shared
+flash_rt_kernels.so (docs/adding_new_model.md §4.3/§4.5).
+
+Exposes the callable the cosmos3_video pipeline uses:
+    qk_norm_rope
+"""
+_BUILD_HINT = (
+    "cosmos3_video_kernels extension not built. Build it once on the target GPU:\n"
+    "  cd flash_rt/models/cosmos3_video/kernels && python3 setup.py build_ext --inplace"
+)
+
+try:
+    from . import cosmos3_video_kernels as _ext  # the built .so sits in this package
+except ImportError as e:  # pragma: no cover - surfaced to the user with a fix
+    raise ImportError(f"{_BUILD_HINT}\n(original error: {e})") from e
+
+qk_norm_rope = _ext.qk_norm_rope
+
+__all__ = ["qk_norm_rope"]

--- a/flash_rt/models/cosmos3_video/kernels/csrc/bindings.cpp
+++ b/flash_rt/models/cosmos3_video/kernels/csrc/bindings.cpp
@@ -1,0 +1,17 @@
+// cosmos3_video model-local kernel extension — pybind module `cosmos3_video_kernels`.
+//
+// The text2video fp8 denoise path needs one model-specific kernel that is NOT in
+// the production flash_rt_kernels.so (per docs/adding_new_model.md §4.3 it lives
+// in this model-local object library, not the shared .so):
+//   - qk_norm_rope    fused RMS qk-norm + qwen36 partial rope (one launch)
+#include <pybind11/pybind11.h>
+#include <cstdint>
+
+void qk_norm_rope(int64_t, int64_t, int64_t, int64_t, int64_t, int64_t,
+                  int, int, int, int, double, int64_t);
+
+PYBIND11_MODULE(cosmos3_video_kernels, m) {
+  m.doc() = "Cosmos3-video model-local kernels (additive; not in flash_rt_kernels.so)";
+  m.def("qk_norm_rope", &qk_norm_rope,
+        "Fused RMS qk-norm + qwen36 partial rope (q,k in place)");
+}

--- a/flash_rt/models/cosmos3_video/kernels/csrc/fused_qk_norm_rope.cu
+++ b/flash_rt/models/cosmos3_video/kernels/csrc/fused_qk_norm_rope.cu
@@ -1,0 +1,61 @@
+#include <cuda_bf16.h>
+// One warp (32 lanes) per (token,head); D=128 -> 4 elements/lane. Warp-shuffle
+// RMS reduction (no block sync, no oversized shared). Multiple warps/block to
+// amortize launch. Matches FlashRT rms_norm + partial_rope math (bf16-rounded
+// normed before rope, out = bf16(bf16(rot*sin)+x*cos), full rotation).
+template<int D>
+__global__ void qk_norm_rope_kernel(
+    __nv_bfloat16* __restrict__ Q, __nv_bfloat16* __restrict__ K,
+    const __nv_bfloat16* __restrict__ qw, const __nv_bfloat16* __restrict__ kw,
+    const __nv_bfloat16* __restrict__ cosb, const __nv_bfloat16* __restrict__ sinb,
+    int n, int H, int KV, float eps) {
+  constexpr int EPT = D / 32;                       // elems/lane (128/32=4)
+  const int warp = (blockIdx.x * (blockDim.x >> 5)) + (threadIdx.x >> 5);
+  const int lane = threadIdx.x & 31;
+  const int qwarps = n * H;
+  const int total = qwarps + n * KV;
+  if (warp >= total) return;
+  __nv_bfloat16* X; const __nv_bfloat16* Wt; int heads, row, head;
+  if (warp < qwarps) { X = Q; Wt = qw; heads = H; row = warp / H; head = warp % H; }
+  else { int b = warp - qwarps; X = K; Wt = kw; heads = KV; row = b / KV; head = b % KV; }
+  const size_t base = ((size_t)row * heads + head) * D;
+
+  float xv[EPT]; float ss = 0.f;
+  #pragma unroll
+  for (int i = 0; i < EPT; ++i) { int c = lane + i * 32; xv[i] = __bfloat162float(X[base + c]); ss += xv[i] * xv[i]; }
+  #pragma unroll
+  for (int o = 16; o > 0; o >>= 1) ss += __shfl_xor_sync(0xffffffff, ss, o);
+  const float rms = rsqrtf(ss / D + eps);
+
+  // bf16-rounded normed, kept per-lane; rope needs col +/- D/2 -> exchange via shfl
+  float nb[EPT];
+  #pragma unroll
+  for (int i = 0; i < EPT; ++i) { int c = lane + i * 32;
+    nb[i] = __bfloat162float(__float2bfloat16(xv[i] * rms * __bfloat162float(Wt[c]))); }
+  const int half = D >> 1;                           // rope_dim==D
+  #pragma unroll
+  for (int i = 0; i < EPT; ++i) {
+    int c = lane + i * 32;
+    int rc = (c < half) ? (c + half) : (c - half);   // partner col
+    int ri = rc >> 5, rl = rc & 31;                  // partner (elem-idx, lane)
+    float rot = __shfl_sync(0xffffffff, nb[ri], rl);
+    if (c < half) rot = -rot;
+    float cv = __bfloat162float(cosb[(size_t)row * D + c]);
+    float sv = __bfloat162float(sinb[(size_t)row * D + c]);
+    float rs = __bfloat162float(__float2bfloat16(rot * sv));
+    X[base + c] = __float2bfloat16(rs + nb[i] * cv);
+  }
+}
+
+void qk_norm_rope(int64_t Q, int64_t K, int64_t qw, int64_t kw,
+                  int64_t cosb, int64_t sinb,
+                  int n, int H, int KV, int D, double eps, int64_t stream) {
+  const int warps = n * (H + KV);
+  const int wpb = 8;                                 // warps/block
+  const int blocks = (warps + wpb - 1) / wpb;
+  qk_norm_rope_kernel<128><<<blocks, wpb * 32, 0, (cudaStream_t)stream>>>(
+      (__nv_bfloat16*)Q, (__nv_bfloat16*)K,
+      (const __nv_bfloat16*)qw, (const __nv_bfloat16*)kw,
+      (const __nv_bfloat16*)cosb, (const __nv_bfloat16*)sinb,
+      n, H, KV, (float)eps);
+}

--- a/flash_rt/models/cosmos3_video/kernels/setup.py
+++ b/flash_rt/models/cosmos3_video/kernels/setup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Build the Cosmos3-video model-local kernel extension `cosmos3_video_kernels`.
+
+Additive + isolated: produces a standalone .so inside this package; does NOT touch
+the production flash_rt_kernels.so or its CMake (docs/adding_new_model.md §4.5). The
+one kernel here (fused qk-norm + rope) depends only on the CUDA toolkit. Run ONCE on
+the target machine (RTX 5090 / sm_120):
+
+    cd flash_rt/models/cosmos3_video/kernels && python3 setup.py build_ext --inplace
+
+All paths are derived from this file's location — no hard-coded host paths.
+"""
+import os
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_CSRC = os.path.join(_HERE, "csrc")
+# -DNDEBUG: CUDA's bf16 headers use device-side assert(); release build no-ops it.
+_nvcc = ["-O3", "-DNDEBUG", "--expt-relaxed-constexpr", "--use_fast_math",
+         "-gencode=arch=compute_120a,code=sm_120a"]
+
+setup(
+    name="cosmos3_video_kernels",
+    ext_modules=[CUDAExtension(
+        name="cosmos3_video_kernels",
+        sources=[os.path.join(_CSRC, f) for f in (
+            "bindings.cpp", "fused_qk_norm_rope.cu")],
+        include_dirs=[_CSRC],
+        extra_compile_args={"cxx": ["-O3"], "nvcc": _nvcc},
+    )],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/flash_rt/models/cosmos3_video/pipeline_rtx.py
+++ b/flash_rt/models/cosmos3_video/pipeline_rtx.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Cosmos3-Nano text2video denoise compute path (RTX SM120).
+
+Per docs/adding_new_model.md §0 rule 1, this is the model's own
+``models/cosmos3_video/pipeline_<hw>.py``. It is fully self-contained: the
+two-tower MoT kernel-call sequence, the per-step CUDA-graph capture, and the
+model-local fused qk-norm-rope kernel all live in this package — no dependency
+on any other model.
+
+The gen tower carries the all-noisy vision sequence and the head is llm2vae
+(-> [N_vis, patch_latent_dim]). The text (und) tower is identical across denoise
+steps, so it is computed once and its per-layer K/V cached; each step runs only
+the gen (vision) tower against the cached text K/V. qk-norm+rope is fused.
+
+Precision (selected by the frontend, not the environment):
+  - quant="fp8"  : w8a8 FP8 E4M3 GEMMs (fp8_gemm_descale_bf16out). Near-lossless
+                   for the vision latent and the production default.
+  - quant="bf16" : reference-accuracy path.
+bf16_projs / bf16_layers keep named projections / layers in bf16. This module
+reads no environment variables.
+"""
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+import flash_rt.flash_rt_kernels as fvk
+from flash_rt import flash_rt_fa2 as fa2
+from .kernels import qk_norm_rope
+
+# Cosmos3-Nano two-tower MoT dimensions (fixed by the architecture).
+DEV = "cuda"
+EPS = 1e-6
+H, KV, D, FF, HID, NL = 32, 8, 128, 12288, 4096, 36
+BF = torch.bfloat16
+PATCH = 192  # patch_latent_dim = latent_channels(48) * patch(2) * patch(2)
+ALL_PROJS = ("q_proj", "k_proj", "v_proj", "o_proj", "gate", "up", "down")
+
+
+def patchify(x, C=48, p=2):
+    """[1,C,T,H,W] -> [T*h*w, p*p*C]  (h=H/p, w=W/p)."""
+    x = x[0]
+    _, T, Hh, Ww = x.shape
+    h, w = Hh // p, Ww // p
+    x = x.reshape(C, T, h, p, w, p)
+    return torch.einsum("cthpwq->thwpqc", x).reshape(T * h * w, p * p * C)
+
+
+def unpatchify(v, C, T, h, w, p=2):
+    """[T*h*w, p*p*C] -> [1,C,T,h*p,w*p]."""
+    v = v.reshape(T, h, w, p, p, C)
+    return torch.einsum("thwpqc->cthpwq", v).reshape(1, C, T, h * p, w * p)
+
+
+class CosmosVideo:
+    def __init__(self, weights, nu, ng, quant="fp8", *, bf16_projs=(),
+                 bf16_layers=()):
+        self._wpath = weights
+        self.quant = quant
+        if quant == "bf16":
+            self.bf16_projs = set(ALL_PROJS)
+        else:
+            self.bf16_projs = {p for p in bf16_projs if p}
+        self.bf16_layers = set(bf16_layers)
+        self._bf16_keys = set()
+        self.NU, self.NG, self.NJ = nu, ng, nu + ng
+        wf = safe_open(weights, "pt", device=DEV)
+        T = lambda k: wf.get_tensor(k).to(BF).t().contiguous()
+        N = lambda k: wf.get_tensor(k).to(BF)
+
+        def qf8(w_nk):   # per-tensor FP8 E4M3; fp8_gemm_descale wants B as [K,N]
+            w = w_nk.t().contiguous()
+            s = max(w.float().abs().max().item() / 448.0, 1e-12)
+            f8 = (w.float() / s).clamp(-448, 448).to(torch.float8_e4m3fn).contiguous()
+            return f8, torch.tensor([s], dtype=torch.float32, device=DEV)
+
+        self.Wt_bf16 = {}; self.Wf8 = {}; self.Wds = {}; self.Wn = {}
+        for li in range(NL):
+            P = f"language_model.model.layers.{li}."
+            for suf in ("", "_moe_gen"):
+                bf16_layer = li in self.bf16_layers
+
+                def store(nm, wk):
+                    if nm in self.bf16_projs or bf16_layer:
+                        self.Wt_bf16[(li, suf, nm)] = T(wk)
+                        self._bf16_keys.add((li, suf, nm))
+                    else:
+                        self.Wf8[(li, suf, nm)], self.Wds[(li, suf, nm)] = qf8(N(wk))
+
+                for nm in ("q_proj", "k_proj", "v_proj", "o_proj"):
+                    store(nm, P + f"self_attn.{nm}{suf}.weight")
+                for nm, mk in (("gate", "gate_proj"), ("up", "up_proj"), ("down", "down_proj")):
+                    store(nm, P + f"mlp{suf}.{mk}.weight")
+                for nm in ("input_layernorm", "post_attention_layernorm", "self_attn.q_norm", "self_attn.k_norm"):
+                    self.Wn[(li, suf, nm)] = N(P + f"{nm}{suf}.weight")
+        self.norm_g = N("language_model.model.norm_moe_gen.weight")
+        self.Wll_vae = T("llm2vae.weight")
+        self.bll_vae = N("llm2vae.bias")
+        self.Wvae2llm = T("vae2llm.weight")
+        self.bvae2llm = N("vae2llm.bias")
+        self.gemm = fvk.GemmRunner()
+        self.NSM = torch.cuda.get_device_properties(0).multi_processor_count
+        z = lambda *s: torch.zeros(*s, device=DEV, dtype=BF)
+        NJ, NG = self.NJ, self.NG
+        self.Hb = z(NJ, HID); self.nrm = z(NJ, HID); self.nrm2 = z(NJ, HID)
+        self.Qb = z(NJ, H, D); self.Kb = z(NJ, KV, D); self.Vb = z(NJ, KV, D)
+        self.attn = z(NJ, H * D); self.ob = z(NJ, HID)
+        self.g = z(NJ, FF); self.u = z(NJ, FF); self.act = z(NJ, FF); self.dn = z(NJ, HID)
+        self.cos = z(NJ, D); self.sin = z(NJ, D)
+        self.vtmp = z(NG, PATCH); self.vel = z(NG, PATCH)
+        self.bll_vaeB = self.bll_vae.unsqueeze(0).expand(NG, PATCH).contiguous()
+        self.lse = torch.empty(1, H, NJ, dtype=torch.float32, device=DEV)
+        # FP8 activation scratch (per distinct (M,K)) + shared device scale
+        self.af8 = {}
+        for (M, K) in [(self.NU, HID), (NG, HID), (self.NU, FF), (NG, FF)]:
+            self.af8[(M, K)] = torch.empty(M, K, dtype=torch.float8_e4m3fn, device=DEV)
+        self.asc = torch.empty(1, dtype=torch.float32, device=DEV)
+        # static text K/V cache (text tower is identical across denoise steps)
+        self.cK = torch.zeros(NL, self.NU, KV, D, device=DEV, dtype=BF)
+        self.cV = torch.zeros(NL, self.NU, KV, D, device=DEV, dtype=BF)
+        self._und_ready = False
+        self.gr = None
+        torch.cuda.synchronize()
+
+    # ---- shared two-tower MoT kernel helpers (self-contained) ----
+    def _s(self):
+        return torch.cuda.current_stream().cuda_stream
+
+    def _rms(self, x, w, out, rows, dim):
+        fvk.rms_norm(x.data_ptr(), w.data_ptr(), out.data_ptr(), rows, dim, EPS, self._s())
+
+    def _radd_rms(self, h, x, w, out, rows):
+        fvk.residual_add_rms_norm(h.data_ptr(), x.data_ptr(), w.data_ptr(), out.data_ptr(), rows, HID, EPS, self._s())
+
+    def _silu(self, g, u, out, n):
+        fvk.silu_mul_qwen36_bf16(g.data_ptr(), u.data_ptr(), out.data_ptr(), n, self._s())
+
+    def _fa(self, q, k, v, o, nq, nk, causal):
+        s = self._s()
+        fwd = fa2.fwd_bf16_causal if causal else fa2.fwd_bf16
+        qs = (nq * H * D, H * D, D); ks = (nk * KV * D, KV * D, D)   # (batch, seq, head) strides
+        fwd(Q=q.data_ptr(), K=k.data_ptr(), V=v.data_ptr(), O=o.data_ptr(), softmax_lse=self.lse.data_ptr(),
+            softmax_lse_accum=0, o_accum=0, batch=1, seqlen_q=nq, seqlen_k=nk, num_heads_q=H, num_heads_kv=KV, head_dim=D,
+            q_strides=qs, k_strides=ks, v_strides=ks, o_strides=qs,
+            softmax_scale=D ** -0.5, num_sms=self.NSM, stream=s)
+
+    def capture(self):
+        st = torch.cuda.Stream(); st.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(st):
+            for _ in range(3): self.forward()
+        torch.cuda.current_stream().wait_stream(st)
+        self.gr = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self.gr): self.forward()
+
+    def replay(self):
+        self.gr.replay(); return self.vel
+
+    def set_rope(self, cos_und, cos_gen, sin_und, sin_gen):
+        self.cos[0:self.NU].copy_(cos_und); self.cos[self.NU:self.NJ].copy_(cos_gen)
+        self.sin[0:self.NU].copy_(sin_und); self.sin[self.NU:self.NJ].copy_(sin_gen)
+
+    def set_gen(self, gen_in):
+        self.Hb[self.NU:self.NJ].copy_(gen_in)
+
+    def embed_gen(self, vae2llm_in, timestep_emb):
+        """gen hidden = vae2llm(patchified noisy latent) + timestep embedding."""
+        h = F.linear(vae2llm_in.to(BF), self.Wvae2llm.t(), self.bvae2llm)
+        self.set_gen(h + timestep_emb.to(BF))
+
+    def _proj(self, A, key, out, Nn):
+        if key in self._bf16_keys:
+            M, K = A.shape
+            self.gemm.bf16_nn(A.data_ptr(), self.Wt_bf16[key].data_ptr(), out.data_ptr(), M, Nn, K, self._s())
+        else:
+            M, K = A.shape; s = self._s()
+            af8 = self.af8[(M, K)]
+            fvk.quantize_fp8_device(A.data_ptr(), af8.data_ptr(), self.asc.data_ptr(), M * K, s)
+            fvk.fp8_gemm_descale_bf16out(af8.data_ptr(), self.Wf8[key].data_ptr(), out.data_ptr(),
+                                         M, Nn, K, self.asc.data_ptr(), self.Wds[key].data_ptr(), s)
+
+    def _qkv_rope(self, suf, lo, hi, n, li):
+        s = self._s()
+        self._proj(self.nrm[lo:hi], (li, suf, "q_proj"), self.Qb[lo:hi].view(n, H * D), HID)
+        self._proj(self.nrm[lo:hi], (li, suf, "k_proj"), self.Kb[lo:hi].view(n, KV * D), KV * D)
+        self._proj(self.nrm[lo:hi], (li, suf, "v_proj"), self.Vb[lo:hi].view(n, KV * D), KV * D)
+        qk_norm_rope(self.Qb[lo:hi].data_ptr(), self.Kb[lo:hi].data_ptr(),
+                     self.Wn[(li, suf, "self_attn.q_norm")].data_ptr(),
+                     self.Wn[(li, suf, "self_attn.k_norm")].data_ptr(),
+                     self.cos[lo:hi].data_ptr(), self.sin[lo:hi].data_ptr(), n, H, KV, D, EPS, s)
+
+    def _gen_attn(self, li):
+        NU, NG, NJ = self.NU, self.NG, self.NJ
+        self._fa(self.Qb[NU:NJ], self.Kb[0:NJ], self.Vb[0:NJ], self.attn[NU:NJ].view(NG, H, D), NG, NJ, False)
+
+    def _o_ffn(self, suf, lo, hi, n, li, last):
+        s = self._s()
+        self._proj(self.attn[lo:hi], (li, suf, "o_proj"), self.ob[lo:hi], HID)
+        self._radd_rms(self.Hb[lo:hi], self.ob[lo:hi], self.Wn[(li, suf, "post_attention_layernorm")], self.nrm2[lo:hi], n)
+        self._proj(self.nrm2[lo:hi], (li, suf, "gate"), self.g[lo:hi], FF)
+        self._proj(self.nrm2[lo:hi], (li, suf, "up"), self.u[lo:hi], FF)
+        self._silu(self.g[lo:hi], self.u[lo:hi], self.act[lo:hi], n * FF)
+        self._proj(self.act[lo:hi], (li, suf, "down"), self.dn[lo:hi], HID)
+        if not last:
+            self._radd_rms(self.Hb[lo:hi], self.dn[lo:hi], self.Wn[(li + 1, suf, "input_layernorm")], self.nrm[lo:hi], n)
+        else:
+            fvk.residual_add(self.Hb[lo:hi].data_ptr(), self.dn[lo:hi].data_ptr(), n * HID, s)
+
+    def precompute_und(self, und_in):
+        """One-time exact text tower; snapshot post-rope text K + raw V per layer."""
+        NU = self.NU
+        self.Hb[0:NU].copy_(und_in)
+        self._rms(self.Hb[0:NU], self.Wn[(0, "", "input_layernorm")], self.nrm[0:NU], NU, HID)
+        for li in range(NL):
+            self._qkv_rope("", 0, NU, NU, li)
+            self.cK[li].copy_(self.Kb[0:NU]); self.cV[li].copy_(self.Vb[0:NU])
+            self._fa(self.Qb[0:NU], self.Kb[0:NU], self.Vb[0:NU], self.attn[0:NU].view(NU, H, D), NU, NU, True)
+            self._o_ffn("", 0, NU, NU, li, li == NL - 1)
+        torch.cuda.synchronize()
+        self._und_ready = True
+
+    def forward(self):
+        """Per-step gen (vision) tower only; text K/V from the static cache."""
+        s = self._s()
+        NU, NG, NJ = self.NU, self.NG, self.NJ
+        suf = "_moe_gen"
+        self._rms(self.Hb[NU:NJ], self.Wn[(0, suf, "input_layernorm")], self.nrm[NU:NJ], NG, HID)
+        for li in range(NL):
+            self._qkv_rope(suf, NU, NJ, NG, li)
+            self.Kb[0:NU].copy_(self.cK[li]); self.Vb[0:NU].copy_(self.cV[li])
+            self._gen_attn(li)
+            self._o_ffn(suf, NU, NJ, NG, li, li == NL - 1)
+        self._rms(self.Hb[NU:NJ], self.norm_g, self.nrm[NU:NJ], NG, HID)
+        self.gemm.bf16_nn(self.nrm[NU:NJ].data_ptr(), self.Wll_vae.data_ptr(), self.vtmp.data_ptr(), NG, PATCH, HID, s)
+        fvk.add_bf16_out(self.vtmp.data_ptr(), self.bll_vaeB.data_ptr(), self.vel.data_ptr(), NG * PATCH, s)
+        return self.vel


### PR DESCRIPTION
Self-contained FlashRT model (config="cosmos3_video"), following docs/adding_new_model.md §0: its own models/cosmos3_video/pipeline_rtx.py, frontend, config, and model-local kernel — no dependency on any other model.

- two-tower MoT denoise: gen tower = all-noisy vision latent, head = llm2vae; text tower computed once with static per-layer K/V cache; one CUDA graph/step
- precision via load_model(use_fp8): fp8 E4M3 (default, near-lossless for the video latent) or bf16; per-projection/per-layer bf16 overrides
- conditioning via set_prompt(ref=...); runtime knobs via infer(teacache_skip=, shift=, ...) — typed parameters, no environment configuration
- model-local cosmos3_video_kernels extension (fused qk-norm-rope); built on the target GPU via setup.py, .so not committed
- frontend + config + _PIPELINE_MAP registration + usage doc + quickstart

Verified (RTX 5090, 480p/49f/10-step UniPC, typed API):
  fp8           latent cos 0.98603
  fp8+TeaCache  latent cos 0.98125
  bf16          latent cos 0.99940