### PR TITLE
Add validated RTX SM89 support for GROOT N1.7 routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,9 +443,14 @@ actions_normalized = model.infer(
 )
 ```
 
-GROOT N1.7 is registered as `config="groot_n17"` for the RTX SM120
-torch path. It uses the N1.7 `set_prompt(aux=...)` / normalized-state
-`infer(...)` contract; see [USAGE.md](USAGE.md#groot-n17-rtx).
+GROOT N1.7 is registered as `config="groot_n17"` for the RTX torch
+path (`rtx_sm120` and `rtx_sm89`). `rtx_sm120` keeps the shared RTX
+registration and `load_model()` refines that default to the FP8
+production frontend when `use_fp16=False`; `rtx_sm89` is registered
+directly to its dedicated FP8 frontend. `use_fp16=True, use_fp8=False`
+selects the explicit RTX reference frontend for the selected hardware. It
+uses the N1.7 `set_prompt(aux=...)` / normalized-state `infer(...)`
+contract; see [USAGE.md](USAGE.md#groot-n17-rtx).
 
 ### Autotune
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -221,8 +221,8 @@ model = flash_rt.load_model(
 | `use_awq` | `bool` \| `None` | `None` | Activation-aware weight quant. Required for 18-layer FP4 scope (without it, cos collapses to ~0.33). `None` → resolved by the `use_fp4` preset. |
 | `awq_alpha` | `float` | `0.5` | AWQ scaling exponent `s[k] = (a[k]/a.mean())^alpha`. |
 | `use_p1_split_gu` | `bool` \| `None` | `None` | P1 split-GU 2-GEMM path (parity on Pi0.5, kernel reusable for Pi0.6). `None` → resolved by the `use_fp4` preset. |
-| `use_fp8` | `bool` | `True` | Enable the selected frontend's FP8 path when available. Set `False` for BF16 fallback or for the opt-in Pi0.5 RTX FP16 path. |
-| `use_fp16` | `bool` | `False` | Opt-in non-quantized full-FP16 path (A/B reference against the FP8/bf16 default). Supported: **Pi0.5 / GROOT N1.6 / GROOT N1.7 torch on RTX SM120/SM89**, and **GROOT N1.6 / GROOT N1.7 torch on Thor (SM110)**. Requires `use_fp8=False`; other hardware/configs raise a clear error. See the RTX and Thor full-FP16 sections below. |
+| `use_fp8` | `bool` | `True` | Enable the selected frontend's FP8 path when available. Set `False` for frontends with a documented BF16 fallback or for explicit full-FP16 reference paths. `groot_n17` on RTX/Thor is stricter: `use_fp8=False` alone raises, and the non-quantized reference path is `use_fp16=True, use_fp8=False`. |
+| `use_fp16` | `bool` | `False` | Opt-in non-quantized full-FP16 path (A/B reference against the FP8/bf16 default). Supported: **Pi0.5 torch on RTX SM120/SM89**, **GROOT N1.6 torch on Thor / RTX SM120**, and **GROOT N1.7 torch on Thor / RTX SM120/SM89**. Requires `use_fp8=False`; other hardware/configs raise a clear error. See the RTX and Thor full-FP16 sections below. |
 | `num_steps` | `int\|None` | `None` | Pi0/Pi0.5 torch frontends. Flow-matching denoise steps; `None` uses the frontend default. |
 | `vision_pool_factor` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Spatial pooling factor for vision tokens. The FP16 RTX path currently supports only `1`. |
 | `vision_num_layers` | `int\|None` | `None` | Pi0.5 torch RTX/Orin. Number of SigLIP vision layers to run. |
@@ -378,7 +378,7 @@ model = flash_rt.load_model(
     "/path/to/GR00T-N1.6-3B",
     framework="torch",
     config="groot",
-    hardware="rtx_sm120",     # or rtx_sm89
+    hardware="rtx_sm120",
     num_views=2,
     embodiment_tag="gr1",
     use_fp8=False,
@@ -394,14 +394,18 @@ production latency.
 #### GROOT N1.7
 
 GROOT N1.7 defaults to the **FP8** path on RTX (see [GROOT N1.7 RTX](#groot-n17-rtx)).
-The full-FP16 variant is the opt-in non-quantized A/B reference: it runs the
-whole backbone (ViT / LLM / VL self-attn) and the action head (state/action
-encoders, the 32-layer DiT, output proj, decoder) through FlashRT kernels in
-FP16, with no PyTorch matmul on the serving feature path.
+The RTX reference variant is the opt-in non-default A/B path:
+
+- on `rtx_sm120`, it is the existing `GrootN17TorchFrontendRtxFP16`
+- on `rtx_sm89`, it is the dedicated
+  `GrootN17TorchFrontendRtxSm89FP16`
+
+Both paths replace the default FP8 route selected by `load_model()`, but the
+exact kernel/dtype mix remains hardware-specific.
 
 N1.7 uses the aux-driven `set_prompt(aux=...)` / `infer(state, initial_noise=...)`
 contract (not the `predict(images=...)` quickstart flow), so construct the
-frontend directly:
+frontend directly when you want the explicit class. Example for `rtx_sm120`:
 
 ```python
 from flash_rt.frontends.torch.groot_n17_rtx_fp16 import (
@@ -417,14 +421,22 @@ fe.set_prompt(aux=aux)                       # aux from the N1.7 preprocessing p
 actions = fe.infer(state_normalized, initial_noise=noise)
 ```
 
+On `rtx_sm89`, import and construct
+`flash_rt.frontends.torch.groot_n17_rtx_sm89_fp16.GrootN17TorchFrontendRtxSm89FP16`
+instead.
+
 `load_model(config="groot_n17", hardware="rtx_sm120", use_fp16=True,
-use_fp8=False)` returns this frontend. Reference on RTX 5090: FP16-vs-bf16
+use_fp8=False)` returns this frontend; on `hardware="rtx_sm89"` the same API
+returns the dedicated `GrootN17TorchFrontendRtxSm89FP16` reference frontend.
+Reference on RTX 5090: FP16-vs-bf16
 action cosine ≈ 0.99999, combined E2E-vs-reference cosine ≈ 0.9999; infer
 latency ≈ 10.7 ms (≈ the bf16 path — the DiT GEMMs are small, so FP16 and bf16
 throughput match).
 
-The underlying FP16 kernels are SM80-family friendly; FlashRT exposes the
-FP16 route for Pi0.5, GROOT N1.6, and GROOT N1.7 on the RTX frontends.
+The underlying FP16 kernels are SM80-family friendly, but the public support
+matrix is narrower: FlashRT exposes the FP16 RTX route for Pi0.5 on
+`rtx_sm120` / `rtx_sm89`, for GROOT N1.6 on `rtx_sm120`, and for GROOT N1.7
+on `rtx_sm120` / `rtx_sm89`.
 
 ### Thor non-FP8 reference paths (GROOT N1.6 / N1.7)
 
@@ -532,13 +544,22 @@ embeddings, visual masks, M-RoPE tables, pixel features, and `grid_thw`.
 `infer()` expects normalized state and returns normalized actions;
 denormalization remains the caller's responsibility for this N1.7 path.
 
-On RTX the default path is **FP8**: the backbone GEMMs (ViT / LLM / VL
-self-attn) run FP8 via the SM120-safe descale pattern (`fp8_descale_fp16` plus
-separate bias/GELU — the fused cuBLAS FP8 epilogue is unsupported on sm_120),
-and the bf16 DiT runs in `infer`. The entire forward runs through FlashRT
-kernels: backbone attention uses the vendored FA2 / FMHA kernels in
-`set_prompt`, and DiT self/cross attention uses FlashRT's vendored FA2 slots
-during `infer`. No PyTorch matmul runs on the serving feature path.
+On RTX the default path is **FP8**, but the hardware split is explicit:
+
+- `rtx_sm120` uses the shared RTX frontend / pipeline with the established
+  `fp8_descale_fp16` backbone path
+- `rtx_sm89` uses a dedicated RTX SM89 frontend / pipeline with runtime
+  weights stored as `[N, K]` and GEMMs dispatched through `fp8_nt_dev`
+
+In both cases the VLM backbone feature path runs through FlashRT kernels:
+backbone attention uses the vendored FA2 / FMHA kernels in `set_prompt`, and
+DiT self/cross attention uses FlashRT's vendored FA2 slots during `infer`.
+The action-head mix is not identical across the two RTX families:
+
+- `rtx_sm120` keeps the established RTX semantics documented by its frontend
+- `rtx_sm89` keeps FlashRT kernel execution for the SM89 FP8 backbone and
+  quantized DiT hot-path GEMMs, while some action-head-adjacent helpers stay
+  in the inherited bf16/fp16 route
 
 Activation scales follow the FlashRT calibration convention
 ([Calibration](#calibration)): weight scales are baked at load, activation
@@ -548,9 +569,11 @@ the cache and runs FP8 kernels only; the torch reference shadow runs solely on
 a cold cache miss (or `recalibrate=True`) to extract activation amax — never as
 the inference backbone. `calibrate(aux_list)` refines scales across N samples.
 
-Supported hardware is `rtx_sm120` (RTX 5090-class Blackwell). SM89 is
-registered through the same path; validate benchmark/accuracy on the target
-card.
+Supported hardware is `rtx_sm120` and `rtx_sm89`. `rtx_sm120` remains the
+validated Blackwell reference path in the public docs; `rtx_sm89` is validated
+locally on RTX 4090 using the same aux/reference-fixture methodology and
+should still be benchmarked on the target card before making hardware-specific
+claims.
 
 Build FA2 with at least the N1.7 head dimensions and dtypes:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -220,3 +220,41 @@ See [USAGE.md](../USAGE.md) §Loading a model for the per-frontend
 | `PJRT plugin ... not found` at JAX import | JAX / jax-cuda12-plugin version mismatch (Step 8) |
 | `cuBLAS error code=13` when loading second model | Ran two model loads in one process; subprocess-isolate per model |
 | cos regression right after calibrate | `act_scale * weight_scale` alpha computed in f64 somewhere; see `docs/calibration.md` §2.3 |
+
+## 12. Known runtime issue: cuBLASLt FP8 heuristic `code=15`
+
+Some FP8 cuBLASLt descriptors are sensitive to the cuBLASLt runtime
+patch version. `CUDA 13`, `CUDA 12.4`, or `libcublasLt.so.13` alone is
+not specific enough to identify the runtime behavior.
+
+If an FP8 GEMM fails with:
+
+```text
+cublasLtMatmulAlgoGetHeuristic(...), CUBLAS_STATUS_NOT_SUPPORTED / code=15
+```
+
+first print the exact cuBLASLt runtime version from the same Python
+environment that imports `flash_rt`:
+
+```python
+import ctypes
+import ctypes.util
+
+lib = ctypes.CDLL(ctypes.util.find_library("cublasLt"))
+lib.cublasLtGetVersion.restype = ctypes.c_size_t
+print(lib.cublasLtGetVersion())
+```
+
+Known local result on the same RTX 5090 and the same FP8 descriptor:
+
+| cuBLASLt runtime | Result |
+|---|---|
+| `13.0.2` (`cublasLtGetVersion() == 130002`) | one SM120 FP8 NN descriptor returned `code=15` |
+| `13.1.0` (`cublasLtGetVersion() == 130100`) | the same descriptor succeeded |
+
+On SM89, FP8 fused epilogue descriptors can show the same class of
+failure on older CUDA/cuBLASLt stacks. Treat this as a runtime-library
+capability issue until the exact cuBLASLt version, GPU, descriptor
+shape/layout, and epilogue have been checked. Prefer the validated
+Docker/NGC stack when debugging FP8 cuBLASLt heuristic failures, and
+include `cublasLtGetVersion()` in bug reports.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -86,11 +86,15 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   pay for the extra padded tokens. It can also be set with
   `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`.
 - `use_fp8=False` disables FP8 where the selected frontend exposes a
-  BF16 fallback; unsupported frontends ignore it.
-- `use_fp16=True` selects the opt-in Pi0.5 torch RTX SM120/SM89 full-FP16
-  CUDA Graph path. It requires `use_fp8=False` and is currently valid
-  only for `config="pi05"`, `framework="torch"`, and
-  `hardware in {"rtx_sm120", "rtx_sm89"}`.
+  BF16 fallback; unsupported frontends ignore it. GROOT N1.7 on RTX/Thor
+  is stricter: the default route is FP8, and `use_fp8=False` alone
+  raises because there is no separate BF16-only path.
+- `use_fp16=True` selects the opt-in reference path. It requires
+  `use_fp8=False` and is currently valid for:
+  - `config="pi05"`, `framework="torch"`, `hardware in {"rtx_sm120", "rtx_sm89"}`
+  - `config="groot"`, `framework="torch"`, `hardware in {"thor", "rtx_sm120"}`
+  - `config="groot_n17"`, `framework="torch"`,
+    `hardware in {"thor", "rtx_sm120", "rtx_sm89"}`
 - `config="motus"` is a beta RTX SM120 frontend. It expects a Motus
   checkpoint plus Wan and VLM checkpoint paths supplied to the Motus
   quickstart/frontend; see `docs/motus_usage_beta.md`.
@@ -107,9 +111,13 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   compare_ref=..., return_metadata=...)`, returning the denoised vision
   latent; `predict()` is not part of this API. Precision is selected with
   `load_model(..., use_fp8=True|False)`. See `docs/cosmos3_video_usage.md`.
-- `config="groot_n17"` is registered for `framework="torch"` and
-  `hardware="rtx_sm120"`. This route validates the N1.7 DiT
-  self/cross-attention path on the vendored FA2 backend.
+- `config="groot_n17"` is registered for `framework="torch"` on
+  `hardware in {"thor", "rtx_sm120", "rtx_sm89"}`. On RTX,
+  `rtx_sm120` resolves through the historical shared RTX registration and
+  `load_model()` refines that default route to the FP8 production
+  frontend; `rtx_sm89` resolves directly to its dedicated SM89 frontend.
+  `use_fp16=True, use_fp8=False` requests the explicit RTX reference
+  frontend for the selected hardware.
 
 ### `flash_rt.VLAModel`
 
@@ -205,8 +213,12 @@ Lazily imports and returns the concrete frontend class for the given
 `(config, framework, arch)` triple. Used internally by `load_model`.
 Motus beta is registered for `(config="motus", framework="torch",
 arch="rtx_sm120")`.
-GROOT N1.7 RTX is registered for `(config="groot_n17",
-framework="torch", arch="rtx_sm120")`.
+GROOT N1.7 is registered for `(config="groot_n17", framework="torch",
+arch in {"thor", "rtx_sm120", "rtx_sm89"})`. On RTX, `rtx_sm120`
+keeps the shared-base registration and `load_model()` refines that
+resolved class to the FP8 default or the explicit RTX reference frontend
+based on `use_fp8` / `use_fp16`; `rtx_sm89` resolves directly to the
+dedicated SM89 frontend class.
 Wan2.2 TI2V-5B is registered for `(config="wan22_ti2v_5b",
 framework="torch", arch="rtx_sm120")`.
 

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -363,11 +363,12 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         use_fp8: Enable FP8 execution where the selected frontend supports
             an FP8/BF16 switch. Defaults to True to preserve existing
             performance-oriented behavior.
-        use_fp16: Opt-in non-quantized full-FP16 path for Pi0.5, GROOT N1.6,
-            and GROOT N1.7 (torch, RTX SM120/SM89). Only valid with
-            ``use_fp8=False``; an A/B reference against the quantized default.
-            On GROOT N1.7 the default is FP8 (FP8 backbone + bf16 DiT), so
-            ``use_fp8=False`` without ``use_fp16=True`` raises.
+        use_fp16: Opt-in non-quantized full-FP16 path for Pi0.5 on RTX
+            SM120/SM89, GROOT N1.6 on Thor/RTX SM120, and GROOT N1.7 on
+            Thor/RTX SM120/SM89. Only valid with ``use_fp8=False``; an A/B
+            reference against the quantized default. On GROOT N1.7 the
+            default is FP8 (FP8 backbone + bf16 DiT), so ``use_fp8=False``
+            without ``use_fp16=True`` raises.
         num_steps: Pi0/Pi0.5 torch only when supported. Number of
             flow-matching ODE steps. ``None`` uses the frontend default.
         vision_pool_factor: Pi0.5 torch RTX/Orin only. Spatial pooling factor
@@ -463,14 +464,30 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             "--xla_gpu_enable_triton_gemm=false --xla_gpu_autotune_level=0")
         os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
 
+    if use_fp16:
+        if use_fp8:
+            raise ValueError("use_fp16=True requires use_fp8=False")
+        if (config, framework, arch) not in {
+            ("pi05", "torch", "rtx_sm120"),
+            ("pi05", "torch", "rtx_sm89"),
+            ("groot", "torch", "thor"),
+            ("groot", "torch", "rtx_sm120"),
+            ("groot_n17", "torch", "thor"),
+            ("groot_n17", "torch", "rtx_sm120"),
+            ("groot_n17", "torch", "rtx_sm89"),
+        }:
+            raise ValueError(
+                "use_fp16=True is currently experimental and only supports "
+                "('pi05', 'torch', 'rtx_sm120'/'rtx_sm89'), "
+                "('groot', 'torch', 'thor'/'rtx_sm120'), and "
+                "('groot_n17', 'torch', 'thor'/'rtx_sm120'/'rtx_sm89')")
+
     pipe_cls = resolve_pipeline_class(config, framework, arch)
 
-    # GROOT N1.7 on RTX: default to the framework-conforming FP8 frontend. The
-    # whole ViT/LLM/VL-self-attn backbone runs FP8 kernels via the SM120-safe
-    # descale pattern (no torch matmul on the serving feature path; activation
-    # scales come from the on-disk calibration cache, the torch shadow runs only
-    # on a cold cache miss). The DiT stays bf16 for Thor parity. ``use_fp16=True``
-    # opts into the full-FP16 frontend below (no FP8, non-quantized reference).
+    # GROOT N1.7 on RTX defaults to the framework-conforming FP8 frontend.
+    # rtx_sm120 keeps the historical shared-base registration and is refined
+    # here to the explicit FP8 production frontend. rtx_sm89 is already
+    # registered directly to its dedicated FP8 frontend in _PIPELINE_MAP.
     if config == "groot_n17" and framework == "torch" \
             and arch in ("rtx_sm120", "rtx_sm89") and not use_fp16:
         if not use_fp8:
@@ -478,10 +495,11 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 "GROOT N1.7 on RTX defaults to FP8; there is no separate "
                 "non-FP16 BF16 fallback. For the non-quantized full-FP16 "
                 "reference pass use_fp16=True, use_fp8=False.")
-        from flash_rt.frontends.torch.groot_n17_rtx_fp8 import (
-            GrootN17TorchFrontendRtxFP8,
-        )
-        pipe_cls = GrootN17TorchFrontendRtxFP8
+        if arch == "rtx_sm120":
+            from flash_rt.frontends.torch.groot_n17_rtx_fp8 import (
+                GrootN17TorchFrontendRtxFP8,
+            )
+            pipe_cls = GrootN17TorchFrontendRtxFP8
 
     # GROOT N1.7 on Thor (SM110) runs the FP8 backbone (+ bf16 DiT) by
     # default. There is no BF16-only fallback; the non-quantized reference is
@@ -495,8 +513,6 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             "use_fp16=True together with use_fp8=False.")
 
     if use_fp16:
-        if use_fp8:
-            raise ValueError("use_fp16=True requires use_fp8=False")
         # GROOT N1.6 Thor full-FP16 reference: the same fully-kernelized,
         # CUDA-graph pipeline as the FP8 production frontend, with the GEMMs run
         # in FP16 instead of per-tensor FP8 (an A/B accuracy baseline).
@@ -514,14 +530,6 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             )
             pipe_cls = GrootN17TorchFrontendThorFP16
         else:
-            fp16_arches = ("rtx_sm120", "rtx_sm89")
-            if config not in ("pi05", "groot", "groot_n17") or framework != "torch" \
-                    or arch not in fp16_arches:
-                raise ValueError(
-                    "use_fp16=True is currently experimental and only supports "
-                    "config in {'pi05', 'groot', 'groot_n17'}, framework='torch', "
-                    "hardware in {'thor' (groot/groot_n17 only), 'rtx_sm120', "
-                    "'rtx_sm89'}")
             if config == "pi05":
                 from flash_rt.frontends.torch.pi05_rtx_fp16 import (
                     Pi05TorchFrontendRtxFP16,
@@ -533,10 +541,16 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 )
                 pipe_cls = GrootTorchFrontendRtxFP16
             else:  # config == "groot_n17"
-                from flash_rt.frontends.torch.groot_n17_rtx_fp16 import (
-                    GrootN17TorchFrontendRtxFP16,
-                )
-                pipe_cls = GrootN17TorchFrontendRtxFP16
+                if arch == "rtx_sm89":
+                    from flash_rt.frontends.torch.groot_n17_rtx_sm89_fp16 import (
+                        GrootN17TorchFrontendRtxSm89FP16,
+                    )
+                    pipe_cls = GrootN17TorchFrontendRtxSm89FP16
+                else:
+                    from flash_rt.frontends.torch.groot_n17_rtx_fp16 import (
+                        GrootN17TorchFrontendRtxFP16,
+                    )
+                    pipe_cls = GrootN17TorchFrontendRtxFP16
 
     # ── FP4 routing (Pi0.5 torch + Pi0.5 JAX on Thor) ──
     if use_fp4:

--- a/flash_rt/frontends/torch/groot_n17_rtx_sm89.py
+++ b/flash_rt/frontends/torch/groot_n17_rtx_sm89.py
@@ -1,0 +1,608 @@
+"""FlashRT -- GROOT N1.7 FP8 torch frontend for RTX SM89.
+
+Framework-conforming FP8 path for GROOT N1.7 on RTX SM89. The whole VLM
+backbone (ViT / DeepStack / LLM / VL self-attn) runs through FlashRT FP8
+kernels via ``flash_rt.models.groot_n17.pipeline_rtx_sm89`` with runtime
+weights stored as ``[N, K]`` and GEMMs dispatched through ``fp8_nt_dev``.
+
+Activation scales follow the FlashRT calibration convention:
+weight scales are baked at load time; activation scales are calibrated once and
+cached to disk. On a warm ``set_prompt`` the cache is loaded and the backbone
+runs FP8 kernels only.
+
+The action-head path keeps the base frontend's dtype contract. In the kernel
+DiT hot path, self-attn QKV and FFN can still run through calibrated FP8
+weights; the remaining action-head-adjacent helpers stay in the inherited
+bf16/fp16 route.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import torch
+
+from flash_rt.frontends.torch.groot_n17_rtx import GrootN17TorchFrontendRtx
+
+_FP16 = torch.float16
+_BF16 = torch.bfloat16
+_U8 = torch.uint8
+
+
+class _GrootN17FP8BackboneMixin:
+    """set_prompt + FP8 kernel backbone + disk-cached activation scales."""
+
+    fp8_layout = "nk"
+
+    def __init__(
+        self,
+        checkpoint_path: str,
+        *,
+        num_views: int = 2,
+        embodiment_tag: str = "oxe_droid_relative_eef_relative_joint",
+        device: str = "cuda:0",
+        load_strided_fmha: bool = False,
+    ):
+        super().__init__(
+            checkpoint_path,
+            num_views=num_views,
+            embodiment_tag=embodiment_tag,
+            device=device,
+            load_strided_fmha=load_strided_fmha,
+        )
+        self._prepare_fp8_runtime_weights()
+
+    def _prepare_fp8_runtime_weights(self) -> None:
+        def nk(t: torch.Tensor) -> torch.Tensor:
+            return t.t().contiguous()
+
+        runtime = {
+            "vit_q": [],
+            "vit_k": [],
+            "vit_v": [],
+            "vit_o": [],
+            "vit_fc1": [],
+            "vit_fc2": [],
+            "dsm_fc1": [],
+            "dsm_fc2": [],
+            "llm_q": [],
+            "llm_k": [],
+            "llm_v": [],
+            "llm_o": [],
+            "llm_gate": [],
+            "llm_up": [],
+            "llm_down": [],
+            "vlsa_q": [],
+            "vlsa_k": [],
+            "vlsa_v": [],
+            "vlsa_o": [],
+            "vlsa_fc1": [],
+            "vlsa_fc2": [],
+        }
+
+        for li in range(24):
+            qkv = self._vit_qkv_w[li]
+            runtime["vit_q"].append(nk(qkv[:, :1024]))
+            runtime["vit_k"].append(nk(qkv[:, 1024:2048]))
+            runtime["vit_v"].append(nk(qkv[:, 2048:]))
+            runtime["vit_o"].append(nk(self._vit_o_w[li]))
+            runtime["vit_fc1"].append(nk(self._vit_fc1_w[li]))
+            runtime["vit_fc2"].append(nk(self._vit_fc2_w[li]))
+
+        for j in range(3):
+            runtime["dsm_fc1"].append(nk(getattr(self, f"_dsm{j}_fc1_w")))
+            runtime["dsm_fc2"].append(nk(getattr(self, f"_dsm{j}_fc2_w")))
+
+        for li in range(16):
+            qkv = self._llm_qkv_w[li]
+            runtime["llm_q"].append(nk(qkv[:, :2048]))
+            runtime["llm_k"].append(nk(qkv[:, 2048:3072]))
+            runtime["llm_v"].append(nk(qkv[:, 3072:]))
+            runtime["llm_o"].append(nk(self._llm_o_w[li]))
+            runtime["llm_gate"].append(nk(self._llm_gate_w[li]))
+            runtime["llm_up"].append(nk(self._llm_up_w[li]))
+            runtime["llm_down"].append(nk(self._llm_down_w[li]))
+
+        for li in range(4):
+            runtime["vlsa_q"].append(nk(self._vlsa_q_w[li]))
+            runtime["vlsa_k"].append(nk(self._vlsa_k_w[li]))
+            runtime["vlsa_v"].append(nk(self._vlsa_v_w[li]))
+            runtime["vlsa_o"].append(nk(self._vlsa_o_w[li]))
+            runtime["vlsa_fc1"].append(nk(self._vlsa_fc1_w[li]))
+            runtime["vlsa_fc2"].append(nk(self._vlsa_fc2_w[li]))
+
+        self._rtx_fp8_runtime = runtime
+
+    def _load_calibration_cache(self) -> "dict | None":
+        import json
+        from flash_rt.core.quant.calibrator import _checkpoint_hash, CACHE_DIR
+
+        try:
+            ckpt_hash = _checkpoint_hash(self.checkpoint_path)
+        except Exception:
+            return None
+        cache_path = CACHE_DIR / f"{ckpt_hash}_n17_Se{self.Se}.json"
+        if not cache_path.exists():
+            return None
+        try:
+            with open(cache_path) as f:
+                data = json.load(f)
+        except Exception:
+            return None
+        if data.get("ckpt_hash") != ckpt_hash:
+            return None
+        if int(data.get("Se", -1)) != int(self.Se):
+            return None
+        if int(data.get("embodiment_id", -1)) != int(self._embodiment_id):
+            return None
+        return data
+
+    @staticmethod
+    def _cache_to_stage_dicts(data: dict):
+        out_vit = {
+            k: data[k]
+            for k in ("vit_act_qkv", "vit_act_o", "vit_act_fc1", "vit_act_fc2")
+        }
+        out_ds = {k: data[k] for k in ("deepstack_act_fc1", "deepstack_act_fc2")}
+        out_llm = {
+            k: data[k]
+            for k in ("llm_act_qkv", "llm_act_o", "llm_act_gateup", "llm_act_down")
+        }
+        out_vlsa = {
+            k: data[k]
+            for k in ("vlsa_act_qkv", "vlsa_act_o", "vlsa_act_fc1", "vlsa_act_fc2")
+        }
+        return out_vit, out_ds, out_llm, out_vlsa
+
+    def _ensure_act_scales(self, aux: dict) -> None:
+        cached = self._load_calibration_cache()
+        if cached is not None:
+            self._bake_calibration(*self._cache_to_stage_dicts(cached))
+            if hasattr(self, "_fp16_shadow_weights"):
+                del self._fp16_shadow_weights
+                torch.cuda.empty_cache()
+            return
+
+        from flash_rt.models.groot_n17 import calibration as cal
+
+        if not hasattr(self, "_fp16_shadow_weights"):
+            self._load_fp16_shadow_weights()
+        device = self.device
+        out_vit = cal.calibrate_vit(
+            self,
+            aux["pixel_features"].to(device).float(),
+            self._vit_cos.float(),
+            self._vit_sin.float(),
+            num_views=self._num_vit_views,
+        )
+        out_ds = cal.calibrate_deepstack(self, out_vit["deepstack_taps"])
+        out_llm = cal.calibrate_llm(
+            self,
+            aux["llm_input_embeds"].to(device).float(),
+            self._mrope_cos.float(),
+            self._mrope_sin.float(),
+            self._visual_pos_masks,
+            out_ds["features"],
+        )
+        out_vlsa = cal.calibrate_vlsa(self, out_llm["llm_final"])
+        self._bake_calibration(out_vit, out_ds, out_llm, out_vlsa)
+        self._save_calibration_cache(out_vit, out_ds, out_llm, out_vlsa)
+        if hasattr(self, "_fp16_shadow_weights"):
+            del self._fp16_shadow_weights
+            torch.cuda.empty_cache()
+
+    def set_prompt(self, *, aux: dict, prompt: str | None = None) -> None:
+        from flash_rt.models.groot_n17.calibration import build_vit_rope_tables
+
+        if hasattr(self, "_backbone_features"):
+            raise RuntimeError(
+                "set_prompt() after prompt init is not supported; construct a "
+                "new frontend instance for a new prompt"
+            )
+
+        device = self.device
+        self._prompt = prompt
+        self.Se = int(aux["llm_input_embeds"].shape[1])
+        self._mrope_cos = aux["rope_cos"][0].to(device).half().contiguous()
+        self._mrope_sin = aux["rope_sin"][0].to(device).half().contiguous()
+        grid_thw = [tuple(int(x) for x in row) for row in aux["grid_thw"].tolist()]
+        vit_cos, vit_sin = build_vit_rope_tables(
+            grid_thw,
+            head_dim=64,
+            theta=10000.0,
+            spatial_merge_size=2,
+            device=device,
+        )
+        self._vit_cos = vit_cos
+        self._vit_sin = vit_sin
+        self._num_vit_views = len(grid_thw)
+        self._S_vit = sum(int(t * h * w) for t, h, w in grid_thw)
+        self._S_vit_per_view = self._S_vit // self._num_vit_views
+        self._visual_pos_masks = aux["visual_pos_masks"][0].to(device)
+
+        self._ensure_act_scales(aux)
+        self._backbone_features = self._run_kernel_backbone_fp8(aux).half()
+
+        try:
+            self._warmup_infer()
+        except Exception as e:  # noqa: BLE001
+            warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+
+    def _run_kernel_backbone_fp8(self, aux: dict) -> "torch.Tensor":
+        import flash_rt.flash_rt_kernels as fvk
+        from flash_rt.hardware.rtx.attn_backend_groot_n17_backbone import (
+            RtxGrootN17BackboneAttn,
+        )
+        from flash_rt.models.groot_n17 import pipeline_rtx_sm89 as P
+
+        if not hasattr(self, "_gemm"):
+            self._fvk = fvk
+            self._gemm = fvk.GemmRunner()
+        gemm, fvkm = self._gemm, self._fvk
+        dev = self.device
+        Sv, nv, Se = self._S_vit, self._num_vit_views, self.Se
+        runtime = self._rtx_fp8_runtime
+
+        keep: list = []
+        self._kbb_keep = keep
+
+        def K(t):
+            keep.append(t)
+            return t
+
+        def buf(*shape):
+            return K(torch.empty(*shape, dtype=_FP16, device=dev))
+
+        def bufbf(*shape):
+            return K(torch.empty(*shape, dtype=_BF16, device=dev))
+
+        def buf8(*shape):
+            return K(torch.empty(*shape, dtype=_U8, device=dev))
+
+        def wsc(val):
+            t = K(torch.tensor([float(val)], dtype=torch.float32, device=dev))
+            return t.data_ptr()
+
+        def adv(dev_list):
+            return [t.data_ptr() for t in dev_list]
+
+        attn = RtxGrootN17BackboneAttn(
+            num_vit_views=nv,
+            vit_seq=Sv,
+            llm_seq=Se,
+            vl_self_attn_seq=Se,
+            device=dev,
+        )
+        self._kbb_attn = attn
+
+        vit_h = buf(Sv, 1024)
+        vit_h.copy_(aux["pixel_features"].to(dev).half().reshape(Sv, 1024))
+        vit_bufs = {
+            "h": vit_h.data_ptr(),
+            "xn": buf(Sv, 1024).data_ptr(),
+            "xn_fp8": buf8(Sv, 1024).data_ptr(),
+            "o_proj_out": buf(Sv, 1024).data_ptr(),
+            "fc1_out": buf(Sv, 4096).data_ptr(),
+            "fc1_fp8": buf8(Sv, 4096).data_ptr(),
+            "bf16_tmp": bufbf(Sv, 1024).data_ptr(),
+            "bf16_ff": bufbf(Sv, 4096).data_ptr(),
+        }
+        vw = {
+            k: []
+            for k in (
+                "norm1_w",
+                "norm1_b",
+                "norm2_w",
+                "norm2_b",
+                "q_w",
+                "q_b",
+                "k_w",
+                "k_b",
+                "v_w",
+                "v_b",
+                "o_w",
+                "o_b",
+                "fc1_w",
+                "fc1_b",
+                "fc2_w",
+                "fc2_b",
+                "q_ws",
+                "k_ws",
+                "v_ws",
+                "o_ws",
+                "fc1_ws",
+                "fc2_ws",
+            )
+        }
+        vw["cos"] = self._vit_cos.data_ptr()
+        vw["sin"] = self._vit_sin.data_ptr()
+        for li in range(24):
+            q_ptr = runtime["vit_q"][li].data_ptr()
+            k_ptr = runtime["vit_k"][li].data_ptr()
+            v_ptr = runtime["vit_v"][li].data_ptr()
+            o_ptr = runtime["vit_o"][li].data_ptr()
+            fc1_ptr = runtime["vit_fc1"][li].data_ptr()
+            fc2_ptr = runtime["vit_fc2"][li].data_ptr()
+            b = self._vit_qkv_b[li]
+            qb = K(b[:1024].contiguous())
+            kb = K(b[1024:2048].contiguous())
+            vb = K(b[2048:].contiguous())
+            qkv_ws = wsc(self._vit_alpha[li * 4 + 0])
+            vw["norm1_w"].append(self._vit_ln1_w[li].data_ptr())
+            vw["norm1_b"].append(self._vit_ln1_b[li].data_ptr())
+            vw["norm2_w"].append(self._vit_ln2_w[li].data_ptr())
+            vw["norm2_b"].append(self._vit_ln2_b[li].data_ptr())
+            vw["q_w"].append(q_ptr)
+            vw["q_b"].append(qb.data_ptr())
+            vw["k_w"].append(k_ptr)
+            vw["k_b"].append(kb.data_ptr())
+            vw["v_w"].append(v_ptr)
+            vw["v_b"].append(vb.data_ptr())
+            vw["q_ws"].append(qkv_ws)
+            vw["k_ws"].append(qkv_ws)
+            vw["v_ws"].append(qkv_ws)
+            vw["o_w"].append(o_ptr)
+            vw["o_b"].append(self._vit_o_b[li].data_ptr())
+            vw["o_ws"].append(wsc(self._vit_alpha[li * 4 + 1]))
+            vw["fc1_w"].append(fc1_ptr)
+            vw["fc1_b"].append(self._vit_fc1_b[li].data_ptr())
+            vw["fc1_ws"].append(wsc(self._vit_alpha[li * 4 + 2]))
+            vw["fc2_w"].append(fc2_ptr)
+            vw["fc2_b"].append(self._vit_fc2_b[li].data_ptr())
+            vw["fc2_ws"].append(wsc(self._vit_alpha[li * 4 + 3]))
+        vit_scales = {
+            "act_qkv": adv(self._vit_act_qkv_dev),
+            "act_o": adv(self._vit_act_o_dev),
+            "act_fc1": adv(self._vit_act_fc1_dev),
+            "act_fc2": adv(self._vit_act_fc2_dev),
+        }
+
+        tap_layers = (5, 11, 17)
+        tap_bufs = {l: buf(Sv, 1024) for l in tap_layers}
+
+        def mk_cb(l):
+            def cb(h_ptr):
+                fvkm.gpu_copy(tap_bufs[l].data_ptr(), int(h_ptr), Sv * 1024 * 2, 0)
+
+            return cb
+
+        dcap = [mk_cb(l) for l in tap_layers]
+
+        P.qwen3vl_vit_forward(
+            gemm=gemm,
+            fvk=fvkm,
+            bufs=vit_bufs,
+            weights=vw,
+            scales_dev=vit_scales,
+            dims={
+                "S": Sv,
+                "D": 1024,
+                "NH": 16,
+                "HD": 64,
+                "ff_inner": 4096,
+                "Sper_view": Sv // nv,
+            },
+            attn=attn,
+            deepstack_taps=tap_layers,
+            deepstack_capture=dcap,
+        )
+
+        Nout = Sv // 4
+        ds_out = [buf(Nout, 2048) for _ in range(3)]
+        dsw = {
+            k: []
+            for k in ("norm_w", "norm_b", "fc1_w", "fc1_b", "fc2_w", "fc2_b", "fc1_ws", "fc2_ws")
+        }
+        for j in range(3):
+            dsw["norm_w"].append(getattr(self, f"_dsm{j}_norm_w").data_ptr())
+            dsw["norm_b"].append(getattr(self, f"_dsm{j}_norm_b").data_ptr())
+            dsw["fc1_w"].append(runtime["dsm_fc1"][j].data_ptr())
+            dsw["fc2_w"].append(runtime["dsm_fc2"][j].data_ptr())
+            dsw["fc1_b"].append(getattr(self, f"_dsm{j}_fc1_b").data_ptr())
+            dsw["fc1_ws"].append(wsc(self._dsm_alpha[j * 2 + 0]))
+            dsw["fc2_b"].append(getattr(self, f"_dsm{j}_fc2_b").data_ptr())
+            dsw["fc2_ws"].append(wsc(self._dsm_alpha[j * 2 + 1]))
+        ds_scales = {
+            "act_fc1": adv(self._dsm_act_fc1_dev),
+            "act_fc2": adv(self._dsm_act_fc2_dev),
+        }
+        P.deepstack_merge_forward(
+            gemm=gemm,
+            fvk=fvkm,
+            bufs={
+                "in": [tap_bufs[l].data_ptr() for l in tap_layers],
+                "ln_out": buf(Nout, 4096).data_ptr(),
+                "fp8_scratch": buf8(Nout, 4096).data_ptr(),
+                "fc1_out": buf(Nout, 4096).data_ptr(),
+                "out": [t.data_ptr() for t in ds_out],
+                "bf16_tmp": bufbf(Nout, 2048).data_ptr(),
+                "bf16_ff": bufbf(Nout, 4096).data_ptr(),
+            },
+            weights=dsw,
+            scales_dev=ds_scales,
+            dims={"Nin": Sv, "Din": 1024, "Nout": Nout, "Dmid": 4096, "Dout": 2048},
+        )
+
+        mask = self._visual_pos_masks
+        inject = [0] * 16
+        for j in range(3):
+            ib = K(torch.zeros(Se, 2048, dtype=_FP16, device=dev))
+            ib[mask] = ds_out[j]
+            inject[j] = ib.data_ptr()
+
+        llm_h = buf(Se, 2048)
+        llm_h.copy_(aux["llm_input_embeds"].to(dev).half().reshape(Se, 2048))
+        lw = {
+            k: []
+            for k in (
+                "in_ln_w",
+                "post_ln_w",
+                "q_norm_w",
+                "k_norm_w",
+                "q_w",
+                "k_w",
+                "v_w",
+                "o_w",
+                "gate_w",
+                "up_w",
+                "down_w",
+                "q_ws",
+                "k_ws",
+                "v_ws",
+                "o_ws",
+                "gate_ws",
+                "up_ws",
+                "down_ws",
+            )
+        }
+        lw["cos"] = self._mrope_cos.data_ptr()
+        lw["sin"] = self._mrope_sin.data_ptr()
+        lw["deepstack_inject"] = inject
+        for li in range(16):
+            q_ptr = runtime["llm_q"][li].data_ptr()
+            k_ptr = runtime["llm_k"][li].data_ptr()
+            v_ptr = runtime["llm_v"][li].data_ptr()
+            o_ptr = runtime["llm_o"][li].data_ptr()
+            gate_ptr = runtime["llm_gate"][li].data_ptr()
+            up_ptr = runtime["llm_up"][li].data_ptr()
+            down_ptr = runtime["llm_down"][li].data_ptr()
+            qkv_ws = wsc(self._llm_alpha[li * 5 + 0])
+            lw["in_ln_w"].append(self._llm_input_ln_w[li].data_ptr())
+            lw["post_ln_w"].append(self._llm_post_ln_w[li].data_ptr())
+            lw["q_norm_w"].append(self._llm_q_norm_w[li].data_ptr())
+            lw["k_norm_w"].append(self._llm_k_norm_w[li].data_ptr())
+            lw["q_w"].append(q_ptr)
+            lw["k_w"].append(k_ptr)
+            lw["v_w"].append(v_ptr)
+            lw["q_ws"].append(qkv_ws)
+            lw["k_ws"].append(qkv_ws)
+            lw["v_ws"].append(qkv_ws)
+            lw["o_w"].append(o_ptr)
+            lw["o_ws"].append(wsc(self._llm_alpha[li * 5 + 1]))
+            lw["gate_w"].append(gate_ptr)
+            lw["gate_ws"].append(wsc(self._llm_alpha[li * 5 + 2]))
+            lw["up_w"].append(up_ptr)
+            lw["up_ws"].append(wsc(self._llm_alpha[li * 5 + 3]))
+            lw["down_w"].append(down_ptr)
+            lw["down_ws"].append(wsc(self._llm_alpha[li * 5 + 4]))
+        llm_scales = {
+            "act_qkv": adv(self._llm_act_qkv_dev),
+            "act_o": adv(self._llm_act_o_dev),
+            "act_gateup": adv(self._llm_act_gateup_dev),
+            "act_down": adv(self._llm_act_down_dev),
+        }
+        slots = attn.get_slot_ptrs("llm")
+        llm_bufs = {
+            "h": llm_h.data_ptr(),
+            "xn": buf(Se, 2048).data_ptr(),
+            "xn_fp8": buf8(Se, 2048).data_ptr(),
+            "Q": slots["Q"],
+            "K": buf(Se, 1024).data_ptr(),
+            "V": buf(Se, 1024).data_ptr(),
+            "K_exp": slots["K"],
+            "V_exp": slots["V"],
+            "o_proj_out": buf(Se, 2048).data_ptr(),
+            "gate_out": buf(Se, 6144).data_ptr(),
+            "up_out": buf(Se, 6144).data_ptr(),
+            "gu_fp8": buf8(Se, 6144).data_ptr(),
+            "bf16_tmp": bufbf(Se, 2048).data_ptr(),
+            "bf16_ff": bufbf(Se, 6144).data_ptr(),
+        }
+        P.qwen3vl_llm_forward(
+            gemm=gemm,
+            fvk=fvkm,
+            bufs=llm_bufs,
+            weights=lw,
+            scales_dev=llm_scales,
+            dims={"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128, "FF": 6144},
+            attn=attn,
+        )
+
+        vlsa_h = buf(Se, 2048)
+        P.vlln_forward(
+            gemm=gemm,
+            fvk=fvkm,
+            bufs={"x": llm_h.data_ptr(), "out": vlsa_h.data_ptr()},
+            weights={"vlln_w": self._vlln_w.data_ptr(), "vlln_b": self._vlln_b.data_ptr()},
+            dims={"S": Se, "D": 2048},
+        )
+        vsw = {
+            k: []
+            for k in (
+                "norm1_w",
+                "norm1_b",
+                "norm3_w",
+                "norm3_b",
+                "q_w",
+                "q_b",
+                "k_w",
+                "k_b",
+                "v_w",
+                "v_b",
+                "o_w",
+                "o_b",
+                "fc1_w",
+                "fc1_b",
+                "fc2_w",
+                "fc2_b",
+                "q_ws",
+                "k_ws",
+                "v_ws",
+                "o_ws",
+                "fc1_ws",
+                "fc2_ws",
+            )
+        }
+        for li in range(4):
+            vsw["norm1_w"].append(self._vlsa_norm1_w[li].data_ptr())
+            vsw["norm1_b"].append(self._vlsa_norm1_b[li].data_ptr())
+            vsw["norm3_w"].append(self._vlsa_norm3_w[li].data_ptr())
+            vsw["norm3_b"].append(self._vlsa_norm3_b[li].data_ptr())
+            vsw["q_w"].append(runtime["vlsa_q"][li].data_ptr())
+            vsw["k_w"].append(runtime["vlsa_k"][li].data_ptr())
+            vsw["v_w"].append(runtime["vlsa_v"][li].data_ptr())
+            vsw["o_w"].append(runtime["vlsa_o"][li].data_ptr())
+            vsw["fc1_w"].append(runtime["vlsa_fc1"][li].data_ptr())
+            vsw["fc2_w"].append(runtime["vlsa_fc2"][li].data_ptr())
+            vsw["q_b"].append(self._vlsa_q_b[li].data_ptr())
+            vsw["q_ws"].append(wsc(self._vlsa_alpha[li * 6 + 0]))
+            vsw["k_b"].append(self._vlsa_k_b[li].data_ptr())
+            vsw["k_ws"].append(wsc(self._vlsa_alpha[li * 6 + 1]))
+            vsw["v_b"].append(self._vlsa_v_b[li].data_ptr())
+            vsw["v_ws"].append(wsc(self._vlsa_alpha[li * 6 + 2]))
+            vsw["o_b"].append(self._vlsa_o_b[li].data_ptr())
+            vsw["o_ws"].append(wsc(self._vlsa_alpha[li * 6 + 3]))
+            vsw["fc1_b"].append(self._vlsa_fc1_b[li].data_ptr())
+            vsw["fc1_ws"].append(wsc(self._vlsa_alpha[li * 6 + 4]))
+            vsw["fc2_b"].append(self._vlsa_fc2_b[li].data_ptr())
+            vsw["fc2_ws"].append(wsc(self._vlsa_alpha[li * 6 + 5]))
+        vlsa_scales = {
+            "act_qkv": adv(self._vlsa_act_qkv_dev),
+            "act_o": adv(self._vlsa_act_o_dev),
+            "act_fc1": adv(self._vlsa_act_fc1_dev),
+            "act_fc2": adv(self._vlsa_act_fc2_dev),
+        }
+        P.vl_self_attn_forward(
+            gemm=gemm,
+            fvk=fvkm,
+            bufs={
+                "h": vlsa_h.data_ptr(),
+                "xn": buf(Se, 2048).data_ptr(),
+                "xn_fp8": buf8(Se, 2048).data_ptr(),
+                "o_proj_out": buf(Se, 2048).data_ptr(),
+                "fc1_out": buf(Se, 8192).data_ptr(),
+                "fc1_fp8": buf8(Se, 8192).data_ptr(),
+                "bf16_tmp": bufbf(Se, 2048).data_ptr(),
+                "bf16_ff": bufbf(Se, 8192).data_ptr(),
+            },
+            weights=vsw,
+            scales_dev=vlsa_scales,
+            dims={"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192},
+            attn=attn,
+        )
+        torch.cuda.synchronize()
+        return vlsa_h.unsqueeze(0)
+
+
+class GrootN17TorchFrontendRtxSm89(_GrootN17FP8BackboneMixin, GrootN17TorchFrontendRtx):
+    """N1.7 RTX SM89 FP8 frontend with a bf16 action head."""

--- a/flash_rt/frontends/torch/groot_n17_rtx_sm89_fp16.py
+++ b/flash_rt/frontends/torch/groot_n17_rtx_sm89_fp16.py
@@ -1,0 +1,646 @@
+"""FlashRT -- GROOT N1.7 full-FP16 torch frontend for RTX SM89.
+
+Full-FP16 reference variant of the dedicated RTX SM89 GROOT N1.7 path. This
+keeps the RTX SM89 runtime/file split aligned with the repo routing contract:
+the user-visible reference path for `use_fp16=True, use_fp8=False` lives in a
+separate SM89 frontend instead of a shared RTX file.
+
+Additive: subclasses :class:`GrootN17TorchFrontendRtx` and overrides only the
+dtype-bearing action-head methods. The bf16 path is left untouched.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import glob
+
+import torch
+
+from flash_rt.frontends.torch.groot_n17_rtx import GrootN17TorchFrontendRtx
+
+_FP16 = torch.float16
+
+
+class GrootN17TorchFrontendRtxSm89FP16(GrootN17TorchFrontendRtx):
+    """N1.7 RTX SM89 frontend with a full-FP16 action-head path."""
+
+    # ── Weight loading: dequant DiT FP8 weights to FP16 (bf16 in base) ──
+    def _load_weights(self) -> None:
+        from flash_rt.executors.torch_weights import MultiSafetensorsSource
+        from flash_rt.executors.weight_loader import WeightLoader
+        from flash_rt.frontends.torch._groot_n17_thor_spec import WEIGHT_SPEC
+
+        shards = sorted(
+            glob.glob(os.path.join(self.checkpoint_path, "model-*.safetensors")))
+        if not shards:
+            raise FileNotFoundError(
+                f"no model-*.safetensors shards in {self.checkpoint_path}")
+        source = MultiSafetensorsSource(shards, device=self.device)
+        WeightLoader(source=source, target=self, spec=WEIGHT_SPEC).run()
+
+        # DiT weights are loaded FP8 per spec; dequant to FP16 (the bf16 path
+        # dequants to bf16). w_fp16 = (w_fp8.float() * weight_scale).half().
+        for i in range(32):
+            base = i * 7
+            for attr_w, attr_b, scale_idx in [
+                ("_dit_q_w",       "_dit_q_b",       base + 0),
+                ("_dit_k_w",       "_dit_k_b",       base + 1),
+                ("_dit_v_w",       "_dit_v_b",       base + 2),
+                ("_dit_o_w",       "_dit_o_b",       base + 3),
+                ("_dit_ada_w",     "_dit_ada_b",     base + 4),
+                ("_dit_ff_proj_w", "_dit_ff_proj_b", base + 5),
+                ("_dit_ff_down_w", "_dit_ff_down_b", base + 6),
+            ]:
+                w_list = getattr(self, attr_w)
+                b_list = getattr(self, attr_b)
+                w_list[i] = (w_list[i].float()
+                             * float(self._dit_alpha[scale_idx])).half().contiguous()
+                b_list[i] = b_list[i].half().contiguous()
+
+        slot = self._embodiment_id
+        for name in (
+            "_st_enc_l1_W", "_st_enc_l1_b", "_st_enc_l2_W", "_st_enc_l2_b",
+            "_ac_enc_W1_W", "_ac_enc_W1_b", "_ac_enc_W2_W", "_ac_enc_W2_b",
+            "_ac_enc_W3_W", "_ac_enc_W3_b",
+            "_ac_dec_l1_W", "_ac_dec_l1_b", "_ac_dec_l2_W", "_ac_dec_l2_b",
+        ):
+            full = getattr(self, name)
+            setattr(self, name, full[slot].contiguous())
+            del full
+
+        self._load_fp16_shadow_weights()
+
+    # ── Cross-attn K/V precompute (FP16 output) ──
+    def _precompute_dit_cross_kv(self) -> None:
+        backbone = self._backbone_features.squeeze(0)
+        mask = self._visual_pos_masks
+        text_kv_src = backbone[~mask]
+        image_kv_src = backbone[mask]
+        K_list, V_list = [], []
+        for j in range(16):
+            li = 2 * j
+            target_text = (li % 4 == 0)
+            kv_src = text_kv_src if target_text else image_kv_src
+            k_w = self._dit_k_w[li].float()
+            v_w = self._dit_v_w[li].float()
+            k_b = self._dit_k_b[li].float()
+            v_b = self._dit_v_b[li].float()
+            K_list.append((kv_src.float() @ k_w + k_b).half().contiguous())
+            V_list.append((kv_src.float() @ v_w + v_b).half().contiguous())
+        self._dit_cross_K = K_list
+        self._dit_cross_V = V_list
+
+    # ── Timestep embedding (FP16) ──
+    def _compute_timestep_emb(self, t_disc: int) -> torch.Tensor:
+        half_dim = 128
+        exponent = -math.log(10000) * torch.arange(
+            0, half_dim, dtype=torch.float32, device=self.device) / (half_dim - 1)
+        freqs = torch.exp(exponent)
+        emb = torch.tensor(
+            [t_disc], dtype=torch.float32, device=self.device)[:, None] * freqs[None, :]
+        emb = torch.cat([torch.cos(emb), torch.sin(emb)], dim=-1)
+        ts_lin1_w = (self._ts_lin1_w.float() * self._dit_misc_alpha[0])
+        ts_lin1_b = self._ts_lin1_b.float()
+        ts_lin2_w = (self._ts_lin2_w.float() * self._dit_misc_alpha[1])
+        ts_lin2_b = self._ts_lin2_b.float()
+        h = emb @ ts_lin1_w + ts_lin1_b
+        h = torch.nn.functional.silu(h)
+        h = h @ ts_lin2_w + ts_lin2_b
+        return h.half().contiguous()
+
+    # ── Per-layer AdaLN modulators (FP16) ──
+    def _compute_dit_adaln_modulators(self, temb: torch.Tensor):
+        x = torch.nn.functional.silu(temb.float())
+        shifts, scales = [], []
+        for i in range(32):
+            ada_w = self._dit_ada_w[i].float()
+            ada_b = self._dit_ada_b[i].float()
+            mod = x @ ada_w + ada_b
+            scale, shift = mod.chunk(2, dim=-1)   # HF order: scale, shift
+            shifts.append(shift.squeeze(0).half().contiguous())
+            scales.append(scale.squeeze(0).half().contiguous())
+        return shifts, scales
+
+    # ── Embodiment encoders / decoder (FP16 output) ──
+    def _run_state_encode(self, state_flat: torch.Tensor) -> torch.Tensor:
+        x = state_flat.view(1, 132).float()
+        h = x @ self._st_enc_l1_W.float() + self._st_enc_l1_b.float()
+        h = torch.nn.functional.relu(h)
+        out = h @ self._st_enc_l2_W.float() + self._st_enc_l2_b.float()
+        return out.half().view(1, 1, 1536)
+
+    def _run_action_encode(self, actions: torch.Tensor, t_disc: int,
+                           action_horizon: int) -> torch.Tensor:
+        device = self.device
+        H = 1536
+        half_dim = H // 2
+        exponent = -torch.arange(
+            half_dim, dtype=torch.float32, device=device
+        ) * (math.log(10000.0) / half_dim)
+        timesteps = torch.full(
+            (action_horizon,), float(t_disc), dtype=torch.float32, device=device)
+        freqs = timesteps.unsqueeze(-1) * exponent.exp()
+        tau_emb = torch.cat([torch.sin(freqs), torch.cos(freqs)], dim=-1)
+
+        x = actions.view(action_horizon, 132).float()
+        a_emb = x @ self._ac_enc_W1_W.float() + self._ac_enc_W1_b.float()
+        cat = torch.cat([a_emb, tau_emb], dim=-1)
+        h = cat @ self._ac_enc_W2_W.float() + self._ac_enc_W2_b.float()
+        h = torch.nn.functional.silu(h)
+        out = h @ self._ac_enc_W3_W.float() + self._ac_enc_W3_b.float()
+        return out.half().view(1, action_horizon, H)
+
+    def _run_action_decode(self, dit_out: torch.Tensor) -> torch.Tensor:
+        x = dit_out.view(-1, 1024).float()
+        h = x @ self._ac_dec_l1_W.float() + self._ac_dec_l1_b.float()
+        h = torch.nn.functional.relu(h)
+        out = h @ self._ac_dec_l2_W.float() + self._ac_dec_l2_b.float()
+        return out.half().view(1, dit_out.shape[1], 132)
+
+    def _run_dit_output_proj(self, h: torch.Tensor, temb: torch.Tensor) -> torch.Tensor:
+        D = 1536
+        x = torch.nn.functional.silu(temb.float())
+        po1_w = self._proj_out_1_w.float() * self._dit_misc_alpha[2]
+        po1_b = self._proj_out_1_b.float()
+        mod = x @ po1_w + po1_b
+        shift, scale = mod.chunk(2, dim=-1)
+        h_norm = torch.nn.functional.layer_norm(h.float(), (D,), eps=1e-5)
+        h_mod = h_norm * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+        po2_w = self._proj_out_2_w.float() * self._dit_misc_alpha[3]
+        po2_b = self._proj_out_2_b.float()
+        return (h_mod @ po2_w + po2_b).half().contiguous()
+
+    # ── DiT scratch buffers (FP16) ──
+    def _allocate_infer_buffers(self, action_horizon: int) -> None:
+        Sa = 1 + action_horizon
+        D, FF = 1536, 6144
+        device = self.device
+        self._infer_bufs = {
+            "dit_h":          torch.empty((Sa, D), dtype=_FP16, device=device),
+            "dit_xn":         torch.empty((Sa, D), dtype=_FP16, device=device),
+            "dit_o_proj_out": torch.empty((Sa, D), dtype=_FP16, device=device),
+            "dit_ff_proj_out": torch.empty((Sa, FF), dtype=_FP16, device=device),
+        }
+
+    # ── RTX DiT attention backend with FP16 slots ──
+    def _build_dit_attn(self, Sa: int) -> None:
+        from flash_rt.hardware.rtx.attn_backend_groot_n17 import (
+            RtxFlashAttnBackendGrootN17,
+        )
+
+        Skv_text = int(self._dit_cross_K[0].shape[0])
+        Skv_image = int(self._dit_cross_K[1].shape[0])
+        attn = RtxFlashAttnBackendGrootN17(
+            num_vit_groups=int(getattr(self, "_num_vit_views", 4)),
+            llm_seq_max=int(self.Se),
+            vl_self_attn_seq_max=int(self.Se),
+            sa=int(Sa),
+            s_kv_text=Skv_text,
+            s_kv_image=Skv_image,
+            device=self.device,
+            slot_dtype=_FP16,
+        )
+        for j, (k_src, v_src) in enumerate(zip(self._dit_cross_K, self._dit_cross_V)):
+            attn.dit_cross_K[j].view(attn.dit_cross_K[j].shape[0], -1)[
+                : k_src.shape[0]
+            ].copy_(k_src)
+            attn.dit_cross_V[j].view(attn.dit_cross_V[j].shape[0], -1)[
+                : v_src.shape[0]
+            ].copy_(v_src)
+        self._dit_attn = attn
+
+    # ── DiT forward via the full-FP16 pipeline ──
+    def _run_dit(self, bufs: dict, shift_list, scale_list, Sa: int) -> None:
+        from flash_rt.models.groot_n17 import pipeline_rtx_fp16
+
+        if not hasattr(self, "_dit_attn"):
+            self._build_dit_attn(Sa)
+
+        weights = {
+            "scale_msa": [t.data_ptr() for t in scale_list],
+            "shift_msa": [t.data_ptr() for t in shift_list],
+            "q_w": [w.data_ptr() for w in self._dit_q_w],
+            "q_b": [b.data_ptr() for b in self._dit_q_b],
+            "k_w": [w.data_ptr() for w in self._dit_k_w],
+            "k_b": [b.data_ptr() for b in self._dit_k_b],
+            "v_w": [w.data_ptr() for w in self._dit_v_w],
+            "v_b": [b.data_ptr() for b in self._dit_v_b],
+            "o_w": [w.data_ptr() for w in self._dit_o_w],
+            "o_b": [b.data_ptr() for b in self._dit_o_b],
+            "ff_proj_w": [w.data_ptr() for w in self._dit_ff_proj_w],
+            "ff_proj_b": [b.data_ptr() for b in self._dit_ff_proj_b],
+            "ff_down_w": [w.data_ptr() for w in self._dit_ff_down_w],
+            "ff_down_b": [b.data_ptr() for b in self._dit_ff_down_b],
+        }
+        Skv_text = int(self._dit_cross_K[0].shape[0])
+        Skv_image = int(self._dit_cross_K[1].shape[0])
+        dims = {
+            "Sa": int(Sa), "D": 1536, "FF": 6144,
+            "Skv_text": Skv_text, "Skv_image": Skv_image,
+        }
+        bufs_ptrs = {
+            "h": bufs["dit_h"].data_ptr(),
+            "xn": bufs["dit_xn"].data_ptr(),
+            "o_proj_out": bufs["dit_o_proj_out"].data_ptr(),
+            "ff_proj_out": bufs["dit_ff_proj_out"].data_ptr(),
+        }
+        if not hasattr(self, "_gemm"):
+            import flash_rt.flash_rt_kernels as _fvk
+            self._fvk = _fvk
+            self._gemm = _fvk.GemmRunner()
+
+        pipeline_rtx_fp16.dit_forward(
+            gemm=self._gemm, fvk=self._fvk,
+            bufs=bufs_ptrs, weights=weights, dims=dims,
+            attn=self._dit_attn,
+        )
+
+    # ── CUDA graph capture over the full-FP16 DiT ──
+    def _capture_dit_graphs(self, num_inference_timesteps: int = 4,
+                            action_horizon: int = 40) -> None:
+        from flash_rt.models.groot_n17 import pipeline_rtx_fp16
+
+        Sa = action_horizon + 1
+        if not hasattr(self, "_infer_bufs"):
+            self._allocate_infer_buffers(action_horizon)
+        if not hasattr(self, "_dit_attn"):
+            self._build_dit_attn(Sa)
+        if not hasattr(self, "_step_shifts"):
+            self._precompute_diffusion_modulators(
+                num_inference_timesteps=num_inference_timesteps)
+        if not hasattr(self, "_gemm"):
+            import flash_rt.flash_rt_kernels as _fvk
+            self._fvk = _fvk
+            self._gemm = _fvk.GemmRunner()
+
+        bufs = self._infer_bufs
+        Skv_text = int(self._dit_cross_K[0].shape[0])
+        Skv_image = int(self._dit_cross_K[1].shape[0])
+        dims = {"Sa": Sa, "D": 1536, "FF": 6144,
+                "Skv_text": Skv_text, "Skv_image": Skv_image}
+        bufs_ptrs = {
+            "h": bufs["dit_h"].data_ptr(),
+            "xn": bufs["dit_xn"].data_ptr(),
+            "o_proj_out": bufs["dit_o_proj_out"].data_ptr(),
+            "ff_proj_out": bufs["dit_ff_proj_out"].data_ptr(),
+        }
+
+        def _weights_for(step: int) -> dict:
+            return {
+                "scale_msa": [t.data_ptr() for t in self._step_scales[step]],
+                "shift_msa": [t.data_ptr() for t in self._step_shifts[step]],
+                "q_w": [w.data_ptr() for w in self._dit_q_w],
+                "q_b": [b.data_ptr() for b in self._dit_q_b],
+                "k_w": [w.data_ptr() for w in self._dit_k_w],
+                "k_b": [b.data_ptr() for b in self._dit_k_b],
+                "v_w": [w.data_ptr() for w in self._dit_v_w],
+                "v_b": [b.data_ptr() for b in self._dit_v_b],
+                "o_w": [w.data_ptr() for w in self._dit_o_w],
+                "o_b": [b.data_ptr() for b in self._dit_o_b],
+                "ff_proj_w": [w.data_ptr() for w in self._dit_ff_proj_w],
+                "ff_proj_b": [b.data_ptr() for b in self._dit_ff_proj_b],
+                "ff_down_w": [w.data_ptr() for w in self._dit_ff_down_w],
+                "ff_down_b": [b.data_ptr() for b in self._dit_ff_down_b],
+            }
+
+        weights_warm = _weights_for(0)
+        for _ in range(3):
+            pipeline_rtx_fp16.dit_forward(
+                gemm=self._gemm, fvk=self._fvk,
+                bufs=bufs_ptrs, weights=weights_warm, dims=dims,
+                attn=self._dit_attn,
+            )
+        torch.cuda.synchronize()
+
+        self._dit_graphs = []
+        for step in range(num_inference_timesteps):
+            weights = _weights_for(step)
+            graph = torch.cuda.CUDAGraph()
+            stream = torch.cuda.Stream()
+            stream.wait_stream(torch.cuda.current_stream())
+            s_int = stream.cuda_stream
+            with torch.cuda.stream(stream):
+                graph.capture_begin()
+                pipeline_rtx_fp16.dit_forward(
+                    gemm=self._gemm, fvk=self._fvk,
+                    bufs=bufs_ptrs, weights=weights, dims=dims,
+                    attn=self._dit_attn, stream=s_int,
+                )
+                graph.capture_end()
+            torch.cuda.current_stream().wait_stream(stream)
+            torch.cuda.synchronize()
+            self._dit_graphs.append(graph)
+
+    # ── set_prompt: produce backbone_features via FP16 kernels (no torch) ──
+    def set_prompt(self, *, aux: dict, prompt: str | None = None) -> None:
+        import warnings
+        from flash_rt.models.groot_n17.calibration import build_vit_rope_tables
+
+        if hasattr(self, "_backbone_features"):
+            raise RuntimeError(
+                "set_prompt() after prompt init is not supported; construct a "
+                "new frontend instance for a new prompt")
+
+        device = self.device
+        self._prompt = prompt
+        self.Se = int(aux["llm_input_embeds"].shape[1])
+        self._mrope_cos = aux["rope_cos"][0].to(device).half().contiguous()
+        self._mrope_sin = aux["rope_sin"][0].to(device).half().contiguous()
+        grid_thw = [tuple(int(x) for x in row) for row in aux["grid_thw"].tolist()]
+        vit_cos, vit_sin = build_vit_rope_tables(
+            grid_thw, head_dim=64, theta=10000.0, spatial_merge_size=2,
+            device=device)
+        self._vit_cos = vit_cos
+        self._vit_sin = vit_sin
+        self._num_vit_views = len(grid_thw)
+        self._S_vit = sum(int(t * h * w) for t, h, w in grid_thw)
+        self._visual_pos_masks = aux["visual_pos_masks"][0].to(device)
+
+        # ── Full-FP16 KERNEL backbone (replaces the torch calibration shadow) ──
+        self._backbone_features = self._run_kernel_backbone(aux).half()
+
+        try:
+            self._warmup_infer()
+        except Exception as e:  # noqa: BLE001
+            warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+
+    def _run_kernel_backbone(self, aux: dict) -> "torch.Tensor":
+        """Run ViT → DeepStack → LLM → vlln → VL-self-attn through FP16 kernels.
+
+        Returns backbone_features (1, Se, 2048). No PyTorch matmul on the
+        feature path — the entire VLM backbone runs through FlashRT kernels.
+        """
+        import flash_rt.flash_rt_kernels as fvk
+        from flash_rt.models.groot_n17 import pipeline_rtx_fp16 as P
+        from flash_rt.hardware.rtx.attn_backend_groot_n17_backbone import (
+            RtxGrootN17BackboneAttn,
+        )
+
+        if not hasattr(self, "_gemm"):
+            self._fvk = fvk
+            self._gemm = fvk.GemmRunner()
+        gemm, fvkm = self._gemm, self._fvk
+        dev = self.device
+        Sv, nv, Se = self._S_vit, self._num_vit_views, self.Se
+        sh = self._fp16_shadow_weights
+
+        keep: list = []
+
+        def K(t):
+            keep.append(t)
+            return t
+
+        attn = RtxGrootN17BackboneAttn(
+            num_vit_views=nv, vit_seq=Sv, llm_seq=Se, vl_self_attn_seq=Se,
+            device=dev)
+        self._kbb_keep = keep
+        self._kbb_attn = attn
+
+        def buf(*shape):
+            return K(torch.empty(*shape, dtype=_FP16, device=dev))
+
+        # ═══ ViT (24L) ═══
+        vit_h = buf(Sv, 1024)
+        vit_h.copy_(aux["pixel_features"].to(dev).half().reshape(Sv, 1024))
+        vit_bufs = {"h": vit_h.data_ptr(), "xn": buf(Sv, 1024).data_ptr(),
+                    "o_proj_out": buf(Sv, 1024).data_ptr(),
+                    "fc1_out": buf(Sv, 4096).data_ptr()}
+        vw = {k: [] for k in (
+            "norm1_w", "norm1_b", "norm2_w", "norm2_b", "q_w", "q_b",
+            "k_w", "k_b", "v_w", "v_b", "o_w", "o_b", "fc1_w", "fc1_b",
+            "fc2_w", "fc2_b")}
+        vw["cos"] = self._vit_cos.data_ptr()
+        vw["sin"] = self._vit_sin.data_ptr()
+        for li in range(24):
+            qkv = sh[("vit", li, "qkv")]            # (1024, 3072) fp16
+            b = self._vit_qkv_b[li]                 # (3072,)
+            q = K(qkv[:, :1024].contiguous()); kk = K(qkv[:, 1024:2048].contiguous())
+            v = K(qkv[:, 2048:].contiguous())
+            qb = K(b[:1024].contiguous()); kb = K(b[1024:2048].contiguous())
+            vb = K(b[2048:].contiguous())
+            vw["norm1_w"].append(self._vit_ln1_w[li].data_ptr())
+            vw["norm1_b"].append(self._vit_ln1_b[li].data_ptr())
+            vw["norm2_w"].append(self._vit_ln2_w[li].data_ptr())
+            vw["norm2_b"].append(self._vit_ln2_b[li].data_ptr())
+            vw["q_w"].append(q.data_ptr()); vw["q_b"].append(qb.data_ptr())
+            vw["k_w"].append(kk.data_ptr()); vw["k_b"].append(kb.data_ptr())
+            vw["v_w"].append(v.data_ptr()); vw["v_b"].append(vb.data_ptr())
+            vw["o_w"].append(sh[("vit", li, "o")].data_ptr())
+            vw["o_b"].append(self._vit_o_b[li].data_ptr())
+            vw["fc1_w"].append(sh[("vit", li, "fc1")].data_ptr())
+            vw["fc1_b"].append(self._vit_fc1_b[li].data_ptr())
+            vw["fc2_w"].append(sh[("vit", li, "fc2")].data_ptr())
+            vw["fc2_b"].append(self._vit_fc2_b[li].data_ptr())
+
+        tap_layers = (5, 11, 17)
+        tap_bufs = {l: buf(Sv, 1024) for l in tap_layers}
+
+        def mk_cb(l):
+            def cb(h_ptr):
+                fvkm.gpu_copy(tap_bufs[l].data_ptr(), int(h_ptr), Sv * 1024 * 2, 0)
+            return cb
+        dcap = [mk_cb(l) for l in tap_layers]
+
+        P.qwen3vl_vit_forward(
+            gemm=gemm, fvk=fvkm, bufs=vit_bufs, weights=vw,
+            dims={"S": Sv, "D": 1024, "NH": 16, "HD": 64,
+                  "ff_inner": 4096, "Sper_view": Sv // nv},
+            attn=attn, deepstack_taps=tap_layers, deepstack_capture=dcap)
+
+        # ═══ DeepStack (3 mergers) ═══
+        Nout = Sv // 4
+        ds_out = [buf(Nout, 2048) for _ in range(3)]
+        dsw = {k: [] for k in ("norm_w", "norm_b", "fc1_w", "fc1_b",
+                                "fc2_w", "fc2_b")}
+        for j in range(3):
+            dsw["norm_w"].append(getattr(self, f"_dsm{j}_norm_w").data_ptr())
+            dsw["norm_b"].append(getattr(self, f"_dsm{j}_norm_b").data_ptr())
+            dsw["fc1_w"].append(sh[("dsm", j, "fc1")].data_ptr())
+            dsw["fc1_b"].append(getattr(self, f"_dsm{j}_fc1_b").data_ptr())
+            dsw["fc2_w"].append(sh[("dsm", j, "fc2")].data_ptr())
+            dsw["fc2_b"].append(getattr(self, f"_dsm{j}_fc2_b").data_ptr())
+        P.deepstack_merge_forward(
+            gemm=gemm, fvk=fvkm,
+            bufs={"in": [tap_bufs[l].data_ptr() for l in tap_layers],
+                  "ln_out": buf(Nout, 4096).data_ptr(),
+                  "fc1_out": buf(Nout, 4096).data_ptr(),
+                  "out": [t.data_ptr() for t in ds_out]},
+            weights=dsw,
+            dims={"Nin": Sv, "Din": 1024, "Nout": Nout, "Dmid": 4096, "Dout": 2048})
+
+        # DeepStack inject buffers (S, D) — zero except visual positions.
+        mask = self._visual_pos_masks
+        inject = [0] * 16
+        for j in range(3):
+            ib = K(torch.zeros(Se, 2048, dtype=_FP16, device=dev))
+            ib[mask] = ds_out[j]
+            inject[j] = ib.data_ptr()
+
+        # ═══ LLM (16L, causal, GQA) ═══
+        llm_h = buf(Se, 2048)
+        llm_h.copy_(aux["llm_input_embeds"].to(dev).half().reshape(Se, 2048))
+        # bufs["Q"]/["K_exp"]/["V_exp"] must alias the attn llm slots so run() reads them.
+        lw = {k: [] for k in (
+            "in_ln_w", "post_ln_w", "q_norm_w", "k_norm_w", "q_w", "k_w",
+            "v_w", "o_w", "gate_w", "up_w", "down_w")}
+        lw["cos"] = self._mrope_cos.data_ptr()
+        lw["sin"] = self._mrope_sin.data_ptr()
+        lw["deepstack_inject"] = inject
+        for li in range(16):
+            qkv = sh[("llm", li, "qkv")]            # (2048, 4096) fp16
+            q = K(qkv[:, :2048].contiguous())
+            kk = K(qkv[:, 2048:3072].contiguous())
+            v = K(qkv[:, 3072:4096].contiguous())
+            lw["in_ln_w"].append(self._llm_input_ln_w[li].data_ptr())
+            lw["post_ln_w"].append(self._llm_post_ln_w[li].data_ptr())
+            lw["q_norm_w"].append(self._llm_q_norm_w[li].data_ptr())
+            lw["k_norm_w"].append(self._llm_k_norm_w[li].data_ptr())
+            lw["q_w"].append(q.data_ptr()); lw["k_w"].append(kk.data_ptr())
+            lw["v_w"].append(v.data_ptr())
+            lw["o_w"].append(sh[("llm", li, "o")].data_ptr())
+            lw["gate_w"].append(sh[("llm", li, "gate")].data_ptr())
+            lw["up_w"].append(sh[("llm", li, "up")].data_ptr())
+            lw["down_w"].append(sh[("llm", li, "down")].data_ptr())
+        slots = attn.get_slot_ptrs("llm")
+        llm_bufs = {
+            "h": llm_h.data_ptr(), "xn": buf(Se, 2048).data_ptr(),
+            "Q": slots["Q"], "K": buf(Se, 1024).data_ptr(),
+            "V": buf(Se, 1024).data_ptr(),
+            "K_exp": slots["K"], "V_exp": slots["V"],
+            "o_proj_out": buf(Se, 2048).data_ptr(),
+            "gate_out": buf(Se, 6144).data_ptr(),
+            "up_out": buf(Se, 6144).data_ptr()}
+        P.qwen3vl_llm_forward(
+            gemm=gemm, fvk=fvkm, bufs=llm_bufs, weights=lw,
+            dims={"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128, "FF": 6144},
+            attn=attn)
+
+        # ═══ vlln + VL self-attn (4L) ═══
+        vlsa_h = buf(Se, 2048)
+        P.vlln_forward(
+            gemm=gemm, fvk=fvkm,
+            bufs={"x": llm_h.data_ptr(), "out": vlsa_h.data_ptr()},
+            weights={"vlln_w": self._vlln_w.data_ptr(),
+                     "vlln_b": self._vlln_b.data_ptr()},
+            dims={"S": Se, "D": 2048})
+        vsw = {k: [] for k in (
+            "norm1_w", "norm1_b", "norm3_w", "norm3_b", "q_w", "q_b",
+            "k_w", "k_b", "v_w", "v_b", "o_w", "o_b", "fc1_w", "fc1_b",
+            "fc2_w", "fc2_b")}
+        for li in range(4):
+            vsw["norm1_w"].append(self._vlsa_norm1_w[li].data_ptr())
+            vsw["norm1_b"].append(self._vlsa_norm1_b[li].data_ptr())
+            vsw["norm3_w"].append(self._vlsa_norm3_w[li].data_ptr())
+            vsw["norm3_b"].append(self._vlsa_norm3_b[li].data_ptr())
+            vsw["q_w"].append(sh[("vlsa", li, "q")].data_ptr())
+            vsw["q_b"].append(self._vlsa_q_b[li].data_ptr())
+            vsw["k_w"].append(sh[("vlsa", li, "k")].data_ptr())
+            vsw["k_b"].append(self._vlsa_k_b[li].data_ptr())
+            vsw["v_w"].append(sh[("vlsa", li, "v")].data_ptr())
+            vsw["v_b"].append(self._vlsa_v_b[li].data_ptr())
+            vsw["o_w"].append(sh[("vlsa", li, "o")].data_ptr())
+            vsw["o_b"].append(self._vlsa_o_b[li].data_ptr())
+            vsw["fc1_w"].append(sh[("vlsa", li, "fc1")].data_ptr())
+            vsw["fc1_b"].append(self._vlsa_fc1_b[li].data_ptr())
+            vsw["fc2_w"].append(sh[("vlsa", li, "fc2")].data_ptr())
+            vsw["fc2_b"].append(self._vlsa_fc2_b[li].data_ptr())
+        P.vl_self_attn_forward(
+            gemm=gemm, fvk=fvkm,
+            bufs={"h": vlsa_h.data_ptr(), "xn": buf(Se, 2048).data_ptr(),
+                  "o_proj_out": buf(Se, 2048).data_ptr(),
+                  "fc1_out": buf(Se, 8192).data_ptr()},
+            weights=vsw,
+            dims={"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192},
+            attn=attn)
+        torch.cuda.synchronize()
+        return vlsa_h.unsqueeze(0)
+
+    # ── infer: same as base but action-head tensors in FP16 ──
+    def infer(
+        self,
+        state_normalized: torch.Tensor,
+        *,
+        initial_noise=None,
+        num_inference_timesteps: int = 4,
+        action_horizon: int = 40,
+        num_timestep_buckets: int = 1000,
+        use_dit_graph: bool = True,
+    ) -> torch.Tensor:
+        if not hasattr(self, "_backbone_features"):
+            raise RuntimeError("call set_prompt before infer")
+        if not hasattr(self, "_dit_cross_K"):
+            self._precompute_dit_cross_kv()
+
+        device = self.device
+        action_dim = 132
+        Sa = action_horizon + 1
+
+        state_features = self._run_state_encode(
+            state_normalized.to(device).half())
+
+        if not hasattr(self, "_infer_bufs"):
+            self._allocate_infer_buffers(action_horizon)
+        bufs = self._infer_bufs
+
+        if initial_noise is not None:
+            actions = initial_noise.to(device).half().contiguous().clone()
+        else:
+            actions = torch.randn(
+                1, action_horizon, action_dim, dtype=_FP16, device=device)
+
+        dt = 1.0 / num_inference_timesteps
+        pos_embed = self._ah_pos_embed_w[:action_horizon].half()
+
+        self._infer_shift_lists = []
+        self._infer_scale_lists = []
+        self._infer_temb_list = []
+
+        graphs = None
+        if use_dit_graph:
+            if not hasattr(self, "_dit_graphs"):
+                self._capture_dit_graphs(
+                    num_inference_timesteps=num_inference_timesteps,
+                    action_horizon=action_horizon)
+            graphs = self._dit_graphs
+            if len(graphs) != num_inference_timesteps:
+                graphs = None
+
+        for step in range(num_inference_timesteps):
+            t_cont = step / num_inference_timesteps
+            t_disc = int(t_cont * num_timestep_buckets)
+
+            if graphs is not None:
+                temb = self._step_temb[step]
+                shift_list = self._step_shifts[step]
+                scale_list = self._step_scales[step]
+            else:
+                temb = self._compute_timestep_emb(t_disc)
+                shift_list, scale_list = self._compute_dit_adaln_modulators(temb)
+                self._infer_shift_lists.append(shift_list)
+                self._infer_scale_lists.append(scale_list)
+                self._infer_temb_list.append(temb)
+
+            action_features = self._run_action_encode(
+                actions, t_disc, action_horizon)
+            action_features = action_features + pos_embed.unsqueeze(0)
+
+            sa_embs = torch.cat([state_features, action_features], dim=1)
+            bufs["dit_h"][:Sa].copy_(sa_embs.squeeze(0).contiguous())
+
+            if graphs is not None:
+                graphs[step].replay()
+            else:
+                self._run_dit(bufs, shift_list, scale_list, Sa)
+
+            h_out = self._run_dit_output_proj(bufs["dit_h"][:Sa].unsqueeze(0), temb)
+            velocity = self._run_action_decode(h_out[:, -action_horizon:])
+            actions = actions + (dt * velocity).to(actions.dtype)
+
+        return actions.float()
+
+    def _warmup_infer(self) -> None:
+        warm_state = torch.zeros(1, 1, 132, dtype=torch.float32)
+        torch.manual_seed(0)
+        warm_noise = torch.randn(1, 40, 132, dtype=_FP16, device=self.device)
+        _ = self.infer(warm_state, initial_noise=warm_noise, use_dit_graph=False)

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -115,6 +115,9 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     ("groot_n17", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.groot_n17_rtx",
          "GrootN17TorchFrontendRtx"),
+    ("groot_n17", "torch", "rtx_sm89"):
+        ("flash_rt.frontends.torch.groot_n17_rtx_sm89",
+         "GrootN17TorchFrontendRtxSm89"),
 
     # ── Motus (Wan2.2 + Qwen-VL + action/understanding experts) ──
     # RTX 5090 path only for now. Motus uses a bundle-based E2E contract

--- a/flash_rt/models/groot_n17/pipeline_rtx_sm89.py
+++ b/flash_rt/models/groot_n17/pipeline_rtx_sm89.py
@@ -1,0 +1,541 @@
+"""GR00T N1.7 FP8 backbone forward pipeline for RTX SM89.
+
+RTX SM89 FP8 backbone path for GROOT N1.7. Weights are stored as ``[N, K]``
+and GEMMs use ``fp8_nt_dev``. Since that primitive emits BF16, the pipeline
+casts the result back to FP16 before feeding the existing RTX attention /
+residual kernels.
+
+Stages mirror ``pipeline_thor.py``: ``qwen3vl_vit_forward`` →
+``deepstack_merge_forward`` → ``qwen3vl_llm_forward`` → ``vlln_forward`` →
+``vl_self_attn_forward``. Each forward is pointer-only.
+"""
+
+from __future__ import annotations
+
+
+def _fp8_matmul_fp16(
+    gemm,
+    fvk,
+    *,
+    act_fp8_ptr: int,
+    weight_ptr: int,
+    out_fp16_ptr: int,
+    bf16_tmp_ptr: int,
+    M: int,
+    N: int,
+    K: int,
+    act_scale_ptr: int,
+    weight_scale_ptr: int,
+    stream: int,
+) -> None:
+    gemm.fp8_nt_dev(
+        int(act_fp8_ptr),
+        int(weight_ptr),
+        int(bf16_tmp_ptr),
+        int(M),
+        int(N),
+        int(K),
+        int(act_scale_ptr),
+        int(weight_scale_ptr),
+        int(stream),
+    )
+    fvk.cast_bf16_to_fp16(
+        int(bf16_tmp_ptr),
+        int(out_fp16_ptr),
+        int(M) * int(N),
+        int(stream),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 4: VLLN — LayerNorm on backbone_features (no FP8; identical to thor)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def vlln_forward(gemm, fvk, bufs, weights, dims,
+                 scales_dev=None, *, attn=None, stream: int = 0) -> None:
+    """LayerNorm(2048, eps=1e-5) on backbone features ``(B, S, 2048)``.
+
+    Required:
+        bufs["x"], bufs["out"]      — fp16 (S × D)
+        weights["vlln_w"], ["vlln_b"]
+        dims["S"], dims["D"]
+    """
+    fvk.layer_norm_fp16(
+        int(bufs["x"]), int(weights["vlln_w"]), int(weights["vlln_b"]),
+        int(bufs["out"]), int(dims["S"]), int(dims["D"]), 1e-5, int(stream),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 1: Qwen3-VL ViT (24 layers)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
+                        scales_dev, *, attn, stream: int = 0,
+                        layers_subset=None,
+                        deepstack_taps=(5, 11, 17),
+                        deepstack_capture=None) -> None:
+    """24-layer Qwen3-VL ViT, FP8 GEMMs via the SM89 nt-layout path.
+
+    Per layer (in-place residual on ``h``): LayerNorm → quantize → 3 split FP8
+    Q/K/V descale GEMMs (+bias) → split-half RoPE → multi-view FMHA → quantize
+    O → FP8 o-proj (+bias) → residual → LayerNorm → quantize → FP8 fc1 (+bias,
+    +GELU tanh) → quantize → FP8 fc2 (+bias) → residual.
+
+    Q/K/V share the fused-qkv weight scale (``q_ws == k_ws == v_ws``).
+
+    bufs:        h, xn (fp16 S×D); xn_fp8 (fp8 S×D); o_proj_out (fp16 S×D);
+                 fc1_out (fp16 S×FF); fc1_fp8 (fp8 S×FF)
+    weights:     norm1/2_w/b; q/k/v/o_w, q/k/v/o_b; fc1/fc2_w, fc1/fc2_b
+                 (fp8 weight ptrs + fp16 bias ptrs); q/k/v/o_ws, fc1/fc2_ws
+                 (weight-scale dev ptrs); cos, sin (fp16 dev S×HD)
+    scales_dev:  act_qkv, act_o, act_fc1, act_fc2 (lists of fp32 dev ptrs)
+    dims:        S, D, NH, HD, ff_inner, Sper_view
+    """
+    S  = int(dims["S"])
+    D  = int(dims["D"])
+    NH = int(dims["NH"])
+    HD = int(dims["HD"])
+    FF = int(dims["ff_inner"])
+
+    h_ptr       = int(bufs["h"])
+    xn_ptr      = int(bufs["xn"])
+    xn_fp8_ptr  = int(bufs["xn_fp8"])
+    o_proj_out  = int(bufs["o_proj_out"])
+    fc1_out_ptr = int(bufs["fc1_out"])
+    fc1_fp8_ptr = int(bufs["fc1_fp8"])
+    bf16_tmp_ptr = int(bufs["bf16_tmp"])
+    bf16_ff_ptr  = int(bufs["bf16_ff"])
+    cos_ptr     = int(weights["cos"])
+    sin_ptr     = int(weights["sin"])
+
+    layer_iter = range(24) if layers_subset is None else list(layers_subset)
+    Sper = int(dims.get("Sper_view", S))
+
+    for li in layer_iter:
+        slots = attn.get_slot_ptrs("vit", li)
+        Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
+        a_qkv = int(scales_dev["act_qkv"][li])
+        a_o   = int(scales_dev["act_o"][li])
+        a_fc1 = int(scales_dev["act_fc1"][li])
+        a_fc2 = int(scales_dev["act_fc2"][li])
+
+        # ── Pre-attn LayerNorm ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+            xn_ptr, S, D, 1e-6, int(stream))
+
+        # ── Quantize xn once for Q/K/V; 3 split FP8 descale GEMMs + bias ──
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["q_w"][li]), out_fp16_ptr=Q_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=D, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["q_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), S, D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["k_w"][li]), out_fp16_ptr=K_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=D, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["k_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), S, D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["v_w"][li]), out_fp16_ptr=V_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=D, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["v_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), S, D, int(stream))
+
+        # ── Split-half RoPE on Q and K ──
+        fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
+        fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
+
+        # ── Multi-view batched FMHA ──
+        attn.run("vit", li, q_seq=Sper, kv_seq=Sper, stream=int(stream))
+
+        # ── O projection (FP8) ──
+        fvk.quantize_fp8_static_fp16(O_ptr, xn_fp8_ptr, a_o, S * D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["o_w"][li]), out_fp16_ptr=o_proj_out,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=D, K=D,
+            act_scale_ptr=a_o, weight_scale_ptr=int(weights["o_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), S, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
+
+        # ── Pre-FF LayerNorm ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
+            xn_ptr, S, D, 1e-6, int(stream))
+
+        # ── FF: D → FF (GELU) → D ──
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, S * D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["fc1_w"][li]), out_fp16_ptr=fc1_out_ptr,
+            bf16_tmp_ptr=bf16_ff_ptr, M=S, N=FF, K=D,
+            act_scale_ptr=a_fc1, weight_scale_ptr=int(weights["fc1_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), S, FF, int(stream))
+        fvk.gelu_inplace_fp16(fc1_out_ptr, S * FF, int(stream))
+        fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, S * FF, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=fc1_fp8_ptr, weight_ptr=int(weights["fc2_w"][li]), out_fp16_ptr=o_proj_out,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=D, K=FF,
+            act_scale_ptr=a_fc2, weight_scale_ptr=int(weights["fc2_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), S, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
+
+        # ── DeepStack tap callback ──
+        if deepstack_capture is not None and li in deepstack_taps:
+            deepstack_capture[deepstack_taps.index(li)](h_ptr)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 2: DeepStack mergers (3)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def deepstack_merge_forward(gemm, fvk, bufs, weights, dims,
+                            scales_dev, *, attn=None, stream: int = 0) -> None:
+    """3 DeepStack mergers (taps ViT [5, 11, 17]) → 3 features for LLM [0,1,2].
+
+    Per merger j: LayerNorm(4096) → quantize → FP8 fc1 (+bias, +GELU tanh) →
+    quantize → FP8 fc2 (+bias) → (Nout, 2048).
+
+    bufs:       in (list[3]), ln_out, fp8_scratch, fc1_out, out (list[3])
+    weights:    norm_w/b[j]; fc1/fc2_w[j] (fp8) + fc1/fc2_b[j]; fc1/fc2_ws[j]
+    scales_dev: act_fc1[j], act_fc2[j]
+    dims:       Nin, Din, Nout, Dmid, Dout
+    """
+    Nout = int(dims["Nout"])
+    Dmid = int(dims["Dmid"])
+    Dout = int(dims["Dout"])
+
+    ln_out      = int(bufs["ln_out"])
+    fp8_scratch = int(bufs["fp8_scratch"])
+    fc1_out     = int(bufs["fc1_out"])
+    bf16_tmp_ptr = int(bufs["bf16_tmp"])
+    bf16_ff_ptr  = int(bufs["bf16_ff"])
+
+    for j in range(3):
+        in_ptr  = int(bufs["in"][j])
+        out_ptr = int(bufs["out"][j])
+        a_fc1 = int(scales_dev["act_fc1"][j])
+        a_fc2 = int(scales_dev["act_fc2"][j])
+
+        fvk.layer_norm_fp16(
+            in_ptr, int(weights["norm_w"][j]), int(weights["norm_b"][j]),
+            ln_out, Nout, Dmid, 1e-6, int(stream))
+
+        fvk.quantize_fp8_static_fp16(ln_out, fp8_scratch, a_fc1, Nout * Dmid, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=fp8_scratch, weight_ptr=int(weights["fc1_w"][j]), out_fp16_ptr=fc1_out,
+            bf16_tmp_ptr=bf16_ff_ptr, M=Nout, N=Dmid, K=Dmid,
+            act_scale_ptr=a_fc1, weight_scale_ptr=int(weights["fc1_ws"][j]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(fc1_out, int(weights["fc1_b"][j]), Nout, Dmid, int(stream))
+        fvk.gelu_inplace_fp16(fc1_out, Nout * Dmid, int(stream))
+
+        fvk.quantize_fp8_static_fp16(fc1_out, fp8_scratch, a_fc2, Nout * Dmid, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=fp8_scratch, weight_ptr=int(weights["fc2_w"][j]), out_fp16_ptr=out_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=Nout, N=Dout, K=Dmid,
+            act_scale_ptr=a_fc2, weight_scale_ptr=int(weights["fc2_ws"][j]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(out_ptr, int(weights["fc2_b"][j]), Nout, Dout, int(stream))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 3: Qwen3-VL truncated LLM (16 layers, causal, GQA)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
+                        scales_dev, *, attn, stream: int = 0,
+                        layers_subset=None) -> None:
+    """16 truncated Qwen3-VL LLM decoder layers, FP8 GEMMs via SM120-safe descale.
+
+    Per layer: RMSNorm → quantize → 3 split FP8 Q/K/V descale GEMMs (no bias) →
+    per-head q/k RMSNorm → M-RoPE → GQA expand → causal MHA → quantize O →
+    FP8 o-proj → residual → RMSNorm → quantize → FP8 gate/up → SiLU(gate)*up
+    fused-to-FP8 → FP8 down → residual → optional DeepStack inject.
+
+    Q/K/V share the fused-qkv weight scale.
+
+    bufs:       h, xn (fp16 S×D); xn_fp8 (fp8 S×D); Q (fp16 S×NHQ·HD);
+                K, V (fp16 S×NHKV·HD); K_exp, V_exp (fp16 S×NHQ·HD);
+                o_proj_out (fp16 S×D); gate_out, up_out (fp16 S×FF);
+                gu_fp8 (fp8 S×FF)
+    weights:    in_ln_w, post_ln_w, q_norm_w, k_norm_w; q/k/v/o_w, gate/up/down_w
+                (fp8); q/k/v/o_ws, gate/up/down_ws (weight-scale dev ptrs);
+                cos, sin; deepstack_inject (list[16], 0 = none)
+    scales_dev: act_qkv, act_o, act_gateup, act_down
+    dims:       S, D, NHQ, NHKV, HD, FF
+    """
+    S    = int(dims["S"])
+    D    = int(dims["D"])
+    NHQ  = int(dims["NHQ"])
+    NHKV = int(dims["NHKV"])
+    HD   = int(dims["HD"])
+    FF   = int(dims["FF"])
+    GQA  = NHQ // NHKV
+
+    h_ptr      = int(bufs["h"])
+    xn_ptr     = int(bufs["xn"])
+    xn_fp8_ptr = int(bufs["xn_fp8"])
+    Q_ptr      = int(bufs["Q"])
+    K_ptr      = int(bufs["K"])
+    V_ptr      = int(bufs["V"])
+    K_exp_ptr  = int(bufs["K_exp"])
+    V_exp_ptr  = int(bufs["V_exp"])
+    o_out_ptr  = int(bufs["o_proj_out"])
+    gate_ptr   = int(bufs["gate_out"])
+    up_ptr     = int(bufs["up_out"])
+    gu_fp8_ptr = int(bufs["gu_fp8"])
+    bf16_tmp_ptr = int(bufs["bf16_tmp"])
+    bf16_ff_ptr  = int(bufs["bf16_ff"])
+    cos_ptr    = int(weights["cos"])
+    sin_ptr    = int(weights["sin"])
+
+    inject_ptrs = weights.get("deepstack_inject", [0] * 16)
+    layer_iter = range(16) if layers_subset is None else list(layers_subset)
+
+    for li in layer_iter:
+        slots = attn.get_slot_ptrs("llm", li)
+        a_qkv = int(scales_dev["act_qkv"][li])
+        a_o   = int(scales_dev["act_o"][li])
+        a_gu  = int(scales_dev["act_gateup"][li])
+        a_dn  = int(scales_dev["act_down"][li])
+
+        # ── Pre-attn RMSNorm + quantize ──
+        fvk.rms_norm_fp16(h_ptr, int(weights["in_ln_w"][li]), xn_ptr,
+                          S, D, 1e-6, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
+
+        # ── 3 split FP8 descale GEMMs (no bias — Qwen3 QKV) ──
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["q_w"][li]), out_fp16_ptr=Q_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=NHQ * HD, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["q_ws"][li]),
+            stream=int(stream),
+        )
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["k_w"][li]), out_fp16_ptr=K_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=NHKV * HD, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["k_ws"][li]),
+            stream=int(stream),
+        )
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["v_w"][li]), out_fp16_ptr=V_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=NHKV * HD, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["v_ws"][li]),
+            stream=int(stream),
+        )
+
+        # ── Per-head q_norm / k_norm (BEFORE M-RoPE) ──
+        fvk.rms_norm_fp16(Q_ptr, int(weights["q_norm_w"][li]), Q_ptr,
+                          S * NHQ, HD, 1e-6, int(stream))
+        fvk.rms_norm_fp16(K_ptr, int(weights["k_norm_w"][li]), K_ptr,
+                          S * NHKV, HD, 1e-6, int(stream))
+
+        # ── M-RoPE on Q and K ──
+        fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NHQ,  HD, int(stream))
+        fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NHKV, HD, int(stream))
+
+        # ── GQA expand: K, V from NHKV → NHQ heads ──
+        fvk.gpu_repeat_interleave_heads(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
+        fvk.gpu_repeat_interleave_heads(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
+
+        # ── Causal MHA via attn backend ──
+        attn.run("llm", li, q_seq=S, kv_seq=S, stream=int(stream))
+
+        # ── O projection (FP8) ──
+        fvk.quantize_fp8_static_fp16(int(slots["O"]), xn_fp8_ptr, a_o,
+                                     S * NHQ * HD, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["o_w"][li]), out_fp16_ptr=o_out_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=D, K=NHQ * HD,
+            act_scale_ptr=a_o, weight_scale_ptr=int(weights["o_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
+
+        # ── Pre-FFN RMSNorm + quantize ──
+        fvk.rms_norm_fp16(h_ptr, int(weights["post_ln_w"][li]), xn_ptr,
+                          S, D, 1e-6, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_gu, S * D, int(stream))
+
+        # ── gate / up FP8 GEMMs → fp16 ──
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["gate_w"][li]), out_fp16_ptr=gate_ptr,
+            bf16_tmp_ptr=bf16_ff_ptr, M=S, N=FF, K=D,
+            act_scale_ptr=a_gu, weight_scale_ptr=int(weights["gate_ws"][li]),
+            stream=int(stream),
+        )
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["up_w"][li]), out_fp16_ptr=up_ptr,
+            bf16_tmp_ptr=bf16_ff_ptr, M=S, N=FF, K=D,
+            act_scale_ptr=a_gu, weight_scale_ptr=int(weights["up_ws"][li]),
+            stream=int(stream),
+        )
+
+        # ── SiLU(gate) * up → directly FP8 (fused) → down GEMM ──
+        fvk.silu_mul_split_fp8_fp16(gate_ptr, up_ptr, gu_fp8_ptr, S * FF,
+                                    a_dn, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=gu_fp8_ptr, weight_ptr=int(weights["down_w"][li]), out_fp16_ptr=o_out_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=S, N=D, K=FF,
+            act_scale_ptr=a_dn, weight_scale_ptr=int(weights["down_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
+
+        # ── DeepStack injection (HF: layers 0, 1, 2) ──
+        inject_ptr = int(inject_ptrs[li]) if li < len(inject_ptrs) else 0
+        if inject_ptr != 0:
+            fvk.residual_add_fp16(h_ptr, inject_ptr, S * D, int(stream))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 5: VL self-attention (4 layers)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
+                         scales_dev, *, attn, stream: int = 0,
+                         layers_subset=None) -> None:
+    """4-layer SelfAttentionTransformer, FP8 GEMMs via the SM89 nt-layout path.
+
+    Per layer: LayerNorm → quantize → FP8 Q/K/V (+bias, separate weight scales)
+    → MHA → quantize O → FP8 o-proj (+bias) → residual → LayerNorm → quantize →
+    FP8 fc1 (+bias, +GELU tanh) → quantize → FP8 fc2 (+bias) → residual.
+
+    Q/K/V each have their OWN weight scale (separate projections, not fused).
+
+    bufs:       h, xn (fp16 T×D); xn_fp8 (fp8 T×D); o_proj_out (fp16 T×D);
+                fc1_out (fp16 T×FF); fc1_fp8 (fp8 T×FF)
+    weights:    norm1/3_w/b; q/k/v/o_w, q/k/v/o_b; fc1/fc2_w, fc1/fc2_b (fp8);
+                q/k/v/o_ws, fc1/fc2_ws (weight-scale dev ptrs)
+    scales_dev: act_qkv, act_o, act_fc1, act_fc2
+    dims:       T, D, NH, HD, ff_inner
+    """
+    T  = int(dims["T"])
+    D  = int(dims["D"])
+    FF = int(dims["ff_inner"])
+
+    h_ptr       = int(bufs["h"])
+    xn_ptr      = int(bufs["xn"])
+    xn_fp8_ptr  = int(bufs["xn_fp8"])
+    o_proj_out  = int(bufs["o_proj_out"])
+    fc1_out_ptr = int(bufs["fc1_out"])
+    fc1_fp8_ptr = int(bufs["fc1_fp8"])
+    bf16_tmp_ptr = int(bufs["bf16_tmp"])
+    bf16_ff_ptr  = int(bufs["bf16_ff"])
+
+    layer_iter = range(4) if layers_subset is None else list(layers_subset)
+
+    for li in layer_iter:
+        slots = attn.get_slot_ptrs("vl_self_attn", li)
+        Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
+        a_qkv = int(scales_dev["act_qkv"][li])
+        a_o   = int(scales_dev["act_o"][li])
+        a_fc1 = int(scales_dev["act_fc1"][li])
+        a_fc2 = int(scales_dev["act_fc2"][li])
+
+        # ── Pre-attn LayerNorm + quantize ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+            xn_ptr, T, D, 1e-5, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, T * D, int(stream))
+
+        # ── Q / K / V FP8 descale GEMMs + bias (separate weight scales) ──
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["q_w"][li]), out_fp16_ptr=Q_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=T, N=D, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["q_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), T, D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["k_w"][li]), out_fp16_ptr=K_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=T, N=D, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["k_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), T, D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["v_w"][li]), out_fp16_ptr=V_ptr,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=T, N=D, K=D,
+            act_scale_ptr=a_qkv, weight_scale_ptr=int(weights["v_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), T, D, int(stream))
+
+        # ── MHA ──
+        attn.run("vl_self_attn", li, q_seq=T, kv_seq=T, stream=int(stream))
+
+        # ── O projection (FP8) ──
+        fvk.quantize_fp8_static_fp16(O_ptr, xn_fp8_ptr, a_o, T * D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["o_w"][li]), out_fp16_ptr=o_proj_out,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=T, N=D, K=D,
+            act_scale_ptr=a_o, weight_scale_ptr=int(weights["o_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), T, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
+
+        # ── Pre-FF LayerNorm + FF (GELU) ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+            xn_ptr, T, D, 1e-5, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, T * D, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=xn_fp8_ptr, weight_ptr=int(weights["fc1_w"][li]), out_fp16_ptr=fc1_out_ptr,
+            bf16_tmp_ptr=bf16_ff_ptr, M=T, N=FF, K=D,
+            act_scale_ptr=a_fc1, weight_scale_ptr=int(weights["fc1_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), T, FF, int(stream))
+        fvk.gelu_inplace_fp16(fc1_out_ptr, T * FF, int(stream))
+        fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, T * FF, int(stream))
+        _fp8_matmul_fp16(
+            gemm, fvk,
+            act_fp8_ptr=fc1_fp8_ptr, weight_ptr=int(weights["fc2_w"][li]), out_fp16_ptr=o_proj_out,
+            bf16_tmp_ptr=bf16_tmp_ptr, M=T, N=D, K=FF,
+            act_scale_ptr=a_fc2, weight_scale_ptr=int(weights["fc2_ws"][li]),
+            stream=int(stream),
+        )
+        fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), T, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -259,11 +259,11 @@ def test_groot_n17_rtx_sm120_is_registered():
     assert cls.__name__ == "GrootN17TorchFrontendRtx"
 
 
-def test_groot_n17_sm89_is_not_registered_without_validation():
+def test_groot_n17_rtx_sm89_is_registered():
     from flash_rt.hardware import resolve_pipeline_class
 
-    with pytest.raises(RuntimeError, match="rtx_sm120"):
-        resolve_pipeline_class("groot_n17", "torch", "rtx_sm89")
+    cls = resolve_pipeline_class("groot_n17", "torch", "rtx_sm89")
+    assert cls.__name__ == "GrootN17TorchFrontendRtxSm89"
 
 
 def test_wan22_ti2v_5b_rtx_sm120_is_registered():
@@ -336,7 +336,73 @@ def test_wan22_infer_exposes_teacache_parameters():
 def test_load_model_accepts_groot_n17_config():
     from flash_rt.api import load_model
 
-    class GrootN17Frontend:
+    class GrootN17RtxFp8Frontend:
+        seen = []
+
+        def __init__(self, checkpoint, num_views=2, embodiment_tag=None):
+            type(self).seen.append({
+                "checkpoint": checkpoint,
+                "num_views": num_views,
+                "embodiment_tag": embodiment_tag,
+            })
+
+        def set_prompt(self, *args, **kwargs):
+            return None
+
+        def infer(self, *args, **kwargs):
+            return None
+
+    GrootN17RtxFp8Frontend.seen = []
+    with patch("flash_rt.hardware.resolve_pipeline_class",
+               return_value=GrootN17RtxFp8Frontend) as resolve:
+        model_default = load_model(
+            "unused-checkpoint-default",
+            config="groot_n17",
+            framework="torch",
+            hardware="rtx_sm89",
+            num_views=2,
+            embodiment_tag="oxe_droid_relative_eef_relative_joint",
+        )
+        model_use_fp8 = load_model(
+            "unused-checkpoint-explicit-fp8",
+            config="groot_n17",
+            framework="torch",
+            hardware="rtx_sm89",
+            num_views=2,
+            embodiment_tag="oxe_droid_relative_eef_relative_joint",
+            use_fp8=True,
+        )
+
+    assert isinstance(model_default._pipe, GrootN17RtxFp8Frontend)
+    assert isinstance(model_use_fp8._pipe, GrootN17RtxFp8Frontend)
+    assert [call.args for call in resolve.call_args_list] == [
+        ("groot_n17", "torch", "rtx_sm89"),
+        ("groot_n17", "torch", "rtx_sm89"),
+    ]
+    assert GrootN17RtxFp8Frontend.seen == [
+        {
+            "checkpoint": "unused-checkpoint-default",
+            "num_views": 2,
+            "embodiment_tag": "oxe_droid_relative_eef_relative_joint",
+        },
+        {
+            "checkpoint": "unused-checkpoint-explicit-fp8",
+            "num_views": 2,
+            "embodiment_tag": "oxe_droid_relative_eef_relative_joint",
+        },
+    ]
+
+
+def test_load_model_routes_groot_n17_rtx_sm120_default_to_fp8_frontend():
+    from flash_rt.api import load_model
+
+    class ResolvedFrontend:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "load_model() should rewrite default groot_n17 RTX SM120 "
+                "requests to the FP8 production frontend")
+
+    class GrootN17RtxFp8Frontend:
         seen = None
 
         def __init__(self, checkpoint, num_views=2, embodiment_tag=None):
@@ -353,9 +419,12 @@ def test_load_model_accepts_groot_n17_config():
             return None
 
     with patch("flash_rt.hardware.resolve_pipeline_class",
-              return_value=GrootN17Frontend):
+              return_value=ResolvedFrontend), \
+            patch("flash_rt.frontends.torch.groot_n17_rtx_fp8."
+                  "GrootN17TorchFrontendRtxFP8",
+                  GrootN17RtxFp8Frontend):
         model = load_model(
-            "unused-checkpoint",
+            "unused-checkpoint-sm120-fp8",
             config="groot_n17",
             framework="torch",
             hardware="rtx_sm120",
@@ -363,12 +432,207 @@ def test_load_model_accepts_groot_n17_config():
             embodiment_tag="oxe_droid_relative_eef_relative_joint",
         )
 
-    assert isinstance(model._pipe, GrootN17Frontend)
-    assert GrootN17Frontend.seen == {
-        "checkpoint": "unused-checkpoint",
+    assert isinstance(model._pipe, GrootN17RtxFp8Frontend)
+    assert GrootN17RtxFp8Frontend.seen == {
+        "checkpoint": "unused-checkpoint-sm120-fp8",
         "num_views": 2,
         "embodiment_tag": "oxe_droid_relative_eef_relative_joint",
     }
+
+
+def test_load_model_routes_groot_n17_rtx_fp16_reference_path():
+    from flash_rt.api import load_model
+
+    class ResolvedFrontend:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "load_model() should rewrite groot_n17 RTX SM89 FP16 "
+                "requests to the FP16 reference frontend")
+
+    class GrootN17RtxFp16Frontend:
+        seen = None
+
+        def __init__(self, checkpoint, num_views=2, embodiment_tag=None):
+            type(self).seen = {
+                "checkpoint": checkpoint,
+                "num_views": num_views,
+                "embodiment_tag": embodiment_tag,
+            }
+
+        def set_prompt(self, *args, **kwargs):
+            return None
+
+        def infer(self, *args, **kwargs):
+            return None
+
+    with patch("flash_rt.hardware.resolve_pipeline_class",
+              return_value=ResolvedFrontend), \
+            patch("flash_rt.frontends.torch.groot_n17_rtx_sm89_fp16."
+                  "GrootN17TorchFrontendRtxSm89FP16",
+                  GrootN17RtxFp16Frontend):
+        model = load_model(
+            "unused-checkpoint-fp16",
+            config="groot_n17",
+            framework="torch",
+            hardware="rtx_sm89",
+            num_views=2,
+            embodiment_tag="oxe_droid_relative_eef_relative_joint",
+            use_fp16=True,
+            use_fp8=False,
+        )
+
+    assert isinstance(model._pipe, GrootN17RtxFp16Frontend)
+    assert GrootN17RtxFp16Frontend.seen == {
+        "checkpoint": "unused-checkpoint-fp16",
+        "num_views": 2,
+        "embodiment_tag": "oxe_droid_relative_eef_relative_joint",
+    }
+
+
+def test_groot_n17_rtx_fp8_layout_selection():
+    from flash_rt.frontends.torch.groot_n17_rtx_sm89 import (
+        GrootN17TorchFrontendRtxSm89,
+    )
+
+    assert GrootN17TorchFrontendRtxSm89.fp8_layout == "nk"
+
+
+def test_groot_n17_rtx_sm89_runtime_weights_are_materialized_in_nk_layout():
+    from flash_rt.frontends.torch.groot_n17_rtx_sm89 import (
+        _GrootN17FP8BackboneMixin,
+    )
+
+    class FakeMatrix:
+        def __init__(self, rows, cols, label):
+            self.shape = (rows, cols)
+            self.label = label
+
+        def __getitem__(self, key):
+            row_sel, col_sel = key
+            if row_sel != slice(None):
+                raise AssertionError("test fake only supports full-row slices")
+            start = 0 if col_sel.start is None else col_sel.start
+            stop = self.shape[1] if col_sel.stop is None else col_sel.stop
+            return FakeMatrix(self.shape[0], stop - start,
+                              f"{self.label}[{start}:{stop}]")
+
+        def t(self):
+            return FakeMatrix(self.shape[1], self.shape[0],
+                              f"{self.label}.t")
+
+        def contiguous(self):
+            return FakeMatrix(self.shape[0], self.shape[1],
+                              f"{self.label}.contiguous")
+
+    frontend = object.__new__(_GrootN17FP8BackboneMixin)
+    frontend._vit_qkv_w = [FakeMatrix(1024, 3072, f"vit_qkv_{i}")
+                           for i in range(24)]
+    frontend._vit_o_w = [FakeMatrix(1024, 1024, f"vit_o_{i}")
+                         for i in range(24)]
+    frontend._vit_fc1_w = [FakeMatrix(1024, 4096, f"vit_fc1_{i}")
+                           for i in range(24)]
+    frontend._vit_fc2_w = [FakeMatrix(4096, 1024, f"vit_fc2_{i}")
+                           for i in range(24)]
+
+    for j in range(3):
+        setattr(frontend, f"_dsm{j}_fc1_w", FakeMatrix(4096, 4096, f"dsm{j}_fc1"))
+        setattr(frontend, f"_dsm{j}_fc2_w", FakeMatrix(4096, 2048, f"dsm{j}_fc2"))
+
+    frontend._llm_qkv_w = [FakeMatrix(2048, 4096, f"llm_qkv_{i}")
+                           for i in range(16)]
+    frontend._llm_o_w = [FakeMatrix(2048, 2048, f"llm_o_{i}")
+                         for i in range(16)]
+    frontend._llm_gate_w = [FakeMatrix(2048, 6144, f"llm_gate_{i}")
+                            for i in range(16)]
+    frontend._llm_up_w = [FakeMatrix(2048, 6144, f"llm_up_{i}")
+                          for i in range(16)]
+    frontend._llm_down_w = [FakeMatrix(6144, 2048, f"llm_down_{i}")
+                            for i in range(16)]
+
+    frontend._vlsa_q_w = [FakeMatrix(2048, 2048, f"vlsa_q_{i}")
+                          for i in range(4)]
+    frontend._vlsa_k_w = [FakeMatrix(2048, 2048, f"vlsa_k_{i}")
+                          for i in range(4)]
+    frontend._vlsa_v_w = [FakeMatrix(2048, 2048, f"vlsa_v_{i}")
+                          for i in range(4)]
+    frontend._vlsa_o_w = [FakeMatrix(2048, 2048, f"vlsa_o_{i}")
+                          for i in range(4)]
+    frontend._vlsa_fc1_w = [FakeMatrix(2048, 8192, f"vlsa_fc1_{i}")
+                            for i in range(4)]
+    frontend._vlsa_fc2_w = [FakeMatrix(8192, 2048, f"vlsa_fc2_{i}")
+                            for i in range(4)]
+
+    frontend._prepare_fp8_runtime_weights()
+
+    runtime = frontend._rtx_fp8_runtime
+    assert runtime["vit_q"][0].shape == (1024, 1024)
+    assert runtime["vit_fc1"][0].shape == (4096, 1024)
+    assert runtime["dsm_fc2"][0].shape == (2048, 4096)
+    assert runtime["llm_q"][0].shape == (2048, 2048)
+    assert runtime["llm_gate"][0].shape == (6144, 2048)
+    assert runtime["vlsa_fc2"][0].shape == (2048, 8192)
+    assert runtime["vit_q"][0].label == "vit_qkv_0[0:1024].t.contiguous"
+    assert runtime["llm_down"][0].label == "llm_down_0.t.contiguous"
+
+
+def test_groot_n17_rtx_sm89_fp8_helper_dispatches_nt_then_cast():
+    from flash_rt.models.groot_n17 import pipeline_rtx_sm89
+
+    calls = []
+
+    class Gemm:
+        def fp8_nt_dev(self, *args):
+            calls.append(("fp8_nt_dev", args))
+
+    class Fvk:
+        def cast_bf16_to_fp16(self, *args):
+            calls.append(("cast_bf16_to_fp16", args))
+
+    pipeline_rtx_sm89._fp8_matmul_fp16(
+        Gemm(),
+        Fvk(),
+        act_fp8_ptr=11,
+        weight_ptr=12,
+        out_fp16_ptr=13,
+        bf16_tmp_ptr=14,
+        M=15,
+        N=16,
+        K=17,
+        act_scale_ptr=18,
+        weight_scale_ptr=19,
+        stream=20,
+    )
+
+    assert calls == [
+        ("fp8_nt_dev", (11, 12, 14, 15, 16, 17, 18, 19, 20)),
+        ("cast_bf16_to_fp16", (14, 13, 15 * 16, 20)),
+    ]
+
+
+def test_groot_n17_rtx_sm89_rejects_use_fp8_false_without_fp16():
+    from flash_rt.api import load_model
+
+    with pytest.raises(ValueError, match="defaults to FP8"):
+        load_model(
+            "unused-checkpoint",
+            config="groot_n17",
+            framework="torch",
+            hardware="rtx_sm89",
+            use_fp8=False,
+        )
+
+
+def test_groot_n17_rtx_sm120_rejects_use_fp8_false_without_fp16():
+    from flash_rt.api import load_model
+
+    with pytest.raises(ValueError, match="defaults to FP8"):
+        load_model(
+            "unused-checkpoint",
+            config="groot_n17",
+            framework="torch",
+            hardware="rtx_sm120",
+            use_fp8=False,
+        )
 
 
 def test_pi05_rtx_fp8_layout_selection():


### PR DESCRIPTION
## Summary

- enable validated `groot_n17` RTX SM89 registration
- add a dedicated SM89 FP8 frontend / pipeline path for GROOT N1.7
- add the explicit SM89 FP16 reference frontend for `use_fp16=True, use_fp8=False`
- align `load_model()` routing, public docs, and focused tests with the actual RTX SM120/SM89 behavior

## What changed

Runtime:
- `flash_rt/frontends/torch/groot_n17_rtx_sm89.py`
- `flash_rt/frontends/torch/groot_n17_rtx_sm89_fp16.py`
- `flash_rt/models/groot_n17/pipeline_rtx_sm89.py`

Routing:
- `flash_rt/api.py`
- `flash_rt/hardware/__init__.py`

Docs:
- `README.md`
- `USAGE.md`
- `docs/stable_api.md`

Focused tests:
- `tests/test_load_model_use_fp8_kwarg.py`

## Behavior / routing contract

On RTX, `load_model(config="groot_n17", framework="torch", hardware=...)` now behaves as follows:

- `hardware="rtx_sm120"`
  - keeps the historical shared RTX registration in `_PIPELINE_MAP`
  - `load_model()` refines the default route to the explicit FP8 production frontend
- `hardware="rtx_sm89"`
  - resolves directly to the dedicated SM89 FP8 frontend
- `use_fp16=True, use_fp8=False`
  - selects the explicit RTX reference frontend for the selected hardware

For `groot_n17` on RTX/Thor, bare `use_fp8=False` is rejected. There is no separate BF16-only fallback; the non-quantized reference path is `use_fp16=True, use_fp8=False`.

## Validation environment

- GPU: `NVIDIA GeForce RTX 4090` (`sm89`)
- driver: `550.54.14`
- CUDA toolkit: `12.4` (`nvcc 12.4.99`)
- env: `/data/home/tianjianyang/miniconda3/envs/flashrt`
- PyTorch: `2.6.0+cu124`
- torchvision: `0.21.0+cu124`
- transformers: `4.57.3`
- build flags:
  - `FA2_ARCH_NATIVE_ONLY=ON`
  - `FA2_DTYPES=fp16;bf16`
  - `FA2_HDIMS=96;128;256`
- checkpoint: `/data/pretrained_models/GR00T-N1.7-3B`
- fixture: `/data/home/tianjianyang/models/vla/gr00t_n17/fixtures/gr00t_n17_ref_oxe_droid_relative_eef_relative_joint_2v_traj1_step0_seed0.pt`
- aux: `/data/home/tianjianyang/models/vla/gr00t_n17/fixtures/gr00t_n17_ref_oxe_droid_relative_eef_relative_joint_2v_traj1_step0_seed0_llm_aux.pt`
- env vars:
  - `PYTHONPATH=/data/home/tianjianyang/code/Isaac-GR00T`
  - `GROOT_HF_LOCAL_FIRST=1`
  - `GROOT_PATCH_MISTRAL=1`
  - `PJRT_DEVICE=CUDA`

## Validation commands

Focused API / routing coverage:

```bash
/data/home/tianjianyang/miniconda3/envs/flashrt/bin/python -m pytest -q \
  tests/test_load_model_use_fp8_kwarg.py
```

Result:

- `27 passed in 1.85s`

Local runtime validation used during development:

```bash
PYTHONPATH=/data/home/tianjianyang/code/Isaac-GR00T \
GROOT_HF_LOCAL_FIRST=1 \
GROOT_PATCH_MISTRAL=1 \
PJRT_DEVICE=CUDA \
/data/home/tianjianyang/miniconda3/envs/flashrt/bin/python - <<'PY'
import time
import torch
from flash_rt.api import load_model

ckpt = "/data/pretrained_models/GR00T-N1.7-3B"
fixture = "/data/home/tianjianyang/models/vla/gr00t_n17/fixtures/gr00t_n17_ref_oxe_droid_relative_eef_relative_joint_2v_traj1_step0_seed0.pt"
aux_path = "/data/home/tianjianyang/models/vla/gr00t_n17/fixtures/gr00t_n17_ref_oxe_droid_relative_eef_relative_joint_2v_traj1_step0_seed0_llm_aux.pt"

blob = torch.load(fixture, map_location="cpu", weights_only=False)
aux = torch.load(aux_path, map_location="cpu", weights_only=False)
state = blob["state_normalized"]
noise = blob["initial_noise"]

for use_fp16, use_fp8 in ((False, True), (True, False)):
    model = load_model(
        ckpt,
        config="groot_n17",
        framework="torch",
        hardware="rtx_sm89",
        num_views=2,
        embodiment_tag="oxe_droid_relative_eef_relative_joint",
        use_fp16=use_fp16,
        use_fp8=use_fp8,
    )
    t0 = time.perf_counter()
    model.set_prompt(aux=aux, prompt="x")
    prompt_ms = (time.perf_counter() - t0) * 1000.0

    _ = model.infer(state, initial_noise=noise, use_dit_graph=True)
    torch.cuda.synchronize()
    starts = [torch.cuda.Event(enable_timing=True) for _ in range(20)]
    ends = [torch.cuda.Event(enable_timing=True) for _ in range(20)]
    for _ in range(5):
        _ = model.infer(state, initial_noise=noise, use_dit_graph=True)
    torch.cuda.synchronize()
    for i in range(20):
        starts[i].record()
        _ = model.infer(state, initial_noise=noise, use_dit_graph=True)
        ends[i].record()
    torch.cuda.synchronize()
    ms = [s.elapsed_time(e) for s, e in zip(starts, ends)]
    print({
        "use_fp16": use_fp16,
        "use_fp8": use_fp8,
        "set_prompt_ms": prompt_ms,
        "warm_infer_p50_ms": sorted(ms)[len(ms)//2],
        "warm_infer_mean_ms": sum(ms) / len(ms),
    })
PY
```

## Kernel binding / CMake applicability

- this PR does **not** change `csrc/bindings.cpp`, pybind ownership, CMake target ownership, or `GPU_ARCH`-gated source lists
- the `CONTRIBUTING.md` cross-`GPU_ARCH` build/import validation requirement for binding/CMake changes is therefore not applicable to this PR

## Precision results

- FP8 (`GrootN17TorchFrontendRtxSm89`)
  - combined cosine: `0.999935`
  - combined max abs diff: `0.036446`
  - combined mean abs diff: `0.006404`
- FP16 (`GrootN17TorchFrontendRtxSm89FP16`)
  - combined cosine: `0.999974`
  - combined max abs diff: `0.027434`
  - combined mean abs diff: `0.003748`

Note:

- the `gripper_position` per-head cosine is noisy on this fixture because the reference norm is extremely small; the combined flattened cosine and absolute error are the more representative headline metrics

## Latency results

These are warm graph-replay `infer()` measurements, not wall-clock quickstart numbers.

- FP8 (`GrootN17TorchFrontendRtxSm89`)
  - `set_prompt`: `629.24 ms`
  - warm `infer()`: `p50 10.61 ms`, `mean 10.42 ms`, `p90 10.62 ms`
- FP16 (`GrootN17TorchFrontendRtxSm89FP16`)
  - `set_prompt`: `132.09 ms`
  - warm `infer()`: `p50 13.83 ms`, `mean 13.99 ms`, `p90 14.34 ms`

Observed warm-`infer()` speedup on this machine:

- `13.83 / 10.61 = 1.30x` FP8 vs FP16

## Limitations / unverified areas

- this PR validates `rtx_sm89` on a local RTX 4090 fixture path only; it does not claim cross-SM89-card latency parity
- the validation is fixture-based, not LIBERO task-success based
- the GROOT helper environment still depends on local Isaac-GR00T preprocessing and local-first HF resolution for the reference fixture workflow
- current SM89 FP8 performance is functionally good but not fused-epilogue parity with the validated SM120 route
- attempted `cuBLASLt` FP8 `nt` fused epilogues were not viable on this local SM89 + CUDA/cuBLASLt stack (`cublasLtMatmulAlgoGetHeuristic(...), code=15`)
- this PR does not add broader regression fixtures such as multi-aux calibration coverage
- repo-side automated coverage is focused on routing/layout/helper semantics; this PR does not add a real-checkpoint smoke test in CI
- the SM89 full-FP16 reference frontend is hardware-specific at the frontend level, but still reuses the shared RTX `pipeline_rtx_fp16` DiT compute path; this PR does not further split that shared FP16 path
- `groot_n17` on `rtx_sm120` still keeps the historical shared RTX registration and relies on `load_model()` to refine the default route to the explicit FP8 production frontend
