### PR TITLE
fix(sm120): restore groot n1.7 dit fp8 graph

### DIFF
--- a/flash_rt/frontends/torch/groot_n17_rtx_fp8.py
+++ b/flash_rt/frontends/torch/groot_n17_rtx_fp8.py
@@ -399,6 +399,8 @@ class _GrootN17FP8BackboneMixin:
 class GrootN17TorchFrontendRtxFP8(_GrootN17FP8BackboneMixin, GrootN17TorchFrontendRtx):
     """N1.7 RTX FP8 frontend with a bf16 action head (Thor-parity dtype)."""
 
+    _DIT_FP8_IMPL = "sm120_safe"
+
 
 class GrootN17TorchFrontendRtxFP8FP16DiT(
         _GrootN17FP8BackboneMixin, GrootN17TorchFrontendRtxFP16):

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -44,6 +44,7 @@ class GrootN17TorchFrontendThor:
     # subclass sets this False so the DiT stays bf16 (a fully non-quantized
     # accuracy baseline).
     _DIT_USE_FP8 = True
+    _DIT_FP8_IMPL = "thor_epilogue"
 
     def __init__(
         self,
@@ -627,7 +628,10 @@ class GrootN17TorchFrontendThor:
         self._k_ff_fp16 = torch.empty(Sa, 6144, dtype=torch.float16, device=dev)
         self._k_ff_fp8 = torch.empty(Sa, 6144, dtype=f8, device=dev)
         self._dit_ff_fp8_keep = []
+        dit_fp8_impl = getattr(self, "_DIT_FP8_IMPL", "thor_epilogue")
+        use_sm120_safe = dit_fp8_impl == "sm120_safe"
         proj_fp8, down_fp8, projb16 = [], [], []
+        proj_ws, down_fp8_nt, down_ws = [], [], []
         a_fc1, a_fc2, s_fc1, s_fc2 = [], [], [], []
         for li in range(32):
             pw = self._dit_ff_proj_w[li].float()
@@ -644,13 +648,21 @@ class GrootN17TorchFrontendThor:
             proj_fp8.append(pf.data_ptr()); down_fp8.append(df.data_ptr())
             projb16.append(pb.data_ptr())
             s_fc1.append(sf1.data_ptr()); s_fc2.append(sf2.data_ptr())
+            if use_sm120_safe:
+                df_nt = df.t().contiguous()
+                sw_p = torch.tensor([ws_p], dtype=torch.float32, device=dev)
+                sw_d = torch.tensor([ws_d], dtype=torch.float32, device=dev)
+                self._dit_ff_fp8_keep += [df_nt, sw_p, sw_d]
+                proj_ws.append(sw_p.data_ptr())
+                down_fp8_nt.append(df_nt.data_ptr())
+                down_ws.append(sw_d.data_ptr())
             a_fc1.append((act_fc1[li] / FP8_MAX) * ws_p)
             a_fc2.append((act_fc2[li] / FP8_MAX) * ws_d)
         # Fused FP8 QKV for the 16 self-attn layers: concat q/k/v ([D,D] each)
         # → [D, 3D], quantize per-tensor. j indexes self-attn layers (li=2j+1).
         self._k_qkv_buf = torch.empty(Sa, 3 * 1536, dtype=torch.bfloat16, device=dev)
         self._k_qkv_xn_fp8 = torch.empty(Sa, 1536, dtype=f8, device=dev)
-        qkv_fp8, qkv_b, a_qkv, s_qkv = [], [], [], []
+        qkv_fp8, qkv_fp8_nt, qkv_b, a_qkv, s_qkv, qkv_ws = [], [], [], [], [], []
         for j in range(16):
             li = 2 * j + 1
             qw = torch.cat([self._dit_q_w[li], self._dit_k_w[li], self._dit_v_w[li]], dim=1).float()
@@ -660,15 +672,35 @@ class GrootN17TorchFrontendThor:
             sq = torch.tensor([act_qkv[j] / FP8_MAX], dtype=torch.float32, device=dev)
             self._dit_ff_fp8_keep += [qf, qb, sq]
             qkv_fp8.append(qf.data_ptr()); qkv_b.append(qb.data_ptr()); s_qkv.append(sq.data_ptr())
+            if use_sm120_safe:
+                qf_nt = qf.t().contiguous()
+                sw_q = torch.tensor([ws_q], dtype=torch.float32, device=dev)
+                self._dit_ff_fp8_keep += [qf_nt, sw_q]
+                qkv_fp8_nt.append(qf_nt.data_ptr())
+                qkv_ws.append(sw_q.data_ptr())
             a_qkv.append((act_qkv[j] / FP8_MAX) * ws_q)
         for step in range(num_inference_timesteps):
-            step_weights[step].update(
-                ff_proj_w_fp8=proj_fp8, ff_down_w_fp8=down_fp8,
-                ff_proj_b=projb16,  # fp16 bias for the GELU epilogue
-                alpha_fc1=a_fc1, alpha_fc2=a_fc2,
-                act_fc1_scale=s_fc1, act_fc2_scale=s_fc2,
-                qkv_w_fp8=qkv_fp8, qkv_b=qkv_b,
-                alpha_qkv=a_qkv, act_qkv_scale=s_qkv)
+            if use_sm120_safe:
+                step_weights[step].update(
+                    ff_proj_w_fp8_sm120=proj_fp8,
+                    ff_proj_weight_scale=proj_ws,
+                    ff_down_w_fp8_nt=down_fp8_nt,
+                    ff_down_weight_scale=down_ws,
+                    ff_proj_b=projb16,  # fp16 bias for the explicit GELU path
+                    act_fc1_scale=s_fc1,
+                    act_fc2_scale=s_fc2,
+                    qkv_w_fp8_nt=qkv_fp8_nt,
+                    qkv_weight_scale=qkv_ws,
+                    qkv_b=qkv_b,
+                    act_qkv_scale=s_qkv)
+            else:
+                step_weights[step].update(
+                    ff_proj_w_fp8=proj_fp8, ff_down_w_fp8=down_fp8,
+                    ff_proj_b=projb16,  # fp16 bias for the GELU epilogue
+                    alpha_fc1=a_fc1, alpha_fc2=a_fc2,
+                    act_fc1_scale=s_fc1, act_fc2_scale=s_fc2,
+                    qkv_w_fp8=qkv_fp8, qkv_b=qkv_b,
+                    alpha_qkv=a_qkv, act_qkv_scale=s_qkv)
         bp.update(xn_fp8=self._k_xn_fp8.data_ptr(),
                   ff_fp16=self._k_ff_fp16.data_ptr(),
                   ff_fp8=self._k_ff_fp8.data_ptr(),

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -834,7 +834,8 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
         # kernel — the AdaLN output feeds only the QKV projection, so it can
         # be emitted directly as fp8 (one kernel instead of AdaLN + quantize).
         # Cross-attn and the bf16 fallback keep the bf16 AdaLN.
-        is_self_fp8 = is_self and "qkv_w_fp8" in weights
+        is_self_fp8_sm120 = is_self and "qkv_w_fp8_nt" in weights
+        is_self_fp8 = is_self and ("qkv_w_fp8" in weights or is_self_fp8_sm120)
         j_self = (li - 1) // 2
         if is_self_fp8:
             fvk.ada_layer_norm_fp8(
@@ -860,7 +861,20 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
         # CUBLAS_STATUS_NOT_SUPPORTED at M=Sa=41 (M not 16-aligned). Match
         # N1.6's calibrate path: bf16_nn (no epilogue) + explicit
         # add_bias_bf16. Slightly more launches but works on every shape.
-        if is_self_fp8:
+        if is_self_fp8_sm120:
+            gemm.fp8_nt_dev(
+                int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8_nt"][j_self]),
+                int(bufs["qkv_buf"]), Sa, 3 * D, D,
+                int(weights["act_qkv_scale"][j_self]),
+                int(weights["qkv_weight_scale"][j_self]), int(stream))
+            fvk.add_bias_bf16(
+                int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
+                Sa, 3 * D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+            attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
+        elif is_self_fp8:
             # Fused FP8 QKV (self-attn): q/k/v share the post-AdaLN input,
             # so one [D, 3D] GEMM (compute-bound, unlike 3 launch-bound D→D
             # GEMMs) + a strided split into the Q/K/V slots. Cross-attn keeps
@@ -912,7 +926,30 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
         # FFN weights/scales are supplied; otherwise the bf16 path runs. The
         # attention GEMMs stay bf16 — at M=41 they are launch-bound, so FP8
         # gives no speedup there.
-        if "ff_proj_w_fp8" in weights:
+        if "ff_proj_w_fp8_sm120" in weights:
+            fvk.quantize_fp8_static(
+                xn_ptr, int(bufs["xn_fp8"]),
+                int(weights["act_fc1_scale"][li]), Sa * D, int(stream))
+            gemm.fp8_descale_fp16(
+                int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8_sm120"][li]),
+                int(bufs["ff_fp16"]), Sa, FF, D,
+                int(weights["act_fc1_scale"][li]),
+                int(weights["ff_proj_weight_scale"][li]), int(stream))
+            fvk.add_bias_fp16(
+                int(bufs["ff_fp16"]), int(weights["ff_proj_b"][li]),
+                Sa, FF, int(stream))
+            fvk.gelu_inplace_fp16(int(bufs["ff_fp16"]), Sa * FF, int(stream))
+            fvk.quantize_fp8_static_fp16(
+                int(bufs["ff_fp16"]), int(bufs["ff_fp8"]),
+                int(weights["act_fc2_scale"][li]), Sa * FF, int(stream))
+            gemm.fp8_nt_dev(
+                int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8_nt"][li]),
+                o_out_ptr, Sa, D, FF,
+                int(weights["act_fc2_scale"][li]),
+                int(weights["ff_down_weight_scale"][li]), int(stream))
+            fvk.add_bias_bf16(o_out_ptr, int(weights["ff_down_b"][li]),
+                              Sa, D, int(stream))
+        elif "ff_proj_w_fp8" in weights:
             fvk.quantize_fp8_static(
                 xn_ptr, int(bufs["xn_fp8"]),
                 int(weights["act_fc1_scale"][li]), Sa * D, int(stream))

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -266,6 +266,22 @@ def test_groot_n17_rtx_sm89_is_registered():
     assert cls.__name__ == "GrootN17TorchFrontendRtxSm89"
 
 
+def test_groot_n17_sm120_uses_sm120_safe_dit_fp8_only_on_sm120_frontend():
+    from flash_rt.frontends.torch.groot_n17_rtx_fp8 import (
+        GrootN17TorchFrontendRtxFP8,
+    )
+    from flash_rt.frontends.torch.groot_n17_rtx_sm89 import (
+        GrootN17TorchFrontendRtxSm89,
+    )
+    from flash_rt.frontends.torch.groot_n17_thor_fp8 import (
+        GrootN17TorchFrontendThorFP8,
+    )
+
+    assert GrootN17TorchFrontendRtxFP8._DIT_FP8_IMPL == "sm120_safe"
+    assert GrootN17TorchFrontendRtxSm89._DIT_FP8_IMPL == "thor_epilogue"
+    assert GrootN17TorchFrontendThorFP8._DIT_FP8_IMPL == "thor_epilogue"
+
+
 def test_wan22_ti2v_5b_rtx_sm120_is_registered():
     from flash_rt.hardware import resolve_pipeline_class
 


### PR DESCRIPTION
GPU: RTX 5090 / SM120
CUDA: 13.0
PyTorch: 2.9.0a0+cu130
Build: GPU_ARCH=120, FLASHRT_ENABLE_MOTUS=ON
GROOT N1.7 fixture:
GrootN17TorchFrontendRtxFP8 graph=False
p50=17.31ms

GrootN17TorchFrontendRtxFP8 graph=True
p50=8.36ms

GrootN17TorchFrontendRtxFP16 graph=True
p50=10.29ms
Regression/unit checks:
PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_load_model_use_fp8_kwarg.py -k 'groot_n17_sm120_uses_sm120_safe_dit_fp8_only_on_sm120_frontend or routes_groot_n17_rtx_sm120_default_to_fp8_frontend or rtx_sm120_rejects_use_fp8_false_without_fp16 or rtx_sm89'
7 passed
Import smoke:
groot_n17_rtx_fp8 import ok
groot_n17_thor_fp8 import ok
groot_n17_rtx_sm89 import ok
qwen36_rtx import ok
motus_rtx import ok
Impact Scope
This is intended to affect only:
config=groot_n17
framework=torch
hardware=rtx_sm120
default use_fp8=True frontend
Thor and SM89 keep their existing DiT FP8 mode and do not opt into the SM120-safe branch.