### PR TITLE
Qwen3 vl prefill

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -892,7 +892,8 @@ if(FLASHRT_BUILD_QWEN3_VL)
   pybind11_add_module(flash_rt_qwen3_vl_kernels
     csrc/qwen3_vl_bindings.cpp
     csrc/kernels/rope_neox_qk_bf16.cu
-    csrc/kernels/norm_act_to_fp8_block128.cu)
+    csrc/kernels/norm_act_to_fp8_block128.cu
+    csrc/kernels/bias_epilogue_bf16.cu)
   set_target_properties(flash_rt_qwen3_vl_kernels PROPERTIES
     CUDA_STANDARD 17
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt

--- a/csrc/kernels/bias_epilogue_bf16.cu
+++ b/csrc/kernels/bias_epilogue_bf16.cu
@@ -1,0 +1,91 @@
+// ================================================================
+// FlashRT — fused bias epilogues (bf16)
+//
+// When a GEMM's bias cannot ride its own epilogue (e.g. a shared
+// block-scaled FP8/FP4 GEMM with a fixed epilogue), the per-column bias
+// add would otherwise be a standalone kernel that re-reads and re-writes
+// the whole GEMM output. These kernels fold that bias add into the op
+// that consumes the GEMM output, so the bias never round-trips HBM:
+//
+//   residual_add_bias_bf16 : residual += (x + bias)   (proj / fc2 -> res)
+//   qkv_split_bias_bf16    : split (x + bias) into q/k/v   (qkv -> attn)
+//
+// ``bias`` is broadcast over rows. General (model-agnostic).
+// ================================================================
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace kernels {
+
+namespace {
+
+__global__ void residual_add_bias_kernel(
+    __nv_bfloat16* __restrict__ residual,
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ bias,
+    int dim, long total) {
+  const long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  for (long idx = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x;
+       idx < total; idx += stride) {
+    const int i = idx % dim;
+    residual[idx] = __float2bfloat16(
+        __bfloat162float(residual[idx]) + __bfloat162float(x[idx]) +
+        __bfloat162float(bias[i]));
+  }
+}
+
+// qkv = (rows, Hq+Hk+Hv); split column-wise into q/k/v with the matching
+// bias slice added. q/k/v are (rows, H*) row-major.
+__global__ void qkv_split_bias_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ bias,
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ v,
+    int Hq, int Hk, int Hv, long total) {
+  const int W = Hq + Hk + Hv;
+  const long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  for (long idx = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x;
+       idx < total; idx += stride) {
+    const int m = idx / W;
+    const int col = idx - static_cast<long>(m) * W;
+    const float val =
+        __bfloat162float(qkv[idx]) + __bfloat162float(bias[col]);
+    if (col < Hq) {
+      q[static_cast<long>(m) * Hq + col] = __float2bfloat16(val);
+    } else if (col < Hq + Hk) {
+      k[static_cast<long>(m) * Hk + (col - Hq)] = __float2bfloat16(val);
+    } else {
+      v[static_cast<long>(m) * Hv + (col - Hq - Hk)] = __float2bfloat16(val);
+    }
+  }
+}
+
+int grid_for(long total) {
+  const long b = (total + 255) / 256;
+  return static_cast<int>(b < 65535 ? (b < 1 ? 1 : b) : 65535);
+}
+
+}  // namespace
+
+void residual_add_bias_bf16(
+    __nv_bfloat16* residual, const __nv_bfloat16* x,
+    const __nv_bfloat16* bias, int rows, int dim, cudaStream_t stream) {
+  const long total = static_cast<long>(rows) * dim;
+  residual_add_bias_kernel<<<grid_for(total), 256, 0, stream>>>(
+      residual, x, bias, dim, total);
+}
+
+void qkv_split_bias_bf16(
+    const __nv_bfloat16* qkv, const __nv_bfloat16* bias,
+    __nv_bfloat16* q, __nv_bfloat16* k, __nv_bfloat16* v,
+    int rows, int hq, int hk, int hv, cudaStream_t stream) {
+  const long total = static_cast<long>(rows) * (hq + hk + hv);
+  qkv_split_bias_kernel<<<grid_for(total), 256, 0, stream>>>(
+      qkv, bias, q, k, v, hq, hk, hv, total);
+}
+
+}  // namespace kernels
+}  // namespace flash_rt

--- a/csrc/kernels/norm_act_to_fp8_block128.cu
+++ b/csrc/kernels/norm_act_to_fp8_block128.cu
@@ -137,6 +137,35 @@ __global__ void gelu_tanh_to_fp8_block128_kernel(
   }
 }
 
+// Like ``gelu_tanh_to_fp8_block128_kernel`` but adds a per-column bias
+// before the GELU (``bias`` is broadcast over rows). Fuses the preceding
+// GEMM's bias add into this op so it never round-trips through HBM.
+__global__ void gelu_tanh_bias_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ bias,
+    __nv_fp8_e4m3* __restrict__ out,
+    float* __restrict__ scale,
+    int dim) {
+  __shared__ float sh[4];
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* xr = x + static_cast<long>(m) * dim;
+  __nv_fp8_e4m3* orow = out + static_cast<long>(m) * dim;
+
+  const int n_kb = dim / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float g = gelu_tanh(
+        __bfloat162float(xr[i]) + __bfloat162float(bias[i]));
+    const float amax = block_reduce128(fabsf(g), sh, true);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = g / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    orow[i] = __nv_fp8_e4m3(q);
+  }
+}
+
 }  // namespace
 
 void layer_norm_to_fp8_block128_bf16(
@@ -152,6 +181,14 @@ void gelu_tanh_to_fp8_block128_bf16(
     int rows, int dim, cudaStream_t stream) {
   gelu_tanh_to_fp8_block128_kernel<<<rows, kBlock, 0, stream>>>(
       x, out, scale, dim);
+}
+
+void gelu_tanh_bias_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, const __nv_bfloat16* bias,
+    __nv_fp8_e4m3* out, float* scale, int rows, int dim,
+    cudaStream_t stream) {
+  gelu_tanh_bias_to_fp8_block128_kernel<<<rows, kBlock, 0, stream>>>(
+      x, bias, out, scale, dim);
 }
 
 }  // namespace kernels

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -43,6 +43,19 @@ void layer_norm_to_fp8_block128_bf16(
 void gelu_tanh_to_fp8_block128_bf16(
     const __nv_bfloat16* x, __nv_fp8_e4m3* out, float* scale,
     int rows, int dim, cudaStream_t stream);
+
+void gelu_tanh_bias_to_fp8_block128_bf16(
+    const __nv_bfloat16* x, const __nv_bfloat16* bias, __nv_fp8_e4m3* out,
+    float* scale, int rows, int dim, cudaStream_t stream);
+
+void residual_add_bias_bf16(
+    __nv_bfloat16* residual, const __nv_bfloat16* x,
+    const __nv_bfloat16* bias, int rows, int dim, cudaStream_t stream);
+
+void qkv_split_bias_bf16(
+    const __nv_bfloat16* qkv, const __nv_bfloat16* bias, __nv_bfloat16* q,
+    __nv_bfloat16* k, __nv_bfloat16* v, int rows, int hq, int hk, int hv,
+    cudaStream_t stream);
 }  // namespace kernels
 }  // namespace flash_rt
 
@@ -101,4 +114,43 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         },
         py::arg("x"), py::arg("out"), py::arg("scale"), py::arg("rows"),
         py::arg("dim"), py::arg("stream") = 0);
+
+    m.def(
+        "gelu_tanh_bias_to_fp8_block128_bf16",
+        [](uintptr_t x, uintptr_t bias, uintptr_t out, uintptr_t scale,
+           int rows, int dim, uintptr_t stream) {
+            flash_rt::kernels::gelu_tanh_bias_to_fp8_block128_bf16(
+                as_ptr<const __nv_bfloat16>(x),
+                as_ptr<const __nv_bfloat16>(bias), as_ptr<__nv_fp8_e4m3>(out),
+                as_ptr<float>(scale), rows, dim, to_stream(stream));
+        },
+        py::arg("x"), py::arg("bias"), py::arg("out"), py::arg("scale"),
+        py::arg("rows"), py::arg("dim"), py::arg("stream") = 0);
+
+    m.def(
+        "residual_add_bias_bf16",
+        [](uintptr_t residual, uintptr_t x, uintptr_t bias, int rows, int dim,
+           uintptr_t stream) {
+            flash_rt::kernels::residual_add_bias_bf16(
+                as_ptr<__nv_bfloat16>(residual),
+                as_ptr<const __nv_bfloat16>(x),
+                as_ptr<const __nv_bfloat16>(bias), rows, dim,
+                to_stream(stream));
+        },
+        py::arg("residual"), py::arg("x"), py::arg("bias"), py::arg("rows"),
+        py::arg("dim"), py::arg("stream") = 0);
+
+    m.def(
+        "qkv_split_bias_bf16",
+        [](uintptr_t qkv, uintptr_t bias, uintptr_t q, uintptr_t k,
+           uintptr_t v, int rows, int hq, int hk, int hv, uintptr_t stream) {
+            flash_rt::kernels::qkv_split_bias_bf16(
+                as_ptr<const __nv_bfloat16>(qkv),
+                as_ptr<const __nv_bfloat16>(bias), as_ptr<__nv_bfloat16>(q),
+                as_ptr<__nv_bfloat16>(k), as_ptr<__nv_bfloat16>(v),
+                rows, hq, hk, hv, to_stream(stream));
+        },
+        py::arg("qkv"), py::arg("bias"), py::arg("q"), py::arg("k"),
+        py::arg("v"), py::arg("rows"), py::arg("hq"), py::arg("hk"),
+        py::arg("hv"), py::arg("stream") = 0);
 }

--- a/docs/qwen3_vl_nvfp4.md
+++ b/docs/qwen3_vl_nvfp4.md
@@ -21,39 +21,47 @@ image + text prompt, 1581 LLM tokens (1564 vision + 17 text), FlashRT.png
 
 | Metric | HF SDPA (bf16) | FlashRT |
 |---|---:|---:|
-| TTFT (prefill, image+text) | 206 ms | **99 ms** |
-| Decode (warm CUDA Graph)   | ~48 tok/s | **143 tok/s** |
+| TTFT (full request, image+text) | 206 ms | **~100 ms** |
+| Decode (warm CUDA Graph)   | ~48 tok/s | **~150 tok/s** |
 
-TTFT is dominated by the ViT tower (~60 ms) plus the NVFP4 language
-prefill (~39 ms). After the FP8 GEMMs, the two remaining ViT costs are
-the full-attention over 6256 patches (~31 ms, ~75% of bf16 roofline at
-head_dim 72) and the FP8 GEMMs (~20 ms); both are compute-bound. Decode
-reuses the Qwen3-8B NVFP4 W4A4 + CUDA-Graph path and lands at the same
-~143 tok/s ceiling; the MRoPE position continues past the image while the
-KV-cache slot advances from the image-compressed prompt length.
+Same 5090, FlashRT.png, full resolution (1581 prompt tokens). FlashRT TTFT
+is GPU image preprocessing (~8 ms) + the **CUDA-graph prefill** (~93 ms);
+decode is the NVFP4 W4A4 + graph path. Both prefill and decode replay as
+pure-kernel CUDA graphs (no per-request Python/torch dispatch), so latency
+is low and stable.
 
-TTFT history on this path (5090): 621 ms (initial eager) → 121 ms (ViT
-FFN on the fast GEMM + bf16) → 102 ms (FP8 block-128 ViT GEMMs) → **99 ms**
-(FP8 activation quant fused into the producing LayerNorm / GELU).
+The prefill graph captures the whole single-image path (embed → ViT tower →
+image-feature scatter → NVFP4 layers + DeepStack → final norm) into one
+graph; lm_head runs eager on the last row. Multi-image / video fall back to
+the eager prefill. Inside the graph the costs are the ViT full-attention
+over 6256 patches (~31 ms, ~75 % bf16 roofline at head_dim 72), the FP8 +
+NVFP4 GEMMs, and the attention; all compute-bound.
+
+Prefill history on this path (5090, prefill-only ms): 621 → 121 (ViT FFN on
+the fast GEMM) → 102 (FP8 block-128 ViT GEMMs) → 99 (FP8 quant fused into
+LayerNorm/GELU) → 95 (merger FP8 + whole-prefill CUDA graph) → **93** (ViT
+bias adds fused into adjacent kernels). Image preprocessing moved CPU → GPU
+(24 → 8 ms), so the full request TTFT is ~100 ms.
 
 ### TTFT vs resolution (the dominant knob)
 
-The 99 ms above is the **full-resolution** benchmark: the 2172×724 image
+The ~100 ms above is the **full-resolution** benchmark: the 2172×724 image
 patchifies to 6256 patches → 1564 of the 1581 LLM tokens are vision. The
 patch count (≈ pixels / 16²) sets both the ViT cost and the LLM prefill
 length, so capping resolution cuts both at once. Pass ``max_pixels`` (the
 processor's smart_resize rounds to the patch grid); the description is
-unchanged across this range:
+unchanged across this range (full-request TTFT = GPU preprocessing + graph
+prefill):
 
 | `max_pixels` | patches | LLM tokens | TTFT |
 |---|---:|---:|---:|
-| none (full) | 6256 | 1581 | 99 ms |
-| 1.0 M | 3888 | 989 | 57 ms |
-| 0.5 M | 1824 | 473 | **30 ms** |
-| 0.25 M | 972 | 260 | 22 ms |
+| none (full) | 6256 | 1581 | 100 ms |
+| 1.0 M | 3888 | 989 | 59 ms |
+| 0.5 M | 1824 | 473 | **32 ms** |
+| 0.25 M | 972 | 260 | 25 ms |
 
 ```python
-fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=1_000_000)  # or pass --max-pixels
+fe = Qwen3VlTorchFrontendRtx(ckpt, max_pixels=1_000_000)  # or --max-pixels
 ```
 
 Reproduce:
@@ -162,7 +170,11 @@ images and videos.
 
 Per-prompt geometry (3D MRoPE position ids, MRoPE / vision-RoPE tables,
 the interpolated vision position embedding) is precomputed once in
-`set_prompt`; the forward runs only kernels. The vision tower's
+`set_prompt` (with the image processor running on the GPU), which also
+stages the captured-prefill static input buffers. The single-image prefill
+then replays as one CUDA graph — pure kernel, no torch dispatch — and the
+eager paths (`prefill`, multi-image / video) run only kernels. The vision
+tower's
 intermediate (4304) is zero-padded to 4352 at load so every FFN GEMM uses
 the fast `w16a16` kernel (the unpadded fc2 fell back to an M=1-tuned
 matmul that dominated the tower at ~19 ms/call).
@@ -208,8 +220,11 @@ the description is unchanged).
   grid is split per frame so each frame's temporal index is 0 and the
   inter-frame timestamp text tokens carry the temporal position). Frame
   sampling follows the processor defaults.
-- **Next TTFT levers** (both need new kernels): an FP8 ViT attention
-  (Sage/FA on sm_120 only ships head_dim 128/256, so head_dim 72 would
-  need padding), and an FP8 language prefill (the stack is NVFP4, whose
-  large-M GEMM dequantizes to bf16 compute).
+- **Compute core is at the kernel floor for this shape** (measured): the
+  ViT attention (bf16 FA2, head_dim 72) ties the best community kernels
+  (sm_120 has no FP8/INT8 attention that holds the accuracy — INT8-QK
+  collapses image_embeds cosine), and the NVFP4 language prefill GEMM is
+  already faster than an FP8 block-128 path at these shapes. Further TTFT
+  comes from capping `max_pixels` (above) or an algorithm change (fewer
+  patches / windowed attention) that would alter outputs.
 - **No KV-cache offload**; prompt + generation must fit in `max_seq`.

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -156,7 +156,7 @@ class Qwen3VlVisionRtx:
 
     # ── primitives ──
 
-    def _gemm(self, x, lin, M, N, K, stream):
+    def _gemm(self, x, lin, M, N, K, stream, add_bias=True):
         """y = x @ W.T + bias via FP8 block-128 (2× tensor-core vs bf16).
 
         ``lin`` is a (weight_fp8, weight_block_scale, bias) tuple. The
@@ -185,7 +185,7 @@ class Qwen3VlVisionRtx:
             fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
                 x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
                 x_scale.data_ptr(), ws.data_ptr(), stream)
-        if bias is not None:
+        if bias is not None and add_bias:
             fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
 
@@ -197,13 +197,14 @@ class Qwen3VlVisionRtx:
             M, D, self.ln_eps, stream)
         return y
 
-    def _gemm_fp8(self, x_fp8, x_scale, lin, M, N, K, stream):
+    def _gemm_fp8(self, x_fp8, x_scale, lin, M, N, K, stream, add_bias=True):
         """FP8 block-128 GEMM from an already-quantized activation.
 
         ``x_fp8`` / ``x_scale`` are the FP8 e4m3 values and their per-token,
         per-128-K-block descale, as produced by the fused norm/gelu kernels.
         Same epilogue (bf16 out, optional bias) as the FP8 branch of
-        ``_gemm``; it just skips the internal quantization step.
+        ``_gemm``; it just skips the internal quantization step. ``add_bias``
+        False leaves the bias for a downstream fused kernel.
         """
         import torch
         w8, ws, bias = lin
@@ -211,7 +212,7 @@ class Qwen3VlVisionRtx:
         self._fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
             x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
             x_scale.data_ptr(), ws.data_ptr(), stream)
-        if bias is not None:
+        if bias is not None and add_bias:
             self._fvk.add_bias_bf16(
                 y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
@@ -237,6 +238,17 @@ class Qwen3VlVisionRtx:
             x.data_ptr(), xf.data_ptr(), xs.data_ptr(), M, D, stream)
         return xf, xs
 
+    def _gelu_bias_to_fp8(self, x, bias, M, D, stream):
+        """fc1 bias + GELU-tanh + FP8 block-128 quant in one kernel (the
+        bias rides this op instead of a standalone add_bias)."""
+        import torch
+        xf = torch.empty(M, D, dtype=torch.float8_e4m3fn, device=self.device)
+        xs = torch.empty(M, D // 128, dtype=torch.float32, device=self.device)
+        self._vlk.gelu_tanh_bias_to_fp8_block128_bf16(
+            x.data_ptr(), bias.data_ptr(), xf.data_ptr(), xs.data_ptr(),
+            M, D, stream)
+        return xf, xs
+
     def _merger_forward(self, h, mg, stream):
         merge = self.spatial_merge_size * self.spatial_merge_size
         S = h.shape[0]
@@ -251,8 +263,14 @@ class Qwen3VlVisionRtx:
                 xs, mg['norm_w'], mg['norm_b'], xs.shape[0], norm_dim, stream)
         M = xn.shape[0]
         din = self.hidden * merge
-        f1 = self._gemm(xn, mg['fc1'], M, din, din, stream)
-        self._fvk.gelu_inplace(f1.data_ptr(), M * din, stream)
+        # fc1 bias rides the bias+GELU kernel (no standalone add_bias).
+        f1 = self._gemm(xn, mg['fc1'], M, din, din, stream, add_bias=False)
+        b1 = mg['fc1'][2]
+        if b1 is not None:
+            self._fvk.bias_gelu_inplace_bf16(
+                f1.data_ptr(), b1.data_ptr(), M, din, stream)
+        else:
+            self._fvk.gelu_inplace(f1.data_ptr(), M * din, stream)
         return self._gemm(f1, mg['fc2'], M, self.out_hidden, din, stream)
 
     # ── forward ──
@@ -304,13 +322,17 @@ class Qwen3VlVisionRtx:
             if fp8:
                 xf, xs = self._layer_norm_to_fp8(
                     h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
-                qkv = self._gemm_fp8(xf, xs, blk['qkv'], S, 3 * H, H, stream)
+                qkv = self._gemm_fp8(xf, xs, blk['qkv'], S, 3 * H, H, stream,
+                                     add_bias=False)
             else:
                 xn = self._layer_norm(
                     h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
-                qkv = self._gemm(xn, blk['qkv'], S, 3 * H, H, stream)
-            fvk.qkv_split(qkv.data_ptr(), q.data_ptr(), k.data_ptr(),
-                          v.data_ptr(), S, H, H, H, stream)
+                qkv = self._gemm(xn, blk['qkv'], S, 3 * H, H, stream,
+                                 add_bias=False)
+            # qkv bias rides the split (no standalone add_bias).
+            vlk.qkv_split_bias_bf16(
+                qkv.data_ptr(), blk['qkv'][2].data_ptr(), q.data_ptr(),
+                k.data_ptr(), v.data_ptr(), S, H, H, H, stream)
             vlk.rope_neox_qk_bf16(
                 q.data_ptr(), k.data_ptr(), rope_cos.data_ptr(),
                 rope_sin.data_ptr(), q.data_ptr(), k.data_ptr(),
@@ -330,24 +352,36 @@ class Qwen3VlVisionRtx:
                 o_strides=(o.stride(0), o.stride(1), o.stride(2)),
                 softmax_scale=scale, num_sms=self._num_sms, stream=stream)
             # proj input is the attention output (not a norm/gelu), so its
-            # quant cannot be fused upstream; keep the internal quant in _gemm.
-            attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream)
-            fvk.residual_add(h.data_ptr(), attn.data_ptr(), S * H, stream)
+            # quant cannot be fused upstream; the proj bias rides the residual.
+            attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream,
+                              add_bias=False)
+            vlk.residual_add_bias_bf16(
+                h.data_ptr(), attn.data_ptr(), blk['proj'][2].data_ptr(),
+                S, H, stream)
 
             inter = self.intermediate
             if fp8:
                 xf2, xs2 = self._layer_norm_to_fp8(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
-                f1 = self._gemm_fp8(xf2, xs2, blk['fc1'], S, inter, H, stream)
-                gf, gs = self._gelu_to_fp8(f1, S, inter, stream)
-                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream)
+                f1 = self._gemm_fp8(xf2, xs2, blk['fc1'], S, inter, H, stream,
+                                    add_bias=False)
+                gf, gs = self._gelu_bias_to_fp8(
+                    f1, blk['fc1'][2], S, inter, stream)
+                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream,
+                                    add_bias=False)
             else:
                 xn2 = self._layer_norm(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
-                f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream)
-                fvk.gelu_inplace(f1.data_ptr(), S * inter, stream)
-                f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream)
-            fvk.residual_add(h.data_ptr(), f2.data_ptr(), S * H, stream)
+                f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream,
+                                add_bias=False)
+                fvk.bias_gelu_inplace_bf16(
+                    f1.data_ptr(), blk['fc1'][2].data_ptr(), S, inter, stream)
+                f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream,
+                                add_bias=False)
+            # fc2 bias rides the residual.
+            vlk.residual_add_bias_bf16(
+                h.data_ptr(), f2.data_ptr(), blk['fc2'][2].data_ptr(),
+                S, H, stream)
 
             if i in self.deepstack_indexes:
                 j = self.deepstack_indexes.index(i)

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -434,13 +434,22 @@ def _pad_cols(t, n_cols: int):
 
 
 def _load_merger(load_fn, lin_fn, prefix: str) -> dict:
+    # The merger linears run FP8 block-128 when 128-aligned (the Qwen3-VL
+    # dims are): preflight showed image_embeds cosine 0.9703 -> 0.9698
+    # (argmax-safe) for ~-2.6 ms across the four mergers. The norm output is
+    # bounded post-LayerNorm, so FP8 here does not touch the massive-
+    # activation residual stream.
+    def _merger_lin(name):
+        w = load_fn(prefix + name + '.weight')
+        bias = load_fn(prefix + name + '.bias')
+        aligned = w.shape[0] % 128 == 0 and w.shape[1] % 128 == 0
+        return lin_fn(w, bias, fp8=aligned)
+
     return {
         'norm_w': load_fn(prefix + 'norm.weight'),
         'norm_b': load_fn(prefix + 'norm.bias'),
-        'fc1': lin_fn(load_fn(prefix + 'linear_fc1.weight'),
-                      load_fn(prefix + 'linear_fc1.bias'), fp8=False),
-        'fc2': lin_fn(load_fn(prefix + 'linear_fc2.weight'),
-                      load_fn(prefix + 'linear_fc2.bias'), fp8=False),
+        'fc1': _merger_lin('linear_fc1'),
+        'fc2': _merger_lin('linear_fc2'),
     }
 
 

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -30,6 +30,9 @@ _QWEN3_VL_KERNEL_FNS = (
     'rope_neox_qk_bf16',
     'layer_norm_to_fp8_block128_bf16',
     'gelu_tanh_to_fp8_block128_bf16',
+    'gelu_tanh_bias_to_fp8_block128_bf16',
+    'residual_add_bias_bf16',
+    'qkv_split_bias_bf16',
 )
 
 

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -134,9 +134,13 @@ class Qwen3VlTorchFrontendRtx:
 
         from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
 
+        # device=self.device runs the fast image processor's resize /
+        # normalize / patchify on the GPU (~10x over the CPU path), so the
+        # whole preprocess is off the CPU.
         inputs = self.processor.apply_chat_template(
             messages, add_generation_prompt=True, tokenize=True,
-            return_dict=True, return_tensors='pt').to(self.device)
+            return_dict=True, return_tensors='pt',
+            device=self.device).to(self.device)
         input_ids = inputs['input_ids'][0]
         S = int(input_ids.shape[0])
         if S > self.max_seq:

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -280,6 +280,137 @@ class Qwen3VlTorchFrontendRtx:
         torch.cuda.synchronize()
         return logits
 
+    # ── Prefill via a captured CUDA Graph (single image) ──
+
+    def _prefill_graph_body(self, st, P, S, a, b):
+        """Capture body: embed gather -> ViT tower -> scatter image features
+        -> NVFP4 decoder layers with DeepStack inject -> final RMSNorm into
+        ``self._pg_last_hidden[:S]``. No lm_head (run eager post-replay so one
+        graph serves all real_S <= bucket). All torch glue (gather/scatter/
+        clone/copy) traces into the graph, so replay is pure-kernel.
+
+        ``st`` is the dict of static input buffers; the graph reads only from
+        them. Mirrors the eager ``prefill`` single-image path exactly so
+        captured and eager hidden state match bit-for-bit.
+        """
+        import torch
+        from flash_rt import flash_rt_kernels as fvk
+
+        llm = self.llm
+        bf16 = torch.bfloat16
+        stream = torch.cuda.current_stream().cuda_stream
+        hidden = llm._cfg['hidden_size']
+        eps = float(llm._cfg['rms_norm_eps'])
+        n_layers = llm._cfg['num_hidden_layers']
+
+        emb, ds = self.vision.forward(
+            st['pixel'], st['pos'], st['vcos'], st['vsin'])
+        h = llm._weights.anchors[0][st['ids']].to(bf16).view(1, S, hidden)
+        h = h.contiguous()
+        h[0, a:b] = emb.to(bf16)
+
+        cur = h
+        for layer in range(n_layers):
+            cur = llm._layer_forward_full_nvfp4_prefill(
+                layer, cur, st['mcos'], st['msin'], 0, S)
+            if layer < self._deepstack_layers:
+                cur = cur.clone()
+                fvk.residual_add(
+                    cur[0, a:b].data_ptr(),
+                    ds[layer].to(bf16).data_ptr(), (b - a) * hidden, stream)
+                cur = cur.contiguous()
+
+        h2 = cur.view(S, hidden).contiguous()
+        fvk.rms_norm(
+            h2.data_ptr(), int(llm._weights.ptrs['final_norm_w']),
+            self._pg_last_hidden[:S].data_ptr(), S, hidden, eps, stream)
+
+    def _capture_prefill_graph(self, st, P, S, a, b):
+        """2-iter warmup then capture the prefill body for one (P,S,a) bucket.
+        Mirrors qwen3_rtx._ensure_prefill_graph (inference_mode + capture
+        stream)."""
+        import torch
+
+        llm = self.llm
+        gs = llm._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        # no_grad (not inference_mode) to match the ViT forward_graph and the
+        # decode-graph capture this composes with; inference_mode flags the
+        # ViT's per-call scratch as inference tensors and trips capture_begin.
+        with torch.cuda.stream(gs), torch.no_grad():
+            for _ in range(2):
+                self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.no_grad():
+            self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        return graph
+
+    def prefill_graph(self):
+        """Pure-kernel prefill via a captured CUDA Graph (single image).
+
+        Falls back to the eager ``prefill`` for multi-image / video (variable
+        segment structure is not graph-capturable). Returns ``(1, vocab)``
+        bf16 next-token logits.
+        """
+        import torch
+        from flash_rt import flash_rt_kernels as fvk
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill_graph()')
+        p = self._prompt
+        if len(p['spans']) != 1:
+            return self.prefill()
+
+        llm = self.llm
+        hidden = llm._cfg['hidden_size']
+        vocab = llm._cfg['vocab_size']
+        S = p['S']
+        P = p['seg_patches'][0]
+        a, b = p['spans'][0]
+        key = (P, S, a, b)
+        llm.reset_state()
+
+        if not hasattr(self, '_pg_last_hidden'):
+            self._pg_last_hidden = torch.empty(
+                self.max_seq, hidden, dtype=torch.bfloat16, device=self.device)
+            self._prefill_graphs: dict = {}
+
+        entry = self._prefill_graphs.get(key)
+        if entry is None:
+            st = {
+                'ids': p['input_ids'].clone(),
+                'pixel': p['pixel_values'].clone(),
+                'pos': p['pos_embeds'].clone(),
+                'vcos': p['vcos'].clone(), 'vsin': p['vsin'].clone(),
+                'mcos': p['mcos'].clone(), 'msin': p['msin'].clone(),
+            }
+            graph = self._capture_prefill_graph(st, P, S, a, b)
+            entry = (graph, st)
+            self._prefill_graphs[key] = entry
+        graph, st = entry
+
+        st['ids'].copy_(p['input_ids'])
+        st['pixel'].copy_(p['pixel_values'])
+        st['pos'].copy_(p['pos_embeds'])
+        st['vcos'].copy_(p['vcos'])
+        st['vsin'].copy_(p['vsin'])
+        st['mcos'].copy_(p['mcos'])
+        st['msin'].copy_(p['msin'])
+        graph.replay()
+
+        stream = torch.cuda.current_stream().cuda_stream
+        last = self._pg_last_hidden[S - 1:S].contiguous()
+        logits = torch.empty(
+            1, vocab, dtype=torch.bfloat16, device=self.device)
+        fvk.bf16_matmul_qwen36_bf16(
+            last.data_ptr(), int(llm._weights.ptrs['lm_head_w']),
+            logits.data_ptr(), 1, vocab, hidden, stream)
+        torch.cuda.synchronize()
+        return logits
+
     def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
         """Lazy-capture a decode CUDA Graph for one cache slot.
 
@@ -332,7 +463,7 @@ class Qwen3VlTorchFrontendRtx:
         captured CUDA Graph for each decode step.
         """
         self.set_prompt(messages)
-        logits = self.prefill()
+        logits = self.prefill_graph()
         llm = self.llm
         p = self._prompt
         base_slot, base_rope = p['S'], p['mrope_max'] + 1

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -124,6 +124,18 @@ class Qwen3VlTorchFrontendRtx:
         # cache-slot -> captured decode CUDA Graph (rope baked at the
         # MRoPE-continuation position, which differs from the slot).
         self._decode_graphs: dict[int, Any] = {}
+        # Captured single-image prefill: (P,S,a,b) -> graph, plus the static
+        # input buffers set_prompt stages into and the persistent output
+        # buffers the replay + eager lm_head write.
+        self._prefill_graphs: dict = {}
+        self._pg_buffers: dict = {}
+        import torch as _torch
+        hidden = self.llm._cfg['hidden_size']
+        vocab = self.llm._cfg['vocab_size']
+        self._pg_last_hidden = _torch.empty(
+            self.max_seq, hidden, dtype=_torch.bfloat16, device=device)
+        self._pg_logits = _torch.empty(
+            1, vocab, dtype=_torch.bfloat16, device=device)
 
     # ── Prompt ──
 
@@ -212,6 +224,30 @@ class Qwen3VlTorchFrontendRtx:
             'pos_embeds': pos_embeds, 'S': S,
             'mrope_max': int(pos_ids.max()),
         }
+        # Single image: stage the captured-prefill static inputs here (this is
+        # one-time set-up glue), so prefill_graph's hot path is just replay +
+        # lm_head with no per-request torch copy.
+        if len(spans) == 1:
+            self._prompt['pg_key'] = self._stage_prefill_inputs(
+                seg_patches[0], S, spans[0])
+
+    _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
+                'vcos', 'vsin', 'mcos', 'msin')
+
+    def _stage_prefill_inputs(self, P: int, S: int, span):
+        """Copy the per-prompt tensors into persistent static buffers keyed by
+        (P, S, a, b). The captured prefill graph reads only from these, so the
+        replay path needs no torch copy. Returns the key."""
+        p = self._prompt
+        key = (P, S, span[0], span[1])
+        bufs = self._pg_buffers.get(key)
+        if bufs is None:
+            bufs = {k: p[k].clone() for k in self._PG_KEYS}
+            self._pg_buffers[key] = bufs
+        else:
+            for k in self._PG_KEYS:
+                bufs[k].copy_(p[k])
+        return key
 
     # ── Forward ──
 
@@ -308,8 +344,9 @@ class Qwen3VlTorchFrontendRtx:
         n_layers = llm._cfg['num_hidden_layers']
 
         emb, ds = self.vision.forward(
-            st['pixel'], st['pos'], st['vcos'], st['vsin'])
-        h = llm._weights.anchors[0][st['ids']].to(bf16).view(1, S, hidden)
+            st['pixel_values'], st['pos_embeds'], st['vcos'], st['vsin'])
+        h = llm._weights.anchors[0][st['input_ids']].to(bf16).view(
+            1, S, hidden)
         h = h.contiguous()
         h[0, a:b] = emb.to(bf16)
 
@@ -365,55 +402,35 @@ class Qwen3VlTorchFrontendRtx:
         if self._prompt is None:
             raise RuntimeError('call set_prompt() before prefill_graph()')
         p = self._prompt
-        if len(p['spans']) != 1:
+        if p.get('pg_key') is None:           # multi-image / video: eager
             return self.prefill()
 
         llm = self.llm
         hidden = llm._cfg['hidden_size']
         vocab = llm._cfg['vocab_size']
         S = p['S']
-        P = p['seg_patches'][0]
-        a, b = p['spans'][0]
-        key = (P, S, a, b)
-        llm.reset_state()
+        key = p['pg_key']
+        P, _, a, b = key
+        st = self._pg_buffers[key]            # already staged by set_prompt
+        # No reset_state: the captured layers write K/V[0:S] (which is all the
+        # causal prefill reads), and the subsequent decode overwrites
+        # K/V[>=S] before reading it (same as qwen3_rtx.prefill_with_graph).
 
-        if not hasattr(self, '_pg_last_hidden'):
-            self._pg_last_hidden = torch.empty(
-                self.max_seq, hidden, dtype=torch.bfloat16, device=self.device)
-            self._prefill_graphs: dict = {}
-
-        entry = self._prefill_graphs.get(key)
-        if entry is None:
-            st = {
-                'ids': p['input_ids'].clone(),
-                'pixel': p['pixel_values'].clone(),
-                'pos': p['pos_embeds'].clone(),
-                'vcos': p['vcos'].clone(), 'vsin': p['vsin'].clone(),
-                'mcos': p['mcos'].clone(), 'msin': p['msin'].clone(),
-            }
+        graph = self._prefill_graphs.get(key)
+        if graph is None:
             graph = self._capture_prefill_graph(st, P, S, a, b)
-            entry = (graph, st)
-            self._prefill_graphs[key] = entry
-        graph, st = entry
+            self._prefill_graphs[key] = graph
 
-        st['ids'].copy_(p['input_ids'])
-        st['pixel'].copy_(p['pixel_values'])
-        st['pos'].copy_(p['pos_embeds'])
-        st['vcos'].copy_(p['vcos'])
-        st['vsin'].copy_(p['vsin'])
-        st['mcos'].copy_(p['mcos'])
-        st['msin'].copy_(p['msin'])
+        # Hot path: pure-kernel graph replay + eager lm_head (one buffer, no
+        # per-request torch alloc/copy).
         graph.replay()
-
         stream = torch.cuda.current_stream().cuda_stream
         last = self._pg_last_hidden[S - 1:S].contiguous()
-        logits = torch.empty(
-            1, vocab, dtype=torch.bfloat16, device=self.device)
         fvk.bf16_matmul_qwen36_bf16(
             last.data_ptr(), int(llm._weights.ptrs['lm_head_w']),
-            logits.data_ptr(), 1, vocab, hidden, stream)
+            self._pg_logits.data_ptr(), 1, vocab, hidden, stream)
         torch.cuda.synchronize()
-        return logits
+        return self._pg_logits
 
     def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
         """Lazy-capture a decode CUDA Graph for one cache slot.

--- a/tests/test_qwen3_vl_smoke.py
+++ b/tests/test_qwen3_vl_smoke.py
@@ -47,6 +47,24 @@ def test_require_kernels_fails_fast_on_missing_symbols():
     assert 'FLASHRT_BUILD_QWEN3_VL' in str(ei.value)
 
 
+def test_fail_fast_on_each_missing_symbol():
+    """Dropping ANY single required symbol (e.g. a stale .so without the
+    fused-bias kernels) must raise at the check, naming the missing one —
+    not crash mid-ViT with an AttributeError."""
+    from flash_rt.frontends.torch.qwen3_vl_rtx import (
+        _QWEN3_VL_KERNEL_FNS,
+        _check_qwen3_vl_kernels,
+    )
+
+    for missing in _QWEN3_VL_KERNEL_FNS:
+        stub = type('Stub', (), {fn: (lambda *a, **k: None)
+                                 for fn in _QWEN3_VL_KERNEL_FNS
+                                 if fn != missing})()
+        with pytest.raises(RuntimeError) as ei:
+            _check_qwen3_vl_kernels(stub)
+        assert missing in str(ei.value)
+
+
 def test_kernel_module_complete_when_built():
     """If the gated module is built, it must expose every symbol the tower
     calls (otherwise skip -- this build did not enable it)."""


### PR DESCRIPTION
## Summary

Makes the Qwen3-VL single-image prefill run as a pure-kernel CUDA-graph
replay (zero per-request torch dispatch, like decode), moves image
preprocessing onto the GPU, and folds the ViT bias adds into adjacent
kernels. Full-request TTFT (5090, full-res 1581-token prompt) ~100 ms;
prefill 93 ms; decode ~150 tok/s.

Additive: the shared `flash_rt_kernels.so` is untouched; new kernels live
in the opt-in `flash_rt_qwen3_vl_kernels` module.

## What's in it

- Whole-prefill CUDA graph (embed → ViT tower → scatter → NVFP4 layers +
  DeepStack → final norm); lm_head eager on the last row. Multi-image /
  video keep the eager prefill.
- GPU image preprocessing via `apply_chat_template(device=...)` (set_prompt
  24 → 8 ms).
- Merger FP8 (−2.6 ms).
- Bias fusion — the per-column bias rides the op that consumes the GEMM
  output (3 new general kernels: `gelu_tanh_bias_to_fp8_block128_bf16`,
  `residual_add_bias_bf16`, `qkv_split_bias_bf16`); no bias round-trips HBM.

## Correctness (vs HF bf16)

Next-token argmax matches HF: image 785, two-image 8420, video 785; prefill
graph eager-vs-replay logits cos 0.99999; new-kernel standalone cos ≥ 0.9997.

## Build

`cmake -B build -S . -DGPU_ARCH=120 -DFLASHRT_BUILD_QWEN3_VL=ON`, build
`flash_rt_qwen3_vl_kernels`. Smoke: `pytest tests/test_qwen3_vl_smoke.py`.