### PR TITLE
Document Pi0.5 JAX FP4 Thor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,9 +511,9 @@ data regardless of cache.
 ### NVFP4 encoder FFN (Pi0.5 only)
 
 Optional NVFP4 (Blackwell block-scaled FP4) quantization on the Pi0.5 encoder
-FFN stack. Currently implemented for **Pi0.5 torch only** — passing
+FFN stack. Implemented for **Pi0.5 torch and JAX on Thor** — passing
 `use_fp4=True` with any other config (pi0 / groot / pi0fast) emits a warning
-and falls back to FP8.
+and uses the FP8 route.
 
 ```python
 model = flash_rt.load_model(
@@ -549,8 +549,8 @@ L7-9 subset).
   `enable_llm_nvfp4` style — `output_quantizer` disabled).
 
 **Requirements**:
-- SM100+ GPU (validated on Thor SM110). Non-SM100 hardware silently falls
-  back to FP8.
+- SM100+ GPU (validated on Thor SM110). Non-SM100 hardware logs a warning
+  and uses the FP8 route.
 - `flash_rt_fp4.so` extension (built alongside `flash_rt_kernels.so`).
 
 **Measured on Thor SM110, Pi0.5 / LIBERO Spatial 10 × 50 = 500 episodes**:
@@ -572,12 +572,12 @@ stratified calibration, 50 graph replays, Thor SM110)**:
 | **NVFP4 encoder (torch)** | **31.91 ms** | **39.78 ms** | **51.51 ms** | **0.998932** |
 | **NVFP4 encoder (jax, Orbax)** | **34.39 ms** | **43.65 ms** | **56.90 ms** | **0.999030** |
 
-Encoder FP4 preserves cosine **≥ 0.9989** vs the PyTorch FP32 reference
-across view counts, with no latency regression relative to the FP8
-torch baseline. The JAX FP4 path derives NVFP4 weights directly from the
-Orbax checkpoint (no torch dependency at runtime) and uses the same
-two-phase multi-sample calibration flow as the torch FP4 path, producing
-a slightly higher cos (0.99903 vs 0.99893 at 3v, same AWQ refit tuning).
+Encoder FP4 preserves cosine **≥ 0.9989** vs the same-origin PyTorch
+reference in these Thor replay-latency checks. The JAX FP4 path derives
+NVFP4 weights directly from the Orbax checkpoint (no torch dependency at
+runtime) and uses the same two-phase multi-sample calibration flow as the
+torch FP4 path. Treat the table as Thor correctness / availability evidence,
+not a broad performance claim across every view count or host.
 Reproduce with
 [`tests/bench_pi05_thor_views.py`](tests/bench_pi05_thor_views.py)
 (defaults now include `jax_fp4`).

--- a/USAGE.md
+++ b/USAGE.md
@@ -1365,10 +1365,9 @@ Max-perf mode is ~1.5s (decode graph capture dominates after cache hit).
 ## NVFP4 (Pi0.5 only)
 
 Optional NVFP4 (Blackwell block-scaled FP4) quantization on the Pi0.5
-encoder FFN stack, enabled via a single flag `use_fp4=True`. **Currently
-only supported on Pi0.5 torch.** The gate applies in two directions:
-- Other configs (`pi0` / `groot` / `pi0fast`) log a warning and fall back to FP8.
-- `framework="jax"` with `use_fp4=True` also logs a warning and falls back to FP8, even with `config="pi05"` — JAX FP4 is not yet wired up (planned, see handoff prompt Task A).
+encoder FFN stack, enabled via a single flag `use_fp4=True`. It is supported
+for **Pi0.5 torch and JAX on Thor**. Other configs (`pi0` / `groot` /
+`pi0fast`) log a warning and use the FP8 route.
 
 ```python
 # Production-recommended — single flag, best-known config:
@@ -1430,14 +1429,16 @@ When `use_fp4=True` and a sub-flag (`fp4_layers`, `use_awq`,
 ### Weight loading
 
 When `use_fp4=True`, the FP4 layer weights are loaded directly as fp16 from
-safetensors and NVFP4-quantized offline (no FP8 intermediate). This matches
-the NVIDIA modelopt design and avoids a double-lossy FP8 → fp16 → FP4
-round-trip. A fp8-dequant fallback path exists if direct fp16 load fails.
+the selected framework checkpoint and NVFP4-quantized offline (no FP8
+intermediate). Torch uses safetensors checkpoints. JAX uses Orbax checkpoints
+and depends on the Orbax loader accepting current `StepMetadata` checkpoint
+metadata. This matches the NVIDIA modelopt design and avoids a double-lossy
+FP8 → fp16 → FP4 round-trip.
 
 ### Requirements
 
 - SM100+ GPU with Blackwell Tensor Cores (validated on Thor SM110).
-  Hardware without NVFP4 support silently falls back to FP8.
+  Hardware without NVFP4 support logs a warning and uses the FP8 route.
 - `flash_rt_fp4.so` extension built alongside `flash_rt_kernels.so`
   (automatic in standard install).
 
@@ -1466,6 +1467,20 @@ Multi-model precision regression (`tests/test_all_models_precision.py`):
 | Pi0 | (unchanged) | vs_pytorch_ref=0.9972 | 46.7 ms |
 | Pi0 JAX | (unchanged) | vs_pytorch_ref=0.9983 | 45.1 ms |
 | GROOT N1.6 | (unchanged) | vs_pytorch_ref=0.9986 | 46.2 ms |
+
+Thor replay-latency / precision check for the JAX Orbax path:
+
+| Frontend | Views | P50 | P95 | cos vs same-origin PyTorch ref | max diff |
+|---|---:|---:|---:|---:|---:|
+| `jax_fp8` | 3 | 55.03 ms | 55.23 ms | 0.999358 | 0.0638 |
+| `jax_fp4` | 3 | 50.30 ms | 56.58 ms | 0.998351 | 0.0994 |
+
+The JAX reference was generated from the same `pi05_libero_jax` Orbax
+checkpoint via the upstream OpenPI conversion script and
+`PI0Pytorch.sample_actions`; do not compare this validation against a separate
+HF / LeRobot safetensors checkpoint. These numbers are correctness /
+availability evidence for the Thor JAX FP4 path, not a broad performance
+claim.
 
 ### Layer selection
 

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -65,7 +65,9 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   Pi0-FAST.
 - `embodiment_tag` and `action_horizon` apply to GROOT.
 - `use_fp4`, `fp4_layers`, `use_awq`, `awq_alpha`, and
-  `use_p1_split_gu` apply to the Pi0.5 torch NVFP4 encoder path.
+  `use_p1_split_gu` apply to the Pi0.5 torch and JAX NVFP4 encoder path on
+  Thor. The JAX path loads Orbax checkpoints; the torch path loads
+  safetensors checkpoints.
 - `num_steps`, `vision_pool_factor`, `vision_num_layers`, and
   `cache_frames` apply only to frontends that expose those constructor
   parameters today. The Pi0.5 torch RTX/Orin frontend validates

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -559,11 +559,12 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
 
     # ── FP4 routing (Pi0.5 torch + Pi0.5 JAX on Thor) ──
     if use_fp4:
-        if config != "pi05" or framework not in ("torch", "jax"):
+        if config != "pi05" or framework not in ("torch", "jax") or arch != "thor":
             logger.warning(
                 "use_fp4=True is only supported for config='pi05' with "
-                "framework in ('torch', 'jax'); got config='%s' framework='%s'. "
-                "Falling back to FP8.", config, framework)
+                "framework in ('torch', 'jax') on Thor; got config='%s' "
+                "framework='%s' hardware='%s'. Falling back to FP8.",
+                config, framework, arch)
             use_fp4 = False
         else:
             try:

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -351,15 +351,20 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
         action_horizon: GROOT only. Number of action steps to generate per
             inference (default = ``ACTION_HORIZON_MAX`` = 50). Set to a
             smaller value (e.g. 16 for LIBERO) to reduce DiT compute.
-        use_fp4: Pi0.5 torch only. If True, enable NVFP4 quantization on the
-            selected encoder FFN layers (Gate+Up + Down GEMMs). Requires
-            SM100+ GPU (Thor SM110) and the flash_rt_fp4 extension. Falls
-            back to FP8 with a warning if the extension is unavailable.
-            Default False (production FP8 baseline).
-            Validated on LIBERO Spatial: 491/500 = 98.2% (matches baseline).
+        use_fp4: Pi0.5 torch and JAX on Thor. If True, enable NVFP4
+            quantization on the selected encoder FFN layers (Gate+Up + Down
+            GEMMs). Requires SM100+ GPU (Thor SM110) and the flash_rt_fp4
+            extension. Uses the FP8 route with a warning if the extension is
+            unavailable. Default False (production FP8 baseline).
+            Torch uses safetensors checkpoints; JAX uses Orbax checkpoints.
+            Validated on LIBERO Spatial for the torch path: 491/500 = 98.2%
+            (matches baseline). JAX FP4 has Thor precision / replay-latency
+            validation against a same-origin PyTorch reference.
         fp4_layers: Tuple of encoder layer indices to FP4-quantize (only
-            applies when use_fp4=True). Default (7, 8, 9) = middle FFN
-            subset, LIBERO-validated. Other subsets untested at task level.
+            applies when use_fp4=True). ``None`` resolves to the production
+            preset, full 18 encoder FFN layers with AWQ + P1 split-GU.
+            Explicit tuples override the preset; `(7, 8, 9)` is the
+            conservative middle-FFN subset.
         use_fp8: Enable FP8 execution where the selected frontend supports
             an FP8/BF16 switch. Defaults to True to preserve existing
             performance-oriented behavior.

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -310,6 +310,72 @@ def test_load_model_routes_pi05_jax_thor_fp4_and_preset_kwargs(monkeypatch):
     }
 
 
+@pytest.mark.parametrize(
+    "framework, hardware, module_name, class_name",
+    [
+        (
+            "jax",
+            "rtx_sm89",
+            "flash_rt.frontends.jax.pi05_thor_fp4",
+            "Pi05JaxFrontendThorFP4",
+        ),
+        (
+            "torch",
+            "rtx_sm120",
+            "flash_rt.frontends.torch.pi05_thor_fp4",
+            "Pi05TorchFrontendThorFP4",
+        ),
+    ],
+)
+def test_load_model_does_not_route_pi05_non_thor_fp4_to_thor_frontend(
+        monkeypatch, framework, hardware, module_name, class_name):
+    from flash_rt.api import load_model
+
+    class ResolvedFrontend:
+        seen = None
+
+        def __init__(self, checkpoint, *, num_views=2, use_fp8=True):
+            type(self).seen = {
+                "checkpoint": checkpoint,
+                "num_views": num_views,
+                "use_fp8": use_fp8,
+            }
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    class UnexpectedThorFP4Frontend:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "non-Thor Pi0.5 use_fp4=True must keep the resolved "
+                "hardware frontend instead of rewriting to a Thor FP4 class")
+
+    fp4_ext = types.ModuleType("flash_rt.flash_rt_fp4")
+    fp4_ext.has_nvfp4 = lambda: True
+    thor_fp4_mod = types.ModuleType(module_name)
+    setattr(thor_fp4_mod, class_name, UnexpectedThorFP4Frontend)
+    monkeypatch.setitem(sys.modules, "flash_rt.flash_rt_fp4", fp4_ext)
+    monkeypatch.setitem(sys.modules, module_name, thor_fp4_mod)
+
+    with patch("flash_rt.hardware.resolve_pipeline_class",
+               return_value=ResolvedFrontend):
+        model = load_model(
+            "unused-checkpoint",
+            config="pi05",
+            framework=framework,
+            hardware=hardware,
+            num_views=3,
+            use_fp4=True,
+        )
+
+    assert isinstance(model._pipe, ResolvedFrontend)
+    assert ResolvedFrontend.seen == {
+        "checkpoint": "unused-checkpoint",
+        "num_views": 3,
+        "use_fp8": True,
+    }
+
+
 def test_sm87_rejects_unvalidated_pi0_and_jax_backends():
     from flash_rt.hardware import resolve_pipeline_class
 

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -1,6 +1,8 @@
-from unittest.mock import patch
 import ast
 from pathlib import Path
+import sys
+import types
+from unittest.mock import patch
 
 import pytest
 
@@ -237,6 +239,74 @@ def test_load_model_propagates_pi05_orin_tuning_kwargs_when_supported():
         "vision_pool_factor": 2,
         "vision_num_layers": 18,
         "cache_frames": 2,
+    }
+
+
+def test_load_model_routes_pi05_jax_thor_fp4_and_preset_kwargs(monkeypatch):
+    from flash_rt.api import load_model
+
+    class ResolvedFrontend:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError(
+                "load_model() should rewrite Pi0.5 JAX Thor FP4 requests "
+                "to Pi05JaxFrontendThorFP4")
+
+    class Pi05JaxFrontendThorFP4:
+        seen = None
+
+        def __init__(self, checkpoint, *, num_views=2, autotune=3,
+                     weight_cache=True, use_fp8=True,
+                     use_fp4_encoder_ffn=False, fp4_layers=(),
+                     use_awq=False, awq_alpha=0.5,
+                     use_p1_split_gu=False):
+            type(self).seen = {
+                "checkpoint": checkpoint,
+                "num_views": num_views,
+                "autotune": autotune,
+                "weight_cache": weight_cache,
+                "use_fp8": use_fp8,
+                "use_fp4_encoder_ffn": use_fp4_encoder_ffn,
+                "fp4_layers": fp4_layers,
+                "use_awq": use_awq,
+                "awq_alpha": awq_alpha,
+                "use_p1_split_gu": use_p1_split_gu,
+            }
+
+        def infer(self, obs):
+            return {"actions": None}
+
+    fp4_ext = types.ModuleType("flash_rt.flash_rt_fp4")
+    fp4_ext.has_nvfp4 = lambda: True
+    jax_fp4_mod = types.ModuleType("flash_rt.frontends.jax.pi05_thor_fp4")
+    jax_fp4_mod.Pi05JaxFrontendThorFP4 = Pi05JaxFrontendThorFP4
+    monkeypatch.setitem(sys.modules, "flash_rt.flash_rt_fp4", fp4_ext)
+    monkeypatch.setitem(
+        sys.modules, "flash_rt.frontends.jax.pi05_thor_fp4", jax_fp4_mod)
+
+    with patch("flash_rt.hardware.resolve_pipeline_class",
+               return_value=ResolvedFrontend):
+        model = load_model(
+            "unused-orbax-checkpoint",
+            config="pi05",
+            framework="jax",
+            hardware="thor",
+            num_views=3,
+            autotune=0,
+            use_fp4=True,
+        )
+
+    assert isinstance(model._pipe, Pi05JaxFrontendThorFP4)
+    assert Pi05JaxFrontendThorFP4.seen == {
+        "checkpoint": "unused-orbax-checkpoint",
+        "num_views": 3,
+        "autotune": 0,
+        "weight_cache": True,
+        "use_fp8": True,
+        "use_fp4_encoder_ffn": True,
+        "fp4_layers": tuple(range(18)),
+        "use_awq": True,
+        "awq_alpha": 0.5,
+        "use_p1_split_gu": True,
     }
 
 


### PR DESCRIPTION
## Summary

- Align README, USAGE, stable API, and `load_model()` docs with the existing Pi0.5 JAX NVFP4 Thor route.
- Remove stale wording that described JAX `use_fp4=True` as not wired up / FP8-only.
- Clarify that the torch FP4 path uses safetensors checkpoints and the JAX FP4 path uses Orbax checkpoints.
- Add a CPU-only route regression proving `load_model(config="pi05", framework="jax", hardware="thor", use_fp4=True)` selects `Pi05JaxFrontendThorFP4` and forwards the production preset kwargs.

## Dependency

This docs / route-test PR depends on the Orbax StepMetadata loader fix in #99 for full Thor JAX Orbax checkpoint validation in the current CUDA13-era JAX / Orbax stack.

This PR itself does **not** include the loader changes from #99.

## Validation

Local static check:

```text
python -m py_compile flash_rt/api.py tests/test_load_model_use_fp8_kwarg.py
-> passed
```

Local route regression:

```text
/data/home/tianjianyang/miniconda3/envs/flashrt/bin/python -m pytest tests/test_load_model_use_fp8_kwarg.py -q
-> 29 passed in 1.92s
```

Whitespace:

```text
git diff --check
-> passed
```

Thor validation performed during development with #99 applied:

```text
GPU: NVIDIA Thor, compute capability (11, 0)
Python: 3.12.0
PyTorch: 2.10.0
CUDA runtime: 13.0
JAX stack: jax==0.9.2, jaxlib==0.9.2,
           jax-cuda13-pjrt==0.9.2, jax-cuda13-plugin==0.9.2
NumPy: 2.2.6
XLA_FLAGS=--xla_gpu_autotune_level=0
```

Same-origin PyTorch reference:

```text
/tmp/pytorch_reference.npz
sha256=b21609fda4e0ef326a2c72a75c12e1b3db45611820f3ec4a72c7816f5036f6e7
```

The reference was generated from the same `pi05_libero_jax` Orbax checkpoint used on Thor via the upstream OpenPI conversion script and `PI0Pytorch.sample_actions`; it is not the separate HF / LeRobot safetensors checkpoint.

Thor replay-latency / precision checks:

```text
python tests/bench_pi05_thor_views.py --frontends jax_fp8 --views 3
-> calibrate_ms=479.4, p50_ms=55.03, p95_ms=55.23,
   cos_vs_fp32_ref=0.999358, maxdiff_vs_ref=0.0638

python tests/bench_pi05_thor_views.py --frontends jax_fp4 --views 3
-> calibrate_ms=36150.3, p50_ms=50.30, p95_ms=56.58,
   cos_vs_fp32_ref=0.998351, maxdiff_vs_ref=0.0994
```

## Limits / Notes

- No kernel, CMake, pybind, Orbax loader, or runtime kernel code changes are included.
- This does not add FP4 support for Pi0, GROOT, or Pi0-FAST.
- The Thor numbers are correctness / availability evidence for the JAX FP4 path, not a broad performance claim across every view count or host.
- Broader Thor calibration matrix tests such as `tests/test_thor_calibrate_matrix.py --models pi05_jax_fp4 --n 8` were not rerun for this docs PR.
