### PR TITLE
Fix/pi05 thor fixed state

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -115,7 +115,7 @@ actions = model.predict(
 
 State changes update the prompt embeddings. Because the discretized state is
 rendered into the prompt, its token length drifts with the state values. The
-RTX Pi0.5 frontend offers two strategies via `state_prompt_mode`:
+Pi0.5 RTX/Thor frontends offer two strategies via `state_prompt_mode`:
 
 **`"exact"` (default) — per-length capture + manual warmup.**
 A separate pipeline is captured per exact prompt length and cached, so a
@@ -136,25 +136,25 @@ warmed = model.warm_state_prompt_buckets(
 
 **`"fixed"` (opt-in) — one graph, no warmup.**
 ONE pipeline and ONE captured CUDA Graph at the max prompt length serve every
-length: the padded prefix keys are masked (FlashAttention-2 `seqused_k`) and the
-decoder's action K/V are appended right after the *valid* prefix
-(`qkv_split_rope_devpos`), so a changing state-token length **never re-captures
-a graph or reruns autotune** — no warmup needed. The trade-off is latency:
-every inference runs at the padded max length, so `"fixed"` is ~+1.0 ms (2
-views) / +1.2 ms (3 views) slower than `"exact"` at a typical prompt length
-(measured fp8, RTX 5090; the decoder joint-attention uses a graph-safe
-split-KV kernel that keeps the padding overhead small). That ~1 ms makes
+length: padded prefix keys are masked with a device-side valid length and the
+decoder's action K/V are appended right after the *valid* prefix, so a changing
+state-token length **never re-captures a graph or reruns autotune** — no warmup
+needed. The trade-off is latency: every inference runs at the padded max length.
+On Thor, keeping `state_prompt_fixed_max_len` close to the actual maximum
+(for example 120 for a 117-token prompt) normally costs about 1 ms versus a
+warmed exact graph; larger caps pay for the extra padded tokens. That makes
 `"fixed"` the low-friction choice when the state-token length drifts: zero
 recapture, no length enumeration. Prefer `"exact"` + `warm_state_prompt_buckets()`
 only when you need absolute peak latency at a known, stable set of lengths.
-(Lowering `PI05_STATE_PROMPT_MAX_LEN` toward your real maximum shrinks the
-padding and the gap further.) Enable `"fixed"` like so:
+Enable `"fixed"` like so:
 
 ```python
 model = flash_rt.load_model(
     checkpoint="/path/to/pi05", framework="torch", config="pi05",
-    state_prompt_mode="fixed")
+    state_prompt_mode="fixed",
+    state_prompt_fixed_max_len=120)  # choose a cap >= your observed max
 # or, without code changes: FLASHRT_PI05_STATE_PROMPT_MODE=fixed
+# set FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN=120 to tune the cap in serving
 # predict() handles any state length with a single captured graph
 ```
 
@@ -227,7 +227,8 @@ model = flash_rt.load_model(
 | `vision_pool_factor` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Spatial pooling factor for vision tokens. The FP16 RTX path currently supports only `1`. |
 | `vision_num_layers` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Number of SigLIP vision layers to run. |
 | `cache_frames` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Temporal encoder K/V cache period; `1` means no temporal reuse. |
-| `state_prompt_mode` | `str` | `"exact"` | Pi0.5 torch RTX. State-in-prompt graph strategy: `"exact"` (per-length capture + `warm_state_prompt_buckets()`) or `"fixed"` (one graph at the max length, no recapture; ~+4.6 ms/2v, +6.7 ms/3v). Env override `FLASHRT_PI05_STATE_PROMPT_MODE`. See [Pi0.5 State Prompts](#pi05-state-prompts). |
+| `state_prompt_mode` | `str` | `"exact"` | Pi0.5 RTX/Thor. State-in-prompt graph strategy: `"exact"` (exact prompt length; RTX can pre-warm recurring buckets) or `"fixed"` (one graph at a configured max length, no recapture). Env override `FLASHRT_PI05_STATE_PROMPT_MODE`. See [Pi0.5 State Prompts](#pi05-state-prompts). |
+| `state_prompt_fixed_max_len` | `int\|None` | `None` | Pi0.5 Thor fixed mode. `None` keeps the default 200-token cap; set a lower cap when serving can bound the state-prompt length. The cap must be >= the actual token length. Env override `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`. |
 
 ### Pi0.5 state prompt bucket warmup
 

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -1236,6 +1236,27 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("S"), py::arg("Q_dim"), py::arg("K_dim"), py::arg("HD"), py::arg("qkv_stride"),
        py::arg("kc_offset"), py::arg("kc_stride"), py::arg("stream") = 0);
 
+    // QKV Split + RoPE + KV Cache (FP16) with runtime device K/V row offset.
+    // Same shape contract as qkv_split_rope_kvcache_fp16; K/V row =
+    // devpos[0] + token row inside the layer slab.
+    m.def("qkv_split_rope_kvcache_fp16_devpos", [](uintptr_t qkv, uintptr_t rope,
+                                              uintptr_t Q, uintptr_t Kc, uintptr_t Vc,
+                                              uintptr_t devpos,
+                                              int S, int Q_dim, int K_dim, int HD, int qkv_stride,
+                                              int kc_offset, int kc_stride, uintptr_t stream) {
+        qkv_split_rope_kvcache_fp16_devpos(reinterpret_cast<const __half*>(qkv),
+                                     reinterpret_cast<const __half*>(rope),
+                                     reinterpret_cast<__half*>(Q),
+                                     reinterpret_cast<__half*>(Kc),
+                                     reinterpret_cast<__half*>(Vc),
+                                     reinterpret_cast<const int*>(devpos),
+                                     S, Q_dim, K_dim, HD, qkv_stride,
+                                     kc_offset, kc_stride, to_stream(stream));
+    }, py::arg("qkv"), py::arg("rope"), py::arg("Q"), py::arg("Kc"), py::arg("Vc"),
+       py::arg("devpos"),
+       py::arg("S"), py::arg("Q_dim"), py::arg("K_dim"), py::arg("HD"), py::arg("qkv_stride"),
+       py::arg("kc_offset"), py::arg("kc_stride"), py::arg("stream") = 0);
+
     // Elementwise FP16
     m.def("bias_residual_fp16", [](uintptr_t residual, uintptr_t x, uintptr_t bias,
                                     int seq_len, int dim, uintptr_t stream) {
@@ -1562,6 +1583,26 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("logits"), py::arg("out"),
        py::arg("S"), py::arg("S_kv"), py::arg("NH"), py::arg("HD"),
        py::arg("attn_scale") = 1.0f, py::arg("stream") = 0);
+
+    // Fixed-shape cuBLAS decomposed attention. S_kv_max is graph-captured;
+    // seqused_k is a device int32[1] containing the valid K/V rows.
+    m.def("attention_qkv_fp16_seqused", [](FvkContext& ctx, uintptr_t Q, uintptr_t K, uintptr_t V,
+                                    uintptr_t logits, uintptr_t out,
+                                    int S, int S_kv_max, int NH, int HD,
+                                    uintptr_t seqused_k, float attn_scale, uintptr_t stream) {
+        attention_qkv_fp16_seqused(ctx.cublas_handle,
+                            reinterpret_cast<const __half*>(Q),
+                            reinterpret_cast<const __half*>(K),
+                            reinterpret_cast<const __half*>(V),
+                            reinterpret_cast<__half*>(logits),
+                            reinterpret_cast<__half*>(out),
+                            S, S_kv_max, NH, HD,
+                            reinterpret_cast<const int*>(seqused_k),
+                            attn_scale, to_stream(stream));
+    }, py::arg("ctx"), py::arg("Q"), py::arg("K"), py::arg("V"),
+       py::arg("logits"), py::arg("out"),
+       py::arg("S"), py::arg("S_kv_max"), py::arg("NH"), py::arg("HD"),
+       py::arg("seqused_k"), py::arg("attn_scale") = 1.0f, py::arg("stream") = 0);
 
     // Padded attention: supports odd S_kv (pads logits lda to even).
     // logits buffer must have room for S*NH * (S_kv + S_kv%2) elements.

--- a/csrc/kernels/attention_cublas.cu
+++ b/csrc/kernels/attention_cublas.cu
@@ -68,6 +68,73 @@ void attention_qkv_fp16(
         CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
 }
 
+// Mask rows [seqused_k[0], S_kv_max) in every logits column.
+// logits is col-major [S_kv_max, S*NH].
+__global__ void mask_seqused_logits_kernel(
+    __half* logits, int S_kv_max, int S_NH, const int* __restrict__ seqused_k)
+{
+    int valid = seqused_k[0];
+    if (valid < 0) valid = 0;
+    if (valid > S_kv_max) valid = S_kv_max;
+    int mask_rows = S_kv_max - valid;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = S_NH * mask_rows;
+    if (idx >= total) return;
+    int col = idx / mask_rows;
+    int row = valid + (idx % mask_rows);
+    logits[col * S_kv_max + row] = __float2half(-65504.0f);
+}
+
+void mask_seqused_logits_fp16(__half* logits, int S_kv_max, int S_NH,
+                              const int* seqused_k, cudaStream_t stream) {
+    // Launch even when valid == S_kv_max; the kernel exits with total=0.
+    int total = S_NH * S_kv_max;
+    if (total > 0) {
+        mask_seqused_logits_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
+            logits, S_kv_max, S_NH, seqused_k);
+    }
+}
+
+void attention_qkv_fp16_seqused(
+    cublasHandle_t handle,
+    const __half* Q,
+    const __half* K,
+    const __half* V,
+    __half* logits,
+    __half* out,
+    int S, int S_kv_max, int NH, int HD,
+    const int* seqused_k,
+    float attn_scale,
+    cudaStream_t stream)
+{
+    cublasSetStream(handle, stream);
+
+    float zero = 0.0f;
+    cublasGemmEx(handle,
+        CUBLAS_OP_T, CUBLAS_OP_N,
+        S_kv_max, S * NH, HD,
+        &attn_scale,
+        K, CUDA_R_16F, HD,
+        Q, CUDA_R_16F, HD,
+        &zero,
+        logits, CUDA_R_16F, S_kv_max,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+
+    mask_seqused_logits_fp16(logits, S_kv_max, S * NH, seqused_k, stream);
+    softmax_fp16(logits, S * NH, S_kv_max, stream);
+
+    float one = 1.0f;
+    cublasGemmEx(handle,
+        CUBLAS_OP_N, CUBLAS_OP_N,
+        HD, S * NH, S_kv_max,
+        &one,
+        V, CUDA_R_16F, HD,
+        logits, CUDA_R_16F, S_kv_max,
+        &zero,
+        out, CUDA_R_16F, HD,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+}
+
 
 // Combined mask kernel: pad column + state mask in one launch.
 // logits is col-major [S_kv_pad, S_NH].

--- a/csrc/kernels/attention_cublas.cuh
+++ b/csrc/kernels/attention_cublas.cuh
@@ -22,6 +22,21 @@ void attention_qkv_fp16(
     float attn_scale,        // 1/sqrt(HD)
     cudaStream_t stream = 0);
 
+// Fixed-shape attention with a device-side valid K/V length.
+// QK and PV keep the graph-captured S_kv_max shape; logits rows
+// [seqused_k[0], S_kv_max) are masked before softmax.
+void attention_qkv_fp16_seqused(
+    cublasHandle_t handle,
+    const __half* Q,         // (S*NH, HD)
+    const __half* K,         // (S_kv_max, HD)
+    const __half* V,         // (S_kv_max, HD)
+    __half* logits,          // scratch: (S*NH, S_kv_max)
+    __half* out,             // (S*NH, HD)
+    int S, int S_kv_max, int NH, int HD,
+    const int* seqused_k,    // device int32[1], valid K/V rows
+    float attn_scale,
+    cudaStream_t stream = 0);
+
 // Same as attention_qkv_fp16 but supports ODD S_kv.
 // Internally pads logits leading dimension to even for __half2 alignment.
 // logits buffer must have room for S*NH * (S_kv+1) elements when S_kv is odd.

--- a/csrc/kernels/rope.cu
+++ b/csrc/kernels/rope.cu
@@ -344,3 +344,67 @@ void qkv_split_rope_kvcache_fp16(
         qkv, rope, Q, Kc, Vc, S, Q_dim, K_dim, HD, qkv_stride,
         kc_offset, kc_stride);
 }
+
+__global__ void qkv_split_rope_kvcache_fp16_devpos_kernel(
+    const __half* __restrict__ qkv, const __half* __restrict__ rope,
+    __half* __restrict__ Q, __half* __restrict__ Kc, __half* __restrict__ Vc,
+    const int* __restrict__ devpos,
+    int S, int Q_dim, int K_dim, int HD, int qkv_stride,
+    int kc_offset, int kc_stride) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = S * qkv_stride;
+    if (idx >= total) return;
+    int s = idx / qkv_stride;
+    int c = idx % qkv_stride;
+    int pos = devpos[0];
+
+    if (c < Q_dim) {
+        int d_in_head = c % HD;
+        int pair = d_in_head / 2;
+        int is_odd = d_in_head & 1;
+        int pair_base = s * qkv_stride + (c / HD) * HD + pair * 2;
+        float x0 = __half2float(qkv[pair_base]);
+        float x1 = __half2float(qkv[pair_base + 1]);
+        int rope_base = s * HD + pair * 2;
+        float cos_v = __half2float(rope[rope_base]);
+        float sin_v = __half2float(rope[rope_base + 1]);
+        if (is_odd == 0)
+            Q[s * Q_dim + c] = __float2half(x0 * cos_v - x1 * sin_v);
+        else
+            Q[s * Q_dim + c] = __float2half(x1 * cos_v + x0 * sin_v);
+    } else if (c < Q_dim + K_dim) {
+        int k_col = c - Q_dim;
+        int pair = k_col / 2;
+        int is_odd = k_col & 1;
+        int pair_base = s * qkv_stride + Q_dim + pair * 2;
+        float x0 = __half2float(qkv[pair_base]);
+        float x1 = __half2float(qkv[pair_base + 1]);
+        int rope_base = s * HD + pair * 2;
+        float cos_v = __half2float(rope[rope_base]);
+        float sin_v = __half2float(rope[rope_base + 1]);
+        __half val;
+        if (is_odd == 0)
+            val = __float2half(x0 * cos_v - x1 * sin_v);
+        else
+            val = __float2half(x1 * cos_v + x0 * sin_v);
+        Kc[kc_offset + (pos + s) * kc_stride + k_col] = val;
+    } else {
+        int v_col = c - Q_dim - K_dim;
+        Vc[kc_offset + (pos + s) * kc_stride + v_col] = qkv[idx];
+    }
+}
+
+void qkv_split_rope_kvcache_fp16_devpos(
+    const __half* qkv, const __half* rope,
+    __half* Q, __half* Kc, __half* Vc,
+    const int* devpos,
+    int S, int Q_dim, int K_dim, int HD, int qkv_stride,
+    int kc_offset, int kc_stride,
+    cudaStream_t stream) {
+    int total = S * qkv_stride;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    qkv_split_rope_kvcache_fp16_devpos_kernel<<<blocks, threads, 0, stream>>>(
+        qkv, rope, Q, Kc, Vc, devpos, S, Q_dim, K_dim, HD, qkv_stride,
+        kc_offset, kc_stride);
+}

--- a/csrc/kernels/rope.cuh
+++ b/csrc/kernels/rope.cuh
@@ -52,3 +52,13 @@ void qkv_split_rope_kvcache_fp16(
     int S, int Q_dim, int K_dim, int HD, int qkv_stride,
     int kc_offset, int kc_stride,
     cudaStream_t stream = 0);
+
+// Same FP16 math and argument contract as qkv_split_rope_kvcache_fp16, but
+// K/V write rows are shifted by device-side devpos[0] within the layer slab.
+void qkv_split_rope_kvcache_fp16_devpos(
+    const __half* qkv, const __half* rope,
+    __half* Q, __half* Kc, __half* Vc,
+    const int* devpos,
+    int S, int Q_dim, int K_dim, int HD, int qkv_stride,
+    int kc_offset, int kc_stride,
+    cudaStream_t stream = 0);

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -50,6 +50,7 @@ def load_model(
     vision_num_layers: int | None = None,
     cache_frames: int | None = None,
     state_prompt_mode: str = "exact",
+    state_prompt_fixed_max_len: int | None = None,
     # Frontends with an FP8/BF16 switch:
     use_fp8: bool = True,
     # Pi0.5 torch RTX SM120/SM89 opt-in:
@@ -74,7 +75,16 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   execution. `"exact"` tracks the exact token length (RTX caches recurring
   lengths; Thor reuses same-length updates). `"fixed"` captures one max-length
   graph and masks padded state-prompt tokens with a device-side valid length;
-  use it when live robot state changes make token lengths drift.
+  use it when live robot state changes make token lengths drift. The default
+  remains `"exact"`, so existing calls keep the exact-length path and the
+  50-step Pi0.5 action graph is unchanged.
+- `state_prompt_fixed_max_len` applies only to Pi0.5 Thor fixed mode. `None`
+  keeps the default 200-token state-prompt cap; serving code can lower it when
+  it knows the live state-prompt bound. The cap must cover the actual token
+  length. On Thor, a close cap such as 120 for a 117-token prompt measured
+  roughly a 1 ms normal overhead versus a warmed exact graph, while larger caps
+  pay for the extra padded tokens. It can also be set with
+  `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`.
 - `use_fp8=False` disables FP8 where the selected frontend exposes a
   BF16 fallback; unsupported frontends ignore it.
 - `use_fp16=True` selects the opt-in Pi0.5 torch RTX SM120/SM89 full-FP16

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -39,7 +39,7 @@ def load_model(
     # GROOT-specific:
     embodiment_tag: str | None = None,
     action_horizon: int | None = None,
-    # Pi0.5 torch-specific:
+    # Pi0.5-specific:
     use_fp4: bool = False,
     fp4_layers: tuple[int, ...] | None = None,
     use_awq: bool | None = None,
@@ -49,6 +49,7 @@ def load_model(
     vision_pool_factor: int | None = None,
     vision_num_layers: int | None = None,
     cache_frames: int | None = None,
+    state_prompt_mode: str = "exact",
     # Frontends with an FP8/BF16 switch:
     use_fp8: bool = True,
     # Pi0.5 torch RTX SM120/SM89 opt-in:
@@ -69,6 +70,11 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   parameters today. The Pi0.5 torch RTX/Orin frontend validates
   `vision_pool_factor in {1, 2, 4}`, `vision_num_layers in [1, 27]`, and
   `cache_frames >= 1`.
+- `state_prompt_mode` applies to Pi0.5 RTX/Thor state-in-prompt
+  execution. `"exact"` tracks the exact token length (RTX caches recurring
+  lengths; Thor reuses same-length updates). `"fixed"` captures one max-length
+  graph and masks padded state-prompt tokens with a device-side valid length;
+  use it when live robot state changes make token lengths drift.
 - `use_fp8=False` disables FP8 where the selected frontend exposes a
   BF16 fallback; unsupported frontends ignore it.
 - `use_fp16=True` selects the opt-in Pi0.5 torch RTX SM120/SM89 full-FP16
@@ -141,8 +147,9 @@ class VLAModel:
     convention: normalized in-range values usually become 0..255, while
     values below -1 become -1. RTX/Thor torch frontends and the JAX Thor
     Pi0.5 frontend accept `state` in `set_prompt()` and through `predict()`.
-    Same-length state prompt updates reuse the captured graph; recurring
-    RTX prompt lengths reuse the cached pipeline instead of rebuilding.
+    Same-length state prompt updates reuse the captured graph. RTX exact mode
+    reuses cached recurring prompt lengths; RTX/Thor fixed mode uses one
+    max-length graph for drifting state-token lengths.
   - Pi0-FAST encodes state in the FAST token prefix.
   - GROOT N1.6 consumes proprioceptive state from `obs["state"]`; if omitted,
     the backend uses zeros.

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -297,7 +297,8 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                cache_frames=None,
                use_fp16=False,
                use_fp8=True,
-               state_prompt_mode="exact"):
+               state_prompt_mode="exact",
+               state_prompt_fixed_max_len=None):
     """Load a FlashRT model.
 
     Args:
@@ -400,6 +401,13 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 prefer ``"exact"`` + warmup for absolute peak latency at known
                 lengths.
             Env override: ``FLASHRT_PI05_STATE_PROMPT_MODE``.
+        state_prompt_fixed_max_len: Pi0.5 Thor fixed mode only. Padded
+            state-prompt token capacity used when ``state_prompt_mode="fixed"``.
+            ``None`` keeps the frontend default (200 tokens). Lower this when
+            the serving stack can bound the live state prompt length; for
+            example, a cap near the actual length (120 vs. 117 tokens) measured
+            about a 1 ms normal overhead on Thor versus warmed exact mode.
+            Env override: ``FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN``.
 
     Returns:
         VLAModel instance with .predict() method.
@@ -616,6 +624,9 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         # capture) / "fixed" (opt-in, one graph). Forwarded only if accepted.
         if "state_prompt_mode" in sig.parameters:
             kwargs["state_prompt_mode"] = state_prompt_mode
+        if (state_prompt_fixed_max_len is not None and
+                "state_prompt_fixed_max_len" in sig.parameters):
+            kwargs["state_prompt_fixed_max_len"] = state_prompt_fixed_max_len
         # FP4 frontend accepts these extra kwargs (only set when the class
         # actually accepts them — base class ignores, FP4 subclass uses).
         if use_fp4 and "use_fp4_encoder_ffn" in sig.parameters:

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -379,22 +379,26 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             1 runs the full vision+encoder+decoder path on every frame; 2
             alternates full and decoder-only frames. ``None`` keeps the
             frontend default.
-        state_prompt_mode: Pi0.5 torch RTX only. How the variable-length
+        state_prompt_mode: Pi0.5 RTX/Thor only. How the variable-length
             state-in-prompt is mapped to CUDA graphs:
-              ``"exact"`` (default) — one captured graph per exact prompt
-                length, cached; pair with ``warm_state_prompt_buckets()`` to
-                front-load the lengths you expect. Unchanged legacy behavior.
+              ``"exact"`` (default) — graph shape tracks the exact prompt
+                length. RTX caches recurring lengths and can front-load them
+                with ``warm_state_prompt_buckets()``; Thor reuses same-length
+                updates and recaptures when the exact length changes.
               ``"fixed"`` — ONE graph at the max prompt length serves every
-                length (padded prefix masked via FA2 ``seqused_k`` + decoder
-                K/V appended at the valid offset); a changing length never
-                re-captures and no warmup is needed. Requires the vendored
-                bf16 FA2 path (``FVK_RTX_FA2=1``, encoder+decoder sites on).
+                length (padded prefix masked by a device-side valid length +
+                decoder K/V appended at the valid offset); a changing length
+                never re-captures and no warmup is needed. RTX uses the
+                vendored bf16 FA2 path; Thor uses its cuBLAS-decomposed
+                attention path.
                 Cost: every inference runs at the padded max length, so it is
                 ~1 ms slower than a warmed ``"exact"`` graph (split-KV decoder
-                joint-attention keeps the padding overhead small). Prefer
-                ``"fixed"`` when the state-token length drifts and you'd rather
-                not enumerate/warm lengths; prefer ``"exact"`` + warmup for
-                absolute peak latency at known lengths.
+                joint-attention keeps the padding overhead small on RTX; Thor
+                uses its cuBLAS-decomposed attention path with device-side
+                valid-length masking). Prefer ``"fixed"`` when the state-token
+                length drifts and you'd rather not enumerate/warm lengths;
+                prefer ``"exact"`` + warmup for absolute peak latency at known
+                lengths.
             Env override: ``FLASHRT_PI05_STATE_PROMPT_MODE``.
 
     Returns:

--- a/flash_rt/core/thor_frontend_utils.py
+++ b/flash_rt/core/thor_frontend_utils.py
@@ -14,6 +14,7 @@ Stage 5 rollout adds functions incrementally:
 from __future__ import annotations
 
 import os
+from functools import lru_cache
 
 import numpy as np
 
@@ -76,11 +77,22 @@ def _tokenize_sentencepiece(prompt_text: str):
     command if the file is missing — see
     USAGE.md → 'PaliGemma tokenizer setup' for details.
     """
+    sp = _paligemma_sentencepiece()
+    return [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+
+
+@lru_cache(maxsize=1)
+def _paligemma_sentencepiece():
     from flash_rt.utils.paligemma_tokenizer import (
         load_paligemma_sentencepiece,
     )
-    sp = load_paligemma_sentencepiece()
-    return [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+    return load_paligemma_sentencepiece()
+
+
+@lru_cache(maxsize=4)
+def _openpi_paligemma_tokenizer(max_len: int):
+    from openpi.models.tokenizer import PaligemmaTokenizer
+    return PaligemmaTokenizer(max_len=max_len)
 
 
 def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48,
@@ -98,8 +110,7 @@ def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48,
     import torch.nn.functional as F
 
     try:
-        from openpi.models.tokenizer import PaligemmaTokenizer
-        tokenizer = PaligemmaTokenizer(max_len=max_len)
+        tokenizer = _openpi_paligemma_tokenizer(int(max_len))
         tokens_np, mask_np = tokenizer.tokenize(prompt_text, state=state)
         prompt_len = int(mask_np.sum())
         token_ids = torch.tensor(
@@ -108,10 +119,7 @@ def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48,
         if state is None:
             tokens = _tokenize_sentencepiece(prompt_text)
         else:
-            from flash_rt.utils.paligemma_tokenizer import (
-                load_paligemma_sentencepiece,
-            )
-            sp = load_paligemma_sentencepiece()
+            sp = _paligemma_sentencepiece()
             tokens = sp.Encode(format_pi05_prompt(prompt_text, state),
                                add_bos=True)
         token_ids = torch.tensor(tokens, dtype=torch.long, device='cuda')
@@ -125,16 +133,13 @@ def embed_prompt_torch(prompt_text, embedding_weight, max_len: int = 48,
 
 
 def embed_prompt_numpy(prompt_text, embedding_weight_np, max_len: int = 48,
-                       state=None):
+                       state=None, already_scaled: bool = False):
     """Numpy-side tokenize + embed (used by JAX frontends).
 
     No torch dependency. Returns (embeds_fp16_np, prompt_len).
     """
     if state is not None:
-        from flash_rt.utils.paligemma_tokenizer import (
-            load_paligemma_sentencepiece,
-        )
-        sp = load_paligemma_sentencepiece()
+        sp = _paligemma_sentencepiece()
         tokens = sp.Encode(format_pi05_prompt(prompt_text, state),
                            add_bos=True)
     else:
@@ -142,5 +147,6 @@ def embed_prompt_numpy(prompt_text, embedding_weight_np, max_len: int = 48,
     token_ids = np.array(tokens, dtype=np.int32)
     prompt_len = len(token_ids)
     embeds = embedding_weight_np[token_ids]
-    embeds = embeds * float(embeds.shape[-1] ** 0.5)
+    if not already_scaled:
+        embeds = embeds * float(embeds.shape[-1] ** 0.5)
     return embeds.astype(np.float16), prompt_len

--- a/flash_rt/frontends/jax/pi05_thor.py
+++ b/flash_rt/frontends/jax/pi05_thor.py
@@ -63,7 +63,8 @@ class Pi05JaxFrontendThor:
 
     def __init__(self, checkpoint_dir, engine_path=None, fmha_path=None,
                  use_cuda_graph=True, num_views=2, autotune=3,
-                 weight_cache=True, use_fp8=True, **kwargs):
+                 weight_cache=True, use_fp8=True,
+                 state_prompt_mode: str = "exact", **kwargs):
         """
         Args:
             autotune: CUDA Graph autotune trials per set_prompt().
@@ -80,6 +81,13 @@ class Pi05JaxFrontendThor:
 
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.use_fp8 = bool(use_fp8)
+        mode = os.environ.get("FLASHRT_PI05_STATE_PROMPT_MODE",
+                              state_prompt_mode)
+        if mode not in ("exact", "fixed"):
+            raise ValueError(
+                "state_prompt_mode must be 'exact' or 'fixed', "
+                f"got {mode!r}")
+        self._state_prompt_mode = mode
 
         # ── Load norm stats (openpi or lerobot HF release) ──
         from flash_rt.core.utils.norm_stats import (
@@ -147,6 +155,8 @@ class Pi05JaxFrontendThor:
         # ── State ──
         self._checkpoint_path = str(checkpoint_dir)
         self.current_prompt = None
+        self.current_prompt_len = 0
+        self._fixed_shape_active = False
         self.calibrated = False
         self._real_data_calibrated = False
 
@@ -202,8 +212,18 @@ class Pi05JaxFrontendThor:
         self.autotune = int(autotune) if autotune is not True else 3
         if autotune is False:
             self.autotune = 0
+        self.enc_seqused = CudaBuffer.device_empty(1, np.int32)
+        self.dec_seqused = CudaBuffer.device_empty(1, np.int32)
+        self.dec_devpos = CudaBuffer.device_empty(1, np.int32)
         self._rng_key = jax.random.PRNGKey(0)
         logger.info("JAX backend initialized (cache_hit=%s)", cache_hit)
+
+    def _set_fixed_control_values(self, enc_seqused: int, dec_seqused: int,
+                                  dec_devpos: int) -> None:
+        self.enc_seqused.upload(np.array([enc_seqused], dtype=np.int32))
+        self.dec_seqused.upload(np.array([dec_seqused], dtype=np.int32))
+        self.dec_devpos.upload(np.array([dec_devpos], dtype=np.int32))
+        self._sync()
 
     def _prefetch_weights(self):
         """Weights are already managed (cudaMallocManaged). No conversion needed.
@@ -356,6 +376,9 @@ class Pi05JaxFrontendThor:
 
         # Embedding: keep as numpy for _embed_prompt
         self._embedding_np = engine_w["encoder.embedding"].astype(fp16)
+        self._embedding_scaled_np = (
+            self._embedding_np * float(self._embedding_np.shape[-1] ** 0.5)
+        ).astype(fp16)
 
         _ainw = engine_w["action.in_proj.weight"].astype(fp16)
         _ainb = engine_w["action.in_proj.bias"].astype(fp16)
@@ -576,6 +599,9 @@ class Pi05JaxFrontendThor:
         # Numpy arrays
         for attr in self._CACHE_NUMPY:
             setattr(self, attr, _get_numpy(attr))
+        self._embedding_scaled_np = (
+            self._embedding_np * float(self._embedding_np.shape[-1] ** 0.5)
+        ).astype(fp16)
 
         # Per-layer numpy lists
         for attr in self._CACHE_NUMPY_LISTS:
@@ -679,17 +705,74 @@ class Pi05JaxFrontendThor:
             # Raw token IDs
             token_ids = np.asarray(prompt_text, dtype=np.int64)
             prompt_len = len(token_ids)
-            embeds_np = self._embedding_np[token_ids]
-            embeds_np = (embeds_np * float(embeds_np.shape[-1] ** 0.5)).astype(np.float16)
+            embeds_np = self._embedding_scaled_np[token_ids]
         else:
             max_len = PI05_STATE_PROMPT_MAX_LEN if state is not None else 48
             embeds_np, prompt_len = _embed_prompt(
-                prompt_text, self._embedding_np, max_len=max_len, state=state)
-        Se = S + prompt_len
-        if Se % 2 != 0:
-            Se += 1
+                prompt_text, self._embedding_scaled_np, max_len=max_len,
+                state=state, already_scaled=True)
+        fixed_shape = (
+            self._state_prompt_mode == "fixed"
+            and state is not None
+            and self._rl_config is None
+        )
+
+        if fixed_shape:
+            Se = S + PI05_STATE_PROMPT_MAX_LEN
+            if Se % 2 != 0:
+                Se += 1
+            actual_lang = Se - S
+            valid_lang = prompt_len
+            if (S + valid_lang) % 2 != 0:
+                valid_lang += 1
+            if valid_lang > actual_lang:
+                raise ValueError(
+                    f"prompt_len {prompt_len} exceeds fixed state prompt "
+                    f"capacity {actual_lang}")
+            padded = np.zeros(
+                (actual_lang, embeds_np.shape[1]), dtype=np.float16)
+            padded[:prompt_len] = embeds_np[:prompt_len]
+            if valid_lang > prompt_len:
+                padded[prompt_len:valid_lang] = embeds_np[-1:]
+            embeds_np = padded
+            valid_prefix = S + valid_lang
+        else:
+            Se = S + prompt_len
+            if Se % 2 != 0:
+                Se += 1
+            actual_lang = Se - S
+            if actual_lang > prompt_len:
+                embeds_np = np.concatenate([embeds_np, embeds_np[-1:]], axis=0)
+            valid_prefix = Se
+
+        if (hasattr(self, "siglip_graph") and hasattr(self, "enc_ae_graph")
+                and hasattr(self, "lang_emb") and self.S_lang == actual_lang
+                and self.Se == Se):
+            self.lang_emb.upload(embeds_np[:actual_lang].astype(fp16))
+            dec_start = valid_prefix if fixed_shape else Se
+            dec_rope_np = np.concatenate(
+                [self._kc_t[dec_start:dec_start+self.Sa, :, None],
+                 self._ks_t[dec_start:dec_start+self.Sa, :, None]], 2
+            ).reshape(self.Sa, 256)
+            self.dec_rope.upload(dec_rope_np.astype(fp16))
+            self._fixed_shape_active = fixed_shape
+            self.current_prompt_len = int(prompt_len)
+            if self._attn is not None:
+                self._attn.set_fixed_shape(fixed_shape)
+                if fixed_shape:
+                    self._attn.set_fixed_valid_len(valid_prefix)
+            self.current_prompt = prompt_text
+            logger.info(
+                "Updated Pi0.5 JAX Thor prompt in place: '%s' "
+                "(%d tokens, Se=%d, state=%s, mode=%s)",
+                prompt_text, prompt_len, Se, state is not None,
+                "fixed" if fixed_shape else "exact")
+            return
+
         self.Se = Se
         self.total_keys = Se + self.Sa
+        self._fixed_shape_active = fixed_shape
+        self.current_prompt_len = int(prompt_len)
 
         # Stage 1.5 — build AttentionBackend. total_keys must be set first
         # (see sibling comment in frontends/torch/pi05_thor.py). Rebuilt
@@ -725,11 +808,16 @@ class Pi05JaxFrontendThor:
                 "layer_stride": layer_stride,
                 "scale":        attn_scale,
             },
+            fixed_control={
+                "enc_seqused": self.enc_seqused.ptr.value,
+                "dec_seqused": self.dec_seqused.ptr.value,
+                "dec_devpos": self.dec_devpos.ptr.value,
+                "set_valid_len": self._set_fixed_control_values,
+            },
         )
-
-        actual_lang = Se - S
-        if actual_lang > prompt_len:
-            embeds_np = np.concatenate([embeds_np, embeds_np[-1:]], axis=0)
+        self._attn.set_fixed_shape(fixed_shape)
+        if fixed_shape:
+            self._attn.set_fixed_valid_len(valid_prefix)
         self.lang_emb = CB.from_numpy(embeds_np[:actual_lang].astype(fp16))
         self.S_lang = actual_lang
 
@@ -737,7 +825,7 @@ class Pi05JaxFrontendThor:
         enc_rope_np = np.concatenate(
             [self._kc_t[:Se, :, None], self._ks_t[:Se, :, None]], 2).reshape(Se, 256)
         self.enc_rope = CB.from_numpy(enc_rope_np.astype(fp16))
-        dec_start = Se
+        dec_start = valid_prefix if fixed_shape else Se
         dec_rope_np = np.concatenate(
             [self._kc_t[dec_start:dec_start+self.Sa, :, None],
              self._ks_t[dec_start:dec_start+self.Sa, :, None]], 2).reshape(self.Sa, 256)
@@ -859,10 +947,12 @@ class Pi05JaxFrontendThor:
              'aow': self.aow.ptr.value, 'aob': self.aob.ptr.value,
              'fs': self.ae_w_static[13].ptr.value, 'rope': self.dec_rope.ptr.value,
              'w_scales': self.ae_w_dev.ptr.value,
+             'dec_devpos': self.dec_devpos.ptr.value,
              'act_scales': self.ae_calib_scales.ptr.value},
             {'S': self.Sa, 'D': self.Da, 'H': self.Ha, 'NH': 8, 'HD': 256,
              'steps': self.steps, 'layers': self.La, 'enc_seq': self.Se,
-             'total_keys': self.total_keys}
+             'total_keys': self.total_keys,
+             'fixed_shape': self._fixed_shape_active}
         )
 
     def _calibrate(self):

--- a/flash_rt/frontends/jax/pi05_thor.py
+++ b/flash_rt/frontends/jax/pi05_thor.py
@@ -64,7 +64,8 @@ class Pi05JaxFrontendThor:
     def __init__(self, checkpoint_dir, engine_path=None, fmha_path=None,
                  use_cuda_graph=True, num_views=2, autotune=3,
                  weight_cache=True, use_fp8=True,
-                 state_prompt_mode: str = "exact", **kwargs):
+                 state_prompt_mode: str = "exact",
+                 state_prompt_fixed_max_len=None, **kwargs):
         """
         Args:
             autotune: CUDA Graph autotune trials per set_prompt().
@@ -88,6 +89,19 @@ class Pi05JaxFrontendThor:
                 "state_prompt_mode must be 'exact' or 'fixed', "
                 f"got {mode!r}")
         self._state_prompt_mode = mode
+        fixed_cap = PI05_STATE_PROMPT_MAX_LEN
+        if mode == "fixed":
+            fixed_cap = os.environ.get(
+                "FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN",
+                state_prompt_fixed_max_len)
+            if fixed_cap is None:
+                fixed_cap = PI05_STATE_PROMPT_MAX_LEN
+            fixed_cap = int(fixed_cap)
+            if fixed_cap <= 0:
+                raise ValueError(
+                    "state_prompt_fixed_max_len must be a positive integer, "
+                    f"got {fixed_cap}")
+        self._state_prompt_fixed_max_len = fixed_cap
 
         # ── Load norm stats (openpi or lerobot HF release) ──
         from flash_rt.core.utils.norm_stats import (
@@ -701,24 +715,26 @@ class Pi05JaxFrontendThor:
         fp16 = np.float16
 
         S = self.sig_dims[0]  # num_views * 256
+        fixed_shape = (
+            self._state_prompt_mode == "fixed"
+            and state is not None
+            and self._rl_config is None
+        )
         if isinstance(prompt_text, (np.ndarray, list)):
             # Raw token IDs
             token_ids = np.asarray(prompt_text, dtype=np.int64)
             prompt_len = len(token_ids)
             embeds_np = self._embedding_scaled_np[token_ids]
         else:
-            max_len = PI05_STATE_PROMPT_MAX_LEN if state is not None else 48
+            max_len = (self._state_prompt_fixed_max_len
+                       if fixed_shape else PI05_STATE_PROMPT_MAX_LEN)
+            max_len = max_len if state is not None else 48
             embeds_np, prompt_len = _embed_prompt(
                 prompt_text, self._embedding_scaled_np, max_len=max_len,
                 state=state, already_scaled=True)
-        fixed_shape = (
-            self._state_prompt_mode == "fixed"
-            and state is not None
-            and self._rl_config is None
-        )
 
         if fixed_shape:
-            Se = S + PI05_STATE_PROMPT_MAX_LEN
+            Se = S + self._state_prompt_fixed_max_len
             if Se % 2 != 0:
                 Se += 1
             actual_lang = Se - S

--- a/flash_rt/frontends/jax/pi05_thor_fp4.py
+++ b/flash_rt/frontends/jax/pi05_thor_fp4.py
@@ -80,6 +80,7 @@ class Pi05JaxFrontendThorFP4(Pi05JaxFrontendThor):
         awq_calib_iters: int = 8,
         use_p1_split_gu: bool = False,
         use_fp8: bool = True,
+        state_prompt_mode: str = "exact",
         **kwargs,
     ):
         # Set FP4 state BEFORE super().__init__ because the base class
@@ -120,6 +121,7 @@ class Pi05JaxFrontendThorFP4(Pi05JaxFrontendThor):
             autotune=autotune,
             weight_cache=weight_cache,
             use_fp8=use_fp8,
+            state_prompt_mode=state_prompt_mode,
             **kwargs,
         )
 

--- a/flash_rt/frontends/jax/pi05_thor_fp4.py
+++ b/flash_rt/frontends/jax/pi05_thor_fp4.py
@@ -81,6 +81,7 @@ class Pi05JaxFrontendThorFP4(Pi05JaxFrontendThor):
         use_p1_split_gu: bool = False,
         use_fp8: bool = True,
         state_prompt_mode: str = "exact",
+        state_prompt_fixed_max_len=None,
         **kwargs,
     ):
         # Set FP4 state BEFORE super().__init__ because the base class
@@ -122,6 +123,7 @@ class Pi05JaxFrontendThorFP4(Pi05JaxFrontendThor):
             weight_cache=weight_cache,
             use_fp8=use_fp8,
             state_prompt_mode=state_prompt_mode,
+            state_prompt_fixed_max_len=state_prompt_fixed_max_len,
             **kwargs,
         )
 

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -13,6 +13,7 @@ import ctypes
 import json
 import math
 import logging
+import os
 import pathlib
 import time
 from typing import Optional, Union
@@ -83,7 +84,7 @@ class Pi05TorchFrontendThor:
 
     def __init__(self, checkpoint_dir: str, num_views: int = 2,
                  use_cuda_graph: bool = True, autotune: int = 3,
-                 use_fp8: bool = True):
+                 use_fp8: bool = True, state_prompt_mode: str = "exact"):
         """
         Args:
             autotune: CUDA Graph autotune trials per set_prompt().
@@ -91,6 +92,11 @@ class Pi05TorchFrontendThor:
                 Torch usually finds fast graph on trial 0-1.
         """
         checkpoint_dir = pathlib.Path(checkpoint_dir)
+        _spm = os.environ.get("FLASHRT_PI05_STATE_PROMPT_MODE", state_prompt_mode)
+        if _spm not in ("fixed", "exact"):
+            raise ValueError(
+                f"state_prompt_mode must be 'fixed' or 'exact', got {_spm!r}")
+        self._state_prompt_mode = _spm
         self.num_views = num_views
         self.use_cuda_graph = use_cuda_graph
         self.use_fp8 = bool(use_fp8)
@@ -101,6 +107,8 @@ class Pi05TorchFrontendThor:
         self.calibrated = False
         self.graph_captured = False
         self._real_data_calibrated = False
+        self.current_prompt_len = 0
+        self._fixed_shape_active = False
 
         # ---- RL CFG state (set via set_rl_mode) ----
         # When ``_rl_config`` is non-None, ``set_prompt`` builds an
@@ -945,25 +953,70 @@ class Pi05TorchFrontendThor:
                 prompt_text, self.embedding_weight, max_len=max_len,
                 state=state)
 
-        # Se must be EVEN for cuBLASLt FP8
-        Se = S_sig + prompt_len
-        if Se % 2 != 0:
-            Se += 1
-        actual_lang = Se - S_sig
-        if actual_lang > prompt_len:
-            embeds = torch.cat([embeds, embeds[-1:]], dim=0)
+        fixed_shape = (
+            self._state_prompt_mode == "fixed"
+            and state is not None
+            and self._rl_config is None
+        )
+
+        # Se must be EVEN for cuBLASLt FP8. In fixed state-prompt mode the
+        # graph captures the max state-prompt shape and masks padded K/V rows
+        # through the Thor attention backend's device-side seqused buffers.
+        if fixed_shape:
+            Se = S_sig + PI05_STATE_PROMPT_MAX_LEN
+            if Se % 2 != 0:
+                Se += 1
+            actual_lang = Se - S_sig
+            valid_lang = prompt_len
+            if (S_sig + valid_lang) % 2 != 0:
+                valid_lang += 1
+            if valid_lang > actual_lang:
+                raise ValueError(
+                    f"prompt_len {prompt_len} exceeds fixed state prompt "
+                    f"capacity {actual_lang}")
+            padded = torch.zeros(
+                actual_lang, embeds.shape[1],
+                dtype=embeds.dtype, device=embeds.device)
+            padded[:prompt_len].copy_(embeds)
+            if valid_lang > prompt_len:
+                padded[prompt_len:valid_lang].copy_(embeds[-1:].expand(
+                    valid_lang - prompt_len, -1))
+            embeds = padded
+            valid_prefix = S_sig + valid_lang
+        else:
+            Se = S_sig + prompt_len
+            if Se % 2 != 0:
+                Se += 1
+            actual_lang = Se - S_sig
+            if actual_lang > prompt_len:
+                embeds = torch.cat([embeds, embeds[-1:]], dim=0)
+            valid_prefix = Se
 
         if (self.graph_captured and self._lang_emb is not None
                 and self._S_lang == actual_lang and self.Se == Se):
             self._lang_emb.copy_(embeds)
+            dec_start = valid_prefix if fixed_shape else Se
+            self._dec_rope.copy_(
+                torch.cat([self._kc_t[dec_start:dec_start + self.Sa, :, None],
+                           self._ks_t[dec_start:dec_start + self.Sa, :, None]], dim=2)
+                .reshape(self.Sa, 256))
+            self._fixed_shape_active = fixed_shape
+            self.current_prompt_len = int(prompt_len)
+            if self._attn is not None:
+                self._attn.set_fixed_shape(fixed_shape)
+                if fixed_shape:
+                    self._attn.set_fixed_valid_len(valid_prefix)
             logger.info(
                 "Updated Pi0.5 Thor prompt in place: '%s' "
-                "(%d tokens, Se=%d, state=%s)",
-                prompt_text, prompt_len, Se, state is not None)
+                "(%d tokens, Se=%d, state=%s, mode=%s)",
+                prompt_text, prompt_len, Se, state is not None,
+                "fixed" if fixed_shape else "exact")
             return
 
         self.Se = Se
         self.total_keys = Se + self.Sa
+        self._fixed_shape_active = fixed_shape
+        self.current_prompt_len = int(prompt_len)
 
         # Stage 1.4 — build AttentionBackend. total_keys must be set first
         # because the encoder/decoder KV cache layer_stride is computed from
@@ -1004,6 +1057,9 @@ class Pi05TorchFrontendThor:
                 "scale":        attn_scale,
             },
         )
+        self._attn.set_fixed_shape(fixed_shape)
+        if fixed_shape:
+            self._attn.set_fixed_valid_len(valid_prefix)
 
         self._lang_emb = embeds
         self._S_lang = actual_lang
@@ -1012,7 +1068,7 @@ class Pi05TorchFrontendThor:
         self._enc_rope[:Se].copy_(
             torch.cat([self._kc_t[:Se, :, None],
                        self._ks_t[:Se, :, None]], dim=2).reshape(Se, 256))
-        dec_start = Se
+        dec_start = valid_prefix if fixed_shape else Se
         self._dec_rope.copy_(
             torch.cat([self._kc_t[dec_start:dec_start + self.Sa, :, None],
                        self._ks_t[dec_start:dec_start + self.Sa, :, None]], dim=2)
@@ -1096,7 +1152,9 @@ class Pi05TorchFrontendThor:
 
         self.graph_captured = True
         self.calibrated = True
-        logger.info("set_prompt done: '%s' (%d tokens, Se=%d)", prompt_text, prompt_len, Se)
+        logger.info("set_prompt done: '%s' (%d tokens, Se=%d, mode=%s)",
+                    prompt_text, prompt_len, Se,
+                    "fixed" if fixed_shape else "exact")
 
     # -----------------------------------------------------------------------
     # Calibration
@@ -1213,6 +1271,7 @@ class Pi05TorchFrontendThor:
             'qw':        self._dec_qkv_flat.data_ptr(),
             'Kc':        self._Kc.reshape(-1).data_ptr(),
             'Vc':        self._Vc.reshape(-1).data_ptr(),
+            'dec_devpos': self._attn.dec_devpos.data_ptr(),
             'ow':        self._dec_o_flat.data_ptr(),
             'sf':        self._sf_all.data_ptr(),
             'gw':        self._dec_gu_flat.data_ptr(),
@@ -1229,6 +1288,7 @@ class Pi05TorchFrontendThor:
             'S': Sa, 'D': Da, 'H': Ha, 'NH': 8, 'HD': 256,
             'steps': 10, 'layers': self.La, 'enc_seq': Se,
             'total_keys': total_keys,
+            'fixed_shape': self._fixed_shape_active,
         }
 
         # Decoder scratch buffers
@@ -1406,6 +1466,7 @@ class Pi05TorchFrontendThor:
             'qw':         self._dec_qkv_flat.data_ptr(),
             'Kc':         self._Kc.reshape(-1).data_ptr(),
             'Vc':         self._Vc.reshape(-1).data_ptr(),
+            'dec_devpos': self._attn.dec_devpos.data_ptr(),
             'ow':         self._dec_o_flat.data_ptr(),
             'sf':         self._sf_all.data_ptr(),
             'gw':         self._dec_gu_flat.data_ptr(),
@@ -1423,6 +1484,7 @@ class Pi05TorchFrontendThor:
             'S': Sa, 'D': Da, 'H': Ha, 'NH': 8, 'HD': 256,
             'steps': 10, 'layers': La, 'enc_seq': Se,
             'total_keys': total_keys,
+            'fixed_shape': self._fixed_shape_active,
         }
 
         # Warmup
@@ -2248,6 +2310,7 @@ class Pi05TorchFrontendThor:
             'qw':         self._dec_qkv_flat.data_ptr(),
             'Kc':         self._Kc.reshape(-1).data_ptr(),
             'Vc':         self._Vc.reshape(-1).data_ptr(),
+            'dec_devpos': self._attn.dec_devpos.data_ptr(),
             'ow':         self._dec_o_flat.data_ptr(),
             'sf':         self._sf_all.data_ptr(),
             'gw':         self._dec_gu_flat.data_ptr(),
@@ -2264,6 +2327,7 @@ class Pi05TorchFrontendThor:
             'S': Sa, 'D': Da, 'H': Ha, 'NH': 8, 'HD': 256,
             'steps': 10, 'layers': self.La, 'enc_seq': Se,
             'total_keys': total_keys,
+            'fixed_shape': self._fixed_shape_active,
         }
 
         _ae_calib_buf = torch.zeros(ae_scale_count, dtype=torch.float32, device='cuda')
@@ -2364,6 +2428,7 @@ class Pi05TorchFrontendThor:
             'qw':         self._dec_qkv_flat.data_ptr(),
             'Kc':         self._Kc.reshape(-1).data_ptr(),
             'Vc':         self._Vc.reshape(-1).data_ptr(),
+            'dec_devpos': self._attn.dec_devpos.data_ptr(),
             'ow':         self._dec_o_flat.data_ptr(),
             'sf':         self._sf_all.data_ptr(),
             'gw':         self._dec_gu_flat.data_ptr(),
@@ -2380,6 +2445,7 @@ class Pi05TorchFrontendThor:
             'S': Sa, 'D': Da, 'H': Ha, 'NH': 8, 'HD': 256,
             'steps': 10, 'layers': La, 'enc_seq': Se,
             'total_keys': total_keys,
+            'fixed_shape': self._fixed_shape_active,
         }
 
         per_sample_enc: list[np.ndarray] = []

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -84,7 +84,8 @@ class Pi05TorchFrontendThor:
 
     def __init__(self, checkpoint_dir: str, num_views: int = 2,
                  use_cuda_graph: bool = True, autotune: int = 3,
-                 use_fp8: bool = True, state_prompt_mode: str = "exact"):
+                 use_fp8: bool = True, state_prompt_mode: str = "exact",
+                 state_prompt_fixed_max_len: Optional[int] = None):
         """
         Args:
             autotune: CUDA Graph autotune trials per set_prompt().
@@ -97,6 +98,19 @@ class Pi05TorchFrontendThor:
             raise ValueError(
                 f"state_prompt_mode must be 'fixed' or 'exact', got {_spm!r}")
         self._state_prompt_mode = _spm
+        _fixed_cap = PI05_STATE_PROMPT_MAX_LEN
+        if _spm == "fixed":
+            _fixed_cap = os.environ.get(
+                "FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN",
+                state_prompt_fixed_max_len)
+            if _fixed_cap is None:
+                _fixed_cap = PI05_STATE_PROMPT_MAX_LEN
+            _fixed_cap = int(_fixed_cap)
+            if _fixed_cap <= 0:
+                raise ValueError(
+                    "state_prompt_fixed_max_len must be a positive integer, "
+                    f"got {_fixed_cap}")
+        self._state_prompt_fixed_max_len = _fixed_cap
         self.num_views = num_views
         self.use_cuda_graph = use_cuda_graph
         self.use_fp8 = bool(use_fp8)
@@ -940,6 +954,12 @@ class Pi05TorchFrontendThor:
         S_sig = self.sig_S
         nv = self.num_views
 
+        fixed_shape = (
+            self._state_prompt_mode == "fixed"
+            and state is not None
+            and self._rl_config is None
+        )
+
         # ---- Tokenize ----
         if isinstance(prompt_text, (np.ndarray, list)):
             token_ids = np.asarray(prompt_text, dtype=np.int64)
@@ -948,22 +968,18 @@ class Pi05TorchFrontendThor:
                 torch.from_numpy(token_ids).long().cuda(), self.embedding_weight)
             embeds = embeds * float(embeds.shape[-1] ** 0.5)
         else:
-            max_len = PI05_STATE_PROMPT_MAX_LEN if state is not None else 48
+            max_len = (self._state_prompt_fixed_max_len
+                       if fixed_shape else PI05_STATE_PROMPT_MAX_LEN)
+            max_len = max_len if state is not None else 48
             embeds, prompt_len = embed_prompt(
                 prompt_text, self.embedding_weight, max_len=max_len,
                 state=state)
-
-        fixed_shape = (
-            self._state_prompt_mode == "fixed"
-            and state is not None
-            and self._rl_config is None
-        )
 
         # Se must be EVEN for cuBLASLt FP8. In fixed state-prompt mode the
         # graph captures the max state-prompt shape and masks padded K/V rows
         # through the Thor attention backend's device-side seqused buffers.
         if fixed_shape:
-            Se = S_sig + PI05_STATE_PROMPT_MAX_LEN
+            Se = S_sig + self._state_prompt_fixed_max_len
             if Se % 2 != 0:
                 Se += 1
             actual_lang = Se - S_sig

--- a/flash_rt/frontends/torch/pi05_thor_fp4.py
+++ b/flash_rt/frontends/torch/pi05_thor_fp4.py
@@ -53,11 +53,13 @@ class Pi05TorchFrontendThorFP4(Pi05TorchFrontendThor):
                  awq_alpha: float = 0.5,
                  awq_calib_iters: int = 8,
                  use_p1_split_gu: bool = False,
-                 use_fp8: bool = True):
+                 use_fp8: bool = True,
+                 state_prompt_mode: str = "exact"):
         # Base init (loads weights, allocates all FP8 buffers, etc.)
         super().__init__(checkpoint_dir, num_views=num_views,
                          use_cuda_graph=use_cuda_graph, autotune=autotune,
-                         use_fp8=use_fp8)
+                         use_fp8=use_fp8,
+                         state_prompt_mode=state_prompt_mode)
 
         self.use_fp4_encoder_ffn = bool(use_fp4_encoder_ffn)
         self._fp4_layers = frozenset(fp4_layers) if self.use_fp4_encoder_ffn else frozenset()
@@ -661,6 +663,7 @@ class Pi05TorchFrontendThorFP4(Pi05TorchFrontendThor):
             'qw':         self._dec_qkv_flat.data_ptr(),
             'Kc':         self._Kc.reshape(-1).data_ptr(),
             'Vc':         self._Vc.reshape(-1).data_ptr(),
+            'dec_devpos': self._attn.dec_devpos.data_ptr(),
             'ow':         self._dec_o_flat.data_ptr(),
             'sf':         self._sf_all.data_ptr(),
             'gw':         self._dec_gu_flat.data_ptr(),
@@ -678,6 +681,7 @@ class Pi05TorchFrontendThorFP4(Pi05TorchFrontendThor):
             'S': Sa, 'D': Da, 'H': Ha, 'NH': 8, 'HD': 256,
             'steps': 10, 'layers': La, 'enc_seq': Se,
             'total_keys': total_keys,
+            'fixed_shape': self._fixed_shape_active,
         }
 
         fp4_layers = self._fp4_layers

--- a/flash_rt/frontends/torch/pi05_thor_fp4.py
+++ b/flash_rt/frontends/torch/pi05_thor_fp4.py
@@ -54,12 +54,14 @@ class Pi05TorchFrontendThorFP4(Pi05TorchFrontendThor):
                  awq_calib_iters: int = 8,
                  use_p1_split_gu: bool = False,
                  use_fp8: bool = True,
-                 state_prompt_mode: str = "exact"):
+                 state_prompt_mode: str = "exact",
+                 state_prompt_fixed_max_len=None):
         # Base init (loads weights, allocates all FP8 buffers, etc.)
         super().__init__(checkpoint_dir, num_views=num_views,
                          use_cuda_graph=use_cuda_graph, autotune=autotune,
                          use_fp8=use_fp8,
-                         state_prompt_mode=state_prompt_mode)
+                         state_prompt_mode=state_prompt_mode,
+                         state_prompt_fixed_max_len=state_prompt_fixed_max_len)
 
         self.use_fp4_encoder_ffn = bool(use_fp4_encoder_ffn)
         self._fp4_layers = frozenset(fp4_layers) if self.use_fp4_encoder_ffn else frozenset()

--- a/flash_rt/hardware/thor/attn_backend.py
+++ b/flash_rt/hardware/thor/attn_backend.py
@@ -47,7 +47,8 @@ class ThorFlashAttnBackend(AttentionBackendBase):
     # ────────────────────────────────────────────────────────────────
     def __init__(self, spec: AttentionSpec, ctx, *,
                  siglip_slots: dict, encoder_slots: dict,
-                 decoder_slots: dict) -> None:
+                 decoder_slots: dict,
+                 fixed_control: Optional[dict] = None) -> None:
         """
         Args:
             spec: AttentionSpec with exactly the sites
@@ -69,6 +70,11 @@ class ThorFlashAttnBackend(AttentionBackendBase):
                 logits       (int) — scratch for P = QK^T
                 layer_stride (int) — bytes between successive layers in Kc/Vc
                 scale        (float) — 1/sqrt(head_dim)
+            fixed_control: optional dict for fixed-shape state-prompt mode.
+                When omitted and torch CUDA is available, the backend
+                allocates the three int32 device scalars itself. JAX callers
+                pass CudaBuffer-backed pointers plus a setter callback to keep
+                this module independent of PyTorch.
 
         Invariants enforced:
             * spec has the three expected sites with correct layer counts.
@@ -130,6 +136,44 @@ class ThorFlashAttnBackend(AttentionBackendBase):
         # construct the backend without a fully-initialised fvk env.
         self._fvk = None
 
+        self._fixed_shape = False
+        self._fixed_set_valid_len = None
+        self.enc_seqused = None
+        self.dec_seqused = None
+        self.dec_devpos = None
+        if fixed_control is not None:
+            self.enc_seqused = fixed_control.get("enc_seqused")
+            self.dec_seqused = fixed_control.get("dec_seqused")
+            self.dec_devpos = fixed_control.get("dec_devpos")
+            self._fixed_set_valid_len = fixed_control.get("set_valid_len")
+        else:
+            try:
+                import torch
+                if torch.cuda.is_available():
+                    self.enc_seqused = torch.zeros(
+                        1, dtype=torch.int32, device="cuda")
+                    self.dec_seqused = torch.zeros(
+                        1, dtype=torch.int32, device="cuda")
+                    self.dec_devpos = torch.zeros(
+                        1, dtype=torch.int32, device="cuda")
+            except Exception:
+                pass
+        self._enc_seqused_ptr = self._device_ptr(self.enc_seqused)
+        self._dec_seqused_ptr = self._device_ptr(self.dec_seqused)
+        self._dec_devpos_ptr = self._device_ptr(self.dec_devpos)
+
+    @staticmethod
+    def _device_ptr(obj) -> int:
+        if obj is None:
+            return 0
+        if isinstance(obj, int):
+            return int(obj)
+        if hasattr(obj, "data_ptr"):
+            return int(obj.data_ptr())
+        if hasattr(obj, "ptr"):
+            return int(obj.ptr.value)
+        return int(obj)
+
     def _require_keys(self, site: str, keys: tuple[str, ...]) -> None:
         slot = self._slots[site]
         for k in keys:
@@ -147,6 +191,52 @@ class ThorFlashAttnBackend(AttentionBackendBase):
             import flash_rt.flash_rt_kernels as fvk
             self._fvk = fvk
         return self._fvk
+
+    def set_fixed_shape(self, enabled: bool) -> None:
+        """Enable/disable fixed-shape state-prompt masking.
+
+        When enabled, encoder and decoder standard attention use
+        ``attention_qkv_fp16_seqused``. The captured K/V max shape stays fixed;
+        :meth:`set_fixed_valid_len` updates the device-side valid lengths.
+        """
+        if enabled and not (
+            self._enc_seqused_ptr and self._dec_seqused_ptr
+            and self._dec_devpos_ptr
+        ):
+            raise RuntimeError(
+                "Thor fixed-shape attention requires enc_seqused, "
+                "dec_seqused, and dec_devpos device scalars")
+        self._fixed_shape = bool(enabled)
+
+    def set_fixed_valid_len(self, valid_prefix_len: int) -> None:
+        """Update device-side valid prefix length for fixed-shape replay."""
+        v = int(valid_prefix_len)
+        enc_max = self._spec.site("encoder").max_kv_seq
+        dec_max = self._spec.site("decoder").max_kv_seq
+        chunk = self._spec.site("decoder").max_q_seq
+        if not (0 < v <= enc_max):
+            raise ValueError(
+                f"valid_prefix_len={v} out of range for encoder max {enc_max}")
+        if v + chunk > dec_max:
+            raise ValueError(
+                f"decoder valid length {v + chunk} exceeds max {dec_max}")
+        if self._fixed_set_valid_len is not None:
+            self._fixed_set_valid_len(v, v + chunk, v)
+            return
+        if not (hasattr(self.enc_seqused, "fill_")
+                and hasattr(self.dec_seqused, "fill_")
+                and hasattr(self.dec_devpos, "fill_")):
+            raise RuntimeError(
+                "Thor fixed-shape scalars are pointer-only; caller must "
+                "provide fixed_control['set_valid_len']")
+        self.enc_seqused.fill_(v)
+        self.dec_seqused.fill_(v + chunk)
+        self.dec_devpos.fill_(v)
+        try:
+            import torch
+            torch.cuda.synchronize()
+        except Exception:
+            pass
 
     # ────────────────────────────────────────────────────────────────
     # Protocol: get_slot_ptrs
@@ -258,14 +348,27 @@ class ThorFlashAttnBackend(AttentionBackendBase):
                 float(s["scale"]), stream,
             )
         elif kernel == "standard":
-            fvk.attention_qkv_fp16(
-                self._ctx_cpp,
-                int(s["Q_O"]), K_ptr, V_ptr,
-                int(s["logits"]), int(s["Q_O"]),
-                q_seq, kv_seq,
-                site_spec.num_q_heads, site_spec.head_dim,
-                float(s["scale"]), stream,
-            )
+            if self._fixed_shape and site in ("encoder", "decoder"):
+                seqused = (self._enc_seqused_ptr if site == "encoder"
+                           else self._dec_seqused_ptr)
+                fvk.attention_qkv_fp16_seqused(
+                    self._ctx_cpp,
+                    int(s["Q_O"]), K_ptr, V_ptr,
+                    int(s["logits"]), int(s["Q_O"]),
+                    q_seq, kv_seq,
+                    site_spec.num_q_heads, site_spec.head_dim,
+                    seqused,
+                    float(s["scale"]), stream,
+                )
+            else:
+                fvk.attention_qkv_fp16(
+                    self._ctx_cpp,
+                    int(s["Q_O"]), K_ptr, V_ptr,
+                    int(s["logits"]), int(s["Q_O"]),
+                    q_seq, kv_seq,
+                    site_spec.num_q_heads, site_spec.head_dim,
+                    float(s["scale"]), stream,
+                )
         else:
             raise ValueError(
                 f"unknown kernel {kernel!r} for site {site!r} "

--- a/flash_rt/models/pi05/pipeline_thor.py
+++ b/flash_rt/models/pi05/pipeline_thor.py
@@ -90,6 +90,9 @@ def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None,
     layers = dims['layers']
     enc_seq = dims['enc_seq']
     total_keys = dims['total_keys']
+    fixed_shape = bool(dims.get('fixed_shape', False))
+    if fixed_shape and attn is None:
+        raise ValueError("Pi0.5 Thor fixed_shape decoder requires attn backend")
     D3 = 3 * D
     Q_dim = NH * HD
     K_dim = HD
@@ -154,10 +157,17 @@ def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None,
                                        act_scale_qkv, w_scale_qkv, stream)
 
             # ── C2b: Fused RoPE + QKV split + KV cache ──
-            kv_offset = l * total_keys * HD + enc_seq * HD
-            fvk.qkv_split_rope_kvcache_fp16(qkv, rope, attn_out, Kc, Vc,
-                                             S, Q_dim, K_dim, HD, 2560,
-                                             kv_offset, HD, stream)
+            if fixed_shape:
+                kv_offset = l * total_keys * HD
+                fvk.qkv_split_rope_kvcache_fp16_devpos(
+                    qkv, rope, attn_out, Kc, Vc, weights['dec_devpos'],
+                    S, Q_dim, K_dim, HD, 2560,
+                    kv_offset, HD, stream)
+            else:
+                kv_offset = l * total_keys * HD + enc_seq * HD
+                fvk.qkv_split_rope_kvcache_fp16(qkv, rope, attn_out, Kc, Vc,
+                                                 S, Q_dim, K_dim, HD, 2560,
+                                                 kv_offset, HD, stream)
 
             # ── C3: Cross-attention ──
             if attn is not None:
@@ -233,6 +243,9 @@ def _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None)
     NH = dims['NH']; HD = dims['HD']
     steps = dims['steps']; layers = dims['layers']
     enc_seq = dims['enc_seq']; total_keys = dims['total_keys']
+    fixed_shape = bool(dims.get('fixed_shape', False))
+    if fixed_shape and attn is None:
+        raise ValueError("Pi0.5 Thor fixed_shape decoder requires attn backend")
     D3 = 3 * D
     Q_dim = NH * HD
     K_dim = HD
@@ -270,10 +283,17 @@ def _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None)
             fvk.gmm_fp16(ctx, xn, qw_ptr, qkv, S, 2560, D, 0.0, stream)
 
             # C2b: Split + RoPE + KV cache write
-            kv_offset = l * total_keys * HD + enc_seq * HD
-            fvk.qkv_split_rope_kvcache_fp16(qkv, rope, attn_out, Kc, Vc,
-                                             S, Q_dim, K_dim, HD, 2560,
-                                             kv_offset, HD, stream)
+            if fixed_shape:
+                kv_offset = l * total_keys * HD
+                fvk.qkv_split_rope_kvcache_fp16_devpos(
+                    qkv, rope, attn_out, Kc, Vc, weights['dec_devpos'],
+                    S, Q_dim, K_dim, HD, 2560,
+                    kv_offset, HD, stream)
+            else:
+                kv_offset = l * total_keys * HD + enc_seq * HD
+                fvk.qkv_split_rope_kvcache_fp16(qkv, rope, attn_out, Kc, Vc,
+                                                 S, Q_dim, K_dim, HD, 2560,
+                                                 kv_offset, HD, stream)
 
             # C3: Attention
             if attn is not None:
@@ -333,6 +353,9 @@ def decoder_forward_calibrate(ctx, fvk_mod, bufs, weights, dims,
     NH = dims['NH']; HD = dims['HD']
     steps = dims['steps']; layers = dims['layers']
     enc_seq = dims['enc_seq']; total_keys = dims['total_keys']
+    fixed_shape = bool(dims.get('fixed_shape', False))
+    if fixed_shape and attn is None:
+        raise ValueError("Pi0.5 Thor fixed_shape decoder requires attn backend")
     Q_dim = NH * HD
     attn_scale = 1.0 / math.sqrt(float(HD))
     D3 = 3 * D
@@ -388,10 +411,17 @@ def decoder_forward_calibrate(ctx, fvk_mod, bufs, weights, dims,
                                            cs_qkv, ws_qkv, stream)
 
             # C2b: Split+RoPE
-            kv_offset = l * total_keys * HD + enc_seq * HD
-            fvk_mod.qkv_split_rope_kvcache_fp16(qkv, rope, attn_out, Kc, Vc,
-                                                  S, Q_dim, HD, HD, 2560,
-                                                  kv_offset, HD, stream)
+            if fixed_shape:
+                kv_offset = l * total_keys * HD
+                fvk_mod.qkv_split_rope_kvcache_fp16_devpos(
+                    qkv, rope, attn_out, Kc, Vc, weights['dec_devpos'],
+                    S, Q_dim, HD, HD, 2560,
+                    kv_offset, HD, stream)
+            else:
+                kv_offset = l * total_keys * HD + enc_seq * HD
+                fvk_mod.qkv_split_rope_kvcache_fp16(qkv, rope, attn_out, Kc, Vc,
+                                                      S, Q_dim, HD, HD, 2560,
+                                                      kv_offset, HD, stream)
 
             # C3: Attention
             if attn is not None:

--- a/tests/test_prompt_runtime_lifecycle.py
+++ b/tests/test_prompt_runtime_lifecycle.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 
 class _FakeAttnBackend:
@@ -146,6 +147,39 @@ def test_vla_model_warms_pi05_state_prompt_buckets(monkeypatch):
     assert [p.max_prompt_len for p in FakePipeline.instances] == [17, 23]
     assert model._needs_real_data_calibration is False
     assert model.prompt is None
+
+
+@pytest.mark.parametrize("framework", ["torch", "jax"])
+def test_load_model_forwards_state_prompt_mode_to_pi05_thor(
+        monkeypatch, framework):
+    import flash_rt
+    import flash_rt.hardware as hw
+
+    seen = {}
+
+    class FakeThorFrontend:
+        def __init__(self, checkpoint, num_views=2, autotune=3,
+                     state_prompt_mode="exact"):
+            seen["checkpoint"] = checkpoint
+            seen["num_views"] = num_views
+            seen["autotune"] = autotune
+            seen["state_prompt_mode"] = state_prompt_mode
+
+    monkeypatch.setattr(
+        hw, "resolve_pipeline_class",
+        lambda config, framework, arch: FakeThorFrontend)
+
+    model = flash_rt.load_model(
+        "/tmp/pi05", framework=framework, config="pi05", hardware="thor",
+        num_views=3, autotune=0, state_prompt_mode="fixed")
+
+    assert isinstance(model._pipe, FakeThorFrontend)
+    assert seen == {
+        "checkpoint": "/tmp/pi05",
+        "num_views": 3,
+        "autotune": 0,
+        "state_prompt_mode": "fixed",
+    }
 
 
 def test_predict_recalibrates_when_prompt_bucket_changes():

--- a/tests/test_prompt_runtime_lifecycle.py
+++ b/tests/test_prompt_runtime_lifecycle.py
@@ -159,11 +159,13 @@ def test_load_model_forwards_state_prompt_mode_to_pi05_thor(
 
     class FakeThorFrontend:
         def __init__(self, checkpoint, num_views=2, autotune=3,
-                     state_prompt_mode="exact"):
+                     state_prompt_mode="exact",
+                     state_prompt_fixed_max_len=None):
             seen["checkpoint"] = checkpoint
             seen["num_views"] = num_views
             seen["autotune"] = autotune
             seen["state_prompt_mode"] = state_prompt_mode
+            seen["state_prompt_fixed_max_len"] = state_prompt_fixed_max_len
 
     monkeypatch.setattr(
         hw, "resolve_pipeline_class",
@@ -171,7 +173,8 @@ def test_load_model_forwards_state_prompt_mode_to_pi05_thor(
 
     model = flash_rt.load_model(
         "/tmp/pi05", framework=framework, config="pi05", hardware="thor",
-        num_views=3, autotune=0, state_prompt_mode="fixed")
+        num_views=3, autotune=0, state_prompt_mode="fixed",
+        state_prompt_fixed_max_len=120)
 
     assert isinstance(model._pipe, FakeThorFrontend)
     assert seen == {
@@ -179,6 +182,7 @@ def test_load_model_forwards_state_prompt_mode_to_pi05_thor(
         "num_views": 3,
         "autotune": 0,
         "state_prompt_mode": "fixed",
+        "state_prompt_fixed_max_len": 120,
     }
 
 


### PR DESCRIPTION
## Summary

- Add `state_prompt_fixed_max_len` to `load_model()` for Pi0.5 Thor fixed state-prompt mode.
- Let Thor torch/JAX fixed mode use the configured cap for tokenization and fixed graph shape.
- Keep default behavior unchanged: `state_prompt_mode="exact"` remains the default and ignores fixed-cap env/API settings.
- Pass the new option through Thor FP4 frontends.
- Update API docs and usage notes with the fixed-mode latency tradeoff and serving-side cap guidance.

## Validation

- `python -m py_compile flash_rt/api.py flash_rt/frontends/torch/pi05_thor.py flash_rt/frontends/jax/pi05_thor.py flash_rt/frontends/torch/pi05_thor_fp4.py flash_rt/frontends/jax/pi05_thor_fp4.py`
- `git diff --check`
- In `openpi-jax`:
  - `PYTHONPATH=. pytest -q tests/test_pi05_state_prompt.py tests/test_thor_attn_backend.py tests/test_prompt_runtime_lifecycle.py`
  - 23 passed
- Thor Pi0.5 2-view runtime sanity:
  - Torch exact no-state: P50 44.31 ms
  - Torch exact state117: P50 46.56 ms
  - Torch fixed120 state117: P50 47.77 ms, cosine vs exact 0.999988
  - JAX exact/fixed precision checks: cosine > 0.99995
- Boundary check:
  - exact mode ignores invalid `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`
  - fixed mode rejects invalid cap with a clear `ValueError`pi05 thor fixed state