### PR TITLE
refactor(kernels): neutral ownership for generic bf16 matmul + embedding helpers (#112)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1033,6 +1033,7 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/rms_norm_gated_silu_qwen36.cu
   csrc/kernels/silu_mul_qwen36.cu
   csrc/kernels/silu_mul_to_nvfp4_swizzled.cu
+  csrc/kernels/embedding_lookup_bf16.cu
   csrc/kernels/qwen36_misc.cu
   # qwen3_5_moe-family RTX SM120 kernels are NOT listed here -- they are
   # gated into the module below (FLASHRT_ENABLE_QWEN35MOE), so SM89/87/110

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -917,6 +917,7 @@ if(FLASHRT_BUILD_QWEN3_VL)
       csrc/gemm/fp8_gemv_m1_sm89.cu
       csrc/quantize/fp8_per_token_block_quant.cu
       csrc/kernels/qwen3_qkv_post_proc.cu
+      csrc/kernels/bf16_matmul_bf16.cu
       csrc/kernels/bf16_matmul_qwen36.cu)
   endif()
   pybind11_add_module(flash_rt_qwen3_vl_kernels ${QWEN3_VL_SOURCES})
@@ -1044,6 +1045,7 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/fp4_w4a4_mma_warpsplit_sm120.cu
   csrc/kernels/fp4_w4a4_mma_warpsplit_mrows_sm120.cu
   csrc/kernels/bf16_matvec_qwen36.cu
+  csrc/kernels/bf16_matmul_bf16.cu
   csrc/kernels/bf16_matmul_qwen36.cu
   csrc/kernels/bf16_matmul_qwen36_thor.cu
   csrc/attention/fmha_dispatch.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -940,7 +940,7 @@ if(FLASHRT_BUILD_QWEN3_VL)
     >)
   target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cudart)
   if(GPU_ARCH STREQUAL "89")
-    # bf16_matmul_qwen36 (ViT bf16 linears on SM89) uses cuBLASLt.
+    # bf16_matmul_bf16 (ViT bf16 linears on SM89) uses cuBLASLt.
     target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cublasLt)
   endif()
   install(TARGETS flash_rt_qwen3_vl_kernels

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -917,8 +917,7 @@ if(FLASHRT_BUILD_QWEN3_VL)
       csrc/gemm/fp8_gemv_m1_sm89.cu
       csrc/quantize/fp8_per_token_block_quant.cu
       csrc/kernels/qwen3_qkv_post_proc.cu
-      csrc/kernels/bf16_matmul_bf16.cu
-      csrc/kernels/bf16_matmul_qwen36.cu)
+      csrc/kernels/bf16_matmul_bf16.cu)
   endif()
   pybind11_add_module(flash_rt_qwen3_vl_kernels ${QWEN3_VL_SOURCES})
   if(GPU_ARCH STREQUAL "89")

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -139,6 +139,7 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #include "kernels/silu_mul_to_nvfp4_swizzled.cuh"
 #include "kernels/rms_norm_gated_silu_qwen36.cuh"
 #include "kernels/silu_mul_qwen36.cuh"
+#include "kernels/embedding_lookup_bf16.cuh"
 #include "kernels/qwen36_misc.cuh"
 #ifdef FLASHRT_HAVE_QWEN35MOE
 #include "kernels/qwen35moe_layout.cuh"
@@ -4273,6 +4274,22 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         },
         py::arg("x"), py::arg("W_ab"), py::arg("out_ab"),
         py::arg("M"), py::arg("stream") = 0);
+
+    // Neutral name for the model-neutral bf16 embedding lookup (#112). The
+    // legacy qwen36_embedding_lookup_bf16 below is a thin wrapper over this
+    // same implementation; both bindings are kept so existing call sites keep
+    // working while non-Qwen3.6 paths migrate to the neutral name.
+    m.def("embedding_lookup_bf16",
+        [](uintptr_t token_ids, uintptr_t embed, uintptr_t out,
+           int rows, int hidden, uintptr_t stream) {
+            flash_rt::kernels::embedding_lookup_bf16(
+                reinterpret_cast<const int64_t*>(token_ids),
+                reinterpret_cast<const __nv_bfloat16*>(embed),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                rows, hidden, to_stream(stream));
+        },
+        py::arg("token_ids"), py::arg("embed"), py::arg("out"),
+        py::arg("rows"), py::arg("hidden"), py::arg("stream") = 0);
 
     m.def("qwen36_embedding_lookup_bf16",
         [](uintptr_t token_ids, uintptr_t embed, uintptr_t out,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -157,6 +157,7 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #include "kernels/w16a16_gemm_sm120.cuh"
 #endif  // FLASHRT_HAVE_QWEN35MOE
 #include "kernels/bf16_matvec_qwen36.cuh"
+#include "kernels/bf16_matmul_bf16.cuh"
 #include "kernels/bf16_matmul_qwen36.cuh"
 #include "kernels/bf16_matmul_qwen36_thor.cuh"
 #include "kernels/fp4_w4a4_matvec_sm120.cuh"
@@ -4181,6 +4182,22 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     // times. Replaces the K-loop matvec at lin-attn unquantized
     // projections (in_proj_qkv / in_proj_z / out_proj). Stream-invariant
     // and CUDA Graph compatible.
+    // Neutral name for the model-neutral small-M bf16 matmul (#112). The
+    // legacy bf16_matmul_qwen36_bf16 below is a thin wrapper over this same
+    // implementation; both bindings are kept so existing call sites keep
+    // working while non-Qwen3.6 paths migrate to the neutral name.
+    m.def("bf16_matmul_bf16",
+        [](uintptr_t x, uintptr_t W, uintptr_t out,
+           int M, int N, int K, uintptr_t stream) {
+            flash_rt::kernels::bf16_matmul_bf16(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const __nv_bfloat16*>(W),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                M, N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("W"), py::arg("out"),
+        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+
     m.def("bf16_matmul_qwen36_bf16",
         [](uintptr_t x, uintptr_t W, uintptr_t out,
            int M, int N, int K, uintptr_t stream) {

--- a/csrc/kernels/bf16_matmul_bf16.cu
+++ b/csrc/kernels/bf16_matmul_bf16.cu
@@ -1,0 +1,292 @@
+// Generic bf16 row-major matmul (small-M) — see header for design notes.
+// Warp-per-output pattern: block grid (ceil(N/8), M), one block computes
+// 8 output elements for one (m, n-tile). W is read once per (n-tile) block
+// and reused across M rows via L2.
+//
+// Moved here from bf16_matmul_qwen36.cu as part of the generic-helper
+// ownership cleanup (#112). The kernel algorithm is unchanged; only the file
+// and the public symbol name (bf16_matmul_bf16) are neutral now.
+
+#include "bf16_matmul_bf16.cuh"
+
+#include <cublasLt.h>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kWarpsPerBlock = 8;
+constexpr int kThreads = kWarpsPerBlock * 32;  // 256
+
+#define FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(expr)                         \
+    do {                                                                 \
+        cublasStatus_t _st = (expr);                                     \
+        if (_st != CUBLAS_STATUS_SUCCESS) {                              \
+            throw std::runtime_error(                                    \
+                std::string("cuBLASLt error ") +                        \
+                std::to_string(static_cast<int>(_st)) +                  \
+                " at " + __FILE__ + ":" + std::to_string(__LINE__));   \
+        }                                                                \
+    } while (0)
+
+struct Bf16LtPlan {
+    cublasLtMatmulDesc_t desc = nullptr;
+    cublasLtMatrixLayout_t a_desc = nullptr;
+    cublasLtMatrixLayout_t b_desc = nullptr;
+    cublasLtMatrixLayout_t c_desc = nullptr;
+    cublasLtMatmulAlgo_t algo{};
+};
+
+struct Bf16LtKey {
+    int M;
+    int N;
+    int K;
+
+    bool operator==(const Bf16LtKey& other) const {
+        return M == other.M && N == other.N && K == other.K;
+    }
+};
+
+struct Bf16LtKeyHash {
+    size_t operator()(const Bf16LtKey& key) const {
+        size_t h = static_cast<size_t>(key.M);
+        h = h * 1315423911u + static_cast<size_t>(key.N);
+        h = h * 1315423911u + static_cast<size_t>(key.K);
+        return h;
+    }
+};
+
+static cublasLtHandle_t g_bf16_lt = nullptr;
+static void* g_bf16_workspace = nullptr;
+static size_t g_bf16_workspace_size = 32 * 1024 * 1024;
+static std::mutex g_bf16_mu;
+static std::unordered_map<Bf16LtKey, Bf16LtPlan, Bf16LtKeyHash>
+    g_bf16_plans;
+
+static void ensure_bf16_lt() {
+    if (g_bf16_lt) return;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtCreate(&g_bf16_lt));
+    cudaError_t err = cudaMalloc(&g_bf16_workspace, g_bf16_workspace_size);
+    if (err != cudaSuccess) {
+        throw std::runtime_error(
+            std::string("cudaMalloc failed for BF16 cuBLASLt workspace: ") +
+            cudaGetErrorString(err));
+    }
+}
+
+static Bf16LtPlan& get_bf16_lt_plan(int M, int N, int K) {
+    std::lock_guard<std::mutex> lock(g_bf16_mu);
+    ensure_bf16_lt();
+    Bf16LtKey key{M, N, K};
+    auto it = g_bf16_plans.find(key);
+    if (it != g_bf16_plans.end()) return it->second;
+
+    Bf16LtPlan plan;
+    cublasOperation_t op_n = CUBLAS_OP_N;
+    cublasOperation_t op_t = CUBLAS_OP_T;
+    cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(
+        cublasLtMatmulDescCreate(&plan.desc, CUBLAS_COMPUTE_32F, CUDA_R_32F));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSA, &op_n, sizeof(op_n)));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
+        plan.desc, CUBLASLT_MATMUL_DESC_TRANSB, &op_t, sizeof(op_t)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.a_desc, CUDA_R_16BF, M, K, K));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.b_desc, CUDA_R_16BF, N, K, K));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
+        &plan.c_desc, CUDA_R_16BF, M, N, N));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
+        plan.c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
+        sizeof(row_order)));
+
+    cublasLtMatmulPreference_t pref;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceCreate(&pref));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceSetAttribute(
+        pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &g_bf16_workspace_size, sizeof(g_bf16_workspace_size)));
+    cublasLtMatmulHeuristicResult_t heuristic;
+    int returned = 0;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulAlgoGetHeuristic(
+        g_bf16_lt, plan.desc, plan.a_desc, plan.b_desc,
+        plan.c_desc, plan.c_desc, pref, 1, &heuristic, &returned));
+    cublasLtMatmulPreferenceDestroy(pref);
+    if (returned == 0) {
+        throw std::runtime_error("cuBLASLt: no generic BF16 GEMM algorithm");
+    }
+    plan.algo = heuristic.algo;
+
+    auto [inserted, _] = g_bf16_plans.emplace(key, plan);
+    return inserted->second;
+}
+
+// Vectorized: each thread reads 8 bf16 = 16 bytes per iter via int4.
+// Block grid: (ceil(N/8), M). Each block handles one M row × 8 N elements.
+// W is shared across M rows (read once per (n-tile) block; M blocks load
+// the same w_row for the same n-tile, so the L2 cache absorbs reuse).
+template<int K_FIXED>
+__global__ void bf16_matmul_warp_kernel(
+    const __nv_bfloat16* __restrict__ x,        // (M, K)
+    const __nv_bfloat16* __restrict__ W,        // (N, K)
+    __nv_bfloat16* __restrict__ out,            // (M, N)
+    int M, int N) {
+    __shared__ __nv_bfloat16 x_sh[K_FIXED];
+
+    const int m = blockIdx.y;
+    if (m >= M) return;
+
+    // Cooperative load of x[m, :] into smem.
+    const int4* x_i4 = reinterpret_cast<const int4*>(x + m * K_FIXED);
+    int4* x_sh_i4 = reinterpret_cast<int4*>(x_sh);
+    const int K_int4 = K_FIXED / 8;
+    #pragma unroll 1
+    for (int j = threadIdx.x; j < K_int4; j += kThreads) {
+        x_sh_i4[j] = x_i4[j];
+    }
+    __syncthreads();
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x & 31;
+    const int n = blockIdx.x * kWarpsPerBlock + warp_id;
+    if (n >= N) return;
+
+    const int4* w_row_i4 = reinterpret_cast<const int4*>(W + n * K_FIXED);
+
+    float acc = 0.0f;
+    #pragma unroll 1
+    for (int i4 = lane; i4 < K_int4; i4 += 32) {
+        int4 wv = w_row_i4[i4];
+        int4 xv = x_sh_i4[i4];
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            __nv_bfloat162 wb = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&wv)[k]));
+            __nv_bfloat162 xb = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&xv)[k]));
+            float2 wf = __bfloat1622float2(wb);
+            float2 xf = __bfloat1622float2(xb);
+            acc = fmaf(xf.x, wf.x, acc);
+            acc = fmaf(xf.y, wf.y, acc);
+        }
+    }
+
+    #pragma unroll
+    for (int off = 16; off > 0; off /= 2) {
+        acc += __shfl_xor_sync(0xffffffff, acc, off);
+    }
+    if (lane == 0) {
+        out[m * N + n] = __float2bfloat16(acc);
+    }
+}
+
+// Generic-K fallback (chunked smem). Same warp pattern.
+__global__ void bf16_matmul_warp_kernel_generic(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ W,
+    __nv_bfloat16* __restrict__ out,
+    int M, int N, int K) {
+    extern __shared__ __nv_bfloat16 x_sh[];
+    const int K_chunk_max = 4096;
+
+    const int m = blockIdx.y;
+    if (m >= M) return;
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x & 31;
+    const int n = blockIdx.x * kWarpsPerBlock + warp_id;
+
+    float acc = 0.0f;
+
+    for (int k_off = 0; k_off < K; k_off += K_chunk_max) {
+        const int chunk = min(K_chunk_max, K - k_off);
+        for (int j = threadIdx.x; j < chunk; j += kThreads) {
+            x_sh[j] = x[m * K + k_off + j];
+        }
+        __syncthreads();
+
+        if (n < N) {
+            const __nv_bfloat16* w_row = W + n * K + k_off;
+            #pragma unroll 1
+            for (int j = lane; j < chunk; j += 32) {
+                float xv = static_cast<float>(x_sh[j]);
+                float wv = static_cast<float>(w_row[j]);
+                acc = fmaf(xv, wv, acc);
+            }
+        }
+        __syncthreads();
+    }
+
+    if (n >= N) return;
+
+    #pragma unroll
+    for (int off = 16; off > 0; off /= 2) {
+        acc += __shfl_xor_sync(0xffffffff, acc, off);
+    }
+    if (lane == 0) {
+        out[m * N + n] = __float2bfloat16(acc);
+    }
+}
+
+}  // namespace
+
+void bf16_matmul_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M, int N, int K,
+    cudaStream_t stream) {
+    dim3 grid((N + kWarpsPerBlock - 1) / kWarpsPerBlock, M);
+    // Specialization set must match the bf16_matvec sibling so the
+    // M=1 reference and the M=K test produce bit-identical reductions
+    // (different chunking → different fma order → bf16 drift). matvec
+    // specializes K=5120 and K=4096; everything else (incl. K=6144 for
+    // lin_K out_proj) falls to the generic chunked path.
+    if (K == 5120) {
+        bf16_matmul_warp_kernel<5120>
+            <<<grid, kThreads, 0, stream>>>(x, W, out, M, N);
+    } else if (K == 4096) {
+        bf16_matmul_warp_kernel<4096>
+            <<<grid, kThreads, 0, stream>>>(x, W, out, M, N);
+    } else {
+        const int smem_bytes = 4096 * sizeof(__nv_bfloat16);
+        bf16_matmul_warp_kernel_generic
+            <<<grid, kThreads, smem_bytes, stream>>>(x, W, out, M, N, K);
+    }
+}
+
+void bf16_matmul_cublaslt_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M, int N, int K,
+    cudaStream_t stream) {
+    if (M <= 0 || N <= 0 || K <= 0) return;
+    Bf16LtPlan& plan = get_bf16_lt_plan(M, N, K);
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmul(
+        g_bf16_lt, plan.desc, &alpha,
+        x, plan.a_desc,
+        W, plan.b_desc,
+        &beta,
+        out, plan.c_desc,
+        out, plan.c_desc,
+        &plan.algo, g_bf16_workspace, g_bf16_workspace_size, stream));
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/bf16_matmul_bf16.cuh
+++ b/csrc/kernels/bf16_matmul_bf16.cuh
@@ -1,0 +1,48 @@
+// Generic bf16 row-major matmul (small-M) — model-neutral.
+//
+//   out[m, n] = sum_k x[m, k] * W[n, k],   m in [0, M), n in [0, N)
+//
+// Two implementations share this header:
+//   - bf16_matmul_bf16: stream-invariant, deterministic warp-per-output
+//     kernel (fixed K-order fp32 fma, no cuBLAS handle, CUDA Graph safe).
+//     Reads W exactly once and broadcasts across the M output rows.
+//   - bf16_matmul_cublaslt_bf16: cuBLASLt BF16 GEMM with a per-(M,N,K)
+//     cached plan, for the larger-M / throughput path.
+//
+// These were historically named under Qwen3.6 (bf16_matmul_qwen36*), but they
+// are model-neutral by shape and semantics and are reused by Qwen3, Qwen3-VL
+// and the Qwen3-VL SM89 FP8 path. The legacy name bf16_matmul_qwen36_bf16 is
+// kept as a thin wrapper over bf16_matmul_bf16 (see bf16_matmul_qwen36.cu) so
+// existing call sites and bindings keep working.
+//
+// Shapes:
+//   x   : (M, K)      bf16, row-major
+//   W   : (N, K)      bf16, row-major
+//   out : (M, N)      bf16, row-major
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace flash_rt::kernels {
+
+void bf16_matmul_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M,
+    int N,
+    int K,
+    cudaStream_t stream);
+
+void bf16_matmul_cublaslt_bf16(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M,
+    int N,
+    int K,
+    cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/bf16_matmul_qwen36.cu
+++ b/csrc/kernels/bf16_matmul_qwen36.cu
@@ -1,8 +1,14 @@
-// bf16 row-major matmul (small-M) — see header for design notes.
-// Mirrors the warp-per-output pattern of bf16_matvec_qwen36 and
-// extends it across M rows by launching M-many (n-tile) blocks.
+// Qwen3.6 AB96 bf16 matmul kernels (in_proj qkv/z, out_proj at K=5120,
+// N=96) — see header for design notes. The generic small-M bf16 matmul and
+// the cuBLASLt BF16 GEMM that used to live here moved to bf16_matmul_bf16.cu
+// as part of the generic-helper ownership cleanup (#112); this file now keeps
+// only the Qwen3.6-specific AB96 kernels plus a thin legacy wrapper
+// (bf16_matmul_qwen36_bf16 -> bf16_matmul_bf16) so existing call sites and
+// bindings keep working unchanged.
 
 #include "bf16_matmul_qwen36.cuh"
+
+#include "bf16_matmul_bf16.cuh"
 
 #include <cublasLt.h>
 #include <mutex>
@@ -38,45 +44,11 @@ struct Ab96LtPlan {
     cublasLtMatmulAlgo_t algo{};
 };
 
-struct Bf16LtPlan {
-    cublasLtMatmulDesc_t desc = nullptr;
-    cublasLtMatrixLayout_t a_desc = nullptr;
-    cublasLtMatrixLayout_t b_desc = nullptr;
-    cublasLtMatrixLayout_t c_desc = nullptr;
-    cublasLtMatmulAlgo_t algo{};
-};
-
-struct Bf16LtKey {
-    int M;
-    int N;
-    int K;
-
-    bool operator==(const Bf16LtKey& other) const {
-        return M == other.M && N == other.N && K == other.K;
-    }
-};
-
-struct Bf16LtKeyHash {
-    size_t operator()(const Bf16LtKey& key) const {
-        size_t h = static_cast<size_t>(key.M);
-        h = h * 1315423911u + static_cast<size_t>(key.N);
-        h = h * 1315423911u + static_cast<size_t>(key.K);
-        return h;
-    }
-};
-
 static cublasLtHandle_t g_ab96_lt = nullptr;
 static void* g_ab96_workspace = nullptr;
 static size_t g_ab96_workspace_size = 16 * 1024 * 1024;
 static std::mutex g_ab96_mu;
 static std::unordered_map<int, Ab96LtPlan> g_ab96_plans;
-
-static cublasLtHandle_t g_bf16_lt = nullptr;
-static void* g_bf16_workspace = nullptr;
-static size_t g_bf16_workspace_size = 32 * 1024 * 1024;
-static std::mutex g_bf16_mu;
-static std::unordered_map<Bf16LtKey, Bf16LtPlan, Bf16LtKeyHash>
-    g_bf16_plans;
 
 static void ensure_ab96_lt() {
     if (g_ab96_lt) return;
@@ -85,17 +57,6 @@ static void ensure_ab96_lt() {
     if (err != cudaSuccess) {
         throw std::runtime_error(
             std::string("cudaMalloc failed for AB96 cuBLASLt workspace: ") +
-            cudaGetErrorString(err));
-    }
-}
-
-static void ensure_bf16_lt() {
-    if (g_bf16_lt) return;
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtCreate(&g_bf16_lt));
-    cudaError_t err = cudaMalloc(&g_bf16_workspace, g_bf16_workspace_size);
-    if (err != cudaSuccess) {
-        throw std::runtime_error(
-            std::string("cudaMalloc failed for BF16 cuBLASLt workspace: ") +
             cudaGetErrorString(err));
     }
 }
@@ -154,170 +115,6 @@ static Ab96LtPlan& get_ab96_lt_plan(int M) {
 
     auto [inserted, _] = g_ab96_plans.emplace(M, plan);
     return inserted->second;
-}
-
-static Bf16LtPlan& get_bf16_lt_plan(int M, int N, int K) {
-    std::lock_guard<std::mutex> lock(g_bf16_mu);
-    ensure_bf16_lt();
-    Bf16LtKey key{M, N, K};
-    auto it = g_bf16_plans.find(key);
-    if (it != g_bf16_plans.end()) return it->second;
-
-    Bf16LtPlan plan;
-    cublasOperation_t op_n = CUBLAS_OP_N;
-    cublasOperation_t op_t = CUBLAS_OP_T;
-    cublasLtOrder_t row_order = CUBLASLT_ORDER_ROW;
-
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(
-        cublasLtMatmulDescCreate(&plan.desc, CUBLAS_COMPUTE_32F, CUDA_R_32F));
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
-        plan.desc, CUBLASLT_MATMUL_DESC_TRANSA, &op_n, sizeof(op_n)));
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulDescSetAttribute(
-        plan.desc, CUBLASLT_MATMUL_DESC_TRANSB, &op_t, sizeof(op_t)));
-
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
-        &plan.a_desc, CUDA_R_16BF, M, K, K));
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
-        plan.a_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
-        sizeof(row_order)));
-
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
-        &plan.b_desc, CUDA_R_16BF, N, K, K));
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
-        plan.b_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
-        sizeof(row_order)));
-
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutCreate(
-        &plan.c_desc, CUDA_R_16BF, M, N, N));
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatrixLayoutSetAttribute(
-        plan.c_desc, CUBLASLT_MATRIX_LAYOUT_ORDER, &row_order,
-        sizeof(row_order)));
-
-    cublasLtMatmulPreference_t pref;
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceCreate(&pref));
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceSetAttribute(
-        pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
-        &g_bf16_workspace_size, sizeof(g_bf16_workspace_size)));
-    cublasLtMatmulHeuristicResult_t heuristic;
-    int returned = 0;
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulAlgoGetHeuristic(
-        g_bf16_lt, plan.desc, plan.a_desc, plan.b_desc,
-        plan.c_desc, plan.c_desc, pref, 1, &heuristic, &returned));
-    cublasLtMatmulPreferenceDestroy(pref);
-    if (returned == 0) {
-        throw std::runtime_error("cuBLASLt: no generic BF16 GEMM algorithm");
-    }
-    plan.algo = heuristic.algo;
-
-    auto [inserted, _] = g_bf16_plans.emplace(key, plan);
-    return inserted->second;
-}
-
-// Vectorized: each thread reads 8 bf16 = 16 bytes per iter via int4.
-// Block grid: (ceil(N/8), M). Each block handles one M row × 8 N elements.
-// W is shared across M rows (read once per (n-tile) block; M blocks load
-// the same w_row for the same n-tile, so the L2 cache absorbs reuse).
-template<int K_FIXED>
-__global__ void bf16_matmul_warp_kernel(
-    const __nv_bfloat16* __restrict__ x,        // (M, K)
-    const __nv_bfloat16* __restrict__ W,        // (N, K)
-    __nv_bfloat16* __restrict__ out,            // (M, N)
-    int M, int N) {
-    __shared__ __nv_bfloat16 x_sh[K_FIXED];
-
-    const int m = blockIdx.y;
-    if (m >= M) return;
-
-    // Cooperative load of x[m, :] into smem.
-    const int4* x_i4 = reinterpret_cast<const int4*>(x + m * K_FIXED);
-    int4* x_sh_i4 = reinterpret_cast<int4*>(x_sh);
-    const int K_int4 = K_FIXED / 8;
-    #pragma unroll 1
-    for (int j = threadIdx.x; j < K_int4; j += kThreads) {
-        x_sh_i4[j] = x_i4[j];
-    }
-    __syncthreads();
-
-    const int warp_id = threadIdx.x / 32;
-    const int lane = threadIdx.x & 31;
-    const int n = blockIdx.x * kWarpsPerBlock + warp_id;
-    if (n >= N) return;
-
-    const int4* w_row_i4 = reinterpret_cast<const int4*>(W + n * K_FIXED);
-
-    float acc = 0.0f;
-    #pragma unroll 1
-    for (int i4 = lane; i4 < K_int4; i4 += 32) {
-        int4 wv = w_row_i4[i4];
-        int4 xv = x_sh_i4[i4];
-        #pragma unroll
-        for (int k = 0; k < 4; ++k) {
-            __nv_bfloat162 wb = *reinterpret_cast<__nv_bfloat162*>(
-                &(reinterpret_cast<int*>(&wv)[k]));
-            __nv_bfloat162 xb = *reinterpret_cast<__nv_bfloat162*>(
-                &(reinterpret_cast<int*>(&xv)[k]));
-            float2 wf = __bfloat1622float2(wb);
-            float2 xf = __bfloat1622float2(xb);
-            acc = fmaf(xf.x, wf.x, acc);
-            acc = fmaf(xf.y, wf.y, acc);
-        }
-    }
-
-    #pragma unroll
-    for (int off = 16; off > 0; off /= 2) {
-        acc += __shfl_xor_sync(0xffffffff, acc, off);
-    }
-    if (lane == 0) {
-        out[m * N + n] = __float2bfloat16(acc);
-    }
-}
-
-// Generic-K fallback (chunked smem). Same warp pattern.
-__global__ void bf16_matmul_warp_kernel_generic(
-    const __nv_bfloat16* __restrict__ x,
-    const __nv_bfloat16* __restrict__ W,
-    __nv_bfloat16* __restrict__ out,
-    int M, int N, int K) {
-    extern __shared__ __nv_bfloat16 x_sh[];
-    const int K_chunk_max = 4096;
-
-    const int m = blockIdx.y;
-    if (m >= M) return;
-
-    const int warp_id = threadIdx.x / 32;
-    const int lane = threadIdx.x & 31;
-    const int n = blockIdx.x * kWarpsPerBlock + warp_id;
-
-    float acc = 0.0f;
-
-    for (int k_off = 0; k_off < K; k_off += K_chunk_max) {
-        const int chunk = min(K_chunk_max, K - k_off);
-        for (int j = threadIdx.x; j < chunk; j += kThreads) {
-            x_sh[j] = x[m * K + k_off + j];
-        }
-        __syncthreads();
-
-        if (n < N) {
-            const __nv_bfloat16* w_row = W + n * K + k_off;
-            #pragma unroll 1
-            for (int j = lane; j < chunk; j += 32) {
-                float xv = static_cast<float>(x_sh[j]);
-                float wv = static_cast<float>(w_row[j]);
-                acc = fmaf(xv, wv, acc);
-            }
-        }
-        __syncthreads();
-    }
-
-    if (n >= N) return;
-
-    #pragma unroll
-    for (int off = 16; off > 0; off /= 2) {
-        acc += __shfl_xor_sync(0xffffffff, acc, off);
-    }
-    if (lane == 0) {
-        out[m * N + n] = __float2bfloat16(acc);
-    }
 }
 
 template<int K_FIXED>
@@ -559,49 +356,16 @@ __global__ void bf16_matmul_ab96_mtile_pair_kernel(
 
 }  // namespace
 
+// Thin legacy wrapper: bf16_matmul_qwen36_bf16 is the historical name for the
+// model-neutral small-M matmul, kept so Qwen3.6 call sites and the existing
+// binding stay unchanged. The implementation lives in bf16_matmul_bf16.cu.
 void bf16_matmul_qwen36_bf16(
     const __nv_bfloat16* x,
     const __nv_bfloat16* W,
     __nv_bfloat16* out,
     int M, int N, int K,
     cudaStream_t stream) {
-    dim3 grid((N + kWarpsPerBlock - 1) / kWarpsPerBlock, M);
-    // Specialization set must match the bf16_matvec sibling so the
-    // M=1 reference and the M=K test produce bit-identical reductions
-    // (different chunking → different fma order → bf16 drift). matvec
-    // specializes K=5120 and K=4096; everything else (incl. K=6144 for
-    // lin_K out_proj) falls to the generic chunked path.
-    if (K == 5120) {
-        bf16_matmul_warp_kernel<5120>
-            <<<grid, kThreads, 0, stream>>>(x, W, out, M, N);
-    } else if (K == 4096) {
-        bf16_matmul_warp_kernel<4096>
-            <<<grid, kThreads, 0, stream>>>(x, W, out, M, N);
-    } else {
-        const int smem_bytes = 4096 * sizeof(__nv_bfloat16);
-        bf16_matmul_warp_kernel_generic
-            <<<grid, kThreads, smem_bytes, stream>>>(x, W, out, M, N, K);
-    }
-}
-
-void bf16_matmul_cublaslt_bf16(
-    const __nv_bfloat16* x,
-    const __nv_bfloat16* W,
-    __nv_bfloat16* out,
-    int M, int N, int K,
-    cudaStream_t stream) {
-    if (M <= 0 || N <= 0 || K <= 0) return;
-    Bf16LtPlan& plan = get_bf16_lt_plan(M, N, K);
-    const float alpha = 1.0f;
-    const float beta = 0.0f;
-    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmul(
-        g_bf16_lt, plan.desc, &alpha,
-        x, plan.a_desc,
-        W, plan.b_desc,
-        &beta,
-        out, plan.c_desc,
-        out, plan.c_desc,
-        &plan.algo, g_bf16_workspace, g_bf16_workspace_size, stream));
+    bf16_matmul_bf16(x, W, out, M, N, K, stream);
 }
 
 void bf16_matmul_qwen36_ab96_bf16(

--- a/csrc/kernels/bf16_matmul_qwen36.cuh
+++ b/csrc/kernels/bf16_matmul_qwen36.cuh
@@ -1,27 +1,18 @@
-// bf16 row-major matmul (small-M) for Qwen3.6 — stream-invariant,
-// deterministic. Designed as an add-only sibling of
-// bf16_matvec_qwen36 to support the S=K verify path:
+// Qwen3.6 AB96 bf16 matmul kernels (K=5120, N=96) plus the legacy
+// bf16_matmul_qwen36_bf16 name.
+//
+// bf16_matmul_qwen36_bf16 is the historical name for the model-neutral small-M
+// matmul. The implementation moved to bf16_matmul_bf16.cu (symbol
+// bf16_matmul_bf16) as part of the generic-helper ownership cleanup (#112);
+// this declaration is kept as a thin wrapper so existing Qwen3.6 call sites and
+// the existing binding stay unchanged. The generic cuBLASLt BF16 GEMM
+// (bf16_matmul_cublaslt_bf16) also moved to bf16_matmul_bf16.cuh.
 //
 //   D[m, n] = sum_k x[m, k] * W[n, k],   m in [0, M), n in [0, N)
 //
-// Replaces a Python K-loop of bf16_matvec_qwen36_bf16 calls (which
-// reads the full W weight K times) with a single launch that reads
-// W exactly once and broadcasts across the M output rows. Eliminates
-// the (M-1) × |W| redundant weight read at the lin-attn unquantized
-// projections (in_proj_qkv 100MB, in_proj_z 60MB, out_proj 60MB),
-// which is the dominant cost of the verify forward at S>=2 (profile:
-// verify K=4 = 45ms vs S=1 = 28ms; the 17ms delta is this read).
-//
-// Stream-invariance and CUDA Graph compatibility match the matvec:
-// each thread sums in fixed K-order with fp32 fma, no cuBLAS handle.
-//
-// Shapes:
-//   x   : (M, K)      bf16, row-major
-//   W   : (N, K)      bf16, row-major
-//   out : (M, N)      bf16, row-major
-//
-// Launch: (ceil(N/8), M) blocks of 256 threads. One block computes
-// 8 output elements (= 8 warps × 1 element/warp) for one (m, n-tile).
+// The AB96 kernels below remain Qwen3.6-specific: they hardcode N=96 / K=5120
+// for the lin-attn unquantized projections (in_proj_qkv/z, out_proj) and the
+// MTP tile shapes, so they stay in this Qwen3.6-named file.
 
 #pragma once
 
@@ -31,15 +22,6 @@
 namespace flash_rt::kernels {
 
 void bf16_matmul_qwen36_bf16(
-    const __nv_bfloat16* x,
-    const __nv_bfloat16* W,
-    __nv_bfloat16* out,
-    int M,
-    int N,
-    int K,
-    cudaStream_t stream);
-
-void bf16_matmul_cublaslt_bf16(
     const __nv_bfloat16* x,
     const __nv_bfloat16* W,
     __nv_bfloat16* out,

--- a/csrc/kernels/embedding_lookup_bf16.cu
+++ b/csrc/kernels/embedding_lookup_bf16.cu
@@ -1,0 +1,46 @@
+// Generic bf16 embedding lookup — see header for design notes.
+// Moved here from qwen36_misc.cu as part of the generic-helper ownership
+// cleanup (#112). The kernel is unchanged; only the file and the public symbol
+// name (embedding_lookup_bf16) are neutral now.
+
+#include "embedding_lookup_bf16.cuh"
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kThreads = 256;
+
+__global__ void embedding_lookup_bf16_kernel(
+    const int64_t* __restrict__ token_ids,
+    const __nv_bfloat16* __restrict__ embed,
+    __nv_bfloat16* __restrict__ out,
+    int rows,
+    int hidden)
+{
+  const int row = blockIdx.y;
+  if (row >= rows) return;
+  const int col = blockIdx.x * blockDim.x + threadIdx.x;
+  if (col >= hidden) return;
+  const int64_t tok = token_ids[row];
+  out[row * hidden + col] = embed[tok * hidden + col];
+}
+
+}  // namespace
+
+void embedding_lookup_bf16(
+    const int64_t* token_ids,
+    const __nv_bfloat16* embed,
+    __nv_bfloat16* out,
+    int rows,
+    int hidden,
+    cudaStream_t stream)
+{
+  if (rows <= 0 || hidden <= 0) return;
+  const dim3 block(kThreads);
+  const dim3 grid((hidden + kThreads - 1) / kThreads, rows);
+  embedding_lookup_bf16_kernel<<<grid, block, 0, stream>>>(
+      token_ids, embed, out, rows, hidden);
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/embedding_lookup_bf16.cuh
+++ b/csrc/kernels/embedding_lookup_bf16.cuh
@@ -1,0 +1,29 @@
+// Generic bf16 embedding lookup — model-neutral.
+//
+//   out[r, :] = embed[token_ids[r], :],   r in [0, rows)
+//
+// A plain gather of bf16 embedding rows by token id. Historically named
+// qwen36_embedding_lookup_bf16, but it is model-neutral and reused by Qwen3,
+// the Qwen3-VL SM89 FP8 path and GROOT N1.7. Moved here from qwen36_misc.cu as
+// part of the generic-helper ownership cleanup (#112). The legacy name
+// qwen36_embedding_lookup_bf16 is kept as a thin wrapper over
+// embedding_lookup_bf16 (see qwen36_misc.cu) so existing call sites and the
+// existing binding keep working.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt::kernels {
+
+void embedding_lookup_bf16(
+    const int64_t* token_ids,
+    const __nv_bfloat16* embed,
+    __nv_bfloat16* out,
+    int rows,
+    int hidden,
+    cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen36_misc.cu
+++ b/csrc/kernels/qwen36_misc.cu
@@ -1,5 +1,7 @@
 #include "qwen36_misc.cuh"
 
+#include "embedding_lookup_bf16.cuh"
+
 #include <limits>
 
 namespace flash_rt::kernels {
@@ -7,21 +9,6 @@ namespace flash_rt::kernels {
 namespace {
 
 constexpr int kThreads = 256;
-
-__global__ void embedding_lookup_bf16_kernel(
-    const int64_t* __restrict__ token_ids,
-    const __nv_bfloat16* __restrict__ embed,
-    __nv_bfloat16* __restrict__ out,
-    int rows,
-    int hidden)
-{
-  const int row = blockIdx.y;
-  if (row >= rows) return;
-  const int col = blockIdx.x * blockDim.x + threadIdx.x;
-  if (col >= hidden) return;
-  const int64_t tok = token_ids[row];
-  out[row * hidden + col] = embed[tok * hidden + col];
-}
 
 __device__ __forceinline__ __nv_bfloat16 partial_rope_value(
     const __nv_bfloat16* __restrict__ x,
@@ -256,6 +243,10 @@ __global__ void spec_accept_kernel(
 
 }  // namespace
 
+// Thin legacy wrapper: qwen36_embedding_lookup_bf16 is the historical name for
+// the model-neutral embedding lookup, kept so Qwen3.6 call sites and the
+// existing binding stay unchanged. The implementation lives in
+// embedding_lookup_bf16.cu.
 void qwen36_embedding_lookup_bf16(
     const int64_t* token_ids,
     const __nv_bfloat16* embed,
@@ -264,11 +255,7 @@ void qwen36_embedding_lookup_bf16(
     int hidden,
     cudaStream_t stream)
 {
-  if (rows <= 0 || hidden <= 0) return;
-  const dim3 block(kThreads);
-  const dim3 grid((hidden + kThreads - 1) / kThreads, rows);
-  embedding_lookup_bf16_kernel<<<grid, block, 0, stream>>>(
-      token_ids, embed, out, rows, hidden);
+  embedding_lookup_bf16(token_ids, embed, out, rows, hidden, stream);
 }
 
 void qwen36_partial_rope_qk_bf16(

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -34,7 +34,10 @@
 #include "gemm/fp8_gemv_m1_sm89.cuh"
 #include "quantize/fp8_per_token_block_quant.cuh"
 #include "kernels/qwen3_qkv_post_proc.cuh"
-#include "kernels/bf16_matmul_qwen36.cuh"
+// Only bf16_matmul_cublaslt_bf16 is needed here; it lives in the neutral
+// matmul translation unit (#112), so the Qwen3-VL module no longer has to
+// pull in the Qwen3.6 AB96 matmul file.
+#include "kernels/bf16_matmul_bf16.cuh"
 #endif
 
 namespace py = pybind11;

--- a/flash_rt/frontends/torch/_higgs_audio_v3_bf16.py
+++ b/flash_rt/frontends/torch/_higgs_audio_v3_bf16.py
@@ -12,7 +12,7 @@ residual-norms + fused q/k-norm+RoPE+KV-write + FA2 + silu_mul; nothing else.
 
 GEMV kernel is the dedicated M=1 ``bf16_matvec_qwen36_bf16`` (warp-per-output-row,
 no MMA BLOCK_M padding tax), selected over the tiled ``bf16_matmul`` by measured
-full-decode latency. Prefill uses the tiled ``bf16_matmul_qwen36_bf16`` at M=P.
+full-decode latency. Prefill uses the tiled ``bf16_matmul_bf16`` at M=P.
 
 Used by :class:`HiggsAudioV3TorchFrontendRtx` when ``fp8=False``.
 """

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -1437,10 +1437,10 @@ class GrootN17TorchFrontendThor:
         S = self.Se
         nt, ni = self._ck_nt, self._ck_ni
         K.cast_fp16_to_bf16(self._ck_bb_src.data_ptr(), self._ck_bb.data_ptr(), S * 2048, s)
-        K.qwen36_embedding_lookup_bf16(
+        K.embedding_lookup_bf16(
             self._ck_text_idx.data_ptr(), self._ck_bb.data_ptr(),
             self._ck_text_src.data_ptr(), nt, 2048, s)
-        K.qwen36_embedding_lookup_bf16(
+        K.embedding_lookup_bf16(
             self._ck_image_idx.data_ptr(), self._ck_bb.data_ptr(),
             self._ck_image_src.data_ptr(), ni, 2048, s)
         for j in range(16):

--- a/flash_rt/frontends/torch/groot_n17_thor_fp8.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp8.py
@@ -509,7 +509,7 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
                 self._embed_tokens_bf16 = self._embed_tokens_w.to(_BF16).contiguous()
             ids = K(aux["input_ids"].reshape(-1).to(torch.int64).to(dev).contiguous())
             emb_bf16 = K(torch.empty(Se, 2048, dtype=_BF16, device=dev))
-            fvk.qwen36_embedding_lookup_bf16(ids.data_ptr(),
+            fvk.embedding_lookup_bf16(ids.data_ptr(),
                                              self._embed_tokens_bf16.data_ptr(),
                                              emb_bf16.data_ptr(), Se, 2048, 0)
             self._kbb_llm_base = emb_bf16.to(_FP16).contiguous()

--- a/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
+++ b/flash_rt/frontends/torch/higgs_audio_v3_rtx.py
@@ -6,7 +6,7 @@ acoustic frame under a delay pattern, decoded autoregressively with greedy
 sampling. ``predict`` returns raw ``[T, num_codebooks]`` codes; waveform
 synthesis is the codec's responsibility.
 
-Kernels used: ``rms_norm``, ``bf16_matmul_qwen36_bf16``, ``silu_mul_qwen36_bf16``,
+Kernels used: ``rms_norm``, ``bf16_matmul_bf16``, ``silu_mul_qwen36_bf16``,
 ``qwen3_q_norm_rope_qstage_bf16`` / ``qwen3_k_norm_rope_kvwrite_bf16`` (fused
 q/k-norm + full RoPE), and vendored FlashAttention-2 via
 ``RtxFlashAttnBackendQwen3`` (head config 36 / 32q / 8kv / 128 is shared with

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -1268,7 +1268,7 @@ class Qwen3TorchFrontendRtx:
                 self._lmhead_act_scale.data_ptr(), w_descale, s,
             )
         else:
-            fvk.bf16_matmul_qwen36_bf16(
+            fvk.bf16_matmul_bf16(
                 last_row.contiguous().data_ptr(),
                 int(self._weights.ptrs['lm_head_w']),
                 self._logits_buf[:1].data_ptr(), 1, vocab, hidden, s,
@@ -1391,7 +1391,7 @@ class Qwen3TorchFrontendRtx:
 
         # 4) lm_head BF16. M=1 (last row, default) or M=S (full_logits).
         if full_logits:
-            fvk.bf16_matmul_qwen36_bf16(
+            fvk.bf16_matmul_bf16(
                 x_norm.contiguous().data_ptr(),
                 int(self._weights.ptrs['lm_head_w']),
                 self._logits_buf[:S].data_ptr(),

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -929,7 +929,7 @@ class Qwen3TorchFrontendRtx:
         # BW saving justifies. Reverted to BF16. A future NVFP4
         # lm_head with FP8 per-row calibration could potentially
         # recover the gap.
-        fvk.bf16_matmul_qwen36_bf16(
+        fvk.bf16_matmul_bf16(
             x_norm.data_ptr(),
             int(self._weights.ptrs['lm_head_w']),
             self._logits_buf[:1].data_ptr(),

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -1330,7 +1330,7 @@ class Qwen3TorchFrontendRtx:
         # 0) Embed S tokens via the kernel gather (no torch indexing).
         embed_t = self._weights.anchors[0]
         h = self._embed_h_buf[:S]
-        fvk.qwen36_embedding_lookup_bf16(
+        fvk.embedding_lookup_bf16(
             prompt_ids.view(-1).data_ptr(), embed_t.data_ptr(),
             h.data_ptr(), S, hidden, s,
         )
@@ -1518,7 +1518,7 @@ class Qwen3TorchFrontendRtx:
 
         embed_t = self._weights.anchors[0]
         h = self._embed_h_buf[:S]
-        fvk.qwen36_embedding_lookup_bf16(
+        fvk.embedding_lookup_bf16(
             prompt_ids.view(-1).data_ptr(), embed_t.data_ptr(),
             h.data_ptr(), S, hidden, s,
         )

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -103,7 +103,7 @@ class Qwen3VlFp8Sm89TextFrontend:
             'qwen3_q_norm_rope_qstage_bf16',
             'qwen3_k_norm_rope_kvwrite_bf16',
             'qwen36_embedding_lookup_bf16',
-            'bf16_matmul_qwen36_bf16',
+            'bf16_matmul_bf16',
             'rms_norm',
             'residual_add',
         )
@@ -381,7 +381,7 @@ class Qwen3VlFp8Sm89TextFrontend:
                        int(self._weights.ptrs['lm_head_fp8_s']),
                        self._logits_buf, vocab, hidden)
         else:
-            self._fvk.bf16_matmul_qwen36_bf16(
+            self._fvk.bf16_matmul_bf16(
                 last_row.data_ptr(), int(self._weights.ptrs['lm_head_w']),
                 self._logits_buf.data_ptr(), 1, vocab, hidden, s)
         return self._logits_buf

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -102,7 +102,7 @@ class Qwen3VlFp8Sm89TextFrontend:
             'qwen3_qk_norm_rope_kvwrite_batched_bf16',
             'qwen3_q_norm_rope_qstage_bf16',
             'qwen3_k_norm_rope_kvwrite_bf16',
-            'qwen36_embedding_lookup_bf16',
+            'embedding_lookup_bf16',
             'bf16_matmul_bf16',
             'rms_norm',
             'residual_add',
@@ -677,7 +677,7 @@ class Qwen3VlFp8Sm89TextFrontend:
         if token_id.ndim == 1:
             token_id = token_id.view(1, 1)
         h = self._h_a[:1]
-        self._fvk.qwen36_embedding_lookup_bf16(
+        self._fvk.embedding_lookup_bf16(
             token_id.view(-1).data_ptr(),
             int(self._weights.ptrs['embed_w']),
             h.data_ptr(),

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -327,7 +327,7 @@ class Qwen3VlTorchFrontendRtx:
                      xn.data_ptr(), 1, hidden, eps, stream)
         logits = torch.empty(
             1, vocab, dtype=torch.bfloat16, device=self.device)
-        fvk.bf16_matmul_qwen36_bf16(
+        fvk.bf16_matmul_bf16(
             xn.data_ptr(), int(llm._weights.ptrs['lm_head_w']),
             logits.data_ptr(), 1, vocab, hidden, stream)
         torch.cuda.synchronize()
@@ -439,7 +439,7 @@ class Qwen3VlTorchFrontendRtx:
         graph.replay()
         stream = torch.cuda.current_stream().cuda_stream
         last = self._pg_last_hidden[S - 1:S].contiguous()
-        fvk.bf16_matmul_qwen36_bf16(
+        fvk.bf16_matmul_bf16(
             last.data_ptr(), int(llm._weights.ptrs['lm_head_w']),
             self._pg_logits.data_ptr(), 1, vocab, hidden, stream)
         torch.cuda.synchronize()

--- a/tests/test_generic_kernel_bindings.py
+++ b/tests/test_generic_kernel_bindings.py
@@ -1,0 +1,78 @@
+"""Binding-name regression net for the generic-kernel-helper cleanup (#112).
+
+This guards the ownership cleanup that moves model-neutral helpers out of
+Qwen3.6-named files into neutral files. The contract for that refactor is:
+
+- Legacy binding names MUST keep existing (we do not remove old Python
+  bindings in the cleanup PR), so existing call sites and external users do
+  not break.
+- As each neutral helper is introduced, its neutral binding name MUST also
+  exist on the same module, sharing one implementation with the legacy name.
+
+Unit 0 only asserts the legacy baseline (neutral names do not exist yet). The
+neutral-name assertions below are activated in the unit that introduces each
+neutral binding (Unit 1 for matmul, Unit 2 for embedding) by flipping the
+corresponding ``NEUTRAL_*_AVAILABLE`` switch.
+
+These are CPU/import-friendly: importing the compiled ``.so`` does not require
+a CUDA device or any model checkpoint, only that the extension built.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# Cleanup progress switches. Each is flipped to True in the same commit that
+# introduces the corresponding neutral binding, which is also where the
+# matching neutral-name assertion starts being enforced.
+NEUTRAL_MATMUL_AVAILABLE = False  # Unit 1: bf16_matmul_bf16
+NEUTRAL_EMBEDDING_AVAILABLE = False  # Unit 2: embedding_lookup_bf16
+
+
+def _import_kernels():
+    try:
+        return importlib.import_module("flash_rt.flash_rt_kernels")
+    except Exception as exc:  # pragma: no cover - build/env dependent
+        pytest.skip(f"flash_rt_kernels not importable: {exc}")
+
+
+def _import_vl_kernels():
+    try:
+        return importlib.import_module("flash_rt.flash_rt_qwen3_vl_kernels")
+    except Exception as exc:  # pragma: no cover - build/env dependent
+        pytest.skip(f"flash_rt_qwen3_vl_kernels not importable: {exc}")
+
+
+def test_legacy_matmul_bindings_exist():
+    m = _import_kernels()
+    assert hasattr(m, "bf16_matmul_qwen36_bf16")
+
+
+def test_legacy_embedding_binding_exists():
+    m = _import_kernels()
+    assert hasattr(m, "qwen36_embedding_lookup_bf16")
+
+
+def test_legacy_cublaslt_binding_exists_on_vl_module():
+    m = _import_vl_kernels()
+    assert hasattr(m, "bf16_matmul_cublaslt_bf16")
+
+
+@pytest.mark.skipif(
+    not NEUTRAL_MATMUL_AVAILABLE,
+    reason="neutral bf16_matmul_bf16 binding introduced in Unit 1",
+)
+def test_neutral_matmul_binding_exists():
+    m = _import_kernels()
+    assert hasattr(m, "bf16_matmul_bf16")
+
+
+@pytest.mark.skipif(
+    not NEUTRAL_EMBEDDING_AVAILABLE,
+    reason="neutral embedding_lookup_bf16 binding introduced in Unit 2",
+)
+def test_neutral_embedding_binding_exists():
+    m = _import_kernels()
+    assert hasattr(m, "embedding_lookup_bf16")

--- a/tests/test_generic_kernel_bindings.py
+++ b/tests/test_generic_kernel_bindings.py
@@ -57,6 +57,11 @@ def test_legacy_embedding_binding_exists():
 
 def test_legacy_cublaslt_binding_exists_on_vl_module():
     m = _import_vl_kernels()
+    if not hasattr(m, "fp8_block128_gemm_blockscaled_sm89_bf16out"):
+        pytest.skip(
+            "bf16_matmul_cublaslt_bf16 is part of the SM89 Qwen3-VL module; "
+            "SM120 builds use the SM120 path instead"
+        )
     assert hasattr(m, "bf16_matmul_cublaslt_bf16")
 
 

--- a/tests/test_generic_kernel_bindings.py
+++ b/tests/test_generic_kernel_bindings.py
@@ -28,7 +28,7 @@ import pytest
 # introduces the corresponding neutral binding, which is also where the
 # matching neutral-name assertion starts being enforced.
 NEUTRAL_MATMUL_AVAILABLE = True  # Unit 1: bf16_matmul_bf16
-NEUTRAL_EMBEDDING_AVAILABLE = False  # Unit 2: embedding_lookup_bf16
+NEUTRAL_EMBEDDING_AVAILABLE = True  # Unit 2: embedding_lookup_bf16
 
 
 def _import_kernels():

--- a/tests/test_generic_kernel_bindings.py
+++ b/tests/test_generic_kernel_bindings.py
@@ -27,7 +27,7 @@ import pytest
 # Cleanup progress switches. Each is flipped to True in the same commit that
 # introduces the corresponding neutral binding, which is also where the
 # matching neutral-name assertion starts being enforced.
-NEUTRAL_MATMUL_AVAILABLE = False  # Unit 1: bf16_matmul_bf16
+NEUTRAL_MATMUL_AVAILABLE = True  # Unit 1: bf16_matmul_bf16
 NEUTRAL_EMBEDDING_AVAILABLE = False  # Unit 2: embedding_lookup_bf16
 
 


### PR DESCRIPTION
## What

Ownership/name cleanup for issue #112. Several model-neutral CUDA helpers
still lived under Qwen3.6 file/symbol names while non-Qwen3.6 paths reused
them. This moves the generic helpers into neutral files and migrates the
non-Qwen3.6 call sites, keeping legacy names as thin wrappers.

**Refactor-only.** No kernel algorithm, dtype policy, dispatch, graph
capture, or runtime fallback change.

## Changes

- **Neutral `bf16_matmul_bf16`** (`csrc/kernels/bf16_matmul_bf16.{cu,cuh}`):
  the model-neutral small-M warp matmul (former `bf16_matmul_qwen36_bf16`
  body) plus `bf16_matmul_cublaslt_bf16` (already a neutral symbol; only its
  file moved). `bf16_matmul_qwen36.cu` keeps the Qwen3.6-specific AB96
  kernels and a thin `bf16_matmul_qwen36_bf16` wrapper that forwards.
- **Neutral `embedding_lookup_bf16`** (`csrc/kernels/embedding_lookup_bf16.{cu,cuh}`):
  the generic bf16 embedding gather (former `qwen36_embedding_lookup_bf16`
  body). `qwen36_misc.cu` keeps its Qwen3.6-specific helpers and a thin
  forwarding wrapper.
- **Bindings**: both neutral and legacy names are bound; no binding removed.
- **Qwen3-VL dedicated module** no longer compiles the Qwen3.6 matmul TU —
  it only needed `bf16_matmul_cublaslt_bf16`, now in the neutral file.
- **Call sites**: non-Qwen3.6 frontends (Qwen3, Qwen3-VL, Qwen3-VL FP8 SM89,
  GROOT N1.7) migrate to the neutral names. Qwen3.6 frontends keep the legacy
  names for auditability. Higgs docstrings updated.

## Commits (each independently buildable)

1. `test`: baseline binding-name net (legacy names)
2. `refactor`: neutral `bf16_matmul_bf16` ownership
3. `build`: drop the Qwen3.6 matmul TU from the Qwen3-VL module (isolated, revertible)
4. `refactor`: neutral `embedding_lookup_bf16` ownership
5. `docs`: point non-Qwen3.6 refs at neutral names + 2 missed call sites
6. `docs`: update a stale cuBLASLt link comment

## Verification (local, RTX 4090 / SM89)

- `flash_rt_kernels`, `flash_rt_fa2`, `flash_rt_qwen3_vl_kernels` build clean.
- Binding test asserts both neutral and legacy names exist on the modules.
- Embedding CUDA equivalence: neutral == reference and legacy == neutral,
  bit-identical.
- Qwen3-VL-2B SM89 multimodal smoke matches the pre-cleanup baseline:
  `prefill_graph cos_vs_eager=1.0`, `decode cos_vs_eager=1.0`.

Closes #112.