### PR TITLE
Document Thor GROOT N1.7 multi-sample calibration

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1009,19 +1009,14 @@ scales for free.
 | `pi05_thor_fp4` (jax, FP4 encoder active) | ✅ | ✅ (two-phase: FP8 + AWQ refit) |
 | `pi0_rtx`, `pi05_rtx` (torch + jax) | ✅ | ✅ |
 | `groot_rtx` (torch) | ✅ | ✅ |
-| `groot_thor` (torch) | ✅ | ❌ (see note) |
-| `pi05_thor` / `pi0_thor` / `pi0fast` (jax, non-FP4) | ✅ | ❌ (see note) |
+| `groot_n17_thor` (torch, aux samples) | ✅ | ✅ |
+| `groot_thor` (torch) | ✅ | Implemented; validate with N1.6 fixtures before deployment |
+| `pi05_thor` / `pi0_thor` / `pi0fast` (jax, non-FP4) | ✅ | Implemented; validate with target fixtures before deployment |
 
-Frontends marked ❌ raise `NotImplementedError` on N >= 2 — pass N = 1
-there today. Reasons:
-
-- **`groot_thor`**: the Thor port of the multi-sample path is staged
-  for the next rollout; the N=1 calibrate path remains the default
-  there. RTX (`groot_rtx`) ships the full N>=2 path today.
-- Non-FP4 JAX Thor frontends (`pi05_thor`, `pi0_thor`, `pi0fast`): the
-  FP8-only JAX path still uses the N=1 implicit-recalibrate shim; the
-  JAX Pi0.5 FP4 frontend (`pi05_thor_fp4` with `framework="jax"`) does
-  support N>=2, using the same two-phase flow as torch.
+GROOT N1.7 Thor is aux-driven rather than `predict()`-driven: its
+calibration samples use the same aux schema consumed by
+`set_prompt(aux=...)`. The obs-list examples above apply to
+`predict()`-style frontends.
 
 `pi05_thor_fp4` uses a two-phase multi-sample flow: Phase 1 reduces
 FP8 activation scales across N samples (same loop the base class

--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -582,7 +582,7 @@ replay path.
 
 Per-frame cost asymptotes to ~128 ms (~2.3× a single 55 ms replay).
 Measured with the same LIBERO dataset and `percentile=99.9` as the RTX
-row, on Pi0.5 LIBERO-FT safetensors in the the PyTorch deploy container container.
+row, on Pi0.5 LIBERO-FT safetensors in the PyTorch deploy container.
 See [`tests/bench_thor_calibration_vs_ref.py`](../tests/bench_thor_calibration_vs_ref.py).
 
 Calibration runs once per deployment session on both platforms. A Thor
@@ -592,13 +592,26 @@ taking for production deployments, but skippable for a 50-shot demo on
 a fixed scene where `N = 1` is already above the accuracy-sufficient
 threshold.
 
+#### GROOT N1.7 Thor aux-list validation
+
+GROOT N1.7 Thor uses aux samples rather than LIBERO obs dicts for
+multi-sample calibration. After `set_prompt(aux=...)` selects the
+deployment prompt, `GrootN17TorchFrontendThor.calibrate(aux_list,
+percentile=99.9)` percentile-reduces FP8 backbone activation scales
+across pre-captured aux samples. The focused Thor regression is
+[`tests/test_thor_groot_n17_calibrate.py`](../tests/test_thor_groot_n17_calibrate.py)
+with `--ns 1,8`.
+
 #### Which Thor frontends implement multi-sample calibration
 
 Thor `Pi05TorchFrontendThor.calibrate(obs_list, percentile=99.9)`
 supports N ≥ 2 today (same shape as the RTX API — see
 [`flash_rt/frontends/torch/pi05_thor.py`](../flash_rt/frontends/torch/pi05_thor.py)
-`_calibrate_multi_frame`). On RTX the same multi-sample API is also
-available for `groot_rtx` (see
+`_calibrate_multi_frame`). The torch Pi0 and Pi0-FAST Thor frontends,
+plus the non-FP4 JAX Thor frontends, follow the same obs-list contract.
+GROOT N1.7 Thor supports N ≥ 2 through its aux-list API described
+above. On RTX the same multi-sample API is also available for
+`groot_rtx` (see
 [`flash_rt/frontends/torch/groot_rtx.py`](../flash_rt/frontends/torch/groot_rtx.py)
 `_calibrate_multi_frame`), which percentile-reduces both the Qwen3 and
 the DiT activation scales after running per-sample shadow forwards
@@ -606,11 +619,9 @@ through both stages. Motus RTX also supports
 `MotusTorchFrontendRtx.calibrate(obs_list, percentile=99.9)` for
 Stage3 bundles; it percentile-reduces Motus FP8 GEMM scales, AWQ-FP8
 action/und scales, G7.24 action/und QKV scales, and VAE FP8 resample
-scales before CUDA Graph capture. The remaining Thor frontends (`pi0_thor`,
-`pi0fast`, `groot_thor`, and their JAX counterparts) still route N ≥ 2
-through the `implicit_calibrate` shim and raise `NotImplementedError`
-— each needs a per-model audit of its calibrate-pass scale buffer
-layout before the same loop generalizes.
+scales before CUDA Graph capture. For the older GROOT N1.6 Thor path
+(`groot_thor`), run `tests/test_thor_groot_calibrate.py --ns 1,8`
+with N1.6 assets before using it as deployment evidence.
 
 ### What remains unchanged
 


### PR DESCRIPTION
## Summary

- Document the validated GROOT N1.7 Thor N=8 multi-sample percentile calibration path in the public calibration docs and support table.
- Clarify that GROOT N1.7 Thor calibration is aux-list driven: `set_prompt(aux=deployment_aux)` selects the deployment prompt, while `calibrate(aux_list, percentile=99.9)` uses pre-captured aux samples for FP8 scale headroom.
- Add Jetson AGX Thor calibration evidence for the focused `tests/test_thor_groot_n17_calibrate.py --ns 1,8` regression.

## Validation Environment

- Hardware: Jetson AGX Thor / SM110
- CUDA capability: `(11, 0)`
- NVIDIA driver: `580.65.06`
- CUDA toolkit: `13.0.0` (`nvcc` `V13.0.48`)
- cuBLASLt runtime: `130100`
- Python: `3.12.0`
- PyTorch: `2.10.0`
- PyTorch CUDA: `13.0`
- Conda env: `/home/nvidia/tianjianyang/conda/envs/flashrt-thor`
- Test checkout: `/home/nvidia/tianjianyang/FlashRT`
- Build flags from `build-thor-sm110/CMakeCache.txt`: `GPU_ARCH=110`, `FA2_ARCH_NATIVE_ONLY=OFF`, `CMAKE_CUDA_ARCHITECTURES=75`
- Source-built extension imports used by this validation: `flash_rt.flash_rt_kernels` and `flash_rt.flash_rt_fp4` imported from `/home/nvidia/tianjianyang/FlashRT/flash_rt/*.so`
- GROOT N1.7 checkpoint: `/home/nvidia/tianjianyang/models/vla/gr00t_n17/checkpoints/GR00T-N1.7-3B`
- Aux/reference fixtures: `/home/nvidia/tianjianyang/models/vla/gr00t_n17/fixtures`
- Isaac-GR00T dependency: `/home/nvidia/tianjianyang/Isaac-GR00T`

## Validation Command

```bash
cd /home/nvidia/tianjianyang/FlashRT
bash scripts/run_thor_test.sh bash -lc '
set -euo pipefail
export USE_TF=0
export TRANSFORMERS_NO_TF=1
export USE_FLAX=0
export TRANSFORMERS_NO_FLAX=1
export HF_HOME=/home/nvidia/tianjianyang/.cache/huggingface
export GROOT_N17_CKPT=/home/nvidia/tianjianyang/models/vla/gr00t_n17/checkpoints/GR00T-N1.7-3B
export GROOT_N17_FX=/home/nvidia/tianjianyang/models/vla/gr00t_n17/fixtures/gr00t_n17_ref_oxe_droid_relative_eef_relative_joint_2v_traj1_step0_seed0.pt
export GROOT_N17_AUX=/home/nvidia/tianjianyang/models/vla/gr00t_n17/fixtures/gr00t_n17_ref_oxe_droid_relative_eef_relative_joint_2v_traj1_step0_seed0_llm_aux.pt
export GROOT_N17_AUX_LIST=/home/nvidia/tianjianyang/models/vla/gr00t_n17/fixtures/gr00t_n17_aux_list_n8.pt
export PYTHONPATH=/home/nvidia/tianjianyang/Isaac-GR00T:${PYTHONPATH:-}
export GROOT_HF_LOCAL_FIRST=1
export GROOT_PATCH_MISTRAL=1
export TRANSFORMERS_OFFLINE=1
export HF_HUB_OFFLINE=1
export NO_ALBUMENTATIONS_UPDATE=1
python tests/test_thor_groot_n17_calibrate.py --ns 1,8
'
```

## Validation Results

```text
N=1    [PASS]  cos=0.99998  calibrate_ms=3.2
N=8    [PASS]  cos=0.99998  calibrate_ms=7356.7
```

Detailed rows:

```text
N=1: cos_vs_ref=0.99998 maxdiff=0.0244 calibrate_ms=3.2    wall_clock_pipe_infer_P50=35.1ms spec_entries=206
N=8: cos_vs_ref=0.99998 maxdiff=0.0244 calibrate_ms=7356.7 wall_clock_pipe_infer_P50=34.7ms spec_entries=206
```

The N=8 run wrote a `precision_spec` with `calibration_method=percentile`, positive finite scales, and 206 entries. The reported P50 is warm wall-clock `pipe.infer(...)` latency over 10 iterations from the regression script, not CUDA Graph replay-only latency.

## Limitations / Not Covered

- This is a documentation and validation-evidence PR only. It does not change runtime code, kernels, CMake, pybind bindings, or fallback behavior.
- This validates `groot_n17_thor` with aux-list samples only.
- This does not validate the older GROOT N1.6 `groot_thor` N>=2 path; that still needs `tests/test_thor_groot_calibrate.py --ns 1,8` with N1.6 assets before being used as deployment evidence.
- This does not add new validation for non-FP4 JAX Thor frontends.
- This does not make an SM89 or RTX claim.
- This does not validate real-robot deployment behavior.

## CONTRIBUTING.md Checklist

- Docs updated for a supported-hardware / calibration-support claim: `USAGE.md`, `docs/calibration.md`.
- Exact hardware, driver/toolkit versions, build flags, runtime environment, command line, precision, and wall-clock latency evidence are included above.
- CMake / kernel binding build+import matrix: not applicable for this diff because no CMake, pybind, or kernel source changed. The validation did run in a source-built Thor env with `GPU_ARCH=110`; the runtime extensions used by the test imported successfully as listed above.
- Unsupported / unverified areas are listed above.