### PR TITLE
Qwen3 vl prefill update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -884,7 +884,8 @@ endif()
 if(FLASHRT_BUILD_QWEN3_VL)
   pybind11_add_module(flash_rt_qwen3_vl_kernels
     csrc/qwen3_vl_bindings.cpp
-    csrc/kernels/rope_neox_qk_bf16.cu)
+    csrc/kernels/rope_neox_qk_bf16.cu
+    csrc/kernels/norm_act_to_fp8_block128.cu)
   set_target_properties(flash_rt_qwen3_vl_kernels PROPERTIES
     CUDA_STANDARD 17
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -892,7 +892,8 @@ if(FLASHRT_BUILD_QWEN3_VL)
   pybind11_add_module(flash_rt_qwen3_vl_kernels
     csrc/qwen3_vl_bindings.cpp
     csrc/kernels/rope_neox_qk_bf16.cu
-    csrc/kernels/norm_act_to_fp8_block128.cu)
+    csrc/kernels/norm_act_to_fp8_block128.cu
+    csrc/kernels/bias_epilogue_bf16.cu)
   set_target_properties(flash_rt_qwen3_vl_kernels PROPERTIES
     CUDA_STANDARD 17
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,11 @@ option(FLASHRT_ENABLE_MOTUS
 # Blackwell build to get the Nex-N2 / Qwen3.6-35B-A3B path.
 option(FLASHRT_ENABLE_QWEN35MOE
        "Build qwen3_5_moe (Nex-N2 / Qwen3.6-35B-A3B) RTX SM120 kernels" OFF)
+# Qwen3-VL adds a handful of kernels (rotate_half RoPE, ...) that the shared
+# binary does not yet need. Built into a SEPARATE flash_rt_qwen3_vl_kernels
+# module so flash_rt_kernels.so stays stable; OFF by default.
+option(FLASHRT_BUILD_QWEN3_VL
+       "Build Qwen3-VL kernels into a separate flash_rt_qwen3_vl_kernels module" OFF)
 if(FLASHRT_ENABLE_MOTUS)
   message(STATUS "Motus beta kernels: ENABLED")
 else()
@@ -869,6 +874,35 @@ if(ENABLE_FA2)
   target_link_libraries(flash_rt_fa2 PRIVATE CUDA::cudart)
   install(TARGETS flash_rt_fa2 DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
   message(STATUS "FA2 pybind module: flash_rt_fa2 (separate .so)")
+endif()
+
+# ── Qwen3-VL kernels (separate module, additive) ──
+# Independent pybind module so the shared flash_rt_kernels.so is not rebuilt
+# for this model. Caller side:
+#     from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+#     vlk.rope_neox_qk_bf16(...)
+if(FLASHRT_BUILD_QWEN3_VL)
+  pybind11_add_module(flash_rt_qwen3_vl_kernels
+    csrc/qwen3_vl_bindings.cpp
+    csrc/kernels/rope_neox_qk_bf16.cu)
+  set_target_properties(flash_rt_qwen3_vl_kernels PROPERTIES
+    CUDA_STANDARD 17
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
+  target_include_directories(flash_rt_qwen3_vl_kernels PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels)
+  target_compile_options(flash_rt_qwen3_vl_kernels PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      --expt-relaxed-constexpr -O3
+      -U__CUDA_NO_BFLOAT16_OPERATORS__
+      -U__CUDA_NO_BFLOAT162_OPERATORS__
+      ${GPU_GENCODE}
+    >)
+  target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cudart)
+  install(TARGETS flash_rt_qwen3_vl_kernels
+    DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
+  message(STATUS "Qwen3-VL pybind module: flash_rt_qwen3_vl_kernels (separate .so)")
 endif()
 
 # ── Qwen3.6 FlashInfer XQA FP8-KV (SM120/SM121 + SM110/Thor) ──

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,6 +882,13 @@ endif()
 #     from flash_rt import flash_rt_qwen3_vl_kernels as vlk
 #     vlk.rope_neox_qk_bf16(...)
 if(FLASHRT_BUILD_QWEN3_VL)
+  # The Qwen3-VL path depends on the SM120 Qwen3 NVFP4 / FP8 block-128
+  # kernels, so this module only builds for RTX 5090 (sm_120).
+  if(NOT GPU_ARCH STREQUAL "120")
+    message(FATAL_ERROR
+      "FLASHRT_BUILD_QWEN3_VL requires GPU_ARCH=120 (RTX 5090 / sm_120); "
+      "got '${GPU_ARCH}'.")
+  endif()
   pybind11_add_module(flash_rt_qwen3_vl_kernels
     csrc/qwen3_vl_bindings.cpp
     csrc/kernels/rope_neox_qk_bf16.cu

--- a/csrc/kernels/bias_epilogue_bf16.cu
+++ b/csrc/kernels/bias_epilogue_bf16.cu
@@ -1,0 +1,91 @@
+// ================================================================
+// FlashRT — fused bias epilogues (bf16)
+//
+// When a GEMM's bias cannot ride its own epilogue (e.g. a shared
+// block-scaled FP8/FP4 GEMM with a fixed epilogue), the per-column bias
+// add would otherwise be a standalone kernel that re-reads and re-writes
+// the whole GEMM output. These kernels fold that bias add into the op
+// that consumes the GEMM output, so the bias never round-trips HBM:
+//
+//   residual_add_bias_bf16 : residual += (x + bias)   (proj / fc2 -> res)
+//   qkv_split_bias_bf16    : split (x + bias) into q/k/v   (qkv -> attn)
+//
+// ``bias`` is broadcast over rows. General (model-agnostic).
+// ================================================================
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace kernels {
+
+namespace {
+
+__global__ void residual_add_bias_kernel(
+    __nv_bfloat16* __restrict__ residual,
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ bias,
+    int dim, long total) {
+  const long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  for (long idx = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x;
+       idx < total; idx += stride) {
+    const int i = idx % dim;
+    residual[idx] = __float2bfloat16(
+        __bfloat162float(residual[idx]) + __bfloat162float(x[idx]) +
+        __bfloat162float(bias[i]));
+  }
+}
+
+// qkv = (rows, Hq+Hk+Hv); split column-wise into q/k/v with the matching
+// bias slice added. q/k/v are (rows, H*) row-major.
+__global__ void qkv_split_bias_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ bias,
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ v,
+    int Hq, int Hk, int Hv, long total) {
+  const int W = Hq + Hk + Hv;
+  const long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  for (long idx = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x;
+       idx < total; idx += stride) {
+    const int m = idx / W;
+    const int col = idx - static_cast<long>(m) * W;
+    const float val =
+        __bfloat162float(qkv[idx]) + __bfloat162float(bias[col]);
+    if (col < Hq) {
+      q[static_cast<long>(m) * Hq + col] = __float2bfloat16(val);
+    } else if (col < Hq + Hk) {
+      k[static_cast<long>(m) * Hk + (col - Hq)] = __float2bfloat16(val);
+    } else {
+      v[static_cast<long>(m) * Hv + (col - Hq - Hk)] = __float2bfloat16(val);
+    }
+  }
+}
+
+int grid_for(long total) {
+  const long b = (total + 255) / 256;
+  return static_cast<int>(b < 65535 ? (b < 1 ? 1 : b) : 65535);
+}
+
+}  // namespace
+
+void residual_add_bias_bf16(
+    __nv_bfloat16* residual, const __nv_bfloat16* x,
+    const __nv_bfloat16* bias, int rows, int dim, cudaStream_t stream) {
+  const long total = static_cast<long>(rows) * dim;
+  residual_add_bias_kernel<<<grid_for(total), 256, 0, stream>>>(
+      residual, x, bias, dim, total);
+}
+
+void qkv_split_bias_bf16(
+    const __nv_bfloat16* qkv, const __nv_bfloat16* bias,
+    __nv_bfloat16* q, __nv_bfloat16* k, __nv_bfloat16* v,
+    int rows, int hq, int hk, int hv, cudaStream_t stream) {
+  const long total = static_cast<long>(rows) * (hq + hk + hv);
+  qkv_split_bias_kernel<<<grid_for(total), 256, 0, stream>>>(
+      qkv, bias, q, k, v, hq, hk, hv, total);
+}
+
+}  // namespace kernels
+}  // namespace flash_rt

--- a/csrc/kernels/norm_act_to_fp8_block128.cu
+++ b/csrc/kernels/norm_act_to_fp8_block128.cu
@@ -1,0 +1,158 @@
+// ================================================================
+// FlashRT — fused {LayerNorm, GELU-tanh} -> FP8 block-128 quantization
+//
+// Produces the exact activation layout consumed by the per-token /
+// per-128-K-block FP8 GEMM (``fp8_block128_gemm_cutlass_sm120_bf16out``):
+// FP8 e4m3 values plus an (M, K/128) f32 descale, where each 128-wide
+// K-block carries its own scale = amax / 448.
+//
+// Fusing the activation quantization into the producing elementwise op
+// removes the intermediate bf16 round-trip (one global write + one read
+// of the M x K activation) and a kernel launch per GEMM input. The math
+// matches the standalone ``layer_norm`` / ``gelu_inplace`` +
+// ``fp8_per_token_block128_quant_bf16`` chain bit-for-bit.
+//
+//   layer_norm_to_fp8_block128_bf16:
+//     out[m,i]   = ((x[m,i]-mean_m)*rstd_m*gamma[i] + beta[i]) / scale
+//     scale[m,kb] = amax_{i in block kb} |normed| / 448
+//   gelu_tanh_to_fp8_block128_bf16:
+//     out[m,i]   = gelu_tanh(x[m,i]) / scale     (same per-block scale)
+//
+// General (model-agnostic): any transformer whose LayerNorm / GELU feeds
+// a block-128 FP8 GEMM can reuse these. K must be a multiple of 128.
+// ================================================================
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace kernels {
+
+namespace {
+
+constexpr int kBlock = 128;          // K-block (and threads per CUDA block)
+constexpr float kFp8Max = 448.0f;
+constexpr float kGeluC = 0.7978845608028654f;   // sqrt(2/pi)
+
+// Reduce across the 128-thread (4-warp) CUDA block; the result is
+// broadcast to every thread via ``sh[0]``. ``is_max`` selects max vs sum.
+__device__ __forceinline__ float block_reduce128(
+    float v, float* sh, bool is_max) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int o = 16; o > 0; o >>= 1) {
+    const float t = __shfl_xor_sync(0xffffffff, v, o);
+    v = is_max ? fmaxf(v, t) : v + t;
+  }
+  if (lane == 0) sh[warp] = v;
+  __syncthreads();
+  if (warp == 0) {
+    v = (lane < 4) ? sh[lane] : (is_max ? 0.0f : 0.0f);
+    for (int o = 2; o > 0; o >>= 1) {
+      const float t = __shfl_xor_sync(0xffffffff, v, o);
+      v = is_max ? fmaxf(v, t) : v + t;
+    }
+    if (lane == 0) sh[0] = v;
+  }
+  __syncthreads();
+  const float r = sh[0];
+  __syncthreads();
+  return r;
+}
+
+__device__ __forceinline__ float gelu_tanh(float v) {
+  const float t = tanhf(kGeluC * (v + 0.044715f * v * v * v));
+  return v * 0.5f * (1.0f + t);
+}
+
+// One CUDA block (128 threads) per row. LayerNorm over ``dim`` then a
+// per-128-K-block FP8 quantization of the normalized row. The normalized
+// value is recomputed in the quant pass (cheap bf16 reload) so no
+// per-row scratch is needed.
+__global__ void layer_norm_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ gamma,
+    const __nv_bfloat16* __restrict__ beta,
+    __nv_fp8_e4m3* __restrict__ out,
+    float* __restrict__ scale,
+    int dim, float eps) {
+  __shared__ float sh[4];
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* xr = x + static_cast<long>(m) * dim;
+  __nv_fp8_e4m3* orow = out + static_cast<long>(m) * dim;
+
+  float s = 0.0f;
+  for (int i = t; i < dim; i += kBlock) s += __bfloat162float(xr[i]);
+  const float mean = block_reduce128(s, sh, false) / dim;
+
+  float vsum = 0.0f;
+  for (int i = t; i < dim; i += kBlock) {
+    const float d = __bfloat162float(xr[i]) - mean;
+    vsum += d * d;
+  }
+  const float rstd = rsqrtf(block_reduce128(vsum, sh, false) / dim + eps);
+
+  const int n_kb = dim / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float normed =
+        (__bfloat162float(xr[i]) - mean) * rstd *
+            __bfloat162float(gamma[i]) +
+        __bfloat162float(beta[i]);
+    const float amax = block_reduce128(fabsf(normed), sh, true);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = normed / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    orow[i] = __nv_fp8_e4m3(q);
+  }
+}
+
+// One CUDA block (128 threads) per row. GELU-tanh then a per-128-K-block
+// FP8 quantization. No cross-row reduction is needed; only the per-block
+// amax.
+__global__ void gelu_tanh_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    __nv_fp8_e4m3* __restrict__ out,
+    float* __restrict__ scale,
+    int dim) {
+  __shared__ float sh[4];
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* xr = x + static_cast<long>(m) * dim;
+  __nv_fp8_e4m3* orow = out + static_cast<long>(m) * dim;
+
+  const int n_kb = dim / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float g = gelu_tanh(__bfloat162float(xr[i]));
+    const float amax = block_reduce128(fabsf(g), sh, true);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = g / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    orow[i] = __nv_fp8_e4m3(q);
+  }
+}
+
+}  // namespace
+
+void layer_norm_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, const __nv_bfloat16* gamma,
+    const __nv_bfloat16* beta, __nv_fp8_e4m3* out, float* scale,
+    int rows, int dim, float eps, cudaStream_t stream) {
+  layer_norm_to_fp8_block128_kernel<<<rows, kBlock, 0, stream>>>(
+      x, gamma, beta, out, scale, dim, eps);
+}
+
+void gelu_tanh_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, __nv_fp8_e4m3* out, float* scale,
+    int rows, int dim, cudaStream_t stream) {
+  gelu_tanh_to_fp8_block128_kernel<<<rows, kBlock, 0, stream>>>(
+      x, out, scale, dim);
+}
+
+}  // namespace kernels
+}  // namespace flash_rt

--- a/csrc/kernels/norm_act_to_fp8_block128.cu
+++ b/csrc/kernels/norm_act_to_fp8_block128.cu
@@ -137,6 +137,35 @@ __global__ void gelu_tanh_to_fp8_block128_kernel(
   }
 }
 
+// Like ``gelu_tanh_to_fp8_block128_kernel`` but adds a per-column bias
+// before the GELU (``bias`` is broadcast over rows). Fuses the preceding
+// GEMM's bias add into this op so it never round-trips through HBM.
+__global__ void gelu_tanh_bias_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ bias,
+    __nv_fp8_e4m3* __restrict__ out,
+    float* __restrict__ scale,
+    int dim) {
+  __shared__ float sh[4];
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* xr = x + static_cast<long>(m) * dim;
+  __nv_fp8_e4m3* orow = out + static_cast<long>(m) * dim;
+
+  const int n_kb = dim / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float g = gelu_tanh(
+        __bfloat162float(xr[i]) + __bfloat162float(bias[i]));
+    const float amax = block_reduce128(fabsf(g), sh, true);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = g / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    orow[i] = __nv_fp8_e4m3(q);
+  }
+}
+
 }  // namespace
 
 void layer_norm_to_fp8_block128_bf16(
@@ -152,6 +181,14 @@ void gelu_tanh_to_fp8_block128_bf16(
     int rows, int dim, cudaStream_t stream) {
   gelu_tanh_to_fp8_block128_kernel<<<rows, kBlock, 0, stream>>>(
       x, out, scale, dim);
+}
+
+void gelu_tanh_bias_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, const __nv_bfloat16* bias,
+    __nv_fp8_e4m3* out, float* scale, int rows, int dim,
+    cudaStream_t stream) {
+  gelu_tanh_bias_to_fp8_block128_kernel<<<rows, kBlock, 0, stream>>>(
+      x, bias, out, scale, dim);
 }
 
 }  // namespace kernels

--- a/csrc/kernels/rope_neox_qk_bf16.cu
+++ b/csrc/kernels/rope_neox_qk_bf16.cu
@@ -1,0 +1,91 @@
+// ================================================================
+// FlashRT — split-half ("rotate_half" / GPT-NeoX) RoPE on Q and K
+//
+// Applies rotary position embedding using the rotate_half convention
+// that pairs element d with d + head_dim/2, matching HuggingFace's
+// apply_rotary_pos_emb:
+//
+//     out[..., d]        = x[..., d]      * cos[d] - x[..., d+half] * sin[d]
+//     out[..., d+half]   = x[..., d+half] * cos[d] + x[..., d]      * sin[d]
+//
+// This is distinct from rope.cu::rope_apply, which uses the interleaved
+// (d, d+1) convention. The kernel is model-agnostic and reusable by any
+// attention site whose RoPE uses the rotate_half form (Qwen3 backbones,
+// SigLIP-style ViT towers, etc.).
+//
+//   q_in / q_out : (rows, q_heads, head_dim) bf16  (in-place allowed)
+//   k_in / k_out : (rows, k_heads, head_dim) bf16  (in-place allowed)
+//   cos  / sin   : (rows, head_dim/2)        bf16
+//
+// One thread handles one (row, head, d<half) triple per tensor; Q and K
+// are rotated in the same launch (k_heads may differ from q_heads).
+// ================================================================
+
+#include <cuda_bf16.h>
+
+#include "common.cuh"
+
+namespace flash_rt {
+namespace kernels {
+
+__global__ void rope_neox_qk_kernel(
+    const __nv_bfloat16* __restrict__ q_in,
+    const __nv_bfloat16* __restrict__ k_in,
+    const __nv_bfloat16* __restrict__ cos_tab,
+    const __nv_bfloat16* __restrict__ sin_tab,
+    __nv_bfloat16* __restrict__ q_out,
+    __nv_bfloat16* __restrict__ k_out,
+    int rows, int q_heads, int k_heads, int head_dim) {
+    const int half = head_dim / 2;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int q_total = rows * q_heads * half;
+    const int k_total = rows * k_heads * half;
+
+    if (idx < q_total) {
+        const int d = idx % half;
+        const int tmp = idx / half;
+        const int head = tmp % q_heads;
+        const int row = tmp / q_heads;
+        const int base = (row * q_heads + head) * head_dim;
+        const float c = to_f32(cos_tab[row * half + d]);
+        const float s = to_f32(sin_tab[row * half + d]);
+        const float x0 = to_f32(q_in[base + d]);
+        const float x1 = to_f32(q_in[base + d + half]);
+        q_out[base + d] = from_f32<__nv_bfloat16>(x0 * c - x1 * s);
+        q_out[base + d + half] = from_f32<__nv_bfloat16>(x1 * c + x0 * s);
+    }
+
+    if (idx < k_total) {
+        const int d = idx % half;
+        const int tmp = idx / half;
+        const int head = tmp % k_heads;
+        const int row = tmp / k_heads;
+        const int base = (row * k_heads + head) * head_dim;
+        const float c = to_f32(cos_tab[row * half + d]);
+        const float s = to_f32(sin_tab[row * half + d]);
+        const float x0 = to_f32(k_in[base + d]);
+        const float x1 = to_f32(k_in[base + d + half]);
+        k_out[base + d] = from_f32<__nv_bfloat16>(x0 * c - x1 * s);
+        k_out[base + d + half] = from_f32<__nv_bfloat16>(x1 * c + x0 * s);
+    }
+}
+
+void rope_neox_qk_bf16(
+    const __nv_bfloat16* q_in, const __nv_bfloat16* k_in,
+    const __nv_bfloat16* cos_tab, const __nv_bfloat16* sin_tab,
+    __nv_bfloat16* q_out, __nv_bfloat16* k_out,
+    int rows, int q_heads, int k_heads, int head_dim,
+    cudaStream_t stream) {
+    const int half = head_dim / 2;
+    const int q_total = rows * q_heads * half;
+    const int k_total = rows * k_heads * half;
+    const int total = q_total > k_total ? q_total : k_total;
+    const int threads = 256;
+    const int blocks = (total + threads - 1) / threads;
+    rope_neox_qk_kernel<<<blocks, threads, 0, stream>>>(
+        q_in, k_in, cos_tab, sin_tab, q_out, k_out,
+        rows, q_heads, k_heads, head_dim);
+}
+
+}  // namespace kernels
+}  // namespace flash_rt

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 
 #include <cuda_bf16.h>
+#include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
 namespace py = pybind11;
@@ -33,6 +34,15 @@ void rope_neox_qk_bf16(
     const __nv_bfloat16* cos_tab, const __nv_bfloat16* sin_tab,
     __nv_bfloat16* q_out, __nv_bfloat16* k_out,
     int rows, int q_heads, int k_heads, int head_dim, cudaStream_t stream);
+
+void layer_norm_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, const __nv_bfloat16* gamma,
+    const __nv_bfloat16* beta, __nv_fp8_e4m3* out, float* scale,
+    int rows, int dim, float eps, cudaStream_t stream);
+
+void gelu_tanh_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, __nv_fp8_e4m3* out, float* scale,
+    int rows, int dim, cudaStream_t stream);
 }  // namespace kernels
 }  // namespace flash_rt
 
@@ -65,4 +75,30 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         py::arg("q_out"), py::arg("k_out"), py::arg("rows"),
         py::arg("q_heads"), py::arg("k_heads"), py::arg("head_dim"),
         py::arg("stream") = 0);
+
+    m.def(
+        "layer_norm_to_fp8_block128_bf16",
+        [](uintptr_t x, uintptr_t gamma, uintptr_t beta, uintptr_t out,
+           uintptr_t scale, int rows, int dim, float eps, uintptr_t stream) {
+            flash_rt::kernels::layer_norm_to_fp8_block128_bf16(
+                as_ptr<const __nv_bfloat16>(x),
+                as_ptr<const __nv_bfloat16>(gamma),
+                as_ptr<const __nv_bfloat16>(beta),
+                as_ptr<__nv_fp8_e4m3>(out), as_ptr<float>(scale),
+                rows, dim, eps, to_stream(stream));
+        },
+        py::arg("x"), py::arg("gamma"), py::arg("beta"), py::arg("out"),
+        py::arg("scale"), py::arg("rows"), py::arg("dim"), py::arg("eps"),
+        py::arg("stream") = 0);
+
+    m.def(
+        "gelu_tanh_to_fp8_block128_bf16",
+        [](uintptr_t x, uintptr_t out, uintptr_t scale, int rows, int dim,
+           uintptr_t stream) {
+            flash_rt::kernels::gelu_tanh_to_fp8_block128_bf16(
+                as_ptr<const __nv_bfloat16>(x), as_ptr<__nv_fp8_e4m3>(out),
+                as_ptr<float>(scale), rows, dim, to_stream(stream));
+        },
+        py::arg("x"), py::arg("out"), py::arg("scale"), py::arg("rows"),
+        py::arg("dim"), py::arg("stream") = 0);
 }

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -1,0 +1,68 @@
+// ============================================================================
+//  FlashRT — pybind module for Qwen3-VL kernels.
+//
+//  Built as a SEPARATE .so (flash_rt_qwen3_vl_kernels) from
+//  flash_rt_kernels.so, gated by the FLASHRT_BUILD_QWEN3_VL CMake option, so
+//  the shared production kernel binary is never rebuilt for this model. Same
+//  pattern as flash_rt_fa2 / fmha_fp16_strided.
+//
+//  Python-side usage:
+//
+//      import flash_rt.flash_rt_kernels        as fvk     # unchanged
+//      import flash_rt.flash_rt_qwen3_vl_kernels as vlk   # additive
+//      vlk.rope_neox_qk_bf16(...)
+//
+//  Kernels here are general (rotate_half RoPE, etc.); they live in this
+//  module only to keep the shared binary stable, and may be promoted to
+//  flash_rt_kernels if another model needs them.
+// ============================================================================
+
+#include <pybind11/pybind11.h>
+
+#include <cstdint>
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace py = pybind11;
+
+namespace flash_rt {
+namespace kernels {
+void rope_neox_qk_bf16(
+    const __nv_bfloat16* q_in, const __nv_bfloat16* k_in,
+    const __nv_bfloat16* cos_tab, const __nv_bfloat16* sin_tab,
+    __nv_bfloat16* q_out, __nv_bfloat16* k_out,
+    int rows, int q_heads, int k_heads, int head_dim, cudaStream_t stream);
+}  // namespace kernels
+}  // namespace flash_rt
+
+static cudaStream_t to_stream(uintptr_t s) {
+    return reinterpret_cast<cudaStream_t>(s);
+}
+
+template <typename T>
+static T* as_ptr(uintptr_t p) {
+    return reinterpret_cast<T*>(p);
+}
+
+PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
+    m.doc() = "FlashRT Qwen3-VL kernels (separate module; additive).";
+
+    m.def(
+        "rope_neox_qk_bf16",
+        [](uintptr_t q_in, uintptr_t k_in, uintptr_t cos, uintptr_t sin,
+           uintptr_t q_out, uintptr_t k_out, int rows, int q_heads,
+           int k_heads, int head_dim, uintptr_t stream) {
+            flash_rt::kernels::rope_neox_qk_bf16(
+                as_ptr<const __nv_bfloat16>(q_in),
+                as_ptr<const __nv_bfloat16>(k_in),
+                as_ptr<const __nv_bfloat16>(cos),
+                as_ptr<const __nv_bfloat16>(sin),
+                as_ptr<__nv_bfloat16>(q_out), as_ptr<__nv_bfloat16>(k_out),
+                rows, q_heads, k_heads, head_dim, to_stream(stream));
+        },
+        py::arg("q_in"), py::arg("k_in"), py::arg("cos"), py::arg("sin"),
+        py::arg("q_out"), py::arg("k_out"), py::arg("rows"),
+        py::arg("q_heads"), py::arg("k_heads"), py::arg("head_dim"),
+        py::arg("stream") = 0);
+}

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -43,6 +43,19 @@ void layer_norm_to_fp8_block128_bf16(
 void gelu_tanh_to_fp8_block128_bf16(
     const __nv_bfloat16* x, __nv_fp8_e4m3* out, float* scale,
     int rows, int dim, cudaStream_t stream);
+
+void gelu_tanh_bias_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, const __nv_bfloat16* bias, __nv_fp8_e4m3* out,
+    float* scale, int rows, int dim, cudaStream_t stream);
+
+void residual_add_bias_bf16(
+    __nv_bfloat16* residual, const __nv_bfloat16* x,
+    const __nv_bfloat16* bias, int rows, int dim, cudaStream_t stream);
+
+void qkv_split_bias_bf16(
+    const __nv_bfloat16* qkv, const __nv_bfloat16* bias, __nv_bfloat16* q,
+    __nv_bfloat16* k, __nv_bfloat16* v, int rows, int hq, int hk, int hv,
+    cudaStream_t stream);
 }  // namespace kernels
 }  // namespace flash_rt
 
@@ -101,4 +114,43 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         },
         py::arg("x"), py::arg("out"), py::arg("scale"), py::arg("rows"),
         py::arg("dim"), py::arg("stream") = 0);
+
+    m.def(
+        "gelu_tanh_bias_to_fp8_block128_bf16",
+        [](uintptr_t x, uintptr_t bias, uintptr_t out, uintptr_t scale,
+           int rows, int dim, uintptr_t stream) {
+            flash_rt::kernels::gelu_tanh_bias_to_fp8_block128_bf16(
+                as_ptr<const __nv_bfloat16>(x),
+                as_ptr<const __nv_bfloat16>(bias), as_ptr<__nv_fp8_e4m3>(out),
+                as_ptr<float>(scale), rows, dim, to_stream(stream));
+        },
+        py::arg("x"), py::arg("bias"), py::arg("out"), py::arg("scale"),
+        py::arg("rows"), py::arg("dim"), py::arg("stream") = 0);
+
+    m.def(
+        "residual_add_bias_bf16",
+        [](uintptr_t residual, uintptr_t x, uintptr_t bias, int rows, int dim,
+           uintptr_t stream) {
+            flash_rt::kernels::residual_add_bias_bf16(
+                as_ptr<__nv_bfloat16>(residual),
+                as_ptr<const __nv_bfloat16>(x),
+                as_ptr<const __nv_bfloat16>(bias), rows, dim,
+                to_stream(stream));
+        },
+        py::arg("residual"), py::arg("x"), py::arg("bias"), py::arg("rows"),
+        py::arg("dim"), py::arg("stream") = 0);
+
+    m.def(
+        "qkv_split_bias_bf16",
+        [](uintptr_t qkv, uintptr_t bias, uintptr_t q, uintptr_t k,
+           uintptr_t v, int rows, int hq, int hk, int hv, uintptr_t stream) {
+            flash_rt::kernels::qkv_split_bias_bf16(
+                as_ptr<const __nv_bfloat16>(qkv),
+                as_ptr<const __nv_bfloat16>(bias), as_ptr<__nv_bfloat16>(q),
+                as_ptr<__nv_bfloat16>(k), as_ptr<__nv_bfloat16>(v),
+                rows, hq, hk, hv, to_stream(stream));
+        },
+        py::arg("qkv"), py::arg("bias"), py::arg("q"), py::arg("k"),
+        py::arg("v"), py::arg("rows"), py::arg("hq"), py::arg("hk"),
+        py::arg("hv"), py::arg("stream") = 0);
 }

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -36,6 +36,26 @@ TTFT history on this path (5090): 621 ms (initial eager) → 121 ms (ViT
 FFN on the fast GEMM + bf16) → 102 ms (FP8 block-128 ViT GEMMs) → **99 ms**
 (FP8 activation quant fused into the producing LayerNorm / GELU).
 
+### TTFT vs resolution (the dominant knob)
+
+The 99 ms above is the **full-resolution** benchmark: the 2172×724 image
+patchifies to 6256 patches → 1564 of the 1581 LLM tokens are vision. The
+patch count (≈ pixels / 16²) sets both the ViT cost and the LLM prefill
+length, so capping resolution cuts both at once. Pass ``max_pixels`` (the
+processor's smart_resize rounds to the patch grid); the description is
+unchanged across this range:
+
+| `max_pixels` | patches | LLM tokens | TTFT |
+|---|---:|---:|---:|
+| none (full) | 6256 | 1581 | 99 ms |
+| 1.0 M | 3888 | 989 | 57 ms |
+| 0.5 M | 1824 | 473 | **30 ms** |
+| 0.25 M | 972 | 260 | 22 ms |
+
+```python
+fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=1_000_000)  # or pass --max-pixels
+```
+
 Reproduce:
 
 ```bash

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -21,10 +21,10 @@ image + text prompt, 1581 LLM tokens (1564 vision + 17 text), FlashRT.png
 
 | Metric | HF SDPA (bf16) | FlashRT |
 |---|---:|---:|
-| TTFT (prefill, image+text) | 206 ms | **102 ms** |
+| TTFT (prefill, image+text) | 206 ms | **99 ms** |
 | Decode (warm CUDA Graph)   | ~48 tok/s | **143 tok/s** |
 
-TTFT is dominated by the ViT tower (~63 ms) plus the NVFP4 language
+TTFT is dominated by the ViT tower (~60 ms) plus the NVFP4 language
 prefill (~39 ms). After the FP8 GEMMs, the two remaining ViT costs are
 the full-attention over 6256 patches (~31 ms, ~75% of bf16 roofline at
 head_dim 72) and the FP8 GEMMs (~20 ms); both are compute-bound. Decode
@@ -33,7 +33,8 @@ reuses the Qwen3-8B NVFP4 W4A4 + CUDA-Graph path and lands at the same
 KV-cache slot advances from the image-compressed prompt length.
 
 TTFT history on this path (5090): 621 ms (initial eager) → 121 ms (ViT
-FFN on the fast GEMM + bf16) → **102 ms** (FP8 block-128 ViT GEMMs).
+FFN on the fast GEMM + bf16) → 102 ms (FP8 block-128 ViT GEMMs) → **99 ms**
+(FP8 activation quant fused into the producing LayerNorm / GELU).
 
 Reproduce:
 
@@ -106,9 +107,13 @@ intermediate (4304) is zero-padded to 4352 at load so every FFN GEMM uses
 the fast `w16a16` kernel (the unpadded fc2 fell back to an M=1-tuned
 matmul that dominated the tower at ~19 ms/call).
 
-New kernel (general, in the separate `flash_rt_qwen3_vl_kernels` module):
+New kernels (general, in the separate `flash_rt_qwen3_vl_kernels` module):
 `rope_neox_qk_bf16`, a rotate_half RoPE for Q/K not covered by the
-interleaved `rope_apply` or the norm-fused Qwen3 RoPE kernels.
+interleaved `rope_apply` or the norm-fused Qwen3 RoPE kernels; and
+`layer_norm_to_fp8_block128_bf16` / `gelu_tanh_to_fp8_block128_bf16`,
+which fuse the per-token / per-128-K-block FP8 activation quant into the
+producing LayerNorm / GELU so the bf16 activation never round-trips to
+HBM before the FP8 GEMM (≈2× over the unfused norm/gelu + quant chain).
 
 ---
 
@@ -139,6 +144,5 @@ the description is unchanged).
 - **Next TTFT levers** (both need new kernels): an FP8 ViT attention
   (Sage/FA on sm_120 only ships head_dim 128/256, so head_dim 72 would
   need padding), and an FP8 language prefill (the stack is NVFP4, whose
-  large-M GEMM dequantizes to bf16 compute). Fusing the FP8 activation
-  quant into the preceding LayerNorm would also remove ~4 ms.
+  large-M GEMM dequantizes to bf16 compute).
 - **No KV-cache offload**; prompt + generation must fit in `max_seq`.

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -140,10 +140,14 @@ the description is unchanged).
 ## 5. Notes & limitations
 
 - **lm_head stays BF16** (same as the Qwen3-8B path).
-- **Multi-image** is supported: the ViT runs once per image (each image is
-  an independent attention window, reproducing HF's block-diagonal
-  cu_seqlens attention), and the features scatter into each image's token
-  span with per-image DeepStack injection. **Video is not yet wired.**
+- **Multi-image and video** are supported. The ViT runs once per vision
+  segment — each image, or each video frame-group, is an independent
+  attention window, reproducing HF's per-window cu_seqlens attention — and
+  the features scatter into each segment's token span with per-segment
+  DeepStack injection. Video uses Qwen3-VL's timestamp-aligned MRoPE (the
+  grid is split per frame so each frame's temporal index is 0 and the
+  inter-frame timestamp text tokens carry the temporal position). Frame
+  sampling follows the processor defaults.
 - **Next TTFT levers** (both need new kernels): an FP8 ViT attention
   (Sage/FA on sm_120 only ships head_dim 128/256, so head_dim 72 would
   need padding), and an FP8 language prefill (the stack is NVFP4, whose

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -19,17 +19,16 @@ RTX 5090 / sm_120 / 32 GB · NVFP4 W4A4 language stack · BF16 ViT tower
 image + text prompt, 1581 LLM tokens (1564 vision + 17 text), FlashRT.png
 ```
 
-| Metric | HF SDPA (bf16) | vLLM 0.22 (bf16) | FlashRT |
-|---|---:|---:|---:|
-| TTFT (full request, image+text) | 206 ms | 126 ms | **~103 ms** |
-| Decode (warm CUDA Graph)   | ~48 tok/s | ~96 tok/s | **~150 tok/s** |
+| Metric | HF SDPA (bf16) | FlashRT |
+|---|---:|---:|
+| TTFT (full request, image+text) | 206 ms | **~103 ms** |
+| Decode (warm CUDA Graph)   | ~48 tok/s | **~150 tok/s** |
 
-vLLM measured in-process on the same 5090 / same image, prefix-caching off
-(fresh prefill), full resolution (both at 1581 prompt tokens). FlashRT TTFT
+Same 5090, FlashRT.png, full resolution (1581 prompt tokens). FlashRT TTFT
 is GPU image preprocessing (~8 ms) + the **CUDA-graph prefill** (~95 ms);
 decode is the NVFP4 W4A4 + graph path. Both prefill and decode replay as
-pure-kernel CUDA graphs — no per-request Python/torch dispatch — which is
-where the stable lead over vLLM's eager V1 engine comes from.
+pure-kernel CUDA graphs (no per-request Python/torch dispatch), so latency
+is low and stable.
 
 The prefill graph captures the whole single-image path (embed → ViT tower →
 image-feature scatter → NVFP4 layers + DeepStack → final norm) into one
@@ -46,19 +45,20 @@ preprocessing moved CPU → GPU (24 → 8 ms), so the full request TTFT is
 
 ### TTFT vs resolution (the dominant knob)
 
-The 99 ms above is the **full-resolution** benchmark: the 2172×724 image
+The ~103 ms above is the **full-resolution** benchmark: the 2172×724 image
 patchifies to 6256 patches → 1564 of the 1581 LLM tokens are vision. The
 patch count (≈ pixels / 16²) sets both the ViT cost and the LLM prefill
 length, so capping resolution cuts both at once. Pass ``max_pixels`` (the
 processor's smart_resize rounds to the patch grid); the description is
-unchanged across this range:
+unchanged across this range (full-request TTFT = GPU preprocessing + graph
+prefill):
 
 | `max_pixels` | patches | LLM tokens | TTFT |
 |---|---:|---:|---:|
-| none (full) | 6256 | 1581 | 99 ms |
-| 1.0 M | 3888 | 989 | 57 ms |
-| 0.5 M | 1824 | 473 | **30 ms** |
-| 0.25 M | 972 | 260 | 22 ms |
+| none (full) | 6256 | 1581 | 103 ms |
+| 1.0 M | 3888 | 989 | 60 ms |
+| 0.5 M | 1824 | 473 | **33 ms** |
+| 0.25 M | 972 | 260 | 25 ms |
 
 ```python
 fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=1_000_000)  # or pass --max-pixels
@@ -170,7 +170,11 @@ images and videos.
 
 Per-prompt geometry (3D MRoPE position ids, MRoPE / vision-RoPE tables,
 the interpolated vision position embedding) is precomputed once in
-`set_prompt`; the forward runs only kernels. The vision tower's
+`set_prompt` (with the image processor running on the GPU), which also
+stages the captured-prefill static input buffers. The single-image prefill
+then replays as one CUDA graph — pure kernel, no torch dispatch — and the
+eager paths (`prefill`, multi-image / video) run only kernels. The vision
+tower's
 intermediate (4304) is zero-padded to 4352 at load so every FFN GEMM uses
 the fast `w16a16` kernel (the unpadded fc2 fell back to an M=1-tuned
 matmul that dominated the tower at ~19 ms/call).
@@ -216,8 +220,11 @@ the description is unchanged).
   grid is split per frame so each frame's temporal index is 0 and the
   inter-frame timestamp text tokens carry the temporal position). Frame
   sampling follows the processor defaults.
-- **Next TTFT levers** (both need new kernels): an FP8 ViT attention
-  (Sage/FA on sm_120 only ships head_dim 128/256, so head_dim 72 would
-  need padding), and an FP8 language prefill (the stack is NVFP4, whose
-  large-M GEMM dequantizes to bf16 compute).
+- **Compute core is at the kernel floor for this shape** (measured): the
+  ViT attention (bf16 FA2, head_dim 72) ties the best community kernels
+  (sm_120 has no FP8/INT8 attention that holds the accuracy — INT8-QK
+  collapses image_embeds cosine), and the NVFP4 language prefill GEMM is
+  already faster than an FP8 block-128 path at these shapes. Further TTFT
+  comes from capping `max_pixels` (above) or an algorithm change (fewer
+  patches / windowed attention) that would alter outputs.
 - **No KV-cache offload**; prompt + generation must fit in `max_seq`.

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -140,7 +140,10 @@ the description is unchanged).
 ## 5. Notes & limitations
 
 - **lm_head stays BF16** (same as the Qwen3-8B path).
-- **Image inputs.** Video and multi-image are not wired in this path.
+- **Multi-image** is supported: the ViT runs once per image (each image is
+  an independent attention window, reproducing HF's block-diagonal
+  cu_seqlens attention), and the features scatter into each image's token
+  span with per-image DeepStack injection. **Video is not yet wired.**
 - **Next TTFT levers** (both need new kernels): an FP8 ViT attention
   (Sage/FA on sm_120 only ships head_dim 128/256, so head_dim 72 would
   need padding), and an FP8 language prefill (the stack is NVFP4, whose

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -19,22 +19,30 @@ RTX 5090 / sm_120 / 32 GB · NVFP4 W4A4 language stack · BF16 ViT tower
 image + text prompt, 1581 LLM tokens (1564 vision + 17 text), FlashRT.png
 ```
 
-| Metric | HF SDPA (bf16) | FlashRT |
-|---|---:|---:|
-| TTFT (prefill, image+text) | 206 ms | **99 ms** |
-| Decode (warm CUDA Graph)   | ~48 tok/s | **143 tok/s** |
+| Metric | HF SDPA (bf16) | vLLM 0.22 (bf16) | FlashRT |
+|---|---:|---:|---:|
+| TTFT (full request, image+text) | 206 ms | 126 ms | **~103 ms** |
+| Decode (warm CUDA Graph)   | ~48 tok/s | ~96 tok/s | **~150 tok/s** |
 
-TTFT is dominated by the ViT tower (~60 ms) plus the NVFP4 language
-prefill (~39 ms). After the FP8 GEMMs, the two remaining ViT costs are
-the full-attention over 6256 patches (~31 ms, ~75% of bf16 roofline at
-head_dim 72) and the FP8 GEMMs (~20 ms); both are compute-bound. Decode
-reuses the Qwen3-8B NVFP4 W4A4 + CUDA-Graph path and lands at the same
-~143 tok/s ceiling; the MRoPE position continues past the image while the
-KV-cache slot advances from the image-compressed prompt length.
+vLLM measured in-process on the same 5090 / same image, prefix-caching off
+(fresh prefill), full resolution (both at 1581 prompt tokens). FlashRT TTFT
+is GPU image preprocessing (~8 ms) + the **CUDA-graph prefill** (~95 ms);
+decode is the NVFP4 W4A4 + graph path. Both prefill and decode replay as
+pure-kernel CUDA graphs — no per-request Python/torch dispatch — which is
+where the stable lead over vLLM's eager V1 engine comes from.
 
-TTFT history on this path (5090): 621 ms (initial eager) → 121 ms (ViT
-FFN on the fast GEMM + bf16) → 102 ms (FP8 block-128 ViT GEMMs) → **99 ms**
-(FP8 activation quant fused into the producing LayerNorm / GELU).
+The prefill graph captures the whole single-image path (embed → ViT tower →
+image-feature scatter → NVFP4 layers + DeepStack → final norm) into one
+graph; lm_head runs eager on the last row. Multi-image / video fall back to
+the eager prefill. Inside the graph the costs are the ViT full-attention
+over 6256 patches (~31 ms, ~75 % bf16 roofline at head_dim 72), the FP8 +
+NVFP4 GEMMs, and the attention; all compute-bound.
+
+Prefill history on this path (5090, prefill-only ms): 621 → 121 (ViT FFN on
+the fast GEMM) → 102 (FP8 block-128 ViT GEMMs) → 99 (FP8 quant fused into
+LayerNorm/GELU) → **95** (merger FP8 + whole-prefill CUDA graph). Image
+preprocessing moved CPU → GPU (24 → 8 ms), so the full request TTFT is
+~103 ms.
 
 ### TTFT vs resolution (the dominant knob)
 

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -1,0 +1,133 @@
+# Qwen3-VL-8B on RTX 5090 (NVFP4 language stack + BF16 ViT)
+
+FlashRT multimodal inference path for
+[Qwen3-VL-8B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct)
+on a single RTX 5090 (sm_120, 32 GB): the dense-Qwen3 language stack runs
+NVFP4 W4A4 (reusing the [Qwen3-8B path](qwen3_8b_nvfp4.md) unchanged) and
+the SigLIP-style ViT tower runs hand-controlled BF16 kernels.
+
+For the framework intro see [`../README.md`](../README.md); for the
+text-only Qwen3-8B path see [`qwen3_8b_nvfp4.md`](qwen3_8b_nvfp4.md).
+
+---
+
+## 1. Headline performance
+
+```
+RTX 5090 / sm_120 / 32 GB · NVFP4 W4A4 language stack · BF16 ViT tower
+image + text prompt, 1581 LLM tokens (1564 vision + 17 text), FlashRT.png
+```
+
+| Metric | HF SDPA (bf16) | FlashRT |
+|---|---:|---:|
+| TTFT (prefill, image+text) | 206 ms | **121 ms** |
+| Decode (warm CUDA Graph)   | ~48 tok/s | **143 tok/s** |
+
+The TTFT is dominated by the ViT tower (~81 ms, FA2-bound at the
+6256-patch full-attention) plus the NVFP4 language prefill (~39 ms).
+Decode reuses the Qwen3-8B NVFP4 W4A4 + CUDA-Graph path and lands at the
+same ~143 tok/s ceiling; the MRoPE position continues past the image
+while the KV-cache slot advances from the image-compressed prompt length.
+
+Reproduce:
+
+```bash
+python examples/qwen3_vl_quickstart.py \
+    --checkpoint /path/to/Qwen3-VL-8B-FlashRT-NVFP4 \
+    --image FlashRT.png --benchmark 20
+```
+
+---
+
+## 2. Quick start
+
+```bash
+# 1. Build the FlashRT checkpoint once (NVFP4 language linears +
+#    BF16 vision tower + combined config), from a stock BF16 ckpt.
+python tools/quantize_qwen3_vl_nvfp4.py \
+    --src /path/to/Qwen3-VL-8B-Instruct \
+    --dst /path/to/Qwen3-VL-8B-FlashRT-NVFP4
+
+# 2. Describe an image.
+python examples/qwen3_vl_quickstart.py \
+    --checkpoint /path/to/Qwen3-VL-8B-FlashRT-NVFP4 \
+    --image FlashRT.png \
+    --prompt "Describe this image in one sentence."
+```
+
+```python
+from PIL import Image
+from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+
+fe = Qwen3VlTorchFrontendRtx('/path/to/Qwen3-VL-8B-FlashRT-NVFP4')
+messages = [{'role': 'user', 'content': [
+    {'type': 'image', 'image': Image.open('FlashRT.png').convert('RGB')},
+    {'type': 'text', 'text': 'Describe this image in one sentence.'},
+]}]
+print(fe.generate(messages, max_new_tokens=128))
+```
+
+The build needs the `flash_rt_qwen3_vl_kernels` module
+(`cmake -B build -S . -DGPU_ARCH=120 -DFLASHRT_BUILD_QWEN3_VL=ON` then
+build that target); the shared `flash_rt_kernels.so` is unchanged.
+
+---
+
+## 3. Inference architecture
+
+```
+  image pixels (patchified)
+    └─ ViT tower (BF16, 27 blocks, hidden 1152, 16 heads × head_dim 72)
+         patch_embed → +interpolated pos_embed
+         per block: LayerNorm → qkv → 2D rotate_half RoPE → FA2 (full,
+                    bidirectional) → proj → residual → LayerNorm →
+                    fc1 → GELU(tanh) → fc2 → residual
+         DeepStack taps at layers 8 / 16 / 24
+         2×2 patch merger → image_embeds (out_hidden 4096)
+    └─ scatter image_embeds into the embedding stream at the image span
+  text tokens → embed_tokens (BF16)
+    └─ language stack (NVFP4 W4A4, 36 layers, reused from Qwen3-8B)
+         interleaved-MRoPE; DeepStack added at the first 3 layers
+         final RMSNorm → lm_head (BF16)
+  ↓
+  logits → greedy decode (CUDA Graph replay)
+```
+
+Per-prompt geometry (3D MRoPE position ids, MRoPE / vision-RoPE tables,
+the interpolated vision position embedding) is precomputed once in
+`set_prompt`; the forward runs only kernels. The vision tower's
+intermediate (4304) is zero-padded to 4352 at load so every FFN GEMM uses
+the fast `w16a16` kernel (the unpadded fc2 fell back to an M=1-tuned
+matmul that dominated the tower at ~19 ms/call).
+
+New kernel (general, in the separate `flash_rt_qwen3_vl_kernels` module):
+`rope_neox_qk_bf16`, a rotate_half RoPE for Q/K not covered by the
+interleaved `rope_apply` or the norm-fused Qwen3 RoPE kernels.
+
+---
+
+## 4. Correctness
+
+Validated against the stock HF bf16 reference on an image+text prompt:
+
+| Check | Result |
+|---|---|
+| ViT block (cumulative, layer 8) cosine | 0.9998 |
+| DeepStack features cosine | 0.9999 / 0.9986 / 0.9967 |
+| image_embeds (merger) cosine | 0.984 |
+| Next-token argmax vs HF | match |
+| End-to-end image description | correct |
+
+The image_embeds 0.984 is a single massive-activation channel in the last
+ViT block (a known bf16 sensitivity); it does not change the generated
+token sequence.
+
+---
+
+## 5. Notes & limitations
+
+- **lm_head stays BF16** (same as the Qwen3-8B path).
+- **Image inputs.** Video and multi-image are not wired in this path.
+- **Vision is BF16.** The ViT GEMMs (~52% of TTFT) are the next lever; an
+  FP8 vision tower would roughly halve the GEMM time.
+- **No KV-cache offload**; prompt + generation must fit in `max_seq`.

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -98,6 +98,46 @@ The build needs the `flash_rt_qwen3_vl_kernels` module
 (`cmake -B build -S . -DGPU_ARCH=120 -DFLASHRT_BUILD_QWEN3_VL=ON` then
 build that target); the shared `flash_rt_kernels.so` is unchanged.
 
+### Inputs (image / multi-image / video)
+
+`messages` follows the processor's chat format. Mix any number of images
+and/or one video; the frontend builds the per-segment geometry and scatter
+automatically.
+
+```python
+# Multiple images
+content = [
+    {'type': 'image', 'image': img_a},
+    {'type': 'image', 'image': img_b},
+    {'type': 'text', 'text': 'Compare the two images.'},
+]
+
+# Video (numpy (T,H,W,C) array or a list of PIL frames; frame sampling
+# follows the processor defaults)
+content = [
+    {'type': 'video', 'video': frames},
+    {'type': 'text', 'text': 'What happens in this video?'},
+]
+```
+
+### Resolution (`max_pixels`) — explicit, opt-in
+
+`max_pixels` is **not** set by default (`None` = the checkpoint's full
+resolution, so behaviour is unchanged and the output is bit-identical).
+Because the patch count drives both the ViT and the LLM prefill length
+(see §1), set it explicitly to trade visual detail for latency — it is the
+single biggest TTFT lever:
+
+```python
+fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=1_000_000)   # ~57 ms
+fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=500_000)     # ~30 ms
+```
+
+The same knob is exposed as `--max-pixels` on
+`examples/qwen3_vl_quickstart.py` and `examples/qwen3_vl_openai_server.py`.
+It applies the processor's smart_resize (rounds to the patch grid) to both
+images and videos.
+
 ---
 
 ## 3. Inference architecture

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -21,11 +21,11 @@ image + text prompt, 1581 LLM tokens (1564 vision + 17 text), FlashRT.png
 
 | Metric | HF SDPA (bf16) | FlashRT |
 |---|---:|---:|
-| TTFT (full request, image+text) | 206 ms | **~103 ms** |
+| TTFT (full request, image+text) | 206 ms | **~100 ms** |
 | Decode (warm CUDA Graph)   | ~48 tok/s | **~150 tok/s** |
 
 Same 5090, FlashRT.png, full resolution (1581 prompt tokens). FlashRT TTFT
-is GPU image preprocessing (~8 ms) + the **CUDA-graph prefill** (~95 ms);
+is GPU image preprocessing (~8 ms) + the **CUDA-graph prefill** (~93 ms);
 decode is the NVFP4 W4A4 + graph path. Both prefill and decode replay as
 pure-kernel CUDA graphs (no per-request Python/torch dispatch), so latency
 is low and stable.
@@ -39,13 +39,13 @@ NVFP4 GEMMs, and the attention; all compute-bound.
 
 Prefill history on this path (5090, prefill-only ms): 621 → 121 (ViT FFN on
 the fast GEMM) → 102 (FP8 block-128 ViT GEMMs) → 99 (FP8 quant fused into
-LayerNorm/GELU) → **95** (merger FP8 + whole-prefill CUDA graph). Image
-preprocessing moved CPU → GPU (24 → 8 ms), so the full request TTFT is
-~103 ms.
+LayerNorm/GELU) → 95 (merger FP8 + whole-prefill CUDA graph) → **93** (ViT
+bias adds fused into adjacent kernels). Image preprocessing moved CPU → GPU
+(24 → 8 ms), so the full request TTFT is ~100 ms.
 
 ### TTFT vs resolution (the dominant knob)
 
-The ~103 ms above is the **full-resolution** benchmark: the 2172×724 image
+The ~100 ms above is the **full-resolution** benchmark: the 2172×724 image
 patchifies to 6256 patches → 1564 of the 1581 LLM tokens are vision. The
 patch count (≈ pixels / 16²) sets both the ViT cost and the LLM prefill
 length, so capping resolution cuts both at once. Pass ``max_pixels`` (the
@@ -55,13 +55,13 @@ prefill):
 
 | `max_pixels` | patches | LLM tokens | TTFT |
 |---|---:|---:|---:|
-| none (full) | 6256 | 1581 | 103 ms |
-| 1.0 M | 3888 | 989 | 60 ms |
-| 0.5 M | 1824 | 473 | **33 ms** |
+| none (full) | 6256 | 1581 | 100 ms |
+| 1.0 M | 3888 | 989 | 59 ms |
+| 0.5 M | 1824 | 473 | **32 ms** |
 | 0.25 M | 972 | 260 | 25 ms |
 
 ```python
-fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=1_000_000)  # or pass --max-pixels
+fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=1_000_000)  # or --max-pixels
 ```
 
 Reproduce:

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -1,10 +1,11 @@
-# Qwen3-VL-8B on RTX 5090 (NVFP4 language stack + BF16 ViT)
+# Qwen3-VL-8B on RTX 5090 (NVFP4 language stack + FP8 ViT)
 
 FlashRT multimodal inference path for
 [Qwen3-VL-8B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct)
 on a single RTX 5090 (sm_120, 32 GB): the dense-Qwen3 language stack runs
 NVFP4 W4A4 (reusing the [Qwen3-8B path](qwen3_8b_nvfp4.md) unchanged) and
-the SigLIP-style ViT tower runs hand-controlled BF16 kernels.
+the SigLIP-style ViT tower runs hand-controlled kernels (FP8 block-128
+W8A8 GEMMs, BF16 attention).
 
 For the framework intro see [`../README.md`](../README.md); for the
 text-only Qwen3-8B path see [`qwen3_8b_nvfp4.md`](qwen3_8b_nvfp4.md).
@@ -20,14 +21,19 @@ image + text prompt, 1581 LLM tokens (1564 vision + 17 text), FlashRT.png
 
 | Metric | HF SDPA (bf16) | FlashRT |
 |---|---:|---:|
-| TTFT (prefill, image+text) | 206 ms | **121 ms** |
+| TTFT (prefill, image+text) | 206 ms | **102 ms** |
 | Decode (warm CUDA Graph)   | ~48 tok/s | **143 tok/s** |
 
-The TTFT is dominated by the ViT tower (~81 ms, FA2-bound at the
-6256-patch full-attention) plus the NVFP4 language prefill (~39 ms).
-Decode reuses the Qwen3-8B NVFP4 W4A4 + CUDA-Graph path and lands at the
-same ~143 tok/s ceiling; the MRoPE position continues past the image
-while the KV-cache slot advances from the image-compressed prompt length.
+TTFT is dominated by the ViT tower (~63 ms) plus the NVFP4 language
+prefill (~39 ms). After the FP8 GEMMs, the two remaining ViT costs are
+the full-attention over 6256 patches (~31 ms, ~75% of bf16 roofline at
+head_dim 72) and the FP8 GEMMs (~20 ms); both are compute-bound. Decode
+reuses the Qwen3-8B NVFP4 W4A4 + CUDA-Graph path and lands at the same
+~143 tok/s ceiling; the MRoPE position continues past the image while the
+KV-cache slot advances from the image-compressed prompt length.
+
+TTFT history on this path (5090): 621 ms (initial eager) → 121 ms (ViT
+FFN on the fast GEMM + bf16) → **102 ms** (FP8 block-128 ViT GEMMs).
 
 Reproduce:
 
@@ -114,13 +120,15 @@ Validated against the stock HF bf16 reference on an image+text prompt:
 |---|---|
 | ViT block (cumulative, layer 8) cosine | 0.9998 |
 | DeepStack features cosine | 0.9999 / 0.9986 / 0.9967 |
-| image_embeds (merger) cosine | 0.984 |
+| image_embeds (merger) cosine | 0.984 bf16 / 0.971 FP8 |
 | Next-token argmax vs HF | match |
 | End-to-end image description | correct |
 
-The image_embeds 0.984 is a single massive-activation channel in the last
-ViT block (a known bf16 sensitivity); it does not change the generated
-token sequence.
+A single massive-activation channel in the last ViT blocks makes
+image_embeds sensitive (a known bf16 effect, amplified by FP8): patch
+embed, the mergers and the first 3 blocks stay bf16 to hold the cosine at
+0.971. It does not change the generated token sequence (argmax matches HF,
+the description is unchanged).
 
 ---
 
@@ -128,6 +136,9 @@ token sequence.
 
 - **lm_head stays BF16** (same as the Qwen3-8B path).
 - **Image inputs.** Video and multi-image are not wired in this path.
-- **Vision is BF16.** The ViT GEMMs (~52% of TTFT) are the next lever; an
-  FP8 vision tower would roughly halve the GEMM time.
+- **Next TTFT levers** (both need new kernels): an FP8 ViT attention
+  (Sage/FA on sm_120 only ships head_dim 128/256, so head_dim 72 would
+  need padding), and an FP8 language prefill (the stack is NVFP4, whose
+  large-M GEMM dequantizes to bf16 compute). Fusing the FP8 activation
+  quant into the preceding LayerNorm would also remove ~4 ms.
 - **No KV-cache offload**; prompt + generation must fit in `max_seq`.

--- a/examples/qwen3_vl_openai_server.py
+++ b/examples/qwen3_vl_openai_server.py
@@ -72,6 +72,9 @@ def main() -> None:
     p.add_argument('--device', default='cuda:0')
     p.add_argument('--max-seq', type=int, default=4096)
     p.add_argument('--max-new-tokens', type=int, default=256)
+    p.add_argument('--max-pixels', type=int, default=None,
+                   help='cap image/video resolution (pixels) to bound TTFT; '
+                        'default keeps full resolution')
     p.add_argument('--model-name', default='qwen3-vl')
     args = p.parse_args()
 
@@ -83,7 +86,8 @@ def main() -> None:
     from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
 
     fe = Qwen3VlTorchFrontendRtx(
-        args.checkpoint, device=args.device, max_seq=args.max_seq)
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_pixels=args.max_pixels)
     lock = asyncio.Lock()
     app = FastAPI(title='FlashRT Qwen3-VL OpenAI-compatible server')
 

--- a/examples/qwen3_vl_openai_server.py
+++ b/examples/qwen3_vl_openai_server.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Minimal OpenAI-compatible vision chat server for Qwen3-VL on FlashRT.
+
+Exposes ``POST /v1/chat/completions`` (non-streaming) for image+text
+chat, backed by the FlashRT Qwen3-VL NVFP4 path. Multimodal messages use
+the OpenAI ``image_url`` content format (``http(s)://`` or ``data:`` base64
+URLs). Single-GPU, batch 1; concurrent requests are serialised.
+
+    pip install fastapi uvicorn
+    python examples/qwen3_vl_openai_server.py \\
+        --checkpoint /path/to/Qwen3-VL-8B-FlashRT-NVFP4 --port 8000
+
+    curl http://localhost:8000/v1/chat/completions \\
+        -H 'Content-Type: application/json' \\
+        -d '{"model":"qwen3-vl","messages":[{"role":"user","content":[
+              {"type":"image_url","image_url":{"url":"https://.../x.png"}},
+              {"type":"text","text":"What is in this image?"}]}]}'
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import pathlib
+import sys
+import time
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_image(url: str):
+    from PIL import Image
+    if url.startswith('data:'):
+        raw = base64.b64decode(url.split(',', 1)[1])
+    elif url.startswith(('http://', 'https://')):
+        with urllib.request.urlopen(url) as r:
+            raw = r.read()
+    else:
+        with open(url, 'rb') as f:
+            raw = f.read()
+    return Image.open(io.BytesIO(raw)).convert('RGB')
+
+
+def _to_frontend_messages(messages: list) -> list:
+    """Translate OpenAI chat messages (with ``image_url`` parts) into the
+    processor's content format (``{'type': 'image', 'image': PIL}``)."""
+    out = []
+    for m in messages:
+        content = m.get('content')
+        if isinstance(content, str):
+            out.append({'role': m['role'], 'content': content})
+            continue
+        parts = []
+        for part in content or []:
+            if part.get('type') == 'text':
+                parts.append({'type': 'text', 'text': part['text']})
+            elif part.get('type') == 'image_url':
+                parts.append({'type': 'image',
+                              'image': _load_image(part['image_url']['url'])})
+        out.append({'role': m['role'], 'content': parts})
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--checkpoint', required=True)
+    p.add_argument('--host', default='0.0.0.0')
+    p.add_argument('--port', type=int, default=8000)
+    p.add_argument('--device', default='cuda:0')
+    p.add_argument('--max-seq', type=int, default=4096)
+    p.add_argument('--max-new-tokens', type=int, default=256)
+    p.add_argument('--model-name', default='qwen3-vl')
+    args = p.parse_args()
+
+    import asyncio
+
+    import uvicorn
+    from fastapi import FastAPI, HTTPException
+
+    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+
+    fe = Qwen3VlTorchFrontendRtx(
+        args.checkpoint, device=args.device, max_seq=args.max_seq)
+    lock = asyncio.Lock()
+    app = FastAPI(title='FlashRT Qwen3-VL OpenAI-compatible server')
+
+    @app.get('/health')
+    def health():
+        return {'status': 'ok'}
+
+    @app.get('/v1/models')
+    def models():
+        return {'object': 'list',
+                'data': [{'id': args.model_name, 'object': 'model'}]}
+
+    @app.post('/v1/chat/completions')
+    async def chat(body: dict):
+        messages = body.get('messages')
+        if not isinstance(messages, list) or not messages:
+            raise HTTPException(400, "'messages' must be a non-empty list")
+        max_new = int(body.get('max_tokens') or args.max_new_tokens)
+        try:
+            fe_messages = _to_frontend_messages(messages)
+        except Exception as e:  # noqa: BLE001 - surface a clean 400
+            raise HTTPException(400, f'bad message content: {e}')
+        async with lock:
+            text = await asyncio.to_thread(
+                fe.generate, fe_messages, max_new_tokens=max_new)
+        return {
+            'id': f'chatcmpl-{int(time.time()*1000)}',
+            'object': 'chat.completion',
+            'created': int(time.time()),
+            'model': args.model_name,
+            'choices': [{
+                'index': 0,
+                'message': {'role': 'assistant', 'content': text},
+                'finish_reason': 'stop',
+            }],
+        }
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/qwen3_vl_openai_server.py
+++ b/examples/qwen3_vl_openai_server.py
@@ -110,9 +110,12 @@ def main() -> None:
             fe_messages = _to_frontend_messages(messages)
         except Exception as e:  # noqa: BLE001 - surface a clean 400
             raise HTTPException(400, f'bad message content: {e}')
-        async with lock:
-            text = await asyncio.to_thread(
-                fe.generate, fe_messages, max_new_tokens=max_new)
+        try:
+            async with lock:
+                text = await asyncio.to_thread(
+                    fe.generate, fe_messages, max_new_tokens=max_new)
+        except ValueError as e:  # e.g. text-only prompt to the VL frontend
+            raise HTTPException(400, str(e))
         return {
             'id': f'chatcmpl-{int(time.time()*1000)}',
             'object': 'chat.completion',

--- a/examples/qwen3_vl_quickstart.py
+++ b/examples/qwen3_vl_quickstart.py
@@ -48,6 +48,10 @@ def main() -> None:
     p.add_argument('--max-new-tokens', type=int, default=256)
     p.add_argument('--device', default='cuda:0')
     p.add_argument('--max-seq', type=int, default=4096)
+    p.add_argument('--max-pixels', type=int, default=None,
+                   help='cap image resolution (pixels); the patch count '
+                        'drives TTFT, so e.g. 1000000 roughly halves it. '
+                        'Default: checkpoint full resolution.')
     p.add_argument('--benchmark', type=int, default=0,
                    help='if >0, run that many timed iterations')
     args = p.parse_args()
@@ -57,7 +61,8 @@ def main() -> None:
     from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
 
     fe = Qwen3VlTorchFrontendRtx(
-        args.checkpoint, device=args.device, max_seq=args.max_seq)
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_pixels=args.max_pixels)
     messages = _build_messages(args.image, args.prompt)
 
     text = fe.generate(messages, max_new_tokens=args.max_new_tokens)

--- a/examples/qwen3_vl_quickstart.py
+++ b/examples/qwen3_vl_quickstart.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Qwen3-VL FlashRT quickstart.
+
+Runs the Qwen3-VL multimodal path (NVFP4 language stack + BF16 ViT tower)
+on a single image + text prompt and prints the generated description. The
+checkpoint is the self-contained directory produced by
+``tools/quantize_qwen3_vl_nvfp4.py``.
+
+Examples:
+    # One-shot description
+    python examples/qwen3_vl_quickstart.py \\
+        --checkpoint /path/to/Qwen3-VL-8B-FlashRT-NVFP4 \\
+        --image FlashRT.png \\
+        --prompt "Describe this image in one sentence."
+
+    # Latency benchmark (prefill TTFT + decode tok/s)
+    python examples/qwen3_vl_quickstart.py \\
+        --checkpoint /path/to/Qwen3-VL-8B-FlashRT-NVFP4 \\
+        --image FlashRT.png --benchmark 20
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _build_messages(image_path: str, prompt: str) -> list:
+    from PIL import Image
+    image = Image.open(image_path).convert('RGB')
+    return [{'role': 'user', 'content': [
+        {'type': 'image', 'image': image},
+        {'type': 'text', 'text': prompt},
+    ]}]
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument('--checkpoint', required=True,
+                   help='FlashRT Qwen3-VL NVFP4 checkpoint directory')
+    p.add_argument('--image', required=True, help='input image path')
+    p.add_argument('--prompt', default='Describe this image in one sentence.')
+    p.add_argument('--max-new-tokens', type=int, default=256)
+    p.add_argument('--device', default='cuda:0')
+    p.add_argument('--max-seq', type=int, default=4096)
+    p.add_argument('--benchmark', type=int, default=0,
+                   help='if >0, run that many timed iterations')
+    args = p.parse_args()
+
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+
+    fe = Qwen3VlTorchFrontendRtx(
+        args.checkpoint, device=args.device, max_seq=args.max_seq)
+    messages = _build_messages(args.image, args.prompt)
+
+    text = fe.generate(messages, max_new_tokens=args.max_new_tokens)
+    print('--- generated ---')
+    print(text)
+
+    if args.benchmark > 0:
+        # TTFT (prefill) timing.
+        fe.set_prompt(messages)
+        torch.cuda.synchronize()
+        ttft = []
+        for _ in range(args.benchmark):
+            t0 = time.perf_counter()
+            fe.prefill()
+            torch.cuda.synchronize()
+            ttft.append((time.perf_counter() - t0) * 1e3)
+        ttft.sort()
+
+        # Decode throughput.
+        t0 = time.perf_counter()
+        out = fe.generate(messages, max_new_tokens=args.max_new_tokens)
+        torch.cuda.synchronize()
+        dt = time.perf_counter() - t0
+        n_tok = len(fe.processor.tokenizer(out).input_ids)
+
+        s = fe._prompt['S']
+        print('--- benchmark ---')
+        print(f'prompt tokens (incl. vision) : {s}')
+        print(f'TTFT prefill P50             : {ttft[len(ttft)//2]:.1f} ms')
+        print(f'decode throughput            : {n_tok / dt:.1f} tok/s '
+              f'({n_tok} tok in {dt*1e3:.0f} ms)')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/qwen3_vl_quickstart.py
+++ b/examples/qwen3_vl_quickstart.py
@@ -76,19 +76,22 @@ def main() -> None:
             ttft.append((time.perf_counter() - t0) * 1e3)
         ttft.sort()
 
-        # Decode throughput.
+        # Decode throughput with warm CUDA Graphs.
+        s = fe._prompt['S']
+        n_dec = args.max_new_tokens
+        fe.warmup_decode_graphs(n_dec)
+        torch.cuda.synchronize()
         t0 = time.perf_counter()
-        out = fe.generate(messages, max_new_tokens=args.max_new_tokens)
+        for j in range(n_dec):
+            fe._decode_step_graph(0, s + j, fe._prompt['mrope_max'] + 1 + j)
         torch.cuda.synchronize()
         dt = time.perf_counter() - t0
-        n_tok = len(fe.processor.tokenizer(out).input_ids)
 
-        s = fe._prompt['S']
         print('--- benchmark ---')
         print(f'prompt tokens (incl. vision) : {s}')
         print(f'TTFT prefill P50             : {ttft[len(ttft)//2]:.1f} ms')
-        print(f'decode throughput            : {n_tok / dt:.1f} tok/s '
-              f'({n_tok} tok in {dt*1e3:.0f} ms)')
+        print(f'decode throughput (warm graph): {n_dec / dt:.1f} tok/s '
+              f'({n_dec} tok in {dt*1e3:.0f} ms)')
 
 
 if __name__ == '__main__':

--- a/flash_rt/frontends/torch/_qwen3_vl_geometry.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_geometry.py
@@ -14,37 +14,68 @@ HuggingFace model object:
   * ``vision_pos_embeds``   — bilinear-interpolated learned position
     embedding for the patch grid, in 2×2-merge token order.
 
-Image inputs only (the multimodal scope of this path); the MRoPE builder
-mirrors HF's text/image span walk.
+Image and video inputs; the MRoPE builder mirrors HF's text/image/video
+span walk (videos use timestamp alignment: the grid is split per frame so
+each frame's temporal index is 0 and the inter-frame timestamp text tokens
+carry the temporal information).
 """
 from __future__ import annotations
 
 import torch
 
 
-def mrope_position_ids(input_ids, image_grid_thw, *, image_token_id,
-                       vision_start_token_id, spatial_merge_size):
+def mrope_position_ids(input_ids, image_grid_thw=None, video_grid_thw=None, *,
+                       image_token_id, video_token_id, vision_start_token_id,
+                       spatial_merge_size):
     """3D MRoPE position ids for a single (unpadded) sequence.
+
+    Mirrors HF ``Qwen3VLModel.get_rope_index``: walks the interleaved text /
+    image / video spans in token order. A video grid (t, h, w) is split into
+    ``t`` per-frame rows (t -> 1) so each frame is encoded like an image and
+    the temporal position is carried by the timestamp text tokens between
+    frames.
 
     Args:
       input_ids: (S,) long.
-      image_grid_thw: (num_images, 3) long — (t, h, w) per image.
+      image_grid_thw: (num_images, 3) long — (t, h, w) per image, or None.
+      video_grid_thw: (num_videos, 3) long — (t, h, w) per video, or None.
     Returns:
       (3, S) long position ids (t, h, w rows).
     """
+    if video_grid_thw is not None and len(video_grid_thw):
+        vg = video_grid_thw.clone()
+        vg = torch.repeat_interleave(vg, vg[:, 0], dim=0)
+        vg[:, 0] = 1
+    else:
+        vg = None
+
     ids = input_ids.tolist()
     n = len(ids)
+    m = spatial_merge_size
     starts = [i for i, tok in enumerate(ids) if tok == vision_start_token_id]
     image_nums = sum(1 for i in starts if ids[i + 1] == image_token_id)
+    video_nums = sum(1 for i in starts if ids[i + 1] == video_token_id)
 
     parts: list = []
     st = 0
-    img = 0
-    for _ in range(image_nums):
-        ed = ids.index(image_token_id, st)
-        t, h, w = (int(x) for x in image_grid_thw[img])
-        img += 1
-        gt, gh, gw = t, h // spatial_merge_size, w // spatial_merge_size
+    im = vi = 0
+    rem_i, rem_v = image_nums, video_nums
+    for _ in range(image_nums + video_nums):
+        ed_i = ids.index(image_token_id, st) if (
+            image_token_id in ids and rem_i > 0) else n + 1
+        ed_v = ids.index(video_token_id, st) if (
+            video_token_id in ids and rem_v > 0) else n + 1
+        if ed_i < ed_v:
+            t, h, w = (int(x) for x in image_grid_thw[im])
+            im += 1
+            rem_i -= 1
+            ed = ed_i
+        else:
+            t, h, w = (int(x) for x in vg[vi])
+            vi += 1
+            rem_v -= 1
+            ed = ed_v
+        gt, gh, gw = t, h // m, w // m
         text_len = ed - st
         base = int(parts[-1].max()) + 1 if parts else 0
         parts.append(

--- a/flash_rt/frontends/torch/_qwen3_vl_geometry.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_geometry.py
@@ -24,6 +24,69 @@ from __future__ import annotations
 import torch
 
 
+def vision_segments(input_ids, image_grid_thw=None, video_grid_thw=None, *,
+                    image_token_id, video_token_id, spatial_merge_size):
+    """Walk the image/video token runs of a sequence in order.
+
+    Videos are split into per-frame rows (t -> 1) so each frame is one
+    segment. Returns a list of dicts, one per vision segment, in sequence
+    order:
+
+      {'span': (start, end),     # token indices of the run
+       'grid': (t, h, w),        # per-frame grid (t == 1 for video frames)
+       'kind': 'image'|'video',
+       'kind_index': k,          # index within that modality's pixel tensor
+       'patches': t*h*w}         # patches the ViT consumes for this segment
+
+    Raises ValueError if there is no vision segment (text-only prompt) or a
+    run length does not match its grid (t*(h/m)*(w/m)).
+    """
+    if video_grid_thw is not None and len(video_grid_thw):
+        vg = torch.as_tensor(video_grid_thw).clone()
+        vg = torch.repeat_interleave(vg, vg[:, 0], dim=0)
+        vg[:, 0] = 1
+    else:
+        vg = None
+
+    ids = input_ids.tolist() if hasattr(input_ids, 'tolist') else list(
+        input_ids)
+    n = len(ids)
+    m = spatial_merge_size
+    segs: list = []
+    im = vi = 0
+    i = 0
+    while i < n:
+        tok = ids[i]
+        if tok not in (image_token_id, video_token_id):
+            i += 1
+            continue
+        j = i
+        while j < n and ids[j] == tok:
+            j += 1
+        if tok == image_token_id:
+            t, h, w = (int(x) for x in image_grid_thw[im])
+            kind, kind_index = 'image', im
+            im += 1
+        else:
+            t, h, w = (int(x) for x in vg[vi])
+            kind, kind_index = 'video', vi
+            vi += 1
+        if j - i != t * (h // m) * (w // m):
+            raise ValueError(
+                f'vision-token span [{i},{j}) does not match its grid '
+                f'{(t, h, w)} (expected {t * (h // m) * (w // m)} tokens)')
+        segs.append({'span': (i, j), 'grid': (t, h, w), 'kind': kind,
+                     'kind_index': kind_index, 'patches': t * h * w})
+        i = j
+
+    if not segs:
+        raise ValueError(
+            'Qwen3-VL frontend requires at least one image or video '
+            'segment; for text-only prompts use the Qwen3 text path '
+            '(Qwen3TorchFrontendRtx).')
+    return segs
+
+
 def mrope_position_ids(input_ids, image_grid_thw=None, video_grid_thw=None, *,
                        image_token_id, video_token_id, vision_start_token_id,
                        spatial_merge_size):
@@ -101,7 +164,6 @@ def mrope_cos_sin(position_ids, *, head_dim, rope_theta, mrope_section,
     Returns:
       (cos, sin) each (S, head_dim/2) on ``device`` in ``dtype``.
     """
-    half = head_dim // 2
     inv_freq = 1.0 / (rope_theta ** (
         torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
     pos = position_ids.to(torch.float32)

--- a/flash_rt/frontends/torch/_qwen3_vl_geometry.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_geometry.py
@@ -1,0 +1,165 @@
+"""FlashRT — Qwen3-VL position geometry builders (set-prompt precompute).
+
+Pure-torch reimplementations of the three deterministic geometry steps
+that Qwen3-VL needs before the kernel pipeline runs. They are evaluated
+once per prompt (not on the decode hot path) and are independent of the
+HuggingFace model object:
+
+  * ``mrope_position_ids``  — the 3D (t, h, w) MRoPE position ids over the
+    interleaved text + image-grid sequence;
+  * ``mrope_cos_sin``       — interleaved-MRoPE cos/sin for the language
+    stack (mrope_section [t, h, w]);
+  * ``vision_rope_cos_sin`` — rotate_half 2D-RoPE cos/sin for the ViT
+    patch grid;
+  * ``vision_pos_embeds``   — bilinear-interpolated learned position
+    embedding for the patch grid, in 2×2-merge token order.
+
+Image inputs only (the multimodal scope of this path); the MRoPE builder
+mirrors HF's text/image span walk.
+"""
+from __future__ import annotations
+
+import torch
+
+
+def mrope_position_ids(input_ids, image_grid_thw, *, image_token_id,
+                       vision_start_token_id, spatial_merge_size):
+    """3D MRoPE position ids for a single (unpadded) sequence.
+
+    Args:
+      input_ids: (S,) long.
+      image_grid_thw: (num_images, 3) long — (t, h, w) per image.
+    Returns:
+      (3, S) long position ids (t, h, w rows).
+    """
+    ids = input_ids.tolist()
+    n = len(ids)
+    starts = [i for i, tok in enumerate(ids) if tok == vision_start_token_id]
+    image_nums = sum(1 for i in starts if ids[i + 1] == image_token_id)
+
+    parts: list = []
+    st = 0
+    img = 0
+    for _ in range(image_nums):
+        ed = ids.index(image_token_id, st)
+        t, h, w = (int(x) for x in image_grid_thw[img])
+        img += 1
+        gt, gh, gw = t, h // spatial_merge_size, w // spatial_merge_size
+        text_len = ed - st
+        base = int(parts[-1].max()) + 1 if parts else 0
+        parts.append(
+            torch.arange(text_len).view(1, -1).expand(3, -1) + base)
+        t_idx = torch.arange(gt).view(-1, 1).expand(-1, gh * gw).flatten()
+        h_idx = torch.arange(gh).view(1, -1, 1).expand(gt, -1, gw).flatten()
+        w_idx = torch.arange(gw).view(1, 1, -1).expand(gt, gh, -1).flatten()
+        parts.append(
+            torch.stack([t_idx, h_idx, w_idx]) + text_len + base)
+        st = ed + gt * gh * gw
+    if st < n:
+        base = int(parts[-1].max()) + 1 if parts else 0
+        parts.append(torch.arange(n - st).view(1, -1).expand(3, -1) + base)
+    return torch.cat(parts, dim=1).reshape(3, n)
+
+
+def mrope_cos_sin(position_ids, *, head_dim, rope_theta, mrope_section,
+                  device='cuda:0', dtype=torch.bfloat16):
+    """Interleaved-MRoPE cos/sin tables for the language stack.
+
+    Args:
+      position_ids: (3, S) long.
+    Returns:
+      (cos, sin) each (S, head_dim/2) on ``device`` in ``dtype``.
+    """
+    half = head_dim // 2
+    inv_freq = 1.0 / (rope_theta ** (
+        torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    pos = position_ids.to(torch.float32)
+    freqs = pos[:, :, None] * inv_freq[None, None, :]            # (3, S, half)
+    out = freqs[0].clone()
+    for axis, offset in ((1, 1), (2, 2)):
+        idx = slice(offset, mrope_section[axis] * 3, 3)
+        out[:, idx] = freqs[axis][:, idx]
+    cos = out.cos().to(device).to(dtype).contiguous()
+    sin = out.sin().to(device).to(dtype).contiguous()
+    return cos, sin
+
+
+def vision_rope_cos_sin(grid_thw, *, head_dim, spatial_merge_size,
+                        rope_theta=10000.0, device='cuda:0',
+                        dtype=torch.bfloat16):
+    """rotate_half 2D-RoPE cos/sin for the ViT patch grid.
+
+    Returns (cos, sin) each (S, head_dim/2) — S = total patches.
+    """
+    dim = head_dim // 2
+    inv_freq = 1.0 / (rope_theta ** (
+        torch.arange(0, dim, 2, dtype=torch.float32) / dim))       # (dim/2,)
+    max_hw = int(grid_thw[:, 1:].max())
+    # freq_table: (max_hw, dim/2)
+    freq_table = torch.outer(
+        torch.arange(max_hw, dtype=torch.float32), inv_freq)
+
+    coords = []
+    for t, h, w in grid_thw:
+        t, h, w = int(t), int(h), int(w)
+        mh, mw = h // spatial_merge_size, w // spatial_merge_size
+        m = spatial_merge_size
+        rows = (torch.arange(mh)[:, None, None, None] * m
+                + torch.arange(m)[None, None, :, None])
+        cols = (torch.arange(mw)[None, :, None, None] * m
+                + torch.arange(m)[None, None, None, :])
+        rows = rows.expand(mh, mw, m, m).reshape(-1)
+        cols = cols.expand(mh, mw, m, m).reshape(-1)
+        c = torch.stack((rows, cols), dim=-1)
+        if t > 1:
+            c = c.repeat(t, 1)
+        coords.append(c)
+    pos_ids = torch.cat(coords, dim=0)                             # (S, 2)
+    freqs = freq_table[pos_ids].flatten(1)                         # (S, dim)
+    cos = freqs.cos().to(device).to(dtype).contiguous()
+    sin = freqs.sin().to(device).to(dtype).contiguous()
+    return cos, sin
+
+
+def vision_pos_embeds(grid_thw, pos_embed_table, *, num_grid_per_side,
+                      spatial_merge_size, device='cuda:0',
+                      dtype=torch.bfloat16):
+    """Bilinear-interpolated learned position embedding, in merge order.
+
+    Args:
+      pos_embed_table: (num_grid_per_side^2, hidden) cuda tensor.
+    Returns:
+      (S, hidden) bf16 cuda.
+    """
+    gs = num_grid_per_side
+    table = pos_embed_table.float()
+    out_parts = []
+    for t, h, w in grid_thw:
+        t, h, w = int(t), int(h), int(w)
+        hi = torch.linspace(0, gs - 1, h)
+        wi = torch.linspace(0, gs - 1, w)
+        hf, wf = hi.int(), wi.int()
+        hc = (hf + 1).clip(max=gs - 1)
+        wc = (wf + 1).clip(max=gs - 1)
+        dh, dw = hi - hf, wi - wf
+        base, base_c = hf * gs, hc * gs
+        idx = [
+            (base[:, None] + wf[None]).flatten(),
+            (base[:, None] + wc[None]).flatten(),
+            (base_c[:, None] + wf[None]).flatten(),
+            (base_c[:, None] + wc[None]).flatten(),
+        ]
+        wt = [
+            ((1 - dh)[:, None] * (1 - dw)[None]).flatten(),
+            ((1 - dh)[:, None] * dw[None]).flatten(),
+            (dh[:, None] * (1 - dw)[None]).flatten(),
+            (dh[:, None] * dw[None]).flatten(),
+        ]
+        pe = sum(table[idx[i].to(table.device)]
+                 * wt[i].to(table.device)[:, None] for i in range(4))
+        m = spatial_merge_size
+        pe = pe.repeat(t, 1)
+        pe = (pe.view(t, h // m, m, w // m, m, -1)
+              .permute(0, 1, 3, 2, 4, 5).flatten(0, 4))
+        out_parts.append(pe)
+    return torch.cat(out_parts, dim=0).to(device).to(dtype).contiguous()

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -197,6 +197,45 @@ class Qwen3VlVisionRtx:
             M, D, self.ln_eps, stream)
         return y
 
+    def _gemm_fp8(self, x_fp8, x_scale, lin, M, N, K, stream):
+        """FP8 block-128 GEMM from an already-quantized activation.
+
+        ``x_fp8`` / ``x_scale`` are the FP8 e4m3 values and their per-token,
+        per-128-K-block descale, as produced by the fused norm/gelu kernels.
+        Same epilogue (bf16 out, optional bias) as the FP8 branch of
+        ``_gemm``; it just skips the internal quantization step.
+        """
+        import torch
+        w8, ws, bias = lin
+        y = torch.empty(M, N, dtype=torch.bfloat16, device=self.device)
+        self._fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
+            x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+            x_scale.data_ptr(), ws.data_ptr(), stream)
+        if bias is not None:
+            self._fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
+        return y
+
+    def _layer_norm_to_fp8(self, x, w, b, M, D, stream):
+        """LayerNorm fused with the FP8 block-128 activation quant (one
+        kernel, no bf16 round-trip). Returns (fp8 values, per-block scale)
+        ready for ``_gemm_fp8``."""
+        import torch
+        xf = torch.empty(M, D, dtype=torch.float8_e4m3fn, device=self.device)
+        xs = torch.empty(M, D // 128, dtype=torch.float32, device=self.device)
+        self._vlk.layer_norm_to_fp8_block128_bf16(
+            x.data_ptr(), w.data_ptr(), b.data_ptr(), xf.data_ptr(),
+            xs.data_ptr(), M, D, self.ln_eps, stream)
+        return xf, xs
+
+    def _gelu_to_fp8(self, x, M, D, stream):
+        """GELU-tanh fused with the FP8 block-128 activation quant."""
+        import torch
+        xf = torch.empty(M, D, dtype=torch.float8_e4m3fn, device=self.device)
+        xs = torch.empty(M, D // 128, dtype=torch.float32, device=self.device)
+        self._vlk.gelu_tanh_to_fp8_block128_bf16(
+            x.data_ptr(), xf.data_ptr(), xs.data_ptr(), M, D, stream)
+        return xf, xs
+
     def _merger_forward(self, h, mg, stream):
         merge = self.spatial_merge_size * self.spatial_merge_size
         S = h.shape[0]
@@ -256,9 +295,19 @@ class Qwen3VlVisionRtx:
 
         deepstack: list = [None] * len(self.deepstack_indexes)
         for i, blk in enumerate(self.blocks):
-            xn = self._layer_norm(
-                h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
-            qkv = self._gemm(xn, blk['qkv'], S, 3 * H, H, stream)
+            # FP8 blocks fuse the activation quant into the producing
+            # LayerNorm / GELU (one kernel, no bf16 round-trip); bf16 blocks
+            # (the first few, protecting the massive-activation channel) keep
+            # the plain norm + w16a16 path.
+            fp8 = blk['qkv'][0] is not None
+            if fp8:
+                xf, xs = self._layer_norm_to_fp8(
+                    h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
+                qkv = self._gemm_fp8(xf, xs, blk['qkv'], S, 3 * H, H, stream)
+            else:
+                xn = self._layer_norm(
+                    h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
+                qkv = self._gemm(xn, blk['qkv'], S, 3 * H, H, stream)
             fvk.qkv_split(qkv.data_ptr(), q.data_ptr(), k.data_ptr(),
                           v.data_ptr(), S, H, H, H, stream)
             vlk.rope_neox_qk_bf16(
@@ -279,15 +328,24 @@ class Qwen3VlVisionRtx:
                 v_strides=(vv.stride(0), vv.stride(1), vv.stride(2)),
                 o_strides=(o.stride(0), o.stride(1), o.stride(2)),
                 softmax_scale=scale, num_sms=self._num_sms, stream=stream)
+            # proj input is the attention output (not a norm/gelu), so its
+            # quant cannot be fused upstream; keep the internal quant in _gemm.
             attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream)
             fvk.residual_add(h.data_ptr(), attn.data_ptr(), S * H, stream)
 
-            xn2 = self._layer_norm(
-                h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
             inter = self.intermediate
-            f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream)
-            fvk.gelu_inplace(f1.data_ptr(), S * inter, stream)
-            f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream)
+            if fp8:
+                xf2, xs2 = self._layer_norm_to_fp8(
+                    h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
+                f1 = self._gemm_fp8(xf2, xs2, blk['fc1'], S, inter, H, stream)
+                gf, gs = self._gelu_to_fp8(f1, S, inter, stream)
+                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream)
+            else:
+                xn2 = self._layer_norm(
+                    h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
+                f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream)
+                fvk.gelu_inplace(f1.data_ptr(), S * inter, stream)
+                f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream)
             fvk.residual_add(h.data_ptr(), f2.data_ptr(), S * H, stream)
 
             if i in self.deepstack_indexes:

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -156,7 +156,7 @@ class Qwen3VlVisionRtx:
 
     # ── primitives ──
 
-    def _gemm(self, x, lin, M, N, K, stream):
+    def _gemm(self, x, lin, M, N, K, stream, add_bias=True):
         """y = x @ W.T + bias via FP8 block-128 (2× tensor-core vs bf16).
 
         ``lin`` is a (weight_fp8, weight_block_scale, bias) tuple. The
@@ -185,7 +185,7 @@ class Qwen3VlVisionRtx:
             fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
                 x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
                 x_scale.data_ptr(), ws.data_ptr(), stream)
-        if bias is not None:
+        if bias is not None and add_bias:
             fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
 
@@ -197,13 +197,14 @@ class Qwen3VlVisionRtx:
             M, D, self.ln_eps, stream)
         return y
 
-    def _gemm_fp8(self, x_fp8, x_scale, lin, M, N, K, stream):
+    def _gemm_fp8(self, x_fp8, x_scale, lin, M, N, K, stream, add_bias=True):
         """FP8 block-128 GEMM from an already-quantized activation.
 
         ``x_fp8`` / ``x_scale`` are the FP8 e4m3 values and their per-token,
         per-128-K-block descale, as produced by the fused norm/gelu kernels.
         Same epilogue (bf16 out, optional bias) as the FP8 branch of
-        ``_gemm``; it just skips the internal quantization step.
+        ``_gemm``; it just skips the internal quantization step. ``add_bias``
+        False leaves the bias for a downstream fused kernel.
         """
         import torch
         w8, ws, bias = lin
@@ -211,7 +212,7 @@ class Qwen3VlVisionRtx:
         self._fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
             x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
             x_scale.data_ptr(), ws.data_ptr(), stream)
-        if bias is not None:
+        if bias is not None and add_bias:
             self._fvk.add_bias_bf16(
                 y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
@@ -237,6 +238,17 @@ class Qwen3VlVisionRtx:
             x.data_ptr(), xf.data_ptr(), xs.data_ptr(), M, D, stream)
         return xf, xs
 
+    def _gelu_bias_to_fp8(self, x, bias, M, D, stream):
+        """fc1 bias + GELU-tanh + FP8 block-128 quant in one kernel (the
+        bias rides this op instead of a standalone add_bias)."""
+        import torch
+        xf = torch.empty(M, D, dtype=torch.float8_e4m3fn, device=self.device)
+        xs = torch.empty(M, D // 128, dtype=torch.float32, device=self.device)
+        self._vlk.gelu_tanh_bias_to_fp8_block128_bf16(
+            x.data_ptr(), bias.data_ptr(), xf.data_ptr(), xs.data_ptr(),
+            M, D, stream)
+        return xf, xs
+
     def _merger_forward(self, h, mg, stream):
         merge = self.spatial_merge_size * self.spatial_merge_size
         S = h.shape[0]
@@ -251,8 +263,14 @@ class Qwen3VlVisionRtx:
                 xs, mg['norm_w'], mg['norm_b'], xs.shape[0], norm_dim, stream)
         M = xn.shape[0]
         din = self.hidden * merge
-        f1 = self._gemm(xn, mg['fc1'], M, din, din, stream)
-        self._fvk.gelu_inplace(f1.data_ptr(), M * din, stream)
+        # fc1 bias rides the bias+GELU kernel (no standalone add_bias).
+        f1 = self._gemm(xn, mg['fc1'], M, din, din, stream, add_bias=False)
+        b1 = mg['fc1'][2]
+        if b1 is not None:
+            self._fvk.bias_gelu_inplace_bf16(
+                f1.data_ptr(), b1.data_ptr(), M, din, stream)
+        else:
+            self._fvk.gelu_inplace(f1.data_ptr(), M * din, stream)
         return self._gemm(f1, mg['fc2'], M, self.out_hidden, din, stream)
 
     # ── forward ──
@@ -304,13 +322,17 @@ class Qwen3VlVisionRtx:
             if fp8:
                 xf, xs = self._layer_norm_to_fp8(
                     h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
-                qkv = self._gemm_fp8(xf, xs, blk['qkv'], S, 3 * H, H, stream)
+                qkv = self._gemm_fp8(xf, xs, blk['qkv'], S, 3 * H, H, stream,
+                                     add_bias=False)
             else:
                 xn = self._layer_norm(
                     h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
-                qkv = self._gemm(xn, blk['qkv'], S, 3 * H, H, stream)
-            fvk.qkv_split(qkv.data_ptr(), q.data_ptr(), k.data_ptr(),
-                          v.data_ptr(), S, H, H, H, stream)
+                qkv = self._gemm(xn, blk['qkv'], S, 3 * H, H, stream,
+                                 add_bias=False)
+            # qkv bias rides the split (no standalone add_bias).
+            vlk.qkv_split_bias_bf16(
+                qkv.data_ptr(), blk['qkv'][2].data_ptr(), q.data_ptr(),
+                k.data_ptr(), v.data_ptr(), S, H, H, H, stream)
             vlk.rope_neox_qk_bf16(
                 q.data_ptr(), k.data_ptr(), rope_cos.data_ptr(),
                 rope_sin.data_ptr(), q.data_ptr(), k.data_ptr(),
@@ -330,24 +352,36 @@ class Qwen3VlVisionRtx:
                 o_strides=(o.stride(0), o.stride(1), o.stride(2)),
                 softmax_scale=scale, num_sms=self._num_sms, stream=stream)
             # proj input is the attention output (not a norm/gelu), so its
-            # quant cannot be fused upstream; keep the internal quant in _gemm.
-            attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream)
-            fvk.residual_add(h.data_ptr(), attn.data_ptr(), S * H, stream)
+            # quant cannot be fused upstream; the proj bias rides the residual.
+            attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream,
+                              add_bias=False)
+            vlk.residual_add_bias_bf16(
+                h.data_ptr(), attn.data_ptr(), blk['proj'][2].data_ptr(),
+                S, H, stream)
 
             inter = self.intermediate
             if fp8:
                 xf2, xs2 = self._layer_norm_to_fp8(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
-                f1 = self._gemm_fp8(xf2, xs2, blk['fc1'], S, inter, H, stream)
-                gf, gs = self._gelu_to_fp8(f1, S, inter, stream)
-                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream)
+                f1 = self._gemm_fp8(xf2, xs2, blk['fc1'], S, inter, H, stream,
+                                    add_bias=False)
+                gf, gs = self._gelu_bias_to_fp8(
+                    f1, blk['fc1'][2], S, inter, stream)
+                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream,
+                                    add_bias=False)
             else:
                 xn2 = self._layer_norm(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
-                f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream)
-                fvk.gelu_inplace(f1.data_ptr(), S * inter, stream)
-                f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream)
-            fvk.residual_add(h.data_ptr(), f2.data_ptr(), S * H, stream)
+                f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream,
+                                add_bias=False)
+                fvk.bias_gelu_inplace_bf16(
+                    f1.data_ptr(), blk['fc1'][2].data_ptr(), S, inter, stream)
+                f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream,
+                                add_bias=False)
+            # fc2 bias rides the residual.
+            vlk.residual_add_bias_bf16(
+                h.data_ptr(), f2.data_ptr(), blk['fc2'][2].data_ptr(),
+                S, H, stream)
 
             if i in self.deepstack_indexes:
                 j = self.deepstack_indexes.index(i)

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -434,13 +434,22 @@ def _pad_cols(t, n_cols: int):
 
 
 def _load_merger(load_fn, lin_fn, prefix: str) -> dict:
+    # The merger linears run FP8 block-128 when 128-aligned (the Qwen3-VL
+    # dims are): preflight showed image_embeds cosine 0.9703 -> 0.9698
+    # (argmax-safe) for ~-2.6 ms across the four mergers. The norm output is
+    # bounded post-LayerNorm, so FP8 here does not touch the massive-
+    # activation residual stream.
+    def _merger_lin(name):
+        w = load_fn(prefix + name + '.weight')
+        bias = load_fn(prefix + name + '.bias')
+        aligned = w.shape[0] % 128 == 0 and w.shape[1] % 128 == 0
+        return lin_fn(w, bias, fp8=aligned)
+
     return {
         'norm_w': load_fn(prefix + 'norm.weight'),
         'norm_b': load_fn(prefix + 'norm.bias'),
-        'fc1': lin_fn(load_fn(prefix + 'linear_fc1.weight'),
-                      load_fn(prefix + 'linear_fc1.bias'), fp8=False),
-        'fc2': lin_fn(load_fn(prefix + 'linear_fc2.weight'),
-                      load_fn(prefix + 'linear_fc2.bias'), fp8=False),
+        'fc1': _merger_lin('linear_fc1'),
+        'fc2': _merger_lin('linear_fc2'),
     }
 
 

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -39,6 +39,9 @@ class Qwen3VlVisionRtx:
         self._fvk = None
         self._fa2 = None
         self._vlk = None
+        # patch-count -> (graph, static_inputs, captured_outputs)
+        self._graphs: dict = {}
+        self._graph_stream = None
 
         cfg = config if config is not None else _read_vision_config(
             checkpoint_path)
@@ -48,6 +51,7 @@ class Qwen3VlVisionRtx:
         self.head_dim = self.hidden // self.num_heads
         self.spatial_merge_size = int(cfg['spatial_merge_size'])
         self.out_hidden = int(cfg['out_hidden_size'])
+        self.intermediate = int(cfg['intermediate_size'])
         self.deepstack_indexes = tuple(cfg['deepstack_visual_indexes'])
         self.ln_eps = float(cfg.get('layer_norm_eps', 1e-6))
 
@@ -74,6 +78,15 @@ class Qwen3VlVisionRtx:
         self.patch_proj_b = _w(p + 'patch_embed.proj.bias')
         self.pos_embed = _w(p + 'pos_embed.weight')
 
+        # The FFN GEMMs use w16a16 (K % 128 == 0); the ViT intermediate
+        # (4304) is not 128-aligned, so the intermediate is zero-padded to
+        # the next multiple of 128 at load time. Padded fc1 rows / bias and
+        # fc2 columns are zero, so GELU(0)=0 keeps the pad inert and the
+        # result is unchanged — but fc2 now runs on the fast w16a16 kernel
+        # instead of the M=1-tuned arbitrary-K matmul (~56x faster at S>>1).
+        self.intermediate_padded = (
+            (self.intermediate + 127) // 128) * 128
+
         self.blocks: list[dict] = []
         for i in range(self.depth):
             bp = f'{p}blocks.{i}.'
@@ -86,9 +99,12 @@ class Qwen3VlVisionRtx:
                 'qkv_b': _w(bp + 'attn.qkv.bias'),
                 'proj_w': _w(bp + 'attn.proj.weight'),
                 'proj_b': _w(bp + 'attn.proj.bias'),
-                'fc1_w': _w(bp + 'mlp.linear_fc1.weight'),
-                'fc1_b': _w(bp + 'mlp.linear_fc1.bias'),
-                'fc2_w': _w(bp + 'mlp.linear_fc2.weight'),
+                'fc1_w': _pad_rows(_w(bp + 'mlp.linear_fc1.weight'),
+                                   self.intermediate_padded),
+                'fc1_b': _pad_rows(_w(bp + 'mlp.linear_fc1.bias'),
+                                   self.intermediate_padded),
+                'fc2_w': _pad_cols(_w(bp + 'mlp.linear_fc2.weight'),
+                                   self.intermediate_padded),
                 'fc2_b': _w(bp + 'mlp.linear_fc2.bias'),
             })
         self.merger = _load_merger(_w, p + 'merger.')
@@ -243,6 +259,70 @@ class Qwen3VlVisionRtx:
 
         image_embeds = self._merger_forward(h, self.merger, stream)
         return image_embeds, deepstack
+
+    def forward_graph(self, pixel_values, pos_embeds, rope_cos, rope_sin):
+        """CUDA-Graph-accelerated ``forward``.
+
+        The tower is launch-bound (hundreds of small kernels), so a
+        captured graph removes nearly all launch overhead. One graph per
+        distinct patch count; inputs are staged into fixed buffers and
+        the graph is replayed. Returns the captured output tensors (valid
+        until the next replay at the same patch count) — clone if the
+        caller needs to keep them across calls.
+        """
+        import torch
+
+        self._kernels()
+        if self._graph_stream is None:
+            self._graph_stream = torch.cuda.Stream(device=self.device)
+        S = pixel_values.shape[0]
+        g = self._graphs.get(S)
+        if g is None:
+            si = {
+                'pixel': pixel_values.clone(),
+                'pos': pos_embeds.clone(),
+                'cos': rope_cos.clone(),
+                'sin': rope_sin.clone(),
+            }
+            gs = self._graph_stream
+            gs.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(gs), torch.no_grad():
+                for _ in range(2):
+                    self.forward(si['pixel'], si['pos'], si['cos'], si['sin'])
+            gs.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=gs), torch.no_grad():
+                out = self.forward(
+                    si['pixel'], si['pos'], si['cos'], si['sin'])
+            gs.synchronize()
+            torch.cuda.current_stream().wait_stream(gs)
+            g = (graph, si, out)
+            self._graphs[S] = g
+        graph, si, out = g
+        si['pixel'].copy_(pixel_values)
+        si['pos'].copy_(pos_embeds)
+        si['cos'].copy_(rope_cos)
+        si['sin'].copy_(rope_sin)
+        graph.replay()
+        return out
+
+
+def _pad_rows(t, n_rows: int):
+    import torch
+    if t.shape[0] >= n_rows:
+        return t
+    pad = torch.zeros(n_rows - t.shape[0], *t.shape[1:],
+                      dtype=t.dtype, device=t.device)
+    return torch.cat([t, pad], dim=0).contiguous()
+
+
+def _pad_cols(t, n_cols: int):
+    import torch
+    if t.shape[-1] >= n_cols:
+        return t
+    pad = torch.zeros(*t.shape[:-1], n_cols - t.shape[-1],
+                      dtype=t.dtype, device=t.device)
+    return torch.cat([t, pad], dim=-1).contiguous()
 
 
 def _load_merger(load_fn, prefix: str) -> dict:

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -212,7 +212,8 @@ class Qwen3VlVisionRtx:
             x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
             x_scale.data_ptr(), ws.data_ptr(), stream)
         if bias is not None:
-            self._fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
+            self._fvk.add_bias_bf16(
+                y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
 
     def _layer_norm_to_fp8(self, x, w, b, M, D, stream):

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -1,0 +1,263 @@
+"""FlashRT — Qwen3-VL ViT tower forward (RTX SM120, BF16).
+
+Kernelized SigLIP-style vision tower for ``Qwen3-VL``: patch embed →
+learned position embedding → ``depth`` transformer blocks (rotate_half
+2D-RoPE, full bidirectional FA2 attention, GELU-tanh MLP) → 2×2 patch
+merger, with DeepStack feature taps at the configured layers.
+
+All heavy compute runs through ``flash_rt_kernels`` / ``flash_rt_fa2`` /
+``flash_rt_qwen3_vl_kernels``; tensor reshapes are metadata-only views.
+The tower is prefill-once per image and the sequence length is
+image-resolution dependent, so scratch is sized per forward (CUDA-Graph
+bucketing by patch count is layered on top separately).
+
+Sibling of the language path in ``qwen3_rtx`` / ``qwen3_vl_rtx``.
+"""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+class Qwen3VlVisionRtx:
+    """Qwen3-VL ViT tower. Loads BF16 vision weights from a checkpoint
+    directory and runs the forward against the FlashRT kernel modules.
+
+    Public surface:
+      __init__(checkpoint_path, *, device='cuda:0')
+      forward(pixel_values, rope_cos, rope_sin)
+        -> (image_embeds, deepstack_features)
+    """
+
+    def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
+                 config: dict | None = None) -> None:
+        import torch
+
+        from safetensors import safe_open
+
+        self.device = device
+        self._fvk = None
+        self._fa2 = None
+        self._vlk = None
+
+        cfg = config if config is not None else _read_vision_config(
+            checkpoint_path)
+        self.depth = int(cfg['depth'])
+        self.hidden = int(cfg['hidden_size'])
+        self.num_heads = int(cfg['num_heads'])
+        self.head_dim = self.hidden // self.num_heads
+        self.spatial_merge_size = int(cfg['spatial_merge_size'])
+        self.out_hidden = int(cfg['out_hidden_size'])
+        self.deepstack_indexes = tuple(cfg['deepstack_visual_indexes'])
+        self.ln_eps = float(cfg.get('layer_norm_eps', 1e-6))
+
+        import json
+        import os
+        index_path = os.path.join(
+            checkpoint_path, 'model.safetensors.index.json')
+        wmap = json.load(open(index_path))['weight_map']
+        shards: dict[str, Any] = {}
+
+        def _w(key: str):
+            shard = wmap[key]
+            if shard not in shards:
+                shards[shard] = safe_open(
+                    os.path.join(checkpoint_path, shard),
+                    framework='pt', device='cpu')
+            return shards[shard].get_tensor(key).to(
+                torch.bfloat16).to(device).contiguous()
+
+        p = 'model.visual.'
+        # patch_embed.proj.weight is (hidden, in_ch, T, ph, pw) → (hidden, K)
+        self.patch_proj_w = _w(p + 'patch_embed.proj.weight').reshape(
+            self.hidden, -1).contiguous()
+        self.patch_proj_b = _w(p + 'patch_embed.proj.bias')
+        self.pos_embed = _w(p + 'pos_embed.weight')
+
+        self.blocks: list[dict] = []
+        for i in range(self.depth):
+            bp = f'{p}blocks.{i}.'
+            self.blocks.append({
+                'norm1_w': _w(bp + 'norm1.weight'),
+                'norm1_b': _w(bp + 'norm1.bias'),
+                'norm2_w': _w(bp + 'norm2.weight'),
+                'norm2_b': _w(bp + 'norm2.bias'),
+                'qkv_w': _w(bp + 'attn.qkv.weight'),
+                'qkv_b': _w(bp + 'attn.qkv.bias'),
+                'proj_w': _w(bp + 'attn.proj.weight'),
+                'proj_b': _w(bp + 'attn.proj.bias'),
+                'fc1_w': _w(bp + 'mlp.linear_fc1.weight'),
+                'fc1_b': _w(bp + 'mlp.linear_fc1.bias'),
+                'fc2_w': _w(bp + 'mlp.linear_fc2.weight'),
+                'fc2_b': _w(bp + 'mlp.linear_fc2.bias'),
+            })
+        self.merger = _load_merger(_w, p + 'merger.')
+        self.deepstack_mergers = [
+            _load_merger(_w, f'{p}deepstack_merger_list.{k}.')
+            for k in range(len(self.deepstack_indexes))
+        ]
+
+    # ── kernel handles (lazy) ──
+
+    def _kernels(self):
+        if self._fvk is None:
+            from flash_rt import flash_rt_fa2 as fa2
+            from flash_rt import flash_rt_kernels as fvk
+            from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+            self._fvk, self._fa2, self._vlk = fvk, fa2, vlk
+            import torch
+            self._num_sms = torch.cuda.get_device_properties(
+                torch.device(self.device)).multi_processor_count
+        return self._fvk, self._fa2, self._vlk
+
+    # ── primitives ──
+
+    def _gemm(self, x, w, bias, M, N, K, stream):
+        import torch
+        fvk = self._fvk
+        y = torch.empty(M, N, dtype=torch.bfloat16, device=self.device)
+        if K % 128 == 0:
+            fvk.w16a16_gemm_sm120_bf16(
+                x.data_ptr(), w.data_ptr(), y.data_ptr(), M, N, K, 1.0, stream)
+        else:
+            # w16a16 requires K % 128 == 0; the arbitrary-K bf16 matmul
+            # also preserves accumulation precision on the ViT FFN
+            # (K=intermediate) massive-activation channels.
+            fvk.bf16_matmul_qwen36_bf16(
+                x.data_ptr(), w.data_ptr(), y.data_ptr(), M, N, K, stream)
+        if bias is not None:
+            fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
+        return y
+
+    def _layer_norm(self, x, w, b, M, D, stream):
+        import torch
+        y = torch.empty(M, D, dtype=torch.bfloat16, device=self.device)
+        self._fvk.layer_norm(
+            x.data_ptr(), w.data_ptr(), b.data_ptr(), y.data_ptr(),
+            M, D, self.ln_eps, stream)
+        return y
+
+    def _merger_forward(self, h, mg, stream):
+        merge = self.spatial_merge_size * self.spatial_merge_size
+        S = h.shape[0]
+        norm_dim = mg['norm_w'].shape[0]
+        if norm_dim == self.hidden:                    # pre-shuffle norm
+            xn = self._layer_norm(
+                h, mg['norm_w'], mg['norm_b'], S, self.hidden, stream)
+            xn = xn.view(S // merge, self.hidden * merge).contiguous()
+        else:                                          # post-shuffle norm
+            xs = h.view(S // merge, norm_dim).contiguous()
+            xn = self._layer_norm(
+                xs, mg['norm_w'], mg['norm_b'], xs.shape[0], norm_dim, stream)
+        M = xn.shape[0]
+        din = self.hidden * merge
+        f1 = self._gemm(xn, mg['fc1_w'], mg['fc1_b'], M, din, din, stream)
+        self._fvk.gelu_inplace(f1.data_ptr(), M * din, stream)
+        return self._gemm(
+            f1, mg['fc2_w'], mg['fc2_b'], M, self.out_hidden, din, stream)
+
+    # ── forward ──
+
+    def forward(self, pixel_values, pos_embeds, rope_cos, rope_sin):
+        """Run the ViT tower.
+
+        Args:
+          pixel_values: (S, patch_in) bf16 cuda — pre-patchified pixels,
+            S = number of patches.
+          pos_embeds: (S, hidden) bf16 cuda — grid-interpolated learned
+            position embedding (built once per image by the caller).
+          rope_cos / rope_sin: (S, head_dim/2) bf16 cuda — the 2D-RoPE
+            tables for the patch grid (rotate_half convention).
+
+        Returns:
+          (image_embeds (S/merge^2, out_hidden), [deepstack features]).
+        """
+        import torch
+
+        fvk, fa2, vlk = self._kernels()
+        stream = torch.cuda.current_stream().cuda_stream
+        S, K = pixel_values.shape
+        H = self.hidden
+        nh, hd = self.num_heads, self.head_dim
+        scale = 1.0 / math.sqrt(hd)
+        s_round = ((S + 127) // 128) * 128
+
+        bf16 = torch.bfloat16
+        dev = self.device
+
+        # patch embed + grid-interpolated learned pos embed.
+        h = self._gemm(pixel_values, self.patch_proj_w, self.patch_proj_b,
+                       S, H, K, stream)
+        fvk.residual_add(h.data_ptr(), pos_embeds.data_ptr(), S * H, stream)
+
+        q = torch.empty(S, H, dtype=bf16, device=dev)
+        k = torch.empty(S, H, dtype=bf16, device=dev)
+        v = torch.empty(S, H, dtype=bf16, device=dev)
+        o = torch.empty(1, S, nh, hd, dtype=bf16, device=dev)
+        lse = torch.empty(1, nh, s_round, dtype=torch.float32, device=dev)
+
+        deepstack: list = [None] * len(self.deepstack_indexes)
+        for i, blk in enumerate(self.blocks):
+            xn = self._layer_norm(
+                h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
+            qkv = self._gemm(
+                xn, blk['qkv_w'], blk['qkv_b'], S, 3 * H, H, stream)
+            fvk.qkv_split(qkv.data_ptr(), q.data_ptr(), k.data_ptr(),
+                          v.data_ptr(), S, H, H, H, stream)
+            vlk.rope_neox_qk_bf16(
+                q.data_ptr(), k.data_ptr(), rope_cos.data_ptr(),
+                rope_sin.data_ptr(), q.data_ptr(), k.data_ptr(),
+                S, nh, nh, hd, stream)
+            qv = q.view(1, S, nh, hd)
+            kv = k.view(1, S, nh, hd)
+            vv = v.view(1, S, nh, hd)
+            fa2.fwd_bf16(
+                Q=qv.data_ptr(), K=kv.data_ptr(), V=vv.data_ptr(),
+                O=o.data_ptr(), softmax_lse=lse.data_ptr(),
+                softmax_lse_accum=0, o_accum=0, batch=1,
+                seqlen_q=S, seqlen_k=S,
+                num_heads_q=nh, num_heads_kv=nh, head_dim=hd,
+                q_strides=(qv.stride(0), qv.stride(1), qv.stride(2)),
+                k_strides=(kv.stride(0), kv.stride(1), kv.stride(2)),
+                v_strides=(vv.stride(0), vv.stride(1), vv.stride(2)),
+                o_strides=(o.stride(0), o.stride(1), o.stride(2)),
+                softmax_scale=scale, num_sms=self._num_sms, stream=stream)
+            attn = self._gemm(o.view(S, H), blk['proj_w'], blk['proj_b'],
+                              S, H, H, stream)
+            fvk.residual_add(h.data_ptr(), attn.data_ptr(), S * H, stream)
+
+            xn2 = self._layer_norm(
+                h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
+            inter = blk['fc1_w'].shape[0]
+            f1 = self._gemm(
+                xn2, blk['fc1_w'], blk['fc1_b'], S, inter, H, stream)
+            fvk.gelu_inplace(f1.data_ptr(), S * inter, stream)
+            f2 = self._gemm(
+                f1, blk['fc2_w'], blk['fc2_b'], S, H, inter, stream)
+            fvk.residual_add(h.data_ptr(), f2.data_ptr(), S * H, stream)
+
+            if i in self.deepstack_indexes:
+                j = self.deepstack_indexes.index(i)
+                deepstack[j] = self._merger_forward(
+                    h, self.deepstack_mergers[j], stream)
+
+        image_embeds = self._merger_forward(h, self.merger, stream)
+        return image_embeds, deepstack
+
+
+def _load_merger(load_fn, prefix: str) -> dict:
+    return {
+        'norm_w': load_fn(prefix + 'norm.weight'),
+        'norm_b': load_fn(prefix + 'norm.bias'),
+        'fc1_w': load_fn(prefix + 'linear_fc1.weight'),
+        'fc1_b': load_fn(prefix + 'linear_fc1.bias'),
+        'fc2_w': load_fn(prefix + 'linear_fc2.weight'),
+        'fc2_b': load_fn(prefix + 'linear_fc2.bias'),
+    }
+
+
+def _read_vision_config(checkpoint_path: str) -> dict:
+    import json
+    import os
+    cfg = json.load(open(os.path.join(checkpoint_path, 'config.json')))
+    return cfg['vision_config']

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -1,4 +1,4 @@
-"""FlashRT — Qwen3-VL ViT tower forward (RTX SM120, BF16).
+"""FlashRT — Qwen3-VL ViT tower forward (RTX SM120).
 
 Kernelized SigLIP-style vision tower for ``Qwen3-VL``: patch embed →
 learned position embedding → ``depth`` transformer blocks (rotate_half
@@ -7,9 +7,12 @@ merger, with DeepStack feature taps at the configured layers.
 
 All heavy compute runs through ``flash_rt_kernels`` / ``flash_rt_fa2`` /
 ``flash_rt_qwen3_vl_kernels``; tensor reshapes are metadata-only views.
+The linear layers run FP8 block-128 W8A8 (2× tensor-core vs bf16); the
+activation is dynamically quantized per GEMM and the residual stream
+(which carries the late-layer massive-activation outlier) stays bf16.
 The tower is prefill-once per image and the sequence length is
 image-resolution dependent, so scratch is sized per forward (CUDA-Graph
-bucketing by patch count is layered on top separately).
+bucketing by patch count is layered on top via ``forward_graph``).
 
 Sibling of the language path in ``qwen3_rtx`` / ``qwen3_vl_rtx``.
 """
@@ -20,12 +23,13 @@ from typing import Any
 
 
 class Qwen3VlVisionRtx:
-    """Qwen3-VL ViT tower. Loads BF16 vision weights from a checkpoint
-    directory and runs the forward against the FlashRT kernel modules.
+    """Qwen3-VL ViT tower. Loads the vision weights from a checkpoint
+    directory (norms BF16, linears FP8 block-128) and runs the forward
+    against the FlashRT kernel modules.
 
     Public surface:
       __init__(checkpoint_path, *, device='cuda:0')
-      forward(pixel_values, rope_cos, rope_sin)
+      forward(pixel_values, pos_embeds, rope_cos, rope_sin)
         -> (image_embeds, deepstack_features)
     """
 
@@ -71,47 +75,71 @@ class Qwen3VlVisionRtx:
             return shards[shard].get_tensor(key).to(
                 torch.bfloat16).to(device).contiguous()
 
-        p = 'model.visual.'
-        # patch_embed.proj.weight is (hidden, in_ch, T, ph, pw) → (hidden, K)
-        self.patch_proj_w = _w(p + 'patch_embed.proj.weight').reshape(
-            self.hidden, -1).contiguous()
-        self.patch_proj_b = _w(p + 'patch_embed.proj.bias')
-        self.pos_embed = _w(p + 'pos_embed.weight')
+        def _lin(w, bias, fp8: bool = True):
+            """Pack a linear. fp8=True → (fp8 weight, block scale, bias);
+            fp8=False → (None, bf16 weight, bias) for the bf16 path. The
+            residual-writing GEMMs (attn proj, FFN fc2) stay bf16: their
+            output feeds the late-layer massive-activation channel, where
+            accumulated FP8 noise would be amplified."""
+            if not fp8:
+                return (None, w, bias)
+            w8, ws = _quant_fp8_block128(w)
+            return (w8, ws, bias)
 
-        # The FFN GEMMs use w16a16 (K % 128 == 0); the ViT intermediate
-        # (4304) is not 128-aligned, so the intermediate is zero-padded to
-        # the next multiple of 128 at load time. Padded fc1 rows / bias and
-        # fc2 columns are zero, so GELU(0)=0 keeps the pad inert and the
-        # result is unchanged — but fc2 now runs on the fast w16a16 kernel
-        # instead of the M=1-tuned arbitrary-K matmul (~56x faster at S>>1).
+        # FP8 block-128 GEMMs need K % 128 == 0; the ViT intermediate
+        # (4304) is not aligned, so fc1 (rows) / fc2 (cols) are zero-padded
+        # to the next multiple of 128. Padded fc1 rows/bias and fc2 columns
+        # are zero, so GELU(0)=0 keeps the pad inert and the result is
+        # unchanged.
         self.intermediate_padded = (
             (self.intermediate + 127) // 128) * 128
+
+        p = 'model.visual.'
+        # patch_embed (runs once, at layer 0) and the mergers (the output
+        # projection, on the massive-activation hidden) stay bf16: they are
+        # cheap and FP8 noise there is amplified through the whole tower.
+        # The per-block GEMMs (the compute bulk, 27x) run FP8.
+        self.patch_embed = _lin(
+            _w(p + 'patch_embed.proj.weight').reshape(self.hidden, -1),
+            _w(p + 'patch_embed.proj.bias'), fp8=False)
+        self.pos_embed = _w(p + 'pos_embed.weight')
+
+        # FP8 the bulk of the tower, but keep the first few blocks in bf16.
+        # The late layers grow a massive-activation channel that amplifies
+        # perturbations from the earliest blocks the most; protecting the
+        # first 3 blocks recovers image_embeds cosine from 0.86 (all-FP8)
+        # to 0.97 for ~+2 ms, vs 0.984 / +21 ms for the all-bf16 tower.
+        self.bf16_first_blocks = max(0, int(cfg.get('_bf16_first_blocks', 3)))
 
         self.blocks: list[dict] = []
         for i in range(self.depth):
             bp = f'{p}blocks.{i}.'
+            f8 = i >= self.bf16_first_blocks
             self.blocks.append({
                 'norm1_w': _w(bp + 'norm1.weight'),
                 'norm1_b': _w(bp + 'norm1.bias'),
                 'norm2_w': _w(bp + 'norm2.weight'),
                 'norm2_b': _w(bp + 'norm2.bias'),
-                'qkv_w': _w(bp + 'attn.qkv.weight'),
-                'qkv_b': _w(bp + 'attn.qkv.bias'),
-                'proj_w': _w(bp + 'attn.proj.weight'),
-                'proj_b': _w(bp + 'attn.proj.bias'),
-                'fc1_w': _pad_rows(_w(bp + 'mlp.linear_fc1.weight'),
-                                   self.intermediate_padded),
-                'fc1_b': _pad_rows(_w(bp + 'mlp.linear_fc1.bias'),
-                                   self.intermediate_padded),
-                'fc2_w': _pad_cols(_w(bp + 'mlp.linear_fc2.weight'),
-                                   self.intermediate_padded),
-                'fc2_b': _w(bp + 'mlp.linear_fc2.bias'),
+                'qkv': _lin(_w(bp + 'attn.qkv.weight'),
+                            _w(bp + 'attn.qkv.bias'), fp8=f8),
+                'proj': _lin(_w(bp + 'attn.proj.weight'),
+                             _w(bp + 'attn.proj.bias'), fp8=f8),
+                'fc1': _lin(
+                    _pad_rows(_w(bp + 'mlp.linear_fc1.weight'),
+                              self.intermediate_padded),
+                    _pad_rows(_w(bp + 'mlp.linear_fc1.bias'),
+                              self.intermediate_padded), fp8=f8),
+                'fc2': _lin(
+                    _pad_cols(_w(bp + 'mlp.linear_fc2.weight'),
+                              self.intermediate_padded),
+                    _w(bp + 'mlp.linear_fc2.bias'), fp8=f8),
             })
-        self.merger = _load_merger(_w, p + 'merger.')
+        self.merger = _load_merger(_w, _lin, p + 'merger.')
         self.deepstack_mergers = [
-            _load_merger(_w, f'{p}deepstack_merger_list.{k}.')
+            _load_merger(_w, _lin, f'{p}deepstack_merger_list.{k}.')
             for k in range(len(self.deepstack_indexes))
         ]
+        self.intermediate = self.intermediate_padded
 
     # ── kernel handles (lazy) ──
 
@@ -128,19 +156,35 @@ class Qwen3VlVisionRtx:
 
     # ── primitives ──
 
-    def _gemm(self, x, w, bias, M, N, K, stream):
+    def _gemm(self, x, lin, M, N, K, stream):
+        """y = x @ W.T + bias via FP8 block-128 (2× tensor-core vs bf16).
+
+        ``lin`` is a (weight_fp8, weight_block_scale, bias) tuple. The
+        bf16 activation is dynamically quantized to FP8 with per-token,
+        per-128-K-block scales; the GEMM accumulates in FP32 and emits
+        bf16. The massive-activation outlier lives in the bf16 residual
+        stream (added after the GEMM), so it is unaffected.
+        """
         import torch
+
         fvk = self._fvk
+        w8, ws, bias = lin
         y = torch.empty(M, N, dtype=torch.bfloat16, device=self.device)
-        if K % 128 == 0:
+        if w8 is None:                                  # bf16 path (w16a16)
             fvk.w16a16_gemm_sm120_bf16(
-                x.data_ptr(), w.data_ptr(), y.data_ptr(), M, N, K, 1.0, stream)
-        else:
-            # w16a16 requires K % 128 == 0; the arbitrary-K bf16 matmul
-            # also preserves accumulation precision on the ViT FFN
-            # (K=intermediate) massive-activation channels.
-            fvk.bf16_matmul_qwen36_bf16(
-                x.data_ptr(), w.data_ptr(), y.data_ptr(), M, N, K, stream)
+                x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K, 1.0,
+                stream)
+        else:                                           # FP8 block-128 W8A8
+            x_fp8 = torch.empty(
+                M, K, dtype=torch.float8_e4m3fn, device=self.device)
+            x_scale = torch.empty(
+                M, K // 128, dtype=torch.float32, device=self.device)
+            fvk.fp8_per_token_block128_quant_bf16(
+                x.data_ptr(), x_fp8.data_ptr(), x_scale.data_ptr(),
+                M, K, stream)
+            fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
+                x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                x_scale.data_ptr(), ws.data_ptr(), stream)
         if bias is not None:
             fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
@@ -167,10 +211,9 @@ class Qwen3VlVisionRtx:
                 xs, mg['norm_w'], mg['norm_b'], xs.shape[0], norm_dim, stream)
         M = xn.shape[0]
         din = self.hidden * merge
-        f1 = self._gemm(xn, mg['fc1_w'], mg['fc1_b'], M, din, din, stream)
+        f1 = self._gemm(xn, mg['fc1'], M, din, din, stream)
         self._fvk.gelu_inplace(f1.data_ptr(), M * din, stream)
-        return self._gemm(
-            f1, mg['fc2_w'], mg['fc2_b'], M, self.out_hidden, din, stream)
+        return self._gemm(f1, mg['fc2'], M, self.out_hidden, din, stream)
 
     # ── forward ──
 
@@ -202,8 +245,7 @@ class Qwen3VlVisionRtx:
         dev = self.device
 
         # patch embed + grid-interpolated learned pos embed.
-        h = self._gemm(pixel_values, self.patch_proj_w, self.patch_proj_b,
-                       S, H, K, stream)
+        h = self._gemm(pixel_values, self.patch_embed, S, H, K, stream)
         fvk.residual_add(h.data_ptr(), pos_embeds.data_ptr(), S * H, stream)
 
         q = torch.empty(S, H, dtype=bf16, device=dev)
@@ -216,8 +258,7 @@ class Qwen3VlVisionRtx:
         for i, blk in enumerate(self.blocks):
             xn = self._layer_norm(
                 h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
-            qkv = self._gemm(
-                xn, blk['qkv_w'], blk['qkv_b'], S, 3 * H, H, stream)
+            qkv = self._gemm(xn, blk['qkv'], S, 3 * H, H, stream)
             fvk.qkv_split(qkv.data_ptr(), q.data_ptr(), k.data_ptr(),
                           v.data_ptr(), S, H, H, H, stream)
             vlk.rope_neox_qk_bf16(
@@ -238,18 +279,15 @@ class Qwen3VlVisionRtx:
                 v_strides=(vv.stride(0), vv.stride(1), vv.stride(2)),
                 o_strides=(o.stride(0), o.stride(1), o.stride(2)),
                 softmax_scale=scale, num_sms=self._num_sms, stream=stream)
-            attn = self._gemm(o.view(S, H), blk['proj_w'], blk['proj_b'],
-                              S, H, H, stream)
+            attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream)
             fvk.residual_add(h.data_ptr(), attn.data_ptr(), S * H, stream)
 
             xn2 = self._layer_norm(
                 h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
-            inter = blk['fc1_w'].shape[0]
-            f1 = self._gemm(
-                xn2, blk['fc1_w'], blk['fc1_b'], S, inter, H, stream)
+            inter = self.intermediate
+            f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream)
             fvk.gelu_inplace(f1.data_ptr(), S * inter, stream)
-            f2 = self._gemm(
-                f1, blk['fc2_w'], blk['fc2_b'], S, H, inter, stream)
+            f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream)
             fvk.residual_add(h.data_ptr(), f2.data_ptr(), S * H, stream)
 
             if i in self.deepstack_indexes:
@@ -261,14 +299,10 @@ class Qwen3VlVisionRtx:
         return image_embeds, deepstack
 
     def forward_graph(self, pixel_values, pos_embeds, rope_cos, rope_sin):
-        """CUDA-Graph-accelerated ``forward``.
+        """CUDA-Graph replay of ``forward`` (one graph per patch count).
 
-        The tower is launch-bound (hundreds of small kernels), so a
-        captured graph removes nearly all launch overhead. One graph per
-        distinct patch count; inputs are staged into fixed buffers and
-        the graph is replayed. Returns the captured output tensors (valid
-        until the next replay at the same patch count) — clone if the
-        caller needs to keep them across calls.
+        Inputs are staged into fixed buffers; returns the captured output
+        tensors (valid until the next replay at the same patch count).
         """
         import torch
 
@@ -307,6 +341,21 @@ class Qwen3VlVisionRtx:
         return out
 
 
+def _quant_fp8_block128(w):
+    """Quantize a (N, K) bf16 weight to FP8 e4m3 with per-128x128-block
+    descales. N and K must be multiples of 128. Returns (w_fp8 (N, K),
+    block_scale (N/128, K/128) fp32), matching the convention of
+    ``fp8_block128_gemm_cutlass_sm120_bf16out``."""
+    import torch
+    N, K = w.shape
+    wv = w.float().view(N // 128, 128, K // 128, 128)
+    amax = wv.abs().amax(dim=(1, 3))
+    scale = (amax / 448.0).clamp_min(1e-12)
+    wq = (wv / scale[:, None, :, None]).clamp(-448.0, 448.0)
+    wq = wq.to(torch.float8_e4m3fn).view(N, K).contiguous()
+    return wq, scale.float().contiguous()
+
+
 def _pad_rows(t, n_rows: int):
     import torch
     if t.shape[0] >= n_rows:
@@ -325,14 +374,14 @@ def _pad_cols(t, n_cols: int):
     return torch.cat([t, pad], dim=-1).contiguous()
 
 
-def _load_merger(load_fn, prefix: str) -> dict:
+def _load_merger(load_fn, lin_fn, prefix: str) -> dict:
     return {
         'norm_w': load_fn(prefix + 'norm.weight'),
         'norm_b': load_fn(prefix + 'norm.bias'),
-        'fc1_w': load_fn(prefix + 'linear_fc1.weight'),
-        'fc1_b': load_fn(prefix + 'linear_fc1.bias'),
-        'fc2_w': load_fn(prefix + 'linear_fc2.weight'),
-        'fc2_b': load_fn(prefix + 'linear_fc2.bias'),
+        'fc1': lin_fn(load_fn(prefix + 'linear_fc1.weight'),
+                      load_fn(prefix + 'linear_fc1.bias'), fp8=False),
+        'fc2': lin_fn(load_fn(prefix + 'linear_fc2.weight'),
+                      load_fn(prefix + 'linear_fc2.bias'), fp8=False),
     }
 
 

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -35,7 +35,7 @@ class Qwen3VlTorchFrontendRtx:
     """
 
     def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
-                 max_seq: int = 4096) -> None:
+                 max_seq: int = 4096, max_pixels: int | None = None) -> None:
         from transformers import AutoProcessor
 
         from flash_rt.frontends.torch._qwen3_vl_vision_rtx import (
@@ -72,6 +72,18 @@ class Qwen3VlTorchFrontendRtx:
             max_q_seq=max_seq)
         self.vision = Qwen3VlVisionRtx(checkpoint_path, device=device)
         self.processor = AutoProcessor.from_pretrained(checkpoint_path)
+        # Optional resolution cap. The patch count (≈ pixels / patch_size^2)
+        # sets both the ViT cost and the number of vision tokens the LLM
+        # prefills, so it is the dominant TTFT knob; capping it triggers the
+        # processor's smart_resize (rounds to the patch grid). None keeps the
+        # checkpoint default (full resolution).
+        self.max_pixels = max_pixels
+        if max_pixels is not None:
+            for proc in (getattr(self.processor, 'image_processor', None),
+                         getattr(self.processor, 'video_processor', None)):
+                size = getattr(proc, 'size', None)
+                if isinstance(size, dict) and 'longest_edge' in size:
+                    size['longest_edge'] = int(max_pixels)
 
         self._prompt: dict[str, Any] | None = None
         # cache-slot -> captured decode CUDA Graph (rope baked at the

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -50,6 +50,7 @@ class Qwen3VlTorchFrontendRtx:
         cfg = json.load(
             open(os.path.join(checkpoint_path, 'config.json')))
         self._image_token_id = int(cfg['image_token_id'])
+        self._video_token_id = int(cfg['video_token_id'])
         self._vision_start_token_id = int(cfg['vision_start_token_id'])
         vc = cfg['vision_config']
         self._merge = int(vc['spatial_merge_size'])
@@ -90,51 +91,88 @@ class Qwen3VlTorchFrontendRtx:
             messages, add_generation_prompt=True, tokenize=True,
             return_dict=True, return_tensors='pt').to(self.device)
         input_ids = inputs['input_ids'][0]
-        grid = inputs['image_grid_thw']
-        pixel_values = inputs['pixel_values'].to(torch.bfloat16)
         S = int(input_ids.shape[0])
         if S > self.max_seq:
             raise ValueError(
                 f'prompt length {S} exceeds max_seq {self.max_seq}')
 
-        # Image-token spans, one contiguous run per image (multi-image:
-        # the runs appear in image order, matching the grid rows and the
-        # concatenated pixel_values / vision tables).
-        mask = (input_ids == self._image_token_id).cpu().tolist()
+        m = self._merge
+        image_grid = inputs.get('image_grid_thw')
+        video_grid = inputs.get('video_grid_thw')
+        pix_img = inputs.get('pixel_values')
+        pix_vid = inputs.get('pixel_values_videos')
+        if pix_img is not None:
+            pix_img = pix_img.to(torch.bfloat16)
+        if pix_vid is not None:
+            pix_vid = pix_vid.to(torch.bfloat16)
+        # Videos are split into per-frame rows (t -> 1) so each frame is a
+        # vision segment encoded like an image; the inter-frame timestamp
+        # text tokens carry the temporal position (HF get_rope_index).
+        if video_grid is not None and len(video_grid):
+            vg = torch.repeat_interleave(
+                video_grid, video_grid[:, 0], dim=0).clone()
+            vg[:, 0] = 1
+        else:
+            vg = None
+
+        # Walk the vision token runs in sequence order; each run is one
+        # segment (image, or one video frame), consuming the matching grid
+        # row and patch slice. Images and videos may interleave.
+        ids = input_ids.tolist()
+        seg_pix: list = []
+        seg_grids: list = []
         spans: list[tuple[int, int]] = []
+        seg_patches: list[int] = []
+        im = vi = off_img = off_vid = 0
         i = 0
         while i < S:
-            if mask[i]:
-                j = i
-                while j < S and mask[j]:
-                    j += 1
-                spans.append((i, j))
-                i = j
-            else:
+            tok = ids[i]
+            if tok not in (self._image_token_id, self._video_token_id):
                 i += 1
-        # Patches fed to the ViT per image (t*h*w) and the merged-token span
-        # length (t*(h/m)*(w/m)) it produces; they must line up with spans.
-        m = self._merge
-        seg_patches = [int(t * h * w) for t, h, w in grid.tolist()]
-        for (a, b), (t, h, w) in zip(spans, grid.tolist()):
-            assert b - a == int(t) * (int(h) // m) * (int(w) // m), (
-                'image-token span does not match its grid')
+                continue
+            j = i
+            while j < S and ids[j] == tok:
+                j += 1
+            if tok == self._image_token_id:
+                t, h, w = (int(x) for x in image_grid[im])
+                im += 1
+                npp = t * h * w
+                seg_pix.append(pix_img[off_img:off_img + npp])
+                off_img += npp
+            else:
+                t, h, w = (int(x) for x in vg[vi])
+                vi += 1
+                npp = t * h * w
+                seg_pix.append(pix_vid[off_vid:off_vid + npp])
+                off_vid += npp
+            assert j - i == t * (h // m) * (w // m), (
+                'vision-token span does not match its grid')
+            seg_grids.append((t, h, w))
+            spans.append((i, j))
+            seg_patches.append(npp)
+            i = j
+
+        seg_grid = torch.tensor(seg_grids, dtype=torch.long)
+        pixel_values = torch.cat(seg_pix, dim=0).contiguous()
 
         pos_ids = geo.mrope_position_ids(
-            input_ids.cpu(), grid.cpu(),
+            input_ids.cpu(),
+            image_grid.cpu() if image_grid is not None else None,
+            video_grid.cpu() if video_grid is not None else None,
             image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
             vision_start_token_id=self._vision_start_token_id,
-            spatial_merge_size=self._merge)
+            spatial_merge_size=m)
         mcos, msin = geo.mrope_cos_sin(
             pos_ids, head_dim=self._head_dim, rope_theta=self._rope_theta,
             mrope_section=self._mrope_section, device=self.device)
         vcos, vsin = geo.vision_rope_cos_sin(
-            grid.cpu(), head_dim=self._vis_head_dim,
-            spatial_merge_size=self._merge, device=self.device)
+            seg_grid, head_dim=self._vis_head_dim,
+            spatial_merge_size=m, device=self.device)
         pos_embeds = geo.vision_pos_embeds(
-            grid.cpu(), self.vision.pos_embed,
+            seg_grid, self.vision.pos_embed,
             num_grid_per_side=self._num_grid_per_side,
-            spatial_merge_size=self._merge, device=self.device)
+            spatial_merge_size=m, device=self.device)
 
         self._prompt = {
             'input_ids': input_ids, 'pixel_values': pixel_values,

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -73,6 +73,9 @@ class Qwen3VlTorchFrontendRtx:
         self.processor = AutoProcessor.from_pretrained(checkpoint_path)
 
         self._prompt: dict[str, Any] | None = None
+        # cache-slot -> captured decode CUDA Graph (rope baked at the
+        # MRoPE-continuation position, which differs from the slot).
+        self._decode_graphs: dict[int, Any] = {}
 
     # ── Prompt ──
 
@@ -186,29 +189,75 @@ class Qwen3VlTorchFrontendRtx:
         torch.cuda.synchronize()
         return logits
 
-    def generate(self, messages: list, *, max_new_tokens: int = 256) -> str:
+    def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
+        """Lazy-capture a decode CUDA Graph for one cache slot.
+
+        Mirrors ``qwen3_rtx._ensure_decode_graph`` but bakes the RoPE
+        slice at ``rope_pos`` (the MRoPE continuation position) rather
+        than the cache slot. Reuses the language core's static token
+        buffer, capture stream and decode kernels.
+        """
+        import torch
+
+        llm = self.llm
+        g = self._decode_graphs.get(cache_pos)
+        if g is not None:
+            return g
+        cos, sin = llm._rope_cos_sin(rope_pos)
+        gs = llm._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.no_grad():
+            for _ in range(2):
+                llm.forward_own_decode_nvfp4(
+                    llm._static_token_id, cos, sin, cache_pos)
+        gs.synchronize()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g, stream=gs), torch.no_grad():
+            llm.forward_own_decode_nvfp4(
+                llm._static_token_id, cos, sin, cache_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._decode_graphs[cache_pos] = g
+        return g
+
+    def warmup_decode_graphs(self, n_tokens: int) -> None:
+        """Pre-capture decode graphs for the current prompt's next
+        ``n_tokens`` steps so generation replays warm graphs."""
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before warmup')
+        p = self._prompt
+        for i in range(n_tokens):
+            self._ensure_decode_graph(p['S'] + i, p['mrope_max'] + 1 + i)
+
+    def generate(self, messages: list, *, max_new_tokens: int = 256,
+                 use_graph: bool = True) -> str:
         """Greedy multimodal generation. Returns the decoded text.
 
         Runs the multimodal prefill (which fills the KV cache), then the
         reused Qwen3 NVFP4 decode loop. After the image the MRoPE position
-        is scalar, so the decode RoPE position simply continues from the
-        prompt's max position while the KV-cache slot advances from the
-        (image-compressed) prompt length.
+        is scalar, so the decode RoPE position continues from the prompt's
+        max position while the KV-cache slot advances from the
+        image-compressed prompt length. ``use_graph`` replays a per-slot
+        captured CUDA Graph for each decode step.
         """
         self.set_prompt(messages)
         logits = self.prefill()
-        p = self._prompt
         llm = self.llm
-        cache_pos = p['S']
-        rope_pos = p['mrope_max'] + 1
+        p = self._prompt
+        base_slot, base_rope = p['S'], p['mrope_max'] + 1
 
         tok = int(logits[0].float().argmax())
         out_ids = [tok]
         for i in range(max_new_tokens - 1):
             if tok in self._eos_token_ids:
                 break
-            cos, sin = llm._rope_cos_sin(rope_pos + i)
-            logits = llm.forward_own_decode_nvfp4(tok, cos, sin, cache_pos + i)
+            if use_graph:
+                logits = self._decode_step_graph(
+                    tok, base_slot + i, base_rope + i)
+            else:
+                cos, sin = llm._rope_cos_sin(base_rope + i)
+                logits = llm.forward_own_decode_nvfp4(
+                    tok, cos, sin, base_slot + i)
             tok = int(logits[0].float().argmax())
             out_ids.append(tok)
 
@@ -217,3 +266,9 @@ class Qwen3VlTorchFrontendRtx:
             out_ids = out_ids[:out_ids.index(eos[0])]
         return self.processor.tokenizer.decode(
             out_ids, skip_special_tokens=True)
+
+    def _decode_step_graph(self, token: int, cache_pos: int, rope_pos: int):
+        llm = self.llm
+        llm._static_token_id.fill_(int(token))
+        self._ensure_decode_graph(cache_pos, rope_pos).replay()
+        return llm._logits_buf[:1]

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -24,6 +24,37 @@ import json
 import os
 from typing import Any
 
+# Functions the Qwen3-VL ViT tower needs from the separate, opt-in
+# ``flash_rt_qwen3_vl_kernels`` module (CMake ``-DFLASHRT_BUILD_QWEN3_VL=ON``).
+_QWEN3_VL_KERNEL_FNS = (
+    'rope_neox_qk_bf16',
+    'layer_norm_to_fp8_block128_bf16',
+    'gelu_tanh_to_fp8_block128_bf16',
+)
+
+
+def _check_qwen3_vl_kernels(module) -> None:
+    """Raise a clear error if the Qwen3-VL kernel module is incomplete."""
+    missing = [fn for fn in _QWEN3_VL_KERNEL_FNS if not hasattr(module, fn)]
+    if missing:
+        raise RuntimeError(
+            'flash_rt_qwen3_vl_kernels is missing ' + ', '.join(missing)
+            + '. Rebuild it with -DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=120).')
+
+
+def _require_qwen3_vl_kernels():
+    """Import + validate the Qwen3-VL kernel module up front (fail-fast),
+    before any weights are loaded. Returns the module."""
+    try:
+        from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+    except ImportError as e:
+        raise RuntimeError(
+            'flash_rt_qwen3_vl_kernels is not built. Configure with '
+            '-DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=120) and build the '
+            'flash_rt_qwen3_vl_kernels target.') from e
+    _check_qwen3_vl_kernels(vlk)
+    return vlk
+
 
 class Qwen3VlTorchFrontendRtx:
     """Qwen3-VL-8B-class multimodal inference frontend (RTX SM120, NVFP4).
@@ -46,6 +77,10 @@ class Qwen3VlTorchFrontendRtx:
         self.checkpoint_path = str(checkpoint_path)
         self.device = device
         self.max_seq = int(max_seq)
+
+        # Fail fast if the opt-in kernel module is missing, before loading
+        # the (large) language and vision weights.
+        _require_qwen3_vl_kernels()
 
         cfg = json.load(
             open(os.path.join(checkpoint_path, 'config.json')))
@@ -120,49 +155,28 @@ class Qwen3VlTorchFrontendRtx:
         # Videos are split into per-frame rows (t -> 1) so each frame is a
         # vision segment encoded like an image; the inter-frame timestamp
         # text tokens carry the temporal position (HF get_rope_index).
-        if video_grid is not None and len(video_grid):
-            vg = torch.repeat_interleave(
-                video_grid, video_grid[:, 0], dim=0).clone()
-            vg[:, 0] = 1
-        else:
-            vg = None
-
-        # Walk the vision token runs in sequence order; each run is one
-        # segment (image, or one video frame), consuming the matching grid
-        # row and patch slice. Images and videos may interleave.
-        ids = input_ids.tolist()
+        # Walk the image/video token runs (sequence order; videos split per
+        # frame). Raises ValueError for a text-only prompt or a grid mismatch.
+        segs = geo.vision_segments(
+            input_ids.cpu(), image_grid, video_grid,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id, spatial_merge_size=m)
         seg_pix: list = []
         seg_grids: list = []
         spans: list[tuple[int, int]] = []
         seg_patches: list[int] = []
-        im = vi = off_img = off_vid = 0
-        i = 0
-        while i < S:
-            tok = ids[i]
-            if tok not in (self._image_token_id, self._video_token_id):
-                i += 1
-                continue
-            j = i
-            while j < S and ids[j] == tok:
-                j += 1
-            if tok == self._image_token_id:
-                t, h, w = (int(x) for x in image_grid[im])
-                im += 1
-                npp = t * h * w
+        off_img = off_vid = 0
+        for sg in segs:
+            npp = sg['patches']
+            if sg['kind'] == 'image':
                 seg_pix.append(pix_img[off_img:off_img + npp])
                 off_img += npp
             else:
-                t, h, w = (int(x) for x in vg[vi])
-                vi += 1
-                npp = t * h * w
                 seg_pix.append(pix_vid[off_vid:off_vid + npp])
                 off_vid += npp
-            assert j - i == t * (h // m) * (w // m), (
-                'vision-token span does not match its grid')
-            seg_grids.append((t, h, w))
-            spans.append((i, j))
+            seg_grids.append(sg['grid'])
+            spans.append(sg['span'])
             seg_patches.append(npp)
-            i = j
 
         seg_grid = torch.tensor(seg_grids, dtype=torch.long)
         pixel_values = torch.cat(seg_pix, dim=0).contiguous()

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -134,9 +134,13 @@ class Qwen3VlTorchFrontendRtx:
 
         from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
 
+        # device=self.device runs the fast image processor's resize /
+        # normalize / patchify on the GPU (~10x over the CPU path), so the
+        # whole preprocess is off the CPU.
         inputs = self.processor.apply_chat_template(
             messages, add_generation_prompt=True, tokenize=True,
-            return_dict=True, return_tensors='pt').to(self.device)
+            return_dict=True, return_tensors='pt',
+            device=self.device).to(self.device)
         input_ids = inputs['input_ids'][0]
         S = int(input_ids.shape[0])
         if S > self.max_seq:

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -59,6 +59,11 @@ class Qwen3VlTorchFrontendRtx:
         self._rope_theta = float(cfg['rope_theta'])
         self._head_dim = int(cfg['head_dim'])
         self._mrope_section = tuple(cfg['rope_scaling']['mrope_section'])
+        eos = cfg.get('eos_token_id')
+        if eos is None:
+            self._eos_token_ids: set = set()
+        else:
+            self._eos_token_ids = set(eos if isinstance(eos, list) else [eos])
 
         # Language core (reused unchanged) + ViT tower.
         self.llm = Qwen3TorchFrontendRtx(
@@ -116,6 +121,7 @@ class Qwen3VlTorchFrontendRtx:
             'img_start': img_start, 'img_end': img_end,
             'mcos': mcos, 'msin': msin, 'vcos': vcos, 'vsin': vsin,
             'pos_embeds': pos_embeds, 'S': S,
+            'mrope_max': int(pos_ids.max()),
         }
 
     # ── Forward ──
@@ -135,6 +141,7 @@ class Qwen3VlTorchFrontendRtx:
             raise RuntimeError('call set_prompt() before prefill()')
         p = self._prompt
         llm = self.llm
+        llm.reset_state()
         stream = torch.cuda.current_stream().cuda_stream
         hidden = llm._cfg['hidden_size']
         vocab = llm._cfg['vocab_size']
@@ -178,3 +185,35 @@ class Qwen3VlTorchFrontendRtx:
             logits.data_ptr(), 1, vocab, hidden, stream)
         torch.cuda.synchronize()
         return logits
+
+    def generate(self, messages: list, *, max_new_tokens: int = 256) -> str:
+        """Greedy multimodal generation. Returns the decoded text.
+
+        Runs the multimodal prefill (which fills the KV cache), then the
+        reused Qwen3 NVFP4 decode loop. After the image the MRoPE position
+        is scalar, so the decode RoPE position simply continues from the
+        prompt's max position while the KV-cache slot advances from the
+        (image-compressed) prompt length.
+        """
+        self.set_prompt(messages)
+        logits = self.prefill()
+        p = self._prompt
+        llm = self.llm
+        cache_pos = p['S']
+        rope_pos = p['mrope_max'] + 1
+
+        tok = int(logits[0].float().argmax())
+        out_ids = [tok]
+        for i in range(max_new_tokens - 1):
+            if tok in self._eos_token_ids:
+                break
+            cos, sin = llm._rope_cos_sin(rope_pos + i)
+            logits = llm.forward_own_decode_nvfp4(tok, cos, sin, cache_pos + i)
+            tok = int(logits[0].float().argmax())
+            out_ids.append(tok)
+
+        eos = [t for t in out_ids if t in self._eos_token_ids]
+        if eos:
+            out_ids = out_ids[:out_ids.index(eos[0])]
+        return self.processor.tokenizer.decode(
+            out_ids, skip_special_tokens=True)

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -280,6 +280,137 @@ class Qwen3VlTorchFrontendRtx:
         torch.cuda.synchronize()
         return logits
 
+    # ── Prefill via a captured CUDA Graph (single image) ──
+
+    def _prefill_graph_body(self, st, P, S, a, b):
+        """Capture body: embed gather -> ViT tower -> scatter image features
+        -> NVFP4 decoder layers with DeepStack inject -> final RMSNorm into
+        ``self._pg_last_hidden[:S]``. No lm_head (run eager post-replay so one
+        graph serves all real_S <= bucket). All torch glue (gather/scatter/
+        clone/copy) traces into the graph, so replay is pure-kernel.
+
+        ``st`` is the dict of static input buffers; the graph reads only from
+        them. Mirrors the eager ``prefill`` single-image path exactly so
+        captured and eager hidden state match bit-for-bit.
+        """
+        import torch
+        from flash_rt import flash_rt_kernels as fvk
+
+        llm = self.llm
+        bf16 = torch.bfloat16
+        stream = torch.cuda.current_stream().cuda_stream
+        hidden = llm._cfg['hidden_size']
+        eps = float(llm._cfg['rms_norm_eps'])
+        n_layers = llm._cfg['num_hidden_layers']
+
+        emb, ds = self.vision.forward(
+            st['pixel'], st['pos'], st['vcos'], st['vsin'])
+        h = llm._weights.anchors[0][st['ids']].to(bf16).view(1, S, hidden)
+        h = h.contiguous()
+        h[0, a:b] = emb.to(bf16)
+
+        cur = h
+        for layer in range(n_layers):
+            cur = llm._layer_forward_full_nvfp4_prefill(
+                layer, cur, st['mcos'], st['msin'], 0, S)
+            if layer < self._deepstack_layers:
+                cur = cur.clone()
+                fvk.residual_add(
+                    cur[0, a:b].data_ptr(),
+                    ds[layer].to(bf16).data_ptr(), (b - a) * hidden, stream)
+                cur = cur.contiguous()
+
+        h2 = cur.view(S, hidden).contiguous()
+        fvk.rms_norm(
+            h2.data_ptr(), int(llm._weights.ptrs['final_norm_w']),
+            self._pg_last_hidden[:S].data_ptr(), S, hidden, eps, stream)
+
+    def _capture_prefill_graph(self, st, P, S, a, b):
+        """2-iter warmup then capture the prefill body for one (P,S,a) bucket.
+        Mirrors qwen3_rtx._ensure_prefill_graph (inference_mode + capture
+        stream)."""
+        import torch
+
+        llm = self.llm
+        gs = llm._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        # no_grad (not inference_mode) to match the ViT forward_graph and the
+        # decode-graph capture this composes with; inference_mode flags the
+        # ViT's per-call scratch as inference tensors and trips capture_begin.
+        with torch.cuda.stream(gs), torch.no_grad():
+            for _ in range(2):
+                self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.no_grad():
+            self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        return graph
+
+    def prefill_graph(self):
+        """Pure-kernel prefill via a captured CUDA Graph (single image).
+
+        Falls back to the eager ``prefill`` for multi-image / video (variable
+        segment structure is not graph-capturable). Returns ``(1, vocab)``
+        bf16 next-token logits.
+        """
+        import torch
+        from flash_rt import flash_rt_kernels as fvk
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill_graph()')
+        p = self._prompt
+        if len(p['spans']) != 1:
+            return self.prefill()
+
+        llm = self.llm
+        hidden = llm._cfg['hidden_size']
+        vocab = llm._cfg['vocab_size']
+        S = p['S']
+        P = p['seg_patches'][0]
+        a, b = p['spans'][0]
+        key = (P, S, a, b)
+        llm.reset_state()
+
+        if not hasattr(self, '_pg_last_hidden'):
+            self._pg_last_hidden = torch.empty(
+                self.max_seq, hidden, dtype=torch.bfloat16, device=self.device)
+            self._prefill_graphs: dict = {}
+
+        entry = self._prefill_graphs.get(key)
+        if entry is None:
+            st = {
+                'ids': p['input_ids'].clone(),
+                'pixel': p['pixel_values'].clone(),
+                'pos': p['pos_embeds'].clone(),
+                'vcos': p['vcos'].clone(), 'vsin': p['vsin'].clone(),
+                'mcos': p['mcos'].clone(), 'msin': p['msin'].clone(),
+            }
+            graph = self._capture_prefill_graph(st, P, S, a, b)
+            entry = (graph, st)
+            self._prefill_graphs[key] = entry
+        graph, st = entry
+
+        st['ids'].copy_(p['input_ids'])
+        st['pixel'].copy_(p['pixel_values'])
+        st['pos'].copy_(p['pos_embeds'])
+        st['vcos'].copy_(p['vcos'])
+        st['vsin'].copy_(p['vsin'])
+        st['mcos'].copy_(p['mcos'])
+        st['msin'].copy_(p['msin'])
+        graph.replay()
+
+        stream = torch.cuda.current_stream().cuda_stream
+        last = self._pg_last_hidden[S - 1:S].contiguous()
+        logits = torch.empty(
+            1, vocab, dtype=torch.bfloat16, device=self.device)
+        fvk.bf16_matmul_qwen36_bf16(
+            last.data_ptr(), int(llm._weights.ptrs['lm_head_w']),
+            logits.data_ptr(), 1, vocab, hidden, stream)
+        torch.cuda.synchronize()
+        return logits
+
     def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
         """Lazy-capture a decode CUDA Graph for one cache slot.
 
@@ -332,7 +463,7 @@ class Qwen3VlTorchFrontendRtx:
         captured CUDA Graph for each decode step.
         """
         self.set_prompt(messages)
-        logits = self.prefill()
+        logits = self.prefill_graph()
         llm = self.llm
         p = self._prompt
         base_slot, base_rope = p['S'], p['mrope_max'] + 1

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -124,6 +124,18 @@ class Qwen3VlTorchFrontendRtx:
         # cache-slot -> captured decode CUDA Graph (rope baked at the
         # MRoPE-continuation position, which differs from the slot).
         self._decode_graphs: dict[int, Any] = {}
+        # Captured single-image prefill: (P,S,a,b) -> graph, plus the static
+        # input buffers set_prompt stages into and the persistent output
+        # buffers the replay + eager lm_head write.
+        self._prefill_graphs: dict = {}
+        self._pg_buffers: dict = {}
+        import torch as _torch
+        hidden = self.llm._cfg['hidden_size']
+        vocab = self.llm._cfg['vocab_size']
+        self._pg_last_hidden = _torch.empty(
+            self.max_seq, hidden, dtype=_torch.bfloat16, device=device)
+        self._pg_logits = _torch.empty(
+            1, vocab, dtype=_torch.bfloat16, device=device)
 
     # ── Prompt ──
 
@@ -212,6 +224,30 @@ class Qwen3VlTorchFrontendRtx:
             'pos_embeds': pos_embeds, 'S': S,
             'mrope_max': int(pos_ids.max()),
         }
+        # Single image: stage the captured-prefill static inputs here (this is
+        # one-time set-up glue), so prefill_graph's hot path is just replay +
+        # lm_head with no per-request torch copy.
+        if len(spans) == 1:
+            self._prompt['pg_key'] = self._stage_prefill_inputs(
+                seg_patches[0], S, spans[0])
+
+    _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
+                'vcos', 'vsin', 'mcos', 'msin')
+
+    def _stage_prefill_inputs(self, P: int, S: int, span):
+        """Copy the per-prompt tensors into persistent static buffers keyed by
+        (P, S, a, b). The captured prefill graph reads only from these, so the
+        replay path needs no torch copy. Returns the key."""
+        p = self._prompt
+        key = (P, S, span[0], span[1])
+        bufs = self._pg_buffers.get(key)
+        if bufs is None:
+            bufs = {k: p[k].clone() for k in self._PG_KEYS}
+            self._pg_buffers[key] = bufs
+        else:
+            for k in self._PG_KEYS:
+                bufs[k].copy_(p[k])
+        return key
 
     # ── Forward ──
 
@@ -308,8 +344,9 @@ class Qwen3VlTorchFrontendRtx:
         n_layers = llm._cfg['num_hidden_layers']
 
         emb, ds = self.vision.forward(
-            st['pixel'], st['pos'], st['vcos'], st['vsin'])
-        h = llm._weights.anchors[0][st['ids']].to(bf16).view(1, S, hidden)
+            st['pixel_values'], st['pos_embeds'], st['vcos'], st['vsin'])
+        h = llm._weights.anchors[0][st['input_ids']].to(bf16).view(
+            1, S, hidden)
         h = h.contiguous()
         h[0, a:b] = emb.to(bf16)
 
@@ -365,55 +402,35 @@ class Qwen3VlTorchFrontendRtx:
         if self._prompt is None:
             raise RuntimeError('call set_prompt() before prefill_graph()')
         p = self._prompt
-        if len(p['spans']) != 1:
+        if p.get('pg_key') is None:           # multi-image / video: eager
             return self.prefill()
 
         llm = self.llm
         hidden = llm._cfg['hidden_size']
         vocab = llm._cfg['vocab_size']
         S = p['S']
-        P = p['seg_patches'][0]
-        a, b = p['spans'][0]
-        key = (P, S, a, b)
-        llm.reset_state()
+        key = p['pg_key']
+        P, _, a, b = key
+        st = self._pg_buffers[key]            # already staged by set_prompt
+        # No reset_state: the captured layers write K/V[0:S] (which is all the
+        # causal prefill reads), and the subsequent decode overwrites
+        # K/V[>=S] before reading it (same as qwen3_rtx.prefill_with_graph).
 
-        if not hasattr(self, '_pg_last_hidden'):
-            self._pg_last_hidden = torch.empty(
-                self.max_seq, hidden, dtype=torch.bfloat16, device=self.device)
-            self._prefill_graphs: dict = {}
-
-        entry = self._prefill_graphs.get(key)
-        if entry is None:
-            st = {
-                'ids': p['input_ids'].clone(),
-                'pixel': p['pixel_values'].clone(),
-                'pos': p['pos_embeds'].clone(),
-                'vcos': p['vcos'].clone(), 'vsin': p['vsin'].clone(),
-                'mcos': p['mcos'].clone(), 'msin': p['msin'].clone(),
-            }
+        graph = self._prefill_graphs.get(key)
+        if graph is None:
             graph = self._capture_prefill_graph(st, P, S, a, b)
-            entry = (graph, st)
-            self._prefill_graphs[key] = entry
-        graph, st = entry
+            self._prefill_graphs[key] = graph
 
-        st['ids'].copy_(p['input_ids'])
-        st['pixel'].copy_(p['pixel_values'])
-        st['pos'].copy_(p['pos_embeds'])
-        st['vcos'].copy_(p['vcos'])
-        st['vsin'].copy_(p['vsin'])
-        st['mcos'].copy_(p['mcos'])
-        st['msin'].copy_(p['msin'])
+        # Hot path: pure-kernel graph replay + eager lm_head (one buffer, no
+        # per-request torch alloc/copy).
         graph.replay()
-
         stream = torch.cuda.current_stream().cuda_stream
         last = self._pg_last_hidden[S - 1:S].contiguous()
-        logits = torch.empty(
-            1, vocab, dtype=torch.bfloat16, device=self.device)
         fvk.bf16_matmul_qwen36_bf16(
             last.data_ptr(), int(llm._weights.ptrs['lm_head_w']),
-            logits.data_ptr(), 1, vocab, hidden, stream)
+            self._pg_logits.data_ptr(), 1, vocab, hidden, stream)
         torch.cuda.synchronize()
-        return logits
+        return self._pg_logits
 
     def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
         """Lazy-capture a decode CUDA Graph for one cache slot.

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -1,0 +1,180 @@
+"""FlashRT — PyTorch frontend for Qwen3-VL (multimodal) on RTX SM120.
+
+Class name ``Qwen3VlTorchFrontendRtx`` follows the
+``docs/adding_new_model.md`` §0 naming rule, and the direct-instantiation
+pattern of the text sibling ``qwen3_rtx.Qwen3TorchFrontendRtx`` (the
+Qwen3 LLM paths are not registered in ``_PIPELINE_MAP``; a server or test
+constructs the frontend directly).
+
+The language stack is the existing dense-Qwen3 NVFP4 W4A4 path, reused
+unchanged via ``Qwen3TorchFrontendRtx``; this frontend adds the ViT
+tower (``_qwen3_vl_vision_rtx``), the multimodal image-feature scatter,
+DeepStack injection into the first decoder layers, and interleaved-MRoPE.
+The checkpoint is the self-contained directory produced by
+``tools/quantize_qwen3_vl_nvfp4.py`` (NVFP4 language linears + BF16 vision
+tower + combined config).
+
+Per-prompt geometry (position ids, MRoPE / vision-RoPE tables, the
+interpolated vision position embedding) is precomputed in ``set_prompt``
+by ``_qwen3_vl_geometry``; the forward itself runs only kernels.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+class Qwen3VlTorchFrontendRtx:
+    """Qwen3-VL-8B-class multimodal inference frontend (RTX SM120, NVFP4).
+
+    Public surface:
+      __init__(checkpoint_path, *, device='cuda:0', max_seq=4096)
+      set_prompt(messages)   -- preprocess image+text, build geometry
+      prefill()              -- multimodal prefill, returns next-token logits
+    """
+
+    def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
+                 max_seq: int = 4096) -> None:
+        from transformers import AutoProcessor
+
+        from flash_rt.frontends.torch._qwen3_vl_vision_rtx import (
+            Qwen3VlVisionRtx,
+        )
+        from flash_rt.frontends.torch.qwen3_rtx import Qwen3TorchFrontendRtx
+
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+
+        cfg = json.load(
+            open(os.path.join(checkpoint_path, 'config.json')))
+        self._image_token_id = int(cfg['image_token_id'])
+        self._vision_start_token_id = int(cfg['vision_start_token_id'])
+        vc = cfg['vision_config']
+        self._merge = int(vc['spatial_merge_size'])
+        self._vis_head_dim = vc['hidden_size'] // vc['num_heads']
+        self._num_grid_per_side = int(vc['num_position_embeddings'] ** 0.5)
+        self._deepstack_layers = len(vc['deepstack_visual_indexes'])
+        self._rope_theta = float(cfg['rope_theta'])
+        self._head_dim = int(cfg['head_dim'])
+        self._mrope_section = tuple(cfg['rope_scaling']['mrope_section'])
+
+        # Language core (reused unchanged) + ViT tower.
+        self.llm = Qwen3TorchFrontendRtx(
+            checkpoint_path, device=device, max_seq=max_seq,
+            max_q_seq=max_seq)
+        self.vision = Qwen3VlVisionRtx(checkpoint_path, device=device)
+        self.processor = AutoProcessor.from_pretrained(checkpoint_path)
+
+        self._prompt: dict[str, Any] | None = None
+
+    # ── Prompt ──
+
+    def set_prompt(self, messages: list) -> None:
+        """Preprocess a chat ``messages`` list (image + text) and build the
+        per-prompt geometry consumed by ``prefill``."""
+        import torch
+
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+        inputs = self.processor.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=True,
+            return_dict=True, return_tensors='pt').to(self.device)
+        input_ids = inputs['input_ids'][0]
+        grid = inputs['image_grid_thw']
+        pixel_values = inputs['pixel_values'].to(torch.bfloat16)
+        S = int(input_ids.shape[0])
+        if S > self.max_seq:
+            raise ValueError(
+                f'prompt length {S} exceeds max_seq {self.max_seq}')
+
+        # Contiguous image-token span (single image).
+        mask = (input_ids == self._image_token_id)
+        idx = torch.nonzero(mask, as_tuple=False).flatten()
+        img_start = int(idx[0])
+        img_end = int(idx[-1]) + 1
+
+        pos_ids = geo.mrope_position_ids(
+            input_ids.cpu(), grid.cpu(),
+            image_token_id=self._image_token_id,
+            vision_start_token_id=self._vision_start_token_id,
+            spatial_merge_size=self._merge)
+        mcos, msin = geo.mrope_cos_sin(
+            pos_ids, head_dim=self._head_dim, rope_theta=self._rope_theta,
+            mrope_section=self._mrope_section, device=self.device)
+        vcos, vsin = geo.vision_rope_cos_sin(
+            grid.cpu(), head_dim=self._vis_head_dim,
+            spatial_merge_size=self._merge, device=self.device)
+        pos_embeds = geo.vision_pos_embeds(
+            grid.cpu(), self.vision.pos_embed,
+            num_grid_per_side=self._num_grid_per_side,
+            spatial_merge_size=self._merge, device=self.device)
+
+        self._prompt = {
+            'input_ids': input_ids, 'pixel_values': pixel_values,
+            'img_start': img_start, 'img_end': img_end,
+            'mcos': mcos, 'msin': msin, 'vcos': vcos, 'vsin': vsin,
+            'pos_embeds': pos_embeds, 'S': S,
+        }
+
+    # ── Forward ──
+
+    def prefill(self):
+        """Multimodal prefill. Returns ``(1, vocab)`` bf16 next-token logits.
+
+        Vision tower → scatter image features into the embedding stream →
+        Qwen3 NVFP4 decoder layers (interleaved-MRoPE cos/sin) with
+        DeepStack injection at the first layers → final norm + lm_head.
+        """
+        import torch
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill()')
+        p = self._prompt
+        llm = self.llm
+        stream = torch.cuda.current_stream().cuda_stream
+        hidden = llm._cfg['hidden_size']
+        vocab = llm._cfg['vocab_size']
+        eps = float(llm._cfg['rms_norm_eps'])
+        n_layers = llm._cfg['num_hidden_layers']
+        S = p['S']
+        a, b = p['img_start'], p['img_end']
+
+        # Vision tower → image features + DeepStack.
+        image_embeds, deepstack = self.vision.forward(
+            p['pixel_values'], p['pos_embeds'], p['vcos'], p['vsin'])
+
+        # Embedding lookup + scatter the (contiguous) image span.
+        embed = llm._weights.anchors[0]
+        h = embed[p['input_ids']].to(torch.bfloat16).view(1, S, hidden)
+        h = h.contiguous()
+        h[0, a:b] = image_embeds.to(torch.bfloat16)
+
+        # Decoder layers with MRoPE; DeepStack added at the first layers.
+        cur = h
+        for layer in range(n_layers):
+            cur = llm._layer_forward_full_nvfp4_prefill(
+                layer, cur, p['mcos'], p['msin'], 0, S)
+            if layer < self._deepstack_layers:
+                cur = cur.clone()
+                fvk.residual_add(
+                    cur[0, a:b].data_ptr(),
+                    deepstack[layer].to(torch.bfloat16).data_ptr(),
+                    (b - a) * hidden, stream)
+                cur = cur.contiguous()
+
+        # Final RMSNorm + BF16 lm_head on the last row.
+        x = cur.view(S, hidden)[-1:].contiguous()
+        xn = torch.empty(1, hidden, dtype=torch.bfloat16, device=self.device)
+        fvk.rms_norm(x.data_ptr(), int(llm._weights.ptrs['final_norm_w']),
+                     xn.data_ptr(), 1, hidden, eps, stream)
+        logits = torch.empty(
+            1, vocab, dtype=torch.bfloat16, device=self.device)
+        fvk.bf16_matmul_qwen36_bf16(
+            xn.data_ptr(), int(llm._weights.ptrs['lm_head_w']),
+            logits.data_ptr(), 1, vocab, hidden, stream)
+        torch.cuda.synchronize()
+        return logits

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -97,11 +97,28 @@ class Qwen3VlTorchFrontendRtx:
             raise ValueError(
                 f'prompt length {S} exceeds max_seq {self.max_seq}')
 
-        # Contiguous image-token span (single image).
-        mask = (input_ids == self._image_token_id)
-        idx = torch.nonzero(mask, as_tuple=False).flatten()
-        img_start = int(idx[0])
-        img_end = int(idx[-1]) + 1
+        # Image-token spans, one contiguous run per image (multi-image:
+        # the runs appear in image order, matching the grid rows and the
+        # concatenated pixel_values / vision tables).
+        mask = (input_ids == self._image_token_id).cpu().tolist()
+        spans: list[tuple[int, int]] = []
+        i = 0
+        while i < S:
+            if mask[i]:
+                j = i
+                while j < S and mask[j]:
+                    j += 1
+                spans.append((i, j))
+                i = j
+            else:
+                i += 1
+        # Patches fed to the ViT per image (t*h*w) and the merged-token span
+        # length (t*(h/m)*(w/m)) it produces; they must line up with spans.
+        m = self._merge
+        seg_patches = [int(t * h * w) for t, h, w in grid.tolist()]
+        for (a, b), (t, h, w) in zip(spans, grid.tolist()):
+            assert b - a == int(t) * (int(h) // m) * (int(w) // m), (
+                'image-token span does not match its grid')
 
         pos_ids = geo.mrope_position_ids(
             input_ids.cpu(), grid.cpu(),
@@ -121,7 +138,8 @@ class Qwen3VlTorchFrontendRtx:
 
         self._prompt = {
             'input_ids': input_ids, 'pixel_values': pixel_values,
-            'img_start': img_start, 'img_end': img_end,
+            'spans': spans, 'seg_patches': seg_patches,
+            'img_start': spans[0][0], 'img_end': spans[0][1],
             'mcos': mcos, 'msin': msin, 'vcos': vcos, 'vsin': vsin,
             'pos_embeds': pos_embeds, 'S': S,
             'mrope_max': int(pos_ids.max()),
@@ -151,29 +169,38 @@ class Qwen3VlTorchFrontendRtx:
         eps = float(llm._cfg['rms_norm_eps'])
         n_layers = llm._cfg['num_hidden_layers']
         S = p['S']
-        a, b = p['img_start'], p['img_end']
+        spans = p['spans']
 
-        # Vision tower → image features + DeepStack.
-        image_embeds, deepstack = self.vision.forward(
-            p['pixel_values'], p['pos_embeds'], p['vcos'], p['vsin'])
-
-        # Embedding lookup + scatter the (contiguous) image span.
+        # Vision tower, once per image (each image is an independent
+        # attention window — running the tower per segment reproduces HF's
+        # block-diagonal cu_seqlens attention without a varlen kernel).
         embed = llm._weights.anchors[0]
         h = embed[p['input_ids']].to(torch.bfloat16).view(1, S, hidden)
         h = h.contiguous()
-        h[0, a:b] = image_embeds.to(torch.bfloat16)
+        seg_deepstacks: list = []
+        off = 0
+        for (a, b), n_patch in zip(spans, p['seg_patches']):
+            sl = slice(off, off + n_patch)
+            off += n_patch
+            emb, ds = self.vision.forward(
+                p['pixel_values'][sl], p['pos_embeds'][sl],
+                p['vcos'][sl], p['vsin'][sl])
+            h[0, a:b] = emb.to(torch.bfloat16)
+            seg_deepstacks.append(ds)
 
-        # Decoder layers with MRoPE; DeepStack added at the first layers.
+        # Decoder layers with MRoPE; DeepStack added at the first layers,
+        # each image's features into its own span.
         cur = h
         for layer in range(n_layers):
             cur = llm._layer_forward_full_nvfp4_prefill(
                 layer, cur, p['mcos'], p['msin'], 0, S)
             if layer < self._deepstack_layers:
                 cur = cur.clone()
-                fvk.residual_add(
-                    cur[0, a:b].data_ptr(),
-                    deepstack[layer].to(torch.bfloat16).data_ptr(),
-                    (b - a) * hidden, stream)
+                for (a, b), ds in zip(spans, seg_deepstacks):
+                    fvk.residual_add(
+                        cur[0, a:b].data_ptr(),
+                        ds[layer].to(torch.bfloat16).data_ptr(),
+                        (b - a) * hidden, stream)
                 cur = cur.contiguous()
 
         # Final RMSNorm + BF16 lm_head on the last row.

--- a/flash_rt/models/qwen3_vl/__init__.py
+++ b/flash_rt/models/qwen3_vl/__init__.py
@@ -1,0 +1,19 @@
+"""FlashRT Qwen3-VL (multimodal) model namespace.
+
+Currently targeted: Qwen3-VL-8B-Instruct (RTX SM120).
+
+The language backbone is a strict superset of ``flash_rt.models.qwen3``
+(dense Qwen3-8B: hidden 4096 / 36L / GQA 32:8 / head_dim 128 /
+SwiGLU 12288 / vocab 151936) and reuses that path's NVFP4 W4A4 decoder
+kernels. Qwen3-VL adds a SigLIP-style ViT tower (DeepStack +
+interleaved-MRoPE) ahead of the decoder; that tower lives in the
+RTX frontend / pipeline alongside the reused decoder.
+
+Public re-exports keep the model-namespace surface in line with the
+``flash_rt.models.qwen3`` sibling.
+"""
+from __future__ import annotations
+
+from .pipeline_rtx import Qwen3VlDims, Qwen3VlPipeline
+
+__all__ = ['Qwen3VlDims', 'Qwen3VlPipeline']

--- a/flash_rt/models/qwen3_vl/pipeline_rtx.py
+++ b/flash_rt/models/qwen3_vl/pipeline_rtx.py
@@ -1,0 +1,145 @@
+"""FlashRT — RTX SM120 Qwen3-VL-8B inference pipeline (dim contract).
+
+This file defines the static dimension contract for the Qwen3-VL-8B
+NVFP4 inference path. As with ``flash_rt.models.qwen3.pipeline_rtx``,
+the actual compute lives in the frontend
+(``flash_rt.frontends.torch.qwen3_vl_rtx``) — this module only records
+the dimensions the frontend hard-codes, so external tooling (benches,
+profilers, tests) can read them without instantiating the forward stack.
+
+Architecture summary (Qwen3-VL-8B-Instruct)::
+
+    image pixels (patchified: 3 × Tp=2 × 16 × 16 = 1536 per patch)
+        |
+        v  visual.patch_embed.proj   (Conv as Linear → 1152)
+        v  + visual.pos_embed (learned 2304×1152, grid-interpolated)
+        v  per ViT block ×27 (hidden 1152, 16 heads × head_dim 72):
+        v     LayerNorm(norm1) → qkv(+bias) → 2D-RoPE → MHA(bidirectional)
+        v        → proj(+bias) → residual
+        v     LayerNorm(norm2) → fc1(+bias) → GELU(tanh) → fc2(+bias) → residual
+        v     (layers 8/16/24 also feed a DeepStack merger)
+        v  visual.merger: 2×2 spatial merge (1152·4=4608) → norm → fc1
+        v        → GELU → fc2 → out_hidden 4096
+        |
+        v  scatter image features into the text embedding stream at the
+        v  image-placeholder positions (image_token_id 151655)
+        v  + DeepStack: add merger[k] features (ViT layers 8/16/24) into
+        v        the first 3 LLM hidden states at the image positions
+        |
+        v  ── language backbone: reuses the dense Qwen3-8B decoder ──
+        v  embed_tokens (BF16) → 36 × [Qwen3 full-attn NVFP4 W4A4 layer]
+        v       with interleaved-MRoPE (mrope_section [24,20,20]) cos/sin
+        v  final RMSNorm → lm_head (BF16)
+        |
+    [logits: (B, S, 151936)]
+
+The decoder layer body is byte-for-byte the same kernel sequence as
+``Qwen3TorchFrontendRtx._layer_forward_full_nvfp4``; the only
+language-side delta vs plain Qwen3 is RoPE (interleaved-MRoPE cos/sin
+table instead of plain 1D) and ``rope_theta`` (5e6 vs 1e6).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Qwen3VlTextDims:
+    """Static dim contract for the Qwen3-VL-8B language backbone.
+
+    Read from ``config.json:text_config`` at load time and asserted
+    against these values. Structurally identical to ``Qwen3Dims``
+    except ``rope_theta`` (5e6) and the MRoPE sectioning.
+    """
+
+    # Top-level
+    hidden: int = 4096
+    num_layers: int = 36
+    vocab_size: int = 151_936
+    intermediate: int = 12288
+
+    # Attention
+    num_q_heads: int = 32
+    num_kv_heads: int = 8           # GQA 4:1
+    head_dim: int = 128
+    rotary_dim: int = 128           # full RoPE (rotary_dim == head_dim)
+    rope_theta: float = 5_000_000.0
+    max_pos: int = 262_144
+
+    # interleaved-MRoPE: per-axis frequency split over t / h / w.
+    # sum(mrope_section) == head_dim // 2 == 64.
+    mrope_section: tuple[int, int, int] = (24, 20, 20)
+    mrope_interleaved: bool = True
+
+    # Norm
+    rms_norm_eps: float = 1e-6
+
+
+@dataclass
+class Qwen3VlVisionDims:
+    """Static dim contract for the Qwen3-VL ViT tower.
+
+    Read from ``config.json:vision_config`` at load time.
+    """
+
+    depth: int = 27
+    hidden: int = 1152
+    num_heads: int = 16
+    head_dim: int = 72              # 1152 / 16
+    intermediate: int = 4304
+    in_channels: int = 3
+    patch_size: int = 16
+    temporal_patch_size: int = 2
+    spatial_merge_size: int = 2     # 2×2 patch merge before the projector
+    out_hidden: int = 4096          # projector output == text hidden
+    num_position_embeddings: int = 2304
+    # ViT layers whose features are routed through a DeepStack merger and
+    # added into the first len(...) LLM hidden states.
+    deepstack_visual_indexes: tuple[int, int, int] = (8, 16, 24)
+    # hidden_act == gelu_pytorch_tanh ; norm == LayerNorm(weight+bias)
+    layer_norm_eps: float = 1e-6
+
+
+@dataclass
+class Qwen3VlDims:
+    """Combined Qwen3-VL-8B dimension contract.
+
+    The special token ids drive the multimodal scatter (where image
+    features replace placeholder embeddings) and MRoPE position
+    construction.
+    """
+
+    text: Qwen3VlTextDims = field(default_factory=Qwen3VlTextDims)
+    vision: Qwen3VlVisionDims = field(default_factory=Qwen3VlVisionDims)
+
+    image_token_id: int = 151655
+    video_token_id: int = 151656
+    vision_start_token_id: int = 151652
+    vision_end_token_id: int = 151653
+    bos_token_id: int = 151643
+    eos_token_id: int = 151645
+
+
+class Qwen3VlPipeline:
+    """Framework-agnostic Qwen3-VL pipeline placeholder.
+
+    The actual forward path is hand-written in
+    ``flash_rt.frontends.torch.qwen3_vl_rtx`` against the
+    flash_rt_kernels / flash_rt_fa2 entry points. This class only holds
+    a reference to the frontend's WeightHandles so external tooling can
+    inspect dims without instantiating the full forward stack — mirrors
+    ``flash_rt.models.qwen3.pipeline_rtx.Qwen3Pipeline``.
+    """
+
+    DIMS = Qwen3VlDims()
+
+    def __init__(self, weights) -> None:
+        self.weights = weights
+
+    @property
+    def num_layers(self) -> int:
+        return int(self.weights.ptrs.get('num_layers', self.DIMS.text.num_layers))
+
+    @property
+    def hidden(self) -> int:
+        return int(self.weights.ptrs.get('hidden', self.DIMS.text.hidden))

--- a/tests/test_qwen3_vl_smoke.py
+++ b/tests/test_qwen3_vl_smoke.py
@@ -1,0 +1,156 @@
+"""Smoke tests for the Qwen3-VL multimodal frontend.
+
+CI-friendly: no checkpoint, no GPU. Covers the seams a reviewer needs to
+trust the model is wired in -- frontend import, the fail-fast kernel-module
+check, the pure geometry builders on synthetic image/multi-image/video
+sequences, and the input-validation boundaries (text-only and grid
+mismatch).
+
+The full cos-vs-HF / argmax E2E tests require the checkpoint and the
+SM120 kernels; see docs/qwen3_vl_nvfp4.md (Correctness section).
+
+Run:
+    PYTHONPATH=. python -m pytest tests/test_qwen3_vl_smoke.py -v
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import torch
+
+from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+IMG, VID, VSTART = 100, 101, 102
+MERGE = 2
+
+
+# ── wiring / fail-fast ──
+
+def test_frontend_imports():
+    """The frontend module + class import without a GPU or checkpoint."""
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx')
+    assert hasattr(m, 'Qwen3VlTorchFrontendRtx')
+    assert hasattr(m, '_require_qwen3_vl_kernels')
+
+
+def test_require_kernels_fails_fast_on_missing_symbols():
+    """The kernel-module check raises a clear, actionable RuntimeError (with
+    the CMake flag) instead of crashing mid-forward after the weights load."""
+    from flash_rt.frontends.torch.qwen3_vl_rtx import _check_qwen3_vl_kernels
+
+    class _Empty:                      # stand-in for an incomplete module
+        pass
+
+    with pytest.raises(RuntimeError) as ei:
+        _check_qwen3_vl_kernels(_Empty())
+    assert 'FLASHRT_BUILD_QWEN3_VL' in str(ei.value)
+
+
+def test_kernel_module_complete_when_built():
+    """If the gated module is built, it must expose every symbol the tower
+    calls (otherwise skip -- this build did not enable it)."""
+    try:
+        from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+    except ImportError:
+        pytest.skip('flash_rt_qwen3_vl_kernels not built')
+    from flash_rt.frontends.torch.qwen3_vl_rtx import _check_qwen3_vl_kernels
+    _check_qwen3_vl_kernels(vlk)        # must not raise
+
+
+# ── vision_segments: walk + validation ──
+
+def _image_seq(grids):
+    """Build a synthetic id sequence with one image run per grid row."""
+    ids = [1, 1]
+    for t, h, w in grids:
+        ids.append(VSTART)
+        ids += [IMG] * (t * (h // MERGE) * (w // MERGE))
+    ids.append(1)
+    return torch.tensor(ids, dtype=torch.long)
+
+
+def test_vision_segments_single_image():
+    grids = [(1, 4, 6)]
+    segs = geo.vision_segments(
+        _image_seq(grids), torch.tensor(grids), None,
+        image_token_id=IMG, video_token_id=VID, spatial_merge_size=MERGE)
+    assert len(segs) == 1
+    s = segs[0]
+    assert s['kind'] == 'image' and s['grid'] == (1, 4, 6)
+    assert s['patches'] == 1 * 4 * 6
+    a, b = s['span']
+    assert b - a == (4 // 2) * (6 // 2)
+
+
+def test_vision_segments_multi_image_order():
+    grids = [(1, 4, 6), (1, 2, 2)]
+    segs = geo.vision_segments(
+        _image_seq(grids), torch.tensor(grids), None,
+        image_token_id=IMG, video_token_id=VID, spatial_merge_size=MERGE)
+    assert [s['grid'] for s in segs] == grids
+    assert [s['kind_index'] for s in segs] == [0, 1]
+
+
+def test_vision_segments_video_splits_per_frame():
+    """A (t,h,w) video grid is split into t per-frame segments (t->1)."""
+    t, h, w = 3, 4, 6
+    per_frame = (h // MERGE) * (w // MERGE)
+    ids = [1]
+    for _ in range(t):                 # one vision run per frame
+        ids.append(VSTART)
+        ids += [VID] * per_frame
+    ids.append(1)
+    segs = geo.vision_segments(
+        torch.tensor(ids), None, torch.tensor([(t, h, w)]),
+        image_token_id=IMG, video_token_id=VID, spatial_merge_size=MERGE)
+    assert len(segs) == t
+    assert all(s['kind'] == 'video' and s['grid'] == (1, h, w) for s in segs)
+    assert [s['kind_index'] for s in segs] == list(range(t))
+
+
+def test_vision_segments_text_only_raises():
+    ids = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+    with pytest.raises(ValueError) as ei:
+        geo.vision_segments(
+            ids, None, None, image_token_id=IMG, video_token_id=VID,
+            spatial_merge_size=MERGE)
+    assert 'at least one image or video' in str(ei.value)
+
+
+def test_vision_segments_grid_mismatch_raises():
+    ids = torch.tensor([VSTART, IMG, IMG, IMG, 1], dtype=torch.long)  # 3 tok
+    with pytest.raises(ValueError) as ei:
+        geo.vision_segments(
+            ids, torch.tensor([(1, 4, 6)]), None,  # grid wants 6 tokens
+            image_token_id=IMG, video_token_id=VID, spatial_merge_size=MERGE)
+    assert 'does not match its grid' in str(ei.value)
+
+
+# ── geometry builders: shapes on synthetic inputs ──
+
+def test_mrope_cos_sin_shape():
+    grids = [(1, 4, 6)]
+    ids = _image_seq(grids)
+    pos = geo.mrope_position_ids(
+        ids, torch.tensor(grids), None, image_token_id=IMG,
+        video_token_id=VID, vision_start_token_id=VSTART,
+        spatial_merge_size=MERGE)
+    assert pos.shape == (3, ids.numel())
+    cos, sin = geo.mrope_cos_sin(
+        pos, head_dim=128, rope_theta=5e6, mrope_section=(24, 20, 20),
+        device='cpu')
+    assert cos.shape == (ids.numel(), 64) == sin.shape
+
+
+def test_vision_rope_and_pos_embeds_shapes():
+    grids = torch.tensor([(1, 4, 6)])
+    n_patch = 1 * 4 * 6
+    cos, sin = geo.vision_rope_cos_sin(
+        grids, head_dim=72, spatial_merge_size=MERGE, device='cpu')
+    assert cos.shape == (n_patch, 36) == sin.shape
+    table = torch.randn(48 * 48, 8)    # num_position_embeddings 2304 = 48^2
+    pe = geo.vision_pos_embeds(
+        grids, table, num_grid_per_side=48, spatial_merge_size=MERGE,
+        device='cpu')
+    assert pe.shape == (n_patch, 8)

--- a/tools/quantize_qwen3_vl_nvfp4.py
+++ b/tools/quantize_qwen3_vl_nvfp4.py
@@ -1,0 +1,187 @@
+"""Build a FlashRT Qwen3-VL checkpoint (NVFP4 LLM + BF16 vision tower).
+
+Qwen ships Qwen3-VL only in BF16 / FP8; the FlashRT RTX path expects the
+language stack as a ``compressed-tensors`` ``nvfp4-pack-quantized``
+checkpoint (the same on-disk schema as the Qwen3-8B path,
+docs/qwen3_8b_nvfp4.md §4). This tool produces a single self-contained
+checkpoint directory that the ``qwen3_vl`` RTX frontend consumes:
+
+  * language linears  -> NVFP4 (``model.layers.<i>.<lin>.weight_packed`` /
+    ``.weight_scale`` fp8_e4m3 / ``.weight_global_scale`` fp32), with the
+    ``model.language_model.`` prefix stripped to ``model.`` so the shared
+    ``_qwen3_rtx_nvfp4_weights`` loader resolves it unchanged;
+  * embed_tokens / norm / lm_head, per-layer norms and q/k norms -> BF16;
+  * the whole vision tower (``model.visual.*``) -> BF16, copied verbatim;
+  * a ``config.json`` with the text fields hoisted to top level (for the
+    language loader) plus the original ``vision_config`` and the
+    multimodal token ids (for the vision tower and the frontend);
+  * tokenizer / processor side files.
+
+The dequant convention matches the loader exactly:
+
+    w ~= e2m1(weight_packed) * e4m3(weight_scale) / weight_global_scale
+
+{q,k,v} and {gate,up} share a per-layer global scale so the loader's
+fused-QKV / fused-gate_up GEMM stays homogeneous.
+
+Usage:
+    python tools/quantize_qwen3_vl_nvfp4.py \
+        --src /path/to/Qwen3-VL-8B-Instruct \
+        --dst /path/to/Qwen3-VL-8B-FlashRT-NVFP4
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+FP4_MAX = 6.0
+E4M3_MAX = 448.0
+
+_E2M1_LEVELS = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+_E2M1_THRESH = (_E2M1_LEVELS[1:] + _E2M1_LEVELS[:-1]) / 2.0
+
+QUANT_LINEARS = (
+    'self_attn.q_proj', 'self_attn.k_proj', 'self_attn.v_proj',
+    'self_attn.o_proj', 'mlp.gate_proj', 'mlp.up_proj', 'mlp.down_proj',
+)
+# Linears that must share one per-layer global scale (homogeneous fused GEMM).
+_SHARE_GROUPS = (
+    ('self_attn.q_proj', 'self_attn.k_proj', 'self_attn.v_proj'),
+    ('mlp.gate_proj', 'mlp.up_proj'),
+)
+_BF16_NORMS = (
+    'input_layernorm.weight', 'post_attention_layernorm.weight',
+    'self_attn.q_norm.weight', 'self_attn.k_norm.weight',
+)
+_SIDE_FILES = (
+    'tokenizer.json', 'tokenizer_config.json', 'vocab.json', 'merges.txt',
+    'generation_config.json', 'preprocessor_config.json',
+    'video_preprocessor_config.json', 'chat_template.json',
+)
+
+
+def _e2m1_codes(x: torch.Tensor) -> torch.Tensor:
+    sign = (x < 0).to(torch.uint8)
+    code = torch.bucketize(x.abs(), _E2M1_THRESH.to(x.device)).to(torch.uint8)
+    nib = (sign << 3) | code
+    return torch.where(code == 0, torch.zeros_like(nib), nib)
+
+
+def _quant_linear(w: torch.Tensor, global_scale: float):
+    """NVFP4-pack a (out, in) weight with a given fp32 global scale."""
+    w = w.to(torch.float32)
+    out, cin = w.shape
+    assert cin % 16 == 0, f'in_features {cin} not a multiple of 16'
+    wb = w.view(out, cin // 16, 16)
+    block_amax = wb.abs().amax(dim=-1)
+    sf = (block_amax / FP4_MAX * global_scale).to(torch.float8_e4m3fn)
+    eff = (sf.to(torch.float32) / global_scale).clamp_min(1e-12)
+    nib = _e2m1_codes((wb / eff[..., None]).clamp(-FP4_MAX, FP4_MAX))
+    nib = nib.view(out, cin)
+    packed = (nib[:, 0::2] | (nib[:, 1::2] << 4)).to(torch.uint8).contiguous()
+    return packed, sf.contiguous(), torch.tensor(
+        [global_scale], dtype=torch.float32)
+
+
+def _global_scale(amax: float) -> float:
+    return (E4M3_MAX * FP4_MAX) / max(amax, 1e-12)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--src', required=True, help='source Qwen3-VL ckpt dir')
+    ap.add_argument('--dst', required=True, help='output FlashRT ckpt dir')
+    args = ap.parse_args()
+
+    cfg = json.load(open(os.path.join(args.src, 'config.json')))
+    idx = json.load(
+        open(os.path.join(args.src, 'model.safetensors.index.json')))
+    wmap = idx['weight_map']
+    n_layers = int(cfg['text_config']['num_hidden_layers'])
+
+    shards: dict = {}
+
+    def get(key: str) -> torch.Tensor:
+        fn = wmap[key]
+        if fn not in shards:
+            shards[fn] = safe_open(
+                os.path.join(args.src, fn), framework='pt', device='cpu')
+        return shards[fn].get_tensor(key)
+
+    os.makedirs(args.dst, exist_ok=True)
+    out: dict[str, torch.Tensor] = {}
+    lm = 'model.language_model.'
+
+    out['model.embed_tokens.weight'] = get(
+        lm + 'embed_tokens.weight').to(torch.bfloat16)
+    out['model.norm.weight'] = get(lm + 'norm.weight').to(torch.bfloat16)
+    out['lm_head.weight'] = get('lm_head.weight').to(torch.bfloat16)
+
+    for layer in range(n_layers):
+        src = f'{lm}layers.{layer}.'
+        dst = f'model.layers.{layer}.'
+        for nm in _BF16_NORMS:
+            out[dst + nm] = get(src + nm).to(torch.bfloat16)
+
+        gscale: dict[str, float] = {}
+        for grp in _SHARE_GROUPS:
+            amax = max(float(get(src + lin + '.weight').abs().max())
+                       for lin in grp)
+            for lin in grp:
+                gscale[lin] = _global_scale(amax)
+        for lin in ('self_attn.o_proj', 'mlp.down_proj'):
+            gscale[lin] = _global_scale(
+                float(get(src + lin + '.weight').abs().max()))
+
+        for lin in QUANT_LINEARS:
+            packed, sf, gs = _quant_linear(get(src + lin + '.weight'),
+                                           gscale[lin])
+            out[dst + lin + '.weight_packed'] = packed
+            out[dst + lin + '.weight_scale'] = sf
+            out[dst + lin + '.weight_global_scale'] = gs
+
+    # Vision tower: copied verbatim in BF16.
+    for key in wmap:
+        if key.startswith('model.visual.'):
+            out[key] = get(key).to(torch.bfloat16)
+
+    save_file(out, os.path.join(args.dst, 'model.safetensors'),
+              metadata={'format': 'pt'})
+    json.dump(
+        {'metadata': {},
+         'weight_map': {k: 'model.safetensors' for k in out}},
+        open(os.path.join(args.dst, 'model.safetensors.index.json'), 'w'))
+
+    # config.json: text fields at top level (language loader) + vision_config
+    # + multimodal token ids (vision tower / frontend).
+    flat = dict(cfg['text_config'])
+    flat['model_type'] = 'qwen3'
+    flat['tie_word_embeddings'] = cfg.get('tie_word_embeddings', False)
+    flat['vision_config'] = cfg['vision_config']
+    for tok in ('image_token_id', 'video_token_id',
+                'vision_start_token_id', 'vision_end_token_id'):
+        if tok in cfg:
+            flat[tok] = cfg[tok]
+    flat['quantization_config'] = {
+        'quant_method': 'compressed-tensors',
+        'format': 'nvfp4-pack-quantized',
+    }
+    json.dump(flat, open(os.path.join(args.dst, 'config.json'), 'w'), indent=2)
+
+    for fn in _SIDE_FILES:
+        path = os.path.join(args.src, fn)
+        if os.path.isfile(path):
+            shutil.copy(path, os.path.join(args.dst, fn))
+
+    print(f'wrote {len(out)} tensors -> {args.dst}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Makes the Qwen3-VL single-image prefill run as a **pure-kernel CUDA-graph
replay** (zero per-request torch dispatch, like the decode path), moves
image preprocessing onto the GPU, and fuses the ViT bias adds into adjacent
kernels. Full-request TTFT (5090, full-res 1581-token prompt) ~100 ms;
prefill 93 ms; decode ~150 tok/s. Branches off `qwen3-vl`.

Fully additive: the shared `flash_rt_kernels.so` is untouched; all new
kernels live in the opt-in `flash_rt_qwen3_vl_kernels` module.

## What's in it

- **Whole-prefill CUDA graph** — embed → ViT tower → image-feature scatter →
  NVFP4 decoder layers + DeepStack → final norm, captured into one graph;
  lm_head eager on the last row. Replay is pure kernel, no torch dispatch.
  Multi-image / video keep the eager prefill.
- **GPU image preprocessing** — `apply_chat_template(device=...)` runs the
  fast image processor on the GPU (set_prompt 24 → 8 ms).
- **Merger FP8** — the four mergers run FP8 block-128 (−2.6 ms).
- **Epilogue fusion** — the per-column bias rides the op that consumes the
  GEMM output instead of a standalone add_bias (3 new general kernels:
  `gelu_tanh_bias_to_fp8_block128_bf16`, `residual_add_bias_bf16`,
  `qkv_split_bias_bf16`); no bias round-trips HBM as its own kernel.

## Performance (RTX 5090)

| Metric | HF SDPA bf16 | This branch |
|---|---:|---:|
| TTFT (full request, image+text) | 206 ms | **~100 ms** |
| Decode (warm CUDA Graph) | ~48 tok/s | **~150 tok/s** |

`max_pixels` caps resolution (the dominant TTFT knob): 100 / 59 / 32 / 25 ms
at full / 1.0M / 0.5M / 0.25M pixels.

## Correctness (vs HF bf16)

Next-token argmax matches HF on image (**785**), two-image (**8420**), and
video (**785**); prefill graph eager-vs-replay logits cos 0.99999; ViT
image_embeds cos 0.968. New-kernel standalone cos ≥ 0.9997.

## Build

`cmake -B build -S . -DGPU_ARCH=120 -DFLASHRT_BUILD_QWEN3_VL=ON` then build
`flash_rt_qwen3_vl_kernels`. Smoke tests: `pytest tests/test_qwen3_vl_smoke.py`.