### PR TITLE
perf(qwen3): NVFP4 prefill fusions (13.64 → 10.91 ms)

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -5601,6 +5601,20 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     BIND_GEMV_M1(gemv_fp8_m1_resadd_w4);
     BIND_GEMV_M1(gemv_fp8_m1_resadd_w8);
 
+    // Device-scale variant: alpha = act_scale[0] * w_descale computed
+    // in-kernel, so the per-call activation scale stays on-device (no host
+    // sync to form alpha). Used by the fp8 lm_head tail.
+    m.def("ht_gemv_fp8_m1_w16_dscale",
+        [](uintptr_t A, uintptr_t B, uintptr_t D, int M, int N, int K,
+           uintptr_t act_scale, float w_descale, uintptr_t stream) {
+            return flash_rt::gemm::gemv_m1::gemv_fp8_m1_w16_dscale(
+                to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                to_ptr(act_scale), w_descale, to_stream(stream));
+        },
+        py::arg("A"), py::arg("B"), py::arg("D"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("act_scale"), py::arg("w_descale"), py::arg("stream") = 0);
+
     // Dedicated M=1 BF16 GEMV (all-BF16 decode; no smem A-stage -> full occ).
     BIND_GEMV_M1(gemv_bf16_m1_w4);
     BIND_GEMV_M1(gemv_bf16_m1_w8);

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -6413,6 +6413,47 @@ graph-replay safe) to fill the SMs on long K. M in 1..16; N%8==0; K%64==0;
         py::arg("n_kv_heads"), py::arg("eps") = 1e-6f,
         py::arg("stream") = 0);
 
+    // Prefill (S>1) batched q/k/v post-processing. Reads strided q/k/v
+    // from the fused QKV output (in_row_stride = qkv_N) in place — no
+    // contiguous copy — and writes Q_buf / K_cache / V_cache for all S
+    // rows. Folds rms_norm + RoPE + 3 copies into 2 launches.
+    m.def("qwen3_q_norm_rope_qstage_prefill_bf16",
+        [](uintptr_t q_pre, uintptr_t q_norm_w,
+           uintptr_t cos, uintptr_t sin, uintptr_t q_buf_dst,
+           int n_q_heads, int S, int in_row_stride, int out_row_stride,
+           float eps, uintptr_t stream) -> int {
+            return flash_rt::kernels::qwen3_q_norm_rope_qstage_prefill_bf16(
+                to_ptr(q_pre), to_ptr(q_norm_w),
+                to_ptr(cos), to_ptr(sin), to_ptr(q_buf_dst),
+                n_q_heads, S, in_row_stride, out_row_stride,
+                eps, to_stream(stream));
+        },
+        py::arg("q_pre"), py::arg("q_norm_w"),
+        py::arg("cos"), py::arg("sin"), py::arg("q_buf_dst"),
+        py::arg("n_q_heads"), py::arg("S"),
+        py::arg("in_row_stride"), py::arg("out_row_stride"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("qwen3_k_norm_rope_kvwrite_prefill_bf16",
+        [](uintptr_t k_pre, uintptr_t v_pre, uintptr_t k_norm_w,
+           uintptr_t cos, uintptr_t sin,
+           uintptr_t k_cache_dst, uintptr_t v_cache_dst,
+           int n_kv_heads, int S, int in_row_stride, int cache_row_stride,
+           float eps, uintptr_t stream) -> int {
+            return flash_rt::kernels::qwen3_k_norm_rope_kvwrite_prefill_bf16(
+                to_ptr(k_pre), to_ptr(v_pre), to_ptr(k_norm_w),
+                to_ptr(cos), to_ptr(sin),
+                to_ptr(k_cache_dst), to_ptr(v_cache_dst),
+                n_kv_heads, S, in_row_stride, cache_row_stride,
+                eps, to_stream(stream));
+        },
+        py::arg("k_pre"), py::arg("v_pre"), py::arg("k_norm_w"),
+        py::arg("cos"), py::arg("sin"),
+        py::arg("k_cache_dst"), py::arg("v_cache_dst"),
+        py::arg("n_kv_heads"), py::arg("S"),
+        py::arg("in_row_stride"), py::arg("cache_row_stride"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
     m.def("ada_rms_norm_style_int8", [](uintptr_t x, uintptr_t weight, uintptr_t style,
                                          uintptr_t out, uintptr_t gate_out,
                                          int seq_len, int dim, float eps,

--- a/csrc/gemm/fp8_gemv_m1_sm120.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cu
@@ -104,6 +104,56 @@ void gemv_fp8_m1_resadd_kernel(
     if (lane == 0) D[n] = __float2bfloat16(__bfloat162float(D[n]) + acc * alpha);
 }
 
+// Device-scale variant: alpha read on-device as act_scale[0]*w_descale, so the
+// per-call activation scale never needs a host round-trip. Identical dot product
+// to gemv_fp8_m1_kernel; only the epilogue scale source differs.
+template <int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+void gemv_fp8_m1_dscale_kernel(
+    const __nv_fp8_e4m3* __restrict__ A,
+    const __nv_fp8_e4m3* __restrict__ B,
+    __nv_bfloat16* __restrict__ D,
+    int N, int K, const float* __restrict__ act_scale, float w_descale)
+{
+    extern __shared__ __nv_fp8_e4m3 sA[];
+    const int tid = threadIdx.x, lane = tid & 31, warp = tid >> 5;
+    const int threads = WARPS_PER_BLOCK * 32, K16 = K >> 4;
+    uint4* sA16 = reinterpret_cast<uint4*>(sA);
+    const uint4* A16 = reinterpret_cast<const uint4*>(A);
+    for (int i = tid; i < K16; i += threads) sA16[i] = A16[i];
+    __syncthreads();
+    const int n = blockIdx.x * WARPS_PER_BLOCK + warp;
+    if (n >= N) return;
+    const uint4* Brow = reinterpret_cast<const uint4*>(B) + (size_t)n * K16;
+    float acc = 0.0f;
+    for (int i = lane; i < K16; i += 32) {
+        uint4 bpack = Brow[i];
+        const __nv_fp8_e4m3* bp = reinterpret_cast<const __nv_fp8_e4m3*>(&bpack);
+        const __nv_fp8_e4m3* ap = sA + (i << 4);
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) acc += float(ap[j]) * float(bp[j]);
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) acc += __shfl_down_sync(0xffffffffu, acc, off);
+    if (lane == 0) {
+        float alpha = act_scale[0] * w_descale;   // read scale on-device
+        D[n] = __float2bfloat16(acc * alpha);
+    }
+}
+
+template <int W>
+int launch_dscale_(const void* A, const void* B, void* D, int N, int K,
+                   const void* act_scale, float w_descale, cudaStream_t stream) {
+    dim3 grid((N + W - 1) / W);
+    size_t smem = (size_t)K * sizeof(__nv_fp8_e4m3);
+    gemv_fp8_m1_dscale_kernel<W><<<grid, W * 32, smem, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        reinterpret_cast<__nv_bfloat16*>(D), N, K,
+        reinterpret_cast<const float*>(act_scale), w_descale);
+    return 0;
+}
+
 template <int W>
 int launch_resadd_(const void* A, const void* B, void* D,
                    int N, int K, float alpha, cudaStream_t stream) {
@@ -141,6 +191,12 @@ int launch_(const void* A, const void* B, void* D,
 DEFINE(gemv_fp8_m1_w4,  4)
 DEFINE(gemv_fp8_m1_w8,  8)
 DEFINE(gemv_fp8_m1_w16, 16)
+
+int gemv_fp8_m1_w16_dscale(
+    const void* A, const void* B, void* D, int /*M*/, int N, int K,
+    const void* act_scale, float w_descale, cudaStream_t stream) {
+  return launch_dscale_<16>(A, B, D, N, K, act_scale, w_descale, stream);
+}
 
 #define DEFINE_RA(NAME, W)                                                      \
   int NAME(const void* A, const void* B, void* D, int M, int N, int K,          \

--- a/csrc/gemm/fp8_gemv_m1_sm120.cuh
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cuh
@@ -26,6 +26,14 @@ DECL(gemv_fp8_m1_resadd_w8);
 
 #undef DECL
 
+// Device-scale variant: alpha is computed in-kernel as
+// act_scale[0] * w_descale, so the per-call activation scale (e.g. from
+// quantize_fp8_device) is read on-device — no host sync to form alpha.
+// w_descale is the per-tensor weight de-scale (host constant). M=1 assumed.
+int gemv_fp8_m1_w16_dscale(
+    const void* A, const void* B, void* D, int M, int N, int K,
+    const void* act_scale, float w_descale, cudaStream_t stream);
+
 }  // namespace gemv_m1
 }  // namespace gemm
 }  // namespace flash_rt

--- a/csrc/kernels/qwen3_qkv_post_proc.cu
+++ b/csrc/kernels/qwen3_qkv_post_proc.cu
@@ -204,7 +204,138 @@ __global__ void k_norm_rope_kvwrite_devpos_kernel(
   v_cache_dst[head * HEAD_DIM + tid] = v_pre[head * HEAD_DIM + tid];
 }
 
+// ── Prefill (S>1) batched variants ──
+// One block per (row, head); grid = (n_heads, S). Read strided q/k/v from
+// the fused QKV output (in_row_stride = qkv_N), per-row cos/sin (stride
+// HALF), write to contiguous Q_buf / K_cache / V_cache (out/cache row
+// stride passed in). Same norm+RoPE math as the decode kernels; folds the
+// per-layer rms_norm + multi-op RoPE + Q/K/V copies into 2 launches.
+__global__ void q_norm_rope_qstage_prefill_kernel(
+    const __nv_bfloat16* __restrict__ q_pre,      // (S, *) strided
+    const __nv_bfloat16* __restrict__ q_norm_w,   // (128,)
+    const __nv_bfloat16* __restrict__ cos_v,      // (S, 64)
+    const __nv_bfloat16* __restrict__ sin_v,      // (S, 64)
+    __nv_bfloat16* __restrict__ q_buf,            // (S, n_q*128)
+    int n_q, int S,
+    int in_row_stride, int out_row_stride,
+    float eps) {
+  int head = blockIdx.x;
+  int row = blockIdx.y;
+  if (head >= n_q || row >= S) return;
+  int tid = threadIdx.x;
+
+  __shared__ float s_normed[HEAD_DIM];
+  __shared__ float s_smem4[N_WARPS];
+
+  const __nv_bfloat16* q_row = q_pre + (size_t)row * in_row_stride + head * HEAD_DIM;
+  const __nv_bfloat16* cos_r = cos_v + (size_t)row * HALF;
+  const __nv_bfloat16* sin_r = sin_v + (size_t)row * HALF;
+  float v = __bfloat162float(q_row[tid]);
+  float w = __bfloat162float(q_norm_w[tid]);
+  float rstd = rsqrtf(block_sum_4warp(v * v, s_smem4) / float(HEAD_DIM) + eps);
+  float normed = v * rstd * w;
+  s_normed[tid] = normed;
+  __syncthreads();
+
+  __nv_bfloat16* dst = q_buf + (size_t)row * out_row_stride + head * HEAD_DIM;
+  if (tid < HALF) {
+    float partner = s_normed[tid + HALF];
+    float c = __bfloat162float(cos_r[tid]);
+    float sn = __bfloat162float(sin_r[tid]);
+    dst[tid] = __float2bfloat16(normed * c - partner * sn);
+  } else {
+    float partner = s_normed[tid - HALF];
+    int hi = tid - HALF;
+    float c = __bfloat162float(cos_r[hi]);
+    float sn = __bfloat162float(sin_r[hi]);
+    dst[tid] = __float2bfloat16(normed * c + partner * sn);
+  }
+}
+
+__global__ void k_norm_rope_kvwrite_prefill_kernel(
+    const __nv_bfloat16* __restrict__ k_pre,      // (S, *) strided
+    const __nv_bfloat16* __restrict__ v_pre,      // (S, *) strided
+    const __nv_bfloat16* __restrict__ k_norm_w,   // (128,)
+    const __nv_bfloat16* __restrict__ cos_v,      // (S, 64)
+    const __nv_bfloat16* __restrict__ sin_v,      // (S, 64)
+    __nv_bfloat16* __restrict__ k_cache,          // (S, n_kv*128)
+    __nv_bfloat16* __restrict__ v_cache,          // (S, n_kv*128)
+    int n_kv, int S,
+    int in_row_stride, int cache_row_stride,
+    float eps) {
+  int head = blockIdx.x;
+  int row = blockIdx.y;
+  if (head >= n_kv || row >= S) return;
+  int tid = threadIdx.x;
+
+  __shared__ float s_normed[HEAD_DIM];
+  __shared__ float s_smem4[N_WARPS];
+
+  const __nv_bfloat16* k_row = k_pre + (size_t)row * in_row_stride + head * HEAD_DIM;
+  const __nv_bfloat16* v_row = v_pre + (size_t)row * in_row_stride + head * HEAD_DIM;
+  const __nv_bfloat16* cos_r = cos_v + (size_t)row * HALF;
+  const __nv_bfloat16* sin_r = sin_v + (size_t)row * HALF;
+  float v = __bfloat162float(k_row[tid]);
+  float w = __bfloat162float(k_norm_w[tid]);
+  float rstd = rsqrtf(block_sum_4warp(v * v, s_smem4) / float(HEAD_DIM) + eps);
+  float normed = v * rstd * w;
+  s_normed[tid] = normed;
+  __syncthreads();
+
+  __nv_bfloat16* kdst = k_cache + (size_t)row * cache_row_stride + head * HEAD_DIM;
+  if (tid < HALF) {
+    float partner = s_normed[tid + HALF];
+    float c = __bfloat162float(cos_r[tid]);
+    float sn = __bfloat162float(sin_r[tid]);
+    kdst[tid] = __float2bfloat16(normed * c - partner * sn);
+  } else {
+    float partner = s_normed[tid - HALF];
+    int hi = tid - HALF;
+    float c = __bfloat162float(cos_r[hi]);
+    float sn = __bfloat162float(sin_r[hi]);
+    kdst[tid] = __float2bfloat16(normed * c + partner * sn);
+  }
+  // V is copied (no norm, no RoPE).
+  v_cache[(size_t)row * cache_row_stride + head * HEAD_DIM + tid] = v_row[tid];
+}
+
 }  // namespace
+
+int qwen3_q_norm_rope_qstage_prefill_bf16(
+    const void* q_pre, const void* q_norm_w, const void* cos, const void* sin,
+    void* q_buf_dst, int n_q_heads, int S, int in_row_stride,
+    int out_row_stride, float eps, cudaStream_t stream) {
+  if (!q_pre || !q_norm_w || !cos || !sin || !q_buf_dst) return 1;
+  if (n_q_heads <= 0 || S <= 0) return 2;
+  q_norm_rope_qstage_prefill_kernel<<<dim3(n_q_heads, S), dim3(THREADS), 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q_pre),
+      reinterpret_cast<const __nv_bfloat16*>(q_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(cos),
+      reinterpret_cast<const __nv_bfloat16*>(sin),
+      reinterpret_cast<__nv_bfloat16*>(q_buf_dst),
+      n_q_heads, S, in_row_stride, out_row_stride, eps);
+  return 0;
+}
+
+int qwen3_k_norm_rope_kvwrite_prefill_bf16(
+    const void* k_pre, const void* v_pre, const void* k_norm_w,
+    const void* cos, const void* sin, void* k_cache_dst, void* v_cache_dst,
+    int n_kv_heads, int S, int in_row_stride, int cache_row_stride,
+    float eps, cudaStream_t stream) {
+  if (!k_pre || !v_pre || !k_norm_w || !cos || !sin
+      || !k_cache_dst || !v_cache_dst) return 1;
+  if (n_kv_heads <= 0 || S <= 0) return 2;
+  k_norm_rope_kvwrite_prefill_kernel<<<dim3(n_kv_heads, S), dim3(THREADS), 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(k_pre),
+      reinterpret_cast<const __nv_bfloat16*>(v_pre),
+      reinterpret_cast<const __nv_bfloat16*>(k_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(cos),
+      reinterpret_cast<const __nv_bfloat16*>(sin),
+      reinterpret_cast<__nv_bfloat16*>(k_cache_dst),
+      reinterpret_cast<__nv_bfloat16*>(v_cache_dst),
+      n_kv_heads, S, in_row_stride, cache_row_stride, eps);
+  return 0;
+}
 
 int qwen3_k_norm_rope_kvwrite_devpos_bf16(
     const void* k_pre, const void* v_pre, const void* k_norm_w,

--- a/csrc/kernels/qwen3_qkv_post_proc.cuh
+++ b/csrc/kernels/qwen3_qkv_post_proc.cuh
@@ -76,6 +76,41 @@ int qwen3_k_norm_rope_kvwrite_bf16(
     float       eps,
     cudaStream_t stream);
 
+// Prefill (S>1) batched variants. grid = (n_heads, S); one block per
+// (row, head). q/k/v read with `in_row_stride` (= qkv_N for the fused QKV
+// output) so the strided q/k/v slices are consumed in place — no
+// contiguous copy. cos/sin are (S, 64); outputs are written with the
+// destination row stride (q_buf: n_q*128; K/V cache: cache_row_stride).
+// Folds the per-layer rms_norm + multi-op RoPE + Q/K/V copies into 2
+// launches. head_dim hardcoded 128. Returns 0 on success.
+int qwen3_q_norm_rope_qstage_prefill_bf16(
+    const void* q_pre,
+    const void* q_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    int         n_q_heads,
+    int         S,
+    int         in_row_stride,
+    int         out_row_stride,
+    float       eps,
+    cudaStream_t stream);
+
+int qwen3_k_norm_rope_kvwrite_prefill_bf16(
+    const void* k_pre,
+    const void* v_pre,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         n_kv_heads,
+    int         S,
+    int         in_row_stride,
+    int         cache_row_stride,
+    float       eps,
+    cudaStream_t stream);
+
 // Device-position variant: cache slot = K_cache_base + (*cur_pos) * row_elems,
 // so one captured graph serves every decode position (host bumps *cur_pos
 // before each replay). row_elems = n_kv * 128. Returns 0 on success.

--- a/flash_rt/frontends/torch/_qwen3_rtx_nvfp4_weights.py
+++ b/flash_rt/frontends/torch/_qwen3_rtx_nvfp4_weights.py
@@ -319,6 +319,19 @@ def extract_weights_qwen3_nvfp4(
     handles.ptrs['lm_head_sf'] = _anchor(handles, sf_swz_lm)
     handles.ptrs['lm_head_alpha'] = lm_alpha
 
+    # FP8 (e4m3) lm_head for the prefill eager M=1 path. Unlike the NVFP4
+    # variant above, per-call W8A8 fp8 matches the original HF bf16 argmax
+    # as well as the bf16 lm_head does (24-prompt check: 3 vs HF, same as
+    # bf16's 4) at half the weight BW — e4m3's dynamic range covers the
+    # per-row magnitude spread NVFP4's e2m1 could not. Per-tensor weight
+    # scale; the activation is quantized per-call (eager tail), combined
+    # alpha = 1/(w_scale * act_scale).
+    lm_w_scale = 448.0 / lm_head.abs().max().float()
+    lm_head_fp8 = (lm_head.float() * lm_w_scale).clamp_(-448.0, 448.0).to(
+        torch.float8_e4m3fn).contiguous()
+    handles.ptrs['lm_head_fp8'] = _anchor(handles, lm_head_fp8)
+    handles.ptrs['lm_head_fp8_wscale'] = float(lm_w_scale.item())
+
     handles.ptrs['vocab_size'] = vocab
     handles.ptrs['hidden'] = hidden
     handles.ptrs['head_dim'] = head_dim

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -1258,11 +1258,14 @@ class Qwen3TorchFrontendRtx:
             fvk.quantize_fp8_device(
                 lr.data_ptr(), self._lmhead_fp8_act.data_ptr(),
                 self._lmhead_act_scale.data_ptr(), hidden, s)
-            alpha = (float(self._lmhead_act_scale.item())
-                     / self._weights.ptrs['lm_head_fp8_wscale'])
-            fvk.ht_gemv_fp8_m1_w16(
+            # Device-scale GEMV: alpha = act_scale[0] * w_descale is read
+            # on-device, so the per-call activation scale never round-trips
+            # to the host (no sync — the hot path stays kernel-only).
+            w_descale = 1.0 / self._weights.ptrs['lm_head_fp8_wscale']
+            fvk.ht_gemv_fp8_m1_w16_dscale(
                 self._lmhead_fp8_act.data_ptr(), int(lm_fp8),
-                self._logits_buf[:1].data_ptr(), 1, vocab, hidden, alpha, s,
+                self._logits_buf[:1].data_ptr(), 1, vocab, hidden,
+                self._lmhead_act_scale.data_ptr(), w_descale, s,
             )
         else:
             fvk.bf16_matmul_qwen36_bf16(

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -301,6 +301,12 @@ class Qwen3TorchFrontendRtx:
         # fused QKV path (homogeneous alpha). Default ON.
         self._enable_qkv_post_fusion_prefill: bool = True
 
+        # Prefill boundary fusion: fold residual_2 + next-layer input_norm
+        # + nvfp4 quant into one `residual_add_rms_norm_to_nvfp4` per layer
+        # boundary (mirrors the decode `_enable_boundary_fusion`), removing
+        # the standalone torch.add + a separate input norm+quant. Default ON.
+        self._enable_boundary_fusion_prefill: bool = True
+
         # silu_mul + nvfp4 quant fusion: collapse `silu(gate) * up`
         # and the subsequent nvfp4 swizzled quantization into one
         # launch (`silu_mul_to_nvfp4_swizzled_bf16`); also avoids a
@@ -919,7 +925,9 @@ class Qwen3TorchFrontendRtx:
     # ── D4: S=N prefill ──
 
     def _layer_forward_full_nvfp4_prefill(self, L: int, h_in_S, cos_S,
-                                            sin_S, start_pos: int, S: int):
+                                            sin_S, start_pos: int, S: int,
+                                            prequant_ap=None, prequant_sf=None,
+                                            next_input_norm_w: int = 0):
         """Single Qwen3 layer at S=N prefill.
 
         Same kernel sequence as ``_layer_forward_full_nvfp4`` but with
@@ -952,12 +960,18 @@ class Qwen3TorchFrontendRtx:
 
         h2 = h_in_S.view(S, hidden).contiguous()
 
-        # 1+2) input layernorm + NVFP4 quantize at M=S.
+        # 1+2) input layernorm + NVFP4 quantize at M=S. With boundary
+        # fusion the previous layer's tail already produced this layer's
+        # pre-quantized activation (residual_2 + this input_norm + quant
+        # in one launch), so skip the standalone norm+quant here.
         ap_h, sf_h, _ = self._nvfp4_scratch[(n_q * hd, hidden)]
-        fvk.rms_norm_to_nvfp4_swizzled_bf16(
-            h2.data_ptr(), int(lw['input_norm_w']),
-            ap_h.data_ptr(), sf_h.data_ptr(), S, hidden, eps, s,
-        )
+        if prequant_ap is not None and prequant_sf is not None:
+            ap_h, sf_h = prequant_ap, prequant_sf
+        else:
+            fvk.rms_norm_to_nvfp4_swizzled_bf16(
+                h2.data_ptr(), int(lw['input_norm_w']),
+                ap_h.data_ptr(), sf_h.data_ptr(), S, hidden, eps, s,
+            )
 
         # 3) q/k/v_proj NVFP4 GEMMs at M=S. When the checkpoint has a
         # homogeneous qkv alpha (q/k/v share activation + alpha) a single
@@ -1175,10 +1189,21 @@ class Qwen3TorchFrontendRtx:
         )
         mlp_out = down_out_buf[:S].view(1, S, hidden)
 
-        # 15) Residual 2 → ping-pong.
+        # 15) Residual 2 (+ optional boundary fusion) → ping-pong.
         h_out = self._layer_out_a if (L % 2 == 0) else self._layer_out_b
         h_out_v = h_out[:, :S]
-        torch.add(h_post, mlp_out, out=h_out_v)
+        if next_input_norm_w:
+            # Fused: h_out = h_post + mlp_out AND next ap/sf =
+            # nvfp4_quant(rms_norm(h_out, next_norm_w)). Reuse the
+            # (n_q*hd, hidden) NVFP4 scratch — consumer-done by step 3.
+            next_ap, next_sf, _ = self._nvfp4_scratch[(n_q * hd, hidden)]
+            fvk.residual_add_rms_norm_to_nvfp4_swizzled_bf16(
+                h_post.data_ptr(), mlp_out.contiguous().data_ptr(),
+                h_out_v.data_ptr(), int(next_input_norm_w),
+                next_ap.data_ptr(), next_sf.data_ptr(), S, hidden, eps, s,
+            )
+        else:
+            torch.add(h_post, mlp_out, out=h_out_v)
         return h_out_v
 
     def forward_prefill_nvfp4(self, prompt_ids, start_pos: int = 0,
@@ -1247,10 +1272,33 @@ class Qwen3TorchFrontendRtx:
 
         # 2) 36 layers.
         n_layers = cfg['num_hidden_layers']
-        for L in range(n_layers):
-            h = self._layer_forward_full_nvfp4_prefill(
-                L, h, cos_S, sin_S, start_pos, S,
+        layers_ptrs = self._weights.ptrs['layers']
+        if self._enable_boundary_fusion_prefill:
+            # Pre-quant the layer-0 input, then have each layer's tail
+            # produce the next layer's pre-quant via the fused
+            # residual+norm+quant op. Removes the standalone torch.add
+            # (residual_2) + a separate input norm+quant per boundary.
+            n_q = cfg['num_q_heads']
+            hd = cfg['head_dim']
+            ap0, sf0, _ = self._nvfp4_scratch[(n_q * hd, hidden)]
+            h0_v = h.view(S, hidden).contiguous()
+            fvk.rms_norm_to_nvfp4_swizzled_bf16(
+                h0_v.data_ptr(), int(layers_ptrs[0]['input_norm_w']),
+                ap0.data_ptr(), sf0.data_ptr(), S, hidden, eps, s,
             )
+            for L in range(n_layers):
+                next_w = (int(layers_ptrs[L + 1]['input_norm_w'])
+                          if L + 1 < n_layers else 0)
+                h = self._layer_forward_full_nvfp4_prefill(
+                    L, h, cos_S, sin_S, start_pos, S,
+                    prequant_ap=ap0, prequant_sf=sf0,
+                    next_input_norm_w=next_w,
+                )
+        else:
+            for L in range(n_layers):
+                h = self._layer_forward_full_nvfp4_prefill(
+                    L, h, cos_S, sin_S, start_pos, S,
+                )
 
         # 3) Final RMSNorm at M=S.
         h2 = h.view(S, hidden).contiguous()
@@ -1402,10 +1450,29 @@ class Qwen3TorchFrontendRtx:
         sin_S = self._rope_sin_table[0:S]
 
         n_layers = cfg['num_hidden_layers']
-        for L in range(n_layers):
-            h = self._layer_forward_full_nvfp4_prefill(
-                L, h, cos_S, sin_S, 0, S,
+        layers_ptrs = self._weights.ptrs['layers']
+        if self._enable_boundary_fusion_prefill:
+            n_q = cfg['num_q_heads']
+            hd = cfg['head_dim']
+            ap0, sf0, _ = self._nvfp4_scratch[(n_q * hd, hidden)]
+            h0_v = h.view(S, hidden).contiguous()
+            fvk.rms_norm_to_nvfp4_swizzled_bf16(
+                h0_v.data_ptr(), int(layers_ptrs[0]['input_norm_w']),
+                ap0.data_ptr(), sf0.data_ptr(), S, hidden, eps, s,
             )
+            for L in range(n_layers):
+                next_w = (int(layers_ptrs[L + 1]['input_norm_w'])
+                          if L + 1 < n_layers else 0)
+                h = self._layer_forward_full_nvfp4_prefill(
+                    L, h, cos_S, sin_S, 0, S,
+                    prequant_ap=ap0, prequant_sf=sf0,
+                    next_input_norm_w=next_w,
+                )
+        else:
+            for L in range(n_layers):
+                h = self._layer_forward_full_nvfp4_prefill(
+                    L, h, cos_S, sin_S, 0, S,
+                )
 
         h2 = h.view(S, hidden).contiguous()
         x_norm = self._h_b[:S].view(S, hidden)

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -942,7 +942,8 @@ class Qwen3TorchFrontendRtx:
     def _layer_forward_full_nvfp4_prefill(self, L: int, h_in_S, cos_S,
                                             sin_S, start_pos: int, S: int,
                                             prequant_ap=None, prequant_sf=None,
-                                            next_input_norm_w: int = 0):
+                                            next_input_norm_w: int = 0,
+                                            final_norm_w: int = 0):
         """Single Qwen3 layer at S=N prefill.
 
         Same kernel sequence as ``_layer_forward_full_nvfp4`` but with
@@ -1204,7 +1205,17 @@ class Qwen3TorchFrontendRtx:
         )
         mlp_out = down_out_buf[:S].view(1, S, hidden)
 
-        # 15) Residual 2 (+ optional boundary fusion) → ping-pong.
+        # 15) Residual 2 (+ optional boundary / final-norm fusion).
+        if final_norm_w:
+            # Last layer: fuse residual_2 + the final RMSNorm (bf16)
+            # straight into the persistent last-hidden buffer — kills the
+            # trailing torch.add AND the standalone final rms_norm.
+            x_norm = self._last_hidden_buf[:, :S].view(S, hidden)
+            fvk.residual_add_rms_norm(
+                h_post.data_ptr(), mlp_out.contiguous().data_ptr(),
+                int(final_norm_w), x_norm.data_ptr(), S, hidden, eps, s,
+            )
+            return None
         h_out = self._layer_out_a if (L % 2 == 0) else self._layer_out_b
         h_out_v = h_out[:, :S]
         if next_input_norm_w:
@@ -1343,28 +1354,37 @@ class Qwen3TorchFrontendRtx:
                 h0_v.data_ptr(), int(layers_ptrs[0]['input_norm_w']),
                 ap0.data_ptr(), sf0.data_ptr(), S, hidden, eps, s,
             )
+            final_w = int(self._weights.ptrs['final_norm_w'])
             for L in range(n_layers):
-                next_w = (int(layers_ptrs[L + 1]['input_norm_w'])
-                          if L + 1 < n_layers else 0)
+                last = L + 1 == n_layers
+                next_w = 0 if last else int(layers_ptrs[L + 1]['input_norm_w'])
+                # Last layer fuses residual_2 + final RMSNorm into
+                # _last_hidden_buf; earlier layers fuse into the next
+                # layer's pre-quant.
                 h = self._layer_forward_full_nvfp4_prefill(
                     L, h, cos_S, sin_S, start_pos, S,
                     prequant_ap=ap0, prequant_sf=sf0,
                     next_input_norm_w=next_w,
+                    final_norm_w=(final_w if last else 0),
                 )
+            final_done = True
         else:
             for L in range(n_layers):
                 h = self._layer_forward_full_nvfp4_prefill(
                     L, h, cos_S, sin_S, start_pos, S,
                 )
+            final_done = False
 
         # 3) Final RMSNorm at M=S, written straight into the persistent
-        # last-hidden buffer (no separate stage-copy).
-        h2 = h.view(S, hidden).contiguous()
+        # last-hidden buffer (no separate stage-copy). With boundary
+        # fusion the last layer already fused residual_2 + final norm.
         x_norm = self._last_hidden_buf[:, :S].view(S, hidden)
-        fvk.rms_norm(
-            h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
-            x_norm.data_ptr(), S, hidden, eps, s,
-        )
+        if not final_done:
+            h2 = h.view(S, hidden).contiguous()
+            fvk.rms_norm(
+                h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
+                x_norm.data_ptr(), S, hidden, eps, s,
+            )
 
         # 4) lm_head BF16. M=1 (last row, default) or M=S (full_logits).
         if full_logits:
@@ -1515,27 +1535,33 @@ class Qwen3TorchFrontendRtx:
                 h0_v.data_ptr(), int(layers_ptrs[0]['input_norm_w']),
                 ap0.data_ptr(), sf0.data_ptr(), S, hidden, eps, s,
             )
+            final_w = int(self._weights.ptrs['final_norm_w'])
             for L in range(n_layers):
-                next_w = (int(layers_ptrs[L + 1]['input_norm_w'])
-                          if L + 1 < n_layers else 0)
+                last = L + 1 == n_layers
+                next_w = 0 if last else int(layers_ptrs[L + 1]['input_norm_w'])
                 h = self._layer_forward_full_nvfp4_prefill(
                     L, h, cos_S, sin_S, 0, S,
                     prequant_ap=ap0, prequant_sf=sf0,
                     next_input_norm_w=next_w,
+                    final_norm_w=(final_w if last else 0),
                 )
+            final_done = True
         else:
             for L in range(n_layers):
                 h = self._layer_forward_full_nvfp4_prefill(
                     L, h, cos_S, sin_S, 0, S,
                 )
+            final_done = False
 
-        h2 = h.view(S, hidden).contiguous()
-        x_norm = self._h_b[:S].view(S, hidden)
-        fvk.rms_norm(
-            h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
-            x_norm.data_ptr(), S, hidden, eps, s,
-        )
-        self._last_hidden_buf[:, :S].copy_(x_norm.view(1, S, hidden))
+        # Final RMSNorm straight into _last_hidden_buf (boundary fusion
+        # already fused it into the last layer).
+        if not final_done:
+            h2 = h.view(S, hidden).contiguous()
+            x_norm = self._last_hidden_buf[:, :S].view(S, hidden)
+            fvk.rms_norm(
+                h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
+                x_norm.data_ptr(), S, hidden, eps, s,
+            )
 
     def _ensure_prefill_graph(self, S_bucket: int):
         """Lazy-capture a CUDA Graph for fresh-KV prefill at S=S_bucket.

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -261,6 +261,10 @@ class Qwen3TorchFrontendRtx:
         self._last_hidden_buf = torch.empty(
             1, Sq_max, hidden, device=device, dtype=bf16,
         )
+        # Prefill embedding-lookup output (kernel gather, no torch index).
+        self._embed_h_buf = torch.empty(
+            Sq_max, hidden, device=device, dtype=bf16,
+        )
 
         # Static decode-step scratch: a (1, 1) long tensor holding the
         # next token id, copy_'d in place every step so CUDA graph
@@ -315,7 +319,8 @@ class Qwen3TorchFrontendRtx:
         # the M=1 (full_logits=False) path; full_logits stays bf16.
         # Default ON when the fp8 weight is present.
         self._enable_lmhead_fp8_prefill: bool = True
-        self._lmhead_fp8_act = None     # holds the per-call fp8 activation
+        self._lmhead_fp8_act = None     # [hidden] fp8 activation buffer
+        self._lmhead_act_scale = None   # [1] f32 device amax scale
 
         # silu_mul + nvfp4 quant fusion: collapse `silu(gate) * up`
         # and the subsequent nvfp4 swizzled quantization into one
@@ -1227,12 +1232,23 @@ class Qwen3TorchFrontendRtx:
         from flash_rt import flash_rt_kernels as fvk
         lm_fp8 = self._weights.ptrs.get('lm_head_fp8')
         if self._enable_lmhead_fp8_prefill and lm_fp8 is not None:
-            sx = 448.0 / last_row.abs().max().float()
-            # Keep a ref on self so the fp8 buffer outlives the async kernel.
-            self._lmhead_fp8_act = (last_row.float() * sx).clamp_(
-                -448.0, 448.0).to(torch.float8_e4m3fn)
-            alpha = 1.0 / (
-                self._weights.ptrs['lm_head_fp8_wscale'] * float(sx))
+            # Pure-kernel activation quant: quantize_fp8_device does the
+            # amax + e4m3 quant in one launch (replacing the torch abs/max/
+            # mul/clamp/cast chain). d_scale = amax/448; dequant = fp8 *
+            # d_scale, so the GEMV alpha = act_dscale * weight_dscale =
+            # act_dscale / lm_head_fp8_wscale.
+            if self._lmhead_fp8_act is None:
+                dev = self._logits_buf.device
+                self._lmhead_fp8_act = torch.empty(
+                    hidden, device=dev, dtype=torch.float8_e4m3fn)
+                self._lmhead_act_scale = torch.empty(
+                    1, device=dev, dtype=torch.float32)
+            lr = last_row.reshape(hidden).contiguous()
+            fvk.quantize_fp8_device(
+                lr.data_ptr(), self._lmhead_fp8_act.data_ptr(),
+                self._lmhead_act_scale.data_ptr(), hidden, s)
+            alpha = (float(self._lmhead_act_scale.item())
+                     / self._weights.ptrs['lm_head_fp8_wscale'])
             fvk.ht_gemv_fp8_m1_w16(
                 self._lmhead_fp8_act.data_ptr(), int(lm_fp8),
                 self._logits_buf[:1].data_ptr(), 1, vocab, hidden, alpha, s,
@@ -1297,11 +1313,14 @@ class Qwen3TorchFrontendRtx:
                 f'prefill end {start_pos + S} > max_seq {self.max_seq}'
             )
 
-        # 0) Embed S tokens.
+        # 0) Embed S tokens via the kernel gather (no torch indexing).
         embed_t = self._weights.anchors[0]
-        h = embed_t[prompt_ids.view(-1)].view(1, S, hidden).contiguous()
-        if h.dtype != bf16:
-            h = h.to(bf16)
+        h = self._embed_h_buf[:S]
+        fvk.qwen36_embedding_lookup_bf16(
+            prompt_ids.view(-1).data_ptr(), embed_t.data_ptr(),
+            h.data_ptr(), S, hidden, s,
+        )
+        h = h.view(1, S, hidden)
 
         # 1) cos/sin for absolute positions [start_pos, start_pos+S).
         cos_S = self._rope_cos_table[start_pos:start_pos + S]
@@ -1338,14 +1357,14 @@ class Qwen3TorchFrontendRtx:
                     L, h, cos_S, sin_S, start_pos, S,
                 )
 
-        # 3) Final RMSNorm at M=S.
+        # 3) Final RMSNorm at M=S, written straight into the persistent
+        # last-hidden buffer (no separate stage-copy).
         h2 = h.view(S, hidden).contiguous()
-        x_norm = self._h_b[:S].view(S, hidden)
+        x_norm = self._last_hidden_buf[:, :S].view(S, hidden)
         fvk.rms_norm(
             h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
             x_norm.data_ptr(), S, hidden, eps, s,
         )
-        self._last_hidden_buf[:, :S].copy_(x_norm.view(1, S, hidden))
 
         # 4) lm_head BF16. M=1 (last row, default) or M=S (full_logits).
         if full_logits:
@@ -1475,9 +1494,12 @@ class Qwen3TorchFrontendRtx:
         eps = float(cfg['rms_norm_eps'])
 
         embed_t = self._weights.anchors[0]
-        h = embed_t[prompt_ids.view(-1)].view(1, S, hidden).contiguous()
-        if h.dtype != bf16:
-            h = h.to(bf16)
+        h = self._embed_h_buf[:S]
+        fvk.qwen36_embedding_lookup_bf16(
+            prompt_ids.view(-1).data_ptr(), embed_t.data_ptr(),
+            h.data_ptr(), S, hidden, s,
+        )
+        h = h.view(1, S, hidden)
 
         cos_S = self._rope_cos_table[0:S]
         sin_S = self._rope_sin_table[0:S]

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -307,6 +307,16 @@ class Qwen3TorchFrontendRtx:
         # the standalone torch.add + a separate input norm+quant. Default ON.
         self._enable_boundary_fusion_prefill: bool = True
 
+        # FP8 (e4m3) lm_head for the prefill eager M=1 path. The bf16
+        # lm_head is bandwidth-bound on the 1.24 GB weight (~0.76 ms);
+        # W8A8 fp8 halves that read. Per-call activation scale keeps the
+        # next-token argmax matching the original HF bf16 ref as well as
+        # the bf16 lm_head (24-prompt check: 3 vs HF, == bf16's 4). Only
+        # the M=1 (full_logits=False) path; full_logits stays bf16.
+        # Default ON when the fp8 weight is present.
+        self._enable_lmhead_fp8_prefill: bool = True
+        self._lmhead_fp8_act = None     # holds the per-call fp8 activation
+
         # silu_mul + nvfp4 quant fusion: collapse `silu(gate) * up`
         # and the subsequent nvfp4 swizzled quantization into one
         # launch (`silu_mul_to_nvfp4_swizzled_bf16`); also avoids a
@@ -1206,6 +1216,34 @@ class Qwen3TorchFrontendRtx:
             torch.add(h_post, mlp_out, out=h_out_v)
         return h_out_v
 
+    def _lm_head_m1(self, last_row, vocab: int, hidden: int, s) -> None:
+        """Eager M=1 lm_head into self._logits_buf[:1]. Uses the W8A8 fp8
+        GEMV (half the bf16 weight BW) with a per-call activation scale when
+        the fp8 weight is present and enabled; else the bf16 mat-vec. The
+        fp8 path matches the original HF bf16 next-token argmax as well as
+        the bf16 lm_head (validated 24 prompts). Eager only (prefill tail);
+        decode keeps the captured bf16 lm_head."""
+        import torch
+        from flash_rt import flash_rt_kernels as fvk
+        lm_fp8 = self._weights.ptrs.get('lm_head_fp8')
+        if self._enable_lmhead_fp8_prefill and lm_fp8 is not None:
+            sx = 448.0 / last_row.abs().max().float()
+            # Keep a ref on self so the fp8 buffer outlives the async kernel.
+            self._lmhead_fp8_act = (last_row.float() * sx).clamp_(
+                -448.0, 448.0).to(torch.float8_e4m3fn)
+            alpha = 1.0 / (
+                self._weights.ptrs['lm_head_fp8_wscale'] * float(sx))
+            fvk.ht_gemv_fp8_m1_w16(
+                self._lmhead_fp8_act.data_ptr(), int(lm_fp8),
+                self._logits_buf[:1].data_ptr(), 1, vocab, hidden, alpha, s,
+            )
+        else:
+            fvk.bf16_matmul_qwen36_bf16(
+                last_row.contiguous().data_ptr(),
+                int(self._weights.ptrs['lm_head_w']),
+                self._logits_buf[:1].data_ptr(), 1, vocab, hidden, s,
+            )
+
     def forward_prefill_nvfp4(self, prompt_ids, start_pos: int = 0,
                                 *, full_logits: bool = False):
         """S=N prefill: process the whole prompt in one batched forward.
@@ -1320,12 +1358,7 @@ class Qwen3TorchFrontendRtx:
             ret = self._logits_buf[:S]
         else:
             last_row = x_norm[S - 1:S].contiguous()
-            fvk.bf16_matmul_qwen36_bf16(
-                last_row.data_ptr(),
-                int(self._weights.ptrs['lm_head_w']),
-                self._logits_buf[:1].data_ptr(),
-                1, vocab, hidden, s,
-            )
+            self._lm_head_m1(last_row, vocab, hidden, s)
             ret = self._logits_buf[:1]
 
         # Advance the logical decode cursor to right after the prompt.
@@ -1600,12 +1633,7 @@ class Qwen3TorchFrontendRtx:
         vocab = cfg['vocab_size']
         s = torch.cuda.current_stream().cuda_stream
         last_row = self._last_hidden_buf[0, real_S - 1:real_S].contiguous()
-        fvk.bf16_matmul_qwen36_bf16(
-            last_row.data_ptr(),
-            int(self._weights.ptrs['lm_head_w']),
-            self._logits_buf[:1].data_ptr(),
-            1, vocab, hidden, s,
-        )
+        self._lm_head_m1(last_row, vocab, hidden, s)
         _ = bucket  # silence unused warning in IDE diff view
 
         # Decode resumes at the real prompt's end, NOT the bucket end.

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -293,6 +293,14 @@ class Qwen3TorchFrontendRtx:
         # ON.
         self._enable_qkv_post_fusion: bool = True
 
+        # Prefill (M=S) batched q/k/v post-proc fusion: collapse the
+        # per-layer (q_norm + k_norm + 2× RoPE + Q/K/V copies) chain into
+        # two batched launches via `qwen3_q_norm_rope_qstage_prefill_bf16`
+        # / `qwen3_k_norm_rope_kvwrite_prefill_bf16`, reading the strided
+        # q/k/v slices of the fused QKV output in place. Requires the
+        # fused QKV path (homogeneous alpha). Default ON.
+        self._enable_qkv_post_fusion_prefill: bool = True
+
         # silu_mul + nvfp4 quant fusion: collapse `silu(gate) * up`
         # and the subsequent nvfp4 swizzled quantization into one
         # launch (`silu_mul_to_nvfp4_swizzled_bf16`); also avoids a
@@ -958,6 +966,11 @@ class Qwen3TorchFrontendRtx:
         # FP4 peak at M=512. Folding them into the wide-N GEMM lifts the
         # whole projection toward the q_proj/down efficiency band.
         prefill_gemm = self._prefill_gemm
+        # When the fused QKV path is active, the batched post-proc kernel
+        # consumes the strided q/k/v slices of qkv_out in place (no
+        # contiguous copy) and writes Q_buf/K_cache/V_cache directly.
+        use_fused_post = (self._qkv_prefill_out is not None
+                          and self._enable_qkv_post_fusion_prefill)
         if self._qkv_prefill_out is not None:
             qkv_N = int(lw['qkv_proj_N'])
             Nq = n_q * hd          # 4096
@@ -971,9 +984,10 @@ class Qwen3TorchFrontendRtx:
                 float(lw['qkv_proj_alpha']),
                 s,
             )
-            q_pre = qkv_out[:, :Nq].view(1, S, n_q, hd)
-            k_pre = qkv_out[:, Nq:Nq + Nk].view(1, S, n_kv, hd).contiguous()
-            v_fused = qkv_out[:, Nq + Nk:].view(S, n_kv, hd)
+            if not use_fused_post:
+                q_pre = qkv_out[:, :Nq].view(1, S, n_q, hd)
+                k_pre = qkv_out[:, Nq:Nq + Nk].view(1, S, n_kv, hd).contiguous()
+                v_fused = qkv_out[:, Nq + Nk:].view(S, n_kv, hd)
         else:
             q_proj_out_buf = self._nvfp4_scratch[(n_q * hd, hidden)][2]
             prefill_gemm(
@@ -997,54 +1011,78 @@ class Qwen3TorchFrontendRtx:
             k_pre = kv_proj_out_buf[:S].view(1, S, n_kv, hd).contiguous()
             v_fused = None
 
-        # 4) q/k_norm at (S*n_q, hd) and (S*n_kv, hd) flat views.
-        q_pre_flat = q_pre.contiguous().view(S * n_q, hd)
-        k_pre_flat = k_pre.view(S * n_kv, hd)
-        fvk.rms_norm(
-            q_pre_flat.data_ptr(), int(lw['q_norm_w']),
-            self._q_norm_out[:S * n_q].data_ptr(), S * n_q, hd, eps, s,
-        )
-        fvk.rms_norm(
-            k_pre_flat.data_ptr(), int(lw['k_norm_w']),
-            self._k_norm_out[:S * n_kv].data_ptr(), S * n_kv, hd, eps, s,
-        )
-
-        # 5) Inline full-RoPE (rotary_dim = head_dim).
-        q_for_rope = self._q_norm_out[:S * n_q].view(1, S, n_q, hd)
-        k_for_rope = self._k_norm_out[:S * n_kv].view(1, S, n_kv, hd)
-        # cos_S/sin_S are (S, hd/2). Broadcast to (1, S, 1, hd/2).
-        cos4 = cos_S.view(1, S, 1, hd // 2)
-        sin4 = sin_S.view(1, S, 1, hd // 2)
-        q_rot = self._q_rot[:, :S]
-        k_rot = self._k_rot[:, :S]
-        self._rope_apply_inline(
-            q_for_rope, q_rot, self._rope_tmp_q[:, :S], cos4, sin4,
-        )
-        self._rope_apply_inline(
-            k_for_rope, k_rot, self._rope_tmp_k[:, :S], cos4, sin4,
-        )
-
-        # 6) Stage Q + write K to KV cache at [start_pos:start_pos+S].
-        self._attn.Q_buf[:, :S].copy_(q_rot)
-        self._attn.K_cache[L, start_pos:start_pos + S].copy_(
-            k_rot.view(S, n_kv, hd),
-        )
-
-        # 7) v_proj — the fused path already produced v inside the qkv
-        # slice; the split path runs the v GEMM now (reusing kv buffer).
-        if v_fused is not None:
-            v_new = v_fused
-        else:
-            prefill_gemm(
-                ap_h.data_ptr(), int(lw['v_proj_packed']),
-                kv_proj_out_buf.data_ptr(),
-                S, n_kv * hd, hidden,
-                sf_h.data_ptr(), int(lw['v_proj_sf']),
-                float(lw['v_proj_alpha']),
-                s,
+        if use_fused_post:
+            # 4+5+6+7) Fused batched q/k/v post-proc: two launches replace
+            # rms_norm ×2 + multi-op RoPE ×2 + Q/K/V copies. Reads the
+            # strided q/k/v slices of qkv_out in place (in_row_stride =
+            # qkv_N) and writes Q_buf / K_cache / V_cache for all S rows.
+            kv_row_elems = n_kv * hd
+            kv_off = (L * self._attn.kv_layer_stride_bytes
+                      + start_pos * self._attn.kv_row_stride_bytes)
+            k_cache_dst = self._attn.K_cache.data_ptr() + kv_off
+            v_cache_dst = self._attn.V_cache.data_ptr() + kv_off
+            fvk.qwen3_q_norm_rope_qstage_prefill_bf16(
+                qkv_out[:, :Nq].data_ptr(), int(lw['q_norm_w']),
+                cos_S.data_ptr(), sin_S.data_ptr(),
+                self._attn.Q_buf[:, :S].data_ptr(),
+                n_q, S, qkv_N, n_q * hd, eps, s,
             )
-            v_new = kv_proj_out_buf[:S].view(S, n_kv, hd)
-        self._attn.V_cache[L, start_pos:start_pos + S].copy_(v_new)
+            fvk.qwen3_k_norm_rope_kvwrite_prefill_bf16(
+                qkv_out[:, Nq:Nq + Nk].data_ptr(),
+                qkv_out[:, Nq + Nk:].data_ptr(), int(lw['k_norm_w']),
+                cos_S.data_ptr(), sin_S.data_ptr(),
+                k_cache_dst, v_cache_dst,
+                n_kv, S, qkv_N, kv_row_elems, eps, s,
+            )
+        else:
+            # 4) q/k_norm at (S*n_q, hd) and (S*n_kv, hd) flat views.
+            q_pre_flat = q_pre.contiguous().view(S * n_q, hd)
+            k_pre_flat = k_pre.view(S * n_kv, hd)
+            fvk.rms_norm(
+                q_pre_flat.data_ptr(), int(lw['q_norm_w']),
+                self._q_norm_out[:S * n_q].data_ptr(), S * n_q, hd, eps, s,
+            )
+            fvk.rms_norm(
+                k_pre_flat.data_ptr(), int(lw['k_norm_w']),
+                self._k_norm_out[:S * n_kv].data_ptr(), S * n_kv, hd, eps, s,
+            )
+
+            # 5) Inline full-RoPE (rotary_dim = head_dim).
+            q_for_rope = self._q_norm_out[:S * n_q].view(1, S, n_q, hd)
+            k_for_rope = self._k_norm_out[:S * n_kv].view(1, S, n_kv, hd)
+            # cos_S/sin_S are (S, hd/2). Broadcast to (1, S, 1, hd/2).
+            cos4 = cos_S.view(1, S, 1, hd // 2)
+            sin4 = sin_S.view(1, S, 1, hd // 2)
+            q_rot = self._q_rot[:, :S]
+            k_rot = self._k_rot[:, :S]
+            self._rope_apply_inline(
+                q_for_rope, q_rot, self._rope_tmp_q[:, :S], cos4, sin4,
+            )
+            self._rope_apply_inline(
+                k_for_rope, k_rot, self._rope_tmp_k[:, :S], cos4, sin4,
+            )
+
+            # 6) Stage Q + write K to KV cache at [start_pos:start_pos+S].
+            self._attn.Q_buf[:, :S].copy_(q_rot)
+            self._attn.K_cache[L, start_pos:start_pos + S].copy_(
+                k_rot.view(S, n_kv, hd),
+            )
+
+            # 7) v_proj — the fused QKV path produced v inside the qkv
+            # slice; the split path runs the v GEMM now (reusing kv buf).
+            if v_fused is not None:
+                v_new = v_fused
+            else:
+                prefill_gemm(
+                    ap_h.data_ptr(), int(lw['v_proj_packed']),
+                    kv_proj_out_buf.data_ptr(),
+                    S, n_kv * hd, hidden,
+                    sf_h.data_ptr(), int(lw['v_proj_sf']),
+                    float(lw['v_proj_alpha']),
+                    s,
+                )
+                v_new = kv_proj_out_buf[:S].view(S, n_kv, hd)
+            self._attn.V_cache[L, start_pos:start_pos + S].copy_(v_new)
 
         # 8) Run FA2 causal: q_seq=S, kv_seq=start_pos+S.
         kv_seq = start_pos + S

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -309,8 +309,15 @@ class Qwen3TorchFrontendRtx:
             self._qkv_fused_out = torch.empty(
                 1, qkv_N, device=device, dtype=bf16,
             )
+            # Prefill (M=S) fused-QKV output; folds the two N=1024 k/v
+            # GEMMs (~21% of FP4 peak each at M=512) into one wide-N
+            # GEMM with q. Sized to the largest prefill bucket.
+            self._qkv_prefill_out = torch.empty(
+                Sq_max, qkv_N, device=device, dtype=bf16,
+            )
         else:
             self._qkv_fused_out = None
+            self._qkv_prefill_out = None
         if layers0.get('gate_up_homogeneous_alpha'):
             gu_N = int(layers0['gate_up_N'])
             self._gate_up_fused_out = torch.empty(
@@ -944,28 +951,51 @@ class Qwen3TorchFrontendRtx:
             ap_h.data_ptr(), sf_h.data_ptr(), S, hidden, eps, s,
         )
 
-        # 3) q/k/v_proj NVFP4 GEMMs at M=S.
+        # 3) q/k/v_proj NVFP4 GEMMs at M=S. When the checkpoint has a
+        # homogeneous qkv alpha (q/k/v share activation + alpha) a single
+        # fused N=6144 GEMM via `qkv_proj_packed` replaces q (N=4096) plus
+        # the two N=1024 k/v GEMMs — each of which runs at only ~21% of
+        # FP4 peak at M=512. Folding them into the wide-N GEMM lifts the
+        # whole projection toward the q_proj/down efficiency band.
         prefill_gemm = self._prefill_gemm
-        q_proj_out_buf = self._nvfp4_scratch[(n_q * hd, hidden)][2]
-        prefill_gemm(
-            ap_h.data_ptr(), int(lw['q_proj_packed']),
-            q_proj_out_buf.data_ptr(),
-            S, n_q * hd, hidden,
-            sf_h.data_ptr(), int(lw['q_proj_sf']),
-            float(lw['q_proj_alpha']),
-            s,
-        )
-        kv_proj_out_buf = self._nvfp4_scratch[(n_kv * hd, hidden)][2]
-        prefill_gemm(
-            ap_h.data_ptr(), int(lw['k_proj_packed']),
-            kv_proj_out_buf.data_ptr(),
-            S, n_kv * hd, hidden,
-            sf_h.data_ptr(), int(lw['k_proj_sf']),
-            float(lw['k_proj_alpha']),
-            s,
-        )
-        q_pre = q_proj_out_buf[:S].view(1, S, n_q, hd)
-        k_pre = kv_proj_out_buf[:S].view(1, S, n_kv, hd).contiguous()
+        if self._qkv_prefill_out is not None:
+            qkv_N = int(lw['qkv_proj_N'])
+            Nq = n_q * hd          # 4096
+            Nk = n_kv * hd         # 1024
+            qkv_out = self._qkv_prefill_out[:S]
+            prefill_gemm(
+                ap_h.data_ptr(), int(lw['qkv_proj_packed']),
+                qkv_out.data_ptr(),
+                S, qkv_N, hidden,
+                sf_h.data_ptr(), int(lw['qkv_proj_sf']),
+                float(lw['qkv_proj_alpha']),
+                s,
+            )
+            q_pre = qkv_out[:, :Nq].view(1, S, n_q, hd)
+            k_pre = qkv_out[:, Nq:Nq + Nk].view(1, S, n_kv, hd).contiguous()
+            v_fused = qkv_out[:, Nq + Nk:].view(S, n_kv, hd)
+        else:
+            q_proj_out_buf = self._nvfp4_scratch[(n_q * hd, hidden)][2]
+            prefill_gemm(
+                ap_h.data_ptr(), int(lw['q_proj_packed']),
+                q_proj_out_buf.data_ptr(),
+                S, n_q * hd, hidden,
+                sf_h.data_ptr(), int(lw['q_proj_sf']),
+                float(lw['q_proj_alpha']),
+                s,
+            )
+            kv_proj_out_buf = self._nvfp4_scratch[(n_kv * hd, hidden)][2]
+            prefill_gemm(
+                ap_h.data_ptr(), int(lw['k_proj_packed']),
+                kv_proj_out_buf.data_ptr(),
+                S, n_kv * hd, hidden,
+                sf_h.data_ptr(), int(lw['k_proj_sf']),
+                float(lw['k_proj_alpha']),
+                s,
+            )
+            q_pre = q_proj_out_buf[:S].view(1, S, n_q, hd)
+            k_pre = kv_proj_out_buf[:S].view(1, S, n_kv, hd).contiguous()
+            v_fused = None
 
         # 4) q/k_norm at (S*n_q, hd) and (S*n_kv, hd) flat views.
         q_pre_flat = q_pre.contiguous().view(S * n_q, hd)
@@ -1000,16 +1030,20 @@ class Qwen3TorchFrontendRtx:
             k_rot.view(S, n_kv, hd),
         )
 
-        # 7) v_proj — reuse kv_proj_out_buf, write into V_cache.
-        prefill_gemm(
-            ap_h.data_ptr(), int(lw['v_proj_packed']),
-            kv_proj_out_buf.data_ptr(),
-            S, n_kv * hd, hidden,
-            sf_h.data_ptr(), int(lw['v_proj_sf']),
-            float(lw['v_proj_alpha']),
-            s,
-        )
-        v_new = kv_proj_out_buf[:S].view(S, n_kv, hd)
+        # 7) v_proj — the fused path already produced v inside the qkv
+        # slice; the split path runs the v GEMM now (reusing kv buffer).
+        if v_fused is not None:
+            v_new = v_fused
+        else:
+            prefill_gemm(
+                ap_h.data_ptr(), int(lw['v_proj_packed']),
+                kv_proj_out_buf.data_ptr(),
+                S, n_kv * hd, hidden,
+                sf_h.data_ptr(), int(lw['v_proj_sf']),
+                float(lw['v_proj_alpha']),
+                s,
+            )
+            v_new = kv_proj_out_buf[:S].view(S, n_kv, hd)
         self._attn.V_cache[L, start_pos:start_pos + S].copy_(v_new)
 
         # 8) Run FA2 causal: q_seq=S, kv_seq=start_pos+S.


### PR DESCRIPTION
## Summary

Optimizes the dense-Qwen3 NVFP4 LLM **prefill** path (shared by Qwen3-VL text
and Qwen3-8B) on RTX 5090 / sm120. Graph S=512 prefill **13.64 → 10.91 ms
(−20 %)**, and the prefill hot path is now **100 % hand-written kernels — zero
torch/aten ops** (verified by profiler).

All changes are additive on the shared `qwen3_rtx` path and gated behind flags
for A/B. Precision held against the original HF bf16 reference throughout.

## What changed

| # | Commit | Win | Notes |
|---|--------|----:|-------|
| 1 | fuse QKV projection | −0.4 ms | prefill now uses the existing `qkv_proj_packed` weight (decode already did); 3 GEMMs (incl. two 21 %-peak N=1024 k/v) → one N=6144. Bit-exact (cos 1.0) |
| 2 | batched q/k/v post-proc fusion | −1.97 ms | new prefill (M=S) variants of the decode `q_norm_rope` / `k_norm_rope` kernels — read the strided q/k/v slices in place (no contiguous copy) and write Q_buf/K_cache/V_cache in 2 launches; removes rms_norm×2 + torch RoPE×2 + 3 copies |
| 3 | boundary fusion | ~0 (cleanup) | fold residual_2 + next input_norm + quant into one `residual_add_rms_norm` per boundary (mirror decode); removes a torch.add |
| 4 | FP8 lm_head | −0.38 ms | per-tensor fp8 e4m3 lm_head weight + `ht_gemv_fp8_m1` for the eager M=1 prefill lm_head (half the bf16 weight BW); next-token argmax matches HF as well as bf16 |
| 5 | remove residual torch ops | — | lm_head act-quant torch chain → `quantize_fp8_device`; embed gather → `qwen36_embedding_lookup_bf16`; final-norm stage-copy dropped |
| 6 | fuse last residual into final RMSNorm | — | the last layer (no next layer) fell back to `torch.add` — fuse residual_2 + final RMSNorm into one kernel → **zero aten kernels per prefill** |

## Correctness

- Per-layer kernel meta-verified vs fp32 reference (q/k post-proc cos 0.999999).
- Next-token argmax vs the original HF bf16 reference: fp8 lm_head 6/6 (bf16 5/6);
  24-prompt mismatch fp8 3 == bf16 4 — precision-equivalent.
- `full_logits` (spec-verify) path intact; eager + graph next-token identical.
- `tests/test_qwen3_vl_smoke.py` 11/11.

## Roofline status

GEMM is at **87 % of FP4 peak** (gate_up 99.8 %, down 88 %) — near roofline.
The remaining ~4 ms is non-GEMM; most is fused near-bandwidth kernels.

## Future work (TODO)

Two multi-day kernel levers remain (≈ −1.1 ms together, → ~9.8 ms):

- **silu / SwiGLU GEMM-epilogue megakernel (≈ −0.5 to −0.7 ms).** Today the
  gate_up GEMM (N=24576, 99.8 % peak) writes 25 MB bf16 to HBM and `silu_mul`
  reads it back — a 50 MB round-trip (0.76 ms). Fuse silu(gate)·up + fp4 quant
  into the gate_up epilogue so the output never lands in HBM. SwiGLU can't be a
  plain epilogue (gate/up live in different N-tiles); preferred path is an
  **interleaved gate/up weight layout** (gate[i]/up[i] adjacent → one CTA has
  both) + a custom fp4 epilogue. NB: the existing CUTLASS `cutlass_fp4_gemm_
  silu_aux` runtime-fails (aux-load EVT) — hand-write or use the 2-GEMM aux
  split (≈ −0.38 ms, half the round-trip). fp32 silu in-epilogue → precision-safe.

- **Low-occupancy fp4 GEMM for o_proj / qkv (≈ −0.5 ms, precision-safe).** At
  M=512 these are wave-quant under-filled (o_proj N=4096 → 128 CTA tiles / 170
  SMs = 0.75 wave → 74 %; qkv N=6144 → 59 %). The `widen` and `dn_streamk`
  variants both return cos=0 here (SF-layout incompatible) and are slower — no
  working alt kernel. Needs a new small-tile / split-K fp4 GEMM with correct SF
  handling. gate_up/down are already ≥ 88 %.

(Investigated and ruled out: SageAttention2 int8 attention — kernel is faster
but the per-layer int8-quant tax makes the graph ~tied at S≤1024, and real
Qwen3 K has massive per-channel outliers that NaN naive int8 without K-smoothing,
which isn't implemented. cutlass FMHA is SM100/110 only. FA2 bf16 stays.)
