### PR TITLE
Add SM89 Qwen3-VL official FP8 path (RTX 4090)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,11 +882,12 @@ endif()
 #     from flash_rt import flash_rt_qwen3_vl_kernels as vlk
 #     vlk.rope_neox_qk_bf16(...)
 if(FLASHRT_BUILD_QWEN3_VL)
-  # The Qwen3-VL path depends on the SM120 Qwen3 NVFP4 / FP8 block-128
-  # kernels, so this module only builds for RTX 5090 (sm_120).
-  if(NOT GPU_ARCH STREQUAL "120")
+  # These Qwen3-VL helper kernels are model-agnostic BF16 / FP8 activation
+  # kernels. The SM120 frontend also depends on NVFP4 language kernels, but
+  # the helper module itself can be built for SM89 bring-up as well.
+  if(NOT (GPU_ARCH STREQUAL "89" OR GPU_ARCH STREQUAL "120"))
     message(FATAL_ERROR
-      "FLASHRT_BUILD_QWEN3_VL requires GPU_ARCH=120 (RTX 5090 / sm_120); "
+      "FLASHRT_BUILD_QWEN3_VL requires GPU_ARCH=89 or 120; "
       "got '${GPU_ARCH}'.")
   endif()
   pybind11_add_module(flash_rt_qwen3_vl_kernels
@@ -1083,6 +1084,14 @@ if(GPU_ARCH STREQUAL "120")
     $<TARGET_OBJECTS:sm120_fp8_smallm_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE
     ENABLE_CUTLASS_SM120_BLOCK_FP8=1)
+endif()
+
+# Native Ada block-scaled FP8 GEMM for official Qwen3-VL FP8 prefill.
+if(GPU_ARCH STREQUAL "89")
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/gemm/fp8_block128_gemm_mma_sm89.cu)
+  target_compile_definitions(flash_rt_kernels PRIVATE
+    ENABLE_SM89_BLOCK_FP8_GEMM=1)
 endif()
 
 # Dedicated M=1 decode GEMV (FP8 + BF16); linked + macro defined wherever the

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -10,6 +10,9 @@
 #include "context.h"
 #include "gemm/gemm_runner.h"
 #include "gemm/fp8_block128_gemm.cuh"
+#ifdef ENABLE_SM89_BLOCK_FP8_GEMM
+#include "gemm/fp8_block128_gemm_mma_sm89.cuh"
+#endif
 #ifdef ENABLE_CUTLASS_SM120_BLOCK_FP8
 #include "gemm/cutlass_sm120_block128_fp8_gemm.cuh"
 #include "gemm/fp8_smallM_handtuned_sm120.cuh"
@@ -2794,6 +2797,46 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("output_scale"),
         py::arg("M"), py::arg("K"), py::arg("stream") = 0);
 
+    m.def("rms_norm_to_fp8_block128_bf16",
+        [](uintptr_t input, uintptr_t weight, uintptr_t output_fp8,
+           uintptr_t output_scale, int M, int K, float eps,
+           uintptr_t stream) {
+            flash_rt::quantize::rms_norm_to_fp8_block128_bf16(
+                to_ptr(input), to_ptr(weight), to_ptr(output_fp8),
+                reinterpret_cast<float*>(output_scale),
+                M, K, eps, to_stream(stream));
+        },
+        py::arg("input"), py::arg("weight"), py::arg("output_fp8"),
+        py::arg("output_scale"), py::arg("M"), py::arg("K"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("residual_add_rms_norm_to_fp8_block128_bf16",
+        [](uintptr_t residual, uintptr_t x, uintptr_t residual_out,
+           uintptr_t weight, uintptr_t output_fp8, uintptr_t output_scale,
+           int M, int K, float eps, uintptr_t stream) {
+            flash_rt::quantize::residual_add_rms_norm_to_fp8_block128_bf16(
+                to_ptr(residual), to_ptr(x), to_ptr(residual_out),
+                to_ptr(weight), to_ptr(output_fp8),
+                reinterpret_cast<float*>(output_scale),
+                M, K, eps, to_stream(stream));
+        },
+        py::arg("residual"), py::arg("x"), py::arg("residual_out"),
+        py::arg("weight"), py::arg("output_fp8"), py::arg("output_scale"),
+        py::arg("M"), py::arg("K"), py::arg("eps") = 1e-6f,
+        py::arg("stream") = 0);
+
+    m.def("silu_mul_to_fp8_block128_bf16",
+        [](uintptr_t gate, uintptr_t up, uintptr_t output_fp8,
+           uintptr_t output_scale, int M, int K, uintptr_t stream) {
+            flash_rt::quantize::silu_mul_to_fp8_block128_bf16(
+                to_ptr(gate), to_ptr(up), to_ptr(output_fp8),
+                reinterpret_cast<float*>(output_scale),
+                M, K, to_stream(stream));
+        },
+        py::arg("gate"), py::arg("up"), py::arg("output_fp8"),
+        py::arg("output_scale"), py::arg("M"), py::arg("K"),
+        py::arg("stream") = 0);
+
     // G7.7 — Fused IM2COL + FP8 e4m3 quantize for 3x3x3 stride-1
     // already-padded Conv3d. Caller pads x with F.pad to (T_pad, H_pad, W_pad)
     // first; this kernel emits col_fp8 (M=B*To*Ho*Wo, K=27*Ci) ready for
@@ -4013,6 +4056,85 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("scratch_A_bf16"), py::arg("scratch_B_bf16"),
         py::arg("stream") = 0);
 
+#ifdef ENABLE_SM89_BLOCK_FP8_GEMM
+    // Native Ada (sm_89) block-scaled FP8 GEMM. Reads the FP8 weight
+    // directly (no dequant scratch), applies DeepSeek block-128 scaling in
+    // the mainloop. Drop-in replacement for the descale path on sm_89
+    // prefill — ~3-4x faster on the Qwen3-VL-8B linear shapes (weight
+    // traffic 5x lower). No scratch buffers needed.
+    m.def("fp8_block128_gemm_blockscaled_sm89_bf16out",
+        [](uintptr_t A, uintptr_t B, uintptr_t D,
+           int M, int N, int K,
+           uintptr_t act_scale, uintptr_t w_scale,
+           uintptr_t stream) {
+            int rc = flash_rt::gemm::block128_sm89::
+                fp8_block128_gemm_blockscaled_sm89_bf16out(
+                    to_ptr(A), to_ptr(B), to_ptr(D),
+                    M, N, K,
+                    reinterpret_cast<const float*>(act_scale),
+                    reinterpret_cast<const float*>(w_scale),
+                    to_stream(stream));
+            if (rc != 0)
+                throw std::runtime_error(
+                    "fp8_block128_gemm_blockscaled_sm89_bf16out launch failed");
+        },
+        py::arg("A"), py::arg("B"), py::arg("D"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("act_block_scale"), py::arg("w_block_scale"),
+        py::arg("stream") = 0);
+
+    auto bind_sm89_bs = [&](const char* name, auto fn) {
+        m.def(name,
+            [fn, name](uintptr_t A, uintptr_t B, uintptr_t D,
+                       int M, int N, int K,
+                       uintptr_t act_scale, uintptr_t w_scale,
+                       uintptr_t stream) {
+                int rc = fn(
+                    to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                    reinterpret_cast<const float*>(act_scale),
+                    reinterpret_cast<const float*>(w_scale),
+                    to_stream(stream));
+                if (rc != 0)
+                    throw std::runtime_error(
+                        std::string(name) + " launch failed");
+            },
+            py::arg("A"), py::arg("B"), py::arg("D"),
+            py::arg("M"), py::arg("N"), py::arg("K"),
+            py::arg("act_block_scale"), py::arg("w_block_scale"),
+            py::arg("stream") = 0);
+    };
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_16x64x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_16x64x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_16x128x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_16x128x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_32x64x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_32x64x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_32x128x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_32x128x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_64x64x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_64x64x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_64x128x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_64x128x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_64x128x128_w8",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_64x128x128_w8);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_128x64x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_128x64x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_128x128x128_w4",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_128x128x128_w4);
+    bind_sm89_bs("fp8_block128_gemm_bs_sm89_128x128x128_w8",
+                 flash_rt::gemm::block128_sm89::
+                     fp8_block128_gemm_bs_sm89_128x128x128_w8);
+#endif  // ENABLE_SM89_BLOCK_FP8_GEMM
+
     // Phase 3.2 — causal_conv1d for Qwen3.6 linear-attention. SiLU
     // fused into the epilogue. Two variants for prefill / decode.
     m.def("causal_conv1d_qwen36_bf16",
@@ -4136,6 +4258,18 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         [](uintptr_t x, uintptr_t W, uintptr_t out,
            int M, int N, int K, uintptr_t stream) {
             flash_rt::kernels::bf16_matmul_qwen36_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const __nv_bfloat16*>(W),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                M, N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("W"), py::arg("out"),
+        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+
+    m.def("bf16_matmul_cublaslt_bf16",
+        [](uintptr_t x, uintptr_t W, uintptr_t out,
+           int M, int N, int K, uintptr_t stream) {
+            flash_rt::kernels::bf16_matmul_cublaslt_bf16(
                 reinterpret_cast<const __nv_bfloat16*>(x),
                 reinterpret_cast<const __nv_bfloat16*>(W),
                 reinterpret_cast<__nv_bfloat16*>(out),
@@ -5607,6 +5741,28 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_GEMV_M1(gemv_bf16_m1_w16);
 
 #undef BIND_GEMV_M1
+
+#define BIND_BLOCK128_GEMV_M1(NAME)                                           \
+    m.def("ht_" #NAME,                                                       \
+        [](uintptr_t A, uintptr_t B, uintptr_t D,                            \
+           int M, int N, int K, uintptr_t act_scale, uintptr_t w_scale,       \
+           float alpha, uintptr_t stream) {                                  \
+            return flash_rt::gemm::gemv_m1::NAME(                            \
+                to_ptr(A), to_ptr(B), to_ptr(D),                             \
+                M, N, K, reinterpret_cast<const float*>(act_scale),          \
+                reinterpret_cast<const float*>(w_scale), alpha,              \
+                to_stream(stream));                                          \
+        },                                                                   \
+        py::arg("A"), py::arg("B"), py::arg("D"),                          \
+        py::arg("M"), py::arg("N"), py::arg("K"),                          \
+        py::arg("act_scale"), py::arg("w_scale"), py::arg("alpha"),        \
+        py::arg("stream") = 0)
+
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w4);
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w8);
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w16);
+
+#undef BIND_BLOCK128_GEMV_M1
 #endif  // ENABLE_DECODE_GEMV_M1
 
 #ifdef ENABLE_FP8_CONV3D_V17
@@ -6375,6 +6531,64 @@ graph-replay safe) to fill the SMs on long K. M in 1..16; N%8==0; K%64==0;
         py::arg("merged_gate_up"),
         py::arg("packed"), py::arg("sf_swz"),
         py::arg("rows"), py::arg("cols"), py::arg("stream") = 0);
+
+    m.def("qwen3_qk_norm_rope_kvwrite_bf16",
+        [](uintptr_t q_pre, uintptr_t k_pre, uintptr_t v_pre,
+           uintptr_t q_norm_w, uintptr_t k_norm_w,
+           uintptr_t cos, uintptr_t sin,
+           uintptr_t q_buf_dst,
+           uintptr_t k_cache_dst, uintptr_t v_cache_dst,
+           int n_q_heads, int n_kv_heads, float eps,
+           uintptr_t stream) -> int {
+            return flash_rt::kernels::qwen3_qk_norm_rope_kvwrite_bf16(
+                to_ptr(q_pre), to_ptr(k_pre), to_ptr(v_pre),
+                to_ptr(q_norm_w), to_ptr(k_norm_w),
+                to_ptr(cos), to_ptr(sin),
+                to_ptr(q_buf_dst),
+                to_ptr(k_cache_dst), to_ptr(v_cache_dst),
+                n_q_heads, n_kv_heads, eps, to_stream(stream));
+        },
+        py::arg("q_pre"), py::arg("k_pre"), py::arg("v_pre"),
+        py::arg("q_norm_w"), py::arg("k_norm_w"),
+        py::arg("cos"), py::arg("sin"),
+        py::arg("q_buf_dst"),
+        py::arg("k_cache_dst"), py::arg("v_cache_dst"),
+        py::arg("n_q_heads"), py::arg("n_kv_heads"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("qwen3_qk_norm_rope_kvwrite_batched_bf16",
+        [](uintptr_t q_pre, uintptr_t k_pre, uintptr_t v_pre,
+           uintptr_t q_norm_w, uintptr_t k_norm_w,
+           uintptr_t cos, uintptr_t sin,
+           uintptr_t q_buf_dst,
+           uintptr_t k_cache_dst, uintptr_t v_cache_dst,
+           int seq_len,
+           int q_pre_row_elems, int k_pre_row_elems, int v_pre_row_elems,
+           int q_dst_row_elems, int kv_dst_row_elems,
+           int n_q_heads, int n_kv_heads, float eps,
+           uintptr_t stream) -> int {
+            return flash_rt::kernels::qwen3_qk_norm_rope_kvwrite_batched_bf16(
+                to_ptr(q_pre), to_ptr(k_pre), to_ptr(v_pre),
+                to_ptr(q_norm_w), to_ptr(k_norm_w),
+                to_ptr(cos), to_ptr(sin),
+                to_ptr(q_buf_dst),
+                to_ptr(k_cache_dst), to_ptr(v_cache_dst),
+                seq_len,
+                q_pre_row_elems, k_pre_row_elems, v_pre_row_elems,
+                q_dst_row_elems, kv_dst_row_elems,
+                n_q_heads, n_kv_heads, eps, to_stream(stream));
+        },
+        py::arg("q_pre"), py::arg("k_pre"), py::arg("v_pre"),
+        py::arg("q_norm_w"), py::arg("k_norm_w"),
+        py::arg("cos"), py::arg("sin"),
+        py::arg("q_buf_dst"),
+        py::arg("k_cache_dst"), py::arg("v_cache_dst"),
+        py::arg("seq_len"),
+        py::arg("q_pre_row_elems"), py::arg("k_pre_row_elems"),
+        py::arg("v_pre_row_elems"),
+        py::arg("q_dst_row_elems"), py::arg("kv_dst_row_elems"),
+        py::arg("n_q_heads"), py::arg("n_kv_heads"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
 
     m.def("qwen3_k_norm_rope_kvwrite_bf16",
         [](uintptr_t k_pre, uintptr_t v_pre, uintptr_t k_norm_w,

--- a/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
+++ b/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Native Ada (sm_89) FP8 e4m3 -> BF16 block-128 scaled GEMM.
+// Header: fp8_block128_gemm_mma_sm89.cuh.
+//
+// Adapted from csrc/gemm/fp8_smallM_handtuned_sm120.cu (same cp.async
+// pipeline + m16n8k32 MMA tiling). Two sm_89-specific changes vs that file:
+//   1. MMA uses the plain Ada FP8 op `mma.sync.aligned.m16n8k32.row.col.
+//      f32.e4m3.e4m3.f32` (no `.kind::f8f6f4`, which is sm_120a-only).
+//   2. Per-tensor `alpha` is replaced by DeepSeek-style block-128 scaling:
+//      BLOCK_K is pinned to 128 so each K-iteration is exactly one scale
+//      block. Each k-iter accumulates into a temp, then folds
+//      act_scale[row,kb] * w_scale[n/128,kb] into the running accumulator.
+//
+// This reads the FP8 weight directly (no dequant-to-bf16 scratch), cutting
+// per-linear weight traffic ~5x vs fp8_block128_gemm_descale_bf16out while
+// keeping the per-token activation scale (no precision downgrade).
+
+#include "fp8_block128_gemm_mma_sm89.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt {
+namespace gemm {
+namespace block128_sm89 {
+
+namespace {
+
+__device__ __forceinline__ void mma_m16n8k32_e4m3(
+    float &d0, float &d1, float &d2, float &d3,
+    uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
+    uint32_t b0, uint32_t b1)
+{
+    // Ada (sm_89) FP8 tensor-core op — NO .kind::f8f6f4 qualifier.
+    asm volatile(
+        "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+        "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+        : "+f"(d0), "+f"(d1), "+f"(d2), "+f"(d3)
+        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+}
+
+__device__ __forceinline__ void cp_async_16(uint32_t smem, const uint8_t* src) {
+    int b = (src == nullptr) ? 0 : 16;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 16, %2;\n"
+                 :: "r"(smem), "l"(src), "r"(b));
+}
+
+__device__ __forceinline__ uint32_t to_smem(const void* p) {
+    return static_cast<uint32_t>(__cvta_generic_to_shared(p));
+}
+
+// BLOCK_K is pinned to 128 (one DeepSeek scale block per K-iteration).
+//  - A: [M, K] row-major FP8 e4m3, act_scale [M, K/128] fp32
+//  - B: [N, K] row-major FP8 e4m3, w_scale [N/128, K/128] fp32
+//  - D: [M, N] row-major BF16
+//  - BLOCK_N must keep each warp's 8-wide N-atoms inside one 128 scale block.
+template <int BLOCK_M, int BLOCK_N, int NUM_WARPS, int STAGES,
+          int MIN_BLOCKS_PER_SM>
+__global__ __launch_bounds__(NUM_WARPS * 32, MIN_BLOCKS_PER_SM)
+void fp8_bs_gemm_kernel(
+    const __nv_fp8_e4m3* __restrict__ A,
+    const __nv_fp8_e4m3* __restrict__ B,
+    const float* __restrict__ act_scale,   // [M, K/128]
+    const float* __restrict__ w_scale,     // [N/128, K/128]
+    __nv_bfloat16* __restrict__ D,
+    int M, int N, int K)
+{
+    constexpr int BLOCK_K    = 128;
+    constexpr int THREADS    = NUM_WARPS * 32;
+    constexpr int M_ATOMS    = BLOCK_M / 16;
+    constexpr int N_ATOMS    = BLOCK_N / 8;
+    constexpr int N_ATOMS_PW = N_ATOMS / NUM_WARPS;
+    constexpr int K_ATOMS    = BLOCK_K / 32;        // = 4
+    constexpr int SMEM_K_PAD = BLOCK_K + 16;        // bank-conflict padding
+
+    static_assert(BLOCK_M % 16 == 0, "BLOCK_M multiple of 16");
+    static_assert(BLOCK_N % 8 == 0,  "BLOCK_N multiple of 8");
+    static_assert(BLOCK_N <= 128, "one CTA must fit one N scale block");
+    static_assert((BLOCK_N / 8) % NUM_WARPS == 0, "N-atoms split across warps");
+
+    extern __shared__ uint8_t smem_raw[];
+    uint8_t* A_smem = smem_raw;
+    uint8_t* B_smem = A_smem + STAGES * BLOCK_M * SMEM_K_PAD;
+
+    const int cta_m = blockIdx.x;
+    const int cta_n = blockIdx.y;
+    const int m_base = cta_m * BLOCK_M;
+    const int n_base = cta_n * BLOCK_N;
+
+    const int t = threadIdx.x;
+    const int warp_id = t / 32;
+    const int lane = t % 32;
+    const int l = lane % 4;
+    const int h = lane / 4;
+
+    const int K128 = K >> 7;                        // # scale blocks along K
+
+    auto issue_load = [&](int stage, int k_base) {
+        constexpr int A_TOTAL_16B = BLOCK_M * BLOCK_K / 16;
+        constexpr int A_ITERS = (A_TOTAL_16B + THREADS - 1) / THREADS;
+        #pragma unroll
+        for (int it = 0; it < A_ITERS; ++it) {
+            int idx = it * THREADS + t;
+            if (idx >= A_TOTAL_16B) break;
+            int row_a = idx / (BLOCK_K / 16);
+            int koff_a = (idx % (BLOCK_K / 16)) * 16;
+            int m_glob = m_base + row_a;
+            int k_glob = k_base + koff_a;
+            const uint8_t* a_src = nullptr;
+            if (m_glob < M && k_glob < K) {
+                a_src = reinterpret_cast<const uint8_t*>(&A[m_glob * K + k_glob]);
+            }
+            cp_async_16(
+                to_smem(&A_smem[stage * BLOCK_M * SMEM_K_PAD
+                                + row_a * SMEM_K_PAD + koff_a]),
+                a_src);
+        }
+        constexpr int B_TOTAL_16B = BLOCK_N * BLOCK_K / 16;
+        constexpr int B_ITERS = (B_TOTAL_16B + THREADS - 1) / THREADS;
+        #pragma unroll
+        for (int it = 0; it < B_ITERS; ++it) {
+            int idx = it * THREADS + t;
+            if (idx >= B_TOTAL_16B) break;
+            int row_b = idx / (BLOCK_K / 16);
+            int koff_b = (idx % (BLOCK_K / 16)) * 16;
+            int n_glob = n_base + row_b;
+            int k_glob = k_base + koff_b;
+            const uint8_t* b_src = nullptr;
+            if (n_glob < N && k_glob < K) {
+                b_src = reinterpret_cast<const uint8_t*>(&B[n_glob * K + k_glob]);
+            }
+            cp_async_16(
+                to_smem(&B_smem[stage * BLOCK_N * SMEM_K_PAD
+                                + row_b * SMEM_K_PAD + koff_b]),
+                b_src);
+        }
+    };
+
+    // Running (scaled) accumulators across all K-blocks.
+    float acc[M_ATOMS][N_ATOMS_PW][4];
+    #pragma unroll
+    for (int mi = 0; mi < M_ATOMS; ++mi)
+        #pragma unroll
+        for (int ni = 0; ni < N_ATOMS_PW; ++ni)
+            #pragma unroll
+            for (int j = 0; j < 4; ++j) acc[mi][ni][j] = 0.0f;
+
+    const int K_ITERS = (K + BLOCK_K - 1) / BLOCK_K;
+    #pragma unroll
+    for (int s = 0; s < STAGES - 1; ++s) {
+        int kb = s * BLOCK_K;
+        if (kb < K) issue_load(s, kb);
+        asm volatile("cp.async.commit_group;\n" ::);
+    }
+
+    int compute_stage = 0;
+    for (int k_iter = 0; k_iter < K_ITERS; ++k_iter) {
+        int issue_iter = k_iter + (STAGES - 1);
+        int issue_stage = issue_iter % STAGES;
+        if (issue_iter < K_ITERS) issue_load(issue_stage, issue_iter * BLOCK_K);
+        asm volatile("cp.async.commit_group;\n" ::);
+        asm volatile("cp.async.wait_group %0;\n" :: "n"(STAGES - 1));
+        __syncthreads();
+
+        // This k_iter is exactly one scale block (kb = k_iter).
+        const int kb = k_iter;
+        // w_scale is constant across this CTA's BLOCK_N if it fits one
+        // 128 block; index per warp's N base to stay correct for BLOCK_N>128.
+        float tacc[M_ATOMS][N_ATOMS_PW][4];
+        #pragma unroll
+        for (int mi = 0; mi < M_ATOMS; ++mi)
+            #pragma unroll
+            for (int ni = 0; ni < N_ATOMS_PW; ++ni)
+                #pragma unroll
+                for (int j = 0; j < 4; ++j) tacc[mi][ni][j] = 0.0f;
+
+        #pragma unroll
+        for (int ka = 0; ka < K_ATOMS; ++ka) {
+            int kA0 = ka * 32 + 4 * l;
+            int kA2 = ka * 32 + 4 * l + 16;
+            #pragma unroll
+            for (int mi = 0; mi < M_ATOMS; ++mi) {
+                int rA0 = mi * 16 + h;
+                int rA1 = mi * 16 + h + 8;
+                uint32_t A0 = *reinterpret_cast<const uint32_t*>(
+                    &A_smem[compute_stage * BLOCK_M * SMEM_K_PAD + rA0 * SMEM_K_PAD + kA0]);
+                uint32_t A1 = *reinterpret_cast<const uint32_t*>(
+                    &A_smem[compute_stage * BLOCK_M * SMEM_K_PAD + rA1 * SMEM_K_PAD + kA0]);
+                uint32_t A2 = *reinterpret_cast<const uint32_t*>(
+                    &A_smem[compute_stage * BLOCK_M * SMEM_K_PAD + rA0 * SMEM_K_PAD + kA2]);
+                uint32_t A3 = *reinterpret_cast<const uint32_t*>(
+                    &A_smem[compute_stage * BLOCK_M * SMEM_K_PAD + rA1 * SMEM_K_PAD + kA2]);
+                #pragma unroll
+                for (int ni = 0; ni < N_ATOMS_PW; ++ni) {
+                    int co_n = warp_id * N_ATOMS_PW * 8 + ni * 8 + h;
+                    uint32_t B0 = *reinterpret_cast<const uint32_t*>(
+                        &B_smem[compute_stage * BLOCK_N * SMEM_K_PAD + co_n * SMEM_K_PAD + kA0]);
+                    uint32_t B1 = *reinterpret_cast<const uint32_t*>(
+                        &B_smem[compute_stage * BLOCK_N * SMEM_K_PAD + co_n * SMEM_K_PAD + kA2]);
+                    mma_m16n8k32_e4m3(
+                        tacc[mi][ni][0], tacc[mi][ni][1], tacc[mi][ni][2], tacc[mi][ni][3],
+                        A0, A1, A2, A3, B0, B1);
+                }
+            }
+        }
+
+        // Fold block scales: D += act_scale[row,kb] * w_scale[ncol/128,kb] * tacc
+        // All current SM89 prefill tiles use BLOCK_N <= 128, so a CTA stays
+        // inside one 128-column weight-scale block even for 64-column half
+        // tiles. Load that scale once per K block instead of once per
+        // M/N atom.
+        float ws_cta = w_scale[(size_t)(n_base >> 7) * K128 + kb];
+        #pragma unroll
+        for (int mi = 0; mi < M_ATOMS; ++mi) {
+            int row0 = m_base + mi * 16 + h;
+            int row1 = row0 + 8;
+            float as0 = (row0 < M) ? act_scale[row0 * K128 + kb] : 0.0f;
+            float as1 = (row1 < M) ? act_scale[row1 * K128 + kb] : 0.0f;
+            #pragma unroll
+            for (int ni = 0; ni < N_ATOMS_PW; ++ni) {
+                acc[mi][ni][0] += tacc[mi][ni][0] * (as0 * ws_cta);
+                acc[mi][ni][1] += tacc[mi][ni][1] * (as0 * ws_cta);
+                acc[mi][ni][2] += tacc[mi][ni][2] * (as1 * ws_cta);
+                acc[mi][ni][3] += tacc[mi][ni][3] * (as1 * ws_cta);
+            }
+        }
+        compute_stage = (compute_stage + 1) % STAGES;
+    }
+    asm volatile("cp.async.wait_all;\n" ::);
+
+    // Epilogue: write BF16. m16n8 layout: thread (h,l) -> rows {h,h+8},
+    // cols {2*l, 2*l+1}.
+    #pragma unroll
+    for (int mi = 0; mi < M_ATOMS; ++mi) {
+        int row0 = m_base + mi * 16 + h;
+        int row1 = row0 + 8;
+        #pragma unroll
+        for (int ni = 0; ni < N_ATOMS_PW; ++ni) {
+            int n_pair_base = n_base + warp_id * N_ATOMS_PW * 8 + ni * 8 + 2 * l;
+            #pragma unroll
+            for (int j = 0; j < 4; ++j) {
+                int row = (j < 2) ? row0 : row1;
+                int col = n_pair_base + (j & 1);
+                if (row < M && col < N) {
+                    D[row * N + col] = __float2bfloat16(acc[mi][ni][j]);
+                }
+            }
+        }
+    }
+}
+
+template <int BM, int BN, int W, int STAGES, int MIN_BLK>
+int launch_(const void* A, const void* B, void* D,
+            int M, int N, int K, const float* act_scale,
+            const float* w_scale, cudaStream_t s)
+{
+    constexpr int BK = 128;
+    int grid_m = (M + BM - 1) / BM;
+    int grid_n = (N + BN - 1) / BN;
+    dim3 grid(grid_m, grid_n, 1);
+    dim3 block(W * 32, 1, 1);
+    int smem_bytes = STAGES * (BM + BN) * (BK + 16);
+    if (smem_bytes > 48 * 1024) {
+        cudaFuncSetAttribute(
+            (const void*)&fp8_bs_gemm_kernel<BM, BN, W, STAGES, MIN_BLK>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+    }
+    fp8_bs_gemm_kernel<BM, BN, W, STAGES, MIN_BLK><<<grid, block, smem_bytes, s>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        act_scale, w_scale,
+        reinterpret_cast<__nv_bfloat16*>(D),
+        M, N, K);
+    cudaError_t err = cudaGetLastError();
+    return (err == cudaSuccess) ? 0 : 1;
+}
+
+}  // namespace
+
+#define DEFINE(NAME, BM, BN, W, S, MB)                                        \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,        \
+           const float* act_scale, const float* w_scale, cudaStream_t s) {    \
+    return launch_<BM, BN, W, S, MB>(A, B, D, M, N, K, act_scale, w_scale, s);\
+  }
+
+DEFINE(fp8_block128_gemm_bs_sm89_32x128x128_w4,   32, 128, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_64x128x128_w4,   64, 128, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_64x128x128_w8,   64, 128, 8, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_128x128x128_w4, 128, 128, 4, 2, 2)
+DEFINE(fp8_block128_gemm_bs_sm89_128x128x128_w8, 128, 128, 8, 2, 2)
+DEFINE(fp8_block128_gemm_bs_sm89_32x64x128_w4,    32,  64, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_64x64x128_w4,    64,  64, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_128x64x128_w4,  128,  64, 4, 2, 2)
+DEFINE(fp8_block128_gemm_bs_sm89_16x128x128_w4,   16, 128, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_16x64x128_w4,    16,  64, 4, 2, 4)
+
+#undef DEFINE
+
+int fp8_block128_gemm_blockscaled_sm89_bf16out(
+    const void* A, const void* B, void* D, int M, int N, int K,
+    const float* act_scale, const float* w_scale, cudaStream_t stream)
+{
+    // Tuned on 4090 over Qwen3-VL-8B-FP8 layer shapes (qkv 6144, o 4096,
+    // gate/up 12288, down 4096x12288) at S=79..256. BLOCK_M=32 keeps grid
+    // occupancy high at small M; BLOCK_N=64 wins until M crosses ~128, then
+    // the wider BLOCK_N=128 amortizes better. Tiny-N (<2048) prefers BLOCK_N=64.
+    //
+    // ViT prefill is a different regime: full-res FlashRT.png runs M=6256.
+    // On these large-M shapes the language-prefill heuristic is wrong for
+    // the small-N linears:
+    //   - patch_embed / proj   (N=1152, K≈1152..1536) prefer 32x128
+    //   - fc2 / merger-fc2     (N=1152, K>=4096)      prefer 64x64
+    // Keep the original small-M path intact and only branch once the grid is
+    // already abundant (M>=2048), so text prefill / decode remain unchanged.
+    if (N < 2048)
+    {
+        if (M >= 2048) {
+            if (K >= 4096)
+                return fp8_block128_gemm_bs_sm89_64x64x128_w4(
+                    A, B, D, M, N, K, act_scale, w_scale, stream);
+            return fp8_block128_gemm_bs_sm89_32x128x128_w4(
+                A, B, D, M, N, K, act_scale, w_scale, stream);
+        }
+        return fp8_block128_gemm_bs_sm89_16x64x128_w4(
+            A, B, D, M, N, K, act_scale, w_scale, stream);
+    }
+    if (M >= 1024) {
+        if (N >= 8192 && K == 4096)
+            return fp8_block128_gemm_bs_sm89_128x128x128_w8(
+                A, B, D, M, N, K, act_scale, w_scale, stream);
+        if (N == 4096 && K >= 8192)
+            return fp8_block128_gemm_bs_sm89_64x64x128_w4(
+                A, B, D, M, N, K, act_scale, w_scale, stream);
+    }
+    if (M < 128)
+        return fp8_block128_gemm_bs_sm89_32x64x128_w4(
+            A, B, D, M, N, K, act_scale, w_scale, stream);
+    return fp8_block128_gemm_bs_sm89_32x128x128_w4(
+        A, B, D, M, N, K, act_scale, w_scale, stream);
+}
+
+}  // namespace block128_sm89
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
+++ b/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
@@ -22,6 +22,7 @@
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
 #include <cstdint>
+#include <stdexcept>
 
 namespace flash_rt {
 namespace gemm {
@@ -303,6 +304,12 @@ int fp8_block128_gemm_blockscaled_sm89_bf16out(
     const void* A, const void* B, void* D, int M, int N, int K,
     const float* act_scale, const float* w_scale, cudaStream_t stream)
 {
+    if ((N % 128) != 0)
+        throw std::runtime_error(
+            "fp8_block128_gemm_blockscaled_sm89_bf16out requires N multiple of 128");
+    if ((K % 128) != 0)
+        throw std::runtime_error(
+            "fp8_block128_gemm_blockscaled_sm89_bf16out requires K multiple of 128");
     // Tuned on 4090 over Qwen3-VL-8B-FP8 layer shapes (qkv 6144, o 4096,
     // gate/up 12288, down 4096x12288) at S=79..256. BLOCK_M=32 keeps grid
     // occupancy high at small M; BLOCK_N=64 wins until M crosses ~128, then

--- a/csrc/gemm/fp8_block128_gemm_mma_sm89.cuh
+++ b/csrc/gemm/fp8_block128_gemm_mma_sm89.cuh
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace gemm {
+namespace block128_sm89 {
+
+// Native Ada (sm_89) FP8 e4m3 -> BF16 block-128 scaled GEMM.
+//
+// Computes D_rm[M,N] = (act_fp8 @ w_fp8^T) with DeepSeek-style block-128
+// scaling applied in the mainloop:
+//   D[m,n] = sum_{kb} act_scale[m, kb] * w_scale[n/128, kb]
+//                     * sum_{k in kb} A[m,k] * B[n,k]
+//
+// Inputs (all device pointers):
+//   A         : [M, K]        FP8 e4m3 row-major   (per-token quantized act)
+//   B         : [N, K]        FP8 e4m3 row-major   (= W, ckpt weight)
+//   act_scale : [M, K/128]    fp32 row-major       (per-token block scale)
+//   w_scale   : [N/128, K/128] fp32 row-major      (weight_scale_inv)
+//   D         : [M, N]        BF16 row-major
+//
+// Drop-in replacement for fp8_block128_gemm_descale_bf16out but reads the
+// FP8 weight directly (no dequant scratch). K and N must be multiples of 128.
+// Returns 0 on success.
+
+#define DECL(NAME)                                                            \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,        \
+           const float* act_scale, const float* w_scale, cudaStream_t stream)
+
+DECL(fp8_block128_gemm_bs_sm89_32x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_64x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_64x128x128_w8);
+DECL(fp8_block128_gemm_bs_sm89_128x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_128x128x128_w8);
+DECL(fp8_block128_gemm_bs_sm89_32x64x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_64x64x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_128x64x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_16x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_16x64x128_w4);
+
+#undef DECL
+
+// Auto-dispatch over the tuned tile set above based on (M, N, K).
+int fp8_block128_gemm_blockscaled_sm89_bf16out(
+    const void* A, const void* B, void* D, int M, int N, int K,
+    const float* act_scale, const float* w_scale, cudaStream_t stream);
+
+}  // namespace block128_sm89
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_gemv_m1_sm120.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cu
@@ -104,6 +104,72 @@ void gemv_fp8_m1_resadd_kernel(
     if (lane == 0) D[n] = __float2bfloat16(__bfloat162float(D[n]) + acc * alpha);
 }
 
+template <int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+void gemv_fp8_block128_m1_kernel(
+    const __nv_fp8_e4m3* __restrict__ A,   // [K]
+    const __nv_fp8_e4m3* __restrict__ B,   // [N, K]
+    __nv_bfloat16* __restrict__ D,         // [N]
+    int N, int K,
+    const float* __restrict__ act_scale,   // [K/128]
+    const float* __restrict__ w_scale,     // [N/128, K/128]
+    float alpha)
+{
+    extern __shared__ __nv_fp8_e4m3 sA[];
+    const int tid     = threadIdx.x;
+    const int lane    = tid & 31;
+    const int warp    = tid >> 5;
+    const int threads = WARPS_PER_BLOCK * 32;
+    const int K16     = K >> 4;
+    const int K128    = K >> 7;
+
+    uint4* sA16 = reinterpret_cast<uint4*>(sA);
+    const uint4* A16 = reinterpret_cast<const uint4*>(A);
+    for (int i = tid; i < K16; i += threads) sA16[i] = A16[i];
+    __syncthreads();
+
+    const int n = blockIdx.x * WARPS_PER_BLOCK + warp;
+    if (n >= N) return;
+
+    const uint4* Brow = reinterpret_cast<const uint4*>(B) + (size_t)n * K16;
+    const __nv_fp8_e4m3* sAf = sA;
+    const float* w_scale_row = w_scale + (size_t)(n >> 7) * K128;
+    float acc = 0.0f;
+    for (int i = lane; i < K16; i += 32) {
+        const int kb = i >> 3;
+        const float s = act_scale[kb] * w_scale_row[kb] * alpha;
+        uint4 bpack = Brow[i];
+        const __nv_fp8_e4m3* bp =
+            reinterpret_cast<const __nv_fp8_e4m3*>(&bpack);
+        const __nv_fp8_e4m3* ap = sAf + (i << 4);
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            acc += float(ap[j]) * float(bp[j]) * s;
+        }
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    }
+    if (lane == 0) D[n] = __float2bfloat16(acc);
+}
+
+template <int W>
+int launch_block128_(const void* A, const void* B, void* D,
+                     int /*M*/, int N, int K,
+                     const float* act_scale, const float* w_scale,
+                     float alpha, cudaStream_t stream) {
+    dim3 grid((N + W - 1) / W);
+    dim3 block(W * 32);
+    size_t smem = (size_t)K * sizeof(__nv_fp8_e4m3);
+    gemv_fp8_block128_m1_kernel<W><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        reinterpret_cast<__nv_bfloat16*>(D),
+        N, K, act_scale, w_scale, alpha);
+    return 0;
+}
+
 template <int W>
 int launch_resadd_(const void* A, const void* B, void* D,
                    int N, int K, float alpha, cudaStream_t stream) {
@@ -153,6 +219,20 @@ DEFINE_RA(gemv_fp8_m1_resadd_w8, 8)
 
 #undef DEFINE
 #undef DEFINE_RA
+
+#define DEFINE_BLOCK128(NAME, W)                                               \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,         \
+           const float* act_scale, const float* w_scale, float alpha,          \
+           cudaStream_t stream) {                                              \
+    return launch_block128_<W>(A, B, D, M, N, K, act_scale, w_scale, alpha,    \
+                               stream);                                        \
+  }
+
+DEFINE_BLOCK128(gemv_fp8_block128_m1_w4, 4)
+DEFINE_BLOCK128(gemv_fp8_block128_m1_w8, 8)
+DEFINE_BLOCK128(gemv_fp8_block128_m1_w16, 16)
+
+#undef DEFINE_BLOCK128
 
 }  // namespace gemv_m1
 }  // namespace gemm

--- a/csrc/gemm/fp8_gemv_m1_sm120.cuh
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cuh
@@ -26,6 +26,20 @@ DECL(gemv_fp8_m1_resadd_w8);
 
 #undef DECL
 
+#define DECL_BLOCK128(NAME) \
+  int NAME(const void* A, const void* B, void* D, \
+           int M, int N, int K, const float* act_scale, \
+           const float* w_scale, float alpha, cudaStream_t stream)
+
+// M=1 FP8 e4m3 GEMV with per-token activation scale [K/128] and
+// per-weight 128x128 block scale [N/128, K/128]. This matches official
+// Qwen3-VL FP8 checkpoints that store `.weight` + `.weight_scale_inv`.
+DECL_BLOCK128(gemv_fp8_block128_m1_w4);
+DECL_BLOCK128(gemv_fp8_block128_m1_w8);
+DECL_BLOCK128(gemv_fp8_block128_m1_w16);
+
+#undef DECL_BLOCK128
+
 }  // namespace gemv_m1
 }  // namespace gemm
 }  // namespace flash_rt

--- a/csrc/kernels/bf16_matmul_qwen36.cu
+++ b/csrc/kernels/bf16_matmul_qwen36.cu
@@ -38,11 +38,45 @@ struct Ab96LtPlan {
     cublasLtMatmulAlgo_t algo{};
 };
 
+struct Bf16LtPlan {
+    cublasLtMatmulDesc_t desc = nullptr;
+    cublasLtMatrixLayout_t a_desc = nullptr;
+    cublasLtMatrixLayout_t b_desc = nullptr;
+    cublasLtMatrixLayout_t c_desc = nullptr;
+    cublasLtMatmulAlgo_t algo{};
+};
+
+struct Bf16LtKey {
+    int M;
+    int N;
+    int K;
+
+    bool operator==(const Bf16LtKey& other) const {
+        return M == other.M && N == other.N && K == other.K;
+    }
+};
+
+struct Bf16LtKeyHash {
+    size_t operator()(const Bf16LtKey& key) const {
+        size_t h = static_cast<size_t>(key.M);
+        h = h * 1315423911u + static_cast<size_t>(key.N);
+        h = h * 1315423911u + static_cast<size_t>(key.K);
+        return h;
+    }
+};
+
 static cublasLtHandle_t g_ab96_lt = nullptr;
 static void* g_ab96_workspace = nullptr;
 static size_t g_ab96_workspace_size = 16 * 1024 * 1024;
 static std::mutex g_ab96_mu;
 static std::unordered_map<int, Ab96LtPlan> g_ab96_plans;
+
+static cublasLtHandle_t g_bf16_lt = nullptr;
+static void* g_bf16_workspace = nullptr;
+static size_t g_bf16_workspace_size = 32 * 1024 * 1024;
+static std::mutex g_bf16_mu;
+static std::unordered_map<Bf16LtKey, Bf16LtPlan, Bf16LtKeyHash>
+    g_bf16_plans;
 
 static void ensure_ab96_lt() {
     if (g_ab96_lt) return;
@@ -51,6 +85,17 @@ static void ensure_ab96_lt() {
     if (err != cudaSuccess) {
         throw std::runtime_error(
             std::string("cudaMalloc failed for AB96 cuBLASLt workspace: ") +
+            cudaGetErrorString(err));
+    }
+}
+
+static void ensure_bf16_lt() {
+    if (g_bf16_lt) return;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtCreate(&g_bf16_lt));
+    cudaError_t err = cudaMalloc(&g_bf16_workspace, g_bf16_workspace_size);
+    if (err != cudaSuccess) {
+        throw std::runtime_error(
+            std::string("cudaMalloc failed for BF16 cuBLASLt workspace: ") +
             cudaGetErrorString(err));
     }
 }
@@ -108,6 +153,63 @@ static Ab96LtPlan& get_ab96_lt_plan(int M) {
     plan.algo = heuristic.algo;
 
     auto [inserted, _] = g_ab96_plans.emplace(M, plan);
+    return inserted->second;
+}
+
+static Bf16LtPlan& get_bf16_lt_plan(int M, int N, int K) {
+    std::lock_guard<std::mutex> lock(g_bf16_mu);
+    ensure_bf16_lt();
+    Bf16LtKey key{M, N, K};
+    auto it = g_bf16_plans.find(key);
+    if (it != g_bf16_plans.end()) return it->second;
+
+    Bf16LtPlan plan;
+    cublasOperation_t op_n = CUBLAS_OP_N;
+    cublasOperation_t op_t = CUBLAS_OP_T;
+    cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(
+        cublasLtMatmulDescCreate(&plan.desc, CUBLAS_COMPUTE_32F, CUDA_R_32F));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSA, &op_n, sizeof(op_n)));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSB, &op_t, sizeof(op_t)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.a_desc, CUDA_R_16BF, M, K, K));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.b_desc, CUDA_R_16BF, N, K, K));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.c_desc, CUDA_R_16BF, M, N, N));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    cublasLtMatmulPreference_t pref;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceCreate(&pref));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceSetAttribute(
+        pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &g_bf16_workspace_size, sizeof(g_bf16_workspace_size)));
+    cublasLtMatmulHeuristicResult_t heuristic;
+    int returned = 0;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulAlgoGetHeuristic(
+        g_bf16_lt, plan.desc, plan.a_desc, plan.b_desc,
+        plan.c_desc, plan.c_desc, pref, 1, &heuristic, &returned));
+    cublasLtMatmulPreferenceDestroy(pref);
+    if (returned == 0) {
+        throw std::runtime_error("cuBLASLt: no generic BF16 GEMM algorithm");
+    }
+    plan.algo = heuristic.algo;
+
+    auto [inserted, _] = g_bf16_plans.emplace(key, plan);
     return inserted->second;
 }
 
@@ -480,6 +582,26 @@ void bf16_matmul_qwen36_bf16(
         bf16_matmul_warp_kernel_generic
             <<<grid, kThreads, smem_bytes, stream>>>(x, W, out, M, N, K);
     }
+}
+
+void bf16_matmul_cublaslt_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M, int N, int K,
+    cudaStream_t stream) {
+    if (M <= 0 || N <= 0 || K <= 0) return;
+    Bf16LtPlan& plan = get_bf16_lt_plan(M, N, K);
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmul(
+        g_bf16_lt, plan.desc, &alpha,
+        x, plan.a_desc,
+        W, plan.b_desc,
+        &beta,
+        out, plan.c_desc,
+        out, plan.c_desc,
+        &plan.algo, g_bf16_workspace, g_bf16_workspace_size, stream));
 }
 
 void bf16_matmul_qwen36_ab96_bf16(

--- a/csrc/kernels/bf16_matmul_qwen36.cuh
+++ b/csrc/kernels/bf16_matmul_qwen36.cuh
@@ -39,6 +39,15 @@ void bf16_matmul_qwen36_bf16(
     int K,
     cudaStream_t stream);
 
+void bf16_matmul_cublaslt_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M,
+    int N,
+    int K,
+    cudaStream_t stream);
+
 void bf16_matmul_qwen36_ab96_bf16(
     const __nv_bfloat16* x,
     const __nv_bfloat16* W_ab,

--- a/csrc/kernels/qwen3_qkv_post_proc.cu
+++ b/csrc/kernels/qwen3_qkv_post_proc.cu
@@ -152,6 +152,136 @@ __global__ void k_norm_rope_kvwrite_kernel(
   v_cache_dst[head * HEAD_DIM + tid] = v_pre[head * HEAD_DIM + tid];
 }
 
+__global__ void qk_norm_rope_kvwrite_kernel(
+    const __nv_bfloat16* __restrict__ q_pre,
+    const __nv_bfloat16* __restrict__ k_pre,
+    const __nv_bfloat16* __restrict__ v_pre,
+    const __nv_bfloat16* __restrict__ q_norm_w,
+    const __nv_bfloat16* __restrict__ k_norm_w,
+    const __nv_bfloat16* __restrict__ cos_v,
+    const __nv_bfloat16* __restrict__ sin_v,
+    __nv_bfloat16* __restrict__ q_buf,
+    __nv_bfloat16* __restrict__ k_cache_dst,
+    __nv_bfloat16* __restrict__ v_cache_dst,
+    int n_q,
+    int n_kv,
+    float eps) {
+  const int block = blockIdx.x;
+  const int tid = threadIdx.x;
+  const bool is_q = block < n_q;
+  const int head = is_q ? block : (block - n_q);
+  if ((!is_q) && head >= n_kv) return;
+
+  __shared__ float s_normed[HEAD_DIM];
+  __shared__ float s_smem4[N_WARPS];
+
+  const __nv_bfloat16* x_row =
+      is_q ? (q_pre + head * HEAD_DIM) : (k_pre + head * HEAD_DIM);
+  const __nv_bfloat16* norm_w = is_q ? q_norm_w : k_norm_w;
+  float v = __bfloat162float(x_row[tid]);
+  float w = __bfloat162float(norm_w[tid]);
+
+  float sum_sq = block_sum_4warp(v * v, s_smem4);
+  float rstd = rsqrtf(sum_sq / float(HEAD_DIM) + eps);
+  float normed = v * rstd * w;
+  s_normed[tid] = normed;
+  __syncthreads();
+
+  float partner, c, sn, out;
+  if (tid < HALF) {
+    partner = s_normed[tid + HALF];
+    c = __bfloat162float(cos_v[tid]);
+    sn = __bfloat162float(sin_v[tid]);
+    out = normed * c - partner * sn;
+  } else {
+    partner = s_normed[tid - HALF];
+    int half_idx = tid - HALF;
+    c = __bfloat162float(cos_v[half_idx]);
+    sn = __bfloat162float(sin_v[half_idx]);
+    out = normed * c + partner * sn;
+  }
+
+  if (is_q) {
+    q_buf[head * HEAD_DIM + tid] = __float2bfloat16(out);
+  } else {
+    k_cache_dst[head * HEAD_DIM + tid] = __float2bfloat16(out);
+    v_cache_dst[head * HEAD_DIM + tid] = v_pre[head * HEAD_DIM + tid];
+  }
+}
+
+__global__ void qk_norm_rope_kvwrite_batched_kernel(
+    const __nv_bfloat16* __restrict__ q_pre,
+    const __nv_bfloat16* __restrict__ k_pre,
+    const __nv_bfloat16* __restrict__ v_pre,
+    const __nv_bfloat16* __restrict__ q_norm_w,
+    const __nv_bfloat16* __restrict__ k_norm_w,
+    const __nv_bfloat16* __restrict__ cos,
+    const __nv_bfloat16* __restrict__ sin,
+    __nv_bfloat16* __restrict__ q_buf,
+    __nv_bfloat16* __restrict__ k_cache_dst,
+    __nv_bfloat16* __restrict__ v_cache_dst,
+    int seq_len,
+    int q_pre_row_elems,
+    int k_pre_row_elems,
+    int v_pre_row_elems,
+    int q_dst_row_elems,
+    int kv_dst_row_elems,
+    int n_q,
+    int n_kv,
+    float eps) {
+  const int block = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int heads_total = n_q + n_kv;
+  const int token = block / heads_total;
+  if (token >= seq_len) return;
+  const int inner = block - token * heads_total;
+  const bool is_q = inner < n_q;
+  const int head = is_q ? inner : (inner - n_q);
+  if ((!is_q) && head >= n_kv) return;
+
+  __shared__ float s_normed[HEAD_DIM];
+  __shared__ float s_smem4[N_WARPS];
+
+  const __nv_bfloat16* x_row =
+      is_q ? (q_pre + token * q_pre_row_elems + head * HEAD_DIM)
+           : (k_pre + token * k_pre_row_elems + head * HEAD_DIM);
+  const __nv_bfloat16* norm_w = is_q ? q_norm_w : k_norm_w;
+  const __nv_bfloat16* cos_row = cos + token * HALF;
+  const __nv_bfloat16* sin_row = sin + token * HALF;
+  float v = __bfloat162float(x_row[tid]);
+  float w = __bfloat162float(norm_w[tid]);
+
+  float sum_sq = block_sum_4warp(v * v, s_smem4);
+  float rstd = rsqrtf(sum_sq / float(HEAD_DIM) + eps);
+  float normed = v * rstd * w;
+  s_normed[tid] = normed;
+  __syncthreads();
+
+  float partner, c, sn, out;
+  if (tid < HALF) {
+    partner = s_normed[tid + HALF];
+    c = __bfloat162float(cos_row[tid]);
+    sn = __bfloat162float(sin_row[tid]);
+    out = normed * c - partner * sn;
+  } else {
+    partner = s_normed[tid - HALF];
+    int half_idx = tid - HALF;
+    c = __bfloat162float(cos_row[half_idx]);
+    sn = __bfloat162float(sin_row[half_idx]);
+    out = normed * c + partner * sn;
+  }
+
+  if (is_q) {
+    q_buf[token * q_dst_row_elems + head * HEAD_DIM + tid] =
+        __float2bfloat16(out);
+  } else {
+    k_cache_dst[token * kv_dst_row_elems + head * HEAD_DIM + tid] =
+        __float2bfloat16(out);
+    v_cache_dst[token * kv_dst_row_elems + head * HEAD_DIM + tid] =
+        v_pre[token * v_pre_row_elems + head * HEAD_DIM + tid];
+  }
+}
+
 // Device-position variant: writes K/V into K_cache[*cur_pos] / V_cache[*cur_pos]
 // where cur_pos is read from device memory, so a single captured graph serves
 // every decode position (the host bumps *cur_pos before each replay). row_elems
@@ -247,6 +377,85 @@ int qwen3_q_norm_rope_qstage_bf16(
       reinterpret_cast<const __nv_bfloat16*>(sin),
       reinterpret_cast<__nv_bfloat16*>(q_buf_dst),
       n_q_heads, eps);
+  return 0;
+}
+
+int qwen3_qk_norm_rope_kvwrite_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream) {
+  if (!q_pre || !k_pre || !v_pre || !q_norm_w || !k_norm_w || !cos || !sin
+      || !q_buf_dst || !k_cache_dst || !v_cache_dst) return 1;
+  if (n_q_heads <= 0 || n_kv_heads <= 0) return 2;
+  dim3 grid(n_q_heads + n_kv_heads);
+  dim3 block(THREADS);
+  qk_norm_rope_kvwrite_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q_pre),
+      reinterpret_cast<const __nv_bfloat16*>(k_pre),
+      reinterpret_cast<const __nv_bfloat16*>(v_pre),
+      reinterpret_cast<const __nv_bfloat16*>(q_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(k_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(cos),
+      reinterpret_cast<const __nv_bfloat16*>(sin),
+      reinterpret_cast<__nv_bfloat16*>(q_buf_dst),
+      reinterpret_cast<__nv_bfloat16*>(k_cache_dst),
+      reinterpret_cast<__nv_bfloat16*>(v_cache_dst),
+      n_q_heads, n_kv_heads, eps);
+  return 0;
+}
+
+int qwen3_qk_norm_rope_kvwrite_batched_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         seq_len,
+    int         q_pre_row_elems,
+    int         k_pre_row_elems,
+    int         v_pre_row_elems,
+    int         q_dst_row_elems,
+    int         kv_dst_row_elems,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream) {
+  if (!q_pre || !k_pre || !v_pre || !q_norm_w || !k_norm_w || !cos || !sin
+      || !q_buf_dst || !k_cache_dst || !v_cache_dst) return 1;
+  if (seq_len <= 0 || n_q_heads <= 0 || n_kv_heads <= 0) return 2;
+  dim3 grid(seq_len * (n_q_heads + n_kv_heads));
+  dim3 block(THREADS);
+  qk_norm_rope_kvwrite_batched_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q_pre),
+      reinterpret_cast<const __nv_bfloat16*>(k_pre),
+      reinterpret_cast<const __nv_bfloat16*>(v_pre),
+      reinterpret_cast<const __nv_bfloat16*>(q_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(k_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(cos),
+      reinterpret_cast<const __nv_bfloat16*>(sin),
+      reinterpret_cast<__nv_bfloat16*>(q_buf_dst),
+      reinterpret_cast<__nv_bfloat16*>(k_cache_dst),
+      reinterpret_cast<__nv_bfloat16*>(v_cache_dst),
+      seq_len,
+      q_pre_row_elems, k_pre_row_elems, v_pre_row_elems,
+      q_dst_row_elems, kv_dst_row_elems,
+      n_q_heads, n_kv_heads, eps);
   return 0;
 }
 

--- a/csrc/kernels/qwen3_qkv_post_proc.cuh
+++ b/csrc/kernels/qwen3_qkv_post_proc.cuh
@@ -54,6 +54,51 @@ int qwen3_q_norm_rope_qstage_bf16(
     float       eps,
     cudaStream_t stream);
 
+// Fused q_norm + RoPE + Q_buf write and k_norm + RoPE + KV_cache write in
+// one launch. Decode-only S=1 path, head_dim hardcoded at 128.
+int qwen3_qk_norm_rope_kvwrite_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream);
+
+// Batched fused q_norm + RoPE + Q_buf write and k_norm + RoPE + KV_cache
+// write for prefill (S>=1). q_pre / k_pre / v_pre may be row-strided views
+// into a larger qkv tensor; row strides are in elements, not bytes. cos/sin
+// are (S, 64) bf16 and outputs are contiguous per-position rows in Q_buf /
+// K_cache / V_cache.
+int qwen3_qk_norm_rope_kvwrite_batched_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         seq_len,
+    int         q_pre_row_elems,
+    int         k_pre_row_elems,
+    int         v_pre_row_elems,
+    int         q_dst_row_elems,
+    int         kv_dst_row_elems,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream);
+
 // Fused k_norm + RoPE + K_cache write + V_cache write (S=1 decode).
 //
 //   k_pre        : (n_kv_heads, 128) bf16

--- a/csrc/quantize/fp8_per_token_block_quant.cu
+++ b/csrc/quantize/fp8_per_token_block_quant.cu
@@ -16,6 +16,46 @@ namespace {
 constexpr int kBlock = 128;
 constexpr float kFp8Max = 448.0f;
 
+__device__ __forceinline__ float block_reduce_sum_128(float v, float* sh) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int off = 16; off > 0; off >>= 1) {
+    v += __shfl_xor_sync(0xffffffff, v, off);
+  }
+  if (lane == 0) sh[warp] = v;
+  __syncthreads();
+  if (warp == 0) {
+    v = (lane < 4) ? sh[lane] : 0.0f;
+    v += __shfl_xor_sync(0xffffffff, v, 1);
+    v += __shfl_xor_sync(0xffffffff, v, 2);
+    if (lane == 0) sh[0] = v;
+  }
+  __syncthreads();
+  const float out = sh[0];
+  __syncthreads();
+  return out;
+}
+
+__device__ __forceinline__ float block_reduce_max_128(float v, float* sh) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int off = 16; off > 0; off >>= 1) {
+    v = fmaxf(v, __shfl_xor_sync(0xffffffff, v, off));
+  }
+  if (lane == 0) sh[warp] = v;
+  __syncthreads();
+  if (warp == 0) {
+    v = (lane < 4) ? sh[lane] : 0.0f;
+    v = fmaxf(v, __shfl_xor_sync(0xffffffff, v, 1));
+    v = fmaxf(v, __shfl_xor_sync(0xffffffff, v, 2));
+    if (lane == 0) sh[0] = v;
+  }
+  __syncthreads();
+  const float out = sh[0];
+  __syncthreads();
+  return out;
+}
+
 __global__ void fp8_per_token_block_quant_kernel(
     const __nv_bfloat16* __restrict__ input,
     __nv_fp8_e4m3* __restrict__ output,
@@ -127,6 +167,128 @@ __global__ void fp8_per_token_block_quant_linear_kernel(
   }
 }
 
+__global__ void rms_norm_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const __nv_bfloat16* __restrict__ weight,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int K, float eps)
+{
+  extern __shared__ unsigned char smem[];
+  float* red = reinterpret_cast<float*>(smem);
+  __nv_bfloat16* normed = reinterpret_cast<__nv_bfloat16*>(red + 4);
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* row = input + (size_t)m * K;
+  __nv_fp8_e4m3* out = output + (size_t)m * K;
+
+  float ssq = 0.0f;
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(row[i]);
+    ssq += v * v;
+  }
+  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(row[i]) * inv_rms *
+                    __bfloat162float(weight[i]);
+    normed[i] = __float2bfloat16(v);
+  }
+  __syncthreads();
+
+  const int n_kb = K / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float v = __bfloat162float(normed[i]);
+    const float amax = block_reduce_max_128(fabsf(v), red);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = v / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    out[i] = __nv_fp8_e4m3(q);
+  }
+}
+
+__global__ void residual_add_rms_norm_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ residual,
+    const __nv_bfloat16* __restrict__ x,
+    __nv_bfloat16* __restrict__ residual_out,
+    const __nv_bfloat16* __restrict__ weight,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int K, float eps)
+{
+  extern __shared__ unsigned char smem[];
+  float* red = reinterpret_cast<float*>(smem);
+  __nv_bfloat16* normed = reinterpret_cast<__nv_bfloat16*>(red + 4);
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* rrow = residual + (size_t)m * K;
+  const __nv_bfloat16* xrow = x + (size_t)m * K;
+  __nv_bfloat16* res_out = residual_out + (size_t)m * K;
+  __nv_fp8_e4m3* out = output + (size_t)m * K;
+
+  float ssq = 0.0f;
+  for (int i = t; i < K; i += kBlock) {
+    const float rv = __bfloat162float(rrow[i]) + __bfloat162float(xrow[i]);
+    const __nv_bfloat16 rb = __float2bfloat16(rv);
+    res_out[i] = rb;
+    const float rbf = __bfloat162float(rb);
+    ssq += rbf * rbf;
+  }
+  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(res_out[i]) * inv_rms *
+                    __bfloat162float(weight[i]);
+    normed[i] = __float2bfloat16(v);
+  }
+  __syncthreads();
+
+  const int n_kb = K / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float v = __bfloat162float(normed[i]);
+    const float amax = block_reduce_max_128(fabsf(v), red);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = v / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    out[i] = __nv_fp8_e4m3(q);
+  }
+}
+
+__device__ __forceinline__ float silu_f32(float x) {
+  return x / (1.0f + expf(-x));
+}
+
+__global__ void silu_mul_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ gate,
+    const __nv_bfloat16* __restrict__ up,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int K)
+{
+  const int m = blockIdx.y;
+  const int kb = blockIdx.x;
+  const int t = threadIdx.x;
+  const int k = kb * kBlock + t;
+  const size_t idx = (size_t)m * K + k;
+  __shared__ float red[4];
+
+  const float g = __bfloat162float(gate[idx]);
+  const float u = __bfloat162float(up[idx]);
+  const float silu_g = silu_f32(g);
+  const float silu_bf = __bfloat162float(__float2bfloat16(silu_g));
+  const float v = __bfloat162float(__float2bfloat16(silu_bf * u));
+  const float amax = block_reduce_max_128(fabsf(v), red);
+  const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+  if (t == 0) scale[m * (K / kBlock) + kb] = sc;
+  float q = v / sc;
+  q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+  output[idx] = __nv_fp8_e4m3(q);
+}
+
 }  // namespace
 
 void fp8_per_token_block128_quant_bf16(
@@ -152,6 +314,59 @@ void fp8_per_token_block128_quant_bf16(
         output_scale,
         M, K);
   }
+}
+
+void rms_norm_to_fp8_block128_bf16(
+    const void* input,
+    const void* weight,
+    void* output_fp8,
+    float* output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream)
+{
+  size_t smem = 4 * sizeof(float) + (size_t)K * sizeof(__nv_bfloat16);
+  rms_norm_to_fp8_block128_kernel<<<M, kBlock, smem, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(input),
+      reinterpret_cast<const __nv_bfloat16*>(weight),
+      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+      output_scale, K, eps);
+}
+
+void residual_add_rms_norm_to_fp8_block128_bf16(
+    const void* residual,
+    const void* x,
+    void* residual_out,
+    const void* weight,
+    void* output_fp8,
+    float* output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream)
+{
+  size_t smem = 4 * sizeof(float) + (size_t)K * sizeof(__nv_bfloat16);
+  residual_add_rms_norm_to_fp8_block128_kernel<<<M, kBlock, smem, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(residual),
+      reinterpret_cast<const __nv_bfloat16*>(x),
+      reinterpret_cast<__nv_bfloat16*>(residual_out),
+      reinterpret_cast<const __nv_bfloat16*>(weight),
+      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+      output_scale, K, eps);
+}
+
+void silu_mul_to_fp8_block128_bf16(
+    const void* gate,
+    const void* up,
+    void* output_fp8,
+    float* output_scale,
+    int M, int K,
+    cudaStream_t stream)
+{
+  dim3 block(kBlock);
+  dim3 grid(K / kBlock, M);
+  silu_mul_to_fp8_block128_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(gate),
+      reinterpret_cast<const __nv_bfloat16*>(up),
+      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+      output_scale, K);
 }
 
 }  // namespace quantize

--- a/csrc/quantize/fp8_per_token_block_quant.cu
+++ b/csrc/quantize/fp8_per_token_block_quant.cu
@@ -7,6 +7,7 @@
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
+#include <stdexcept>
 
 namespace flash_rt {
 namespace quantize {
@@ -298,6 +299,9 @@ void fp8_per_token_block128_quant_bf16(
     int M, int K,
     cudaStream_t stream)
 {
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "fp8_per_token_block128_quant_bf16 requires K multiple of 128");
   dim3 block(kBlock);
   if (M <= 65535) {
     dim3 grid(K / kBlock, M);
@@ -324,6 +328,9 @@ void rms_norm_to_fp8_block128_bf16(
     int M, int K, float eps,
     cudaStream_t stream)
 {
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "rms_norm_to_fp8_block128_bf16 requires K multiple of 128");
   size_t smem = 4 * sizeof(float) + (size_t)K * sizeof(__nv_bfloat16);
   rms_norm_to_fp8_block128_kernel<<<M, kBlock, smem, stream>>>(
       reinterpret_cast<const __nv_bfloat16*>(input),
@@ -342,6 +349,9 @@ void residual_add_rms_norm_to_fp8_block128_bf16(
     int M, int K, float eps,
     cudaStream_t stream)
 {
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "residual_add_rms_norm_to_fp8_block128_bf16 requires K multiple of 128");
   size_t smem = 4 * sizeof(float) + (size_t)K * sizeof(__nv_bfloat16);
   residual_add_rms_norm_to_fp8_block128_kernel<<<M, kBlock, smem, stream>>>(
       reinterpret_cast<const __nv_bfloat16*>(residual),
@@ -360,6 +370,9 @@ void silu_mul_to_fp8_block128_bf16(
     int M, int K,
     cudaStream_t stream)
 {
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "silu_mul_to_fp8_block128_bf16 requires K multiple of 128");
   dim3 block(kBlock);
   dim3 grid(K / kBlock, M);
   silu_mul_to_fp8_block128_kernel<<<grid, block, 0, stream>>>(

--- a/csrc/quantize/fp8_per_token_block_quant.cuh
+++ b/csrc/quantize/fp8_per_token_block_quant.cuh
@@ -38,5 +38,31 @@ void fp8_per_token_block128_quant_bf16(
     int M, int K,
     cudaStream_t stream);
 
+void rms_norm_to_fp8_block128_bf16(
+    const void* input,
+    const void* weight,
+    void*       output_fp8,
+    float*      output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream);
+
+void residual_add_rms_norm_to_fp8_block128_bf16(
+    const void* residual,
+    const void* x,
+    void*       residual_out,
+    const void* weight,
+    void*       output_fp8,
+    float*      output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream);
+
+void silu_mul_to_fp8_block128_bf16(
+    const void* gate,
+    const void* up,
+    void*       output_fp8,
+    float*      output_scale,
+    int M, int K,
+    cudaStream_t stream);
+
 }  // namespace quantize
 }  // namespace flash_rt

--- a/docs/qwen3_vl_fp8_sm89.md
+++ b/docs/qwen3_vl_fp8_sm89.md
@@ -1,0 +1,137 @@
+# Qwen3-VL-8B official FP8 on RTX 4090 (SM89)
+
+This path brings up Qwen3-VL-8B on Ada RTX GPUs using the official
+Qwen3-VL FP8 checkpoint. It is the SM89 counterpart to the SM120/NVFP4
+Qwen3-VL path, but it intentionally uses the checkpoint's native block-scaled
+FP8 language weights instead of NVFP4.
+
+## Checkpoint
+
+Use the official FP8 checkpoint:
+
+```text
+Qwen3-VL-8B-Instruct-FP8
+```
+
+The language stack tensors are stored under
+`model.language_model.layers.*`. Linear weights are
+`torch.float8_e4m3fn` with `weight_scale_inv` block scales in a 128x128
+layout. The vision tower in this checkpoint is BF16.
+
+## Build
+
+Build the regular FlashRT kernels and the Qwen3-VL helper module for SM89:
+
+```bash
+cmake -S . -B build -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON
+cmake --build build -j --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels
+```
+
+The SM89 Qwen3-VL path uses:
+
+- `flash_rt_kernels` for FP8 block-128 GEMV/GEMM, fused norm/activation
+  quantization, BF16 cuBLASLt matmul wrappers, and Qwen3 postprocessing.
+- `flash_rt_fa2` for BF16 FlashAttention.
+- `flash_rt_qwen3_vl_kernels` for vision RoPE, layernorm/GELU to FP8, and
+  BF16 bias epilogues.
+
+## Runtime Architecture
+
+The runtime frontend is
+`flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal.Qwen3VlFp8Sm89Frontend`.
+
+The text-only language core is
+`flash_rt.frontends.torch.qwen3_vl_fp8_sm89.Qwen3VlFp8Sm89TextFrontend`.
+
+The dtype mapping is:
+
+| Component | SM89 dtype path |
+|---|---|
+| Language weights | Official block-scaled FP8 e4m3, 128x128 scales |
+| Language activations before linears | BF16 -> per-token/per-128 FP8 |
+| Language GEMV/GEMM output | BF16 |
+| Attention Q/K/V cache | BF16 |
+| Attention backend | BF16 FA2 |
+| Residual stream and norms | BF16 |
+| Vision protected blocks | BF16 |
+| Vision bulk GEMMs | FP8 block-128 activation/weight, BF16 output |
+| `lm_head` default | BF16 |
+
+`use_fp8_lm_head=True` remains an explicit experimental mode. Single-step
+logits can match closely, but multi-token generation can diverge after the
+first generated tokens, so BF16 `lm_head` is the default.
+
+## Quickstart
+
+```bash
+python examples/qwen3_vl_quickstart.py \
+  --arch sm89 \
+  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+  --image FlashRT.png \
+  --prompt "Describe this image in one sentence." \
+  --max-seq 2048 \
+  --max-prefill-seq 2048
+```
+
+For the development smoke benchmark:
+
+```bash
+python scripts/smoke_qwen3_vl_fp8_sm89.py \
+  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+  --multimodal \
+  --iters 5 \
+  --generate-tokens 0
+```
+
+The full-resolution `FlashRT.png` workload produces 6256 vision patches and
+1581 language tokens. This is the workload used for the SM120 Qwen3-VL report,
+so it is the preferred comparison point for full TTFT numbers.
+
+## RTX 4090 Validation
+
+Environment:
+
+- GPU: NVIDIA GeForce RTX 4090, SM89
+- Checkpoint: official Qwen3-VL-8B-Instruct-FP8
+- Workload: `FlashRT.png`, prompt `Describe this image in one sentence.`
+- Prompt shape: 6256 vision patches, 1581 language tokens
+
+Command:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python scripts/smoke_qwen3_vl_fp8_sm89.py \
+  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+  --multimodal \
+  --iters 3 \
+  --generate-tokens 0
+```
+
+Result:
+
+```text
+S=1581 pixel_shape=(6256, 1536) spans=[(4, 1568)]
+set_prompt_warm median=15.711 ms
+vision_only median=88.990 ms
+language_only_no_mm_scatter median=120.634 ms
+prefill median=206.987 ms top=785 finite=True
+prefill_graph median=206.214 ms cos_vs_eager=0.998522 top=785 finite=True
+graph_decode_cache_pos=1581 median=10.681 ms cos_vs_eager=1.000000
+top_eager=2168 top_graph=2168
+```
+
+The same workload on the SM120/NVFP4 path is faster because it uses Blackwell
+NVFP4 language kernels. The SM89 path is intended to use the best available
+Ada-compatible dtype path: official FP8 language weights, BF16 attention and
+residual state, and BF16 `lm_head`.
+
+## Limits
+
+- This is not an NVFP4 implementation. SM89 uses official FP8 weights because
+  NVFP4 is a Blackwell path.
+- `lm_head` stays BF16 by default for generation quality.
+- Single-image prefill has a CUDA Graph replay path. Multi-image and video
+  should use the eager path unless separately validated.
+- Decode graphs are captured per cache position because the FA2 call captures
+  host-side sequence length.
+- The development scripts under `scripts/*qwen3_vl_fp8_sm89*` are local
+  validation and profiling entry points, not CI replacements.

--- a/examples/qwen3_vl_openai_server.py
+++ b/examples/qwen3_vl_openai_server.py
@@ -2,9 +2,11 @@
 """Minimal OpenAI-compatible vision chat server for Qwen3-VL on FlashRT.
 
 Exposes ``POST /v1/chat/completions`` (non-streaming) for image+text
-chat, backed by the FlashRT Qwen3-VL NVFP4 path. Multimodal messages use
-the OpenAI ``image_url`` content format (``http(s)://`` or ``data:`` base64
-URLs). Single-GPU, batch 1; concurrent requests are serialised.
+chat, backed by the FlashRT Qwen3-VL RTX path. ``--arch sm120`` expects the
+FlashRT NVFP4 checkpoint; ``--arch sm89`` expects the official FP8
+checkpoint. Multimodal messages use the OpenAI ``image_url`` content format
+(``http(s)://`` or ``data:`` base64 URLs). Single-GPU, batch 1; concurrent
+requests are serialised.
 
     pip install fastapi uvicorn
     python examples/qwen3_vl_openai_server.py \\
@@ -67,6 +69,8 @@ def _to_frontend_messages(messages: list) -> list:
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--checkpoint', required=True)
+    p.add_argument('--arch', default='sm120', choices=('sm120', 'sm89'),
+                   help='RTX route: sm120 NVFP4 or sm89 official FP8')
     p.add_argument('--host', default='0.0.0.0')
     p.add_argument('--port', type=int, default=8000)
     p.add_argument('--device', default='cuda:0')
@@ -75,6 +79,19 @@ def main() -> None:
     p.add_argument('--max-pixels', type=int, default=None,
                    help='cap image/video resolution (pixels) to bound TTFT; '
                         'default keeps full resolution')
+    p.add_argument('--max-prefill-seq', type=int, default=None,
+                   help='SM89 official-FP8 prefill buffer length; default '
+                        'uses min(max_seq, 128). Only valid with --arch sm89.')
+    p.add_argument('--fuse-gate-up', action='store_true',
+                   help='use SM89 official-FP8 fused gate/up weight when '
+                        'available. Only valid with --arch sm89.')
+    p.add_argument('--fp8-lm-head', action='store_true',
+                   help='use the SM89 official-FP8 explicit experimental '
+                        'FP8 lm_head mode. Only valid with --arch sm89.')
+    p.add_argument('--vision-bf16-first-blocks', type=int, default=3,
+                   help='SM89 vision path: keep the first N ViT blocks in '
+                        'BF16 before switching linears to FP8. '
+                        'Only valid with --arch sm89.')
     p.add_argument('--model-name', default='qwen3-vl')
     args = p.parse_args()
 
@@ -83,11 +100,33 @@ def main() -> None:
     import uvicorn
     from fastapi import FastAPI, HTTPException
 
-    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+    if args.arch == 'sm89':
+        from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+            Qwen3VlFp8Sm89Frontend,
+        )
 
-    fe = Qwen3VlTorchFrontendRtx(
-        args.checkpoint, device=args.device, max_seq=args.max_seq,
-        max_pixels=args.max_pixels)
+        fe = Qwen3VlFp8Sm89Frontend(
+            args.checkpoint, device=args.device, max_seq=args.max_seq,
+            max_pixels=args.max_pixels, max_prefill_seq=args.max_prefill_seq,
+            fuse_gate_up=args.fuse_gate_up,
+            use_fp8_lm_head=args.fp8_lm_head,
+            vision_bf16_first_blocks=args.vision_bf16_first_blocks)
+    else:
+        if args.max_prefill_seq is not None:
+            p.error('--max-prefill-seq is only valid with --arch sm89')
+        if args.fuse_gate_up:
+            p.error('--fuse-gate-up is only valid with --arch sm89')
+        if args.fp8_lm_head:
+            p.error('--fp8-lm-head is only valid with --arch sm89')
+        if args.vision_bf16_first_blocks != 3:
+            p.error('--vision-bf16-first-blocks is only valid with --arch sm89')
+        from flash_rt.frontends.torch.qwen3_vl_rtx import (
+            Qwen3VlTorchFrontendRtx,
+        )
+
+        fe = Qwen3VlTorchFrontendRtx(
+            args.checkpoint, device=args.device, max_seq=args.max_seq,
+            max_pixels=args.max_pixels)
     lock = asyncio.Lock()
     app = FastAPI(title='FlashRT Qwen3-VL OpenAI-compatible server')
 

--- a/examples/qwen3_vl_quickstart.py
+++ b/examples/qwen3_vl_quickstart.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Qwen3-VL FlashRT quickstart.
 
-Runs the Qwen3-VL multimodal path (NVFP4 language stack + BF16 ViT tower)
-on a single image + text prompt and prints the generated description. The
-checkpoint is the self-contained directory produced by
-``tools/quantize_qwen3_vl_nvfp4.py``.
+Runs the Qwen3-VL multimodal RTX path on a single image + text prompt and
+prints the generated description. ``--arch sm120`` expects the self-contained
+NVFP4 checkpoint produced by ``tools/quantize_qwen3_vl_nvfp4.py``; ``--arch
+sm89`` expects the official Qwen3-VL FP8 checkpoint.
 
 Examples:
     # One-shot description
@@ -42,7 +42,9 @@ def _build_messages(image_path: str, prompt: str) -> list:
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument('--checkpoint', required=True,
-                   help='FlashRT Qwen3-VL NVFP4 checkpoint directory')
+                   help='Qwen3-VL checkpoint directory for the selected arch')
+    p.add_argument('--arch', default='sm120', choices=('sm120', 'sm89'),
+                   help='RTX route: sm120 NVFP4 or sm89 official FP8')
     p.add_argument('--image', required=True, help='input image path')
     p.add_argument('--prompt', default='Describe this image in one sentence.')
     p.add_argument('--max-new-tokens', type=int, default=256)
@@ -52,17 +54,52 @@ def main() -> None:
                    help='cap image resolution (pixels); the patch count '
                         'drives TTFT, so e.g. 1000000 roughly halves it. '
                         'Default: checkpoint full resolution.')
+    p.add_argument('--max-prefill-seq', type=int, default=None,
+                   help='SM89 official-FP8 prefill buffer length; default '
+                        'uses min(max_seq, 128). Only valid with --arch sm89.')
+    p.add_argument('--fuse-gate-up', action='store_true',
+                   help='use SM89 official-FP8 fused gate/up weight when '
+                        'available. Only valid with --arch sm89.')
+    p.add_argument('--fp8-lm-head', action='store_true',
+                   help='use the SM89 official-FP8 explicit experimental '
+                        'FP8 lm_head mode. Only valid with --arch sm89.')
+    p.add_argument('--vision-bf16-first-blocks', type=int, default=3,
+                   help='SM89 vision path: keep the first N ViT blocks in '
+                        'BF16 before switching linears to FP8. '
+                        'Only valid with --arch sm89.')
     p.add_argument('--benchmark', type=int, default=0,
                    help='if >0, run that many timed iterations')
     args = p.parse_args()
 
     import torch
 
-    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+    if args.arch == 'sm89':
+        from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+            Qwen3VlFp8Sm89Frontend,
+        )
 
-    fe = Qwen3VlTorchFrontendRtx(
-        args.checkpoint, device=args.device, max_seq=args.max_seq,
-        max_pixels=args.max_pixels)
+        fe = Qwen3VlFp8Sm89Frontend(
+            args.checkpoint, device=args.device, max_seq=args.max_seq,
+            max_pixels=args.max_pixels, max_prefill_seq=args.max_prefill_seq,
+            fuse_gate_up=args.fuse_gate_up,
+            use_fp8_lm_head=args.fp8_lm_head,
+            vision_bf16_first_blocks=args.vision_bf16_first_blocks)
+    else:
+        if args.max_prefill_seq is not None:
+            p.error('--max-prefill-seq is only valid with --arch sm89')
+        if args.fuse_gate_up:
+            p.error('--fuse-gate-up is only valid with --arch sm89')
+        if args.fp8_lm_head:
+            p.error('--fp8-lm-head is only valid with --arch sm89')
+        if args.vision_bf16_first_blocks != 3:
+            p.error('--vision-bf16-first-blocks is only valid with --arch sm89')
+        from flash_rt.frontends.torch.qwen3_vl_rtx import (
+            Qwen3VlTorchFrontendRtx,
+        )
+
+        fe = Qwen3VlTorchFrontendRtx(
+            args.checkpoint, device=args.device, max_seq=args.max_seq,
+            max_pixels=args.max_pixels)
     messages = _build_messages(args.image, args.prompt)
 
     text = fe.generate(messages, max_new_tokens=args.max_new_tokens)
@@ -76,7 +113,7 @@ def main() -> None:
         ttft = []
         for _ in range(args.benchmark):
             t0 = time.perf_counter()
-            fe.prefill()
+            fe.prefill_graph()
             torch.cuda.synchronize()
             ttft.append((time.perf_counter() - t0) * 1e3)
         ttft.sort()
@@ -88,7 +125,11 @@ def main() -> None:
         torch.cuda.synchronize()
         t0 = time.perf_counter()
         for j in range(n_dec):
-            fe._decode_step_graph(0, s + j, fe._prompt['mrope_max'] + 1 + j)
+            if args.arch == 'sm89':
+                fe.decode_step_with_graph(0, s + j)
+            else:
+                fe._decode_step_graph(
+                    0, s + j, fe._prompt['mrope_max'] + 1 + j)
         torch.cuda.synchronize()
         dt = time.perf_counter() - t0
 

--- a/flash_rt/frontends/torch/_qwen3_vl_fp8_weights.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_fp8_weights.py
@@ -1,0 +1,221 @@
+"""Loader for official Qwen3-VL FP8 language weights.
+
+The official Qwen3-VL FP8 checkpoint stores the text stack under
+``model.language_model.*`` with FP8 e4m3 weights plus 128x128 block scales
+(``.weight_scale_inv``). This loader intentionally keeps the original FP8
+layout and records raw device pointers for the SM89 block-scaled GEMV path.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+
+import torch
+
+
+@dataclass
+class WeightHandles:
+    ptrs: dict = field(default_factory=dict)
+    anchors: list = field(default_factory=list)
+
+
+def _anchor(handles: WeightHandles, t: torch.Tensor) -> int:
+    handles.anchors.append(t)
+    return int(t.data_ptr())
+
+
+def _open_shards(ckpt_dir: str):
+    from safetensors import safe_open
+
+    idx_path = os.path.join(ckpt_dir, 'model.safetensors.index.json')
+    if not os.path.isfile(idx_path):
+        raise RuntimeError(f'Qwen3-VL FP8 ckpt missing index: {idx_path}')
+    wmap = json.load(open(idx_path))['weight_map']
+    handles_d = {
+        shard: safe_open(os.path.join(ckpt_dir, shard), framework='pt',
+                         device='cpu')
+        for shard in set(wmap.values())
+    }
+    return handles_d, wmap
+
+
+def _get_tensor(handles_d, wmap, key: str) -> torch.Tensor:
+    if key not in wmap:
+        raise KeyError(f'tensor {key!r} not in weight_map')
+    return handles_d[wmap[key]].get_tensor(key)
+
+
+def _to_bf16(t: torch.Tensor, device: str) -> torch.Tensor:
+    return t.to(torch.bfloat16).to(device).contiguous()
+
+
+def _to_fp8(t: torch.Tensor, device: str) -> torch.Tensor:
+    if t.dtype != torch.float8_e4m3fn:
+        raise TypeError(f'expected torch.float8_e4m3fn weight, got {t.dtype}')
+    return t.to(device).contiguous()
+
+
+def _load_fp8_linear(handles: WeightHandles, out: dict, short: str,
+                     base: str, handles_d, wmap, device: str
+                     ) -> tuple[torch.Tensor, torch.Tensor]:
+    w = _to_fp8(_get_tensor(handles_d, wmap, base + '.weight'), device)
+    s = _get_tensor(handles_d, wmap, base + '.weight_scale_inv').to(
+        torch.float32).to(device).contiguous()
+    out[short + '_w'] = _anchor(handles, w)
+    out[short + '_s'] = _anchor(handles, s)
+    return w, s
+
+
+def extract_weights_qwen3_vl_fp8(ckpt_dir: str, device: str = 'cuda:0',
+                                 quantize_lm_head: bool = True
+                                 ) -> WeightHandles:
+    cfg_path = os.path.join(ckpt_dir, 'config.json')
+    if not os.path.isfile(cfg_path):
+        raise RuntimeError(f'Qwen3-VL FP8 ckpt missing config: {cfg_path}')
+    cfg = json.load(open(cfg_path))
+    text_cfg = cfg['text_config']
+
+    num_layers = int(text_cfg['num_hidden_layers'])
+    hidden = int(text_cfg['hidden_size'])
+    vocab = int(text_cfg['vocab_size'])
+    head_dim = int(text_cfg.get('head_dim') or
+                   (hidden // int(text_cfg['num_attention_heads'])))
+    n_q = int(text_cfg['num_attention_heads'])
+    n_kv = int(text_cfg['num_key_value_heads'])
+    inter = int(text_cfg['intermediate_size'])
+    rms_eps = float(text_cfg.get('rms_norm_eps', 1e-6))
+    rope_scaling = text_cfg.get('rope_scaling') or cfg.get('rope_scaling') or {}
+    rope_theta = float(text_cfg.get('rope_theta') or cfg.get('rope_theta') or
+                       rope_scaling.get('rope_theta') or 1_000_000.0)
+
+    handles = WeightHandles()
+    handles_d, wmap = _open_shards(ckpt_dir)
+
+    embed = _to_bf16(
+        _get_tensor(handles_d, wmap, 'model.language_model.embed_tokens.weight'),
+        device)
+    handles.ptrs['embed_w'] = _anchor(handles, embed)
+    final_norm = _to_bf16(
+        _get_tensor(handles_d, wmap, 'model.language_model.norm.weight'),
+        device)
+    handles.ptrs['final_norm_w'] = _anchor(handles, final_norm)
+    lm_head_cpu = _get_tensor(handles_d, wmap, 'lm_head.weight')
+    N_lm, K_lm = lm_head_cpu.shape
+    handles.ptrs['lm_head_quantized'] = bool(quantize_lm_head)
+    if quantize_lm_head:
+        if N_lm % 128 != 0 or K_lm % 128 != 0:
+            raise RuntimeError(
+                f'lm_head shape must be block128-compatible, got {lm_head_cpu.shape}')
+        lm_head_fp8 = torch.empty(
+            N_lm, K_lm, dtype=torch.float8_e4m3fn, device=device)
+        lm_scale = torch.empty(
+            N_lm // 128, K_lm // 128, dtype=torch.float32, device=device)
+        for row0 in range(0, N_lm, 8192):
+            row1 = min(row0 + 8192, N_lm)
+            chunk = lm_head_cpu[row0:row1].to(torch.bfloat16).to(
+                device).contiguous()
+            rows = row1 - row0
+            view = chunk.float().view(rows // 128, 128, K_lm // 128, 128)
+            amax = view.abs().amax(dim=(1, 3))
+            scale = (amax / 448.0).clamp_min(1e-12)
+            q = (view / scale[:, None, :, None]).clamp(
+                -448.0, 448.0).to(torch.float8_e4m3fn).view(
+                    rows, K_lm).contiguous()
+            lm_head_fp8[row0:row1].copy_(q)
+            lm_scale[row0 // 128:row1 // 128].copy_(scale.float())
+        handles.ptrs['lm_head_fp8_w'] = _anchor(handles, lm_head_fp8)
+        handles.ptrs['lm_head_fp8_s'] = _anchor(handles, lm_scale)
+    else:
+        lm_head = _to_bf16(lm_head_cpu, device)
+        handles.ptrs['lm_head_w'] = _anchor(handles, lm_head)
+
+    per_layer: list[dict] = [None] * num_layers   # type: ignore[list-item]
+    for L in range(num_layers):
+        base = f'model.language_model.layers.{L}.'
+        ld: dict = {'type': 'full_attention', 'quant_format': 'fp8_block128'}
+        ld['input_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, base + 'input_layernorm.weight'),
+            device))
+        ld['post_attn_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap,
+                        base + 'post_attention_layernorm.weight'),
+            device))
+        sa = base + 'self_attn.'
+        q_w, q_s = _load_fp8_linear(handles, ld, 'q_proj', sa + 'q_proj',
+                                    handles_d, wmap, device)
+        k_w, k_s = _load_fp8_linear(handles, ld, 'k_proj', sa + 'k_proj',
+                                    handles_d, wmap, device)
+        v_w, v_s = _load_fp8_linear(handles, ld, 'v_proj', sa + 'v_proj',
+                                    handles_d, wmap, device)
+        _load_fp8_linear(handles, ld, 'o_proj', sa + 'o_proj',
+                         handles_d, wmap, device)
+        qkv_w = torch.cat([q_w, k_w, v_w], dim=0).contiguous()
+        qkv_s = torch.cat([q_s, k_s, v_s], dim=0).contiguous()
+        ld['qkv_proj_w'] = _anchor(handles, qkv_w)
+        ld['qkv_proj_s'] = _anchor(handles, qkv_s)
+        ld['qkv_proj_N'] = int(qkv_w.shape[0])
+
+        ld['q_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, sa + 'q_norm.weight'), device))
+        ld['k_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, sa + 'k_norm.weight'), device))
+
+        mp = base + 'mlp.'
+        gate_w, gate_s = _load_fp8_linear(
+            handles, ld, 'mlp_gate', mp + 'gate_proj',
+            handles_d, wmap, device)
+        up_w, up_s = _load_fp8_linear(
+            handles, ld, 'mlp_up', mp + 'up_proj',
+            handles_d, wmap, device)
+        gate_up_w = torch.cat([gate_w, up_w], dim=0).contiguous()
+        gate_up_s = torch.cat([gate_s, up_s], dim=0).contiguous()
+        ld['gate_up_w'] = _anchor(handles, gate_up_w)
+        ld['gate_up_s'] = _anchor(handles, gate_up_s)
+        ld['gate_up_N'] = int(gate_up_w.shape[0])
+        _load_fp8_linear(handles, ld, 'mlp_down', mp + 'down_proj',
+                         handles_d, wmap, device)
+        per_layer[L] = ld
+
+    handles.ptrs.update({
+        'vocab_size': vocab,
+        'hidden': hidden,
+        'head_dim': head_dim,
+        'num_q_heads': n_q,
+        'num_kv_heads': n_kv,
+        'intermediate': inter,
+        'num_layers': num_layers,
+        'layer_types': ['full_attention'] * num_layers,
+        'rms_norm_eps': rms_eps,
+        'rope_theta': rope_theta,
+        'rope_scaling': rope_scaling,
+        'quant_format': 'fp8_block128',
+        'ckpt_dir': ckpt_dir,
+        'layers': per_layer,
+    })
+    return handles
+
+
+def assert_extraction_invariants_qwen3_vl_fp8(handles: WeightHandles) -> None:
+    p = handles.ptrs
+    assert p.get('quant_format') == 'fp8_block128'
+    if p.get('lm_head_quantized', True):
+        for key in ('lm_head_fp8_w', 'lm_head_fp8_s'):
+            if key not in p:
+                raise AssertionError(f'missing {key}')
+    elif 'lm_head_w' not in p:
+        raise AssertionError('missing lm_head_w')
+    layers = p.get('layers')
+    assert isinstance(layers, list) and len(layers) == p['num_layers']
+    required = {
+        'input_norm_w', 'post_attn_norm_w', 'q_proj_w', 'q_proj_s',
+        'k_proj_w', 'k_proj_s', 'v_proj_w', 'v_proj_s',
+        'o_proj_w', 'o_proj_s', 'qkv_proj_w', 'qkv_proj_s',
+        'qkv_proj_N', 'q_norm_w', 'k_norm_w',
+        'mlp_gate_w', 'mlp_gate_s', 'mlp_up_w', 'mlp_up_s',
+        'gate_up_w', 'gate_up_s', 'gate_up_N', 'mlp_down_w', 'mlp_down_s',
+    }
+    for i, layer in enumerate(layers):
+        missing = required.difference(layer)
+        if missing:
+            raise AssertionError(f'layer {i} missing {sorted(missing)}')

--- a/flash_rt/frontends/torch/_qwen3_vl_geometry.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_geometry.py
@@ -177,6 +177,35 @@ def mrope_cos_sin(position_ids, *, head_dim, rope_theta, mrope_section,
     return cos, sin
 
 
+def build_mrope_cache(*, max_pos, head_dim, rope_theta,
+                      device='cuda:0', dtype=torch.bfloat16):
+    """Precompute per-axis MRoPE cos/sin lookup tables.
+
+    Returns (cos_cache, sin_cache), each (max_pos, head_dim/2). The caller
+    applies Qwen3-VL's interleaving policy for t/h/w axes.
+    """
+    inv_freq = 1.0 / (rope_theta ** (
+        torch.arange(0, head_dim, 2, device=device,
+                     dtype=torch.float32) / head_dim))
+    positions = torch.arange(max_pos, device=device, dtype=torch.float32)
+    freqs = torch.outer(positions, inv_freq)
+    return (freqs.cos().to(dtype).contiguous(),
+            freqs.sin().to(dtype).contiguous())
+
+
+def mrope_cos_sin_cached(position_ids, cos_cache, sin_cache, *,
+                         mrope_section):
+    """Gather interleaved-MRoPE cos/sin from precomputed lookup tables."""
+    pos = position_ids.to(device=cos_cache.device, dtype=torch.long)
+    cos = cos_cache[pos[0]].clone()
+    sin = sin_cache[pos[0]].clone()
+    for axis, offset in ((1, 1), (2, 2)):
+        idx = slice(offset, mrope_section[axis] * 3, 3)
+        cos[:, idx] = cos_cache[pos[axis]][:, idx]
+        sin[:, idx] = sin_cache[pos[axis]][:, idx]
+    return cos.contiguous(), sin.contiguous()
+
+
 def vision_rope_cos_sin(grid_thw, *, head_dim, spatial_merge_size,
                         rope_theta=10000.0, device='cuda:0',
                         dtype=torch.bfloat16):
@@ -212,6 +241,45 @@ def vision_rope_cos_sin(grid_thw, *, head_dim, spatial_merge_size,
     cos = freqs.cos().to(device).to(dtype).contiguous()
     sin = freqs.sin().to(device).to(dtype).contiguous()
     return cos, sin
+
+
+def build_vision_rope_cache(*, max_hw, head_dim, rope_theta=10000.0,
+                            device='cuda:0', dtype=torch.bfloat16):
+    """Precompute rotate-half 2D-RoPE cos/sin lookup tables per coordinate."""
+    dim = head_dim // 2
+    inv_freq = 1.0 / (rope_theta ** (
+        torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    coords = torch.arange(max_hw, dtype=torch.float32)
+    freqs = torch.outer(coords, inv_freq)
+    return (freqs.cos().to(device).to(dtype).contiguous(),
+            freqs.sin().to(device).to(dtype).contiguous())
+
+
+def vision_rope_cos_sin_cached(grid_thw, cos_cache, sin_cache, *,
+                               spatial_merge_size):
+    """Gather rotate-half 2D-RoPE cos/sin from precomputed coordinate tables."""
+    coords = []
+    device = cos_cache.device
+    for t, h, w in grid_thw:
+        t, h, w = int(t), int(h), int(w)
+        mh, mw = h // spatial_merge_size, w // spatial_merge_size
+        m = spatial_merge_size
+        rows = (torch.arange(mh, device=device)[:, None, None, None] * m
+                + torch.arange(m, device=device)[None, None, :, None])
+        cols = (torch.arange(mw, device=device)[None, :, None, None] * m
+                + torch.arange(m, device=device)[None, None, None, :])
+        rows = rows.expand(mh, mw, m, m).reshape(-1)
+        cols = cols.expand(mh, mw, m, m).reshape(-1)
+        c = torch.stack((rows, cols), dim=-1)
+        if t > 1:
+            c = c.repeat(t, 1)
+        coords.append(c)
+    pos_ids = torch.cat(coords, dim=0)
+    cos = torch.cat((cos_cache[pos_ids[:, 0]], cos_cache[pos_ids[:, 1]]),
+                    dim=1)
+    sin = torch.cat((sin_cache[pos_ids[:, 0]], sin_cache[pos_ids[:, 1]]),
+                    dim=1)
+    return cos.contiguous(), sin.contiguous()
 
 
 def vision_pos_embeds(grid_thw, pos_embed_table, *, num_grid_per_side,

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -1,4 +1,4 @@
-"""FlashRT — Qwen3-VL ViT tower forward (RTX SM120).
+"""FlashRT — Qwen3-VL ViT tower forward on RTX.
 
 Kernelized SigLIP-style vision tower for ``Qwen3-VL``: patch embed →
 learned position embedding → ``depth`` transformer blocks (rotate_half
@@ -7,9 +7,10 @@ merger, with DeepStack feature taps at the configured layers.
 
 All heavy compute runs through ``flash_rt_kernels`` / ``flash_rt_fa2`` /
 ``flash_rt_qwen3_vl_kernels``; tensor reshapes are metadata-only views.
-The linear layers run FP8 block-128 W8A8 (2× tensor-core vs bf16); the
-activation is dynamically quantized per GEMM and the residual stream
-(which carries the late-layer massive-activation outlier) stays bf16.
+On SM120 the linear layers run FP8 block-128 W8A8 (2× tensor-core vs bf16);
+on SM89 the same tower uses the BF16 GEMM path because the SM120 FP8 GEMM
+binding is not available on Ada. In both cases the residual stream (which
+carries the late-layer massive-activation outlier) stays bf16.
 The tower is prefill-once per image and the sequence length is
 image-resolution dependent, so scratch is sized per forward (CUDA-Graph
 bucketing by patch count is layered on top via ``forward_graph``).
@@ -24,8 +25,9 @@ from typing import Any
 
 class Qwen3VlVisionRtx:
     """Qwen3-VL ViT tower. Loads the vision weights from a checkpoint
-    directory (norms BF16, linears FP8 block-128) and runs the forward
-    against the FlashRT kernel modules.
+    directory and runs the forward against the FlashRT kernel modules.
+    Eligible linears pack as FP8 block-128 on SM89/SM120; sensitive
+    early-layer paths can stay BF16 via explicit config overrides.
 
     Public surface:
       __init__(checkpoint_path, *, device='cuda:0')
@@ -46,6 +48,7 @@ class Qwen3VlVisionRtx:
         # patch-count -> (graph, static_inputs, captured_outputs)
         self._graphs: dict = {}
         self._graph_stream = None
+        self._use_fp8_gemm = False
 
         cfg = config if config is not None else _read_vision_config(
             checkpoint_path)
@@ -58,6 +61,10 @@ class Qwen3VlVisionRtx:
         self.intermediate = int(cfg['intermediate_size'])
         self.deepstack_indexes = tuple(cfg['deepstack_visual_indexes'])
         self.ln_eps = float(cfg.get('layer_norm_eps', 1e-6))
+        self._device_sm = torch.cuda.get_device_capability(
+            torch.device(device))[0] * 10 + torch.cuda.get_device_capability(
+                torch.device(device))[1]
+        self._use_fp8_gemm = self._device_sm >= 89
 
         import json
         import os
@@ -81,7 +88,7 @@ class Qwen3VlVisionRtx:
             residual-writing GEMMs (attn proj, FFN fc2) stay bf16: their
             output feeds the late-layer massive-activation channel, where
             accumulated FP8 noise would be amplified."""
-            if not fp8:
+            if not fp8 or not self._use_fp8_gemm:
                 return (None, w, bias)
             w8, ws = _quant_fp8_block128(w)
             return (w8, ws, bias)
@@ -110,29 +117,46 @@ class Qwen3VlVisionRtx:
         # first 3 blocks recovers image_embeds cosine from 0.86 (all-FP8)
         # to 0.97 for ~+2 ms, vs 0.984 / +21 ms for the all-bf16 tower.
         self.bf16_first_blocks = max(0, int(cfg.get('_bf16_first_blocks', 3)))
+        raw_bf16_linears = cfg.get('_bf16_block_linears', {})
+        self._bf16_block_linears: dict[int, frozenset[str]] = {}
+        allowed_bf16_linears = frozenset(('qkv', 'proj', 'fc1', 'fc2'))
+        for raw_idx, raw_names in raw_bf16_linears.items():
+            idx = int(raw_idx)
+            names = frozenset(str(name) for name in raw_names)
+            bad = names - allowed_bf16_linears
+            if bad:
+                raise ValueError(
+                    f'unsupported vision bf16 override(s) for block {idx}: '
+                    + ', '.join(sorted(bad)))
+            self._bf16_block_linears[idx] = names
 
         self.blocks: list[dict] = []
         for i in range(self.depth):
             bp = f'{p}blocks.{i}.'
-            f8 = i >= self.bf16_first_blocks
+            f8 = self._use_fp8_gemm and i >= self.bf16_first_blocks
+            bf16_linears = self._bf16_block_linears.get(i, frozenset())
             self.blocks.append({
                 'norm1_w': _w(bp + 'norm1.weight'),
                 'norm1_b': _w(bp + 'norm1.bias'),
                 'norm2_w': _w(bp + 'norm2.weight'),
                 'norm2_b': _w(bp + 'norm2.bias'),
                 'qkv': _lin(_w(bp + 'attn.qkv.weight'),
-                            _w(bp + 'attn.qkv.bias'), fp8=f8),
+                            _w(bp + 'attn.qkv.bias'),
+                            fp8=f8 and 'qkv' not in bf16_linears),
                 'proj': _lin(_w(bp + 'attn.proj.weight'),
-                             _w(bp + 'attn.proj.bias'), fp8=f8),
+                             _w(bp + 'attn.proj.bias'),
+                             fp8=f8 and 'proj' not in bf16_linears),
                 'fc1': _lin(
                     _pad_rows(_w(bp + 'mlp.linear_fc1.weight'),
                               self.intermediate_padded),
                     _pad_rows(_w(bp + 'mlp.linear_fc1.bias'),
-                              self.intermediate_padded), fp8=f8),
+                              self.intermediate_padded),
+                    fp8=f8 and 'fc1' not in bf16_linears),
                 'fc2': _lin(
                     _pad_cols(_w(bp + 'mlp.linear_fc2.weight'),
                               self.intermediate_padded),
-                    _w(bp + 'mlp.linear_fc2.bias'), fp8=f8),
+                    _w(bp + 'mlp.linear_fc2.bias'),
+                    fp8=f8 and 'fc2' not in bf16_linears),
             })
         self.merger = _load_merger(_w, _lin, p + 'merger.')
         self.deepstack_mergers = [
@@ -171,9 +195,14 @@ class Qwen3VlVisionRtx:
         w8, ws, bias = lin
         y = torch.empty(M, N, dtype=torch.bfloat16, device=self.device)
         if w8 is None:                                  # bf16 path (w16a16)
-            fvk.w16a16_gemm_sm120_bf16(
-                x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K, 1.0,
-                stream)
+            if self._device_sm >= 120:
+                fvk.w16a16_gemm_sm120_bf16(
+                    x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K, 1.0,
+                    stream)
+            else:
+                fvk.bf16_matmul_cublaslt_bf16(
+                    x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K,
+                    stream)
         else:                                           # FP8 block-128 W8A8
             x_fp8 = torch.empty(
                 M, K, dtype=torch.float8_e4m3fn, device=self.device)
@@ -182,9 +211,14 @@ class Qwen3VlVisionRtx:
             fvk.fp8_per_token_block128_quant_bf16(
                 x.data_ptr(), x_fp8.data_ptr(), x_scale.data_ptr(),
                 M, K, stream)
-            fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
-                x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
-                x_scale.data_ptr(), ws.data_ptr(), stream)
+            if self._device_sm >= 120:
+                fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
+                    x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                    x_scale.data_ptr(), ws.data_ptr(), stream)
+            else:
+                fvk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+                    x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                    x_scale.data_ptr(), ws.data_ptr(), stream)
         if bias is not None and add_bias:
             fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
@@ -209,9 +243,14 @@ class Qwen3VlVisionRtx:
         import torch
         w8, ws, bias = lin
         y = torch.empty(M, N, dtype=torch.bfloat16, device=self.device)
-        self._fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
-            x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
-            x_scale.data_ptr(), ws.data_ptr(), stream)
+        if self._device_sm >= 120:
+            self._fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
+                x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                x_scale.data_ptr(), ws.data_ptr(), stream)
+        else:
+            self._fvk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+                x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                x_scale.data_ptr(), ws.data_ptr(), stream)
         if bias is not None and add_bias:
             self._fvk.add_bias_bf16(
                 y.data_ptr(), bias.data_ptr(), M, N, stream)
@@ -314,12 +353,12 @@ class Qwen3VlVisionRtx:
 
         deepstack: list = [None] * len(self.deepstack_indexes)
         for i, blk in enumerate(self.blocks):
-            # FP8 blocks fuse the activation quant into the producing
-            # LayerNorm / GELU (one kernel, no bf16 round-trip); bf16 blocks
-            # (the first few, protecting the massive-activation channel) keep
-            # the plain norm + w16a16 path.
-            fp8 = blk['qkv'][0] is not None
-            if fp8:
+            # Activation-side fusion follows the linear that consumes it:
+            # qkv/fc1 use fused norm->FP8 only when that GEMM is FP8; fc2
+            # uses fused GELU->FP8 only when fc2 itself is FP8. This keeps
+            # mixed early blocks legal for bring-up experiments.
+            qkv_fp8 = blk['qkv'][0] is not None
+            if qkv_fp8:
                 xf, xs = self._layer_norm_to_fp8(
                     h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
                 qkv = self._gemm_fp8(xf, xs, blk['qkv'], S, 3 * H, H, stream,
@@ -353,27 +392,45 @@ class Qwen3VlVisionRtx:
                 softmax_scale=scale, num_sms=self._num_sms, stream=stream)
             # proj input is the attention output (not a norm/gelu), so its
             # quant cannot be fused upstream; the proj bias rides the residual.
-            attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream,
-                              add_bias=False)
+            if blk['proj'][0] is not None:
+                ao = o.view(S, H).contiguous()
+                ao_fp8 = torch.empty(
+                    S, H, dtype=torch.float8_e4m3fn, device=dev)
+                ao_scale = torch.empty(
+                    S, H // 128, dtype=torch.float32, device=dev)
+                fvk.fp8_per_token_block128_quant_bf16(
+                    ao.data_ptr(), ao_fp8.data_ptr(), ao_scale.data_ptr(),
+                    S, H, stream)
+                attn = self._gemm_fp8(
+                    ao_fp8, ao_scale, blk['proj'], S, H, H, stream,
+                    add_bias=False)
+            else:
+                attn = self._gemm(
+                    o.view(S, H), blk['proj'], S, H, H, stream,
+                    add_bias=False)
             vlk.residual_add_bias_bf16(
                 h.data_ptr(), attn.data_ptr(), blk['proj'][2].data_ptr(),
                 S, H, stream)
 
             inter = self.intermediate
-            if fp8:
+            fc1_fp8 = blk['fc1'][0] is not None
+            fc2_fp8 = blk['fc2'][0] is not None
+            if fc1_fp8:
                 xf2, xs2 = self._layer_norm_to_fp8(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
                 f1 = self._gemm_fp8(xf2, xs2, blk['fc1'], S, inter, H, stream,
-                                    add_bias=False)
-                gf, gs = self._gelu_bias_to_fp8(
-                    f1, blk['fc1'][2], S, inter, stream)
-                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream,
                                     add_bias=False)
             else:
                 xn2 = self._layer_norm(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
                 f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream,
                                 add_bias=False)
+            if fc2_fp8:
+                gf, gs = self._gelu_bias_to_fp8(
+                    f1, blk['fc1'][2], S, inter, stream)
+                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream,
+                                    add_bias=False)
+            else:
                 fvk.bias_gelu_inplace_bf16(
                     f1.data_ptr(), blk['fc1'][2].data_ptr(), S, inter, stream)
                 f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream,

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -7,9 +7,9 @@ merger, with DeepStack feature taps at the configured layers.
 
 All heavy compute runs through ``flash_rt_kernels`` / ``flash_rt_fa2`` /
 ``flash_rt_qwen3_vl_kernels``; tensor reshapes are metadata-only views.
-On SM120 the linear layers run FP8 block-128 W8A8 (2× tensor-core vs bf16);
-on SM89 the same tower uses the BF16 GEMM path because the SM120 FP8 GEMM
-binding is not available on Ada. In both cases the residual stream (which
+On SM120 the linears use the CUTLASS block-128 FP8 path; on SM89 eligible
+linears use the native Ada block-128 FP8 GEMM. BF16-protected linears use the
+architecture-specific BF16 path. In all cases the residual stream (which
 carries the late-layer massive-activation outlier) stays bf16.
 The tower is prefill-once per image and the sequence length is
 image-resolution dependent, so scratch is sized per forward (CUDA-Graph

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -28,6 +28,9 @@ class Qwen3VlFp8Sm89TextFrontend:
                  fuse_gate_up: bool = False,
                  fuse_qk_postproc: bool = True,
                  use_fp8_lm_head: bool = False) -> None:
+        import json
+        import os
+
         self.checkpoint_path = str(checkpoint_path)
         self.device = device
         self.max_seq = int(max_seq)
@@ -83,6 +86,38 @@ class Qwen3VlFp8Sm89TextFrontend:
                 'and build flash_rt_kernels flash_rt_fa2 '
                 'flash_rt_qwen3_vl_kernels.')
         self._fvk = fvk
+
+        cfg_path = os.path.join(self.checkpoint_path, 'config.json')
+        cfg = json.load(open(cfg_path))
+        text_cfg = cfg['text_config']
+        expected = {
+            'num_hidden_layers': 36,
+            'num_attention_heads': 32,
+            'num_key_value_heads': 8,
+            'head_dim': 128,
+            'hidden_size': 4096,
+            'intermediate_size': 12288,
+        }
+        actual = {
+            'num_hidden_layers': int(text_cfg['num_hidden_layers']),
+            'num_attention_heads': int(text_cfg['num_attention_heads']),
+            'num_key_value_heads': int(text_cfg['num_key_value_heads']),
+            'head_dim': int(text_cfg.get('head_dim')
+                            or text_cfg['hidden_size']
+                            // int(text_cfg['num_attention_heads'])),
+            'hidden_size': int(text_cfg['hidden_size']),
+            'intermediate_size': int(text_cfg['intermediate_size']),
+        }
+        mismatched = [
+            f"{key}={actual[key]} (expected {value})"
+            for key, value in expected.items()
+            if actual[key] != value
+        ]
+        if mismatched:
+            raise RuntimeError(
+                'Qwen3VlFp8Sm89TextFrontend only supports the official '
+                'Qwen3-VL-8B FP8 text stack; got ' + ', '.join(mismatched)
+                + f' from {cfg_path}')
 
         self._load_fp8_path()
         self._alloc_buffers()

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -1,0 +1,595 @@
+"""Qwen3-VL official-FP8 text decode path for RTX SM89.
+
+This frontend targets the language stack inside the official
+Qwen3-VL-8B-Instruct-FP8 checkpoint. It is intentionally text-only for the
+first SM89 bring-up: no vision tower, no multimodal scatter, and no fallback
+route. The hot linears use block-scaled M=1 FP8 GEMV against the checkpoint's
+``weight`` + ``weight_scale_inv`` tensors.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class Qwen3VlFp8Sm89TextFrontend:
+    """Batch-1 Qwen3-VL text-only decode on SM89 official FP8 weights."""
+
+    _FP8_SHAPES: tuple[tuple[int, int], ...] = (
+        (6144, 4096),     # fused q/k/v
+        (4096, 4096),     # o_proj
+        (12288, 4096),    # gate / up
+        (24576, 4096),    # fused gate/up
+        (4096, 12288),    # down
+    )
+
+    def __init__(self, checkpoint_path: str, *,
+                 device: str = 'cuda:0', max_seq: int = 2048,
+                 max_prefill_seq: int | None = None,
+                 fuse_gate_up: bool = False,
+                 fuse_qk_postproc: bool = True,
+                 use_fp8_lm_head: bool = False) -> None:
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+        self.max_prefill_seq = (
+            min(self.max_seq, 128) if max_prefill_seq is None
+            else int(max_prefill_seq)
+        )
+        self.fuse_gate_up = bool(fuse_gate_up)
+        self.fuse_qk_postproc = bool(fuse_qk_postproc)
+        self.use_fp8_lm_head = bool(use_fp8_lm_head)
+        self._tokenizer: Any = None
+        self._weights = None
+        self._cfg: dict | None = None
+        self._attn = None
+        self._cur_pos = 0
+        self._decode_graphs: dict[int, Any] = {}
+
+        self._load_fp8_path()
+        self._alloc_buffers()
+        self._build_rope_table()
+
+    def _load_fp8_path(self) -> None:
+        from transformers import AutoTokenizer
+
+        from flash_rt import flash_rt_kernels as fvk
+        from flash_rt.frontends.torch._qwen3_vl_fp8_weights import (
+            assert_extraction_invariants_qwen3_vl_fp8,
+            extract_weights_qwen3_vl_fp8,
+        )
+
+        self._tokenizer = AutoTokenizer.from_pretrained(self.checkpoint_path)
+        handles = extract_weights_qwen3_vl_fp8(
+            self.checkpoint_path, device=self.device,
+            quantize_lm_head=self.use_fp8_lm_head)
+        assert_extraction_invariants_qwen3_vl_fp8(handles)
+        self._weights = handles
+        p = handles.ptrs
+        self._cfg = {
+            'rms_norm_eps': float(p['rms_norm_eps']),
+            'head_dim': int(p['head_dim']),
+            'hidden_size': int(p['hidden']),
+            'vocab_size': int(p['vocab_size']),
+            'num_hidden_layers': int(p['num_layers']),
+            'layer_types': list(p['layer_types']),
+            'num_q_heads': int(p['num_q_heads']),
+            'num_kv_heads': int(p['num_kv_heads']),
+            'intermediate': int(p['intermediate']),
+            'rope_theta': float(p['rope_theta']),
+            'rotary_dim': int(p['head_dim']),
+        }
+        self._fvk = fvk
+
+    def _alloc_buffers(self) -> None:
+        import torch
+
+        from flash_rt.hardware.rtx.attn_backend_qwen3 import (
+            RtxFlashAttnBackendQwen3,
+        )
+
+        cfg = self._cfg
+        assert cfg is not None
+        device = torch.device(self.device)
+        bf16 = torch.bfloat16
+        f8 = torch.float8_e4m3fn
+        fp32 = torch.float32
+        hidden = cfg['hidden_size']
+        vocab = cfg['vocab_size']
+        n_q = cfg['num_q_heads']
+        n_kv = cfg['num_kv_heads']
+        hd = cfg['head_dim']
+        inter = cfg['intermediate']
+        Sq_max = max(1, self.max_prefill_seq)
+
+        self._attn = RtxFlashAttnBackendQwen3(
+            max_seq=self.max_seq, max_q_seq=Sq_max, dtype=bf16)
+        self._h_a = torch.empty(Sq_max, hidden, device=device, dtype=bf16)
+        self._h_b = torch.empty(Sq_max, hidden, device=device, dtype=bf16)
+        self._res_mid = torch.empty(1, Sq_max, hidden, device=device, dtype=bf16)
+        self._layer_out_a = torch.empty(
+            1, Sq_max, hidden, device=device, dtype=bf16)
+        self._layer_out_b = torch.empty(
+            1, Sq_max, hidden, device=device, dtype=bf16)
+        self._q_norm_out = torch.empty(
+            Sq_max * n_q, hd, device=device, dtype=bf16)
+        self._k_norm_out = torch.empty(
+            Sq_max * n_kv, hd, device=device, dtype=bf16)
+        self._q_pre_flat = torch.empty(
+            Sq_max * n_q, hd, device=device, dtype=bf16)
+        self._k_pre_flat = torch.empty(
+            Sq_max * n_kv, hd, device=device, dtype=bf16)
+        self._q_rot = torch.empty(
+            1, Sq_max, n_q, hd, device=device, dtype=bf16)
+        self._k_rot = torch.empty(
+            1, Sq_max, n_kv, hd, device=device, dtype=bf16)
+        rope_dim = cfg['rotary_dim']
+        half = rope_dim // 2
+        idx_lo = torch.arange(half, rope_dim, device=device, dtype=torch.long)
+        idx_hi = torch.arange(0, half, device=device, dtype=torch.long)
+        self._rope_rotate_idx = torch.cat([idx_lo, idx_hi]).contiguous()
+        self._rope_tmp_q = torch.empty(
+            1, Sq_max, n_q, rope_dim, device=device, dtype=bf16)
+        self._rope_tmp_k = torch.empty(
+            1, Sq_max, n_kv, rope_dim, device=device, dtype=bf16)
+        self._qkv_out = torch.empty(1, n_q * hd + 2 * n_kv * hd,
+                                    device=device, dtype=bf16)
+        self._gate_out = torch.empty(1, inter, device=device, dtype=bf16)
+        self._up_out = torch.empty(1, inter, device=device, dtype=bf16)
+        self._gate_up_out = torch.empty(1, 2 * inter, device=device,
+                                        dtype=bf16)
+        self._mlp_act = torch.empty(1, inter, device=device, dtype=bf16)
+        self._prefill_up_out = torch.empty(
+            Sq_max, inter, device=device, dtype=bf16)
+        self._prefill_mlp_act = torch.empty(
+            Sq_max, inter, device=device, dtype=bf16)
+        self._logits_buf = torch.empty(1, vocab, device=device, dtype=bf16)
+        self._last_hidden_buf = torch.empty(1, Sq_max, hidden, device=device,
+                                            dtype=bf16)
+        self._static_token_id = torch.zeros(1, 1, device=device,
+                                            dtype=torch.long)
+        self._graph_stream = torch.cuda.Stream(device=device)
+
+        self._fp8_scratch: dict[tuple[int, int], tuple[torch.Tensor, ...]] = {}
+        for N, K in self._FP8_SHAPES + ((vocab, hidden),):
+            act = torch.empty(1, K, device=device, dtype=f8)
+            scale = torch.empty(1, K // 128, device=device, dtype=fp32)
+            out = torch.empty(1, N, device=device, dtype=bf16)
+            self._fp8_scratch[(N, K)] = (act, scale, out)
+        self._prefill_fp8_scratch: dict[
+            tuple[int, int], tuple[torch.Tensor, ...]] = {}
+        for N, K in (
+            (n_q * hd + 2 * n_kv * hd, hidden),
+            (hidden, hidden),
+            (inter, hidden),
+            (hidden, inter),
+        ):
+            act = torch.empty(Sq_max, K, device=device, dtype=f8)
+            scale = torch.empty(Sq_max, K // 128, device=device, dtype=fp32)
+            out = torch.empty(Sq_max, N, device=device, dtype=bf16)
+            self._prefill_fp8_scratch[(N, K)] = (act, scale, out)
+
+    def _build_rope_table(self) -> None:
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        device = torch.device(self.device)
+        rope_dim = cfg['rotary_dim']
+        theta = cfg['rope_theta']
+        inv_freq = 1.0 / (
+            theta ** (torch.arange(0, rope_dim, 2, device=device,
+                                    dtype=torch.float32) / rope_dim)
+        )
+        positions = torch.arange(self.max_seq, device=device,
+                                 dtype=torch.float32)
+        freqs = torch.outer(positions, inv_freq)
+        self._rope_cos_table = freqs.cos().to(torch.bfloat16).contiguous()
+        self._rope_sin_table = freqs.sin().to(torch.bfloat16).contiguous()
+
+    def _rope_cos_sin(self, cur_pos: int):
+        return (self._rope_cos_table[cur_pos:cur_pos + 1],
+                self._rope_sin_table[cur_pos:cur_pos + 1])
+
+    def _rope_apply_inline(self, x_in, x_out, tmp, cos4, sin4) -> None:
+        import torch
+
+        rope_dim = self._cfg['rotary_dim']
+        half = rope_dim // 2
+        torch.index_select(x_in, -1, self._rope_rotate_idx, out=tmp)
+        tmp[..., :half].neg_()
+        x_out_lo = x_out[..., :half]
+        x_out_hi = x_out[..., half:]
+        x_in_lo = x_in[..., :half]
+        x_in_hi = x_in[..., half:]
+        tmp_lo = tmp[..., :half]
+        tmp_hi = tmp[..., half:]
+        torch.mul(x_in_lo, cos4, out=x_out_lo)
+        x_out_lo.addcmul_(tmp_lo, sin4)
+        torch.mul(x_in_hi, cos4, out=x_out_hi)
+        x_out_hi.addcmul_(tmp_hi, sin4)
+
+    def reset_state(self) -> None:
+        if self._attn is not None:
+            self._attn.reset_cache()
+        self._cur_pos = 0
+
+    def _quant(self, x, shape: tuple[int, int]):
+        import torch
+        s = torch.cuda.current_stream().cuda_stream
+        act, scale, out = self._fp8_scratch[shape]
+        self._fvk.fp8_per_token_block128_quant_bf16(
+            x.data_ptr(), act.data_ptr(), scale.data_ptr(), 1, shape[1], s)
+        return act, scale, out
+
+    def _gemv(self, act, scale, weight_ptr: int, w_scale_ptr: int,
+              out, N: int, K: int) -> None:
+        import torch
+        s = torch.cuda.current_stream().cuda_stream
+        if N >= 4096:
+            fn = self._fvk.ht_gemv_fp8_block128_m1_w16
+        else:
+            fn = self._fvk.ht_gemv_fp8_block128_m1_w8
+        fn(act.data_ptr(), weight_ptr, out.data_ptr(), 1, N, K,
+           scale.data_ptr(), w_scale_ptr, 1.0, s)
+
+    def _prefill_gemm(self, act, scale, weight_ptr: int,
+                      w_scale_ptr: int, out, N: int, K: int,
+                      S: int) -> None:
+        import torch
+
+        s = torch.cuda.current_stream().cuda_stream
+        # Native Ada FP8 block-128 GEMM: reads the FP8 weight directly and
+        # applies per-token act scale * block-128 weight scale in the
+        # mainloop (no dequant scratch). Same scale semantics as the M=1
+        # decode GEMV; ~3-4x faster than the old dequant-scratch prefill path.
+        self._fvk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+            act.data_ptr(), weight_ptr, out.data_ptr(), S, N, K,
+            scale.data_ptr(), w_scale_ptr, s)
+
+    def _write_logits_from_hidden(self, last_row):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        vocab = cfg['vocab_size']
+        s = torch.cuda.current_stream().cuda_stream
+        last_row = last_row.view(1, hidden).contiguous()
+        if self.use_fp8_lm_head:
+            ap, sc, _ = self._quant(last_row, (vocab, hidden))
+            self._gemv(ap, sc, int(self._weights.ptrs['lm_head_fp8_w']),
+                       int(self._weights.ptrs['lm_head_fp8_s']),
+                       self._logits_buf, vocab, hidden)
+        else:
+            self._fvk.bf16_matmul_qwen36_bf16(
+                last_row.data_ptr(), int(self._weights.ptrs['lm_head_w']),
+                self._logits_buf.data_ptr(), 1, vocab, hidden, s)
+        return self._logits_buf
+
+    def _layer_forward(self, L: int, h_in, cos, sin, cur_pos: int,
+                       *,
+                       prequant=None,
+                       next_input_norm_w: int = 0):
+        import torch
+        from flash_rt import flash_rt_kernels as fvk
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        n_q = cfg['num_q_heads']
+        n_kv = cfg['num_kv_heads']
+        hd = cfg['head_dim']
+        inter = cfg['intermediate']
+        eps = float(cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        lw = self._weights.ptrs['layers'][L]
+        h2 = h_in.view(1, hidden).contiguous()
+
+        if prequant is None:
+            ap, sc, _ = self._fp8_scratch[(6144, hidden)]
+            fvk.rms_norm_to_fp8_block128_bf16(
+                h2.data_ptr(), int(lw['input_norm_w']),
+                ap.data_ptr(), sc.data_ptr(), 1, hidden, eps, s)
+        else:
+            ap, sc = prequant
+        self._gemv(ap, sc, int(lw['qkv_proj_w']), int(lw['qkv_proj_s']),
+                   self._qkv_out, int(lw['qkv_proj_N']), hidden)
+        Nq = n_q * hd
+        Nk = n_kv * hd
+        qkv_out = self._qkv_out[:1]
+        q_pre = qkv_out[:, :Nq]
+        k_pre = qkv_out[:, Nq:Nq + Nk]
+        v_pre = qkv_out[:, Nq + Nk:]
+        kv_layer_stride = self._attn.kv_layer_stride_bytes
+        kv_row_stride = self._attn.kv_row_stride_bytes
+        kv_slot_off = L * kv_layer_stride + cur_pos * kv_row_stride
+        if self.fuse_qk_postproc:
+            fvk.qwen3_qk_norm_rope_kvwrite_bf16(
+                q_pre.data_ptr(), k_pre.data_ptr(), v_pre.data_ptr(),
+                int(lw['q_norm_w']), int(lw['k_norm_w']),
+                cos.data_ptr(), sin.data_ptr(),
+                self._attn.Q_buf[:, :1].data_ptr(),
+                self._attn.K_cache.data_ptr() + kv_slot_off,
+                self._attn.V_cache.data_ptr() + kv_slot_off,
+                n_q, n_kv, eps, s)
+        else:
+            fvk.qwen3_q_norm_rope_qstage_bf16(
+                q_pre.data_ptr(), int(lw['q_norm_w']), cos.data_ptr(),
+                sin.data_ptr(), self._attn.Q_buf[:, :1].data_ptr(),
+                n_q, eps, s)
+            fvk.qwen3_k_norm_rope_kvwrite_bf16(
+                k_pre.data_ptr(), v_pre.data_ptr(), int(lw['k_norm_w']),
+                cos.data_ptr(), sin.data_ptr(),
+                self._attn.K_cache.data_ptr() + kv_slot_off,
+                self._attn.V_cache.data_ptr() + kv_slot_off,
+                n_kv, eps, s)
+
+        self._attn.run(
+            'full', layer_idx=L, q_seq=1, kv_seq=cur_pos + 1,
+            stream=s, causal=True)
+        attn_2d = self._attn.O_buf[:, :1].reshape(1, hidden).contiguous()
+        ap, sc, o_out = self._quant(attn_2d, (hidden, hidden))
+        self._gemv(ap, sc, int(lw['o_proj_w']), int(lw['o_proj_s']),
+                   o_out, hidden, hidden)
+
+        attn_proj = o_out.view(1, 1, hidden)
+        h_post = self._res_mid[:, :1]
+        ap, sc, gate_out = self._fp8_scratch[(inter, hidden)]
+        fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+            h_in.data_ptr(), attn_proj.data_ptr(), h_post.data_ptr(),
+            int(lw['post_attn_norm_w']),
+            ap.data_ptr(), sc.data_ptr(), 1, hidden, eps, s)
+        if self.fuse_gate_up:
+            self._gemv(ap, sc, int(lw['gate_up_w']), int(lw['gate_up_s']),
+                       self._gate_up_out, int(lw['gate_up_N']), hidden)
+            gate_out = self._gate_up_out[:, :inter]
+            up_out = self._gate_up_out[:, inter:]
+        else:
+            self._gemv(ap, sc, int(lw['mlp_gate_w']), int(lw['mlp_gate_s']),
+                       self._gate_out, inter, hidden)
+            self._gemv(ap, sc, int(lw['mlp_up_w']), int(lw['mlp_up_s']),
+                       self._up_out, inter, hidden)
+            gate_out = self._gate_out
+            up_out = self._up_out
+        ap, sc, down_out = self._fp8_scratch[(hidden, inter)]
+        fvk.silu_mul_to_fp8_block128_bf16(
+            gate_out.data_ptr(), up_out.data_ptr(),
+            ap.data_ptr(), sc.data_ptr(), 1, inter, s)
+        self._gemv(ap, sc, int(lw['mlp_down_w']), int(lw['mlp_down_s']),
+                   down_out, hidden, inter)
+
+        h_out = (self._layer_out_a if (L % 2 == 0)
+                 else self._layer_out_b)[:, :1]
+        mlp_out = down_out.view(1, 1, hidden)
+        if next_input_norm_w:
+            next_ap, next_sc, _ = self._fp8_scratch[(6144, hidden)]
+            fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+                h_post.data_ptr(), mlp_out.data_ptr(), h_out.data_ptr(),
+                int(next_input_norm_w),
+                next_ap.data_ptr(), next_sc.data_ptr(), 1, hidden, eps, s)
+            return h_out, (next_ap, next_sc)
+        torch.add(h_post, mlp_out, out=h_out)
+        return h_out, None
+
+    def _layer_forward_prefill_fp8_blockscaled(self, L: int, h_in_S, cos_S,
+                                           sin_S, start_pos: int, S: int):
+        import torch
+
+        from flash_rt import flash_rt_kernels as fvk
+
+        s = torch.cuda.current_stream().cuda_stream
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        n_q = cfg['num_q_heads']
+        n_kv = cfg['num_kv_heads']
+        hd = cfg['head_dim']
+        inter = cfg['intermediate']
+        eps = float(cfg['rms_norm_eps'])
+        lw = self._weights.ptrs['layers'][L]
+        h2 = h_in_S.view(S, hidden)
+
+        ap_h, sc_h, qkv_out = self._prefill_fp8_scratch[(n_q * hd + 2 * n_kv * hd, hidden)]
+        fvk.rms_norm_to_fp8_block128_bf16(
+            h2.data_ptr(), int(lw['input_norm_w']),
+            ap_h.data_ptr(), sc_h.data_ptr(), S, hidden, eps, s)
+        self._prefill_gemm(
+            ap_h, sc_h, int(lw['qkv_proj_w']), int(lw['qkv_proj_s']),
+            qkv_out, int(lw['qkv_proj_N']), hidden, S)
+
+        qkv = qkv_out[:S]
+        Nq = n_q * hd
+        Nk = n_kv * hd
+        fvk.qwen3_qk_norm_rope_kvwrite_batched_bf16(
+            qkv.data_ptr(),
+            qkv[:, Nq:Nq + Nk].data_ptr(),
+            qkv[:, Nq + Nk:].data_ptr(),
+            int(lw['q_norm_w']),
+            int(lw['k_norm_w']),
+            cos_S.data_ptr(),
+            sin_S.data_ptr(),
+            self._attn.Q_buf[:, :S].data_ptr(),
+            self._attn.K_cache[L, start_pos:start_pos + S].data_ptr(),
+            self._attn.V_cache[L, start_pos:start_pos + S].data_ptr(),
+            S,
+            int(qkv.stride(0)),
+            int(qkv[:, Nq:Nq + Nk].stride(0)),
+            int(qkv[:, Nq + Nk:].stride(0)),
+            int(self._attn.Q_buf[:, :S].stride(1)),
+            int(self._attn.K_cache[L, start_pos:start_pos + S].stride(0)),
+            n_q,
+            n_kv,
+            eps,
+            s)
+
+        self._attn.run(
+            'full', layer_idx=L, q_seq=S, kv_seq=start_pos + S,
+            stream=s, causal=True)
+        attn_2d = self._attn.O_buf[:, :S].view(S, hidden)
+        ap_o, sc_o, o_out = self._prefill_fp8_scratch[(hidden, hidden)]
+        fvk.fp8_per_token_block128_quant_bf16(
+            attn_2d.data_ptr(), ap_o.data_ptr(), sc_o.data_ptr(),
+            S, hidden, s)
+        self._prefill_gemm(
+            ap_o, sc_o, int(lw['o_proj_w']), int(lw['o_proj_s']),
+            o_out, hidden, hidden, S)
+
+        h_post = self._res_mid[:, :S]
+        ap_mlp, sc_mlp, gate_out = self._prefill_fp8_scratch[(inter, hidden)]
+        fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+            h_in_S.data_ptr(), o_out[:S].view(1, S, hidden).data_ptr(),
+            h_post.data_ptr(), int(lw['post_attn_norm_w']),
+            ap_mlp.data_ptr(), sc_mlp.data_ptr(), S, hidden, eps, s)
+        up_out = self._prefill_up_out[:S]
+        self._prefill_gemm(
+            ap_mlp, sc_mlp, int(lw['mlp_gate_w']), int(lw['mlp_gate_s']),
+            gate_out, inter, hidden, S)
+        self._prefill_gemm(
+            ap_mlp, sc_mlp, int(lw['mlp_up_w']), int(lw['mlp_up_s']),
+            up_out, inter, hidden, S)
+        ap_dn, sc_dn, down_out = self._prefill_fp8_scratch[(hidden, inter)]
+        fvk.silu_mul_to_fp8_block128_bf16(
+            gate_out[:S].data_ptr(), up_out.data_ptr(),
+            ap_dn.data_ptr(), sc_dn.data_ptr(), S, inter, s)
+        self._prefill_gemm(
+            ap_dn, sc_dn, int(lw['mlp_down_w']), int(lw['mlp_down_s']),
+            down_out, hidden, inter, S)
+
+        h_out = (self._layer_out_a if (L % 2 == 0)
+                 else self._layer_out_b)[:, :S]
+        torch.add(h_post, down_out[:S].view(1, S, hidden), out=h_out)
+        return h_out
+
+    def forward_hidden_prefill_fp8_blockscaled(self, h_S, cos_S, sin_S,
+                                           start_pos: int = 0,
+                                           deepstack_by_layer=None,
+                                           *,
+                                           run_lm_head: bool = True):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        eps = float(cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        S = int(h_S.shape[-2] if h_S.ndim == 3 else h_S.shape[0])
+        if S < 1 or S > self.max_prefill_seq:
+            raise ValueError(
+                f'prefill S={S} out of [1, {self.max_prefill_seq}]; '
+                'construct with a larger max_prefill_seq')
+        if start_pos + S > self.max_seq:
+            raise ValueError(
+                f'prefill end {start_pos + S} > max_seq {self.max_seq}')
+        h = h_S.view(1, S, hidden).to(torch.bfloat16).contiguous()
+        for L in range(cfg['num_hidden_layers']):
+            h = self._layer_forward_prefill_fp8_blockscaled(
+                L, h, cos_S, sin_S, start_pos, S)
+            if deepstack_by_layer is not None and L in deepstack_by_layer:
+                for a, b, ds in deepstack_by_layer[L]:
+                    self._fvk.residual_add(
+                        h[0, a:b].data_ptr(), ds.data_ptr(),
+                        (b - a) * hidden, s)
+
+        h2 = h.view(S, hidden).contiguous()
+        x_norm = self._h_b[:S].view(S, hidden)
+        self._fvk.rms_norm(
+            h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
+            x_norm.data_ptr(), S, hidden, eps, s)
+        self._last_hidden_buf[:, :S].copy_(x_norm.view(1, S, hidden))
+        self._cur_pos = start_pos + S
+        if not run_lm_head:
+            return self._last_hidden_buf[:, :S]
+        return self._write_logits_from_hidden(
+            self._last_hidden_buf[0, S - 1:S])
+
+    def forward_hidden_decode_fp8(self, h, cos_pos, sin_pos, cur_pos: int,
+                                  deepstack_by_layer=None):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        vocab = cfg['vocab_size']
+        eps = float(cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        h = h.view(1, 1, hidden).contiguous()
+        prequant = None
+        for L in range(cfg['num_hidden_layers']):
+            next_norm = 0
+            if L + 1 < cfg['num_hidden_layers']:
+                next_norm = int(self._weights.ptrs['layers'][L + 1]
+                                ['input_norm_w'])
+            h, prequant = self._layer_forward(
+                L, h, cos_pos, sin_pos, cur_pos,
+                prequant=prequant, next_input_norm_w=next_norm)
+            if deepstack_by_layer is not None and L in deepstack_by_layer:
+                h = h.clone()
+                torch.add(h, deepstack_by_layer[L].view(1, 1, hidden), out=h)
+                prequant = None
+
+        x_norm = self._h_b[:1].view(1, hidden)
+        self._fvk.rms_norm(
+            h.view(1, hidden).contiguous().data_ptr(),
+            int(self._weights.ptrs['final_norm_w']), x_norm.data_ptr(),
+            1, hidden, eps, s)
+        self._last_hidden_buf[:, :1].copy_(x_norm.view(1, 1, hidden))
+        return self._write_logits_from_hidden(x_norm)
+
+    def forward_own_decode_fp8(self, token_id, cos_pos, sin_pos, cur_pos: int):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        s = torch.cuda.current_stream().cuda_stream
+        if not isinstance(token_id, torch.Tensor):
+            token_id = torch.tensor([token_id], device=self.device,
+                                    dtype=torch.long)
+        if token_id.ndim == 1:
+            token_id = token_id.view(1, 1)
+        h = self._h_a[:1]
+        self._fvk.qwen36_embedding_lookup_bf16(
+            token_id.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            h.data_ptr(),
+            1, hidden, s)
+        return self.forward_hidden_decode_fp8(h, cos_pos, sin_pos, cur_pos)
+
+    def decode_step(self, token_id, cur_pos: int):
+        cos, sin = self._rope_cos_sin(cur_pos)
+        return self.forward_own_decode_fp8(token_id, cos, sin, cur_pos)
+
+    def _ensure_decode_graph(self, cur_pos: int):
+        import torch
+
+        graph = self._decode_graphs.get(cur_pos)
+        if graph is not None:
+            return graph
+        cos, sin = self._rope_cos_sin(cur_pos)
+        gs = self._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.inference_mode():
+            for _ in range(2):
+                self.forward_own_decode_fp8(
+                    self._static_token_id, cos, sin, cur_pos)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.inference_mode():
+            self.forward_own_decode_fp8(
+                self._static_token_id, cos, sin, cur_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._decode_graphs[cur_pos] = graph
+        return graph
+
+    def decode_step_with_graph(self, token_id, cur_pos: int):
+        import torch
+
+        if isinstance(token_id, torch.Tensor):
+            if token_id.ndim == 1:
+                token_id = token_id.view(1, 1)
+            self._static_token_id.copy_(token_id)
+        else:
+            self._static_token_id.fill_(int(token_id))
+        self._ensure_decode_graph(cur_pos).replay()
+        return self._logits_buf

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -45,6 +45,45 @@ class Qwen3VlFp8Sm89TextFrontend:
         self._cur_pos = 0
         self._decode_graphs: dict[int, Any] = {}
 
+        import torch
+        from flash_rt import flash_rt_kernels as fvk
+
+        device_obj = torch.device(self.device)
+        if device_obj.type != 'cuda' or not torch.cuda.is_available():
+            raise RuntimeError(
+                'Qwen3VlFp8Sm89TextFrontend requires an SM89 CUDA device')
+        cap = torch.cuda.get_device_capability(device_obj)
+        if cap != (8, 9):
+            raise RuntimeError(
+                'Qwen3VlFp8Sm89TextFrontend requires GPU_ARCH=89 / sm_89; '
+                f'got sm_{cap[0]}{cap[1]} on {self.device}')
+        required = (
+            'fp8_block128_gemm_blockscaled_sm89_bf16out',
+            'ht_gemv_fp8_block128_m1_w8',
+            'ht_gemv_fp8_block128_m1_w16',
+            'fp8_per_token_block128_quant_bf16',
+            'rms_norm_to_fp8_block128_bf16',
+            'residual_add_rms_norm_to_fp8_block128_bf16',
+            'silu_mul_to_fp8_block128_bf16',
+            'qwen3_qk_norm_rope_kvwrite_bf16',
+            'qwen3_qk_norm_rope_kvwrite_batched_bf16',
+            'qwen3_q_norm_rope_qstage_bf16',
+            'qwen3_k_norm_rope_kvwrite_bf16',
+            'qwen36_embedding_lookup_bf16',
+            'bf16_matmul_qwen36_bf16',
+            'rms_norm',
+            'residual_add',
+        )
+        missing = [name for name in required if not hasattr(fvk, name)]
+        if missing:
+            raise RuntimeError(
+                'flash_rt_kernels is missing SM89 Qwen3-VL FP8 symbols: '
+                + ', '.join(missing)
+                + '. Rebuild with -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON '
+                'and build flash_rt_kernels flash_rt_fa2 '
+                'flash_rt_qwen3_vl_kernels.')
+        self._fvk = fvk
+
         self._load_fp8_path()
         self._alloc_buffers()
         self._build_rope_table()
@@ -52,7 +91,6 @@ class Qwen3VlFp8Sm89TextFrontend:
     def _load_fp8_path(self) -> None:
         from transformers import AutoTokenizer
 
-        from flash_rt import flash_rt_kernels as fvk
         from flash_rt.frontends.torch._qwen3_vl_fp8_weights import (
             assert_extraction_invariants_qwen3_vl_fp8,
             extract_weights_qwen3_vl_fp8,
@@ -78,7 +116,6 @@ class Qwen3VlFp8Sm89TextFrontend:
             'rope_theta': float(p['rope_theta']),
             'rotary_dim': int(p['head_dim']),
         }
-        self._fvk = fvk
 
     def _alloc_buffers(self) -> None:
         import torch

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
@@ -99,7 +99,7 @@ class Qwen3VlFp8Sm89Frontend:
                 if isinstance(size, dict) and 'longest_edge' in size:
                     size['longest_edge'] = int(max_pixels)
         self._prompt: dict[str, Any] | None = None
-        self._decode_graphs: dict[int, Any] = {}
+        self._decode_graphs: dict[tuple[int, int], Any] = {}
         self._prefill_graphs: dict = {}
         self._pg_buffers: dict = {}
 
@@ -123,6 +123,7 @@ class Qwen3VlFp8Sm89Frontend:
 
         from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
 
+        self._decode_graphs.clear()
         inputs = self.processor.apply_chat_template(
             messages, add_generation_prompt=True, tokenize=True,
             return_dict=True, return_tensors='pt',
@@ -305,7 +306,8 @@ class Qwen3VlFp8Sm89Frontend:
     def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
         import torch
 
-        graph = self._decode_graphs.get(cache_pos)
+        key = (int(cache_pos), int(rope_pos))
+        graph = self._decode_graphs.get(key)
         if graph is not None:
             return graph
         llm = self.llm
@@ -323,7 +325,7 @@ class Qwen3VlFp8Sm89Frontend:
                 llm._static_token_id, cos, sin, cache_pos)
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
-        self._decode_graphs[cache_pos] = graph
+        self._decode_graphs[key] = graph
         return graph
 
     def decode_step_with_graph(self, token_id, cache_pos: int):

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
@@ -1,0 +1,377 @@
+"""Qwen3-VL official-FP8 multimodal path for RTX SM89.
+
+This wrapper combines the SM89 official-FP8 language frontend with the
+Qwen3-VL vision tower. The single-image prefill path is CUDA-Graph captured:
+processor/geometry run once, static buffers stage the prompt tensors, then
+vision + S>1 FP8 blockscaled language prefill + final norm replay as one graph.
+The lm_head runs eager after replay, matching the SM120 RTX frontend shape.
+Decode remains owned by ``Qwen3VlFp8Sm89TextFrontend``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class Qwen3VlFp8Sm89Frontend:
+    """Batch-1 Qwen3-VL prefill/decode frontend for SM89 official FP8."""
+
+    def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
+                 max_seq: int = 4096, max_prefill_seq: int | None = None,
+                 max_pixels: int | None = None,
+                 fuse_gate_up: bool = False,
+                 fuse_qk_postproc: bool = True,
+                 use_fp8_lm_head: bool = False,
+                 vision_bf16_first_blocks: int = 3,
+                 vision_bf16_block_linears: dict[int, tuple[str, ...]]
+                 | None = None) -> None:
+        import json
+        import os
+
+        from transformers import AutoProcessor
+
+        from flash_rt.frontends.torch._qwen3_vl_vision_rtx import (
+            Qwen3VlVisionRtx,
+        )
+        from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+            Qwen3VlFp8Sm89TextFrontend,
+        )
+        from flash_rt.frontends.torch.qwen3_vl_rtx import (
+            _require_qwen3_vl_kernels,
+        )
+
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+        _require_qwen3_vl_kernels()
+        self.max_prefill_seq = (
+            min(self.max_seq, 128) if max_prefill_seq is None
+            else int(max_prefill_seq)
+        )
+        self.llm = Qwen3VlFp8Sm89TextFrontend(
+            checkpoint_path, device=device, max_seq=max_seq,
+            max_prefill_seq=self.max_prefill_seq,
+            fuse_gate_up=fuse_gate_up,
+            fuse_qk_postproc=fuse_qk_postproc,
+            use_fp8_lm_head=use_fp8_lm_head)
+        self.arch = 'sm89'
+        cfg = json.load(open(os.path.join(checkpoint_path, 'config.json')))
+        vcfg = dict(cfg['vision_config'])
+        vcfg['_bf16_first_blocks'] = int(vision_bf16_first_blocks)
+        if vision_bf16_block_linears is not None:
+            vcfg['_bf16_block_linears'] = {
+                int(k): [str(name) for name in names]
+                for k, names in vision_bf16_block_linears.items()
+            }
+        self.vision = Qwen3VlVisionRtx(
+            checkpoint_path, device=device, config=vcfg)
+        self.processor = AutoProcessor.from_pretrained(checkpoint_path)
+        self._image_token_id = int(cfg['image_token_id'])
+        self._video_token_id = int(cfg['video_token_id'])
+        self._vision_start_token_id = int(cfg['vision_start_token_id'])
+        vc = cfg['vision_config']
+        self._merge = int(vc['spatial_merge_size'])
+        self._vis_head_dim = int(vc['hidden_size']) // int(vc['num_heads'])
+        self._num_grid_per_side = int(vc['num_position_embeddings'] ** 0.5)
+        self._deepstack_layers = len(vc['deepstack_visual_indexes'])
+        self._rope_theta = float(cfg['text_config']['rope_theta'])
+        self._head_dim = int(cfg['text_config']['head_dim'])
+        self._mrope_section = tuple(
+            cfg['text_config']['rope_scaling']['mrope_section'])
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+        self._mrope_cos_cache, self._mrope_sin_cache = geo.build_mrope_cache(
+            max_pos=self.max_seq + self._num_grid_per_side,
+            head_dim=self._head_dim, rope_theta=self._rope_theta,
+            device=self.device)
+        self._vision_rope_cos_cache, self._vision_rope_sin_cache = (
+            geo.build_vision_rope_cache(
+                max_hw=self.max_seq * self._merge,
+                head_dim=self._vis_head_dim, device=self.device))
+        eos = cfg.get('eos_token_id')
+        if eos is None:
+            eos = cfg['text_config'].get('eos_token_id')
+        self._eos_token_ids = set(
+            [] if eos is None else (eos if isinstance(eos, list) else [eos]))
+        self.max_pixels = max_pixels
+        if max_pixels is not None:
+            for proc in (getattr(self.processor, 'image_processor', None),
+                         getattr(self.processor, 'video_processor', None)):
+                size = getattr(proc, 'size', None)
+                if isinstance(size, dict) and 'longest_edge' in size:
+                    size['longest_edge'] = int(max_pixels)
+        self._prompt: dict[str, Any] | None = None
+        self._decode_graphs: dict[int, Any] = {}
+        self._prefill_graphs: dict = {}
+        self._pg_buffers: dict = {}
+
+    _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
+                'vcos', 'vsin', 'mcos', 'msin')
+
+    def _stage_prefill_inputs(self, P: int, S: int, span):
+        p = self._prompt
+        key = (P, S, span[0], span[1])
+        bufs = self._pg_buffers.get(key)
+        if bufs is None:
+            bufs = {k: p[k].clone() for k in self._PG_KEYS}
+            self._pg_buffers[key] = bufs
+        else:
+            for k in self._PG_KEYS:
+                bufs[k].copy_(p[k])
+        return key
+
+    def set_prompt(self, messages: list) -> None:
+        import torch
+
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+        inputs = self.processor.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=True,
+            return_dict=True, return_tensors='pt',
+            device=self.device).to(self.device)
+        input_ids = inputs['input_ids'][0]
+        S = int(input_ids.shape[0])
+        if S > self.max_seq:
+            raise ValueError(
+                f'prompt length {S} exceeds max_seq {self.max_seq}')
+
+        image_grid = inputs.get('image_grid_thw')
+        video_grid = inputs.get('video_grid_thw')
+        pix_img = inputs.get('pixel_values')
+        pix_vid = inputs.get('pixel_values_videos')
+        if pix_img is not None:
+            pix_img = pix_img.to(torch.bfloat16)
+        if pix_vid is not None:
+            pix_vid = pix_vid.to(torch.bfloat16)
+
+        segs = geo.vision_segments(
+            input_ids.cpu(), image_grid, video_grid,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
+            spatial_merge_size=self._merge)
+        seg_pix = []
+        seg_grids = []
+        spans = []
+        seg_patches = []
+        off_img = off_vid = 0
+        for sg in segs:
+            npp = sg['patches']
+            if sg['kind'] == 'image':
+                seg_pix.append(pix_img[off_img:off_img + npp])
+                off_img += npp
+            else:
+                seg_pix.append(pix_vid[off_vid:off_vid + npp])
+                off_vid += npp
+            seg_grids.append(sg['grid'])
+            spans.append(sg['span'])
+            seg_patches.append(npp)
+
+        seg_grid = torch.tensor(seg_grids, dtype=torch.long)
+        pos_ids = geo.mrope_position_ids(
+            input_ids.cpu(),
+            image_grid.cpu() if image_grid is not None else None,
+            video_grid.cpu() if video_grid is not None else None,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
+            vision_start_token_id=self._vision_start_token_id,
+            spatial_merge_size=self._merge)
+        mcos, msin = geo.mrope_cos_sin_cached(
+            pos_ids, self._mrope_cos_cache, self._mrope_sin_cache,
+            mrope_section=self._mrope_section)
+        vcos, vsin = geo.vision_rope_cos_sin_cached(
+            seg_grid, self._vision_rope_cos_cache, self._vision_rope_sin_cache,
+            spatial_merge_size=self._merge)
+        pos_embeds = geo.vision_pos_embeds(
+            seg_grid, self.vision.pos_embed,
+            num_grid_per_side=self._num_grid_per_side,
+            spatial_merge_size=self._merge, device=self.device)
+        self._prompt = {
+            'input_ids': input_ids,
+            'pixel_values': torch.cat(seg_pix, dim=0).contiguous(),
+            'spans': spans,
+            'seg_patches': seg_patches,
+            'mcos': mcos,
+            'msin': msin,
+            'vcos': vcos,
+            'vsin': vsin,
+            'pos_embeds': pos_embeds,
+            'S': S,
+            'mrope_max': int(pos_ids.max()),
+        }
+        if len(spans) == 1:
+            self._prompt['pg_key'] = self._stage_prefill_inputs(
+                seg_patches[0], S, spans[0])
+
+    def prefill(self):
+        import torch
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill()')
+        p = self._prompt
+        llm = self.llm
+        llm.reset_state()
+        hidden = llm._cfg['hidden_size']
+        S = int(p['S'])
+        embed = llm._weights.anchors[0]
+        h = embed[p['input_ids']].to(torch.bfloat16).view(S, hidden)
+        seg_deepstacks = []
+        off = 0
+        for (a, b), n_patch in zip(p['spans'], p['seg_patches']):
+            sl = slice(off, off + n_patch)
+            off += n_patch
+            emb, ds = self.vision.forward(
+                p['pixel_values'][sl], p['pos_embeds'][sl],
+                p['vcos'][sl], p['vsin'][sl])
+            h[a:b].copy_(emb.to(torch.bfloat16))
+            seg_deepstacks.append(ds)
+
+        deep = {}
+        for layer in range(self._deepstack_layers):
+            rows = []
+            for (a, b), ds in zip(p['spans'], seg_deepstacks):
+                rows.append((a, b, ds[layer].to(torch.bfloat16).contiguous()))
+            deep[layer] = rows
+        logits = llm.forward_hidden_prefill_fp8_blockscaled(
+            h, p['mcos'], p['msin'], 0, deepstack_by_layer=deep)
+        torch.cuda.synchronize()
+        return logits
+
+    def _prefill_graph_body(self, st, P, S, a, b):
+        import torch
+
+        llm = self.llm
+        hidden = llm._cfg['hidden_size']
+        embed = llm._weights.anchors[0]
+        h = embed[st['input_ids']].to(torch.bfloat16).view(S, hidden)
+        emb, ds = self.vision.forward(
+            st['pixel_values'], st['pos_embeds'], st['vcos'], st['vsin'])
+        h[a:b].copy_(emb.to(torch.bfloat16))
+
+        deep = {}
+        for layer in range(self._deepstack_layers):
+            deep[layer] = [(a, b, ds[layer].to(torch.bfloat16).contiguous())]
+        llm.forward_hidden_prefill_fp8_blockscaled(
+            h, st['mcos'], st['msin'], 0, deepstack_by_layer=deep,
+            run_lm_head=False)
+
+    def _capture_prefill_graph(self, st, P, S, a, b):
+        import torch
+
+        llm = self.llm
+        gs = llm._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.no_grad():
+            for _ in range(2):
+                self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.no_grad():
+            self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        return graph
+
+    def prefill_graph(self):
+        import torch
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill_graph()')
+        p = self._prompt
+        key = p.get('pg_key')
+        if key is None:
+            raise ValueError(
+                'prefill_graph currently supports single-image prompts only; '
+                'call prefill() explicitly for multi-image or video prompts')
+
+        P, S, a, b = key
+        st = self._pg_buffers[key]
+        graph = self._prefill_graphs.get(key)
+        if graph is None:
+            graph = self._capture_prefill_graph(st, P, S, a, b)
+            self._prefill_graphs[key] = graph
+        graph.replay()
+        logits = self.llm._write_logits_from_hidden(
+            self.llm._last_hidden_buf[0, S - 1:S])
+        torch.cuda.synchronize()
+        return logits
+
+    def decode_step(self, token_id, cache_pos: int):
+        if self._prompt is None:
+            rope_pos = cache_pos
+        else:
+            rope_pos = int(self._prompt['mrope_max']) + 1 + (
+                cache_pos - int(self._prompt['S']))
+        cos, sin = self.llm._rope_cos_sin(rope_pos)
+        return self.llm.forward_own_decode_fp8(token_id, cos, sin, cache_pos)
+
+    def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
+        import torch
+
+        graph = self._decode_graphs.get(cache_pos)
+        if graph is not None:
+            return graph
+        llm = self.llm
+        cos, sin = llm._rope_cos_sin(rope_pos)
+        gs = llm._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.inference_mode():
+            for _ in range(2):
+                llm.forward_own_decode_fp8(
+                    llm._static_token_id, cos, sin, cache_pos)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.inference_mode():
+            llm.forward_own_decode_fp8(
+                llm._static_token_id, cos, sin, cache_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._decode_graphs[cache_pos] = graph
+        return graph
+
+    def decode_step_with_graph(self, token_id, cache_pos: int):
+        if self._prompt is None:
+            rope_pos = cache_pos
+        else:
+            rope_pos = int(self._prompt['mrope_max']) + 1 + (
+                cache_pos - int(self._prompt['S']))
+        llm = self.llm
+        if hasattr(token_id, 'ndim'):
+            if token_id.ndim == 1:
+                token_id = token_id.view(1, 1)
+            llm._static_token_id.copy_(token_id)
+        else:
+            llm._static_token_id.fill_(int(token_id))
+        self._ensure_decode_graph(cache_pos, rope_pos).replay()
+        return llm._logits_buf
+
+    def warmup_decode_graphs(self, n_tokens: int) -> None:
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before warmup')
+        base_slot = int(self._prompt['S'])
+        base_rope = int(self._prompt['mrope_max']) + 1
+        for i in range(int(n_tokens)):
+            self._ensure_decode_graph(base_slot + i, base_rope + i)
+
+    def generate(self, messages: list, *, max_new_tokens: int = 256,
+                 use_graph: bool = True) -> str:
+        self.set_prompt(messages)
+        logits = self.prefill_graph() if use_graph else self.prefill()
+        p = self._prompt
+        assert p is not None
+        base_slot = int(p['S'])
+
+        tok = int(logits[0].float().argmax())
+        out_ids = [tok]
+        for i in range(max_new_tokens - 1):
+            if tok in self._eos_token_ids:
+                break
+            if use_graph:
+                logits = self.decode_step_with_graph(tok, base_slot + i)
+            else:
+                logits = self.decode_step(tok, base_slot + i)
+            tok = int(logits[0].float().argmax())
+            out_ids.append(tok)
+
+        eos = [t for t in out_ids if t in self._eos_token_ids]
+        if eos:
+            out_ids = out_ids[:out_ids.index(eos[0])]
+        return self.processor.tokenizer.decode(
+            out_ids, skip_special_tokens=True)

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -42,7 +42,8 @@ def _check_qwen3_vl_kernels(module) -> None:
     if missing:
         raise RuntimeError(
             'flash_rt_qwen3_vl_kernels is missing ' + ', '.join(missing)
-            + '. Rebuild it with -DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=120).')
+            + '. Rebuild it with -DFLASHRT_BUILD_QWEN3_VL=ON '
+            '(GPU_ARCH=89 or 120).')
 
 
 def _require_qwen3_vl_kernels():
@@ -53,7 +54,7 @@ def _require_qwen3_vl_kernels():
     except ImportError as e:
         raise RuntimeError(
             'flash_rt_qwen3_vl_kernels is not built. Configure with '
-            '-DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=120) and build the '
+            '-DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=89 or 120) and build the '
             'flash_rt_qwen3_vl_kernels target.') from e
     _check_qwen3_vl_kernels(vlk)
     return vlk
@@ -98,6 +99,15 @@ class Qwen3VlTorchFrontendRtx:
         self._rope_theta = float(cfg['rope_theta'])
         self._head_dim = int(cfg['head_dim'])
         self._mrope_section = tuple(cfg['rope_scaling']['mrope_section'])
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+        self._mrope_cos_cache, self._mrope_sin_cache = geo.build_mrope_cache(
+            max_pos=self.max_seq + self._num_grid_per_side,
+            head_dim=self._head_dim, rope_theta=self._rope_theta,
+            device=self.device)
+        self._vision_rope_cos_cache, self._vision_rope_sin_cache = (
+            geo.build_vision_rope_cache(
+                max_hw=self.max_seq * self._merge,
+                head_dim=self._vis_head_dim, device=self.device))
         eos = cfg.get('eos_token_id')
         if eos is None:
             self._eos_token_ids: set = set()
@@ -208,12 +218,12 @@ class Qwen3VlTorchFrontendRtx:
             video_token_id=self._video_token_id,
             vision_start_token_id=self._vision_start_token_id,
             spatial_merge_size=m)
-        mcos, msin = geo.mrope_cos_sin(
-            pos_ids, head_dim=self._head_dim, rope_theta=self._rope_theta,
-            mrope_section=self._mrope_section, device=self.device)
-        vcos, vsin = geo.vision_rope_cos_sin(
-            seg_grid, head_dim=self._vis_head_dim,
-            spatial_merge_size=m, device=self.device)
+        mcos, msin = geo.mrope_cos_sin_cached(
+            pos_ids, self._mrope_cos_cache, self._mrope_sin_cache,
+            mrope_section=self._mrope_section)
+        vcos, vsin = geo.vision_rope_cos_sin_cached(
+            seg_grid, self._vision_rope_cos_cache, self._vision_rope_sin_cache,
+            spatial_merge_size=m)
         pos_embeds = geo.vision_pos_embeds(
             seg_grid, self.vision.pos_embed,
             num_grid_per_side=self._num_grid_per_side,

--- a/scripts/bench_qwen3_vl_fp8_sm89_prefill_gemm.py
+++ b/scripts/bench_qwen3_vl_fp8_sm89_prefill_gemm.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Microbench SM89 Qwen3-VL official-FP8 M=S prefill GEMM candidates."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import statistics
+import sys
+from dataclasses import dataclass
+
+import torch
+from safetensors import safe_open
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@dataclass(frozen=True)
+class LinearSpec:
+    name: str
+    key: str
+
+
+def _open_shards(ckpt_dir: str):
+    idx_path = os.path.join(ckpt_dir, "model.safetensors.index.json")
+    with open(idx_path, "r") as f:
+        weight_map = json.load(f)["weight_map"]
+    shards = {
+        shard: safe_open(os.path.join(ckpt_dir, shard), framework="pt",
+                         device="cpu")
+        for shard in sorted(set(weight_map.values()))
+    }
+    return shards, weight_map
+
+
+def _tensor(shards, weight_map, key: str) -> torch.Tensor:
+    return shards[weight_map[key]].get_tensor(key)
+
+
+def _time_cuda(fn, warmup: int, iters: int) -> tuple[float, float, float]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        times.append(float(start.elapsed_time(end)))
+    return statistics.median(times), statistics.mean(times), min(times)
+
+
+def _fmt_triplet(t: tuple[float, float, float]) -> str:
+    return f"{t[0]:8.4f} / {t[1]:8.4f} / {t[2]:8.4f}"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--S", type=int, default=79)
+    p.add_argument("--layer", type=int, default=0)
+    p.add_argument("--warmup", type=int, default=5)
+    p.add_argument("--iters", type=int, default=20)
+    p.add_argument("--device", default="cuda:0")
+    args = p.parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    torch.cuda.set_device(torch.device(args.device))
+
+    from flash_rt import flash_rt_kernels as fvk
+
+    shards, weight_map = _open_shards(args.checkpoint)
+    if "model.language_model.layers.0.self_attn.q_proj.weight" in weight_map:
+        layer_prefix = "model.language_model.layers"
+    else:
+        layer_prefix = "model.layers"
+
+    specs = [
+        LinearSpec("q_proj", "self_attn.q_proj"),
+        LinearSpec("k_proj", "self_attn.k_proj"),
+        LinearSpec("v_proj", "self_attn.v_proj"),
+        LinearSpec("o_proj", "self_attn.o_proj"),
+        LinearSpec("gate_proj", "mlp.gate_proj"),
+        LinearSpec("up_proj", "mlp.up_proj"),
+        LinearSpec("down_proj", "mlp.down_proj"),
+    ]
+    stream = torch.cuda.current_stream().cuda_stream
+    print(f"device={torch.cuda.get_device_name(torch.device(args.device))}")
+    print(f"S={args.S} layer={args.layer} warmup={args.warmup} iters={args.iters}")
+    print("GEMM-only rows match the SM120a blockscaled GEMM timing boundary: "
+          "pre-quantized A + FP8 B + block scales -> BF16 D.")
+    print("e2e rows add activation quantization before the GEMM.")
+    total_descale_gemm = 0.0
+    total_bs_gemm = 0.0
+    total_descale_e2e = 0.0
+    total_bs_e2e = 0.0
+    total_m1_best = 0.0
+    for spec in specs:
+        base = f"{layer_prefix}.{args.layer}.{spec.key}"
+        w = _tensor(shards, weight_map, base + ".weight").to(
+            args.device).contiguous()
+        ws = _tensor(shards, weight_map, base + ".weight_scale_inv").to(
+            torch.float32).to(args.device).contiguous()
+        N, K = w.shape
+        x = torch.randn((args.S, K), dtype=torch.bfloat16, device=args.device)
+        x_fp8 = torch.empty((args.S, K), dtype=torch.float8_e4m3fn,
+                            device=args.device)
+        x_scale = torch.empty((args.S, K // 128), dtype=torch.float32,
+                              device=args.device)
+        out = torch.empty((args.S, N), dtype=torch.bfloat16,
+                          device=args.device)
+        scratch_a = torch.empty((args.S, K), dtype=torch.bfloat16,
+                                device=args.device)
+        scratch_b = torch.empty((N, K), dtype=torch.bfloat16,
+                                device=args.device)
+        fvk.fp8_per_token_block128_quant_bf16(
+            x.data_ptr(), x_fp8.data_ptr(), x_scale.data_ptr(),
+            args.S, K, stream)
+        torch.cuda.synchronize()
+
+        def descale_gemm_call() -> None:
+            fvk.fp8_block128_gemm_descale_bf16out(
+                x_fp8.data_ptr(), w.data_ptr(), out.data_ptr(),
+                args.S, N, K, x_scale.data_ptr(), ws.data_ptr(),
+                scratch_a.data_ptr(), scratch_b.data_ptr(), stream)
+
+        def descale_e2e_call() -> None:
+            fvk.fp8_per_token_block128_quant_bf16(
+                x.data_ptr(), x_fp8.data_ptr(), x_scale.data_ptr(),
+                args.S, K, stream)
+            fvk.fp8_block128_gemm_descale_bf16out(
+                x_fp8.data_ptr(), w.data_ptr(), out.data_ptr(),
+                args.S, N, K, x_scale.data_ptr(), ws.data_ptr(),
+                scratch_a.data_ptr(), scratch_b.data_ptr(), stream)
+
+        descale_gemm = _time_cuda(descale_gemm_call, args.warmup, args.iters)
+        descale_e2e = _time_cuda(descale_e2e_call, args.warmup, args.iters)
+        total_descale_gemm += descale_gemm[0]
+        total_descale_e2e += descale_e2e[0]
+
+        # Native Ada FP8 block-128 GEMM (reads FP8 weight directly, in-module).
+        out_bs = torch.empty((args.S, N), dtype=torch.bfloat16,
+                             device=args.device)
+
+        def bs_gemm_call() -> None:
+            fvk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+                x_fp8.data_ptr(), w.data_ptr(), out_bs.data_ptr(),
+                args.S, N, K, x_scale.data_ptr(), ws.data_ptr(), stream)
+
+        def bs_e2e_call() -> None:
+            fvk.fp8_per_token_block128_quant_bf16(
+                x.data_ptr(), x_fp8.data_ptr(), x_scale.data_ptr(),
+                args.S, K, stream)
+            fvk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+                x_fp8.data_ptr(), w.data_ptr(), out_bs.data_ptr(),
+                args.S, N, K, x_scale.data_ptr(), ws.data_ptr(), stream)
+
+        bs_gemm = _time_cuda(bs_gemm_call, args.warmup, args.iters)
+        bs_e2e = _time_cuda(bs_e2e_call, args.warmup, args.iters)
+        total_bs_gemm += bs_gemm[0]
+        total_bs_e2e += bs_e2e[0]
+        descale_gemm_call()
+        bs_gemm_call()
+        torch.cuda.synchronize()
+        cos = torch.nn.functional.cosine_similarity(
+            out.float().flatten(), out_bs.float().flatten(), dim=0).item()
+
+        x1 = x[:1].contiguous()
+        x1_fp8 = torch.empty((1, K), dtype=torch.float8_e4m3fn,
+                             device=args.device)
+        x1_scale = torch.empty((1, K // 128), dtype=torch.float32,
+                               device=args.device)
+        out1 = torch.empty((1, N), dtype=torch.bfloat16, device=args.device)
+        fvk.fp8_per_token_block128_quant_bf16(
+            x1.data_ptr(), x1_fp8.data_ptr(), x1_scale.data_ptr(),
+            1, K, stream)
+        torch.cuda.synchronize()
+        m1_results = []
+        for fn in (fvk.ht_gemv_fp8_block128_m1_w4,
+                   fvk.ht_gemv_fp8_block128_m1_w8,
+                   fvk.ht_gemv_fp8_block128_m1_w16):
+            def m1_call(fn=fn) -> None:
+                fn(x1_fp8.data_ptr(), w.data_ptr(), out1.data_ptr(),
+                   1, N, K, x1_scale.data_ptr(), ws.data_ptr(), 1.0,
+                   stream)
+            m1_results.append(_time_cuda(m1_call, args.warmup, args.iters)[0])
+        m1_best = min(m1_results)
+        total_m1_best += m1_best * args.S
+        print(f"{spec.name:10s} N,K={(N, K)} "
+              f"descale_gemm {_fmt_triplet(descale_gemm)} "
+              f"bs_sm89_gemm {_fmt_triplet(bs_gemm)} "
+              f"gemm_speedup {descale_gemm[0] / bs_gemm[0]:5.2f}x "
+              f"e2e_speedup {descale_e2e[0] / bs_e2e[0]:5.2f}x "
+              f"cos {cos:.5f} "
+              f"m1_best_xS {m1_best * args.S:8.4f}")
+
+    print("--- one-layer linear total ---")
+    print(f"descale_gemm_total_ms={total_descale_gemm:.4f}")
+    print(f"bs_sm89_gemm_total_ms={total_bs_gemm:.4f}")
+    print(f"gemm_speedup={total_descale_gemm / total_bs_gemm:.2f}x")
+    print(f"descale_e2e_total_ms={total_descale_e2e:.4f}")
+    print(f"bs_sm89_e2e_total_ms={total_bs_e2e:.4f}")
+    print(f"e2e_speedup={total_descale_e2e / total_bs_e2e:.2f}x")
+    print(f"m1_token_loop_estimate_ms={total_m1_best:.4f}")
+    print(f"36_layer_descale_gemm_linear_ms={total_descale_gemm * 36:.2f}")
+    print(f"36_layer_bs_sm89_gemm_linear_ms={total_bs_gemm * 36:.2f}")
+    print(f"36_layer_descale_e2e_linear_ms={total_descale_e2e * 36:.2f}")
+    print(f"36_layer_bs_sm89_e2e_linear_ms={total_bs_e2e * 36:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_qwen3_vl_fp8_sm89_prefill_variants.py
+++ b/scripts/bench_qwen3_vl_fp8_sm89_prefill_variants.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Sweep SM89 FP8 blockscaled GEMM variants on runtime prefill shapes."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+
+import torch
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _time_cuda(fn, warmup: int, iters: int) -> tuple[float, float, float]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        times.append(float(start.elapsed_time(end)))
+    return statistics.median(times), statistics.mean(times), min(times)
+
+
+def _fmt_triplet(t: tuple[float, float, float]) -> str:
+    return f"{t[0]:8.4f} / {t[1]:8.4f} / {t[2]:8.4f}"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--S", type=int, default=1581)
+    p.add_argument("--layer", type=int, default=0)
+    p.add_argument("--warmup", type=int, default=5)
+    p.add_argument("--iters", type=int, default=20)
+    args = p.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    torch.cuda.set_device(torch.device(args.device))
+
+    from flash_rt import flash_rt_kernels as fvk
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+        Qwen3VlFp8Sm89TextFrontend,
+    )
+
+    fe = Qwen3VlFp8Sm89TextFrontend(
+        args.checkpoint, device=args.device, max_seq=max(args.S, 2048),
+        max_prefill_seq=args.S)
+    cfg = fe._cfg
+    assert cfg is not None
+    hidden = int(cfg["hidden_size"])
+    inter = int(cfg["intermediate"])
+    lw = fe._weights.ptrs["layers"][args.layer]
+    stream = torch.cuda.current_stream().cuda_stream
+
+    variants = [
+        ("16x64_w4", fvk.fp8_block128_gemm_bs_sm89_16x64x128_w4),
+        ("16x128_w4", fvk.fp8_block128_gemm_bs_sm89_16x128x128_w4),
+        ("32x64_w4", fvk.fp8_block128_gemm_bs_sm89_32x64x128_w4),
+        ("32x128_w4", fvk.fp8_block128_gemm_bs_sm89_32x128x128_w4),
+        ("64x64_w4", fvk.fp8_block128_gemm_bs_sm89_64x64x128_w4),
+        ("64x128_w4", fvk.fp8_block128_gemm_bs_sm89_64x128x128_w4),
+        ("64x128_w8", fvk.fp8_block128_gemm_bs_sm89_64x128x128_w8),
+        ("128x64_w4", fvk.fp8_block128_gemm_bs_sm89_128x64x128_w4),
+        ("128x128_w4", fvk.fp8_block128_gemm_bs_sm89_128x128x128_w4),
+        ("128x128_w8", fvk.fp8_block128_gemm_bs_sm89_128x128x128_w8),
+        ("auto", fvk.fp8_block128_gemm_blockscaled_sm89_bf16out),
+    ]
+    shapes = [
+        ("qkv", int(lw["qkv_proj_w"]), int(lw["qkv_proj_s"]),
+         int(lw["qkv_proj_N"]), hidden),
+        ("o_proj", int(lw["o_proj_w"]), int(lw["o_proj_s"]), hidden,
+         hidden),
+        ("gate", int(lw["mlp_gate_w"]), int(lw["mlp_gate_s"]), inter,
+         hidden),
+        ("up", int(lw["mlp_up_w"]), int(lw["mlp_up_s"]), inter, hidden),
+        ("down", int(lw["mlp_down_w"]), int(lw["mlp_down_s"]), hidden,
+         inter),
+    ]
+
+    print(f"device={torch.cuda.get_device_name(torch.device(args.device))}")
+    print(f"S={args.S} layer={args.layer} warmup={args.warmup} "
+          f"iters={args.iters}")
+    total_auto = 0.0
+    total_best = 0.0
+    for name, w_ptr, ws_ptr, N, K in shapes:
+        x = torch.randn(args.S, K, device=args.device,
+                        dtype=torch.float32).to(torch.bfloat16)
+        x_fp8 = torch.empty(args.S, K, device=args.device,
+                            dtype=torch.float8_e4m3fn)
+        x_scale = torch.empty(args.S, K // 128, device=args.device,
+                              dtype=torch.float32)
+        out = torch.empty(args.S, N, device=args.device, dtype=torch.bfloat16)
+        fvk.fp8_per_token_block128_quant_bf16(
+            x.data_ptr(), x_fp8.data_ptr(), x_scale.data_ptr(),
+            args.S, K, stream)
+        rows = []
+        for variant_name, fn in variants:
+            def call(fn=fn) -> None:
+                fn(x_fp8.data_ptr(), w_ptr, out.data_ptr(), args.S, N, K,
+                   x_scale.data_ptr(), ws_ptr, stream)
+            t = _time_cuda(call, args.warmup, args.iters)
+            rows.append((t[0], variant_name, t))
+        rows.sort()
+        best = rows[0]
+        auto = next(row for row in rows if row[1] == "auto")
+        total_best += best[0]
+        total_auto += auto[0]
+        print(f"--- {name} M={args.S} N={N} K={K} ---")
+        for _, variant_name, t in rows:
+            marker = " *" if variant_name == "auto" else ""
+            print(f"{variant_name:12s} {_fmt_triplet(t)}{marker}")
+        print(f"best={best[1]} auto_over_best={auto[0] / best[0]:.4f}x")
+
+    print("--- one-layer runtime-shape total ---")
+    print(f"auto_total_ms={total_auto:.4f}")
+    print(f"best_per_shape_total_ms={total_best:.4f}")
+    print(f"auto_over_best={total_auto / total_best:.4f}x")
+    print(f"36_layer_auto_total_ms={total_auto * 36:.2f}")
+    print(f"36_layer_best_per_shape_total_ms={total_best * 36:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_qwen3_vl_fp8_sm89.py
+++ b/scripts/smoke_qwen3_vl_fp8_sm89.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""End-to-end smoke/bench for Qwen3-VL official-FP8 SM89 frontends."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+import time
+
+import torch
+from PIL import Image
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _event_time_ms(fn, iters: int) -> list[float]:
+    times = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        times.append(float(start.elapsed_time(end)))
+    return times
+
+
+def _summarize(times: list[float]) -> str:
+    return (
+        f"median={statistics.median(times):.3f} ms "
+        f"mean={statistics.mean(times):.3f} ms min={min(times):.3f} ms")
+
+
+def _bench_text(args) -> None:
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+        Qwen3VlFp8Sm89TextFrontend,
+    )
+
+    fe = Qwen3VlFp8Sm89TextFrontend(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_prefill_seq=args.max_prefill_seq,
+        fuse_gate_up=args.fuse_gate_up,
+        fuse_qk_postproc=not args.no_fuse_qk_postproc,
+        use_fp8_lm_head=args.fp8_lm_head)
+    hidden = int(fe._cfg["hidden_size"])
+    embed = fe._weights.anchors[0]
+    ids = torch.arange(args.text_token_base, args.text_token_base + args.text_s,
+                       device=args.device, dtype=torch.long)
+    h = embed[ids].to(torch.bfloat16).view(args.text_s, hidden).contiguous()
+    cos = fe._rope_cos_table[:args.text_s]
+    sin = fe._rope_sin_table[:args.text_s]
+
+    fe.reset_state()
+    fe.forward_hidden_prefill_fp8_blockscaled(h, cos, sin, 0)
+    torch.cuda.synchronize()
+    prefill_times = []
+    logits = None
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fe.reset_state()
+        logits = fe.forward_hidden_prefill_fp8_blockscaled(h, cos, sin, 0)
+        torch.cuda.synchronize()
+        prefill_times.append((time.perf_counter() - t0) * 1000.0)
+    logits_f = logits.detach().float().clone()
+
+    fe.reset_state()
+    loop_logits = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for pos in range(args.text_s):
+        loop_logits = fe.forward_hidden_decode_fp8(
+            h[pos], cos[pos:pos + 1], sin[pos:pos + 1], pos)
+    torch.cuda.synchronize()
+    loop_ms = (time.perf_counter() - t0) * 1000.0
+    loop_f = loop_logits.detach().float().clone()
+    cosv = torch.nn.functional.cosine_similarity(logits_f, loop_f).item()
+
+    fe.reset_state()
+    fe.decode_step_with_graph(args.decode_token, args.decode_pos)
+    torch.cuda.synchronize()
+    decode_times = _event_time_ms(
+        lambda: fe.decode_step_with_graph(args.decode_token, args.decode_pos),
+        args.iters)
+
+    print("--- text ---")
+    print(f"S={args.text_s} prefill {_summarize(prefill_times)}")
+    print(f"token_loop_ms={loop_ms:.3f} "
+          f"prefill_speedup={loop_ms / statistics.median(prefill_times):.2f}x "
+          f"logit_cos={cosv:.6f} top_prefill={int(logits_f.argmax())} "
+          f"top_loop={int(loop_f.argmax())}")
+    print(f"graph_decode_pos={args.decode_pos} {_summarize(decode_times)} "
+          f"top={int(fe._logits_buf.argmax())} "
+          f"finite={torch.isfinite(fe._logits_buf).all().item()}")
+
+
+def _bench_multimodal(args) -> None:
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+        Qwen3VlFp8Sm89Frontend,
+    )
+
+    fe = Qwen3VlFp8Sm89Frontend(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_prefill_seq=args.max_prefill_seq, max_pixels=args.max_pixels,
+        fuse_gate_up=args.fuse_gate_up,
+        fuse_qk_postproc=not args.no_fuse_qk_postproc,
+        use_fp8_lm_head=args.fp8_lm_head,
+        vision_bf16_first_blocks=args.vision_bf16_first_blocks,
+        vision_bf16_block_linears=(
+            None if not args.vision_block2_bf16_linears else {
+                2: tuple(
+                    name.strip()
+                    for name in args.vision_block2_bf16_linears.split(",")
+                    if name.strip())
+            }))
+    img = Image.open(args.image).convert("RGB")
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "image", "image": img},
+            {"type": "text", "text": args.prompt},
+        ],
+    }]
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    fe.set_prompt(messages)
+    torch.cuda.synchronize()
+    set_prompt_ms = (time.perf_counter() - t0) * 1000.0
+    set_prompt_warm_times = []
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fe.set_prompt(messages)
+        torch.cuda.synchronize()
+        set_prompt_warm_times.append((time.perf_counter() - t0) * 1000.0)
+    p = fe._prompt
+    assert p is not None
+    llm = fe.llm
+    S = int(p["S"])
+    hidden = int(llm._cfg["hidden_size"])
+    embed = llm._weights.anchors[0]
+    h = embed[p["input_ids"]].to(torch.bfloat16).view(S, hidden).contiguous()
+
+    vision_times = []
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        off = 0
+        for n_patch in p["seg_patches"]:
+            sl = slice(off, off + n_patch)
+            off += n_patch
+            fe.vision.forward(
+                p["pixel_values"][sl], p["pos_embeds"][sl],
+                p["vcos"][sl], p["vsin"][sl])
+        torch.cuda.synchronize()
+        vision_times.append((time.perf_counter() - t0) * 1000.0)
+
+    llm.reset_state()
+    llm.forward_hidden_prefill_fp8_blockscaled(
+        h, p["mcos"], p["msin"], 0, run_lm_head=False)
+    torch.cuda.synchronize()
+    lang_times = []
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        llm.reset_state()
+        llm.forward_hidden_prefill_fp8_blockscaled(
+            h, p["mcos"], p["msin"], 0, run_lm_head=False)
+        torch.cuda.synchronize()
+        lang_times.append((time.perf_counter() - t0) * 1000.0)
+
+    fe.prefill()
+    torch.cuda.synchronize()
+    prefill_times = []
+    logits = None
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        logits = fe.prefill()
+        torch.cuda.synchronize()
+        prefill_times.append((time.perf_counter() - t0) * 1000.0)
+
+    prefill_logits_f = logits.detach().float().clone()
+    graph_logits_f = prefill_logits_f
+    graph_prefill_times = None
+    if len(p["spans"]) == 1:
+        fe.prefill_graph()
+        torch.cuda.synchronize()
+        graph_prefill_times = _event_time_ms(
+            lambda: fe.prefill_graph(), args.iters)
+        graph_logits_f = fe.llm._logits_buf.detach().float().clone()
+
+    tok = int(graph_logits_f.argmax())
+    cache_pos = int(p["S"])
+    eager = fe.decode_step(tok, cache_pos)
+    eager_f = eager.detach().float().clone()
+    graph = fe.decode_step_with_graph(tok, cache_pos)
+    graph_f = graph.detach().float().clone()
+    torch.cuda.synchronize()
+    decode_times = _event_time_ms(
+        lambda: fe.decode_step_with_graph(tok, cache_pos), args.iters)
+    cosv = torch.nn.functional.cosine_similarity(eager_f, graph_f).item()
+
+    generated = ""
+    if args.generate_tokens > 0:
+        generated = fe.generate(
+            messages, max_new_tokens=args.generate_tokens, use_graph=True)
+
+    print("--- multimodal ---")
+    print(f"image={args.image} S={p['S']} "
+          f"pixel_shape={tuple(p['pixel_values'].shape)} "
+          f"spans={p['spans']} set_prompt_ms={set_prompt_ms:.3f}")
+    print(f"set_prompt_warm {_summarize(set_prompt_warm_times)}")
+    print(f"vision_only {_summarize(vision_times)}")
+    print(f"language_only_no_mm_scatter {_summarize(lang_times)}")
+    print(f"prefill {_summarize(prefill_times)} "
+          f"top={int(prefill_logits_f.argmax())} "
+          f"finite={torch.isfinite(prefill_logits_f).all().item()}")
+    if graph_prefill_times is not None:
+        graph_cos = torch.nn.functional.cosine_similarity(
+            prefill_logits_f, graph_logits_f).item()
+        print(f"prefill_graph {_summarize(graph_prefill_times)} "
+              f"cos_vs_eager={graph_cos:.6f} "
+              f"top={int(graph_logits_f.argmax())} "
+              f"finite={torch.isfinite(graph_logits_f).all().item()}")
+    print(f"graph_decode_cache_pos={cache_pos} {_summarize(decode_times)} "
+          f"cos_vs_eager={cosv:.6f} top_eager={int(eager_f.argmax())} "
+          f"top_graph={int(graph_f.argmax())}")
+    if args.generate_tokens > 0:
+        print(f"generate_tokens={args.generate_tokens} text={generated!r}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--max-seq", type=int, default=2048)
+    p.add_argument("--max-prefill-seq", type=int, default=2048)
+    p.add_argument("--warmup", type=int, default=1)
+    p.add_argument("--iters", type=int, default=5)
+    p.add_argument("--text-only", action="store_true")
+    p.add_argument("--multimodal", action="store_true")
+    p.add_argument("--text-s", type=int, default=79)
+    p.add_argument("--text-token-base", type=int, default=100)
+    p.add_argument("--decode-token", type=int, default=100)
+    p.add_argument("--decode-pos", type=int, default=63)
+    p.add_argument("--fuse-gate-up", action="store_true")
+    p.add_argument("--no-fuse-qk-postproc", action="store_true",
+                   help="use the older two-launch Q/K postprocess path")
+    p.add_argument("--fp8-lm-head", action="store_true")
+    p.add_argument("--vision-bf16-first-blocks", type=int, default=3)
+    p.add_argument("--vision-block2-bf16-linears", default="",
+                   help="experimental SM89-only override for vision block 2; "
+                        "comma-separated subset of qkv,proj,fc1,fc2")
+    p.add_argument("--max-pixels", type=int, default=None)
+    p.add_argument("--image", default=str(REPO_ROOT / "FlashRT.png"))
+    p.add_argument("--prompt",
+                   default="Describe this image in one sentence.")
+    p.add_argument("--generate-tokens", type=int, default=2)
+    args = p.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    torch.cuda.set_device(torch.device(args.device))
+    if args.warmup != 1:
+        print("note: --warmup is accepted for CLI symmetry; "
+              "frontends perform their own first-call warmup")
+    run_text = args.text_only or not args.multimodal
+    run_mm = args.multimodal or not args.text_only
+    print(f"device={torch.cuda.get_device_name(torch.device(args.device))}")
+    print(f"checkpoint={args.checkpoint}")
+    if run_text:
+        _bench_text(args)
+    if run_mm:
+        _bench_multimodal(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qwen3_vl_fp8_sm89.py
+++ b/tests/test_qwen3_vl_fp8_sm89.py
@@ -1,0 +1,66 @@
+"""Smoke tests for the Qwen3-VL official-FP8 SM89 text path.
+
+These are CPU/CI-friendly import and schema tests. Real checkpoint and CUDA
+coverage is provided by the local development benchmark/script because the
+official 8B FP8 weights are too large for CI.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+
+
+def test_frontend_imports():
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_fp8_sm89')
+    text_cls = m.Qwen3VlFp8Sm89TextFrontend
+    assert hasattr(m, 'Qwen3VlFp8Sm89TextFrontend')
+    assert 'max_prefill_seq' in inspect.signature(text_cls).parameters
+    assert 'run_lm_head' in inspect.signature(
+        text_cls.forward_hidden_prefill_fp8_blockscaled).parameters
+    mm = importlib.import_module(
+        'flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal')
+    cls = mm.Qwen3VlFp8Sm89Frontend
+    assert hasattr(mm, 'Qwen3VlFp8Sm89Frontend')
+    assert 'max_prefill_seq' in inspect.signature(
+        cls).parameters
+    for name in ('fuse_gate_up', 'fuse_qk_postproc', 'use_fp8_lm_head',
+                 'vision_bf16_first_blocks'):
+        assert name in inspect.signature(cls).parameters
+    for name in (
+        'prefill_graph', 'decode_step_with_graph',
+        'warmup_decode_graphs', 'generate',
+    ):
+        assert hasattr(cls, name)
+
+
+def test_weight_loader_invariants_reject_missing_layer_fields():
+    from flash_rt.frontends.torch._qwen3_vl_fp8_weights import (
+        WeightHandles,
+        assert_extraction_invariants_qwen3_vl_fp8,
+    )
+
+    h = WeightHandles()
+    h.ptrs.update({
+        'quant_format': 'fp8_block128',
+        'num_layers': 1,
+        'lm_head_quantized': False,
+        'layers': [{'input_norm_w': 1}],
+    })
+    try:
+        assert_extraction_invariants_qwen3_vl_fp8(h)
+    except AssertionError as e:
+        assert 'missing' in str(e)
+        assert 'lm_head_w' in str(e)
+    else:
+        raise AssertionError('expected invariant failure')
+
+    h.ptrs.update({
+        'lm_head_w': 1,
+    })
+    try:
+        assert_extraction_invariants_qwen3_vl_fp8(h)
+    except AssertionError as e:
+        assert 'missing' in str(e)
+        assert 'qkv_proj_w' in str(e)
+    else:
+        raise AssertionError('expected layer invariant failure')

--- a/tests/test_qwen3_vl_smoke.py
+++ b/tests/test_qwen3_vl_smoke.py
@@ -161,6 +161,29 @@ def test_mrope_cos_sin_shape():
     assert cos.shape == (ids.numel(), 64) == sin.shape
 
 
+def test_mrope_cos_sin_cached_matches_direct():
+    grids = [(1, 4, 6)]
+    ids = _image_seq(grids)
+    pos = geo.mrope_position_ids(
+        ids, torch.tensor(grids), None, image_token_id=IMG,
+        video_token_id=VID, vision_start_token_id=VSTART,
+        spatial_merge_size=MERGE)
+    kwargs = {
+        'head_dim': 128,
+        'rope_theta': 5e6,
+        'mrope_section': (24, 20, 20),
+        'device': 'cpu',
+    }
+    cos, sin = geo.mrope_cos_sin(pos, **kwargs)
+    cache = geo.build_mrope_cache(
+        max_pos=int(pos.max()) + 1, head_dim=kwargs['head_dim'],
+        rope_theta=kwargs['rope_theta'], device='cpu')
+    cos_cached, sin_cached = geo.mrope_cos_sin_cached(
+        pos, cache[0], cache[1], mrope_section=kwargs['mrope_section'])
+    assert torch.equal(cos, cos_cached)
+    assert torch.equal(sin, sin_cached)
+
+
 def test_vision_rope_and_pos_embeds_shapes():
     grids = torch.tensor([(1, 4, 6)])
     n_patch = 1 * 4 * 6
@@ -172,3 +195,15 @@ def test_vision_rope_and_pos_embeds_shapes():
         grids, table, num_grid_per_side=48, spatial_merge_size=MERGE,
         device='cpu')
     assert pe.shape == (n_patch, 8)
+
+
+def test_vision_rope_cached_matches_direct():
+    grids = torch.tensor([(1, 4, 6), (1, 6, 4)])
+    cos, sin = geo.vision_rope_cos_sin(
+        grids, head_dim=72, spatial_merge_size=MERGE, device='cpu')
+    cache = geo.build_vision_rope_cache(
+        max_hw=int(grids[:, 1:].max()), head_dim=72, device='cpu')
+    cos_cached, sin_cached = geo.vision_rope_cos_sin_cached(
+        grids, cache[0], cache[1], spatial_merge_size=MERGE)
+    assert torch.equal(cos, cos_cached)
+    assert torch.equal(sin, sin_cached)


### PR DESCRIPTION
## Summary

Brings up **Qwen3-VL-8B on Ada RTX 4090 (sm_89)** using the official
`Qwen3-VL-8B-Instruct-FP8` checkpoint. This is the SM89 counterpart to the
SM120/NVFP4 path (#107/#109), but it intentionally uses the checkpoint's
**native block-scaled FP8 language weights** instead of NVFP4 (NVFP4 is a
Blackwell-only path). The vision tower, geometry, scatter, DeepStack and
interleaved-MRoPE are reused from the SM120 Qwen3-VL work; this branch adds
the Ada FP8 language stack and a native sm_89 block-128 GEMM.

The core lever is a **native Ada FP8 e4m3 block-128 scaled GEMM** that reads
the FP8 weight directly (no dequant-to-bf16 scratch), cutting per-linear
weight traffic ~5x while keeping the per-token activation scale. This is the
fix for the SM89 prefill bottleneck (weight-dequant memory bandwidth); the
CUTLASS Ada blockwise route was a dead end at these shapes.

## What's in it

- **Native sm_89 block-128 FP8 GEMM** (`fp8_block128_gemm_mma_sm89.cu`):
  plain Ada `mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32` (no
  `.kind::f8f6f4`, which is sm_120a-only), DeepSeek block-128 scaling folded
  in the mainloop (BLOCK_K pinned to 128). Adapted from the SM120
  `fp8_smallM_handtuned` cp.async pipeline + m16n8k32 tiling. Shape-tuned
  dispatcher over the Qwen3-VL-8B linear shapes.
- **Text frontend** (`qwen3_vl_fp8_sm89.py`): block-scaled M=1 FP8 GEMV
  decode + native block-128 FP8 GEMM prefill; BF16 attention (FA2), BF16
  residual/norms, per-token/per-128 FP8 activation quant fused into
  RMSNorm / residual-add-RMSNorm / SiLU-mul; CUDA-graph decode (per cache
  position). `lm_head` stays **BF16** by default (cuBLASLt); `use_fp8_lm_head`
  is an explicit experimental mode.
- **Multimodal wrapper** (`qwen3_vl_fp8_sm89_multimodal.py`): single-image
  prefill as a captured CUDA-graph replay (vision + S>1 FP8 blockscaled
  language + final norm), lm_head eager after replay; multi-image / video use
  the eager prefill. Decode graphs keyed by `(cache_pos, rope_pos)` so MRoPE
  continuation never reuses a stale rotary position across prompts.
- **FP8 weight loader** (`_qwen3_vl_fp8_weights.py`): keeps the official
  `weight` (e4m3) + `weight_scale_inv` (128x128 block) layout, fuses q/k/v
  and gate/up, optional host-side `lm_head` FP8 quant.
- **Fail-fast & shape guards**: capability `== (8,9)` check, required-symbol
  presence check (rebuild hint), an explicit config check that the checkpoint
  is the official 8B text stack (`36/32/8/128/4096/12288`), and runtime
  `K%128`/`N%128` guards on the new GEMM + block-128 quant entries.
- **Docs / scripts / tests**: `docs/qwen3_vl_fp8_sm89.md`, a smoke benchmark
  (`scripts/smoke_qwen3_vl_fp8_sm89.py`), prefill-GEMM micro-benchmarks, and
  CPU-friendly import/invariant/geometry tests.

Additive on the shared module front: the new GEMM is gated behind
`ENABLE_SM89_BLOCK_FP8_GEMM` (only compiled for `GPU_ARCH=89`); the
block-128 quant helpers are added to the existing quant TU; the SM120 paths
are untouched.

## Performance & correctness (RTX 4090, sm_89)

Environment: NVIDIA GeForce RTX 4090, official `Qwen3-VL-8B-Instruct-FP8`,
workload `FlashRT.png` + prompt `"Describe this image in one sentence."`
(6256 vision patches, 1581 language tokens — same workload as the SM120
report).

```text
S=1581 pixel_shape=(6256, 1536) spans=[(4, 1568)]
set_prompt_warm  median=15.711 ms
vision_only      median=88.990 ms
language_only    median=120.634 ms
prefill          median=206.987 ms  top=785  finite=True
prefill_graph    median=206.214 ms  cos_vs_eager=0.998522  top=785  finite=True
graph_decode     (cache_pos=1581) median=10.681 ms  cos_vs_eager=1.000000  (~94 tok/s)
top_eager=2168   top_graph=2168
```

- Prefill graph eager-vs-replay logits cosine **0.9985**, next-token argmax
  **785** (matches the SM120 report's image token).
- Warm graph decode cosine **1.000000**, decode argmax matches eager
  (`2168`).

The same workload is faster on the SM120/NVFP4 path because it uses Blackwell
NVFP4 language kernels; this branch targets the best Ada-compatible dtype
path (official FP8 weights, BF16 attention/residual/lm_head).

## Build & usage

```bash
cmake -S . -B build -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON
cmake --build build -j --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels

python examples/qwen3_vl_quickstart.py --arch sm89 \
  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
  --image FlashRT.png --prompt "Describe this image in one sentence." \
  --max-seq 2048 --max-prefill-seq 2048

# dev smoke benchmark
python scripts/smoke_qwen3_vl_fp8_sm89.py \
  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 --multimodal --iters 5
```

CPU-friendly tests: `pytest tests/test_qwen3_vl_fp8_sm89.py tests/test_qwen3_vl_smoke.py`.
See `docs/qwen3_vl_fp8_sm89.md` for the full architecture / dtype map / limits.

## Notes (scope)

- Not an NVFP4 implementation — sm_89 uses official FP8 weights by design.
- `lm_head` stays BF16 by default; `use_fp8_lm_head` can match single-step
  logits but multi-token generation can diverge, so it stays experimental.
- Single-image prefill has a CUDA-graph replay path; multi-image / video use
  the eager path.
- Decode graphs are captured per cache position (the FA2 call captures the
  host-side sequence length).
- The frontend is pinned to the official 8B text-stack dims; other Qwen3-VL
  sizes fail fast rather than silently mis-sizing the KV cache.
- The official 8B FP8 weights are too large for CI, so end-to-end numerical
  validation lives in the local smoke script (numbers above); CI covers
  import / loader-invariant / geometry-cache equivalence.
