### PR TITLE
Fix GROOT N1.7 calibration public API signature

### DIFF
--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -128,6 +128,14 @@ class VLAModel:
     def set_prompt(self, *args, **kwargs): ...
     def infer(self, *args, **kwargs): ...
     def predict(self, images, prompt=None, state=None) -> np.ndarray: ...
+    def calibrate(
+        self,
+        observations,
+        *,
+        percentile: float = 99.9,
+        max_samples: int | None = None,
+        verbose: bool = False,
+    ) -> None: ...
     def warm_state_prompt_buckets(self, images, prompt, states) -> list[int]: ...
     def recalibrate(self) -> None: ...
 
@@ -176,6 +184,16 @@ class VLAModel:
   - GROOT N1.7 currently uses the lower-level
     `normalize_state(...)` + `infer(state_normalized, initial_noise=...)`
     contract rather than the image-list `predict()` contract.
+
+- `calibrate(observations, *, percentile=99.9, max_samples=None,
+  verbose=False)` — run the selected frontend's public calibration path.
+  `observations` may be a single observation dict or an iterable of samples in
+  the frontend's calibration format. `max_samples` caps the consumed sample
+  list before the frontend chooses its N=1 or N>=2 path. Frontends that
+  document N>=2 support run dataset calibration with percentile-clipped amax
+  reduction; unsupported frontends raise a clear `NotImplementedError`.
+  GROOT N1.7 uses captured aux dict samples rather than raw image observation
+  dicts.
 
 - `warm_state_prompt_buckets(images, prompt, states)` — Pi0.5 RTX torch
   helper for realtime loops that pass changing state through the prompt.

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -216,16 +216,17 @@ class VLAModel:
         observations,
         *,
         percentile: float = 99.9,
-        max_samples=None,
+        max_samples: int | None = None,
         verbose: bool = False,
     ) -> None:
         """Unified calibration entry point.
 
         Args:
             observations: single dict or iterable of dicts. N=1 triggers
-                the single-frame calibration path (back-compatible); N>=2
-                engages dataset calibration with percentile-clipped amax
-                reduction (RTX frontends only today).
+                the single-frame calibration path (back-compatible). Frontends
+                that document N>=2 support run dataset calibration with
+                percentile-clipped amax reduction; unsupported frontends raise
+                a clear NotImplementedError from their calibrate() method.
             percentile: percentile for multi-sample amax reduction. 99.9
                 by default; 100.0 == traditional max.
             max_samples: optional cap.

--- a/flash_rt/core/calibration_api.py
+++ b/flash_rt/core/calibration_api.py
@@ -1,22 +1,22 @@
-"""Shared ``calibrate()`` shim for frontends that do not yet implement
-a native multi-sample calibration loop.
+"""Shared ``calibrate()`` shim for single-sample implicit recalibration.
 
-Used by Thor frontends (pi0_thor / pi05_thor / pi0fast / groot_thor),
-their JAX counterparts, and groot_rtx — all of which currently rely on
-the implicit "first infer triggers recalibration" mechanism. The shim
-turns that into an explicit public API that matches pi0_rtx / pi05_rtx
-in shape, so user code is portable across frontends.
+Some legacy frontend paths still use an implicit "first infer triggers
+recalibration" mechanism for ``N == 1``. This helper turns that path into
+the explicit public ``calibrate([obs])`` API shape. Frontends with native
+multi-sample dataset calibration define their own ``calibrate`` methods and
+call this helper only for their single-sample compatibility path.
 
 Behaviour:
     N == 1 : run one forward via ``frontend.infer(obs)`` and discard the
              output. This fires whatever implicit calibration hook the
              frontend has (Thor's ``_recalibrate_with_real_data``
              auto-runs in the first infer).
-    N >= 2 : raise NotImplementedError with a clear pointer to the RTX
-             frontends which support multi-sample today.
+    N >= 2 : raise NotImplementedError with a clear pointer that this
+             compatibility shim is single-sample only.
 
-When a frontend later grows a native multi-sample path it should define
-its own ``calibrate`` method and stop calling this helper.
+New frontend code should implement a native ``calibrate`` method for any
+``N >= 2`` dataset path and call this helper only for the legacy ``N == 1``
+branch.
 """
 
 from __future__ import annotations
@@ -24,13 +24,13 @@ from __future__ import annotations
 from typing import Any, Iterable, Optional
 
 
-_THOR_MULTI_SAMPLE_MESSAGE = (
-    "Multi-sample (N>=2) dataset calibration is not yet implemented for "
-    "this frontend. Today it is only supported on the RTX torch frontends "
-    "(Pi0TorchFrontendRtx, Pi05TorchFrontendRtx). Either pass a single "
-    "observation to fall back to the implicit recalibration path, or run "
-    "calibration on the RTX frontend if your deployment environment "
-    "permits. Thor multi-sample support is planned for a future release."
+_IMPLICIT_CALIBRATE_MULTI_SAMPLE_MESSAGE = (
+    "Multi-sample (N>=2) dataset calibration is not supported by the "
+    "implicit_calibrate compatibility shim. Frontends with native "
+    "multi-sample calibration must route N>=2 to their own calibrate "
+    "implementation. Pass a single observation for the implicit "
+    "recalibration path, or use a frontend whose public calibrate() "
+    "documents N>=2 support."
 )
 
 
@@ -44,7 +44,8 @@ def implicit_calibrate(
 ) -> None:
     """Shim: force a single implicit recalibration via ``infer(obs_list[0])``.
 
-    Raises NotImplementedError for N >= 2 (Thor multi-sample path is TODO).
+    Raises NotImplementedError for N >= 2. Native multi-sample frontends
+    should handle that path before calling this helper.
     """
     if isinstance(observations, dict):
         obs_list = [observations]
@@ -61,7 +62,7 @@ def implicit_calibrate(
         raise ValueError(f"percentile must be in [0, 100], got {percentile}")
 
     if n > 1:
-        raise NotImplementedError(_THOR_MULTI_SAMPLE_MESSAGE)
+        raise NotImplementedError(_IMPLICIT_CALIBRATE_MULTI_SAMPLE_MESSAGE)
 
     # Trigger implicit recalibration by running one inference and
     # discarding the result. The frontend's first-infer path will set

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -969,6 +969,7 @@ class GrootN17TorchFrontendThor:
         aux_list,
         *,
         percentile: float = 99.9,
+        max_samples: Optional[int] = None,
         verbose: bool = False,
     ) -> None:
         """Refine FP8 act-scale alphas across N calibration samples.
@@ -1005,6 +1006,8 @@ class GrootN17TorchFrontendThor:
             aux_list: list of aux dicts (or single dict / iterable).
             percentile: percentile along the sample axis. ``100.0`` ==
                 traditional max. ``99.9`` (default) clips outliers.
+            max_samples: optional cap, matching the unified public
+                ``VLAModel.calibrate`` API.
             verbose: log per-stage amax dispersion summaries after
                 reduction.
         """
@@ -1022,6 +1025,8 @@ class GrootN17TorchFrontendThor:
             aux_list = [aux_list]
         else:
             aux_list = list(aux_list)
+        if max_samples is not None:
+            aux_list = aux_list[:max_samples]
         n = len(aux_list)
         if n == 0:
             raise ValueError("aux_list must contain at least 1 sample")

--- a/tests/test_calibration_api.py
+++ b/tests/test_calibration_api.py
@@ -1,0 +1,80 @@
+"""CPU-only tests for the public calibration API contract."""
+
+import pytest
+
+from flash_rt.core.calibration_api import implicit_calibrate
+
+
+def test_implicit_calibrate_single_sample_runs_infer_once():
+    class Frontend:
+        def __init__(self):
+            self.calls = []
+
+        def infer(self, obs):
+            self.calls.append(obs)
+
+    frontend = Frontend()
+    obs = {"frame": 1}
+    implicit_calibrate(frontend, [obs])
+    assert frontend.calls == [obs]
+
+
+def test_implicit_calibrate_multi_sample_error_points_to_shim():
+    class Frontend:
+        def infer(self, obs):
+            raise AssertionError("N>=2 must not call infer")
+
+    with pytest.raises(NotImplementedError) as exc:
+        implicit_calibrate(Frontend(), [{"frame": 1}, {"frame": 2}])
+    msg = str(exc.value)
+    assert "implicit_calibrate compatibility shim" in msg
+    assert "native multi-sample calibration" in msg
+    assert "Thor multi-sample support is planned" not in msg
+
+
+def test_vla_model_calibrate_forwards_public_kwargs():
+    from flash_rt.api import VLAModel
+
+    class Frontend:
+        seen = None
+
+        def calibrate(self, observations, *, percentile, max_samples, verbose):
+            type(self).seen = {
+                "observations": observations,
+                "percentile": percentile,
+                "max_samples": max_samples,
+                "verbose": verbose,
+            }
+
+    obs = [{"frame": 1}, {"frame": 2}]
+    model = VLAModel(Frontend(), framework="torch")
+    model.calibrate(obs, percentile=99.0, max_samples=1, verbose=True)
+
+    assert Frontend.seen == {
+        "observations": obs,
+        "percentile": 99.0,
+        "max_samples": 1,
+        "verbose": True,
+    }
+
+
+def test_groot_n17_calibrate_accepts_public_max_samples_kwarg():
+    from flash_rt.frontends.torch.groot_n17_thor import GrootN17TorchFrontendThor
+
+    frontend = GrootN17TorchFrontendThor.__new__(GrootN17TorchFrontendThor)
+    frontend._backbone_features = object()
+    calls = []
+
+    def snapshot(**kwargs):
+        calls.append(kwargs)
+        return kwargs
+
+    frontend._snapshot_precision_spec = snapshot
+    frontend.calibrate([{"aux": 1}, {"aux": 2}], max_samples=1)
+
+    assert calls == [{
+        "method": "single_frame",
+        "n": 1,
+        "percentile": None,
+    }]
+    assert frontend._precision_spec == calls[0]


### PR DESCRIPTION
## Summary

- align `GrootN17TorchFrontendThor.calibrate()` with the public `VLAModel.calibrate(..., max_samples=...)` keyword set
- apply `max_samples` before GROOT N1.7 calibration sample counting, matching the other calibration frontends
- document `VLAModel.calibrate(...)` in `docs/stable_api.md` and refresh the public wrapper docstring
- refresh the shared `implicit_calibrate()` message so it describes the shim as single-sample only instead of saying Thor multi-sample support is future work
- add CPU-only calibration API contract tests

## Validation

```bash
python -m py_compile \
  flash_rt/core/calibration_api.py \
  flash_rt/api.py \
  flash_rt/frontends/torch/groot_n17_thor.py \
  tests/test_calibration_api.py

/data/home/tianjianyang/miniconda3/envs/flashrt/bin/python -m pytest \
  tests/test_calibration_api.py \
  tests/test_calibration_helpers.py \
  -q

git diff --check
```

Result:

```text
py_compile passed
22 passed in 1.59s
git diff --check passed
```

## Notes

- No kernel bindings, CMake files, CUDA sources, or build flags changed.
- No calibration numerics, graph capture, precision path, or latency-sensitive runtime behavior changed.
- Hardware GROOT N1.7 calibration was not rerun; this PR covers CPU-level public API routing and signature compatibility.
