### PR TITLE
Skip risky SM89 FP8 NT autotune by default

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -837,6 +837,26 @@ CUDA Graph instantiation on Thor is non-deterministic — the same kernels can p
 
 Autotune is part of `set_prompt()`. If you call `predict()` with the same prompt, the cached graph is replayed — no autotune overhead.
 
+### RTX 4090 / SM89 FP8 NT safety policy
+
+Pi0.5 on RTX 4090 / Ada uses FP8 weights in `nk` layout and dispatches
+cuBLASLt FP8 NT GEMMs. On some SM89 driver / cuBLASLt runtime combinations,
+the default heuristic top-1 algorithm is stable but the top-N autotune
+benchmark can expose a non-default candidate that raises CUDA illegal memory
+access. Because that failure poisons the CUDA context, FlashRT avoids the risky
+benchmark path before it runs.
+
+By default (`FLASHRT_FP8_NT_AUTOTUNE=auto`), Pi0.5 skips FP8 NT top-N autotune
+on SM89 and keeps the cuBLASLt heuristic top-1 algorithm. FP8 inference remains
+enabled; only the FP8 NT autotune benchmark is skipped.
+
+Override for debugging / local benchmarking:
+
+```bash
+FLASHRT_FP8_NT_AUTOTUNE=force  # force FP8 NT top-N autotune
+FLASHRT_FP8_NT_AUTOTUNE=safe   # always skip FP8 NT top-N autotune
+```
+
 ---
 
 ## Calibration

--- a/flash_rt/frontends/jax/pi05_rtx.py
+++ b/flash_rt/frontends/jax/pi05_rtx.py
@@ -48,6 +48,7 @@ from flash_rt.frontends.torch.pi05_rtx import (
     MAX_PROMPT_LEN_DEFAULT,
     Pi05TorchFrontendRtx,
     _interleave_qk,
+    _resolve_effective_hardware,
     _select_fp8_layout,
 )
 from flash_rt.core.utils.hardware import supports_fp8
@@ -477,6 +478,7 @@ class Pi05JaxFrontendRtx(Pi05TorchFrontendRtx):
                 f"vision_num_layers must be in [1, {VIS_L}], "
                 f"got {self._vision_num_layers}")
         self.use_fp8 = bool(use_fp8)
+        self.hardware = _resolve_effective_hardware(hardware)
         self.fp8_layout = _select_fp8_layout(hardware, fp8_layout)
 
         self.latency_records: list[float] = []

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -374,6 +374,22 @@ def _select_fp8_layout(hardware: Optional[str], fp8_layout: Optional[str]) -> st
     return "kn"
 
 
+def _resolve_effective_hardware(hardware: Optional[str]) -> Optional[str]:
+    """Resolve the RTX hardware tag used by lower-level policy decisions."""
+    if hardware is not None:
+        return hardware
+    try:
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability()
+            if major == 8 and minor == 9:
+                return "rtx_sm89"
+            if major == 12:
+                return "rtx_sm120"
+    except Exception:
+        pass
+    return hardware
+
+
 def _precompute_decoder_styles(ckpt: dict, chunk_size: int,
                                num_steps: int = NUM_STEPS_DEFAULT) -> dict:
     """Pre-compute the time-MLP + per-layer style modulations in torch.
@@ -525,6 +541,7 @@ class Pi05TorchFrontendRtx:
                 f"got {self._vision_num_layers}")
         # _use_int8_vision_static is set after _force_int8_decoder below
         self.use_fp8 = bool(use_fp8)
+        self.hardware = _resolve_effective_hardware(hardware)
         self.fp8_layout = _select_fp8_layout(hardware, fp8_layout)
 
         self.latency_records: list[float] = []
@@ -936,6 +953,7 @@ class Pi05TorchFrontendRtx:
             "fp8": self._fp8_weights,
             "int8": self._int8_weights,
             "fp8_layout": self.fp8_layout,
+            "hardware": self.hardware,
 
             # Precomputed decoder styles (numpy bf16 as uint16 view)
             "precomputed": self._precomputed_styles,

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import ctypes
 import logging
 import math
+import os
 
 import numpy as np
 import ml_dtypes
@@ -48,6 +49,28 @@ from flash_rt.core.cuda_buffer import CudaBuffer
 from flash_rt.core.cuda_graph import CUDAGraph
 
 logger = logging.getLogger(__name__)
+
+
+def _fp8_nt_autotune_enabled(hardware: str | None, fp8_layout: str) -> bool:
+    """Whether to run cuBLASLt top-N autotune for FP8 NT GEMMs.
+
+    ``auto`` keeps FP8 inference enabled but avoids benchmarking non-top-1
+    FP8 NT candidates on Ada / SM89, where a bad cuBLASLt candidate can poison
+    the CUDA context with an illegal memory access. The default heuristic
+    algorithm selected when the GEMM descriptor is created remains active.
+    """
+    policy = os.environ.get("FLASHRT_FP8_NT_AUTOTUNE", "auto").strip().lower()
+    if policy in ("1", "true", "on", "force"):
+        return True
+    if policy in ("0", "false", "off", "safe", "skip"):
+        return False
+    if policy != "auto":
+        logger.warning(
+            "Unknown FLASHRT_FP8_NT_AUTOTUNE=%r; using auto policy", policy)
+
+    if fp8_layout == "nk" and hardware in ("rtx_sm89", "sm89", "ada"):
+        return False
+    return True
 
 
 # Fixed Pi0.5 model dimensions
@@ -221,6 +244,15 @@ class Pi05Pipeline:
         self.fp8_layout = weights.get("fp8_layout", "kn")
         if self.fp8_layout not in ("kn", "nk"):
             raise ValueError(f"unsupported FP8 layout: {self.fp8_layout!r}")
+        self.hardware = weights.get("hardware")
+        self._autotune_fp8_nt = _fp8_nt_autotune_enabled(
+            self.hardware, self.fp8_layout)
+        if self.fp8_layout == "nk" and not self._autotune_fp8_nt:
+            logger.info(
+                "Skipping FP8 NT top-N autotune for hardware=%s; keeping "
+                "cuBLASLt heuristic top-1 algorithm. Set "
+                "FLASHRT_FP8_NT_AUTOTUNE=force to override.",
+                self.hardware or "unknown")
 
         # Derived sizes
         # vision_seq: full SigLIP token count (pre-pooling) — used for SigLIP buffers
@@ -525,6 +557,8 @@ class Pi05Pipeline:
                              act_scale_ptr: int, weight_scale_ptr: int) -> None:
         """Autotune the FP8 GEMM for the selected weight layout."""
         if self.fp8_layout == "nk":
+            if not getattr(self, "_autotune_fp8_nt", True):
+                return
             self.gemm.autotune_fp8_nt_dev(
                 act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
                 M, N, K, act_scale_ptr, weight_scale_ptr)

--- a/tests/test_pi05_rtx_autotune_scratch.py
+++ b/tests/test_pi05_rtx_autotune_scratch.py
@@ -33,6 +33,7 @@ def _load_pi05_rtx_symbols():
             Pi05Pipeline,
             VIS_D,
             VIS_H,
+            _fp8_nt_autotune_enabled,
         )
     except (ImportError, OSError) as exc:
         pytest.skip(f"Pi05 RTX imports unavailable: {exc}")
@@ -47,6 +48,7 @@ def _load_pi05_rtx_symbols():
         Pi05Pipeline=Pi05Pipeline,
         VIS_D=VIS_D,
         VIS_H=VIS_H,
+        _fp8_nt_autotune_enabled=_fp8_nt_autotune_enabled,
     )
 
 
@@ -266,6 +268,41 @@ def test_fp8_nk_layout_dispatches_to_nt_entrypoints():
     pipe.gemm.autotune_fp8_nt_dev.assert_called_once_with(
         21, 22, 23, 24, 25, 26, 27, 28)
     pipe.gemm.fp8_nn_dev.assert_not_called()
+    pipe.gemm.autotune_fp8_nn_dev.assert_not_called()
+
+
+def test_fp8_nt_autotune_auto_skips_sm89(monkeypatch):
+    symbols = _load_pi05_rtx_symbols()
+    monkeypatch.delenv("FLASHRT_FP8_NT_AUTOTUNE", raising=False)
+    assert not symbols._fp8_nt_autotune_enabled("rtx_sm89", "nk")
+    assert symbols._fp8_nt_autotune_enabled("rtx_sm120", "nk")
+    assert symbols._fp8_nt_autotune_enabled("rtx_sm89", "kn")
+
+
+def test_fp8_nt_autotune_env_override(monkeypatch):
+    symbols = _load_pi05_rtx_symbols()
+    monkeypatch.setenv("FLASHRT_FP8_NT_AUTOTUNE", "force")
+    assert symbols._fp8_nt_autotune_enabled("rtx_sm89", "nk")
+    monkeypatch.setenv("FLASHRT_FP8_NT_AUTOTUNE", "safe")
+    assert not symbols._fp8_nt_autotune_enabled("rtx_sm120", "nk")
+
+
+def test_fp8_nk_layout_skips_nt_autotune_when_policy_disabled(monkeypatch):
+    symbols = _load_pi05_rtx_symbols()
+    monkeypatch.setenv("FLASHRT_FP8_NT_AUTOTUNE", "safe")
+    pipe = symbols.Pi05Pipeline.__new__(symbols.Pi05Pipeline)
+    pipe.fp8_layout = "nk"
+    pipe._autotune_fp8_nt = symbols._fp8_nt_autotune_enabled("rtx_sm89", "nk")
+    pipe.gemm = SimpleNamespace(
+        fp8_nt_dev=Mock(),
+        autotune_fp8_nt_dev=Mock(),
+        fp8_nn_dev=Mock(),
+        autotune_fp8_nn_dev=Mock(),
+    )
+
+    pipe._autotune_fp8_matmul(21, 22, 23, 24, 25, 26, 27, 28)
+
+    pipe.gemm.autotune_fp8_nt_dev.assert_not_called()
     pipe.gemm.autotune_fp8_nn_dev.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- Skip FP8 NT top-N autotune by default for Pi0.5 RTX on SM89 / Ada with `fp8_layout="nk"`
- Keep the cuBLASLt heuristic top-1 algorithm, so FP8 inference remains enabled
- Add `FLASHRT_FP8_NT_AUTOTUNE=force|safe|auto` for explicit override
- Propagate resolved hardware into both torch and JAX Pi0.5 RTX frontends
- Document the SM89 FP8 NT safety policy in `USAGE.md`

## Validation

- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_pi05_rtx_autotune_scratch.py tests/test_load_model_use_fp8_kwarg.py::test_pi05_rtx_fp8_layout_selection`
- Verified on RTX 4090 / SM89 that default policy sets `_autotune_fp8_nt=False` for `fp8_layout="nk"` and Pi0.5 quickstart still returns valid actions.

Fixes / mitigates #105.