### PR TITLE
Restore SM89 FP8 NT path and fix Pi0.5 autotune scratch selection

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -494,6 +494,17 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         }, py::arg("A"), py::arg("B"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"),
            py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("stream") = 0)
+        .def("fp8_nt_dev", [](GemmRunner& self,
+                               uintptr_t A, uintptr_t B, uintptr_t D,
+                               int M, int N, int K,
+                               uintptr_t d_scale_a, uintptr_t d_scale_b,
+                               uintptr_t stream) {
+            self.fp8_nt_dev(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                             reinterpret_cast<float*>(d_scale_a),
+                             reinterpret_cast<float*>(d_scale_b), to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("stream") = 0)
         // FP8 with device descale → FP16 (GemmRunner handle, matching pi05)
         .def("fp8_descale_fp16", [](GemmRunner& self,
                                      uintptr_t A, uintptr_t B, uintptr_t D,
@@ -553,6 +564,17 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                                         uintptr_t d_scale_a, uintptr_t d_scale_b,
                                         int num_algos) {
             self.autotune_fp8_nn_dev(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                                      reinterpret_cast<float*>(d_scale_a),
+                                      reinterpret_cast<float*>(d_scale_b), num_algos);
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("num_algos") = 16)
+        .def("autotune_fp8_nt_dev", [](GemmRunner& self,
+                                        uintptr_t A, uintptr_t B, uintptr_t D,
+                                        int M, int N, int K,
+                                        uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                        int num_algos) {
+            self.autotune_fp8_nt_dev(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
                                       reinterpret_cast<float*>(d_scale_a),
                                       reinterpret_cast<float*>(d_scale_b), num_algos);
         }, py::arg("A"), py::arg("B"), py::arg("D"),

--- a/csrc/gemm/gemm_runner.cu
+++ b/csrc/gemm/gemm_runner.cu
@@ -43,11 +43,11 @@ GemmRunner::CachedGemm& GemmRunner::get_or_create_cached(GemmType type, int M, i
     CachedGemm entry;
     cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
     cublasOperation_t op_N = CUBLAS_OP_N;
+    cublasOperation_t op_T = CUBLAS_OP_T;
 
 #ifdef ENABLE_NVFP4
     if (type == FP4_NN_DEV) {
         CUBLAS_CHECK(cublasLtMatmulDescCreate(&entry.matmul_desc, CUBLAS_COMPUTE_32F, CUDA_R_32F));
-        cublasOperation_t op_T = CUBLAS_OP_T;
         CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc, CUBLASLT_MATMUL_DESC_TRANSA, &op_T, sizeof(op_T)));
         CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc, CUBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
 
@@ -71,6 +71,16 @@ GemmRunner::CachedGemm& GemmRunner::get_or_create_cached(GemmType type, int M, i
         CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&entry.A_desc, CUDA_R_8F_E4M3, M, K, K));
         CUBLAS_CHECK(cublasLtMatrixLayoutSetAttribute(entry.A_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order)));
         CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&entry.B_desc, CUDA_R_8F_E4M3, K, N, N));
+        CUBLAS_CHECK(cublasLtMatrixLayoutSetAttribute(entry.B_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order)));
+        CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&entry.D_desc, CUDA_R_16BF, M, N, N));
+        CUBLAS_CHECK(cublasLtMatrixLayoutSetAttribute(entry.D_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order)));
+    } else if (type == FP8_NT_DEV) {
+        CUBLAS_CHECK(cublasLtMatmulDescCreate(&entry.matmul_desc, CUBLAS_COMPUTE_32F, CUDA_R_32F));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc, CUBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+        CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc, CUBLASLT_MATMUL_DESC_TRANSB, &op_T, sizeof(op_T)));
+        CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&entry.A_desc, CUDA_R_8F_E4M3, M, K, K));
+        CUBLAS_CHECK(cublasLtMatrixLayoutSetAttribute(entry.A_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order)));
+        CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&entry.B_desc, CUDA_R_8F_E4M3, N, K, K));
         CUBLAS_CHECK(cublasLtMatrixLayoutSetAttribute(entry.B_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order)));
         CUBLAS_CHECK(cublasLtMatrixLayoutCreate(&entry.D_desc, CUDA_R_16BF, M, N, N));
         CUBLAS_CHECK(cublasLtMatrixLayoutSetAttribute(entry.D_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order, sizeof(row_order)));
@@ -222,6 +232,14 @@ void GemmRunner::autotune_fp8_nn_dev(void* A, void* B, void* D,
                                       float* d_scale_a, float* d_scale_b,
                                       int num_algos) {
     auto& entry = get_or_create_cached(FP8_NN_DEV, M, N, K);
+    autotune_cached(entry, A, B, D, 1.0f, 0.0f, num_algos, d_scale_a, d_scale_b);
+}
+
+void GemmRunner::autotune_fp8_nt_dev(void* A, void* B, void* D,
+                                      int M, int N, int K,
+                                      float* d_scale_a, float* d_scale_b,
+                                      int num_algos) {
+    auto& entry = get_or_create_cached(FP8_NT_DEV, M, N, K);
     autotune_cached(entry, A, B, D, 1.0f, 0.0f, num_algos, d_scale_a, d_scale_b);
 }
 
@@ -1031,6 +1049,26 @@ void GemmRunner::fp8_nn_dev(void* A, void* B, void* D,
                              cudaStream_t stream) {
     auto& entry = get_or_create_cached(FP8_NN_DEV, M, N, K);
     // Update scale pointers per-call (different layers have different scales)
+    CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc,
+        CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_a, sizeof(d_scale_a)));
+    CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc,
+        CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, &d_scale_b, sizeof(d_scale_b)));
+
+    float alpha = 1.0f, beta = 0.0f;
+    CUBLAS_CHECK(cublasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, A, entry.A_desc, B, entry.B_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}
+
+// FP8 transpose-B path: D_bf16 = A_fp8(M,K) @ B_fp8(N,K)^T
+// with device scale pointers. This layout is used by the SM89 route,
+// where cuBLASLt FP8 rejects the no-transpose NN descriptor.
+void GemmRunner::fp8_nt_dev(void* A, void* B, void* D,
+                             int M, int N, int K,
+                             float* d_scale_a, float* d_scale_b,
+                             cudaStream_t stream) {
+    auto& entry = get_or_create_cached(FP8_NT_DEV, M, N, K);
     CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc,
         CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_a, sizeof(d_scale_a)));
     CUBLAS_CHECK(cublasLtMatmulDescSetAttribute(entry.matmul_desc,

--- a/csrc/gemm/gemm_runner.h
+++ b/csrc/gemm/gemm_runner.h
@@ -121,6 +121,14 @@ public:
                     float* d_scale_a, float* d_scale_b,
                     cudaStream_t stream = 0);
 
+    // FP8 transpose-B path for SM89-compatible cuBLASLt layouts:
+    // D_bf16 = A_fp8(M,K) @ B_fp8(N,K)^T with device scale pointers.
+    // B is stored as (N,K) row-major.
+    void fp8_nt_dev(void* A, void* B, void* D,
+                    int M, int N, int K,
+                    float* d_scale_a, float* d_scale_b,
+                    cudaStream_t stream = 0);
+
     // FP8 with host alpha + BIAS epilogue: D = alpha * A_fp8 @ B_fp8 + bias
     // Matches pi05 gmm_fp8_kn_bias: host scalar alpha, per-GEMM bias vector
     void fp8_nn_bias(void* A, void* B, void* D, void* bias,
@@ -173,6 +181,10 @@ public:
                              int M, int N, int K,
                              float* d_scale_a, float* d_scale_b,
                              int num_algos = 16);
+    void autotune_fp8_nt_dev(void* A, void* B, void* D,
+                             int M, int N, int K,
+                             float* d_scale_a, float* d_scale_b,
+                             int num_algos = 16);
 #ifdef ENABLE_NVFP4
     void autotune_fp4_nn_dev(void* A_fp4, void* SFA, void* B_fp4, void* SFB,
                               void* D, int M, int N, int K,
@@ -188,7 +200,8 @@ private:
     float* d_scale_b_;
 
     // ── GEMM descriptor + algorithm cache ──
-    enum GemmType { BF16_NN = 0, BF16_NN_RES = 1, FP8_NN_DEV = 2, FP16_NN = 4
+    enum GemmType { BF16_NN = 0, BF16_NN_RES = 1, FP8_NN_DEV = 2,
+                    FP8_NT_DEV = 5, FP16_NN = 4
 #ifdef ENABLE_NVFP4
         , FP4_NN_DEV = 3
 #endif

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -1792,12 +1792,9 @@ class Pi05Pipeline:
             ]:
                 w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
                 act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
-                if K_val == VIS_H:
-                    act_buf = B["vis_act_fp8_large"]
-                else:
-                    act_buf = B["vis_act_fp8"]
+                act_buf_ptr, _ = self._pick_fp8_scratch(name_prefix, M_val * K_val)
                 self._autotune_fp8_matmul(
-                    act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
+                    act_buf_ptr, w_fp8_ptr, B[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
 
         # Encoder FP8 shapes
@@ -1810,9 +1807,9 @@ class Pi05Pipeline:
             ]:
                 w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
                 act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
-                act_buf = B["enc_act_fp8_large"] if K_val == ENC_H else B["enc_act_fp8"]
+                act_buf_ptr, _ = self._pick_fp8_scratch(name_prefix, M_val * K_val)
                 self._autotune_fp8_matmul(
-                    act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
+                    act_buf_ptr, w_fp8_ptr, B[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
         # Plain encoder GEMMs fall back to BF16 when neither FP8 nor
         # INT8 owns the encoder matmuls.
@@ -1849,9 +1846,9 @@ class Pi05Pipeline:
             ]:
                 w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
                 act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
-                act_buf = B["dec_act_fp8_large"] if K_val == DEC_H else B["dec_act_fp8"]
+                act_buf_ptr, _ = self._pick_fp8_scratch(name_prefix, M_val * K_val)
                 self._autotune_fp8_matmul(
-                    act_buf.ptr.value, w_fp8_ptr, B[out_key].ptr.value,
+                    act_buf_ptr, w_fp8_ptr, B[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
         # Plain decoder GEMMs fall back to BF16 when neither FP8 nor
         # INT8 owns the decoder matmuls.

--- a/flash_rt/models/pi05/pipeline_rtx_batched.py
+++ b/flash_rt/models/pi05/pipeline_rtx_batched.py
@@ -1044,6 +1044,8 @@ class Pi05BatchedPipeline(Pi05Pipeline):
         """
         # First, the parent's B=1 tune (covers calibration-time GEMMs).
         super().autotune_gemms()
+        if getattr(self, "_gemms_autotuned_b2", False):
+            return
 
         # Then run an additional autotune at the B=2 ``M = B*seq`` shapes.
         # When this code first landed we hit
@@ -1089,10 +1091,10 @@ class Pi05BatchedPipeline(Pi05Pipeline):
             ]:
                 w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
                 act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
-                act_buf = (Bb["vis_act_fp8_large_b2"] if K_val == VIS_H
-                           else Bb["vis_act_fp8_b2"])
+                act_buf_ptr, _ = self._pick_fp8_scratch_b2(
+                    name_prefix, M_val * K_val)
                 self._autotune_fp8_matmul(
-                    act_buf.ptr.value, w_fp8_ptr, Bb[out_key].ptr.value,
+                    act_buf_ptr, w_fp8_ptr, Bb[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
 
         # Encoder FP8 at B*seq
@@ -1105,10 +1107,10 @@ class Pi05BatchedPipeline(Pi05Pipeline):
             ]:
                 w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
                 act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
-                act_buf = (Bb["enc_act_fp8_large_b2"] if K_val == ENC_H
-                           else Bb["enc_act_fp8_b2"])
+                act_buf_ptr, _ = self._pick_fp8_scratch_b2(
+                    name_prefix, M_val * K_val)
                 self._autotune_fp8_matmul(
-                    act_buf.ptr.value, w_fp8_ptr, Bb[out_key].ptr.value,
+                    act_buf_ptr, w_fp8_ptr, Bb[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
 
         # Decoder FP8 at B*ds
@@ -1121,13 +1123,14 @@ class Pi05BatchedPipeline(Pi05Pipeline):
             ]:
                 w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
                 act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
-                act_buf = (Bb["dec_act_fp8_large_b2"] if K_val == DEC_H
-                           else Bb["dec_act_fp8_b2"])
+                act_buf_ptr, _ = self._pick_fp8_scratch_b2(
+                    name_prefix, M_val * K_val)
                 self._autotune_fp8_matmul(
-                    act_buf.ptr.value, w_fp8_ptr, Bb[out_key].ptr.value,
+                    act_buf_ptr, w_fp8_ptr, Bb[out_key].ptr.value,
                     M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
 
         self._cudart.cudaDeviceSynchronize()
+        self._gemms_autotuned_b2 = True
         logger.info("B=%d autotune complete", self.B)
 
     def calibrate_fp8(self) -> None:

--- a/tests/test_pi05_rtx_autotune_scratch.py
+++ b/tests/test_pi05_rtx_autotune_scratch.py
@@ -3,19 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from flash_rt.models.pi05.pipeline_rtx_batched import Pi05BatchedPipeline
-from flash_rt.models.pi05.pipeline_rtx import (
-    DEC_D,
-    DEC_H,
-    DEC_HD,
-    DEC_NH,
-    ENC_D,
-    ENC_H,
-    Pi05Pipeline,
-    VIS_D,
-    VIS_H,
-)
-
 
 class _Buf:
     def __init__(self, ptr, nbytes):
@@ -31,6 +18,36 @@ class _Gemm:
 class _CudaRt:
     def __init__(self):
         self.cudaDeviceSynchronize = Mock(return_value=0)
+
+
+def _load_pi05_rtx_symbols():
+    try:
+        from flash_rt.models.pi05.pipeline_rtx_batched import Pi05BatchedPipeline
+        from flash_rt.models.pi05.pipeline_rtx import (
+            DEC_D,
+            DEC_H,
+            DEC_HD,
+            DEC_NH,
+            ENC_D,
+            ENC_H,
+            Pi05Pipeline,
+            VIS_D,
+            VIS_H,
+        )
+    except (ImportError, OSError) as exc:
+        pytest.skip(f"Pi05 RTX imports unavailable: {exc}")
+    return SimpleNamespace(
+        DEC_D=DEC_D,
+        DEC_H=DEC_H,
+        DEC_HD=DEC_HD,
+        DEC_NH=DEC_NH,
+        ENC_D=ENC_D,
+        ENC_H=ENC_H,
+        Pi05BatchedPipeline=Pi05BatchedPipeline,
+        Pi05Pipeline=Pi05Pipeline,
+        VIS_D=VIS_D,
+        VIS_H=VIS_H,
+    )
 
 
 def _setup_pi05_pipe(pipe_cls):
@@ -92,7 +109,7 @@ def _setup_pi05_pipe(pipe_cls):
     return pipe
 
 
-def _set_base_test_bufs(pipe):
+def _set_base_test_bufs(pipe, symbols):
     pipe.bufs = {
         "vision_patches": _Buf(101, 1),
         "vision_x": _Buf(102, 1),
@@ -106,19 +123,19 @@ def _set_base_test_bufs(pipe):
         "decoder_QKV": _Buf(110, 1),
         "decoder_gate_merged": _Buf(111, 1),
         "x_normed_buf": _Buf(112, 1),
-        "vis_act_fp8": _Buf(201, pipe.vision_seq * VIS_D),
-        "vis_act_fp8_large": _Buf(202, pipe.vision_seq * VIS_H),
+        "vis_act_fp8": _Buf(201, pipe.vision_seq * symbols.VIS_D),
+        "vis_act_fp8_large": _Buf(202, pipe.vision_seq * symbols.VIS_H),
         "vis_act_scale": _Buf(203, 4),
-        "enc_act_fp8": _Buf(301, pipe.encoder_seq_len * ENC_D),
-        "enc_act_fp8_large": _Buf(302, pipe.encoder_seq_len * 2 * ENC_H),
+        "enc_act_fp8": _Buf(301, pipe.encoder_seq_len * symbols.ENC_D),
+        "enc_act_fp8_large": _Buf(302, pipe.encoder_seq_len * 2 * symbols.ENC_H),
         "enc_act_scale": _Buf(303, 4),
-        "dec_act_fp8": _Buf(401, pipe.chunk_size * DEC_D),
-        "dec_act_fp8_large": _Buf(402, pipe.chunk_size * 2 * DEC_H),
+        "dec_act_fp8": _Buf(401, pipe.chunk_size * symbols.DEC_D),
+        "dec_act_fp8_large": _Buf(402, pipe.chunk_size * 2 * symbols.DEC_H),
         "dec_act_scale": _Buf(403, 4),
     }
 
 
-def _set_batched_test_bufs(pipe):
+def _set_batched_test_bufs(pipe, symbols):
     pipe.B = 2
     batched_slack = pipe.B + 1
     pipe.bufs = {
@@ -146,35 +163,42 @@ def _set_batched_test_bufs(pipe):
         "decoder_QKV_b2": _Buf(110, 1),
         "decoder_gate_merged_b2": _Buf(111, 1),
         "x_normed_buf_b2": _Buf(112, 1),
-        "vis_act_fp8": _Buf(201, pipe.vision_seq * VIS_D),
-        "vis_act_fp8_large": _Buf(202, pipe.vision_seq * VIS_H),
-        "vis_act_fp8_b2": _Buf(211, batched_slack * pipe.vision_seq * VIS_D),
-        "vis_act_fp8_large_b2": _Buf(212, batched_slack * pipe.vision_seq * VIS_H),
+        "vis_act_fp8": _Buf(201, pipe.vision_seq * symbols.VIS_D),
+        "vis_act_fp8_large": _Buf(202, pipe.vision_seq * symbols.VIS_H),
+        "vis_act_fp8_b2": _Buf(
+            211, batched_slack * pipe.vision_seq * symbols.VIS_D),
+        "vis_act_fp8_large_b2": _Buf(
+            212, batched_slack * pipe.vision_seq * symbols.VIS_H),
         "vis_act_scale": _Buf(203, 4),
-        "enc_act_fp8": _Buf(301, pipe.encoder_seq_len * ENC_D),
-        "enc_act_fp8_large": _Buf(302, pipe.encoder_seq_len * 2 * ENC_H),
-        "enc_act_fp8_b2": _Buf(311, batched_slack * pipe.encoder_seq_len * ENC_D),
+        "enc_act_fp8": _Buf(301, pipe.encoder_seq_len * symbols.ENC_D),
+        "enc_act_fp8_large": _Buf(302, pipe.encoder_seq_len * 2 * symbols.ENC_H),
+        "enc_act_fp8_b2": _Buf(
+            311, batched_slack * pipe.encoder_seq_len * symbols.ENC_D),
         "enc_act_fp8_large_b2": _Buf(
-            312, batched_slack * pipe.encoder_seq_len * 2 * ENC_H),
+            312, batched_slack * pipe.encoder_seq_len * 2 * symbols.ENC_H),
         "enc_act_scale": _Buf(303, 4),
-        "dec_act_fp8": _Buf(401, pipe.chunk_size * DEC_D),
-        "dec_act_fp8_large": _Buf(402, pipe.chunk_size * 2 * DEC_H),
-        "dec_act_fp8_b2": _Buf(411, batched_slack * pipe.chunk_size * DEC_D),
-        "dec_act_fp8_large_b2": _Buf(412, batched_slack * pipe.chunk_size * 2 * DEC_H),
+        "dec_act_fp8": _Buf(401, pipe.chunk_size * symbols.DEC_D),
+        "dec_act_fp8_large": _Buf(402, pipe.chunk_size * 2 * symbols.DEC_H),
+        "dec_act_fp8_b2": _Buf(
+            411, batched_slack * pipe.chunk_size * symbols.DEC_D),
+        "dec_act_fp8_large_b2": _Buf(
+            412, batched_slack * pipe.chunk_size * 2 * symbols.DEC_H),
         "dec_act_scale": _Buf(403, 4),
     }
 
 
 def test_autotune_uses_large_decoder_fp8_scratch_for_attn_o():
-    pipe = _setup_pi05_pipe(Pi05Pipeline)
-    _set_base_test_bufs(pipe)
+    symbols = _load_pi05_rtx_symbols()
+    pipe = _setup_pi05_pipe(symbols.Pi05Pipeline)
+    _set_base_test_bufs(pipe, symbols)
     pipe._autotune_fp8_matmul = Mock()
 
-    Pi05Pipeline.autotune_gemms(pipe)
+    symbols.Pi05Pipeline.autotune_gemms(pipe)
 
     decoder_attn_o = [
         call.args for call in pipe._autotune_fp8_matmul.call_args_list
-        if call.args[3:6] == (pipe.chunk_size, DEC_D, DEC_NH * DEC_HD)
+        if call.args[3:6] == (
+            pipe.chunk_size, symbols.DEC_D, symbols.DEC_NH * symbols.DEC_HD)
     ]
     assert decoder_attn_o, "decoder attn_o FP8 autotune shape was not visited"
     assert decoder_attn_o[0][0] == pipe.bufs["dec_act_fp8_large"].ptr.value
@@ -182,16 +206,22 @@ def test_autotune_uses_large_decoder_fp8_scratch_for_attn_o():
 
 def test_batched_autotune_uses_size_based_decoder_fp8_scratch_for_attn_o(
         monkeypatch):
-    pipe = _setup_pi05_pipe(Pi05BatchedPipeline)
-    _set_batched_test_bufs(pipe)
+    symbols = _load_pi05_rtx_symbols()
+    pipe = _setup_pi05_pipe(symbols.Pi05BatchedPipeline)
+    _set_batched_test_bufs(pipe, symbols)
     pipe._autotune_fp8_matmul = Mock()
 
-    monkeypatch.setattr(Pi05Pipeline, "autotune_gemms", lambda self: None)
-    Pi05BatchedPipeline.autotune_gemms(pipe)
+    monkeypatch.setattr(
+        symbols.Pi05Pipeline, "autotune_gemms", lambda self: None)
+    symbols.Pi05BatchedPipeline.autotune_gemms(pipe)
 
     decoder_attn_o = [
         call.args for call in pipe._autotune_fp8_matmul.call_args_list
-        if call.args[3:6] == (pipe.B * pipe.chunk_size, DEC_D, DEC_NH * DEC_HD)
+        if call.args[3:6] == (
+            pipe.B * pipe.chunk_size,
+            symbols.DEC_D,
+            symbols.DEC_NH * symbols.DEC_HD,
+        )
     ]
     assert decoder_attn_o, (
         "batched decoder attn_o FP8 autotune shape was not visited")
@@ -199,15 +229,17 @@ def test_batched_autotune_uses_size_based_decoder_fp8_scratch_for_attn_o(
 
 
 def test_batched_autotune_runs_b2_shapes_only_once(monkeypatch):
-    pipe = _setup_pi05_pipe(Pi05BatchedPipeline)
-    _set_batched_test_bufs(pipe)
+    symbols = _load_pi05_rtx_symbols()
+    pipe = _setup_pi05_pipe(symbols.Pi05BatchedPipeline)
+    _set_batched_test_bufs(pipe, symbols)
     pipe._autotune_fp8_matmul = Mock()
 
-    monkeypatch.setattr(Pi05Pipeline, "autotune_gemms", lambda self: None)
+    monkeypatch.setattr(
+        symbols.Pi05Pipeline, "autotune_gemms", lambda self: None)
 
-    Pi05BatchedPipeline.autotune_gemms(pipe)
+    symbols.Pi05BatchedPipeline.autotune_gemms(pipe)
     first_count = pipe._autotune_fp8_matmul.call_count
-    Pi05BatchedPipeline.autotune_gemms(pipe)
+    symbols.Pi05BatchedPipeline.autotune_gemms(pipe)
 
     assert first_count > 0
     assert pipe._autotune_fp8_matmul.call_count == first_count
@@ -216,7 +248,8 @@ def test_batched_autotune_runs_b2_shapes_only_once(monkeypatch):
 
 
 def test_fp8_nk_layout_dispatches_to_nt_entrypoints():
-    pipe = Pi05Pipeline.__new__(Pi05Pipeline)
+    symbols = _load_pi05_rtx_symbols()
+    pipe = symbols.Pi05Pipeline.__new__(symbols.Pi05Pipeline)
     pipe.fp8_layout = "nk"
     pipe.gemm = SimpleNamespace(
         fp8_nt_dev=Mock(),

--- a/tests/test_pi05_rtx_autotune_scratch.py
+++ b/tests/test_pi05_rtx_autotune_scratch.py
@@ -1,0 +1,249 @@
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from flash_rt.models.pi05.pipeline_rtx_batched import Pi05BatchedPipeline
+from flash_rt.models.pi05.pipeline_rtx import (
+    DEC_D,
+    DEC_H,
+    DEC_HD,
+    DEC_NH,
+    ENC_D,
+    ENC_H,
+    Pi05Pipeline,
+    VIS_D,
+    VIS_H,
+)
+
+
+class _Buf:
+    def __init__(self, ptr, nbytes):
+        self.ptr = SimpleNamespace(value=ptr)
+        self.nbytes = nbytes
+
+
+class _Gemm:
+    def __init__(self):
+        self.autotune_bf16_nn = Mock(return_value=None)
+
+
+class _CudaRt:
+    def __init__(self):
+        self.cudaDeviceSynchronize = Mock(return_value=0)
+
+
+def _setup_pi05_pipe(pipe_cls):
+    pipe = pipe_cls.__new__(pipe_cls)
+    pipe._gemms_autotuned = False
+    pipe.use_fp8 = True
+    pipe.fp8_calibrated = True
+    pipe.use_int8_vision = False
+    pipe.use_int8_encoder = False
+    pipe.use_fp8_decoder = True
+    pipe.use_int8_decoder = False
+    pipe.num_views = 2
+    pipe.vision_seq = 512
+    pipe.encoder_seq_len = 692
+    pipe.chunk_size = 10
+    pipe.gemm = _Gemm()
+    pipe._cudart = _CudaRt()
+    pipe.weights = {
+        "vision_patch_embedding_w": 11,
+        "fp8": {
+            "vision_attn_qkv_w_0": True,
+            "vision_attn_o_w_0": True,
+            "vision_ffn_up_w_0": True,
+            "vision_ffn_down_w_0": True,
+            "vision_projector_w": True,
+            "encoder_attn_qkv_w_0": True,
+            "encoder_attn_o_w_0": True,
+            "encoder_ffn_gate_up_w_0": True,
+            "encoder_ffn_down_w_0": True,
+            "decoder_attn_qkv_w_0": True,
+            "decoder_attn_o_w_0": True,
+            "decoder_ffn_gate_up_w_0": True,
+            "decoder_ffn_down_w_0": True,
+        },
+    }
+    scale_names = [
+        "vision_attn_qkv_w_0",
+        "vision_attn_o_w_0",
+        "vision_ffn_up_w_0",
+        "vision_ffn_down_w_0",
+        "vision_projector_w",
+        "encoder_attn_qkv_w_0",
+        "encoder_attn_o_w_0",
+        "encoder_ffn_gate_up_w_0",
+        "encoder_ffn_down_w_0",
+        "decoder_attn_qkv_w_0",
+        "decoder_attn_o_w_0",
+        "decoder_ffn_gate_up_w_0",
+        "decoder_ffn_down_w_0",
+    ]
+    pipe.fp8_act_scales = {
+        name: _Buf(500 + idx, 4) for idx, name in enumerate(scale_names)
+    }
+
+    def _weight_fp8(self, name):
+        return (1000 + hash(name) % 1000, 2000 + hash(name) % 1000)
+
+    pipe._weight_fp8 = MethodType(_weight_fp8, pipe)
+    return pipe
+
+
+def _set_base_test_bufs(pipe):
+    pipe.bufs = {
+        "vision_patches": _Buf(101, 1),
+        "vision_x": _Buf(102, 1),
+        "vision_QKV": _Buf(103, 1),
+        "vision_x_norm": _Buf(104, 1),
+        "vision_hidden": _Buf(105, 1),
+        "encoder_x": _Buf(106, 1),
+        "encoder_QKV": _Buf(107, 1),
+        "encoder_gate_merged": _Buf(108, 1),
+        "encoder_x_norm": _Buf(109, 1),
+        "decoder_QKV": _Buf(110, 1),
+        "decoder_gate_merged": _Buf(111, 1),
+        "x_normed_buf": _Buf(112, 1),
+        "vis_act_fp8": _Buf(201, pipe.vision_seq * VIS_D),
+        "vis_act_fp8_large": _Buf(202, pipe.vision_seq * VIS_H),
+        "vis_act_scale": _Buf(203, 4),
+        "enc_act_fp8": _Buf(301, pipe.encoder_seq_len * ENC_D),
+        "enc_act_fp8_large": _Buf(302, pipe.encoder_seq_len * 2 * ENC_H),
+        "enc_act_scale": _Buf(303, 4),
+        "dec_act_fp8": _Buf(401, pipe.chunk_size * DEC_D),
+        "dec_act_fp8_large": _Buf(402, pipe.chunk_size * 2 * DEC_H),
+        "dec_act_scale": _Buf(403, 4),
+    }
+
+
+def _set_batched_test_bufs(pipe):
+    pipe.B = 2
+    batched_slack = pipe.B + 1
+    pipe.bufs = {
+        "vision_patches": _Buf(1, 1),
+        "vision_x": _Buf(2, 1),
+        "vision_QKV": _Buf(3, 1),
+        "vision_x_norm": _Buf(4, 1),
+        "vision_hidden": _Buf(5, 1),
+        "encoder_x": _Buf(6, 1),
+        "encoder_QKV": _Buf(7, 1),
+        "encoder_gate_merged": _Buf(8, 1),
+        "encoder_x_norm": _Buf(9, 1),
+        "decoder_QKV": _Buf(10, 1),
+        "decoder_gate_merged": _Buf(11, 1),
+        "x_normed_buf": _Buf(12, 1),
+        "vision_patches_b2": _Buf(101, 1),
+        "vision_x_b2": _Buf(102, 1),
+        "vision_QKV_b2": _Buf(103, 1),
+        "vision_x_norm_b2": _Buf(104, 1),
+        "vision_hidden_b2": _Buf(105, 1),
+        "encoder_x_b2": _Buf(106, 1),
+        "encoder_QKV_b2": _Buf(107, 1),
+        "encoder_gate_merged_b2": _Buf(108, 1),
+        "encoder_x_norm_b2": _Buf(109, 1),
+        "decoder_QKV_b2": _Buf(110, 1),
+        "decoder_gate_merged_b2": _Buf(111, 1),
+        "x_normed_buf_b2": _Buf(112, 1),
+        "vis_act_fp8": _Buf(201, pipe.vision_seq * VIS_D),
+        "vis_act_fp8_large": _Buf(202, pipe.vision_seq * VIS_H),
+        "vis_act_fp8_b2": _Buf(211, batched_slack * pipe.vision_seq * VIS_D),
+        "vis_act_fp8_large_b2": _Buf(212, batched_slack * pipe.vision_seq * VIS_H),
+        "vis_act_scale": _Buf(203, 4),
+        "enc_act_fp8": _Buf(301, pipe.encoder_seq_len * ENC_D),
+        "enc_act_fp8_large": _Buf(302, pipe.encoder_seq_len * 2 * ENC_H),
+        "enc_act_fp8_b2": _Buf(311, batched_slack * pipe.encoder_seq_len * ENC_D),
+        "enc_act_fp8_large_b2": _Buf(
+            312, batched_slack * pipe.encoder_seq_len * 2 * ENC_H),
+        "enc_act_scale": _Buf(303, 4),
+        "dec_act_fp8": _Buf(401, pipe.chunk_size * DEC_D),
+        "dec_act_fp8_large": _Buf(402, pipe.chunk_size * 2 * DEC_H),
+        "dec_act_fp8_b2": _Buf(411, batched_slack * pipe.chunk_size * DEC_D),
+        "dec_act_fp8_large_b2": _Buf(412, batched_slack * pipe.chunk_size * 2 * DEC_H),
+        "dec_act_scale": _Buf(403, 4),
+    }
+
+
+def test_autotune_uses_large_decoder_fp8_scratch_for_attn_o():
+    pipe = _setup_pi05_pipe(Pi05Pipeline)
+    _set_base_test_bufs(pipe)
+    pipe._autotune_fp8_matmul = Mock()
+
+    Pi05Pipeline.autotune_gemms(pipe)
+
+    decoder_attn_o = [
+        call.args for call in pipe._autotune_fp8_matmul.call_args_list
+        if call.args[3:6] == (pipe.chunk_size, DEC_D, DEC_NH * DEC_HD)
+    ]
+    assert decoder_attn_o, "decoder attn_o FP8 autotune shape was not visited"
+    assert decoder_attn_o[0][0] == pipe.bufs["dec_act_fp8_large"].ptr.value
+
+
+def test_batched_autotune_uses_size_based_decoder_fp8_scratch_for_attn_o(
+        monkeypatch):
+    pipe = _setup_pi05_pipe(Pi05BatchedPipeline)
+    _set_batched_test_bufs(pipe)
+    pipe._autotune_fp8_matmul = Mock()
+
+    monkeypatch.setattr(Pi05Pipeline, "autotune_gemms", lambda self: None)
+    Pi05BatchedPipeline.autotune_gemms(pipe)
+
+    decoder_attn_o = [
+        call.args for call in pipe._autotune_fp8_matmul.call_args_list
+        if call.args[3:6] == (pipe.B * pipe.chunk_size, DEC_D, DEC_NH * DEC_HD)
+    ]
+    assert decoder_attn_o, (
+        "batched decoder attn_o FP8 autotune shape was not visited")
+    assert decoder_attn_o[0][0] == pipe.bufs["dec_act_fp8_large_b2"].ptr.value
+
+
+def test_batched_autotune_runs_b2_shapes_only_once(monkeypatch):
+    pipe = _setup_pi05_pipe(Pi05BatchedPipeline)
+    _set_batched_test_bufs(pipe)
+    pipe._autotune_fp8_matmul = Mock()
+
+    monkeypatch.setattr(Pi05Pipeline, "autotune_gemms", lambda self: None)
+
+    Pi05BatchedPipeline.autotune_gemms(pipe)
+    first_count = pipe._autotune_fp8_matmul.call_count
+    Pi05BatchedPipeline.autotune_gemms(pipe)
+
+    assert first_count > 0
+    assert pipe._autotune_fp8_matmul.call_count == first_count
+    assert pipe._gemms_autotuned_b2 is True
+    assert pipe._cudart.cudaDeviceSynchronize.call_count == 1
+
+
+def test_fp8_nk_layout_dispatches_to_nt_entrypoints():
+    pipe = Pi05Pipeline.__new__(Pi05Pipeline)
+    pipe.fp8_layout = "nk"
+    pipe.gemm = SimpleNamespace(
+        fp8_nt_dev=Mock(),
+        autotune_fp8_nt_dev=Mock(),
+        fp8_nn_dev=Mock(),
+        autotune_fp8_nn_dev=Mock(),
+    )
+
+    pipe._fp8_matmul(11, 12, 13, 14, 15, 16, 17, 18, 19)
+    pipe._autotune_fp8_matmul(21, 22, 23, 24, 25, 26, 27, 28)
+
+    pipe.gemm.fp8_nt_dev.assert_called_once_with(
+        11, 12, 13, 14, 15, 16, 17, 18, stream=19)
+    pipe.gemm.autotune_fp8_nt_dev.assert_called_once_with(
+        21, 22, 23, 24, 25, 26, 27, 28)
+    pipe.gemm.fp8_nn_dev.assert_not_called()
+    pipe.gemm.autotune_fp8_nn_dev.assert_not_called()
+
+
+def test_gemmrunner_sm89_fp8_nt_surface_exists():
+    try:
+        from flash_rt import flash_rt_kernels as fvk
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"flash_rt_kernels is not built: {exc}")
+    assert hasattr(fvk, "GemmRunner")
+    missing = [
+        name for name in ("fp8_nt_dev", "autotune_fp8_nt_dev")
+        if not hasattr(fvk.GemmRunner, name)
+    ]
+    assert not missing, f"GemmRunner missing FP8 NT symbols: {missing}"


### PR DESCRIPTION
## Summary

This PR fixes the current SM89 Pi0.5 FP8 regression and keeps the scope tight:

1. restore the missing SM89 `nk -> fp8_nt_dev` / `autotune_fp8_nt_dev` binding and cuBLASLt path in `GemmRunner`
2. fix Pi0.5 FP8 autotune scratch selection to use the existing size-based scratch helpers instead of the old `K == *_H` heuristic
3. apply the same size-based autotune scratch fix to the batched RTX path and add a minimal B=2 autotune one-shot guard
4. add regression coverage for base/batched scratch selection, SM89 `nk` dispatch, the B=2 one-shot guard, and the pybind symbol surface

Closes #91.

## Scope

- fixes the default SM89 Pi0.5 FP8 path and the matching batched RTX autotune path
- intentionally does not expand into `pipeline_rtx_fp16.py`, because the public FP16 path explicitly rejects `use_fp8=True` and that dormant branch is outside the supported runtime contract for this PR
- does not include local-only debugging assets, profiling artifacts, or `eval_libero.py` follow-up work

## Validation Environment

- GPU: NVIDIA GeForce RTX 4090
- compute capability: SM89 (`8.9`)
- driver: `550.54.14`
- CUDA toolkit: `12.4` (`nvcc 12.4.99`)
- PyTorch: `2.6.0+cu124`
- framework path validated here: `torch`

## Validation

### Kernel binding / import check

Confirmed the locally built extension imports from the source tree and exposes the restored symbols:

```bash
python - <<'PY'
from flash_rt import flash_rt_kernels as fvk
print(fvk.__file__)
print(hasattr(fvk.GemmRunner, 'fp8_nt_dev'))
print(hasattr(fvk.GemmRunner, 'autotune_fp8_nt_dev'))
PY
```

Observed result:

- imports from `flash_rt/flash_rt_kernels.cpython-310-x86_64-linux-gnu.so`
- `has_fp8_nt_dev == True`
- `has_autotune_fp8_nt_dev == True`

### Focused regression test

```bash
python -m pytest tests/test_pi05_rtx_autotune_scratch.py -q
```

Observed result:

- `5 passed in 0.17s`

### Precision comparison

#### Base path: FP8 vs FP16 baseline on the same fixed noise

Ran two isolated subprocesses through the public API on the same checkpoint,
same observation, same prompt, and the same injected `(10, 32)` diffusion noise.
Compared the final `(10, 7)` action outputs.

Observed result:

- action cosine (`fp8` vs `fp16` baseline): `0.998742`
- max abs diff: `0.064743`
- mean abs diff: `0.013287`

#### Batched path: B=2 slot-0 vs serial B=1

```bash
PI05_LIBERO_PYTORCH_CHECKPOINT=/data/home/tianjianyang/models/vla/pi05-libero \
python -m pytest tests/test_pi05_batched_precision.py -q -s
```

Observed result:

- `1 passed in 38.75s`
- this gate asserts batched Pi0.5 slot-0 cosine vs serial B=1 remains `>= 0.99`

### Runtime quickstart: FP8

```bash
python examples/quickstart.py \
  --checkpoint /data/home/tianjianyang/models/vla/pi05-libero \
  --config pi05 \
  --framework torch \
  --hardware rtx_sm89 \
  --benchmark 5 \
  --warmup 20
```

Observed result:

- output sanity: `PASS`
- prompt reuse: `OK`
- wall-clock benchmark: `P50 41.3 ms (24 Hz)`
- min/mean/max: `37.5 / 42.2 / 49.5 ms`

### Runtime quickstart: FP16 baseline

```bash
python examples/quickstart.py \
  --checkpoint /data/home/tianjianyang/models/vla/pi05-libero \
  --config pi05 \
  --framework torch \
  --hardware rtx_sm89 \
  --use_fp16 \
  --benchmark 5 \
  --warmup 20
```

Observed result:

- output sanity: `PASS`
- prompt reuse: `OK`
- wall-clock benchmark: `P50 51.1 ms (20 Hz)`
- min/mean/max: `46.4 / 49.4 / 51.4 ms`

## Limitations / Not Covered Here

- This PR was validated locally on SM89 / RTX 4090 only.
- I did not run per-architecture rebuild/import checks for other `GPU_ARCH` families in this environment.
- I did not run the larger precision suites that require additional local fixtures / checkpoints beyond this Pi0.5 runtime path.
- `pipeline_rtx_fp16.py` contains a dormant internal FP8 branch with similar old heuristic logic, but the public FP16 path explicitly rejects `use_fp8=True`; that branch is intentionally left out of scope for this PR.
