### PR TITLE
Add SM89 Qwen3-VL FP8 path (8B + 2B)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,8 +133,8 @@ endif()
 #                              pi0.5 / groot need bf16. Default "fp16;bf16".
 set(FA2_ARCH_NATIVE_ONLY OFF CACHE BOOL
     "Only build FA2 for the detected arch (no sm_80/PTX fallback). ~66% faster build.")
-set(FA2_HDIMS "96;128;256" CACHE STRING
-    "Semicolon-separated FA2 head_dim instantiations to build. Shipped models use 96 and 256.")
+set(FA2_HDIMS "64;96;128;256" CACHE STRING
+    "Semicolon-separated FA2 head_dim instantiations to build. Qwen3-VL 2B vision uses 64; other shipped models use 96 and 256.")
 set(FA2_DTYPES "fp16;bf16" CACHE STRING
     "Semicolon-separated FA2 dtype instantiations to build. Pi0 uses fp16; pi0.5/groot use bf16.")
 
@@ -704,8 +704,8 @@ if(ENABLE_FA2)
   set(FA2_BUILT_HDIMS "")
   set(FA2_BUILT_DTYPES "")
   foreach(_hd IN LISTS FA2_HDIMS)
-    if(NOT _hd MATCHES "^(96|128|256)$")
-      message(FATAL_ERROR "FA2_HDIMS entry '${_hd}' not supported. Valid: 96, 128, 256.")
+    if(NOT _hd MATCHES "^(64|96|128|256)$")
+      message(FATAL_ERROR "FA2_HDIMS entry '${_hd}' not supported. Valid: 64, 96, 128, 256.")
     endif()
     list(APPEND FA2_BUILT_HDIMS ${_hd})
     foreach(_dt IN LISTS FA2_DTYPES)
@@ -714,8 +714,15 @@ if(ENABLE_FA2)
       endif()
       list(APPEND FA2_SRCS
         ${FA2_SRC_ROOT}/flash_fwd_hdim${_hd}_${_dt}_sm80.cu
-        ${FA2_SRC_ROOT}/flash_fwd_split_hdim${_hd}_${_dt}_sm80.cu
       )
+      # hdim64 (Qwen3-VL 2B vision full attention) always takes the no-split
+      # path, so skip its split-KV specialization -- that variant is unused
+      # and one of the most expensive objects for ptxas.
+      if(NOT _hd STREQUAL "64")
+        list(APPEND FA2_SRCS
+          ${FA2_SRC_ROOT}/flash_fwd_split_hdim${_hd}_${_dt}_sm80.cu
+        )
+      endif()
     endforeach()
   endforeach()
   foreach(_dt IN LISTS FA2_DTYPES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1099,6 +1099,17 @@ if(GPU_ARCH STREQUAL "120")
     ENABLE_CUTLASS_SM120_BLOCK_FP8=1)
 endif()
 
+# Native Ada (sm_89) block-scaled FP8 GEMM for official Qwen3-VL FP8 prefill.
+# Ada has no TMA / no warp-specialized CUTLASS collective, so this is a
+# hand-written cp.async + ldmatrix + block-128 scaling MMA kernel (see
+# docs/qwen3_vl_fp8_sm89.md for why the SM120a CUTLASS path does not port).
+if(GPU_ARCH STREQUAL "89")
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/gemm/fp8_block128_gemm_mma_sm89.cu)
+  target_compile_definitions(flash_rt_kernels PRIVATE
+    ENABLE_SM89_BLOCK_FP8_GEMM=1)
+endif()
+
 # Dedicated M=1 decode GEMV (FP8 + BF16); linked + macro defined wherever the
 # object is built (sm89 / sm120) so the ENABLE_DECODE_GEMV_M1 bindings always
 # resolve, independent of FLASHRT_ENABLE_MOTUS.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,18 +887,36 @@ endif()
 #     from flash_rt import flash_rt_qwen3_vl_kernels as vlk
 #     vlk.rope_neox_qk_bf16(...)
 if(FLASHRT_BUILD_QWEN3_VL)
-  # The Qwen3-VL path depends on the SM120 Qwen3 NVFP4 / FP8 block-128
-  # kernels, so this module only builds for RTX 5090 (sm_120).
-  if(NOT GPU_ARCH STREQUAL "120")
+  # SM120 (RTX 5090): NVFP4/FP8 ViT helpers. SM89 (Ada): native FP8 block-128
+  # GEMM/GEMV + fused act/norm-quant + QK norm-rope kernels for the official
+  # FP8 Qwen3-VL path. Both build into the same separate module so neither
+  # bloats the central flash_rt_kernels.so.
+  if(NOT (GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89"))
     message(FATAL_ERROR
-      "FLASHRT_BUILD_QWEN3_VL requires GPU_ARCH=120 (RTX 5090 / sm_120); "
-      "got '${GPU_ARCH}'.")
+      "FLASHRT_BUILD_QWEN3_VL requires GPU_ARCH=120 (RTX 5090 / sm_120) or "
+      "GPU_ARCH=89 (Ada / sm_89); got '${GPU_ARCH}'.")
   endif()
-  pybind11_add_module(flash_rt_qwen3_vl_kernels
+  set(QWEN3_VL_SOURCES
     csrc/qwen3_vl_bindings.cpp
     csrc/kernels/rope_neox_qk_bf16.cu
     csrc/kernels/norm_act_to_fp8_block128.cu
     csrc/kernels/bias_epilogue_bf16.cu)
+  if(GPU_ARCH STREQUAL "89")
+    # Ada has no TMA / no warp-specialized CUTLASS collective, so these are
+    # hand-written cp.async + ldmatrix + block-128 scaling kernels (see
+    # docs/qwen3_vl_fp8_sm89.md for why the SM120a CUTLASS path does not port).
+    list(APPEND QWEN3_VL_SOURCES
+      csrc/gemm/fp8_block128_gemm_mma_sm89.cu
+      csrc/gemm/fp8_gemv_m1_sm89.cu
+      csrc/quantize/fp8_per_token_block_quant.cu
+      csrc/kernels/qwen3_qkv_post_proc.cu
+      csrc/kernels/bf16_matmul_qwen36.cu)
+  endif()
+  pybind11_add_module(flash_rt_qwen3_vl_kernels ${QWEN3_VL_SOURCES})
+  if(GPU_ARCH STREQUAL "89")
+    target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
+      ENABLE_SM89_BLOCK_FP8_GEMM=1)
+  endif()
   set_target_properties(flash_rt_qwen3_vl_kernels PROPERTIES
     CUDA_STANDARD 17
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt
@@ -914,6 +932,10 @@ if(FLASHRT_BUILD_QWEN3_VL)
       ${GPU_GENCODE}
     >)
   target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cudart)
+  if(GPU_ARCH STREQUAL "89")
+    # bf16_matmul_qwen36 (ViT bf16 linears on SM89) uses cuBLASLt.
+    target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cublasLt)
+  endif()
   install(TARGETS flash_rt_qwen3_vl_kernels
     DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
   message(STATUS "Qwen3-VL pybind module: flash_rt_qwen3_vl_kernels (separate .so)")
@@ -1097,17 +1119,6 @@ if(GPU_ARCH STREQUAL "120")
     $<TARGET_OBJECTS:sm120_fp8_smallm_obj>)
   target_compile_definitions(flash_rt_kernels PRIVATE
     ENABLE_CUTLASS_SM120_BLOCK_FP8=1)
-endif()
-
-# Native Ada (sm_89) block-scaled FP8 GEMM for official Qwen3-VL FP8 prefill.
-# Ada has no TMA / no warp-specialized CUTLASS collective, so this is a
-# hand-written cp.async + ldmatrix + block-128 scaling MMA kernel (see
-# docs/qwen3_vl_fp8_sm89.md for why the SM120a CUTLASS path does not port).
-if(GPU_ARCH STREQUAL "89")
-  target_sources(flash_rt_kernels PRIVATE
-    csrc/gemm/fp8_block128_gemm_mma_sm89.cu)
-  target_compile_definitions(flash_rt_kernels PRIVATE
-    ENABLE_SM89_BLOCK_FP8_GEMM=1)
 endif()
 
 # Dedicated M=1 decode GEMV (FP8 + BF16); linked + macro defined wherever the

--- a/csrc/attention/fa2_wrapper.cu
+++ b/csrc/attention/fa2_wrapper.cu
@@ -192,7 +192,15 @@ static void dispatch_hdim(int head_dim, int num_splits,
         }
     };
     (void)do_dispatch;  // silence unused warning when all hdims are gated out
-    if (head_dim > 0 && head_dim <= 96) {
+    if (head_dim > 0 && head_dim <= 64 && num_splits <= 1) {
+        // hd64 (Qwen3-VL 2B vision) builds only the no-split path; any
+        // split-KV request falls through to the hd96 bucket below.
+#ifdef FA2_HAS_HDIM_64
+        do_dispatch(std::integral_constant<int, 64>{});
+#else
+        fa2_not_built("head_dim<=64", head_dim);
+#endif
+    } else if (head_dim > 0 && head_dim <= 96) {
 #ifdef FA2_HAS_HDIM_96
         do_dispatch(std::integral_constant<int, 96>{});
 #else
@@ -213,7 +221,7 @@ static void dispatch_hdim(int head_dim, int num_splits,
     } else {
         fprintf(stderr,
             "fvk_attention_fa2_fwd: unsupported head_dim=%d "
-            "(supported buckets: <=96, <=128, <=256).\n", head_dim);
+            "(supported buckets: <=64, <=96, <=128, <=256).\n", head_dim);
         std::abort();
     }
 }

--- a/csrc/attention/flash_attn_2_src/flash_attn/flash_fwd_hdim64_bf16_sm80.cu
+++ b/csrc/attention/flash_attn_2_src/flash_attn/flash_fwd_hdim64_bf16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::bfloat16_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim64<cutlass::bfloat16_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/attention/flash_attn_2_src/flash_attn/flash_fwd_hdim64_fp16_sm80.cu
+++ b/csrc/attention/flash_attn_2_src/flash_attn/flash_fwd_hdim64_fp16_sm80.cu
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, Tri Dao.
+// Splitting the different head dimensions to different files to speed up compilation.
+// This file is auto-generated. See "generate_kernels.py"
+#include "namespace_config.h"
+#include "flash_fwd_launch_template.h"
+
+namespace FLASH_NAMESPACE {
+
+template<>
+void run_mha_fwd_<cutlass::half_t, 64, false>(Flash_fwd_params &params, cudaStream_t stream) {
+    run_mha_fwd_hdim64<cutlass::half_t, false>(params, stream);
+}
+
+} // namespace FLASH_NAMESPACE

--- a/csrc/attention/flash_attn_2_src/flash_attn/flash_fwd_launch_template.h
+++ b/csrc/attention/flash_attn_2_src/flash_attn/flash_fwd_launch_template.h
@@ -206,19 +206,26 @@ void run_mha_fwd_hdim32(Flash_fwd_params &params, cudaStream_t stream) {
 template<typename T, bool Is_causal>
 void run_mha_fwd_hdim64(Flash_fwd_params &params, cudaStream_t stream) {
     constexpr static int Headdim = 64;
+    auto [cc_major, cc_minor] = get_compute_capability(get_current_device());
+    bool is_sm8x = cc_major == 8 && cc_minor > 0;
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         if constexpr(!Is_dropout) {
             // Using 8 warps is 18% slower for seqlen=2k, 2 warps is 5% slower
             // Using block size (64 x 256) is 27% slower for seqlen=2k
             // Using block size (256 x 64) is 85% slower for seqlen=2k, because of register spilling
-            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-            // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
-            // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
+            //
+            // Qwen3-VL 2B vision runs non-causal full attention over S=6256
+            // patches. A standalone tile sweep at that shape on Ada gives
+            // 128x64 = 1.185 ms vs 128x128 = 1.216 ms vs 128x32 = 1.241 ms
+            // (benchmarks/sm89_vision_attn), so use 128x64 for sm8x non-causal.
+            // Keep the upstream 128x128 default for causal / non-SM8x.
+            if (is_sm8x && !Is_causal) {
+                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            } else {
+                run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            }
         } else {
             run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
-            // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, true, T>, Is_dropout, Is_causal>(params, stream);
-            // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 64, 4, true, false, T>, Is_dropout, Is_causal>(params, stream);
-            // run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 128, 128, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         }
     });
 }

--- a/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
+++ b/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Native Ada (sm_89) FP8 e4m3 -> BF16 block-128 scaled GEMM.
+// Header: fp8_block128_gemm_mma_sm89.cuh.
+//
+// Adapted from csrc/gemm/fp8_smallM_handtuned_sm120.cu (same cp.async
+// pipeline + m16n8k32 MMA tiling). Two sm_89-specific changes vs that file:
+//   1. MMA uses the plain Ada FP8 op `mma.sync.aligned.m16n8k32.row.col.
+//      f32.e4m3.e4m3.f32` (no `.kind::f8f6f4`, which is sm_120a-only).
+//   2. Per-tensor `alpha` is replaced by DeepSeek-style block-128 scaling:
+//      BLOCK_K is pinned to 128 so each K-iteration is exactly one scale
+//      block. Each k-iter accumulates into a temp, then folds
+//      act_scale[row,kb] * w_scale[n/128,kb] into the running accumulator.
+//
+// This reads the FP8 weight directly (no dequant-to-bf16 scratch), cutting
+// per-linear weight traffic ~5x vs fp8_block128_gemm_descale_bf16out while
+// keeping the per-token activation scale (no precision downgrade).
+
+#include "fp8_block128_gemm_mma_sm89.cuh"
+// Device-side kernel body. Shared verbatim with the standalone micro-bench
+// (benchmarks/sm89_fp8_block128_gemm), so the bench's `--mode baseline` runs
+// this exact kernel and cannot drift behind production.
+#include "fp8_bs_gemm_device.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <stdexcept>
+
+namespace flash_rt {
+namespace gemm {
+namespace block128_sm89 {
+
+namespace {
+
+template <int BM, int BN, int W, int STAGES, int MIN_BLK>
+int launch_(const void* A, const void* B, void* D,
+            int M, int N, int K, const float* act_scale,
+            const float* w_scale, cudaStream_t s)
+{
+    constexpr int BK = 128;
+    constexpr int SCALE_KTILE = 8;
+    int grid_m = (M + BM - 1) / BM;
+    int grid_n = (N + BN - 1) / BN;
+    dim3 grid(grid_m, grid_n, 1);
+    dim3 block(W * 32, 1, 1);
+    // Swizzled A/B cp.async stages (no pad) + staged scale tile.
+    int smem_bytes = STAGES * (BM + BN) * BK
+                   + (BM * SCALE_KTILE + SCALE_KTILE) * (int)sizeof(float);
+    if (smem_bytes > 48 * 1024) {
+        cudaFuncSetAttribute(
+            (const void*)&fp8_bs_gemm_kernel<BM, BN, W, STAGES, MIN_BLK>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+    }
+    fp8_bs_gemm_kernel<BM, BN, W, STAGES, MIN_BLK><<<grid, block, smem_bytes, s>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        act_scale, w_scale,
+        reinterpret_cast<__nv_bfloat16*>(D),
+        M, N, K);
+    cudaError_t err = cudaGetLastError();
+    return (err == cudaSuccess) ? 0 : 1;
+}
+
+}  // namespace
+
+#define DEFINE(NAME, BM, BN, W, S, MB)                                        \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,        \
+           const float* act_scale, const float* w_scale, cudaStream_t s) {    \
+    return launch_<BM, BN, W, S, MB>(A, B, D, M, N, K, act_scale, w_scale, s);\
+  }
+
+DEFINE(fp8_block128_gemm_bs_sm89_32x128x128_w4,   32, 128, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_64x128x128_w4,   64, 128, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_64x128x128_w8,   64, 128, 8, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_128x128x128_w4, 128, 128, 4, 2, 2)
+DEFINE(fp8_block128_gemm_bs_sm89_128x128x128_w8, 128, 128, 8, 2, 2)
+DEFINE(fp8_block128_gemm_bs_sm89_32x64x128_w4,    32,  64, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_64x64x128_w4,    64,  64, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_128x64x128_w4,  128,  64, 4, 2, 2)
+DEFINE(fp8_block128_gemm_bs_sm89_16x128x128_w4,   16, 128, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_16x64x128_w4,    16,  64, 4, 2, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_32x128x128_w4_s1, 32, 128, 4, 1, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_64x64x128_w4_s1,  64,  64, 4, 1, 4)
+DEFINE(fp8_block128_gemm_bs_sm89_128x128x128_w8_s1, 128, 128, 8, 1, 2)
+
+#undef DEFINE
+
+int fp8_block128_gemm_blockscaled_sm89_bf16out(
+    const void* A, const void* B, void* D, int M, int N, int K,
+    const float* act_scale, const float* w_scale, cudaStream_t stream)
+{
+    if ((N % 128) != 0)
+        throw std::runtime_error(
+            "fp8_block128_gemm_blockscaled_sm89_bf16out requires N multiple of 128");
+    if ((K % 128) != 0)
+        throw std::runtime_error(
+            "fp8_block128_gemm_blockscaled_sm89_bf16out requires K multiple of 128");
+    // Tuned on 4090 over Qwen3-VL-8B-FP8 layer shapes (qkv 6144, o 4096,
+    // gate/up 12288, down 4096x12288) at S=79..256. BLOCK_M=32 keeps grid
+    // occupancy high at small M; BLOCK_N=64 wins until M crosses ~128, then
+    // the wider BLOCK_N=128 amortizes better. Tiny-N (<2048) prefers BLOCK_N=64.
+    //
+    // ViT prefill is a different regime: full-res FlashRT.png runs M=6256.
+    // On these large-M shapes the language-prefill heuristic is wrong for
+    // the small-N linears:
+    //   - patch_embed / proj   (N=1152, K≈1152..1536) prefer 32x128
+    //   - fc2 / merger-fc2     (N=1152, K>=4096)      prefer 64x64
+    // Keep the original small-M path intact and only branch once the grid is
+    // already abundant (M>=2048), so text prefill / decode remain unchanged.
+    if (N < 2048)
+    {
+        if (M >= 2048) {
+            if (K >= 4096)
+                return fp8_block128_gemm_bs_sm89_64x64x128_w4(
+                    A, B, D, M, N, K, act_scale, w_scale, stream);
+            return fp8_block128_gemm_bs_sm89_32x128x128_w4(
+                A, B, D, M, N, K, act_scale, w_scale, stream);
+        }
+        return fp8_block128_gemm_bs_sm89_16x64x128_w4(
+            A, B, D, M, N, K, act_scale, w_scale, stream);
+    }
+    if (M < 128)
+        return fp8_block128_gemm_bs_sm89_32x64x128_w4(
+            A, B, D, M, N, K, act_scale, w_scale, stream);
+    // Language prefill (M>=128, N>=2048) is limited by low eligible warps on
+    // Ada. A single cp.async stage reduces shared-memory pressure and wins on
+    // Qwen3-VL 2B/8B prefill shapes. Keep a short-prefill exception for the
+    // wide 8B MLP, where the 8-warp tile remains slightly faster.
+    if (N >= 8192 && K == 4096 && M < 1024)
+        return fp8_block128_gemm_bs_sm89_128x128x128_w8_s1(
+            A, B, D, M, N, K, act_scale, w_scale, stream);
+    if (N == 2048 && M < 1024)
+        return fp8_block128_gemm_bs_sm89_64x64x128_w4(
+            A, B, D, M, N, K, act_scale, w_scale, stream);
+    return fp8_block128_gemm_bs_sm89_64x64x128_w4_s1(
+        A, B, D, M, N, K, act_scale, w_scale, stream);
+}
+
+}  // namespace block128_sm89
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_block128_gemm_mma_sm89.cuh
+++ b/csrc/gemm/fp8_block128_gemm_mma_sm89.cuh
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace gemm {
+namespace block128_sm89 {
+
+// Native Ada (sm_89) FP8 e4m3 -> BF16 block-128 scaled GEMM.
+//
+// Computes D_rm[M,N] = (act_fp8 @ w_fp8^T) with DeepSeek-style block-128
+// scaling applied in the mainloop:
+//   D[m,n] = sum_{kb} act_scale[m, kb] * w_scale[n/128, kb]
+//                     * sum_{k in kb} A[m,k] * B[n,k]
+//
+// Inputs (all device pointers):
+//   A         : [M, K]        FP8 e4m3 row-major   (per-token quantized act)
+//   B         : [N, K]        FP8 e4m3 row-major   (= W, ckpt weight)
+//   act_scale : [M, K/128]    fp32 row-major       (per-token block scale)
+//   w_scale   : [N/128, K/128] fp32 row-major      (weight_scale_inv)
+//   D         : [M, N]        BF16 row-major
+//
+// Drop-in replacement for fp8_block128_gemm_descale_bf16out but reads the
+// FP8 weight directly (no dequant scratch). K and N must be multiples of 128.
+// Returns 0 on success.
+
+#define DECL(NAME)                                                            \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,        \
+           const float* act_scale, const float* w_scale, cudaStream_t stream)
+
+DECL(fp8_block128_gemm_bs_sm89_32x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_64x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_64x128x128_w8);
+DECL(fp8_block128_gemm_bs_sm89_128x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_128x128x128_w8);
+DECL(fp8_block128_gemm_bs_sm89_32x64x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_64x64x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_128x64x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_16x128x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_16x64x128_w4);
+DECL(fp8_block128_gemm_bs_sm89_32x128x128_w4_s1);
+DECL(fp8_block128_gemm_bs_sm89_64x64x128_w4_s1);
+DECL(fp8_block128_gemm_bs_sm89_128x128x128_w8_s1);
+
+#undef DECL
+
+// Auto-dispatch over the tuned tile set above based on (M, N, K).
+int fp8_block128_gemm_blockscaled_sm89_bf16out(
+    const void* A, const void* B, void* D, int M, int N, int K,
+    const float* act_scale, const float* w_scale, cudaStream_t stream);
+
+}  // namespace block128_sm89
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_bs_gemm_device.cuh
+++ b/csrc/gemm/fp8_bs_gemm_device.cuh
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+// Shared device-side implementation of the SM89 FP8 block-128 scaled GEMM
+// kernel. This header is the single source of truth for the kernel body: both
+// the production launcher (fp8_block128_gemm_mma_sm89.cu) and the standalone
+// micro-benchmark (benchmarks/sm89_fp8_block128_gemm) include it, so the
+// bench's `--mode baseline` runs the *exact* production kernel and cannot
+// drift behind it. When experimenting, copy this kernel into the bench's
+// candidate slot and edit there; once an experiment is accepted and folded
+// back here, the bench baseline tracks it automatically.
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt {
+namespace gemm {
+namespace block128_sm89 {
+
+__device__ __forceinline__ void mma_m16n8k32_e4m3(
+    float &d0, float &d1, float &d2, float &d3,
+    uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
+    uint32_t b0, uint32_t b1)
+{
+    // Ada (sm_89) FP8 tensor-core op — NO .kind::f8f6f4 qualifier.
+    asm volatile(
+        "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+        "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+        : "+f"(d0), "+f"(d1), "+f"(d2), "+f"(d3)
+        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1));
+}
+
+__device__ __forceinline__ void cp_async_16(uint32_t smem, const uint8_t* src) {
+    int b = (src == nullptr) ? 0 : 16;
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 16, %2;\n"
+                 :: "r"(smem), "l"(src), "r"(b));
+}
+
+__device__ __forceinline__ uint32_t to_smem(const void* p) {
+    return static_cast<uint32_t>(__cvta_generic_to_shared(p));
+}
+
+// True when the adjacent output column pair {c, c+1} is fully in bounds, so a
+// 32-bit bfloat162 store is valid. n_pair_base is even (=...+2*l) and N is a
+// multiple of 128, so &D[row*N + c] is 4-byte aligned for the vector store.
+__device__ __forceinline__ bool col_pair_ok(int c, int N) {
+    return c + 1 < N;
+}
+
+// ldmatrix.x4: load four 8x8 b16 fragments from smem into 4 registers/lane in
+// one instruction, replacing 4 scalar 32-bit LDS to offload the LSU pipe
+// (NCU on the scalar path: LSU 67.7%, 54.7M shared loads = 27% of all insts).
+__device__ __forceinline__ void ldmatrix_x4_b16(
+    uint32_t &d0, uint32_t &d1, uint32_t &d2, uint32_t &d3, uint32_t smem_addr)
+{
+    asm volatile(
+        "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+        : "=r"(d0), "=r"(d1), "=r"(d2), "=r"(d3)
+        : "r"(smem_addr));
+}
+
+// BLOCK_K is pinned to 128 (one DeepSeek scale block per K-iteration).
+//  - A: [M, K] row-major FP8 e4m3, act_scale [M, K/128] fp32
+//  - B: [N, K] row-major FP8 e4m3, w_scale [N/128, K/128] fp32
+//  - D: [M, N] row-major BF16
+//  - BLOCK_N must keep each warp's 8-wide N-atoms inside one 128 scale block.
+template <int BLOCK_M, int BLOCK_N, int NUM_WARPS, int STAGES,
+          int MIN_BLOCKS_PER_SM>
+__global__ __launch_bounds__(NUM_WARPS * 32, MIN_BLOCKS_PER_SM)
+void fp8_bs_gemm_kernel(
+    const __nv_fp8_e4m3* __restrict__ A,
+    const __nv_fp8_e4m3* __restrict__ B,
+    const float* __restrict__ act_scale,   // [M, K/128]
+    const float* __restrict__ w_scale,     // [N/128, K/128]
+    __nv_bfloat16* __restrict__ D,
+    int M, int N, int K)
+{
+    constexpr int BLOCK_K    = 128;
+    constexpr int THREADS    = NUM_WARPS * 32;
+    constexpr int M_ATOMS    = BLOCK_M / 16;
+    constexpr int N_ATOMS    = BLOCK_N / 8;
+    constexpr int N_ATOMS_PW = N_ATOMS / NUM_WARPS;
+    constexpr int N_PAIRS_PW = N_ATOMS_PW / 2;      // ldmatrix pairs 2 N-atoms
+    constexpr int K_ATOMS    = BLOCK_K / 32;        // = 4
+    constexpr int NUM_CHUNKS_PER_ROW = BLOCK_K / 16;  // 8 chunks of 16 bytes
+    // 128B swizzle: chunk_sw = chunk ^ (row & SWIZZLE_MASK). Removes the old
+    // SMEM_K_PAD and the bank conflicts; applied identically on cp.async store
+    // and ldmatrix load so the round-trip is bit-exact.
+    constexpr int SWIZZLE_MASK = NUM_CHUNKS_PER_ROW - 1;  // = 7
+
+    static_assert(BLOCK_M % 16 == 0, "BLOCK_M multiple of 16");
+    static_assert(BLOCK_N % 8 == 0,  "BLOCK_N multiple of 8");
+    static_assert(BLOCK_N <= 128, "one CTA must fit one N scale block");
+    static_assert((BLOCK_N / 8) % NUM_WARPS == 0, "N-atoms split across warps");
+    static_assert(N_ATOMS_PW >= 2 && N_ATOMS_PW % 2 == 0,
+                  "ldmatrix pairs 2 N-atoms: N_ATOMS_PW must be even >= 2");
+
+    // Stage the per-CTA activation/weight scales in shared memory with a
+    // coalesced load, so the per-k_iter scale fold reads smem instead of
+    // row-strided scalar global loads (NCU's top global-load bottleneck).
+    // Only SCALE_KTILE scale-block columns are staged at a time, re-staged on
+    // each k-tile boundary, so the smem footprint is K-independent (~2 KB) and
+    // occupancy does not regress on large-K shapes (e.g. down, K128=96).
+    constexpr int SCALE_KTILE = 8;
+    constexpr int A_TILE = BLOCK_M * BLOCK_K;       // swizzled, no pad
+    constexpr int B_TILE = BLOCK_N * BLOCK_K;
+
+    extern __shared__ uint8_t smem_raw[];
+    uint8_t* A_smem = smem_raw;
+    uint8_t* B_smem = A_smem + STAGES * A_TILE;
+    float* as_smem = reinterpret_cast<float*>(B_smem + STAGES * B_TILE);
+    float* ws_smem = as_smem + BLOCK_M * SCALE_KTILE;
+
+    const int cta_m = blockIdx.x;
+    const int cta_n = blockIdx.y;
+    const int m_base = cta_m * BLOCK_M;
+    const int n_base = cta_n * BLOCK_N;
+
+    const int t = threadIdx.x;
+    const int warp_id = t / 32;
+    const int lane = t % 32;
+    const int l = lane % 4;
+    const int h = lane / 4;
+    // ldmatrix.x4 lane -> fragment partition.
+    const int frag_group = lane / 8;       // 0..3 (TL,TR,BL,BR)
+    const int row_in_frag = lane % 8;      // row within an 8x8 fragment
+    const int row_block = frag_group / 2;  // top(0)/bottom(1) 8 rows
+    const int col_block = frag_group % 2;  // left(0)/right(1) 16-byte chunk
+
+    const int K128 = K >> 7;                        // # scale blocks along K
+
+    // Coalesced staging of one SCALE_KTILE-wide scale block into smem.
+    auto stage_scales = [&](int kb0) {
+        const int as_total = BLOCK_M * SCALE_KTILE;
+        for (int idx = t; idx < as_total; idx += THREADS) {
+            int r = idx / SCALE_KTILE;
+            int kc = idx - r * SCALE_KTILE;
+            int row = m_base + r;
+            int kb = kb0 + kc;
+            as_smem[idx] = (row < M && kb < K128)
+                ? act_scale[(size_t)row * K128 + kb] : 0.0f;
+        }
+        for (int kc = t; kc < SCALE_KTILE; kc += THREADS) {
+            int kb = kb0 + kc;
+            ws_smem[kc] = (kb < K128)
+                ? w_scale[(size_t)(n_base >> 7) * K128 + kb] : 0.0f;
+        }
+        __syncthreads();
+    };
+
+    auto issue_load = [&](int stage, int k_base) {
+        constexpr int A_CHUNKS = BLOCK_M * NUM_CHUNKS_PER_ROW;
+        constexpr int A_ITERS = (A_CHUNKS + THREADS - 1) / THREADS;
+        #pragma unroll
+        for (int it = 0; it < A_ITERS; ++it) {
+            int idx = it * THREADS + t;
+            if (idx >= A_CHUNKS) break;
+            int row_a = idx / NUM_CHUNKS_PER_ROW;
+            int chunk_a = idx % NUM_CHUNKS_PER_ROW;
+            int m_glob = m_base + row_a;
+            int k_glob = k_base + chunk_a * 16;
+            const uint8_t* a_src = nullptr;
+            if (m_glob < M && k_glob < K) {
+                a_src = reinterpret_cast<const uint8_t*>(&A[(size_t)m_glob * K + k_glob]);
+            }
+            int csw = chunk_a ^ (row_a & SWIZZLE_MASK);
+            cp_async_16(
+                to_smem(&A_smem[stage * A_TILE + row_a * BLOCK_K + csw * 16]),
+                a_src);
+        }
+        constexpr int B_CHUNKS = BLOCK_N * NUM_CHUNKS_PER_ROW;
+        constexpr int B_ITERS = (B_CHUNKS + THREADS - 1) / THREADS;
+        #pragma unroll
+        for (int it = 0; it < B_ITERS; ++it) {
+            int idx = it * THREADS + t;
+            if (idx >= B_CHUNKS) break;
+            int row_b = idx / NUM_CHUNKS_PER_ROW;
+            int chunk_b = idx % NUM_CHUNKS_PER_ROW;
+            int n_glob = n_base + row_b;
+            int k_glob = k_base + chunk_b * 16;
+            const uint8_t* b_src = nullptr;
+            if (n_glob < N && k_glob < K) {
+                b_src = reinterpret_cast<const uint8_t*>(&B[(size_t)n_glob * K + k_glob]);
+            }
+            int csw = chunk_b ^ (row_b & SWIZZLE_MASK);
+            cp_async_16(
+                to_smem(&B_smem[stage * B_TILE + row_b * BLOCK_K + csw * 16]),
+                b_src);
+        }
+    };
+
+    // Running (scaled) accumulators across all K-blocks.
+    float acc[M_ATOMS][N_ATOMS_PW][4];
+    #pragma unroll
+    for (int mi = 0; mi < M_ATOMS; ++mi)
+        #pragma unroll
+        for (int ni = 0; ni < N_ATOMS_PW; ++ni)
+            #pragma unroll
+            for (int j = 0; j < 4; ++j) acc[mi][ni][j] = 0.0f;
+
+    const int K_ITERS = (K + BLOCK_K - 1) / BLOCK_K;
+    #pragma unroll
+    for (int s = 0; s < STAGES - 1; ++s) {
+        int kb = s * BLOCK_K;
+        if (kb < K) issue_load(s, kb);
+        asm volatile("cp.async.commit_group;\n" ::);
+    }
+
+    int compute_stage = 0;
+    for (int k_iter = 0; k_iter < K_ITERS; ++k_iter) {
+        int issue_iter = k_iter + (STAGES - 1);
+        int issue_stage = issue_iter % STAGES;
+        if (issue_iter < K_ITERS) issue_load(issue_stage, issue_iter * BLOCK_K);
+        asm volatile("cp.async.commit_group;\n" ::);
+        asm volatile("cp.async.wait_group %0;\n" :: "n"(STAGES - 1));
+        __syncthreads();
+
+        // This k_iter is exactly one scale block (kb = k_iter).
+        const int kb = k_iter;
+        // Re-stage the next SCALE_KTILE-wide scale block on each tile boundary.
+        if ((kb % SCALE_KTILE) == 0) stage_scales(kb);
+        // w_scale is constant across this CTA's BLOCK_N if it fits one
+        // 128 block; index per warp's N base to stay correct for BLOCK_N>128.
+        float tacc[M_ATOMS][N_ATOMS_PW][4];
+        #pragma unroll
+        for (int mi = 0; mi < M_ATOMS; ++mi)
+            #pragma unroll
+            for (int ni = 0; ni < N_ATOMS_PW; ++ni)
+                #pragma unroll
+                for (int j = 0; j < 4; ++j) tacc[mi][ni][j] = 0.0f;
+
+        uint8_t* A_stage = A_smem + compute_stage * A_TILE;
+        uint8_t* B_stage = B_smem + compute_stage * B_TILE;
+        #pragma unroll
+        for (int ka = 0; ka < K_ATOMS; ++ka) {
+            // ldmatrix.x4 loads the m16xk32 A fragment (4 regs/lane) per m-atom.
+            uint32_t A_regs[M_ATOMS][4];
+            #pragma unroll
+            for (int mi = 0; mi < M_ATOMS; ++mi) {
+                int row = mi * 16 + row_block * 8 + row_in_frag;
+                int chunk = 2 * ka + col_block;
+                int csw = chunk ^ (row & SWIZZLE_MASK);
+                ldmatrix_x4_b16(A_regs[mi][0], A_regs[mi][1], A_regs[mi][2], A_regs[mi][3],
+                                to_smem(&A_stage[row * BLOCK_K + csw * 16]));
+            }
+            // ldmatrix.x4 loads two N-atoms (n16xk32) per pair.
+            uint32_t B_regs[N_PAIRS_PW][4];
+            #pragma unroll
+            for (int np = 0; np < N_PAIRS_PW; ++np) {
+                int nrow = warp_id * N_ATOMS_PW * 8 + np * 16 + row_block * 8 + row_in_frag;
+                int chunk = 2 * ka + col_block;
+                int csw = chunk ^ (nrow & SWIZZLE_MASK);
+                ldmatrix_x4_b16(B_regs[np][0], B_regs[np][1], B_regs[np][2], B_regs[np][3],
+                                to_smem(&B_stage[nrow * BLOCK_K + csw * 16]));
+            }
+            #pragma unroll
+            for (int mi = 0; mi < M_ATOMS; ++mi) {
+                #pragma unroll
+                for (int np = 0; np < N_PAIRS_PW; ++np) {
+                    int ni0 = np * 2, ni1 = np * 2 + 1;
+                    // ldm fragment -> mma A operand: a0=d0,a1=d2,a2=d1,a3=d3.
+                    mma_m16n8k32_e4m3(
+                        tacc[mi][ni0][0], tacc[mi][ni0][1], tacc[mi][ni0][2], tacc[mi][ni0][3],
+                        A_regs[mi][0], A_regs[mi][2], A_regs[mi][1], A_regs[mi][3],
+                        B_regs[np][0], B_regs[np][1]);
+                    mma_m16n8k32_e4m3(
+                        tacc[mi][ni1][0], tacc[mi][ni1][1], tacc[mi][ni1][2], tacc[mi][ni1][3],
+                        A_regs[mi][0], A_regs[mi][2], A_regs[mi][1], A_regs[mi][3],
+                        B_regs[np][2], B_regs[np][3]);
+                }
+            }
+        }
+
+        // Fold block scales: D += act_scale[row,kb] * w_scale[ncol/128,kb] * tacc
+        // Scales come from the smem stage (coalesced load above), indexed by
+        // the column within the current SCALE_KTILE tile. BLOCK_N <= 128 keeps
+        // the CTA inside one 128-column weight-scale block.
+        int kbt = kb % SCALE_KTILE;
+        float ws_cta = ws_smem[kbt];
+        #pragma unroll
+        for (int mi = 0; mi < M_ATOMS; ++mi) {
+            int row0 = m_base + mi * 16 + h;
+            int row1 = row0 + 8;
+            float as0 = as_smem[(mi * 16 + h) * SCALE_KTILE + kbt];
+            float as1 = as_smem[(mi * 16 + h + 8) * SCALE_KTILE + kbt];
+            #pragma unroll
+            for (int ni = 0; ni < N_ATOMS_PW; ++ni) {
+                acc[mi][ni][0] += tacc[mi][ni][0] * (as0 * ws_cta);
+                acc[mi][ni][1] += tacc[mi][ni][1] * (as0 * ws_cta);
+                acc[mi][ni][2] += tacc[mi][ni][2] * (as1 * ws_cta);
+                acc[mi][ni][3] += tacc[mi][ni][3] * (as1 * ws_cta);
+            }
+        }
+        // Do not let the next cp.async overwrite this shared-memory stage
+        // before all warps finish reading it.
+        __syncthreads();
+        compute_stage = (compute_stage + 1) % STAGES;
+    }
+    asm volatile("cp.async.wait_all;\n" ::);
+
+    // Epilogue: write BF16. m16n8 layout: thread (h,l) -> rows {h,h+8},
+    // cols {2*l, 2*l+1}.
+    #pragma unroll
+    for (int mi = 0; mi < M_ATOMS; ++mi) {
+        int row0 = m_base + mi * 16 + h;
+        int row1 = row0 + 8;
+        #pragma unroll
+        for (int ni = 0; ni < N_ATOMS_PW; ++ni) {
+            int n_pair_base = n_base + warp_id * N_ATOMS_PW * 8 + ni * 8 + 2 * l;
+            // acc[0,1] = row0 cols {2l,2l+1}; acc[2,3] = row1 cols {2l,2l+1}.
+            // Emit one 32-bit bfloat162 store per row instead of two scalar
+            // 16-bit stores (NCU's top store-pattern bottleneck after C1).
+            // Tail (odd last column) falls back to scalar stores.
+            if (row0 < M && col_pair_ok(n_pair_base, N)) {
+                *reinterpret_cast<__nv_bfloat162*>(&D[(size_t)row0 * N + n_pair_base]) =
+                    __floats2bfloat162_rn(acc[mi][ni][0], acc[mi][ni][1]);
+            } else if (row0 < M) {
+                if (n_pair_base < N)     D[(size_t)row0 * N + n_pair_base]   = __float2bfloat16(acc[mi][ni][0]);
+                if (n_pair_base + 1 < N) D[(size_t)row0 * N + n_pair_base+1] = __float2bfloat16(acc[mi][ni][1]);
+            }
+            if (row1 < M && col_pair_ok(n_pair_base, N)) {
+                *reinterpret_cast<__nv_bfloat162*>(&D[(size_t)row1 * N + n_pair_base]) =
+                    __floats2bfloat162_rn(acc[mi][ni][2], acc[mi][ni][3]);
+            } else if (row1 < M) {
+                if (n_pair_base < N)     D[(size_t)row1 * N + n_pair_base]   = __float2bfloat16(acc[mi][ni][2]);
+                if (n_pair_base + 1 < N) D[(size_t)row1 * N + n_pair_base+1] = __float2bfloat16(acc[mi][ni][3]);
+            }
+        }
+    }
+}
+
+}  // namespace block128_sm89
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_gemv_m1_sm89.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm89.cu
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// M=1 FP8 e4m3 -> BF16 block-128 scaled GEMV for SM89 Qwen3-VL decode.
+// Header: fp8_gemv_m1_sm89.cuh.
+//
+// Split out of the SM120 per-tensor GEMV (fp8_gemv_m1_sm120) so the SM89
+// block-128 decode path owns its own file: per-token activation scale
+// [K/128] and DeepSeek-style weight block scale [N/128, K/128], applied in
+// the warp reduction. Warp-per-output-row, A held in smem, 16-byte coalesced
+// B loads. No MMA / no padding tax (M=1).
+
+#include "fp8_gemv_m1_sm89.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt {
+namespace gemm {
+namespace gemv_m1_sm89 {
+
+namespace {
+
+template <int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+void gemv_fp8_block128_m1_kernel(
+    const __nv_fp8_e4m3* __restrict__ A,   // [K]
+    const __nv_fp8_e4m3* __restrict__ B,   // [N, K]
+    __nv_bfloat16* __restrict__ D,         // [N]
+    int N, int K,
+    const float* __restrict__ act_scale,   // [K/128]
+    const float* __restrict__ w_scale,     // [N/128, K/128]
+    float alpha)
+{
+    extern __shared__ __nv_fp8_e4m3 sA[];
+    const int tid     = threadIdx.x;
+    const int lane    = tid & 31;
+    const int warp    = tid >> 5;
+    const int threads = WARPS_PER_BLOCK * 32;
+    const int K16     = K >> 4;
+    const int K128    = K >> 7;
+
+    uint4* sA16 = reinterpret_cast<uint4*>(sA);
+    const uint4* A16 = reinterpret_cast<const uint4*>(A);
+    for (int i = tid; i < K16; i += threads) sA16[i] = A16[i];
+    __syncthreads();
+
+    const int n = blockIdx.x * WARPS_PER_BLOCK + warp;
+    if (n >= N) return;
+
+    const uint4* Brow = reinterpret_cast<const uint4*>(B) + (size_t)n * K16;
+    const __nv_fp8_e4m3* sAf = sA;
+    const float* w_scale_row = w_scale + (size_t)(n >> 7) * K128;
+    float acc = 0.0f;
+    for (int i = lane; i < K16; i += 32) {
+        const int kb = i >> 3;
+        const float s = act_scale[kb] * w_scale_row[kb] * alpha;
+        uint4 bpack = Brow[i];
+        const __nv_fp8_e4m3* bp =
+            reinterpret_cast<const __nv_fp8_e4m3*>(&bpack);
+        const __nv_fp8_e4m3* ap = sAf + (i << 4);
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            acc += float(ap[j]) * float(bp[j]) * s;
+        }
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    }
+    if (lane == 0) D[n] = __float2bfloat16(acc);
+}
+
+template <int W>
+int launch_block128_(const void* A, const void* B, void* D,
+                     int /*M*/, int N, int K,
+                     const float* act_scale, const float* w_scale,
+                     float alpha, cudaStream_t stream) {
+    dim3 grid((N + W - 1) / W);
+    dim3 block(W * 32);
+    size_t smem = (size_t)K * sizeof(__nv_fp8_e4m3);
+    gemv_fp8_block128_m1_kernel<W><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        reinterpret_cast<__nv_bfloat16*>(D),
+        N, K, act_scale, w_scale, alpha);
+    return 0;
+}
+
+}  // namespace
+
+#define DEFINE_BLOCK128(NAME, W)                                               \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,         \
+           const float* act_scale, const float* w_scale, float alpha,          \
+           cudaStream_t stream) {                                              \
+    return launch_block128_<W>(A, B, D, M, N, K, act_scale, w_scale, alpha,    \
+                               stream);                                        \
+  }
+
+DEFINE_BLOCK128(gemv_fp8_block128_m1_w4, 4)
+DEFINE_BLOCK128(gemv_fp8_block128_m1_w8, 8)
+DEFINE_BLOCK128(gemv_fp8_block128_m1_w16, 16)
+
+#undef DEFINE_BLOCK128
+
+}  // namespace gemv_m1_sm89
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/gemm/fp8_gemv_m1_sm89.cuh
+++ b/csrc/gemm/fp8_gemv_m1_sm89.cuh
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace gemm {
+namespace gemv_m1_sm89 {
+
+// M=1 FP8 e4m3 -> BF16 GEMV with per-token activation block scale [K/128] and
+// per-weight 128x128 block scale [N/128, K/128]. Matches official Qwen3-VL FP8
+// checkpoints that store `.weight` + `.weight_scale_inv`. Decode-shape sibling
+// of the M>1 fp8_block128_gemm_mma_sm89 kernel. Warp-per-output-row, A staged
+// in smem, 16-byte coalesced B loads. Returns 0 on success.
+#define DECL_BLOCK128(NAME) \
+  int NAME(const void* A, const void* B, void* D, \
+           int M, int N, int K, const float* act_scale, \
+           const float* w_scale, float alpha, cudaStream_t stream)
+
+DECL_BLOCK128(gemv_fp8_block128_m1_w4);
+DECL_BLOCK128(gemv_fp8_block128_m1_w8);
+DECL_BLOCK128(gemv_fp8_block128_m1_w16);
+
+#undef DECL_BLOCK128
+
+}  // namespace gemv_m1_sm89
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/kernels/bf16_matmul_qwen36.cu
+++ b/csrc/kernels/bf16_matmul_qwen36.cu
@@ -38,11 +38,45 @@ struct Ab96LtPlan {
     cublasLtMatmulAlgo_t algo{};
 };
 
+struct Bf16LtPlan {
+    cublasLtMatmulDesc_t desc = nullptr;
+    cublasLtMatrixLayout_t a_desc = nullptr;
+    cublasLtMatrixLayout_t b_desc = nullptr;
+    cublasLtMatrixLayout_t c_desc = nullptr;
+    cublasLtMatmulAlgo_t algo{};
+};
+
+struct Bf16LtKey {
+    int M;
+    int N;
+    int K;
+
+    bool operator==(const Bf16LtKey& other) const {
+        return M == other.M && N == other.N && K == other.K;
+    }
+};
+
+struct Bf16LtKeyHash {
+    size_t operator()(const Bf16LtKey& key) const {
+        size_t h = static_cast<size_t>(key.M);
+        h = h * 1315423911u + static_cast<size_t>(key.N);
+        h = h * 1315423911u + static_cast<size_t>(key.K);
+        return h;
+    }
+};
+
 static cublasLtHandle_t g_ab96_lt = nullptr;
 static void* g_ab96_workspace = nullptr;
 static size_t g_ab96_workspace_size = 16 * 1024 * 1024;
 static std::mutex g_ab96_mu;
 static std::unordered_map<int, Ab96LtPlan> g_ab96_plans;
+
+static cublasLtHandle_t g_bf16_lt = nullptr;
+static void* g_bf16_workspace = nullptr;
+static size_t g_bf16_workspace_size = 32 * 1024 * 1024;
+static std::mutex g_bf16_mu;
+static std::unordered_map<Bf16LtKey, Bf16LtPlan, Bf16LtKeyHash>
+    g_bf16_plans;
 
 static void ensure_ab96_lt() {
     if (g_ab96_lt) return;
@@ -51,6 +85,17 @@ static void ensure_ab96_lt() {
     if (err != cudaSuccess) {
         throw std::runtime_error(
             std::string("cudaMalloc failed for AB96 cuBLASLt workspace: ") +
+            cudaGetErrorString(err));
+    }
+}
+
+static void ensure_bf16_lt() {
+    if (g_bf16_lt) return;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtCreate(&g_bf16_lt));
+    cudaError_t err = cudaMalloc(&g_bf16_workspace, g_bf16_workspace_size);
+    if (err != cudaSuccess) {
+        throw std::runtime_error(
+            std::string("cudaMalloc failed for BF16 cuBLASLt workspace: ") +
             cudaGetErrorString(err));
     }
 }
@@ -108,6 +153,63 @@ static Ab96LtPlan& get_ab96_lt_plan(int M) {
     plan.algo = heuristic.algo;
 
     auto [inserted, _] = g_ab96_plans.emplace(M, plan);
+    return inserted->second;
+}
+
+static Bf16LtPlan& get_bf16_lt_plan(int M, int N, int K) {
+    std::lock_guard<std::mutex> lock(g_bf16_mu);
+    ensure_bf16_lt();
+    Bf16LtKey key{M, N, K};
+    auto it = g_bf16_plans.find(key);
+    if (it != g_bf16_plans.end()) return it->second;
+
+    Bf16LtPlan plan;
+    cublasOperation_t op_n = CUBLAS_OP_N;
+    cublasOperation_t op_t = CUBLAS_OP_T;
+    cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(
+        cublasLtMatmulDescCreate(&plan.desc, CUBLAS_COMPUTE_32F, CUDA_R_32F));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSA, &op_n, sizeof(op_n)));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSB, &op_t, sizeof(op_t)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.a_desc, CUDA_R_16BF, M, K, K));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.b_desc, CUDA_R_16BF, N, K, K));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.c_desc, CUDA_R_16BF, M, N, N));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    cublasLtMatmulPreference_t pref;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceCreate(&pref));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceSetAttribute(
+        pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &g_bf16_workspace_size, sizeof(g_bf16_workspace_size)));
+    cublasLtMatmulHeuristicResult_t heuristic;
+    int returned = 0;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulAlgoGetHeuristic(
+        g_bf16_lt, plan.desc, plan.a_desc, plan.b_desc,
+        plan.c_desc, plan.c_desc, pref, 1, &heuristic, &returned));
+    cublasLtMatmulPreferenceDestroy(pref);
+    if (returned == 0) {
+        throw std::runtime_error("cuBLASLt: no generic BF16 GEMM algorithm");
+    }
+    plan.algo = heuristic.algo;
+
+    auto [inserted, _] = g_bf16_plans.emplace(key, plan);
     return inserted->second;
 }
 
@@ -480,6 +582,26 @@ void bf16_matmul_qwen36_bf16(
         bf16_matmul_warp_kernel_generic
             <<<grid, kThreads, smem_bytes, stream>>>(x, W, out, M, N, K);
     }
+}
+
+void bf16_matmul_cublaslt_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M, int N, int K,
+    cudaStream_t stream) {
+    if (M <= 0 || N <= 0 || K <= 0) return;
+    Bf16LtPlan& plan = get_bf16_lt_plan(M, N, K);
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmul(
+        g_bf16_lt, plan.desc, &alpha,
+        x, plan.a_desc,
+        W, plan.b_desc,
+        &beta,
+        out, plan.c_desc,
+        out, plan.c_desc,
+        &plan.algo, g_bf16_workspace, g_bf16_workspace_size, stream));
 }
 
 void bf16_matmul_qwen36_ab96_bf16(

--- a/csrc/kernels/bf16_matmul_qwen36.cuh
+++ b/csrc/kernels/bf16_matmul_qwen36.cuh
@@ -39,6 +39,15 @@ void bf16_matmul_qwen36_bf16(
     int K,
     cudaStream_t stream);
 
+void bf16_matmul_cublaslt_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M,
+    int N,
+    int K,
+    cudaStream_t stream);
+
 void bf16_matmul_qwen36_ab96_bf16(
     const __nv_bfloat16* x,
     const __nv_bfloat16* W_ab,

--- a/csrc/kernels/qwen3_qkv_post_proc.cu
+++ b/csrc/kernels/qwen3_qkv_post_proc.cu
@@ -152,6 +152,136 @@ __global__ void k_norm_rope_kvwrite_kernel(
   v_cache_dst[head * HEAD_DIM + tid] = v_pre[head * HEAD_DIM + tid];
 }
 
+__global__ void qk_norm_rope_kvwrite_kernel(
+    const __nv_bfloat16* __restrict__ q_pre,
+    const __nv_bfloat16* __restrict__ k_pre,
+    const __nv_bfloat16* __restrict__ v_pre,
+    const __nv_bfloat16* __restrict__ q_norm_w,
+    const __nv_bfloat16* __restrict__ k_norm_w,
+    const __nv_bfloat16* __restrict__ cos_v,
+    const __nv_bfloat16* __restrict__ sin_v,
+    __nv_bfloat16* __restrict__ q_buf,
+    __nv_bfloat16* __restrict__ k_cache_dst,
+    __nv_bfloat16* __restrict__ v_cache_dst,
+    int n_q,
+    int n_kv,
+    float eps) {
+  const int block = blockIdx.x;
+  const int tid = threadIdx.x;
+  const bool is_q = block < n_q;
+  const int head = is_q ? block : (block - n_q);
+  if ((!is_q) && head >= n_kv) return;
+
+  __shared__ float s_normed[HEAD_DIM];
+  __shared__ float s_smem4[N_WARPS];
+
+  const __nv_bfloat16* x_row =
+      is_q ? (q_pre + head * HEAD_DIM) : (k_pre + head * HEAD_DIM);
+  const __nv_bfloat16* norm_w = is_q ? q_norm_w : k_norm_w;
+  float v = __bfloat162float(x_row[tid]);
+  float w = __bfloat162float(norm_w[tid]);
+
+  float sum_sq = block_sum_4warp(v * v, s_smem4);
+  float rstd = rsqrtf(sum_sq / float(HEAD_DIM) + eps);
+  float normed = v * rstd * w;
+  s_normed[tid] = normed;
+  __syncthreads();
+
+  float partner, c, sn, out;
+  if (tid < HALF) {
+    partner = s_normed[tid + HALF];
+    c = __bfloat162float(cos_v[tid]);
+    sn = __bfloat162float(sin_v[tid]);
+    out = normed * c - partner * sn;
+  } else {
+    partner = s_normed[tid - HALF];
+    int half_idx = tid - HALF;
+    c = __bfloat162float(cos_v[half_idx]);
+    sn = __bfloat162float(sin_v[half_idx]);
+    out = normed * c + partner * sn;
+  }
+
+  if (is_q) {
+    q_buf[head * HEAD_DIM + tid] = __float2bfloat16(out);
+  } else {
+    k_cache_dst[head * HEAD_DIM + tid] = __float2bfloat16(out);
+    v_cache_dst[head * HEAD_DIM + tid] = v_pre[head * HEAD_DIM + tid];
+  }
+}
+
+__global__ void qk_norm_rope_kvwrite_batched_kernel(
+    const __nv_bfloat16* __restrict__ q_pre,
+    const __nv_bfloat16* __restrict__ k_pre,
+    const __nv_bfloat16* __restrict__ v_pre,
+    const __nv_bfloat16* __restrict__ q_norm_w,
+    const __nv_bfloat16* __restrict__ k_norm_w,
+    const __nv_bfloat16* __restrict__ cos,
+    const __nv_bfloat16* __restrict__ sin,
+    __nv_bfloat16* __restrict__ q_buf,
+    __nv_bfloat16* __restrict__ k_cache_dst,
+    __nv_bfloat16* __restrict__ v_cache_dst,
+    int seq_len,
+    int q_pre_row_elems,
+    int k_pre_row_elems,
+    int v_pre_row_elems,
+    int q_dst_row_elems,
+    int kv_dst_row_elems,
+    int n_q,
+    int n_kv,
+    float eps) {
+  const int block = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int heads_total = n_q + n_kv;
+  const int token = block / heads_total;
+  if (token >= seq_len) return;
+  const int inner = block - token * heads_total;
+  const bool is_q = inner < n_q;
+  const int head = is_q ? inner : (inner - n_q);
+  if ((!is_q) && head >= n_kv) return;
+
+  __shared__ float s_normed[HEAD_DIM];
+  __shared__ float s_smem4[N_WARPS];
+
+  const __nv_bfloat16* x_row =
+      is_q ? (q_pre + token * q_pre_row_elems + head * HEAD_DIM)
+           : (k_pre + token * k_pre_row_elems + head * HEAD_DIM);
+  const __nv_bfloat16* norm_w = is_q ? q_norm_w : k_norm_w;
+  const __nv_bfloat16* cos_row = cos + token * HALF;
+  const __nv_bfloat16* sin_row = sin + token * HALF;
+  float v = __bfloat162float(x_row[tid]);
+  float w = __bfloat162float(norm_w[tid]);
+
+  float sum_sq = block_sum_4warp(v * v, s_smem4);
+  float rstd = rsqrtf(sum_sq / float(HEAD_DIM) + eps);
+  float normed = v * rstd * w;
+  s_normed[tid] = normed;
+  __syncthreads();
+
+  float partner, c, sn, out;
+  if (tid < HALF) {
+    partner = s_normed[tid + HALF];
+    c = __bfloat162float(cos_row[tid]);
+    sn = __bfloat162float(sin_row[tid]);
+    out = normed * c - partner * sn;
+  } else {
+    partner = s_normed[tid - HALF];
+    int half_idx = tid - HALF;
+    c = __bfloat162float(cos_row[half_idx]);
+    sn = __bfloat162float(sin_row[half_idx]);
+    out = normed * c + partner * sn;
+  }
+
+  if (is_q) {
+    q_buf[token * q_dst_row_elems + head * HEAD_DIM + tid] =
+        __float2bfloat16(out);
+  } else {
+    k_cache_dst[token * kv_dst_row_elems + head * HEAD_DIM + tid] =
+        __float2bfloat16(out);
+    v_cache_dst[token * kv_dst_row_elems + head * HEAD_DIM + tid] =
+        v_pre[token * v_pre_row_elems + head * HEAD_DIM + tid];
+  }
+}
+
 // Device-position variant: writes K/V into K_cache[*cur_pos] / V_cache[*cur_pos]
 // where cur_pos is read from device memory, so a single captured graph serves
 // every decode position (the host bumps *cur_pos before each replay). row_elems
@@ -378,6 +508,85 @@ int qwen3_q_norm_rope_qstage_bf16(
       reinterpret_cast<const __nv_bfloat16*>(sin),
       reinterpret_cast<__nv_bfloat16*>(q_buf_dst),
       n_q_heads, eps);
+  return 0;
+}
+
+int qwen3_qk_norm_rope_kvwrite_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream) {
+  if (!q_pre || !k_pre || !v_pre || !q_norm_w || !k_norm_w || !cos || !sin
+      || !q_buf_dst || !k_cache_dst || !v_cache_dst) return 1;
+  if (n_q_heads <= 0 || n_kv_heads <= 0) return 2;
+  dim3 grid(n_q_heads + n_kv_heads);
+  dim3 block(THREADS);
+  qk_norm_rope_kvwrite_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q_pre),
+      reinterpret_cast<const __nv_bfloat16*>(k_pre),
+      reinterpret_cast<const __nv_bfloat16*>(v_pre),
+      reinterpret_cast<const __nv_bfloat16*>(q_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(k_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(cos),
+      reinterpret_cast<const __nv_bfloat16*>(sin),
+      reinterpret_cast<__nv_bfloat16*>(q_buf_dst),
+      reinterpret_cast<__nv_bfloat16*>(k_cache_dst),
+      reinterpret_cast<__nv_bfloat16*>(v_cache_dst),
+      n_q_heads, n_kv_heads, eps);
+  return 0;
+}
+
+int qwen3_qk_norm_rope_kvwrite_batched_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         seq_len,
+    int         q_pre_row_elems,
+    int         k_pre_row_elems,
+    int         v_pre_row_elems,
+    int         q_dst_row_elems,
+    int         kv_dst_row_elems,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream) {
+  if (!q_pre || !k_pre || !v_pre || !q_norm_w || !k_norm_w || !cos || !sin
+      || !q_buf_dst || !k_cache_dst || !v_cache_dst) return 1;
+  if (seq_len <= 0 || n_q_heads <= 0 || n_kv_heads <= 0) return 2;
+  dim3 grid(seq_len * (n_q_heads + n_kv_heads));
+  dim3 block(THREADS);
+  qk_norm_rope_kvwrite_batched_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(q_pre),
+      reinterpret_cast<const __nv_bfloat16*>(k_pre),
+      reinterpret_cast<const __nv_bfloat16*>(v_pre),
+      reinterpret_cast<const __nv_bfloat16*>(q_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(k_norm_w),
+      reinterpret_cast<const __nv_bfloat16*>(cos),
+      reinterpret_cast<const __nv_bfloat16*>(sin),
+      reinterpret_cast<__nv_bfloat16*>(q_buf_dst),
+      reinterpret_cast<__nv_bfloat16*>(k_cache_dst),
+      reinterpret_cast<__nv_bfloat16*>(v_cache_dst),
+      seq_len,
+      q_pre_row_elems, k_pre_row_elems, v_pre_row_elems,
+      q_dst_row_elems, kv_dst_row_elems,
+      n_q_heads, n_kv_heads, eps);
   return 0;
 }
 

--- a/csrc/kernels/qwen3_qkv_post_proc.cuh
+++ b/csrc/kernels/qwen3_qkv_post_proc.cuh
@@ -54,6 +54,51 @@ int qwen3_q_norm_rope_qstage_bf16(
     float       eps,
     cudaStream_t stream);
 
+// Fused q_norm + RoPE + Q_buf write and k_norm + RoPE + KV_cache write in
+// one launch. Decode-only S=1 path, head_dim hardcoded at 128.
+int qwen3_qk_norm_rope_kvwrite_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream);
+
+// Batched fused q_norm + RoPE + Q_buf write and k_norm + RoPE + KV_cache
+// write for prefill (S>=1). q_pre / k_pre / v_pre may be row-strided views
+// into a larger qkv tensor; row strides are in elements, not bytes. cos/sin
+// are (S, 64) bf16 and outputs are contiguous per-position rows in Q_buf /
+// K_cache / V_cache.
+int qwen3_qk_norm_rope_kvwrite_batched_bf16(
+    const void* q_pre,
+    const void* k_pre,
+    const void* v_pre,
+    const void* q_norm_w,
+    const void* k_norm_w,
+    const void* cos,
+    const void* sin,
+    void*       q_buf_dst,
+    void*       k_cache_dst,
+    void*       v_cache_dst,
+    int         seq_len,
+    int         q_pre_row_elems,
+    int         k_pre_row_elems,
+    int         v_pre_row_elems,
+    int         q_dst_row_elems,
+    int         kv_dst_row_elems,
+    int         n_q_heads,
+    int         n_kv_heads,
+    float       eps,
+    cudaStream_t stream);
+
 // Fused k_norm + RoPE + K_cache write + V_cache write (S=1 decode).
 //
 //   k_pre        : (n_kv_heads, 128) bf16

--- a/csrc/quantize/fp8_per_token_block_quant.cu
+++ b/csrc/quantize/fp8_per_token_block_quant.cu
@@ -7,6 +7,7 @@
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
+#include <stdexcept>
 
 namespace flash_rt {
 namespace quantize {
@@ -15,6 +16,46 @@ namespace {
 
 constexpr int kBlock = 128;
 constexpr float kFp8Max = 448.0f;
+
+__device__ __forceinline__ float block_reduce_sum_128(float v, float* sh) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int off = 16; off > 0; off >>= 1) {
+    v += __shfl_xor_sync(0xffffffff, v, off);
+  }
+  if (lane == 0) sh[warp] = v;
+  __syncthreads();
+  if (warp == 0) {
+    v = (lane < 4) ? sh[lane] : 0.0f;
+    v += __shfl_xor_sync(0xffffffff, v, 1);
+    v += __shfl_xor_sync(0xffffffff, v, 2);
+    if (lane == 0) sh[0] = v;
+  }
+  __syncthreads();
+  const float out = sh[0];
+  __syncthreads();
+  return out;
+}
+
+__device__ __forceinline__ float block_reduce_max_128(float v, float* sh) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int off = 16; off > 0; off >>= 1) {
+    v = fmaxf(v, __shfl_xor_sync(0xffffffff, v, off));
+  }
+  if (lane == 0) sh[warp] = v;
+  __syncthreads();
+  if (warp == 0) {
+    v = (lane < 4) ? sh[lane] : 0.0f;
+    v = fmaxf(v, __shfl_xor_sync(0xffffffff, v, 1));
+    v = fmaxf(v, __shfl_xor_sync(0xffffffff, v, 2));
+    if (lane == 0) sh[0] = v;
+  }
+  __syncthreads();
+  const float out = sh[0];
+  __syncthreads();
+  return out;
+}
 
 __global__ void fp8_per_token_block_quant_kernel(
     const __nv_bfloat16* __restrict__ input,
@@ -127,6 +168,156 @@ __global__ void fp8_per_token_block_quant_linear_kernel(
   }
 }
 
+__global__ void rms_norm_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const __nv_bfloat16* __restrict__ weight,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int K, float eps)
+{
+  extern __shared__ unsigned char smem[];
+  float* red = reinterpret_cast<float*>(smem);
+  __nv_bfloat16* normed = reinterpret_cast<__nv_bfloat16*>(red + 4);
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* row = input + (size_t)m * K;
+  __nv_fp8_e4m3* out = output + (size_t)m * K;
+
+  float ssq = 0.0f;
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(row[i]);
+    ssq += v * v;
+  }
+  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(row[i]) * inv_rms *
+                    __bfloat162float(weight[i]);
+    normed[i] = __float2bfloat16(v);
+  }
+  __syncthreads();
+
+  const int n_kb = K / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float v = __bfloat162float(normed[i]);
+    const float amax = block_reduce_max_128(fabsf(v), red);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = v / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    out[i] = __nv_fp8_e4m3(q);
+  }
+}
+
+__global__ void residual_add_rms_norm_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ residual,
+    const __nv_bfloat16* __restrict__ x,
+    __nv_bfloat16* __restrict__ residual_out,
+    const __nv_bfloat16* __restrict__ weight,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int K, float eps)
+{
+  extern __shared__ unsigned char smem[];
+  float* red = reinterpret_cast<float*>(smem);
+  __nv_bfloat16* normed = reinterpret_cast<__nv_bfloat16*>(red + 4);
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* rrow = residual + (size_t)m * K;
+  const __nv_bfloat16* xrow = x + (size_t)m * K;
+  __nv_bfloat16* res_out = residual_out + (size_t)m * K;
+  __nv_fp8_e4m3* out = output + (size_t)m * K;
+
+  float ssq = 0.0f;
+  for (int i = t; i < K; i += kBlock) {
+    const float rv = __bfloat162float(rrow[i]) + __bfloat162float(xrow[i]);
+    const __nv_bfloat16 rb = __float2bfloat16(rv);
+    res_out[i] = rb;
+    const float rbf = __bfloat162float(rb);
+    ssq += rbf * rbf;
+  }
+  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(res_out[i]) * inv_rms *
+                    __bfloat162float(weight[i]);
+    normed[i] = __float2bfloat16(v);
+  }
+  __syncthreads();
+
+  const int n_kb = K / kBlock;
+  for (int kb = 0; kb < n_kb; ++kb) {
+    const int i = kb * kBlock + t;
+    const float v = __bfloat162float(normed[i]);
+    const float amax = block_reduce_max_128(fabsf(v), red);
+    const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+    if (t == 0) scale[m * n_kb + kb] = sc;
+    float q = v / sc;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    out[i] = __nv_fp8_e4m3(q);
+  }
+}
+
+__device__ __forceinline__ float silu_f32(float x) {
+  return x / (1.0f + expf(-x));
+}
+
+__global__ void silu_mul_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ gate,
+    const __nv_bfloat16* __restrict__ up,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int K)
+{
+  const int m = blockIdx.y;
+  const int kb = blockIdx.x;
+  const int t = threadIdx.x;
+  const int k = kb * kBlock + t;
+  const size_t idx = (size_t)m * K + k;
+  __shared__ float red[4];
+
+  const float g = __bfloat162float(gate[idx]);
+  const float u = __bfloat162float(up[idx]);
+  const float silu_g = silu_f32(g);
+  const float silu_bf = __bfloat162float(__float2bfloat16(silu_g));
+  const float v = __bfloat162float(__float2bfloat16(silu_bf * u));
+  const float amax = block_reduce_max_128(fabsf(v), red);
+  const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+  if (t == 0) scale[m * (K / kBlock) + kb] = sc;
+  float q = v / sc;
+  q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+  output[idx] = __nv_fp8_e4m3(q);
+}
+
+__global__ void silu_mul_merged_to_fp8_block128_kernel(
+    const __nv_bfloat16* __restrict__ gate_up,
+    __nv_fp8_e4m3* __restrict__ output,
+    float* __restrict__ scale,
+    int K)
+{
+  const int m = blockIdx.y;
+  const int kb = blockIdx.x;
+  const int t = threadIdx.x;
+  const int k = kb * kBlock + t;
+  const size_t out_idx = (size_t)m * K + k;
+  const size_t gate_idx = (size_t)m * (2 * K) + k;
+  const size_t up_idx = gate_idx + K;
+  __shared__ float red[4];
+
+  const float g = __bfloat162float(gate_up[gate_idx]);
+  const float u = __bfloat162float(gate_up[up_idx]);
+  const float silu_g = silu_f32(g);
+  const float silu_bf = __bfloat162float(__float2bfloat16(silu_g));
+  const float v = __bfloat162float(__float2bfloat16(silu_bf * u));
+  const float amax = block_reduce_max_128(fabsf(v), red);
+  const float sc = fmaxf(amax / kFp8Max, 1.0e-12f);
+  if (t == 0) scale[m * (K / kBlock) + kb] = sc;
+  float q = v / sc;
+  q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+  output[out_idx] = __nv_fp8_e4m3(q);
+}
+
 }  // namespace
 
 void fp8_per_token_block128_quant_bf16(
@@ -136,6 +327,9 @@ void fp8_per_token_block128_quant_bf16(
     int M, int K,
     cudaStream_t stream)
 {
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "fp8_per_token_block128_quant_bf16 requires K multiple of 128");
   dim3 block(kBlock);
   if (M <= 65535) {
     dim3 grid(K / kBlock, M);
@@ -152,6 +346,86 @@ void fp8_per_token_block128_quant_bf16(
         output_scale,
         M, K);
   }
+}
+
+void rms_norm_to_fp8_block128_bf16(
+    const void* input,
+    const void* weight,
+    void* output_fp8,
+    float* output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream)
+{
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "rms_norm_to_fp8_block128_bf16 requires K multiple of 128");
+  size_t smem = 4 * sizeof(float) + (size_t)K * sizeof(__nv_bfloat16);
+  rms_norm_to_fp8_block128_kernel<<<M, kBlock, smem, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(input),
+      reinterpret_cast<const __nv_bfloat16*>(weight),
+      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+      output_scale, K, eps);
+}
+
+void residual_add_rms_norm_to_fp8_block128_bf16(
+    const void* residual,
+    const void* x,
+    void* residual_out,
+    const void* weight,
+    void* output_fp8,
+    float* output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream)
+{
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "residual_add_rms_norm_to_fp8_block128_bf16 requires K multiple of 128");
+  size_t smem = 4 * sizeof(float) + (size_t)K * sizeof(__nv_bfloat16);
+  residual_add_rms_norm_to_fp8_block128_kernel<<<M, kBlock, smem, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(residual),
+      reinterpret_cast<const __nv_bfloat16*>(x),
+      reinterpret_cast<__nv_bfloat16*>(residual_out),
+      reinterpret_cast<const __nv_bfloat16*>(weight),
+      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+      output_scale, K, eps);
+}
+
+void silu_mul_to_fp8_block128_bf16(
+    const void* gate,
+    const void* up,
+    void* output_fp8,
+    float* output_scale,
+    int M, int K,
+    cudaStream_t stream)
+{
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "silu_mul_to_fp8_block128_bf16 requires K multiple of 128");
+  dim3 block(kBlock);
+  dim3 grid(K / kBlock, M);
+  silu_mul_to_fp8_block128_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(gate),
+      reinterpret_cast<const __nv_bfloat16*>(up),
+      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+      output_scale, K);
+}
+
+void silu_mul_merged_to_fp8_block128_bf16(
+    const void* gate_up,
+    void* output_fp8,
+    float* output_scale,
+    int M, int K,
+    cudaStream_t stream)
+{
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "silu_mul_merged_to_fp8_block128_bf16 requires K multiple of 128");
+  dim3 block(kBlock);
+  dim3 grid(K / kBlock, M);
+  silu_mul_merged_to_fp8_block128_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(gate_up),
+      reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
+      output_scale, K);
 }
 
 }  // namespace quantize

--- a/csrc/quantize/fp8_per_token_block_quant.cuh
+++ b/csrc/quantize/fp8_per_token_block_quant.cuh
@@ -38,5 +38,38 @@ void fp8_per_token_block128_quant_bf16(
     int M, int K,
     cudaStream_t stream);
 
+void rms_norm_to_fp8_block128_bf16(
+    const void* input,
+    const void* weight,
+    void*       output_fp8,
+    float*      output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream);
+
+void residual_add_rms_norm_to_fp8_block128_bf16(
+    const void* residual,
+    const void* x,
+    void*       residual_out,
+    const void* weight,
+    void*       output_fp8,
+    float*      output_scale,
+    int M, int K, float eps,
+    cudaStream_t stream);
+
+void silu_mul_to_fp8_block128_bf16(
+    const void* gate,
+    const void* up,
+    void*       output_fp8,
+    float*      output_scale,
+    int M, int K,
+    cudaStream_t stream);
+
+void silu_mul_merged_to_fp8_block128_bf16(
+    const void* gate_up,
+    void*       output_fp8,
+    float*      output_scale,
+    int M, int K,
+    cudaStream_t stream);
+
 }  // namespace quantize
 }  // namespace flash_rt

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -25,6 +25,18 @@
 #include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
+// SM89 Qwen3-VL FP8 kernels (block-128 GEMM/GEMV + fused act/norm quant +
+// fused QK norm-rope-kvwrite). Bound here so the SM89 path imports them from
+// this dedicated module, just like the SM120 ViT helpers below, instead of
+// bloating the central flash_rt_kernels bindings.
+#ifdef ENABLE_SM89_BLOCK_FP8_GEMM
+#include "gemm/fp8_block128_gemm_mma_sm89.cuh"
+#include "gemm/fp8_gemv_m1_sm89.cuh"
+#include "quantize/fp8_per_token_block_quant.cuh"
+#include "kernels/qwen3_qkv_post_proc.cuh"
+#include "kernels/bf16_matmul_qwen36.cuh"
+#endif
+
 namespace py = pybind11;
 
 namespace flash_rt {
@@ -67,6 +79,10 @@ template <typename T>
 static T* as_ptr(uintptr_t p) {
     return reinterpret_cast<T*>(p);
 }
+
+#ifdef ENABLE_SM89_BLOCK_FP8_GEMM
+static void* to_ptr(uintptr_t addr) { return reinterpret_cast<void*>(addr); }
+#endif
 
 PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
     m.doc() = "FlashRT Qwen3-VL kernels (separate module; additive).";
@@ -153,4 +169,173 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         py::arg("qkv"), py::arg("bias"), py::arg("q"), py::arg("k"),
         py::arg("v"), py::arg("rows"), py::arg("hq"), py::arg("hk"),
         py::arg("hv"), py::arg("stream") = 0);
+
+#ifdef ENABLE_SM89_BLOCK_FP8_GEMM
+    // ---- SM89 Qwen3-VL FP8 kernels (additive; Ada has no TMA so these are
+    // hand-written, see docs/qwen3_vl_fp8_sm89.md) ----
+    m.def("rms_norm_to_fp8_block128_bf16",
+        [](uintptr_t input, uintptr_t weight, uintptr_t output_fp8,
+           uintptr_t output_scale, int M, int K, float eps,
+           uintptr_t stream) {
+            flash_rt::quantize::rms_norm_to_fp8_block128_bf16(
+                to_ptr(input), to_ptr(weight), to_ptr(output_fp8),
+                reinterpret_cast<float*>(output_scale),
+                M, K, eps, to_stream(stream));
+        },
+        py::arg("input"), py::arg("weight"), py::arg("output_fp8"),
+        py::arg("output_scale"), py::arg("M"), py::arg("K"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("residual_add_rms_norm_to_fp8_block128_bf16",
+        [](uintptr_t residual, uintptr_t x, uintptr_t residual_out,
+           uintptr_t weight, uintptr_t output_fp8, uintptr_t output_scale,
+           int M, int K, float eps, uintptr_t stream) {
+            flash_rt::quantize::residual_add_rms_norm_to_fp8_block128_bf16(
+                to_ptr(residual), to_ptr(x), to_ptr(residual_out),
+                to_ptr(weight), to_ptr(output_fp8),
+                reinterpret_cast<float*>(output_scale),
+                M, K, eps, to_stream(stream));
+        },
+        py::arg("residual"), py::arg("x"), py::arg("residual_out"),
+        py::arg("weight"), py::arg("output_fp8"), py::arg("output_scale"),
+        py::arg("M"), py::arg("K"), py::arg("eps") = 1e-6f,
+        py::arg("stream") = 0);
+
+    m.def("silu_mul_to_fp8_block128_bf16",
+        [](uintptr_t gate, uintptr_t up, uintptr_t output_fp8,
+           uintptr_t output_scale, int M, int K, uintptr_t stream) {
+            flash_rt::quantize::silu_mul_to_fp8_block128_bf16(
+                to_ptr(gate), to_ptr(up), to_ptr(output_fp8),
+                reinterpret_cast<float*>(output_scale),
+                M, K, to_stream(stream));
+        },
+        py::arg("gate"), py::arg("up"), py::arg("output_fp8"),
+        py::arg("output_scale"), py::arg("M"), py::arg("K"),
+        py::arg("stream") = 0);
+
+    m.def("silu_mul_merged_to_fp8_block128_bf16",
+        [](uintptr_t gate_up, uintptr_t output_fp8,
+           uintptr_t output_scale, int M, int K, uintptr_t stream) {
+            flash_rt::quantize::silu_mul_merged_to_fp8_block128_bf16(
+                to_ptr(gate_up), to_ptr(output_fp8),
+                reinterpret_cast<float*>(output_scale),
+                M, K, to_stream(stream));
+        },
+        py::arg("gate_up"), py::arg("output_fp8"),
+        py::arg("output_scale"), py::arg("M"), py::arg("K"),
+        py::arg("stream") = 0);
+
+    m.def("fp8_block128_gemm_blockscaled_sm89_bf16out",
+        [](uintptr_t A, uintptr_t B, uintptr_t D,
+           int M, int N, int K,
+           uintptr_t act_scale, uintptr_t w_scale,
+           uintptr_t stream) {
+            int rc = flash_rt::gemm::block128_sm89::
+                fp8_block128_gemm_blockscaled_sm89_bf16out(
+                    to_ptr(A), to_ptr(B), to_ptr(D),
+                    M, N, K,
+                    reinterpret_cast<const float*>(act_scale),
+                    reinterpret_cast<const float*>(w_scale),
+                    to_stream(stream));
+            if (rc != 0)
+                throw std::runtime_error(
+                    "fp8_block128_gemm_blockscaled_sm89_bf16out launch failed");
+        },
+        py::arg("A"), py::arg("B"), py::arg("D"),
+        py::arg("M"), py::arg("N"), py::arg("K"),
+        py::arg("act_block_scale"), py::arg("w_block_scale"),
+        py::arg("stream") = 0);
+
+    m.def("qwen3_qk_norm_rope_kvwrite_bf16",
+        [](uintptr_t q_pre, uintptr_t k_pre, uintptr_t v_pre,
+           uintptr_t q_norm_w, uintptr_t k_norm_w,
+           uintptr_t cos, uintptr_t sin,
+           uintptr_t q_buf_dst,
+           uintptr_t k_cache_dst, uintptr_t v_cache_dst,
+           int n_q_heads, int n_kv_heads, float eps,
+           uintptr_t stream) -> int {
+            return flash_rt::kernels::qwen3_qk_norm_rope_kvwrite_bf16(
+                to_ptr(q_pre), to_ptr(k_pre), to_ptr(v_pre),
+                to_ptr(q_norm_w), to_ptr(k_norm_w),
+                to_ptr(cos), to_ptr(sin),
+                to_ptr(q_buf_dst),
+                to_ptr(k_cache_dst), to_ptr(v_cache_dst),
+                n_q_heads, n_kv_heads, eps, to_stream(stream));
+        },
+        py::arg("q_pre"), py::arg("k_pre"), py::arg("v_pre"),
+        py::arg("q_norm_w"), py::arg("k_norm_w"),
+        py::arg("cos"), py::arg("sin"),
+        py::arg("q_buf_dst"),
+        py::arg("k_cache_dst"), py::arg("v_cache_dst"),
+        py::arg("n_q_heads"), py::arg("n_kv_heads"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("qwen3_qk_norm_rope_kvwrite_batched_bf16",
+        [](uintptr_t q_pre, uintptr_t k_pre, uintptr_t v_pre,
+           uintptr_t q_norm_w, uintptr_t k_norm_w,
+           uintptr_t cos, uintptr_t sin,
+           uintptr_t q_buf_dst,
+           uintptr_t k_cache_dst, uintptr_t v_cache_dst,
+           int seq_len,
+           int q_pre_row_elems, int k_pre_row_elems, int v_pre_row_elems,
+           int q_dst_row_elems, int kv_dst_row_elems,
+           int n_q_heads, int n_kv_heads, float eps,
+           uintptr_t stream) -> int {
+            return flash_rt::kernels::qwen3_qk_norm_rope_kvwrite_batched_bf16(
+                to_ptr(q_pre), to_ptr(k_pre), to_ptr(v_pre),
+                to_ptr(q_norm_w), to_ptr(k_norm_w),
+                to_ptr(cos), to_ptr(sin),
+                to_ptr(q_buf_dst),
+                to_ptr(k_cache_dst), to_ptr(v_cache_dst),
+                seq_len,
+                q_pre_row_elems, k_pre_row_elems, v_pre_row_elems,
+                q_dst_row_elems, kv_dst_row_elems,
+                n_q_heads, n_kv_heads, eps, to_stream(stream));
+        },
+        py::arg("q_pre"), py::arg("k_pre"), py::arg("v_pre"),
+        py::arg("q_norm_w"), py::arg("k_norm_w"),
+        py::arg("cos"), py::arg("sin"),
+        py::arg("q_buf_dst"),
+        py::arg("k_cache_dst"), py::arg("v_cache_dst"),
+        py::arg("seq_len"),
+        py::arg("q_pre_row_elems"), py::arg("k_pre_row_elems"),
+        py::arg("v_pre_row_elems"),
+        py::arg("q_dst_row_elems"), py::arg("kv_dst_row_elems"),
+        py::arg("n_q_heads"), py::arg("n_kv_heads"),
+        py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+#define BIND_BLOCK128_GEMV_M1(NAME)                                           \
+    m.def("ht_" #NAME,                                                       \
+        [](uintptr_t A, uintptr_t B, uintptr_t D,                            \
+           int M, int N, int K, uintptr_t act_scale, uintptr_t w_scale,       \
+           float alpha, uintptr_t stream) {                                  \
+            return flash_rt::gemm::gemv_m1_sm89::NAME(                            \
+                to_ptr(A), to_ptr(B), to_ptr(D),                             \
+                M, N, K, reinterpret_cast<const float*>(act_scale),          \
+                reinterpret_cast<const float*>(w_scale), alpha,              \
+                to_stream(stream));                                          \
+        },                                                                   \
+        py::arg("A"), py::arg("B"), py::arg("D"),                          \
+        py::arg("M"), py::arg("N"), py::arg("K"),                          \
+        py::arg("act_scale"), py::arg("w_scale"), py::arg("alpha"),        \
+        py::arg("stream") = 0)
+
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w4);
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w8);
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w16);
+
+    // BF16 cuBLASLt matmul for the ViT bf16 linears on SM89 (the SM120 path
+    // uses w16a16_gemm_sm120_bf16 from flash_rt_kernels instead).
+    m.def("bf16_matmul_cublaslt_bf16",
+        [](uintptr_t x, uintptr_t W, uintptr_t out,
+           int M, int N, int K, uintptr_t stream) {
+            flash_rt::kernels::bf16_matmul_cublaslt_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const __nv_bfloat16*>(W),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                M, N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("W"), py::arg("out"),
+        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+#endif  // ENABLE_SM89_BLOCK_FP8_GEMM
 }

--- a/docs/qwen3_vl_fp8_sm89.md
+++ b/docs/qwen3_vl_fp8_sm89.md
@@ -29,11 +29,14 @@ cmake --build build -j --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_
 
 The SM89 Qwen3-VL path uses:
 
-- `flash_rt_kernels` for FP8 block-128 GEMV/GEMM, fused norm/activation
-  quantization, BF16 cuBLASLt matmul wrappers, and Qwen3 postprocessing.
+- `flash_rt_kernels` for generic helpers shared with other RTX paths, such as
+  embedding lookup, RMSNorm, residual add, and the base attention/runtime
+  support.
 - `flash_rt_fa2` for BF16 FlashAttention.
-- `flash_rt_qwen3_vl_kernels` for vision RoPE, layernorm/GELU to FP8, and
-  BF16 bias epilogues.
+- `flash_rt_qwen3_vl_kernels` for Qwen3-VL-specific kernels: SM89 FP8
+  block-128 GEMV/GEMM, fused norm/activation quantization, QK norm/RoPE/KV
+  write, BF16 cuBLASLt ViT matmul wrappers, Qwen3 postprocessing, and the
+  existing SM120 vision RoPE / layernorm-GELU-to-FP8 / BF16 bias epilogues.
 
 ## Runtime Architecture
 

--- a/docs/qwen3_vl_fp8_sm89.md
+++ b/docs/qwen3_vl_fp8_sm89.md
@@ -1,0 +1,169 @@
+# Qwen3-VL-8B official FP8 on RTX 4090 (SM89)
+
+This path brings up Qwen3-VL-8B on Ada RTX GPUs using the official
+Qwen3-VL FP8 checkpoint. It is the SM89 counterpart to the SM120/NVFP4
+Qwen3-VL path, but it intentionally uses the checkpoint's native block-scaled
+FP8 language weights instead of NVFP4.
+
+## Checkpoint
+
+Use the official FP8 checkpoint:
+
+```text
+Qwen3-VL-8B-Instruct-FP8
+```
+
+The language stack tensors are stored under
+`model.language_model.layers.*`. Linear weights are
+`torch.float8_e4m3fn` with `weight_scale_inv` block scales in a 128x128
+layout. The vision tower in this checkpoint is BF16.
+
+## Build
+
+Build the regular FlashRT kernels and the Qwen3-VL helper module for SM89:
+
+```bash
+cmake -S . -B build -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON
+cmake --build build -j --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels
+```
+
+The SM89 Qwen3-VL path uses:
+
+- `flash_rt_kernels` for FP8 block-128 GEMV/GEMM, fused norm/activation
+  quantization, BF16 cuBLASLt matmul wrappers, and Qwen3 postprocessing.
+- `flash_rt_fa2` for BF16 FlashAttention.
+- `flash_rt_qwen3_vl_kernels` for vision RoPE, layernorm/GELU to FP8, and
+  BF16 bias epilogues.
+
+## Runtime Architecture
+
+The runtime frontend is
+`flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal.Qwen3VlFp8Sm89Frontend`.
+
+The text-only language core is
+`flash_rt.frontends.torch.qwen3_vl_fp8_sm89.Qwen3VlFp8Sm89TextFrontend`.
+
+The dtype mapping is:
+
+| Component | SM89 dtype path |
+|---|---|
+| Language weights | Official block-scaled FP8 e4m3, 128x128 scales |
+| Language activations before linears | BF16 -> per-token/per-128 FP8 |
+| Language GEMV/GEMM output | BF16 |
+| Attention Q/K/V cache | BF16 |
+| Attention backend | BF16 FA2 |
+| Residual stream and norms | BF16 |
+| Vision protected blocks | BF16 |
+| Vision bulk GEMMs | FP8 block-128 activation/weight, BF16 output |
+| `lm_head` default | BF16 |
+
+`use_fp8_lm_head=True` remains an explicit experimental mode. Single-step
+logits can match closely, but multi-token generation can diverge after the
+first generated tokens, so BF16 `lm_head` is the default.
+
+## Quickstart
+
+```bash
+python examples/qwen3_vl_quickstart.py \
+  --arch sm89 \
+  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+  --image FlashRT.png \
+  --prompt "Describe this image in one sentence." \
+  --max-seq 2048
+```
+
+By default, the SM89 prefill buffer is sized to `max_seq`, matching the SM120
+Qwen3-VL frontend. Pass `--max-prefill-seq` only to deliberately lower that
+capacity.
+
+For the development smoke benchmark:
+
+```bash
+python scripts/smoke_qwen3_vl_fp8_sm89.py \
+  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+  --multimodal \
+  --iters 5 \
+  --generate-tokens 0
+```
+
+The full-resolution `FlashRT.png` workload produces 6256 vision patches and
+1581 language tokens. This is the workload used for the SM120 Qwen3-VL report,
+so it is the preferred comparison point for full TTFT numbers.
+
+## RTX 4090 Validation
+
+Environment:
+
+- GPU: NVIDIA GeForce RTX 4090, SM89
+- Checkpoint: official Qwen3-VL-8B-Instruct-FP8
+- Workload: `FlashRT.png`, prompt `Describe this image in one sentence.`
+- Prompt shape: 6256 vision patches, 1581 language tokens
+
+Command:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python scripts/smoke_qwen3_vl_fp8_sm89.py \
+  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+  --multimodal \
+  --iters 3 \
+  --generate-tokens 0
+```
+
+Result:
+
+```text
+S=1581 pixel_shape=(6256, 1536) spans=[(4, 1568)]
+set_prompt_warm median=15.711 ms
+vision_only median=88.990 ms
+language_only_no_mm_scatter median=120.634 ms
+prefill median=206.987 ms top=785 finite=True
+prefill_graph median=206.214 ms cos_vs_eager=0.998522 top=785 finite=True
+graph_decode_cache_pos=1581 median=10.681 ms cos_vs_eager=1.000000
+top_eager=2168 top_graph=2168
+```
+
+The same workload on the SM120/NVFP4 path is faster because it uses Blackwell
+NVFP4 language kernels. The SM89 path is intended to use the best available
+Ada-compatible dtype path: official FP8 language weights, BF16 attention and
+residual state, and BF16 `lm_head`.
+
+## Limits
+
+- This is not an NVFP4 implementation. SM89 uses official FP8 weights because
+  NVFP4 is a Blackwell path.
+- `lm_head` stays BF16 by default for generation quality.
+- Single-image prefill has a CUDA Graph replay path. Multi-image and video
+  should use the eager path unless separately validated.
+- Decode graphs are captured per cache position because the FA2 call captures
+  host-side sequence length.
+- The development scripts under `scripts/*qwen3_vl_fp8_sm89*` are local
+  validation and profiling entry points, not CI replacements.
+
+## Why this path is hand-written (no TMA on Ada)
+
+The SM120 Qwen3-VL path runs its block-128 FP8 GEMM through the CUTLASS
+`KernelTmaWarpSpecializedBlockwise` collective: TMA bulk-copy engines feed a
+warp-specialized producer/consumer pipeline, and CUTLASS auto-selects a deep
+(3-4 stage) software pipeline. That design hides global-load latency *without*
+spending registers or occupancy on the staging.
+
+Ada (sm_89) has **no TMA and no warp-specialized CUTLASS collective** (those
+builders are Sm90+/Sm120 only), so that design does not port. Two consequences
+shape this kernel:
+
+- **GEMM** is a hand-written `cp.async` + `ldmatrix.x4` + block-128-scaling MMA
+  kernel (`fp8_block128_gemm_mma_sm89.cu`). With `cp.async` instead of TMA, each
+  extra pipeline stage costs a full shared-memory buffer, and at the tuned
+  64x64 tile the kernel is already register-limited to 4 CTA/SM — so a 2-stage
+  pipeline halves occupancy and regresses. It runs single-stage and is
+  latency-bound; the obvious memory-pattern optimizations (load/store
+  coalescing, `ldmatrix`) are applied, and CUTLASS's own Ada blockwise example
+  is slower than this kernel, so it is not used.
+- **Attention** uses the vendored FlashAttention-2 (Tri Dao) kernels, including
+  an added hdim64 instantiation for the 2B ViT; the FA2 kernel body is upstream
+  and is not modified here.
+
+Net: the SM89 path matches the SM120 design *intent* (block-128 FP8, fused
+act/norm-quant, ldmatrix-based MMA) but cannot reuse the TMA/warp-specialized
+machinery, which is the main reason its prefill is slower than the Blackwell
+NVFP4 path.

--- a/docs/qwen3_vl_fp8_sm89_2b.md
+++ b/docs/qwen3_vl_fp8_sm89_2b.md
@@ -1,0 +1,105 @@
+# Qwen3-VL-2B block-128 FP8 on RTX 4090 (SM89)
+
+This brings up Qwen3-VL-2B on Ada RTX GPUs using the same SM89 block-128 FP8
+language path as the 8B variant. The 2B model shares every kernel, the vision
+tower, the MRoPE geometry, and the CUDA-Graph prefill/decode machinery with
+the 8B path documented in `qwen3_vl_fp8_sm89.md` — only the language-stack
+dimensions differ.
+
+| | 2B | 8B |
+|---|---|---|
+| layers | 28 | 36 |
+| Q / KV heads | 16 / 8 (GQA 2:1) | 32 / 8 (GQA 4:1) |
+| hidden | 2048 | 4096 |
+| intermediate | 6144 | 12288 |
+| fused qkv N | 4096 | 6144 |
+| `rope_theta` / `mrope_section` | 5e6 / [24,20,20] | 5e6 / [24,20,20] |
+| `tie_word_embeddings` | true | false |
+
+The frontend reads all of these from `config.json`; it enforces only the
+kernel constraints (head_dim == 128, every GEMM N/K a multiple of 128, Q heads
+a multiple of KV heads). No code is 2B-specific.
+
+## Checkpoint
+
+The official Qwen3-VL-2B release ships **BF16 only** (single-file
+`model.safetensors`, tied embeddings, no `lm_head.weight`). Produce a
+block-128 FP8 checkpoint in the official layout with the offline quantizer:
+
+```bash
+python scripts/quantize_qwen3_vl_to_fp8_block128.py \
+  --src /path/to/Qwen3-VL-2B-Instruct \
+  --dst /path/to/Qwen3-VL-2B-Instruct-FP8
+```
+
+This quantizes the 196 language-stack linears (`model.language_model.layers.*`
+q/k/v/o + gate/up/down) to e4m3 `weight` + fp32 `weight_scale_inv` (128x128
+blocks, `amax/448` multiply-to-dequant) and copies norms, `embed_tokens`, and
+the BF16 vision tower through unchanged. Tied `lm_head` is **not** materialized
+— the loader synthesizes it from `embed_tokens`. Output is ~2.85 GB.
+
+## Build
+
+Identical to the 8B path:
+
+```bash
+cmake -S . -B build -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON
+cmake --build build -j --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels
+```
+
+## lm_head: optional FP8 mode for 2B
+
+The frontend default is BF16 `lm_head` (shared with the 8B path). For
+throughput-sensitive local validation, pass `use_fp8_lm_head=True` or
+`--fp8-lm-head`. The 152k-vocab projection is a large decode-time weight read,
+so FP8 `lm_head` can reduce bandwidth pressure on 2B. Treat it as a performance
+mode: validate logits and generation quality against the default BF16 head on
+the target checkpoint before using it in production.
+
+## Quickstart
+
+```bash
+python scripts/smoke_qwen3_vl_fp8_sm89.py \
+  --checkpoint /path/to/Qwen3-VL-2B-Instruct-FP8 \
+  --multimodal --fp8-lm-head --iters 10 --generate-tokens 32
+```
+
+## RTX 4090 Validation
+
+Environment: NVIDIA GeForce RTX 4090 (SM89); checkpoint
+`Qwen3-VL-2B-Instruct-FP8` (quantized as above); FP8 `lm_head`.
+
+Text-only (S=79 prefill, decode at cache_pos=63):
+
+```text
+S=79 prefill median=8.489 ms
+prefill_speedup=52.09x logit_cos=0.999426 top_prefill=198 top_loop=198
+graph_decode_pos=63 median=2.653 ms (377 tok/s) top=19564 finite=True
+```
+
+Multimodal (`FlashRT.png`, `Describe this image in one sentence.`, S=1581):
+
+```text
+S=1581 pixel_shape=(6256, 1536) spans=[(4, 1568)]
+vision_only median=69.670 ms
+language_only_no_mm_scatter median=29.827 ms
+prefill median=102.991 ms top=32 finite=True
+prefill_graph median=99.743 ms cos_vs_eager=0.997508 top=32 finite=True
+graph_decode_cache_pos=1581 median=2.966 ms (337 tok/s) cos_vs_eager=1.000000
+  top_eager=3691 top_graph=3691
+generate_tokens=32 text='A black background features the "FlashRT" logo, with
+  an orange lightning bolt symbol next to the stylized text "FlashRT" in white
+  and orange.'
+```
+
+These numbers are local validation points, not CI guarantees. Re-benchmark on
+the target GPU, driver, and build flags before treating them as deployment
+latency targets.
+
+## Limits
+
+- Inherits all 8B-path limits (single-image graph prefill, per-cache-position
+  decode graphs, FP8-not-NVFP4 on Ada). See `qwen3_vl_fp8_sm89.md`.
+- The 2B FP8 checkpoint is produced offline by the repo quantizer; there is no
+  official 2B FP8 release.
+- The `scripts/*qwen3_vl_fp8_sm89*` entry points are local validation, not CI.

--- a/flash_rt/frontends/torch/_qwen3_vl_fp8_weights.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_fp8_weights.py
@@ -1,0 +1,245 @@
+"""Loader for official Qwen3-VL FP8 language weights.
+
+The official Qwen3-VL FP8 checkpoint stores the text stack under
+``model.language_model.*`` with FP8 e4m3 weights plus 128x128 block scales
+(``.weight_scale_inv``). This loader intentionally keeps the original FP8
+layout and records raw device pointers for the SM89 block-scaled GEMV path.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+
+import torch
+
+
+@dataclass
+class WeightHandles:
+    ptrs: dict = field(default_factory=dict)
+    anchors: list = field(default_factory=list)
+
+
+def _anchor(handles: WeightHandles, t: torch.Tensor) -> int:
+    handles.anchors.append(t)
+    return int(t.data_ptr())
+
+
+def _open_shards(ckpt_dir: str):
+    from safetensors import safe_open
+
+    idx_path = os.path.join(ckpt_dir, 'model.safetensors.index.json')
+    if os.path.isfile(idx_path):
+        wmap = json.load(open(idx_path))['weight_map']
+        handles_d = {
+            shard: safe_open(os.path.join(ckpt_dir, shard), framework='pt',
+                             device='cpu')
+            for shard in set(wmap.values())
+        }
+        return handles_d, wmap
+    # Single-file FP8 checkpoints (for example a quantized 2B ckpt written as
+    # one shard) have no index.json. Build a synthetic weight_map from the lone
+    # model.safetensors so the rest of the loader is identical to the sharded
+    # path. Raw BF16 2B checkpoints still need the offline block-128 quantizer.
+    single = os.path.join(ckpt_dir, 'model.safetensors')
+    if not os.path.isfile(single):
+        raise RuntimeError(
+            f'Qwen3-VL FP8 ckpt missing both index and model.safetensors: '
+            f'{ckpt_dir}')
+    h = safe_open(single, framework='pt', device='cpu')
+    wmap = {key: 'model.safetensors' for key in h.keys()}
+    return {'model.safetensors': h}, wmap
+
+
+def _get_tensor(handles_d, wmap, key: str) -> torch.Tensor:
+    if key not in wmap:
+        raise KeyError(f'tensor {key!r} not in weight_map')
+    return handles_d[wmap[key]].get_tensor(key)
+
+
+def _to_bf16(t: torch.Tensor, device: str) -> torch.Tensor:
+    return t.to(torch.bfloat16).to(device).contiguous()
+
+
+def _to_fp8(t: torch.Tensor, device: str) -> torch.Tensor:
+    if t.dtype != torch.float8_e4m3fn:
+        raise TypeError(f'expected torch.float8_e4m3fn weight, got {t.dtype}')
+    return t.to(device).contiguous()
+
+
+def _load_fp8_linear(handles: WeightHandles, out: dict, short: str,
+                     base: str, handles_d, wmap, device: str
+                     ) -> tuple[torch.Tensor, torch.Tensor]:
+    w = _to_fp8(_get_tensor(handles_d, wmap, base + '.weight'), device)
+    s = _get_tensor(handles_d, wmap, base + '.weight_scale_inv').to(
+        torch.float32).to(device).contiguous()
+    out[short + '_w'] = _anchor(handles, w)
+    out[short + '_s'] = _anchor(handles, s)
+    return w, s
+
+
+def extract_weights_qwen3_vl_fp8(ckpt_dir: str, device: str = 'cuda:0',
+                                 quantize_lm_head: bool = True
+                                 ) -> WeightHandles:
+    cfg_path = os.path.join(ckpt_dir, 'config.json')
+    if not os.path.isfile(cfg_path):
+        raise RuntimeError(f'Qwen3-VL FP8 ckpt missing config: {cfg_path}')
+    cfg = json.load(open(cfg_path))
+    text_cfg = cfg['text_config']
+
+    num_layers = int(text_cfg['num_hidden_layers'])
+    hidden = int(text_cfg['hidden_size'])
+    vocab = int(text_cfg['vocab_size'])
+    head_dim = int(text_cfg.get('head_dim') or
+                   (hidden // int(text_cfg['num_attention_heads'])))
+    n_q = int(text_cfg['num_attention_heads'])
+    n_kv = int(text_cfg['num_key_value_heads'])
+    inter = int(text_cfg['intermediate_size'])
+    rms_eps = float(text_cfg.get('rms_norm_eps', 1e-6))
+    rope_scaling = text_cfg.get('rope_scaling') or cfg.get('rope_scaling') or {}
+    rope_theta = float(text_cfg.get('rope_theta') or cfg.get('rope_theta') or
+                       rope_scaling.get('rope_theta') or 1_000_000.0)
+
+    handles = WeightHandles()
+    handles_d, wmap = _open_shards(ckpt_dir)
+
+    embed = _to_bf16(
+        _get_tensor(handles_d, wmap, 'model.language_model.embed_tokens.weight'),
+        device)
+    handles.ptrs['embed_w'] = _anchor(handles, embed)
+    final_norm = _to_bf16(
+        _get_tensor(handles_d, wmap, 'model.language_model.norm.weight'),
+        device)
+    handles.ptrs['final_norm_w'] = _anchor(handles, final_norm)
+    # tie_word_embeddings: the 2B release ties lm_head to embed_tokens and
+    # ships no lm_head.weight. Fall back to the embedding matrix in that case
+    # (identical math: logits = h @ embed_tokens^T).
+    tied = bool(cfg.get('tie_word_embeddings',
+                        text_cfg.get('tie_word_embeddings', False)))
+    if 'lm_head.weight' in wmap:
+        lm_head_cpu = _get_tensor(handles_d, wmap, 'lm_head.weight')
+    elif tied:
+        lm_head_cpu = _get_tensor(
+            handles_d, wmap, 'model.language_model.embed_tokens.weight')
+    else:
+        raise RuntimeError(
+            'Qwen3-VL FP8 ckpt has neither lm_head.weight nor '
+            'tie_word_embeddings=true')
+    N_lm, K_lm = lm_head_cpu.shape
+    handles.ptrs['lm_head_quantized'] = bool(quantize_lm_head)
+    if quantize_lm_head:
+        if N_lm % 128 != 0 or K_lm % 128 != 0:
+            raise RuntimeError(
+                f'lm_head shape must be block128-compatible, got {lm_head_cpu.shape}')
+        lm_head_fp8 = torch.empty(
+            N_lm, K_lm, dtype=torch.float8_e4m3fn, device=device)
+        lm_scale = torch.empty(
+            N_lm // 128, K_lm // 128, dtype=torch.float32, device=device)
+        for row0 in range(0, N_lm, 8192):
+            row1 = min(row0 + 8192, N_lm)
+            chunk = lm_head_cpu[row0:row1].to(torch.bfloat16).to(
+                device).contiguous()
+            rows = row1 - row0
+            view = chunk.float().view(rows // 128, 128, K_lm // 128, 128)
+            amax = view.abs().amax(dim=(1, 3))
+            scale = (amax / 448.0).clamp_min(1e-12)
+            q = (view / scale[:, None, :, None]).clamp(
+                -448.0, 448.0).to(torch.float8_e4m3fn).view(
+                    rows, K_lm).contiguous()
+            lm_head_fp8[row0:row1].copy_(q)
+            lm_scale[row0 // 128:row1 // 128].copy_(scale.float())
+        handles.ptrs['lm_head_fp8_w'] = _anchor(handles, lm_head_fp8)
+        handles.ptrs['lm_head_fp8_s'] = _anchor(handles, lm_scale)
+    else:
+        lm_head = _to_bf16(lm_head_cpu, device)
+        handles.ptrs['lm_head_w'] = _anchor(handles, lm_head)
+
+    per_layer: list[dict] = [None] * num_layers   # type: ignore[list-item]
+    for L in range(num_layers):
+        base = f'model.language_model.layers.{L}.'
+        ld: dict = {'type': 'full_attention', 'quant_format': 'fp8_block128'}
+        ld['input_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, base + 'input_layernorm.weight'),
+            device))
+        ld['post_attn_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap,
+                        base + 'post_attention_layernorm.weight'),
+            device))
+        sa = base + 'self_attn.'
+        q_w, q_s = _load_fp8_linear(handles, ld, 'q_proj', sa + 'q_proj',
+                                    handles_d, wmap, device)
+        k_w, k_s = _load_fp8_linear(handles, ld, 'k_proj', sa + 'k_proj',
+                                    handles_d, wmap, device)
+        v_w, v_s = _load_fp8_linear(handles, ld, 'v_proj', sa + 'v_proj',
+                                    handles_d, wmap, device)
+        _load_fp8_linear(handles, ld, 'o_proj', sa + 'o_proj',
+                         handles_d, wmap, device)
+        qkv_w = torch.cat([q_w, k_w, v_w], dim=0).contiguous()
+        qkv_s = torch.cat([q_s, k_s, v_s], dim=0).contiguous()
+        ld['qkv_proj_w'] = _anchor(handles, qkv_w)
+        ld['qkv_proj_s'] = _anchor(handles, qkv_s)
+        ld['qkv_proj_N'] = int(qkv_w.shape[0])
+
+        ld['q_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, sa + 'q_norm.weight'), device))
+        ld['k_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, sa + 'k_norm.weight'), device))
+
+        mp = base + 'mlp.'
+        gate_w, gate_s = _load_fp8_linear(
+            handles, ld, 'mlp_gate', mp + 'gate_proj',
+            handles_d, wmap, device)
+        up_w, up_s = _load_fp8_linear(
+            handles, ld, 'mlp_up', mp + 'up_proj',
+            handles_d, wmap, device)
+        gate_up_w = torch.cat([gate_w, up_w], dim=0).contiguous()
+        gate_up_s = torch.cat([gate_s, up_s], dim=0).contiguous()
+        ld['gate_up_w'] = _anchor(handles, gate_up_w)
+        ld['gate_up_s'] = _anchor(handles, gate_up_s)
+        ld['gate_up_N'] = int(gate_up_w.shape[0])
+        _load_fp8_linear(handles, ld, 'mlp_down', mp + 'down_proj',
+                         handles_d, wmap, device)
+        per_layer[L] = ld
+
+    handles.ptrs.update({
+        'vocab_size': vocab,
+        'hidden': hidden,
+        'head_dim': head_dim,
+        'num_q_heads': n_q,
+        'num_kv_heads': n_kv,
+        'intermediate': inter,
+        'num_layers': num_layers,
+        'layer_types': ['full_attention'] * num_layers,
+        'rms_norm_eps': rms_eps,
+        'rope_theta': rope_theta,
+        'rope_scaling': rope_scaling,
+        'quant_format': 'fp8_block128',
+        'ckpt_dir': ckpt_dir,
+        'layers': per_layer,
+    })
+    return handles
+
+
+def assert_extraction_invariants_qwen3_vl_fp8(handles: WeightHandles) -> None:
+    p = handles.ptrs
+    assert p.get('quant_format') == 'fp8_block128'
+    if p.get('lm_head_quantized', True):
+        for key in ('lm_head_fp8_w', 'lm_head_fp8_s'):
+            if key not in p:
+                raise AssertionError(f'missing {key}')
+    elif 'lm_head_w' not in p:
+        raise AssertionError('missing lm_head_w')
+    layers = p.get('layers')
+    assert isinstance(layers, list) and len(layers) == p['num_layers']
+    required = {
+        'input_norm_w', 'post_attn_norm_w', 'q_proj_w', 'q_proj_s',
+        'k_proj_w', 'k_proj_s', 'v_proj_w', 'v_proj_s',
+        'o_proj_w', 'o_proj_s', 'qkv_proj_w', 'qkv_proj_s',
+        'qkv_proj_N', 'q_norm_w', 'k_norm_w',
+        'mlp_gate_w', 'mlp_gate_s', 'mlp_up_w', 'mlp_up_s',
+        'gate_up_w', 'gate_up_s', 'gate_up_N', 'mlp_down_w', 'mlp_down_s',
+    }
+    for i, layer in enumerate(layers):
+        missing = required.difference(layer)
+        if missing:
+            raise AssertionError(f'layer {i} missing {sorted(missing)}')

--- a/flash_rt/frontends/torch/_qwen3_vl_geometry.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_geometry.py
@@ -177,6 +177,35 @@ def mrope_cos_sin(position_ids, *, head_dim, rope_theta, mrope_section,
     return cos, sin
 
 
+def build_mrope_cache(*, max_pos, head_dim, rope_theta,
+                      device='cuda:0', dtype=torch.bfloat16):
+    """Precompute per-axis MRoPE cos/sin lookup tables.
+
+    Returns (cos_cache, sin_cache), each (max_pos, head_dim/2). The caller
+    applies Qwen3-VL's interleaving policy for t/h/w axes.
+    """
+    inv_freq = 1.0 / (rope_theta ** (
+        torch.arange(0, head_dim, 2, device=device,
+                     dtype=torch.float32) / head_dim))
+    positions = torch.arange(max_pos, device=device, dtype=torch.float32)
+    freqs = torch.outer(positions, inv_freq)
+    return (freqs.cos().to(dtype).contiguous(),
+            freqs.sin().to(dtype).contiguous())
+
+
+def mrope_cos_sin_cached(position_ids, cos_cache, sin_cache, *,
+                         mrope_section):
+    """Gather interleaved-MRoPE cos/sin from precomputed lookup tables."""
+    pos = position_ids.to(device=cos_cache.device, dtype=torch.long)
+    cos = cos_cache[pos[0]].clone()
+    sin = sin_cache[pos[0]].clone()
+    for axis, offset in ((1, 1), (2, 2)):
+        idx = slice(offset, mrope_section[axis] * 3, 3)
+        cos[:, idx] = cos_cache[pos[axis]][:, idx]
+        sin[:, idx] = sin_cache[pos[axis]][:, idx]
+    return cos.contiguous(), sin.contiguous()
+
+
 def vision_rope_cos_sin(grid_thw, *, head_dim, spatial_merge_size,
                         rope_theta=10000.0, device='cuda:0',
                         dtype=torch.bfloat16):
@@ -212,6 +241,45 @@ def vision_rope_cos_sin(grid_thw, *, head_dim, spatial_merge_size,
     cos = freqs.cos().to(device).to(dtype).contiguous()
     sin = freqs.sin().to(device).to(dtype).contiguous()
     return cos, sin
+
+
+def build_vision_rope_cache(*, max_hw, head_dim, rope_theta=10000.0,
+                            device='cuda:0', dtype=torch.bfloat16):
+    """Precompute rotate-half 2D-RoPE cos/sin lookup tables per coordinate."""
+    dim = head_dim // 2
+    inv_freq = 1.0 / (rope_theta ** (
+        torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    coords = torch.arange(max_hw, dtype=torch.float32)
+    freqs = torch.outer(coords, inv_freq)
+    return (freqs.cos().to(device).to(dtype).contiguous(),
+            freqs.sin().to(device).to(dtype).contiguous())
+
+
+def vision_rope_cos_sin_cached(grid_thw, cos_cache, sin_cache, *,
+                               spatial_merge_size):
+    """Gather rotate-half 2D-RoPE cos/sin from precomputed coordinate tables."""
+    coords = []
+    device = cos_cache.device
+    for t, h, w in grid_thw:
+        t, h, w = int(t), int(h), int(w)
+        mh, mw = h // spatial_merge_size, w // spatial_merge_size
+        m = spatial_merge_size
+        rows = (torch.arange(mh, device=device)[:, None, None, None] * m
+                + torch.arange(m, device=device)[None, None, :, None])
+        cols = (torch.arange(mw, device=device)[None, :, None, None] * m
+                + torch.arange(m, device=device)[None, None, None, :])
+        rows = rows.expand(mh, mw, m, m).reshape(-1)
+        cols = cols.expand(mh, mw, m, m).reshape(-1)
+        c = torch.stack((rows, cols), dim=-1)
+        if t > 1:
+            c = c.repeat(t, 1)
+        coords.append(c)
+    pos_ids = torch.cat(coords, dim=0)
+    cos = torch.cat((cos_cache[pos_ids[:, 0]], cos_cache[pos_ids[:, 1]]),
+                    dim=1)
+    sin = torch.cat((sin_cache[pos_ids[:, 0]], sin_cache[pos_ids[:, 1]]),
+                    dim=1)
+    return cos.contiguous(), sin.contiguous()
 
 
 def vision_pos_embeds(grid_thw, pos_embed_table, *, num_grid_per_side,

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -1,4 +1,4 @@
-"""FlashRT — Qwen3-VL ViT tower forward (RTX SM120).
+"""FlashRT — Qwen3-VL ViT tower forward on RTX.
 
 Kernelized SigLIP-style vision tower for ``Qwen3-VL``: patch embed →
 learned position embedding → ``depth`` transformer blocks (rotate_half
@@ -7,9 +7,10 @@ merger, with DeepStack feature taps at the configured layers.
 
 All heavy compute runs through ``flash_rt_kernels`` / ``flash_rt_fa2`` /
 ``flash_rt_qwen3_vl_kernels``; tensor reshapes are metadata-only views.
-The linear layers run FP8 block-128 W8A8 (2× tensor-core vs bf16); the
-activation is dynamically quantized per GEMM and the residual stream
-(which carries the late-layer massive-activation outlier) stays bf16.
+On SM120 the linears use the CUTLASS block-128 FP8 path; on SM89 eligible
+linears use the native Ada block-128 FP8 GEMM. BF16-protected linears use the
+architecture-specific BF16 path. In all cases the residual stream (which
+carries the late-layer massive-activation outlier) stays bf16.
 The tower is prefill-once per image and the sequence length is
 image-resolution dependent, so scratch is sized per forward (CUDA-Graph
 bucketing by patch count is layered on top via ``forward_graph``).
@@ -24,8 +25,9 @@ from typing import Any
 
 class Qwen3VlVisionRtx:
     """Qwen3-VL ViT tower. Loads the vision weights from a checkpoint
-    directory (norms BF16, linears FP8 block-128) and runs the forward
-    against the FlashRT kernel modules.
+    directory and runs the forward against the FlashRT kernel modules.
+    Eligible linears pack as FP8 block-128 on SM89/SM120; sensitive
+    early-layer paths can stay BF16 via explicit config overrides.
 
     Public surface:
       __init__(checkpoint_path, *, device='cuda:0')
@@ -46,6 +48,7 @@ class Qwen3VlVisionRtx:
         # patch-count -> (graph, static_inputs, captured_outputs)
         self._graphs: dict = {}
         self._graph_stream = None
+        self._use_fp8_gemm = False
 
         cfg = config if config is not None else _read_vision_config(
             checkpoint_path)
@@ -58,6 +61,10 @@ class Qwen3VlVisionRtx:
         self.intermediate = int(cfg['intermediate_size'])
         self.deepstack_indexes = tuple(cfg['deepstack_visual_indexes'])
         self.ln_eps = float(cfg.get('layer_norm_eps', 1e-6))
+        self._device_sm = torch.cuda.get_device_capability(
+            torch.device(device))[0] * 10 + torch.cuda.get_device_capability(
+                torch.device(device))[1]
+        self._use_fp8_gemm = self._device_sm >= 89
 
         import json
         import os
@@ -81,7 +88,7 @@ class Qwen3VlVisionRtx:
             residual-writing GEMMs (attn proj, FFN fc2) stay bf16: their
             output feeds the late-layer massive-activation channel, where
             accumulated FP8 noise would be amplified."""
-            if not fp8:
+            if not fp8 or not self._use_fp8_gemm:
                 return (None, w, bias)
             w8, ws = _quant_fp8_block128(w)
             return (w8, ws, bias)
@@ -110,29 +117,46 @@ class Qwen3VlVisionRtx:
         # first 3 blocks recovers image_embeds cosine from 0.86 (all-FP8)
         # to 0.97 for ~+2 ms, vs 0.984 / +21 ms for the all-bf16 tower.
         self.bf16_first_blocks = max(0, int(cfg.get('_bf16_first_blocks', 3)))
+        raw_bf16_linears = cfg.get('_bf16_block_linears', {})
+        self._bf16_block_linears: dict[int, frozenset[str]] = {}
+        allowed_bf16_linears = frozenset(('qkv', 'proj', 'fc1', 'fc2'))
+        for raw_idx, raw_names in raw_bf16_linears.items():
+            idx = int(raw_idx)
+            names = frozenset(str(name) for name in raw_names)
+            bad = names - allowed_bf16_linears
+            if bad:
+                raise ValueError(
+                    f'unsupported vision bf16 override(s) for block {idx}: '
+                    + ', '.join(sorted(bad)))
+            self._bf16_block_linears[idx] = names
 
         self.blocks: list[dict] = []
         for i in range(self.depth):
             bp = f'{p}blocks.{i}.'
-            f8 = i >= self.bf16_first_blocks
+            f8 = self._use_fp8_gemm and i >= self.bf16_first_blocks
+            bf16_linears = self._bf16_block_linears.get(i, frozenset())
             self.blocks.append({
                 'norm1_w': _w(bp + 'norm1.weight'),
                 'norm1_b': _w(bp + 'norm1.bias'),
                 'norm2_w': _w(bp + 'norm2.weight'),
                 'norm2_b': _w(bp + 'norm2.bias'),
                 'qkv': _lin(_w(bp + 'attn.qkv.weight'),
-                            _w(bp + 'attn.qkv.bias'), fp8=f8),
+                            _w(bp + 'attn.qkv.bias'),
+                            fp8=f8 and 'qkv' not in bf16_linears),
                 'proj': _lin(_w(bp + 'attn.proj.weight'),
-                             _w(bp + 'attn.proj.bias'), fp8=f8),
+                             _w(bp + 'attn.proj.bias'),
+                             fp8=f8 and 'proj' not in bf16_linears),
                 'fc1': _lin(
                     _pad_rows(_w(bp + 'mlp.linear_fc1.weight'),
                               self.intermediate_padded),
                     _pad_rows(_w(bp + 'mlp.linear_fc1.bias'),
-                              self.intermediate_padded), fp8=f8),
+                              self.intermediate_padded),
+                    fp8=f8 and 'fc1' not in bf16_linears),
                 'fc2': _lin(
                     _pad_cols(_w(bp + 'mlp.linear_fc2.weight'),
                               self.intermediate_padded),
-                    _w(bp + 'mlp.linear_fc2.bias'), fp8=f8),
+                    _w(bp + 'mlp.linear_fc2.bias'),
+                    fp8=f8 and 'fc2' not in bf16_linears),
             })
         self.merger = _load_merger(_w, _lin, p + 'merger.')
         self.deepstack_mergers = [
@@ -171,9 +195,14 @@ class Qwen3VlVisionRtx:
         w8, ws, bias = lin
         y = torch.empty(M, N, dtype=torch.bfloat16, device=self.device)
         if w8 is None:                                  # bf16 path (w16a16)
-            fvk.w16a16_gemm_sm120_bf16(
-                x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K, 1.0,
-                stream)
+            if self._device_sm >= 120:
+                fvk.w16a16_gemm_sm120_bf16(
+                    x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K, 1.0,
+                    stream)
+            else:
+                self._vlk.bf16_matmul_cublaslt_bf16(
+                    x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K,
+                    stream)
         else:                                           # FP8 block-128 W8A8
             x_fp8 = torch.empty(
                 M, K, dtype=torch.float8_e4m3fn, device=self.device)
@@ -182,9 +211,14 @@ class Qwen3VlVisionRtx:
             fvk.fp8_per_token_block128_quant_bf16(
                 x.data_ptr(), x_fp8.data_ptr(), x_scale.data_ptr(),
                 M, K, stream)
-            fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
-                x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
-                x_scale.data_ptr(), ws.data_ptr(), stream)
+            if self._device_sm >= 120:
+                fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
+                    x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                    x_scale.data_ptr(), ws.data_ptr(), stream)
+            else:
+                self._vlk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+                    x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                    x_scale.data_ptr(), ws.data_ptr(), stream)
         if bias is not None and add_bias:
             fvk.add_bias_bf16(y.data_ptr(), bias.data_ptr(), M, N, stream)
         return y
@@ -209,9 +243,14 @@ class Qwen3VlVisionRtx:
         import torch
         w8, ws, bias = lin
         y = torch.empty(M, N, dtype=torch.bfloat16, device=self.device)
-        self._fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
-            x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
-            x_scale.data_ptr(), ws.data_ptr(), stream)
+        if self._device_sm >= 120:
+            self._fvk.fp8_block128_gemm_cutlass_sm120_bf16out(
+                x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                x_scale.data_ptr(), ws.data_ptr(), stream)
+        else:
+            self._vlk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+                x_fp8.data_ptr(), w8.data_ptr(), y.data_ptr(), M, N, K,
+                x_scale.data_ptr(), ws.data_ptr(), stream)
         if bias is not None and add_bias:
             self._fvk.add_bias_bf16(
                 y.data_ptr(), bias.data_ptr(), M, N, stream)
@@ -314,12 +353,12 @@ class Qwen3VlVisionRtx:
 
         deepstack: list = [None] * len(self.deepstack_indexes)
         for i, blk in enumerate(self.blocks):
-            # FP8 blocks fuse the activation quant into the producing
-            # LayerNorm / GELU (one kernel, no bf16 round-trip); bf16 blocks
-            # (the first few, protecting the massive-activation channel) keep
-            # the plain norm + w16a16 path.
-            fp8 = blk['qkv'][0] is not None
-            if fp8:
+            # Activation-side fusion follows the linear that consumes it:
+            # qkv/fc1 use fused norm->FP8 only when that GEMM is FP8; fc2
+            # uses fused GELU->FP8 only when fc2 itself is FP8. This keeps
+            # mixed early blocks legal for bring-up experiments.
+            qkv_fp8 = blk['qkv'][0] is not None
+            if qkv_fp8:
                 xf, xs = self._layer_norm_to_fp8(
                     h, blk['norm1_w'], blk['norm1_b'], S, H, stream)
                 qkv = self._gemm_fp8(xf, xs, blk['qkv'], S, 3 * H, H, stream,
@@ -353,27 +392,45 @@ class Qwen3VlVisionRtx:
                 softmax_scale=scale, num_sms=self._num_sms, stream=stream)
             # proj input is the attention output (not a norm/gelu), so its
             # quant cannot be fused upstream; the proj bias rides the residual.
-            attn = self._gemm(o.view(S, H), blk['proj'], S, H, H, stream,
-                              add_bias=False)
+            if blk['proj'][0] is not None:
+                ao = o.view(S, H).contiguous()
+                ao_fp8 = torch.empty(
+                    S, H, dtype=torch.float8_e4m3fn, device=dev)
+                ao_scale = torch.empty(
+                    S, H // 128, dtype=torch.float32, device=dev)
+                fvk.fp8_per_token_block128_quant_bf16(
+                    ao.data_ptr(), ao_fp8.data_ptr(), ao_scale.data_ptr(),
+                    S, H, stream)
+                attn = self._gemm_fp8(
+                    ao_fp8, ao_scale, blk['proj'], S, H, H, stream,
+                    add_bias=False)
+            else:
+                attn = self._gemm(
+                    o.view(S, H), blk['proj'], S, H, H, stream,
+                    add_bias=False)
             vlk.residual_add_bias_bf16(
                 h.data_ptr(), attn.data_ptr(), blk['proj'][2].data_ptr(),
                 S, H, stream)
 
             inter = self.intermediate
-            if fp8:
+            fc1_fp8 = blk['fc1'][0] is not None
+            fc2_fp8 = blk['fc2'][0] is not None
+            if fc1_fp8:
                 xf2, xs2 = self._layer_norm_to_fp8(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
                 f1 = self._gemm_fp8(xf2, xs2, blk['fc1'], S, inter, H, stream,
-                                    add_bias=False)
-                gf, gs = self._gelu_bias_to_fp8(
-                    f1, blk['fc1'][2], S, inter, stream)
-                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream,
                                     add_bias=False)
             else:
                 xn2 = self._layer_norm(
                     h, blk['norm2_w'], blk['norm2_b'], S, H, stream)
                 f1 = self._gemm(xn2, blk['fc1'], S, inter, H, stream,
                                 add_bias=False)
+            if fc2_fp8:
+                gf, gs = self._gelu_bias_to_fp8(
+                    f1, blk['fc1'][2], S, inter, stream)
+                f2 = self._gemm_fp8(gf, gs, blk['fc2'], S, H, inter, stream,
+                                    add_bias=False)
+            else:
                 fvk.bias_gelu_inplace_bf16(
                     f1.data_ptr(), blk['fc1'][2].data_ptr(), S, inter, stream)
                 f2 = self._gemm(f1, blk['fc2'], S, H, inter, stream,

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -1,0 +1,724 @@
+"""Qwen3-VL official-FP8 text decode path for RTX SM89.
+
+This frontend targets the language stack inside the official
+Qwen3-VL-8B-Instruct-FP8 checkpoint. It is intentionally text-only for the
+first SM89 bring-up: no vision tower, no multimodal scatter, and no fallback
+route. The hot linears use block-scaled M=1 FP8 GEMV against the checkpoint's
+``weight`` + ``weight_scale_inv`` tensors.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class _MergedKernels:
+    """Resolve kernel symbols from the dedicated flash_rt_qwen3_vl_kernels
+    module first, then fall back to the generic flash_rt_kernels. Lets the SM89
+    Qwen3-VL FP8 kernels live in their own .so (mirroring the SM120 split)
+    while frontend call sites keep using a single ``fvk`` handle."""
+
+    __slots__ = ('_vl', '_core')
+
+    def __init__(self, vl: Any, core: Any) -> None:
+        self._vl = vl
+        self._core = core
+
+    def __getattr__(self, name: str) -> Any:
+        if self._vl is not None and hasattr(self._vl, name):
+            return getattr(self._vl, name)
+        return getattr(self._core, name)
+
+
+def _import_fvk() -> Any:
+    """flash_rt_kernels (generic) + flash_rt_qwen3_vl_kernels (SM89 FP8)."""
+    from flash_rt import flash_rt_kernels as core
+    try:
+        from flash_rt import flash_rt_qwen3_vl_kernels as vl
+    except ImportError:
+        vl = None
+    return _MergedKernels(vl, core)
+
+
+def _resolve_max_prefill_seq(max_seq: int,
+                             max_prefill_seq: int | None) -> int:
+    return int(max_seq) if max_prefill_seq is None else int(max_prefill_seq)
+
+
+class Qwen3VlFp8Sm89TextFrontend:
+    """Batch-1 Qwen3-VL text-only decode on SM89 official FP8 weights.
+
+    Supports any Qwen3-VL language stack meeting the block-128 FP8 kernel
+    constraints (head_dim == 128, all GEMM dims a multiple of 128). Validated
+    on the official Qwen3-VL-8B-Instruct-FP8 checkpoint and on a block-128
+    quantized Qwen3-VL-2B checkpoint.
+    """
+
+    def __init__(self, checkpoint_path: str, *,
+                 device: str = 'cuda:0', max_seq: int = 2048,
+                 max_prefill_seq: int | None = None,
+                 fuse_gate_up: bool = False,
+                 fuse_qk_postproc: bool = True,
+                 use_fp8_lm_head: bool = False) -> None:
+        import json
+        import os
+
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+        self.max_prefill_seq = _resolve_max_prefill_seq(
+            self.max_seq, max_prefill_seq)
+        self.fuse_gate_up = bool(fuse_gate_up)
+        self.fuse_qk_postproc = bool(fuse_qk_postproc)
+        self.use_fp8_lm_head = bool(use_fp8_lm_head)
+        self._tokenizer: Any = None
+        self._weights = None
+        self._cfg: dict | None = None
+        self._attn = None
+        self._cur_pos = 0
+        self._decode_graphs: dict[int, Any] = {}
+
+        import torch
+        fvk = _import_fvk()
+
+        device_obj = torch.device(self.device)
+        if device_obj.type != 'cuda' or not torch.cuda.is_available():
+            raise RuntimeError(
+                'Qwen3VlFp8Sm89TextFrontend requires an SM89 CUDA device')
+        cap = torch.cuda.get_device_capability(device_obj)
+        if cap != (8, 9):
+            raise RuntimeError(
+                'Qwen3VlFp8Sm89TextFrontend requires GPU_ARCH=89 / sm_89; '
+                f'got sm_{cap[0]}{cap[1]} on {self.device}')
+        required = (
+            'fp8_block128_gemm_blockscaled_sm89_bf16out',
+            'ht_gemv_fp8_block128_m1_w8',
+            'ht_gemv_fp8_block128_m1_w16',
+            'fp8_per_token_block128_quant_bf16',
+            'rms_norm_to_fp8_block128_bf16',
+            'residual_add_rms_norm_to_fp8_block128_bf16',
+            'silu_mul_to_fp8_block128_bf16',
+            'silu_mul_merged_to_fp8_block128_bf16',
+            'qwen3_qk_norm_rope_kvwrite_bf16',
+            'qwen3_qk_norm_rope_kvwrite_batched_bf16',
+            'qwen3_q_norm_rope_qstage_bf16',
+            'qwen3_k_norm_rope_kvwrite_bf16',
+            'qwen36_embedding_lookup_bf16',
+            'bf16_matmul_qwen36_bf16',
+            'rms_norm',
+            'residual_add',
+        )
+        missing = [name for name in required if not hasattr(fvk, name)]
+        if missing:
+            raise RuntimeError(
+                'flash_rt_kernels / flash_rt_qwen3_vl_kernels are missing SM89 '
+                'Qwen3-VL FP8 symbols: '
+                + ', '.join(missing)
+                + '. Rebuild with -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON '
+                'and build flash_rt_kernels flash_rt_fa2 '
+                'flash_rt_qwen3_vl_kernels.')
+        self._fvk = fvk
+
+        cfg_path = os.path.join(self.checkpoint_path, 'config.json')
+        cfg = json.load(open(cfg_path))
+        text_cfg = cfg['text_config']
+        # This path supports Qwen3-VL language stacks whose dimensions satisfy
+        # the SM89 block-128 FP8 kernel constraints and whose checkpoint uses
+        # the official/block-128 FP8 tensor layout loaded below. The config
+        # requirements are: head_dim == 128 (the fused qk-norm/RoPE/KV-write
+        # kernels hardcode it), every GEMM N/K dimension a multiple of 128
+        # (block-128 act/weight scaling), and num_q_heads a multiple of
+        # num_kv_heads (GQA). Other language geometry is read from config.
+        n_q = int(text_cfg['num_attention_heads'])
+        n_kv = int(text_cfg['num_key_value_heads'])
+        head_dim = int(text_cfg.get('head_dim')
+                       or text_cfg['hidden_size'] // n_q)
+        hidden = int(text_cfg['hidden_size'])
+        inter = int(text_cfg['intermediate_size'])
+        vocab = int(text_cfg['vocab_size'])
+        qkv_N = (n_q + 2 * n_kv) * head_dim
+        problems = []
+        if head_dim != 128:
+            problems.append(f'head_dim={head_dim} (kernels require 128)')
+        if n_kv == 0 or (n_q % n_kv) != 0:
+            problems.append(
+                f'num_q_heads={n_q} not a multiple of num_kv_heads={n_kv}')
+        for name, dim in (('hidden_size', hidden), ('intermediate_size', inter),
+                          ('vocab_size', vocab), ('qkv_proj_N', qkv_N)):
+            if (dim % 128) != 0:
+                problems.append(f'{name}={dim} not a multiple of 128')
+        if problems:
+            raise RuntimeError(
+                'Qwen3VlFp8Sm89TextFrontend requires Qwen3-VL config '
+                'dimensions compatible with the SM89 block-128 FP8 kernels: '
+                + '; '.join(problems) + f' (from {cfg_path})')
+
+        self._load_fp8_path()
+        self._alloc_buffers()
+        self._build_rope_table()
+
+    def _load_fp8_path(self) -> None:
+        from transformers import AutoTokenizer
+
+        from flash_rt.frontends.torch._qwen3_vl_fp8_weights import (
+            assert_extraction_invariants_qwen3_vl_fp8,
+            extract_weights_qwen3_vl_fp8,
+        )
+
+        self._tokenizer = AutoTokenizer.from_pretrained(self.checkpoint_path)
+        handles = extract_weights_qwen3_vl_fp8(
+            self.checkpoint_path, device=self.device,
+            quantize_lm_head=self.use_fp8_lm_head)
+        assert_extraction_invariants_qwen3_vl_fp8(handles)
+        self._weights = handles
+        p = handles.ptrs
+        self._cfg = {
+            'rms_norm_eps': float(p['rms_norm_eps']),
+            'head_dim': int(p['head_dim']),
+            'hidden_size': int(p['hidden']),
+            'vocab_size': int(p['vocab_size']),
+            'num_hidden_layers': int(p['num_layers']),
+            'layer_types': list(p['layer_types']),
+            'num_q_heads': int(p['num_q_heads']),
+            'num_kv_heads': int(p['num_kv_heads']),
+            'intermediate': int(p['intermediate']),
+            'rope_theta': float(p['rope_theta']),
+            'rotary_dim': int(p['head_dim']),
+        }
+
+    def _alloc_buffers(self) -> None:
+        import torch
+
+        from flash_rt.hardware.rtx.attn_backend_qwen3 import (
+            RtxFlashAttnBackendQwen3,
+        )
+
+        cfg = self._cfg
+        assert cfg is not None
+        device = torch.device(self.device)
+        bf16 = torch.bfloat16
+        f8 = torch.float8_e4m3fn
+        fp32 = torch.float32
+        hidden = cfg['hidden_size']
+        vocab = cfg['vocab_size']
+        n_q = cfg['num_q_heads']
+        n_kv = cfg['num_kv_heads']
+        hd = cfg['head_dim']
+        inter = cfg['intermediate']
+        Sq_max = max(1, self.max_prefill_seq)
+        qkv_N = n_q * hd + 2 * n_kv * hd
+        self._qkv_N = qkv_N
+        # Block-128 FP8 GEMM/GEMV scratch shapes (N, K), derived from config
+        # so the 8B (qkv 6144) and 2B (qkv 4096) stacks share one code path.
+        self._fp8_shapes = (
+            (qkv_N, hidden),        # fused q/k/v
+            (hidden, hidden),       # o_proj
+            (inter, hidden),        # gate / up
+            (2 * inter, hidden),    # fused gate/up
+            (hidden, inter),        # down
+        )
+
+        self._attn = RtxFlashAttnBackendQwen3(
+            max_seq=self.max_seq, max_q_seq=Sq_max, dtype=bf16,
+            num_layers=cfg['num_hidden_layers'],
+            num_q_heads=n_q, num_kv_heads=n_kv, head_dim=hd,
+            device=self.device)
+        self._h_a = torch.empty(Sq_max, hidden, device=device, dtype=bf16)
+        self._h_b = torch.empty(Sq_max, hidden, device=device, dtype=bf16)
+        self._res_mid = torch.empty(1, Sq_max, hidden, device=device, dtype=bf16)
+        self._layer_out_a = torch.empty(
+            1, Sq_max, hidden, device=device, dtype=bf16)
+        self._layer_out_b = torch.empty(
+            1, Sq_max, hidden, device=device, dtype=bf16)
+        self._q_norm_out = torch.empty(
+            Sq_max * n_q, hd, device=device, dtype=bf16)
+        self._k_norm_out = torch.empty(
+            Sq_max * n_kv, hd, device=device, dtype=bf16)
+        self._q_pre_flat = torch.empty(
+            Sq_max * n_q, hd, device=device, dtype=bf16)
+        self._k_pre_flat = torch.empty(
+            Sq_max * n_kv, hd, device=device, dtype=bf16)
+        self._q_rot = torch.empty(
+            1, Sq_max, n_q, hd, device=device, dtype=bf16)
+        self._k_rot = torch.empty(
+            1, Sq_max, n_kv, hd, device=device, dtype=bf16)
+        rope_dim = cfg['rotary_dim']
+        half = rope_dim // 2
+        idx_lo = torch.arange(half, rope_dim, device=device, dtype=torch.long)
+        idx_hi = torch.arange(0, half, device=device, dtype=torch.long)
+        self._rope_rotate_idx = torch.cat([idx_lo, idx_hi]).contiguous()
+        self._rope_tmp_q = torch.empty(
+            1, Sq_max, n_q, rope_dim, device=device, dtype=bf16)
+        self._rope_tmp_k = torch.empty(
+            1, Sq_max, n_kv, rope_dim, device=device, dtype=bf16)
+        self._qkv_out = torch.empty(1, n_q * hd + 2 * n_kv * hd,
+                                    device=device, dtype=bf16)
+        self._gate_out = torch.empty(1, inter, device=device, dtype=bf16)
+        self._up_out = torch.empty(1, inter, device=device, dtype=bf16)
+        self._gate_up_out = torch.empty(1, 2 * inter, device=device,
+                                        dtype=bf16)
+        self._mlp_act = torch.empty(1, inter, device=device, dtype=bf16)
+        self._prefill_up_out = torch.empty(
+            Sq_max, inter, device=device, dtype=bf16)
+        self._prefill_mlp_act = torch.empty(
+            Sq_max, inter, device=device, dtype=bf16)
+        self._logits_buf = torch.empty(1, vocab, device=device, dtype=bf16)
+        self._last_hidden_buf = torch.empty(1, Sq_max, hidden, device=device,
+                                            dtype=bf16)
+        self._static_token_id = torch.zeros(1, 1, device=device,
+                                            dtype=torch.long)
+        self._graph_stream = torch.cuda.Stream(device=device)
+
+        self._fp8_scratch: dict[tuple[int, int], tuple[torch.Tensor, ...]] = {}
+        for N, K in self._fp8_shapes + ((vocab, hidden),):
+            act = torch.empty(1, K, device=device, dtype=f8)
+            scale = torch.empty(1, K // 128, device=device, dtype=fp32)
+            out = torch.empty(1, N, device=device, dtype=bf16)
+            self._fp8_scratch[(N, K)] = (act, scale, out)
+        self._prefill_fp8_scratch: dict[
+            tuple[int, int], tuple[torch.Tensor, ...]] = {}
+        for N, K in (
+            (n_q * hd + 2 * n_kv * hd, hidden),
+            (hidden, hidden),
+            (inter, hidden),
+            (2 * inter, hidden),
+            (hidden, inter),
+        ):
+            act = torch.empty(Sq_max, K, device=device, dtype=f8)
+            scale = torch.empty(Sq_max, K // 128, device=device, dtype=fp32)
+            out = torch.empty(Sq_max, N, device=device, dtype=bf16)
+            self._prefill_fp8_scratch[(N, K)] = (act, scale, out)
+
+    def _build_rope_table(self) -> None:
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        device = torch.device(self.device)
+        rope_dim = cfg['rotary_dim']
+        theta = cfg['rope_theta']
+        inv_freq = 1.0 / (
+            theta ** (torch.arange(0, rope_dim, 2, device=device,
+                                    dtype=torch.float32) / rope_dim)
+        )
+        positions = torch.arange(self.max_seq, device=device,
+                                 dtype=torch.float32)
+        freqs = torch.outer(positions, inv_freq)
+        self._rope_cos_table = freqs.cos().to(torch.bfloat16).contiguous()
+        self._rope_sin_table = freqs.sin().to(torch.bfloat16).contiguous()
+
+    def _rope_cos_sin(self, cur_pos: int):
+        return (self._rope_cos_table[cur_pos:cur_pos + 1],
+                self._rope_sin_table[cur_pos:cur_pos + 1])
+
+    def _rope_apply_inline(self, x_in, x_out, tmp, cos4, sin4) -> None:
+        import torch
+
+        rope_dim = self._cfg['rotary_dim']
+        half = rope_dim // 2
+        torch.index_select(x_in, -1, self._rope_rotate_idx, out=tmp)
+        tmp[..., :half].neg_()
+        x_out_lo = x_out[..., :half]
+        x_out_hi = x_out[..., half:]
+        x_in_lo = x_in[..., :half]
+        x_in_hi = x_in[..., half:]
+        tmp_lo = tmp[..., :half]
+        tmp_hi = tmp[..., half:]
+        torch.mul(x_in_lo, cos4, out=x_out_lo)
+        x_out_lo.addcmul_(tmp_lo, sin4)
+        torch.mul(x_in_hi, cos4, out=x_out_hi)
+        x_out_hi.addcmul_(tmp_hi, sin4)
+
+    def reset_state(self) -> None:
+        if self._attn is not None:
+            self._attn.reset_cache()
+        self._cur_pos = 0
+
+    def _quant(self, x, shape: tuple[int, int]):
+        import torch
+        s = torch.cuda.current_stream().cuda_stream
+        act, scale, out = self._fp8_scratch[shape]
+        self._fvk.fp8_per_token_block128_quant_bf16(
+            x.data_ptr(), act.data_ptr(), scale.data_ptr(), 1, shape[1], s)
+        return act, scale, out
+
+    def _gemv(self, act, scale, weight_ptr: int, w_scale_ptr: int,
+              out, N: int, K: int) -> None:
+        import torch
+        s = torch.cuda.current_stream().cuda_stream
+        if N >= 4096:
+            fn = self._fvk.ht_gemv_fp8_block128_m1_w16
+        else:
+            fn = self._fvk.ht_gemv_fp8_block128_m1_w8
+        fn(act.data_ptr(), weight_ptr, out.data_ptr(), 1, N, K,
+           scale.data_ptr(), w_scale_ptr, 1.0, s)
+
+    def _prefill_gemm(self, act, scale, weight_ptr: int,
+                      w_scale_ptr: int, out, N: int, K: int,
+                      S: int) -> None:
+        import torch
+
+        s = torch.cuda.current_stream().cuda_stream
+        # Native Ada FP8 block-128 GEMM: reads the FP8 weight directly and
+        # applies per-token act scale * block-128 weight scale in the
+        # mainloop (no dequant scratch). Same scale semantics as the M=1
+        # decode GEMV; ~3-4x faster than the old dequant-scratch prefill path.
+        self._fvk.fp8_block128_gemm_blockscaled_sm89_bf16out(
+            act.data_ptr(), weight_ptr, out.data_ptr(), S, N, K,
+            scale.data_ptr(), w_scale_ptr, s)
+
+    def _write_logits_from_hidden(self, last_row):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        vocab = cfg['vocab_size']
+        s = torch.cuda.current_stream().cuda_stream
+        last_row = last_row.view(1, hidden).contiguous()
+        if self.use_fp8_lm_head:
+            ap, sc, _ = self._quant(last_row, (vocab, hidden))
+            self._gemv(ap, sc, int(self._weights.ptrs['lm_head_fp8_w']),
+                       int(self._weights.ptrs['lm_head_fp8_s']),
+                       self._logits_buf, vocab, hidden)
+        else:
+            self._fvk.bf16_matmul_qwen36_bf16(
+                last_row.data_ptr(), int(self._weights.ptrs['lm_head_w']),
+                self._logits_buf.data_ptr(), 1, vocab, hidden, s)
+        return self._logits_buf
+
+    def _layer_forward(self, L: int, h_in, cos, sin, cur_pos: int,
+                       *,
+                       prequant=None,
+                       next_input_norm_w: int = 0):
+        import torch
+        fvk = _import_fvk()
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        n_q = cfg['num_q_heads']
+        n_kv = cfg['num_kv_heads']
+        hd = cfg['head_dim']
+        inter = cfg['intermediate']
+        eps = float(cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        lw = self._weights.ptrs['layers'][L]
+        h2 = h_in.view(1, hidden).contiguous()
+
+        if prequant is None:
+            ap, sc, _ = self._fp8_scratch[(self._qkv_N, hidden)]
+            fvk.rms_norm_to_fp8_block128_bf16(
+                h2.data_ptr(), int(lw['input_norm_w']),
+                ap.data_ptr(), sc.data_ptr(), 1, hidden, eps, s)
+        else:
+            ap, sc = prequant
+        self._gemv(ap, sc, int(lw['qkv_proj_w']), int(lw['qkv_proj_s']),
+                   self._qkv_out, int(lw['qkv_proj_N']), hidden)
+        Nq = n_q * hd
+        Nk = n_kv * hd
+        qkv_out = self._qkv_out[:1]
+        q_pre = qkv_out[:, :Nq]
+        k_pre = qkv_out[:, Nq:Nq + Nk]
+        v_pre = qkv_out[:, Nq + Nk:]
+        kv_layer_stride = self._attn.kv_layer_stride_bytes
+        kv_row_stride = self._attn.kv_row_stride_bytes
+        kv_slot_off = L * kv_layer_stride + cur_pos * kv_row_stride
+        if self.fuse_qk_postproc:
+            fvk.qwen3_qk_norm_rope_kvwrite_bf16(
+                q_pre.data_ptr(), k_pre.data_ptr(), v_pre.data_ptr(),
+                int(lw['q_norm_w']), int(lw['k_norm_w']),
+                cos.data_ptr(), sin.data_ptr(),
+                self._attn.Q_buf[:, :1].data_ptr(),
+                self._attn.K_cache.data_ptr() + kv_slot_off,
+                self._attn.V_cache.data_ptr() + kv_slot_off,
+                n_q, n_kv, eps, s)
+        else:
+            fvk.qwen3_q_norm_rope_qstage_bf16(
+                q_pre.data_ptr(), int(lw['q_norm_w']), cos.data_ptr(),
+                sin.data_ptr(), self._attn.Q_buf[:, :1].data_ptr(),
+                n_q, eps, s)
+            fvk.qwen3_k_norm_rope_kvwrite_bf16(
+                k_pre.data_ptr(), v_pre.data_ptr(), int(lw['k_norm_w']),
+                cos.data_ptr(), sin.data_ptr(),
+                self._attn.K_cache.data_ptr() + kv_slot_off,
+                self._attn.V_cache.data_ptr() + kv_slot_off,
+                n_kv, eps, s)
+
+        self._attn.run(
+            'full', layer_idx=L, q_seq=1, kv_seq=cur_pos + 1,
+            stream=s, causal=True)
+        attn_2d = self._attn.O_buf[:, :1].reshape(1, hidden).contiguous()
+        ap, sc, o_out = self._quant(attn_2d, (hidden, hidden))
+        self._gemv(ap, sc, int(lw['o_proj_w']), int(lw['o_proj_s']),
+                   o_out, hidden, hidden)
+
+        attn_proj = o_out.view(1, 1, hidden)
+        h_post = self._res_mid[:, :1]
+        ap, sc, gate_out = self._fp8_scratch[(inter, hidden)]
+        fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+            h_in.data_ptr(), attn_proj.data_ptr(), h_post.data_ptr(),
+            int(lw['post_attn_norm_w']),
+            ap.data_ptr(), sc.data_ptr(), 1, hidden, eps, s)
+        if self.fuse_gate_up:
+            self._gemv(ap, sc, int(lw['gate_up_w']), int(lw['gate_up_s']),
+                       self._gate_up_out, int(lw['gate_up_N']), hidden)
+            gate_out = self._gate_up_out[:, :inter]
+            up_out = self._gate_up_out[:, inter:]
+        else:
+            self._gemv(ap, sc, int(lw['mlp_gate_w']), int(lw['mlp_gate_s']),
+                       self._gate_out, inter, hidden)
+            self._gemv(ap, sc, int(lw['mlp_up_w']), int(lw['mlp_up_s']),
+                       self._up_out, inter, hidden)
+            gate_out = self._gate_out
+            up_out = self._up_out
+        ap, sc, down_out = self._fp8_scratch[(hidden, inter)]
+        fvk.silu_mul_to_fp8_block128_bf16(
+            gate_out.data_ptr(), up_out.data_ptr(),
+            ap.data_ptr(), sc.data_ptr(), 1, inter, s)
+        self._gemv(ap, sc, int(lw['mlp_down_w']), int(lw['mlp_down_s']),
+                   down_out, hidden, inter)
+
+        h_out = (self._layer_out_a if (L % 2 == 0)
+                 else self._layer_out_b)[:, :1]
+        mlp_out = down_out.view(1, 1, hidden)
+        if next_input_norm_w:
+            next_ap, next_sc, _ = self._fp8_scratch[(self._qkv_N, hidden)]
+            fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+                h_post.data_ptr(), mlp_out.data_ptr(), h_out.data_ptr(),
+                int(next_input_norm_w),
+                next_ap.data_ptr(), next_sc.data_ptr(), 1, hidden, eps, s)
+            return h_out, (next_ap, next_sc)
+        torch.add(h_post, mlp_out, out=h_out)
+        return h_out, None
+
+    def _layer_forward_prefill_fp8_blockscaled(self, L: int, h_in_S, cos_S,
+                                           sin_S, start_pos: int, S: int):
+        import torch
+
+        fvk = _import_fvk()
+
+        s = torch.cuda.current_stream().cuda_stream
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        n_q = cfg['num_q_heads']
+        n_kv = cfg['num_kv_heads']
+        hd = cfg['head_dim']
+        inter = cfg['intermediate']
+        eps = float(cfg['rms_norm_eps'])
+        lw = self._weights.ptrs['layers'][L]
+        h2 = h_in_S.view(S, hidden)
+
+        ap_h, sc_h, qkv_out = self._prefill_fp8_scratch[(n_q * hd + 2 * n_kv * hd, hidden)]
+        fvk.rms_norm_to_fp8_block128_bf16(
+            h2.data_ptr(), int(lw['input_norm_w']),
+            ap_h.data_ptr(), sc_h.data_ptr(), S, hidden, eps, s)
+        self._prefill_gemm(
+            ap_h, sc_h, int(lw['qkv_proj_w']), int(lw['qkv_proj_s']),
+            qkv_out, int(lw['qkv_proj_N']), hidden, S)
+
+        qkv = qkv_out[:S]
+        Nq = n_q * hd
+        Nk = n_kv * hd
+        fvk.qwen3_qk_norm_rope_kvwrite_batched_bf16(
+            qkv.data_ptr(),
+            qkv[:, Nq:Nq + Nk].data_ptr(),
+            qkv[:, Nq + Nk:].data_ptr(),
+            int(lw['q_norm_w']),
+            int(lw['k_norm_w']),
+            cos_S.data_ptr(),
+            sin_S.data_ptr(),
+            self._attn.Q_buf[:, :S].data_ptr(),
+            self._attn.K_cache[L, start_pos:start_pos + S].data_ptr(),
+            self._attn.V_cache[L, start_pos:start_pos + S].data_ptr(),
+            S,
+            int(qkv.stride(0)),
+            int(qkv[:, Nq:Nq + Nk].stride(0)),
+            int(qkv[:, Nq + Nk:].stride(0)),
+            int(self._attn.Q_buf[:, :S].stride(1)),
+            int(self._attn.K_cache[L, start_pos:start_pos + S].stride(0)),
+            n_q,
+            n_kv,
+            eps,
+            s)
+
+        self._attn.run(
+            'full', layer_idx=L, q_seq=S, kv_seq=start_pos + S,
+            stream=s, causal=True)
+        attn_2d = self._attn.O_buf[:, :S].view(S, hidden)
+        ap_o, sc_o, o_out = self._prefill_fp8_scratch[(hidden, hidden)]
+        fvk.fp8_per_token_block128_quant_bf16(
+            attn_2d.data_ptr(), ap_o.data_ptr(), sc_o.data_ptr(),
+            S, hidden, s)
+        self._prefill_gemm(
+            ap_o, sc_o, int(lw['o_proj_w']), int(lw['o_proj_s']),
+            o_out, hidden, hidden, S)
+
+        h_post = self._res_mid[:, :S]
+        ap_mlp, sc_mlp, gate_out = self._prefill_fp8_scratch[(inter, hidden)]
+        fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+            h_in_S.data_ptr(), o_out[:S].view(1, S, hidden).data_ptr(),
+            h_post.data_ptr(), int(lw['post_attn_norm_w']),
+            ap_mlp.data_ptr(), sc_mlp.data_ptr(), S, hidden, eps, s)
+        up_out = self._prefill_up_out[:S]
+        ap_dn, sc_dn, down_out = self._prefill_fp8_scratch[(hidden, inter)]
+        if self.fuse_gate_up:
+            _, _, gate_up_out = self._prefill_fp8_scratch[(2 * inter, hidden)]
+            self._prefill_gemm(
+                ap_mlp, sc_mlp, int(lw['gate_up_w']), int(lw['gate_up_s']),
+                gate_up_out, int(lw['gate_up_N']), hidden, S)
+            fvk.silu_mul_merged_to_fp8_block128_bf16(
+                gate_up_out[:S].data_ptr(),
+                ap_dn.data_ptr(), sc_dn.data_ptr(), S, inter, s)
+        else:
+            self._prefill_gemm(
+                ap_mlp, sc_mlp, int(lw['mlp_gate_w']), int(lw['mlp_gate_s']),
+                gate_out, inter, hidden, S)
+            self._prefill_gemm(
+                ap_mlp, sc_mlp, int(lw['mlp_up_w']), int(lw['mlp_up_s']),
+                up_out, inter, hidden, S)
+            fvk.silu_mul_to_fp8_block128_bf16(
+                gate_out[:S].data_ptr(), up_out.data_ptr(),
+                ap_dn.data_ptr(), sc_dn.data_ptr(), S, inter, s)
+        self._prefill_gemm(
+            ap_dn, sc_dn, int(lw['mlp_down_w']), int(lw['mlp_down_s']),
+            down_out, hidden, inter, S)
+
+        h_out = (self._layer_out_a if (L % 2 == 0)
+                 else self._layer_out_b)[:, :S]
+        torch.add(h_post, down_out[:S].view(1, S, hidden), out=h_out)
+        return h_out
+
+    def forward_hidden_prefill_fp8_blockscaled(self, h_S, cos_S, sin_S,
+                                           start_pos: int = 0,
+                                           deepstack_by_layer=None,
+                                           *,
+                                           run_lm_head: bool = True):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        eps = float(cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        S = int(h_S.shape[-2] if h_S.ndim == 3 else h_S.shape[0])
+        if S < 1 or S > self.max_prefill_seq:
+            raise ValueError(
+                f'prefill S={S} out of [1, {self.max_prefill_seq}]; '
+                'construct with a larger max_prefill_seq')
+        if start_pos + S > self.max_seq:
+            raise ValueError(
+                f'prefill end {start_pos + S} > max_seq {self.max_seq}')
+        h = h_S.view(1, S, hidden).to(torch.bfloat16).contiguous()
+        for L in range(cfg['num_hidden_layers']):
+            h = self._layer_forward_prefill_fp8_blockscaled(
+                L, h, cos_S, sin_S, start_pos, S)
+            if deepstack_by_layer is not None and L in deepstack_by_layer:
+                for a, b, ds in deepstack_by_layer[L]:
+                    self._fvk.residual_add(
+                        h[0, a:b].data_ptr(), ds.data_ptr(),
+                        (b - a) * hidden, s)
+
+        h2 = h.view(S, hidden).contiguous()
+        x_norm = self._h_b[:S].view(S, hidden)
+        self._fvk.rms_norm(
+            h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
+            x_norm.data_ptr(), S, hidden, eps, s)
+        self._last_hidden_buf[:, :S].copy_(x_norm.view(1, S, hidden))
+        self._cur_pos = start_pos + S
+        if not run_lm_head:
+            return self._last_hidden_buf[:, :S]
+        return self._write_logits_from_hidden(
+            self._last_hidden_buf[0, S - 1:S])
+
+    def forward_hidden_decode_fp8(self, h, cos_pos, sin_pos, cur_pos: int,
+                                  deepstack_by_layer=None):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        vocab = cfg['vocab_size']
+        eps = float(cfg['rms_norm_eps'])
+        s = torch.cuda.current_stream().cuda_stream
+        h = h.view(1, 1, hidden).contiguous()
+        prequant = None
+        for L in range(cfg['num_hidden_layers']):
+            next_norm = 0
+            if L + 1 < cfg['num_hidden_layers']:
+                next_norm = int(self._weights.ptrs['layers'][L + 1]
+                                ['input_norm_w'])
+            h, prequant = self._layer_forward(
+                L, h, cos_pos, sin_pos, cur_pos,
+                prequant=prequant, next_input_norm_w=next_norm)
+            if deepstack_by_layer is not None and L in deepstack_by_layer:
+                h = h.clone()
+                torch.add(h, deepstack_by_layer[L].view(1, 1, hidden), out=h)
+                prequant = None
+
+        x_norm = self._h_b[:1].view(1, hidden)
+        self._fvk.rms_norm(
+            h.view(1, hidden).contiguous().data_ptr(),
+            int(self._weights.ptrs['final_norm_w']), x_norm.data_ptr(),
+            1, hidden, eps, s)
+        self._last_hidden_buf[:, :1].copy_(x_norm.view(1, 1, hidden))
+        return self._write_logits_from_hidden(x_norm)
+
+    def forward_own_decode_fp8(self, token_id, cos_pos, sin_pos, cur_pos: int):
+        import torch
+
+        cfg = self._cfg
+        assert cfg is not None
+        hidden = cfg['hidden_size']
+        s = torch.cuda.current_stream().cuda_stream
+        if not isinstance(token_id, torch.Tensor):
+            token_id = torch.tensor([token_id], device=self.device,
+                                    dtype=torch.long)
+        if token_id.ndim == 1:
+            token_id = token_id.view(1, 1)
+        h = self._h_a[:1]
+        self._fvk.qwen36_embedding_lookup_bf16(
+            token_id.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            h.data_ptr(),
+            1, hidden, s)
+        return self.forward_hidden_decode_fp8(h, cos_pos, sin_pos, cur_pos)
+
+    def decode_step(self, token_id, cur_pos: int):
+        cos, sin = self._rope_cos_sin(cur_pos)
+        return self.forward_own_decode_fp8(token_id, cos, sin, cur_pos)
+
+    def _ensure_decode_graph(self, cur_pos: int):
+        import torch
+
+        graph = self._decode_graphs.get(cur_pos)
+        if graph is not None:
+            return graph
+        cos, sin = self._rope_cos_sin(cur_pos)
+        gs = self._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.inference_mode():
+            for _ in range(2):
+                self.forward_own_decode_fp8(
+                    self._static_token_id, cos, sin, cur_pos)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.inference_mode():
+            self.forward_own_decode_fp8(
+                self._static_token_id, cos, sin, cur_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._decode_graphs[cur_pos] = graph
+        return graph
+
+    def decode_step_with_graph(self, token_id, cur_pos: int):
+        import torch
+
+        if isinstance(token_id, torch.Tensor):
+            if token_id.ndim == 1:
+                token_id = token_id.view(1, 1)
+            self._static_token_id.copy_(token_id)
+        else:
+            self._static_token_id.fill_(int(token_id))
+        self._ensure_decode_graph(cur_pos).replay()
+        return self._logits_buf

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
@@ -1,0 +1,376 @@
+"""Qwen3-VL official-FP8 multimodal path for RTX SM89.
+
+This wrapper combines the SM89 official-FP8 language frontend with the
+Qwen3-VL vision tower. The single-image prefill path is CUDA-Graph captured:
+processor/geometry run once, static buffers stage the prompt tensors, then
+vision + S>1 FP8 blockscaled language prefill + final norm replay as one graph.
+The lm_head runs eager after replay, matching the SM120 RTX frontend shape.
+Decode remains owned by ``Qwen3VlFp8Sm89TextFrontend``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class Qwen3VlFp8Sm89Frontend:
+    """Batch-1 Qwen3-VL prefill/decode frontend for SM89 official FP8."""
+
+    def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
+                 max_seq: int = 4096, max_prefill_seq: int | None = None,
+                 max_pixels: int | None = None,
+                 fuse_gate_up: bool = False,
+                 fuse_qk_postproc: bool = True,
+                 use_fp8_lm_head: bool = False,
+                 vision_bf16_first_blocks: int = 3,
+                 vision_bf16_block_linears: dict[int, tuple[str, ...]]
+                 | None = None) -> None:
+        import json
+        import os
+
+        from transformers import AutoProcessor
+
+        from flash_rt.frontends.torch._qwen3_vl_vision_rtx import (
+            Qwen3VlVisionRtx,
+        )
+        from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+            Qwen3VlFp8Sm89TextFrontend,
+            _resolve_max_prefill_seq,
+        )
+        from flash_rt.frontends.torch.qwen3_vl_rtx import (
+            _require_qwen3_vl_kernels,
+        )
+
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+        _require_qwen3_vl_kernels()
+        self.max_prefill_seq = _resolve_max_prefill_seq(
+            self.max_seq, max_prefill_seq)
+        self.llm = Qwen3VlFp8Sm89TextFrontend(
+            checkpoint_path, device=device, max_seq=max_seq,
+            max_prefill_seq=self.max_prefill_seq,
+            fuse_gate_up=fuse_gate_up,
+            fuse_qk_postproc=fuse_qk_postproc,
+            use_fp8_lm_head=use_fp8_lm_head)
+        self.arch = 'sm89'
+        cfg = json.load(open(os.path.join(checkpoint_path, 'config.json')))
+        vcfg = dict(cfg['vision_config'])
+        vcfg['_bf16_first_blocks'] = int(vision_bf16_first_blocks)
+        if vision_bf16_block_linears is not None:
+            vcfg['_bf16_block_linears'] = {
+                int(k): [str(name) for name in names]
+                for k, names in vision_bf16_block_linears.items()
+            }
+        self.vision = Qwen3VlVisionRtx(
+            checkpoint_path, device=device, config=vcfg)
+        self.processor = AutoProcessor.from_pretrained(checkpoint_path)
+        self._image_token_id = int(cfg['image_token_id'])
+        self._video_token_id = int(cfg['video_token_id'])
+        self._vision_start_token_id = int(cfg['vision_start_token_id'])
+        vc = cfg['vision_config']
+        self._merge = int(vc['spatial_merge_size'])
+        self._vis_head_dim = int(vc['hidden_size']) // int(vc['num_heads'])
+        self._num_grid_per_side = int(vc['num_position_embeddings'] ** 0.5)
+        self._deepstack_layers = len(vc['deepstack_visual_indexes'])
+        self._rope_theta = float(cfg['text_config']['rope_theta'])
+        self._head_dim = int(cfg['text_config']['head_dim'])
+        self._mrope_section = tuple(
+            cfg['text_config']['rope_scaling']['mrope_section'])
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+        self._mrope_cos_cache, self._mrope_sin_cache = geo.build_mrope_cache(
+            max_pos=self.max_seq + self._num_grid_per_side,
+            head_dim=self._head_dim, rope_theta=self._rope_theta,
+            device=self.device)
+        self._vision_rope_cos_cache, self._vision_rope_sin_cache = (
+            geo.build_vision_rope_cache(
+                max_hw=self.max_seq * self._merge,
+                head_dim=self._vis_head_dim, device=self.device))
+        eos = cfg.get('eos_token_id')
+        if eos is None:
+            eos = cfg['text_config'].get('eos_token_id')
+        self._eos_token_ids = set(
+            [] if eos is None else (eos if isinstance(eos, list) else [eos]))
+        self.max_pixels = max_pixels
+        if max_pixels is not None:
+            for proc in (getattr(self.processor, 'image_processor', None),
+                         getattr(self.processor, 'video_processor', None)):
+                size = getattr(proc, 'size', None)
+                if isinstance(size, dict) and 'longest_edge' in size:
+                    size['longest_edge'] = int(max_pixels)
+        self._prompt: dict[str, Any] | None = None
+        self._decode_graphs: dict[tuple[int, int], Any] = {}
+        self._prefill_graphs: dict = {}
+        self._pg_buffers: dict = {}
+
+    _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
+                'vcos', 'vsin', 'mcos', 'msin')
+
+    def _stage_prefill_inputs(self, P: int, S: int, span):
+        p = self._prompt
+        key = (P, S, span[0], span[1])
+        bufs = self._pg_buffers.get(key)
+        if bufs is None:
+            bufs = {k: p[k].clone() for k in self._PG_KEYS}
+            self._pg_buffers[key] = bufs
+        else:
+            for k in self._PG_KEYS:
+                bufs[k].copy_(p[k])
+        return key
+
+    def set_prompt(self, messages: list) -> None:
+        import torch
+
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+        self._decode_graphs.clear()
+        inputs = self.processor.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=True,
+            return_dict=True, return_tensors='pt',
+            device=self.device).to(self.device)
+        input_ids = inputs['input_ids'][0]
+        S = int(input_ids.shape[0])
+        if S > self.max_seq:
+            raise ValueError(
+                f'prompt length {S} exceeds max_seq {self.max_seq}')
+
+        image_grid = inputs.get('image_grid_thw')
+        video_grid = inputs.get('video_grid_thw')
+        pix_img = inputs.get('pixel_values')
+        pix_vid = inputs.get('pixel_values_videos')
+        if pix_img is not None:
+            pix_img = pix_img.to(torch.bfloat16)
+        if pix_vid is not None:
+            pix_vid = pix_vid.to(torch.bfloat16)
+
+        segs = geo.vision_segments(
+            input_ids.cpu(), image_grid, video_grid,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
+            spatial_merge_size=self._merge)
+        seg_pix = []
+        seg_grids = []
+        spans = []
+        seg_patches = []
+        off_img = off_vid = 0
+        for sg in segs:
+            npp = sg['patches']
+            if sg['kind'] == 'image':
+                seg_pix.append(pix_img[off_img:off_img + npp])
+                off_img += npp
+            else:
+                seg_pix.append(pix_vid[off_vid:off_vid + npp])
+                off_vid += npp
+            seg_grids.append(sg['grid'])
+            spans.append(sg['span'])
+            seg_patches.append(npp)
+
+        seg_grid = torch.tensor(seg_grids, dtype=torch.long)
+        pos_ids = geo.mrope_position_ids(
+            input_ids.cpu(),
+            image_grid.cpu() if image_grid is not None else None,
+            video_grid.cpu() if video_grid is not None else None,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
+            vision_start_token_id=self._vision_start_token_id,
+            spatial_merge_size=self._merge)
+        mcos, msin = geo.mrope_cos_sin_cached(
+            pos_ids, self._mrope_cos_cache, self._mrope_sin_cache,
+            mrope_section=self._mrope_section)
+        vcos, vsin = geo.vision_rope_cos_sin_cached(
+            seg_grid, self._vision_rope_cos_cache, self._vision_rope_sin_cache,
+            spatial_merge_size=self._merge)
+        pos_embeds = geo.vision_pos_embeds(
+            seg_grid, self.vision.pos_embed,
+            num_grid_per_side=self._num_grid_per_side,
+            spatial_merge_size=self._merge, device=self.device)
+        self._prompt = {
+            'input_ids': input_ids,
+            'pixel_values': torch.cat(seg_pix, dim=0).contiguous(),
+            'spans': spans,
+            'seg_patches': seg_patches,
+            'mcos': mcos,
+            'msin': msin,
+            'vcos': vcos,
+            'vsin': vsin,
+            'pos_embeds': pos_embeds,
+            'S': S,
+            'mrope_max': int(pos_ids.max()),
+        }
+        if len(spans) == 1:
+            self._prompt['pg_key'] = self._stage_prefill_inputs(
+                seg_patches[0], S, spans[0])
+
+    def prefill(self):
+        import torch
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill()')
+        p = self._prompt
+        llm = self.llm
+        llm.reset_state()
+        hidden = llm._cfg['hidden_size']
+        S = int(p['S'])
+        embed = llm._weights.anchors[0]
+        h = embed[p['input_ids']].to(torch.bfloat16).view(S, hidden)
+        seg_deepstacks = []
+        off = 0
+        for (a, b), n_patch in zip(p['spans'], p['seg_patches']):
+            sl = slice(off, off + n_patch)
+            off += n_patch
+            emb, ds = self.vision.forward(
+                p['pixel_values'][sl], p['pos_embeds'][sl],
+                p['vcos'][sl], p['vsin'][sl])
+            h[a:b].copy_(emb.to(torch.bfloat16))
+            seg_deepstacks.append(ds)
+
+        deep = {}
+        for layer in range(self._deepstack_layers):
+            rows = []
+            for (a, b), ds in zip(p['spans'], seg_deepstacks):
+                rows.append((a, b, ds[layer].to(torch.bfloat16).contiguous()))
+            deep[layer] = rows
+        logits = llm.forward_hidden_prefill_fp8_blockscaled(
+            h, p['mcos'], p['msin'], 0, deepstack_by_layer=deep)
+        torch.cuda.synchronize()
+        return logits
+
+    def _prefill_graph_body(self, st, P, S, a, b):
+        import torch
+
+        llm = self.llm
+        hidden = llm._cfg['hidden_size']
+        embed = llm._weights.anchors[0]
+        h = embed[st['input_ids']].to(torch.bfloat16).view(S, hidden)
+        emb, ds = self.vision.forward(
+            st['pixel_values'], st['pos_embeds'], st['vcos'], st['vsin'])
+        h[a:b].copy_(emb.to(torch.bfloat16))
+
+        deep = {}
+        for layer in range(self._deepstack_layers):
+            deep[layer] = [(a, b, ds[layer].to(torch.bfloat16).contiguous())]
+        llm.forward_hidden_prefill_fp8_blockscaled(
+            h, st['mcos'], st['msin'], 0, deepstack_by_layer=deep,
+            run_lm_head=False)
+
+    def _capture_prefill_graph(self, st, P, S, a, b):
+        import torch
+
+        llm = self.llm
+        gs = llm._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.no_grad():
+            for _ in range(2):
+                self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.no_grad():
+            self._prefill_graph_body(st, P, S, a, b)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        return graph
+
+    def prefill_graph(self):
+        import torch
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill_graph()')
+        p = self._prompt
+        key = p.get('pg_key')
+        if key is None:
+            return self.prefill()
+
+        P, S, a, b = key
+        st = self._pg_buffers[key]
+        graph = self._prefill_graphs.get(key)
+        if graph is None:
+            graph = self._capture_prefill_graph(st, P, S, a, b)
+            self._prefill_graphs[key] = graph
+        graph.replay()
+        logits = self.llm._write_logits_from_hidden(
+            self.llm._last_hidden_buf[0, S - 1:S])
+        torch.cuda.synchronize()
+        return logits
+
+    def decode_step(self, token_id, cache_pos: int):
+        if self._prompt is None:
+            rope_pos = cache_pos
+        else:
+            rope_pos = int(self._prompt['mrope_max']) + 1 + (
+                cache_pos - int(self._prompt['S']))
+        cos, sin = self.llm._rope_cos_sin(rope_pos)
+        return self.llm.forward_own_decode_fp8(token_id, cos, sin, cache_pos)
+
+    def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
+        import torch
+
+        key = (int(cache_pos), int(rope_pos))
+        graph = self._decode_graphs.get(key)
+        if graph is not None:
+            return graph
+        llm = self.llm
+        cos, sin = llm._rope_cos_sin(rope_pos)
+        gs = llm._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.inference_mode():
+            for _ in range(2):
+                llm.forward_own_decode_fp8(
+                    llm._static_token_id, cos, sin, cache_pos)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.inference_mode():
+            llm.forward_own_decode_fp8(
+                llm._static_token_id, cos, sin, cache_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._decode_graphs[key] = graph
+        return graph
+
+    def decode_step_with_graph(self, token_id, cache_pos: int):
+        if self._prompt is None:
+            rope_pos = cache_pos
+        else:
+            rope_pos = int(self._prompt['mrope_max']) + 1 + (
+                cache_pos - int(self._prompt['S']))
+        llm = self.llm
+        if hasattr(token_id, 'ndim'):
+            if token_id.ndim == 1:
+                token_id = token_id.view(1, 1)
+            llm._static_token_id.copy_(token_id)
+        else:
+            llm._static_token_id.fill_(int(token_id))
+        self._ensure_decode_graph(cache_pos, rope_pos).replay()
+        return llm._logits_buf
+
+    def warmup_decode_graphs(self, n_tokens: int) -> None:
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before warmup')
+        base_slot = int(self._prompt['S'])
+        base_rope = int(self._prompt['mrope_max']) + 1
+        for i in range(int(n_tokens)):
+            self._ensure_decode_graph(base_slot + i, base_rope + i)
+
+    def generate(self, messages: list, *, max_new_tokens: int = 256,
+                 use_graph: bool = True) -> str:
+        self.set_prompt(messages)
+        logits = self.prefill_graph() if use_graph else self.prefill()
+        p = self._prompt
+        assert p is not None
+        base_slot = int(p['S'])
+
+        tok = int(logits[0].float().argmax())
+        out_ids = [tok]
+        for i in range(max_new_tokens - 1):
+            if tok in self._eos_token_ids:
+                break
+            if use_graph:
+                logits = self.decode_step_with_graph(tok, base_slot + i)
+            else:
+                logits = self.decode_step(tok, base_slot + i)
+            tok = int(logits[0].float().argmax())
+            out_ids.append(tok)
+
+        eos = [t for t in out_ids if t in self._eos_token_ids]
+        if eos:
+            out_ids = out_ids[:out_ids.index(eos[0])]
+        return self.processor.tokenizer.decode(
+            out_ids, skip_special_tokens=True)

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -42,7 +42,8 @@ def _check_qwen3_vl_kernels(module) -> None:
     if missing:
         raise RuntimeError(
             'flash_rt_qwen3_vl_kernels is missing ' + ', '.join(missing)
-            + '. Rebuild it with -DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=120).')
+            + '. Rebuild it with -DFLASHRT_BUILD_QWEN3_VL=ON '
+            '(GPU_ARCH=89 or 120).')
 
 
 def _require_qwen3_vl_kernels():
@@ -53,7 +54,7 @@ def _require_qwen3_vl_kernels():
     except ImportError as e:
         raise RuntimeError(
             'flash_rt_qwen3_vl_kernels is not built. Configure with '
-            '-DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=120) and build the '
+            '-DFLASHRT_BUILD_QWEN3_VL=ON (GPU_ARCH=89 or 120) and build the '
             'flash_rt_qwen3_vl_kernels target.') from e
     _check_qwen3_vl_kernels(vlk)
     return vlk
@@ -98,6 +99,15 @@ class Qwen3VlTorchFrontendRtx:
         self._rope_theta = float(cfg['rope_theta'])
         self._head_dim = int(cfg['head_dim'])
         self._mrope_section = tuple(cfg['rope_scaling']['mrope_section'])
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+        self._mrope_cos_cache, self._mrope_sin_cache = geo.build_mrope_cache(
+            max_pos=self.max_seq + self._num_grid_per_side,
+            head_dim=self._head_dim, rope_theta=self._rope_theta,
+            device=self.device)
+        self._vision_rope_cos_cache, self._vision_rope_sin_cache = (
+            geo.build_vision_rope_cache(
+                max_hw=self.max_seq * self._merge,
+                head_dim=self._vis_head_dim, device=self.device))
         eos = cfg.get('eos_token_id')
         if eos is None:
             self._eos_token_ids: set = set()
@@ -208,12 +218,12 @@ class Qwen3VlTorchFrontendRtx:
             video_token_id=self._video_token_id,
             vision_start_token_id=self._vision_start_token_id,
             spatial_merge_size=m)
-        mcos, msin = geo.mrope_cos_sin(
-            pos_ids, head_dim=self._head_dim, rope_theta=self._rope_theta,
-            mrope_section=self._mrope_section, device=self.device)
-        vcos, vsin = geo.vision_rope_cos_sin(
-            seg_grid, head_dim=self._vis_head_dim,
-            spatial_merge_size=m, device=self.device)
+        mcos, msin = geo.mrope_cos_sin_cached(
+            pos_ids, self._mrope_cos_cache, self._mrope_sin_cache,
+            mrope_section=self._mrope_section)
+        vcos, vsin = geo.vision_rope_cos_sin_cached(
+            seg_grid, self._vision_rope_cos_cache, self._vision_rope_sin_cache,
+            spatial_merge_size=m)
         pos_embeds = geo.vision_pos_embeds(
             seg_grid, self.vision.pos_embed,
             num_grid_per_side=self._num_grid_per_side,

--- a/flash_rt/hardware/rtx/attn_backend_qwen3.py
+++ b/flash_rt/hardware/rtx/attn_backend_qwen3.py
@@ -46,14 +46,35 @@ class RtxFlashAttnBackendQwen3:
     NUM_KV_HEADS = 8                # GQA 4:1
     HEAD_DIM = 128
 
-    def __init__(self, max_seq: int, max_q_seq: int = 1, dtype=None):
+    def __init__(self, max_seq: int, max_q_seq: int = 1, dtype=None,
+                 *, num_layers: int | None = None,
+                 num_q_heads: int | None = None,
+                 num_kv_heads: int | None = None,
+                 head_dim: int | None = None,
+                 device: str = "cuda"):
         import os
 
         import torch
 
         self._torch = torch
         bf16 = dtype if dtype is not None else torch.bfloat16
-        d = "cuda"
+        d = torch.device(device)
+
+        # Per-instance attention geometry. Defaults match Qwen3-VL-8B
+        # (36/32/8/128); the 2B variant passes 28/16/8/128. Class constants
+        # are kept for the static spec helper / backward compat.
+        self.NUM_FULL_LAYERS = (
+            int(num_layers) if num_layers is not None
+            else type(self).NUM_FULL_LAYERS)
+        self.NUM_Q_HEADS = (
+            int(num_q_heads) if num_q_heads is not None
+            else type(self).NUM_Q_HEADS)
+        self.NUM_KV_HEADS = (
+            int(num_kv_heads) if num_kv_heads is not None
+            else type(self).NUM_KV_HEADS)
+        self.HEAD_DIM = (
+            int(head_dim) if head_dim is not None
+            else type(self).HEAD_DIM)
 
         self._max_seq = int(max_seq)
         self._max_q_seq = int(max_q_seq)
@@ -106,7 +127,7 @@ class RtxFlashAttnBackendQwen3:
         # (bf16, head_dim=128); other shapes fall back to the SDPA path.
         self._fa2_fwd_causal = getattr(_fa2, 'fwd_bf16_causal', None)
         self._num_sms = torch.cuda.get_device_properties(
-            torch.cuda.current_device()
+            d
         ).multi_processor_count
 
         # Optional debug bisect knob (mirror qwen36 sibling).

--- a/scripts/quantize_qwen3_vl_to_fp8_block128.py
+++ b/scripts/quantize_qwen3_vl_to_fp8_block128.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Quantize a BF16 Qwen3-VL checkpoint to the official block-128 FP8 layout.
+
+The official Qwen3-VL-8B release ships an FP8 checkpoint (e4m3 ``weight`` +
+128x128 ``weight_scale_inv`` block scales). The 2B release ships only BF16, so
+this tool produces a byte-compatible FP8 checkpoint for the SM89 block-128 FP8
+language path.
+
+It quantizes exactly the language-stack linear weights
+(``model.language_model.layers.*`` q/k/v/o + gate/up/down ``.weight``) to
+``torch.float8_e4m3fn`` plus a fp32 ``.weight_scale_inv`` of shape
+``(N/128, K/128)`` where each entry is ``amax / 448`` over its 128x128 block
+(multiply-to-dequant) -- the same convention the SM89 GEMM/GEMV kernels and the
+``_qwen3_vl_fp8_weights`` loader expect. Every other tensor (norms,
+``embed_tokens``, the whole BF16 vision tower) is copied through unchanged.
+
+Tied embeddings: the 2B ties ``lm_head`` to ``embed_tokens`` and ships no
+``lm_head.weight``; the loader synthesises it from the embedding matrix, so this
+tool does not materialise a separate (0.6 GB) lm_head.
+
+Usage::
+
+    python scripts/quantize_qwen3_vl_to_fp8_block128.py \
+        --src /path/to/Qwen3-VL-2B-Instruct \
+        --dst /path/to/Qwen3-VL-2B-Instruct-FP8
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+_BLOCK = 128
+_FP8_MAX = 448.0
+
+# Suffixes of language-stack linear weights that get FP8-quantized.
+_QUANT_SUFFIXES = (
+    '.self_attn.q_proj.weight',
+    '.self_attn.k_proj.weight',
+    '.self_attn.v_proj.weight',
+    '.self_attn.o_proj.weight',
+    '.mlp.gate_proj.weight',
+    '.mlp.up_proj.weight',
+    '.mlp.down_proj.weight',
+)
+
+
+def _is_quant_target(key: str) -> bool:
+    if not key.startswith('model.language_model.layers.'):
+        return False
+    return any(key.endswith(suf) for suf in _QUANT_SUFFIXES)
+
+
+def _quantize_block128(w: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """BF16/FP32 [N, K] -> (e4m3 [N, K], fp32 scale [N/128, K/128]).
+
+    scale = amax/448 per 128x128 block; dequant is ``q * scale`` (the loader's
+    ``weight_scale_inv`` semantics).
+    """
+    N, K = w.shape
+    if N % _BLOCK != 0 or K % _BLOCK != 0:
+        raise ValueError(f'weight {tuple(w.shape)} not divisible by {_BLOCK}')
+    wf = w.detach().to(torch.float32)
+    view = wf.view(N // _BLOCK, _BLOCK, K // _BLOCK, _BLOCK)
+    amax = view.abs().amax(dim=(1, 3))
+    scale = (amax / _FP8_MAX).clamp_min(1e-12)
+    q = (view / scale[:, None, :, None]).clamp(-_FP8_MAX, _FP8_MAX)
+    q = q.to(torch.float8_e4m3fn).view(N, K).contiguous()
+    return q, scale.to(torch.float32).contiguous()
+
+
+def _iter_src_tensors(src: str):
+    """Yield (key, tensor) over a sharded or single-file safetensors ckpt."""
+    idx_path = os.path.join(src, 'model.safetensors.index.json')
+    if os.path.isfile(idx_path):
+        wmap = json.load(open(idx_path))['weight_map']
+        shards = sorted(set(wmap.values()))
+        for shard in shards:
+            with safe_open(os.path.join(src, shard), framework='pt',
+                           device='cpu') as f:
+                for key in f.keys():
+                    yield key, f.get_tensor(key)
+    else:
+        single = os.path.join(src, 'model.safetensors')
+        if not os.path.isfile(single):
+            raise RuntimeError(f'no safetensors found under {src}')
+        with safe_open(single, framework='pt', device='cpu') as f:
+            for key in f.keys():
+                yield key, f.get_tensor(key)
+
+
+def _copy_aux_files(src: str, dst: str) -> None:
+    """Copy tokenizer / processor / template config alongside the weights."""
+    names = (
+        'config.json', 'generation_config.json', 'tokenizer.json',
+        'tokenizer_config.json', 'vocab.json', 'merges.txt',
+        'chat_template.json', 'preprocessor_config.json',
+        'video_preprocessor_config.json', 'configuration.json',
+    )
+    for name in names:
+        s = os.path.join(src, name)
+        if os.path.isfile(s):
+            shutil.copy2(s, os.path.join(dst, name))
+
+
+def _write_quant_config(src: str, dst: str) -> None:
+    """Add an fp8 block-128 quantization_config so the ckpt self-describes."""
+    cfg = json.load(open(os.path.join(src, 'config.json')))
+    cfg['quantization_config'] = {
+        'activation_scheme': 'dynamic',
+        'fmt': 'e4m3',
+        'quant_method': 'fp8',
+        'weight_block_size': [_BLOCK, _BLOCK],
+        'modules_to_not_convert': ['lm_head', 'model.visual'],
+    }
+    with open(os.path.join(dst, 'config.json'), 'w') as f:
+        json.dump(cfg, f, indent=2)
+
+
+def _expected_quant_linears(src: str) -> int:
+    cfg = json.load(open(os.path.join(src, 'config.json')))
+    return int(cfg['text_config']['num_hidden_layers']) * len(_QUANT_SUFFIXES)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--src', required=True, help='BF16 source checkpoint dir')
+    ap.add_argument('--dst', required=True, help='output FP8 checkpoint dir')
+    ap.add_argument('--shard-bytes', type=int, default=4_000_000_000,
+                    help='target max bytes per output shard')
+    args = ap.parse_args()
+
+    src = os.path.expanduser(args.src)
+    dst = os.path.expanduser(args.dst)
+    os.makedirs(dst, exist_ok=True)
+
+    out: dict[str, torch.Tensor] = {}
+    n_quant = 0
+    n_copy = 0
+    expected_quant = _expected_quant_linears(src)
+    for key, t in _iter_src_tensors(src):
+        if _is_quant_target(key):
+            q, scale = _quantize_block128(t)
+            out[key] = q
+            out[key[:-len('.weight')] + '.weight_scale_inv'] = scale
+            n_quant += 1
+        else:
+            # Keep norms / embeddings / vision tower in their native dtype
+            # (BF16 for this checkpoint family).
+            out[key] = t.detach().contiguous()
+            n_copy += 1
+
+    if n_quant != expected_quant:
+        raise RuntimeError(
+            f'quantized {n_quant} language linears, expected '
+            f'{expected_quant}; check checkpoint layout under {src}')
+
+    # Shard by accumulated byte size, mirroring the HF safetensors layout.
+    keys = list(out.keys())
+    shards: list[list[str]] = [[]]
+    cur = 0
+    for key in keys:
+        nbytes = out[key].numel() * out[key].element_size()
+        if cur > 0 and cur + nbytes > args.shard_bytes:
+            shards.append([])
+            cur = 0
+        shards[-1].append(key)
+        cur += nbytes
+
+    total = len(shards)
+    weight_map: dict[str, str] = {}
+    if total == 1:
+        shard_name = 'model.safetensors'
+        save_file({k: out[k] for k in shards[0]}, os.path.join(dst, shard_name),
+                  metadata={'format': 'pt'})
+        for k in shards[0]:
+            weight_map[k] = shard_name
+    else:
+        for i, shard_keys in enumerate(shards):
+            shard_name = f'model-{i + 1:05d}-of-{total:05d}.safetensors'
+            save_file({k: out[k] for k in shard_keys},
+                      os.path.join(dst, shard_name),
+                      metadata={'format': 'pt'})
+            for k in shard_keys:
+                weight_map[k] = shard_name
+
+    total_bytes = sum(out[k].numel() * out[k].element_size() for k in keys)
+    with open(os.path.join(dst, 'model.safetensors.index.json'), 'w') as f:
+        json.dump({'metadata': {'total_size': total_bytes},
+                   'weight_map': weight_map}, f, indent=2)
+
+    _copy_aux_files(src, dst)
+    _write_quant_config(src, dst)
+    print(f'quantized {n_quant} linears, copied {n_copy} tensors '
+          f'-> {total} shard(s), {total_bytes / 1e9:.2f} GB at {dst}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/smoke_qwen3_vl_fp8_sm89.py
+++ b/scripts/smoke_qwen3_vl_fp8_sm89.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""End-to-end smoke/bench for Qwen3-VL official-FP8 SM89 frontends."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+import time
+
+import torch
+from PIL import Image
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _event_time_ms(fn, iters: int) -> list[float]:
+    times = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fn()
+        end.record()
+        end.synchronize()
+        times.append(float(start.elapsed_time(end)))
+    return times
+
+
+def _summarize(times: list[float]) -> str:
+    return (
+        f"median={statistics.median(times):.3f} ms "
+        f"mean={statistics.mean(times):.3f} ms min={min(times):.3f} ms")
+
+
+def _bench_text(args) -> None:
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+        Qwen3VlFp8Sm89TextFrontend,
+    )
+
+    fe = Qwen3VlFp8Sm89TextFrontend(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_prefill_seq=args.max_prefill_seq,
+        fuse_gate_up=args.fuse_gate_up,
+        fuse_qk_postproc=not args.no_fuse_qk_postproc,
+        use_fp8_lm_head=args.fp8_lm_head)
+    hidden = int(fe._cfg["hidden_size"])
+    embed = fe._weights.anchors[0]
+    ids = torch.arange(args.text_token_base, args.text_token_base + args.text_s,
+                       device=args.device, dtype=torch.long)
+    h = embed[ids].to(torch.bfloat16).view(args.text_s, hidden).contiguous()
+    cos = fe._rope_cos_table[:args.text_s]
+    sin = fe._rope_sin_table[:args.text_s]
+
+    fe.reset_state()
+    fe.forward_hidden_prefill_fp8_blockscaled(h, cos, sin, 0)
+    torch.cuda.synchronize()
+    prefill_times = []
+    logits = None
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fe.reset_state()
+        logits = fe.forward_hidden_prefill_fp8_blockscaled(h, cos, sin, 0)
+        torch.cuda.synchronize()
+        prefill_times.append((time.perf_counter() - t0) * 1000.0)
+    logits_f = logits.detach().float().clone()
+
+    fe.reset_state()
+    loop_logits = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for pos in range(args.text_s):
+        loop_logits = fe.forward_hidden_decode_fp8(
+            h[pos], cos[pos:pos + 1], sin[pos:pos + 1], pos)
+    torch.cuda.synchronize()
+    loop_ms = (time.perf_counter() - t0) * 1000.0
+    loop_f = loop_logits.detach().float().clone()
+    cosv = torch.nn.functional.cosine_similarity(logits_f, loop_f).item()
+
+    fe.reset_state()
+    fe.decode_step_with_graph(args.decode_token, args.decode_pos)
+    torch.cuda.synchronize()
+    decode_times = _event_time_ms(
+        lambda: fe.decode_step_with_graph(args.decode_token, args.decode_pos),
+        args.iters)
+
+    print("--- text ---")
+    print(f"S={args.text_s} prefill {_summarize(prefill_times)}")
+    print(f"token_loop_ms={loop_ms:.3f} "
+          f"prefill_speedup={loop_ms / statistics.median(prefill_times):.2f}x "
+          f"logit_cos={cosv:.6f} top_prefill={int(logits_f.argmax())} "
+          f"top_loop={int(loop_f.argmax())}")
+    print(f"graph_decode_pos={args.decode_pos} {_summarize(decode_times)} "
+          f"top={int(fe._logits_buf.argmax())} "
+          f"finite={torch.isfinite(fe._logits_buf).all().item()}")
+
+
+def _bench_multimodal(args) -> None:
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+        Qwen3VlFp8Sm89Frontend,
+    )
+
+    fe = Qwen3VlFp8Sm89Frontend(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_prefill_seq=args.max_prefill_seq, max_pixels=args.max_pixels,
+        fuse_gate_up=args.fuse_gate_up,
+        fuse_qk_postproc=not args.no_fuse_qk_postproc,
+        use_fp8_lm_head=args.fp8_lm_head,
+        vision_bf16_first_blocks=args.vision_bf16_first_blocks,
+        vision_bf16_block_linears=(
+            None if not args.vision_block2_bf16_linears else {
+                2: tuple(
+                    name.strip()
+                    for name in args.vision_block2_bf16_linears.split(",")
+                    if name.strip())
+            }))
+    img = Image.open(args.image).convert("RGB")
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "image", "image": img},
+            {"type": "text", "text": args.prompt},
+        ],
+    }]
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    fe.set_prompt(messages)
+    torch.cuda.synchronize()
+    set_prompt_ms = (time.perf_counter() - t0) * 1000.0
+    set_prompt_warm_times = []
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fe.set_prompt(messages)
+        torch.cuda.synchronize()
+        set_prompt_warm_times.append((time.perf_counter() - t0) * 1000.0)
+    p = fe._prompt
+    assert p is not None
+    llm = fe.llm
+    S = int(p["S"])
+    hidden = int(llm._cfg["hidden_size"])
+    embed = llm._weights.anchors[0]
+    h = embed[p["input_ids"]].to(torch.bfloat16).view(S, hidden).contiguous()
+
+    vision_times = []
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        off = 0
+        for n_patch in p["seg_patches"]:
+            sl = slice(off, off + n_patch)
+            off += n_patch
+            fe.vision.forward(
+                p["pixel_values"][sl], p["pos_embeds"][sl],
+                p["vcos"][sl], p["vsin"][sl])
+        torch.cuda.synchronize()
+        vision_times.append((time.perf_counter() - t0) * 1000.0)
+
+    llm.reset_state()
+    llm.forward_hidden_prefill_fp8_blockscaled(
+        h, p["mcos"], p["msin"], 0, run_lm_head=False)
+    torch.cuda.synchronize()
+    lang_times = []
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        llm.reset_state()
+        llm.forward_hidden_prefill_fp8_blockscaled(
+            h, p["mcos"], p["msin"], 0, run_lm_head=False)
+        torch.cuda.synchronize()
+        lang_times.append((time.perf_counter() - t0) * 1000.0)
+
+    fe.prefill()
+    torch.cuda.synchronize()
+    prefill_times = []
+    logits = None
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        logits = fe.prefill()
+        torch.cuda.synchronize()
+        prefill_times.append((time.perf_counter() - t0) * 1000.0)
+
+    prefill_logits_f = logits.detach().float().clone()
+    graph_logits_f = prefill_logits_f
+    graph_prefill_times = None
+    if len(p["spans"]) == 1:
+        fe.prefill_graph()
+        torch.cuda.synchronize()
+        graph_prefill_times = _event_time_ms(
+            lambda: fe.prefill_graph(), args.iters)
+        graph_logits_f = fe.llm._logits_buf.detach().float().clone()
+
+    tok = int(graph_logits_f.argmax())
+    cache_pos = int(p["S"])
+    eager = fe.decode_step(tok, cache_pos)
+    eager_f = eager.detach().float().clone()
+    graph = fe.decode_step_with_graph(tok, cache_pos)
+    graph_f = graph.detach().float().clone()
+    torch.cuda.synchronize()
+    decode_times = _event_time_ms(
+        lambda: fe.decode_step_with_graph(tok, cache_pos), args.iters)
+    cosv = torch.nn.functional.cosine_similarity(eager_f, graph_f).item()
+
+    generated = ""
+    if args.generate_tokens > 0:
+        generated = fe.generate(
+            messages, max_new_tokens=args.generate_tokens, use_graph=True)
+
+    print("--- multimodal ---")
+    print(f"image={args.image} S={p['S']} "
+          f"pixel_shape={tuple(p['pixel_values'].shape)} "
+          f"spans={p['spans']} set_prompt_ms={set_prompt_ms:.3f}")
+    print(f"set_prompt_warm {_summarize(set_prompt_warm_times)}")
+    print(f"vision_only {_summarize(vision_times)}")
+    print(f"language_only_no_mm_scatter {_summarize(lang_times)}")
+    print(f"prefill {_summarize(prefill_times)} "
+          f"top={int(prefill_logits_f.argmax())} "
+          f"finite={torch.isfinite(prefill_logits_f).all().item()}")
+    if graph_prefill_times is not None:
+        graph_cos = torch.nn.functional.cosine_similarity(
+            prefill_logits_f, graph_logits_f).item()
+        print(f"prefill_graph {_summarize(graph_prefill_times)} "
+              f"cos_vs_eager={graph_cos:.6f} "
+              f"top={int(graph_logits_f.argmax())} "
+              f"finite={torch.isfinite(graph_logits_f).all().item()}")
+    print(f"graph_decode_cache_pos={cache_pos} {_summarize(decode_times)} "
+          f"cos_vs_eager={cosv:.6f} top_eager={int(eager_f.argmax())} "
+          f"top_graph={int(graph_f.argmax())}")
+    if args.generate_tokens > 0:
+        print(f"generate_tokens={args.generate_tokens} text={generated!r}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--max-seq", type=int, default=2048)
+    p.add_argument("--max-prefill-seq", type=int, default=None)
+    p.add_argument("--warmup", type=int, default=1)
+    p.add_argument("--iters", type=int, default=5)
+    p.add_argument("--text-only", action="store_true")
+    p.add_argument("--multimodal", action="store_true")
+    p.add_argument("--text-s", type=int, default=79)
+    p.add_argument("--text-token-base", type=int, default=100)
+    p.add_argument("--decode-token", type=int, default=100)
+    p.add_argument("--decode-pos", type=int, default=63)
+    p.add_argument("--fuse-gate-up", action="store_true")
+    p.add_argument("--no-fuse-qk-postproc", action="store_true",
+                   help="use the older two-launch Q/K postprocess path")
+    p.add_argument("--fp8-lm-head", action="store_true")
+    p.add_argument("--vision-bf16-first-blocks", type=int, default=3)
+    p.add_argument("--vision-block2-bf16-linears", default="",
+                   help="experimental SM89-only override for vision block 2; "
+                        "comma-separated subset of qkv,proj,fc1,fc2")
+    p.add_argument("--max-pixels", type=int, default=None)
+    p.add_argument("--image", default=str(REPO_ROOT / "FlashRT.png"))
+    p.add_argument("--prompt",
+                   default="Describe this image in one sentence.")
+    p.add_argument("--generate-tokens", type=int, default=2)
+    args = p.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    torch.cuda.set_device(torch.device(args.device))
+    if args.warmup != 1:
+        print("note: --warmup is accepted for CLI symmetry; "
+              "frontends perform their own first-call warmup")
+    run_text = args.text_only or not args.multimodal
+    run_mm = args.multimodal or not args.text_only
+    print(f"device={torch.cuda.get_device_name(torch.device(args.device))}")
+    print(f"checkpoint={args.checkpoint}")
+    if run_text:
+        _bench_text(args)
+    if run_mm:
+        _bench_multimodal(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qwen3_vl_fp8_sm89.py
+++ b/tests/test_qwen3_vl_fp8_sm89.py
@@ -1,0 +1,95 @@
+"""Smoke tests for the Qwen3-VL official-FP8 SM89 text path.
+
+These are CPU/CI-friendly import and schema tests. Real checkpoint and CUDA
+coverage is provided by the local development benchmark/script because the
+official 8B FP8 weights are too large for CI.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+
+
+def test_frontend_imports():
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_fp8_sm89')
+    text_cls = m.Qwen3VlFp8Sm89TextFrontend
+    assert hasattr(m, 'Qwen3VlFp8Sm89TextFrontend')
+    assert 'max_prefill_seq' in inspect.signature(text_cls).parameters
+    assert 'run_lm_head' in inspect.signature(
+        text_cls.forward_hidden_prefill_fp8_blockscaled).parameters
+    mm = importlib.import_module(
+        'flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal')
+    cls = mm.Qwen3VlFp8Sm89Frontend
+    assert hasattr(mm, 'Qwen3VlFp8Sm89Frontend')
+    assert 'max_prefill_seq' in inspect.signature(
+        cls).parameters
+    for name in ('fuse_gate_up', 'fuse_qk_postproc', 'use_fp8_lm_head',
+                 'vision_bf16_first_blocks'):
+        assert name in inspect.signature(cls).parameters
+    for name in (
+        'prefill_graph', 'decode_step_with_graph',
+        'warmup_decode_graphs', 'generate',
+    ):
+        assert hasattr(cls, name)
+
+
+def test_default_prefill_limit_matches_max_seq_without_cuda():
+    """SM89 VL should behave like SM120: default prefill capacity is max_seq."""
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+        _resolve_max_prefill_seq,
+    )
+
+    assert _resolve_max_prefill_seq(1234, None) == 1234
+    assert _resolve_max_prefill_seq(1234, 256) == 256
+
+
+def test_multimodal_prefill_graph_falls_back_to_eager_without_pg_key():
+    """Match SM120: graph prefill falls back for multi-image/video prompts."""
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+        Qwen3VlFp8Sm89Frontend,
+    )
+
+    fe = Qwen3VlFp8Sm89Frontend.__new__(Qwen3VlFp8Sm89Frontend)
+    fe._prompt = {'S': 7}
+    called = []
+
+    def fake_prefill():
+        called.append(True)
+        return 'eager-logits'
+
+    fe.prefill = fake_prefill
+    assert fe.prefill_graph() == 'eager-logits'
+    assert called == [True]
+
+
+def test_weight_loader_invariants_reject_missing_layer_fields():
+    from flash_rt.frontends.torch._qwen3_vl_fp8_weights import (
+        WeightHandles,
+        assert_extraction_invariants_qwen3_vl_fp8,
+    )
+
+    h = WeightHandles()
+    h.ptrs.update({
+        'quant_format': 'fp8_block128',
+        'num_layers': 1,
+        'lm_head_quantized': False,
+        'layers': [{'input_norm_w': 1}],
+    })
+    try:
+        assert_extraction_invariants_qwen3_vl_fp8(h)
+    except AssertionError as e:
+        assert 'missing' in str(e)
+        assert 'lm_head_w' in str(e)
+    else:
+        raise AssertionError('expected invariant failure')
+
+    h.ptrs.update({
+        'lm_head_w': 1,
+    })
+    try:
+        assert_extraction_invariants_qwen3_vl_fp8(h)
+    except AssertionError as e:
+        assert 'missing' in str(e)
+        assert 'qkv_proj_w' in str(e)
+    else:
+        raise AssertionError('expected layer invariant failure')

--- a/tests/test_qwen3_vl_fp8_sm89_2b.py
+++ b/tests/test_qwen3_vl_fp8_sm89_2b.py
@@ -1,0 +1,73 @@
+"""Smoke tests for the Qwen3-VL-2B block-128 FP8 SM89 path.
+
+CPU/CI-friendly: the config-driven frontend guard and the offline quantizer's
+block-128 round-trip are exercised without the (multi-GB) checkpoints or CUDA.
+Real checkpoint + tps coverage lives in scripts/smoke_qwen3_vl_fp8_sm89.py and
+docs/qwen3_vl_fp8_sm89_2b.md.
+"""
+from __future__ import annotations
+
+import importlib
+
+import torch
+
+
+def test_quantizer_block128_roundtrip():
+    q = importlib.import_module(
+        'scripts.quantize_qwen3_vl_to_fp8_block128')
+    torch.manual_seed(0)
+    # A 2B-shaped fused gate/up tile: N=6144, K=2048, both multiples of 128.
+    w = torch.randn(6144, 2048, dtype=torch.bfloat16) * 0.02
+    fp8, scale = q._quantize_block128(w)
+    assert fp8.dtype == torch.float8_e4m3fn
+    assert fp8.shape == (6144, 2048)
+    assert scale.dtype == torch.float32
+    assert scale.shape == (6144 // 128, 2048 // 128)
+    # Dequant = q * weight_scale_inv (multiply-to-dequant), reconstructed by
+    # broadcasting each 128x128 block's scale. Error must stay within e4m3's
+    # ~6% per-block relative resolution.
+    deq = (fp8.float().view(48, 128, 16, 128)
+           * scale[:, None, :, None]).view(6144, 2048)
+    rel = (deq - w.float()).abs().mean() / w.float().abs().mean()
+    assert rel < 0.05, f'block128 dequant rel-err too high: {rel}'
+
+
+def test_quantizer_targets_only_language_linears():
+    q = importlib.import_module(
+        'scripts.quantize_qwen3_vl_to_fp8_block128')
+    assert q._is_quant_target(
+        'model.language_model.layers.0.self_attn.q_proj.weight')
+    assert q._is_quant_target(
+        'model.language_model.layers.27.mlp.down_proj.weight')
+    # Norms, embeddings, vision tower, and lm_head are NOT quantized.
+    assert not q._is_quant_target(
+        'model.language_model.layers.0.input_layernorm.weight')
+    assert not q._is_quant_target(
+        'model.language_model.embed_tokens.weight')
+    assert not q._is_quant_target(
+        'model.visual.blocks.0.attn.qkv.weight')
+    assert not q._is_quant_target('lm_head.weight')
+
+
+def test_quantizer_expected_count_from_config(tmp_path):
+    q = importlib.import_module(
+        'scripts.quantize_qwen3_vl_to_fp8_block128')
+    (tmp_path / 'config.json').write_text(
+        '{"text_config": {"num_hidden_layers": 28}}')
+    assert q._expected_quant_linears(str(tmp_path)) == 196
+
+
+def test_loader_handles_single_file_and_tied_embeddings(tmp_path):
+    """A single-file (no index.json) tied-embedding ckpt must load via the
+    synthetic weight_map + embed_tokens lm_head fallback."""
+    from safetensors.torch import save_file
+
+    from flash_rt.frontends.torch import _qwen3_vl_fp8_weights as wl
+
+    save_file(
+        {'model.language_model.embed_tokens.weight': torch.zeros(256, 128)},
+        str(tmp_path / 'model.safetensors'), metadata={'format': 'pt'})
+    handles_d, wmap = wl._open_shards(str(tmp_path))
+    assert wmap['model.language_model.embed_tokens.weight'] == \
+        'model.safetensors'
+    assert 'model.safetensors' in handles_d

--- a/tests/test_qwen3_vl_smoke.py
+++ b/tests/test_qwen3_vl_smoke.py
@@ -161,6 +161,29 @@ def test_mrope_cos_sin_shape():
     assert cos.shape == (ids.numel(), 64) == sin.shape
 
 
+def test_mrope_cos_sin_cached_matches_direct():
+    grids = [(1, 4, 6)]
+    ids = _image_seq(grids)
+    pos = geo.mrope_position_ids(
+        ids, torch.tensor(grids), None, image_token_id=IMG,
+        video_token_id=VID, vision_start_token_id=VSTART,
+        spatial_merge_size=MERGE)
+    kwargs = {
+        'head_dim': 128,
+        'rope_theta': 5e6,
+        'mrope_section': (24, 20, 20),
+        'device': 'cpu',
+    }
+    cos, sin = geo.mrope_cos_sin(pos, **kwargs)
+    cache = geo.build_mrope_cache(
+        max_pos=int(pos.max()) + 1, head_dim=kwargs['head_dim'],
+        rope_theta=kwargs['rope_theta'], device='cpu')
+    cos_cached, sin_cached = geo.mrope_cos_sin_cached(
+        pos, cache[0], cache[1], mrope_section=kwargs['mrope_section'])
+    assert torch.equal(cos, cos_cached)
+    assert torch.equal(sin, sin_cached)
+
+
 def test_vision_rope_and_pos_embeds_shapes():
     grids = torch.tensor([(1, 4, 6)])
     n_patch = 1 * 4 * 6
@@ -172,3 +195,15 @@ def test_vision_rope_and_pos_embeds_shapes():
         grids, table, num_grid_per_side=48, spatial_merge_size=MERGE,
         device='cpu')
     assert pe.shape == (n_patch, 8)
+
+
+def test_vision_rope_cached_matches_direct():
+    grids = torch.tensor([(1, 4, 6), (1, 6, 4)])
+    cos, sin = geo.vision_rope_cos_sin(
+        grids, head_dim=72, spatial_merge_size=MERGE, device='cpu')
+    cache = geo.build_vision_rope_cache(
+        max_hw=int(grids[:, 1:].max()), head_dim=72, device='cpu')
+    cos_cached, sin_cached = geo.vision_rope_cos_sin_cached(
+        grids, cache[0], cache[1], spatial_merge_size=MERGE)
+    assert torch.equal(cos, cos_cached)
+    assert torch.equal(sin, sin_cached)


### PR DESCRIPTION
## Summary

Brings up **Qwen3-VL on Ada RTX 4090 (sm_89)** with the checkpoint's native
block-scaled **FP8 language weights**, for both the **8B** and **2B** variants.
This is the SM89 counterpart to the SM120/NVFP4 Qwen3-VL path: the vision tower,
geometry, image scatter and MRoPE are reused from that work; this branch adds
the Ada FP8 language stack, a hand-written sm_89 block-128 GEMM/GEMV, and the
offline quantizer + config-driven generalization that bring up the 2B.

This is a clean re-cut of the earlier prototype branch onto current `main`,
reorganized into reviewable commits with the file scope aligned to the SM120
Qwen3-VL pattern (dedicated `flash_rt_qwen3_vl_kernels` module; no central
`bindings.cpp` churn; iteration/benchmark harnesses kept out of the PR).

## Why hand-written (no TMA on Ada)

The SM120 Qwen3-VL GEMM runs through the CUTLASS
`KernelTmaWarpSpecializedBlockwise` collective — TMA bulk-copy + a
warp-specialized producer/consumer pipeline with an auto-selected deep
(3-4 stage) software pipeline that hides load latency without spending
registers or occupancy on staging.

**Ada (sm_89) has no TMA and no warp-specialized CUTLASS collective** (those
builders are Sm90+/Sm120 only), so that design does not port:

- **GEMM** is a hand-written `cp.async` + `ldmatrix.x4` + block-128-scaling MMA
  kernel (`mma.sync...m16n8k32...e4m3.e4m3.f32`, no `.kind::f8f6f4`). With
  `cp.async` instead of TMA, each extra pipeline stage costs a full smem buffer;
  at the tuned 64x64 tile the kernel is already register-limited to 4 CTA/SM, so
  a 2-stage pipeline halves occupancy and regresses. It runs single-stage and is
  latency-bound. The obvious memory-pattern wins (load/store coalescing,
  `ldmatrix`) are applied; CUTLASS's own Ada blockwise example is slower than
  this kernel at these shapes, so it is not used.
- **Attention** uses vendored FlashAttention-2 (Tri Dao). The only addition is
  an `hdim64` instantiation for the 2B ViT (avoids a 64->96 pad); the FA2 kernel
  body is upstream and unmodified.

So the SM89 path matches the SM120 design *intent* (block-128 FP8, fused
act/norm-quant, ldmatrix MMA) but cannot reuse the TMA/warp-specialized
machinery — the main reason its prefill is slower than the Blackwell NVFP4 path.

## Commits

1. `csrc: add SM89 native FP8 block-128 GEMM kernel`
2. `csrc: add SM89 block-128 M=1 GEMV for Qwen3-VL decode`
3. `csrc: add SM89 Qwen3-VL helper kernels (qk-norm-rope, fp8 block act/norm)`
4. `build: bind SM89 Qwen3-VL kernels into flash_rt_qwen3_vl_kernels`
5. `fa2: add hdim64 instantiation for Qwen3-VL 2B vision attention`
6. `frontend: SM89 Qwen3-VL official-FP8 path (8B + 2B)`
7. `tools: SM89 FP8 block-128 quantizer + smoke/CPU tests`
8. `docs: SM89 Qwen3-VL FP8 (8B + 2B); note no-TMA optimization limits`

## Module layout

SM89-specific kernels (block-128 GEMM/GEMV, fused act/norm-quant, QK
norm-rope-kvwrite, the ViT bf16 cuBLASLt matmul) build into the dedicated
`flash_rt_qwen3_vl_kernels` module (`FLASHRT_BUILD_QWEN3_VL=ON`, now `GPU_ARCH`
89 or 120), keeping `flash_rt_kernels.so` small. The frontend resolves names
from the dedicated module first, then the generic one — the same dual-module
split the SM120 ViT path already uses.

## Build

```bash
cmake -S . -B build -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON
cmake --build build --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels -j
```

## Verification

Built clean for sm_89 (both modules). End-to-end 2B multimodal smoke
(`scripts/smoke_qwen3_vl_fp8_sm89.py --multimodal --fp8-lm-head`, FlashRT.png):
`cos_vs_eager=1.000000`, top token matches eager, prefill ~80 ms, decode
`cos_vs_eager=1.000000`, coherent generation. CPU/CI tests cover the config
guard, the block-128 quant round-trip, and the expected quant-linear count
without the multi-GB checkpoint or CUDA.
