### PR TITLE
build: add opt-in FLASHRT_SLIM_BUILD to trim VLA-deployment kernel compile surface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1028,6 +1028,19 @@ if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121" OR
 endif()
 
 # ── Main module ──
+# flash_rt_kernels is the shared core pybind module. It currently compiles a
+# broad superset of kernels, including several model/architecture-specific
+# translation units that not every deployment needs (Qwen3.6/linear-attention,
+# SM120/NVFP4-named, Motus/video FP8-history). For VLA deployments on weaker
+# machines this is avoidable build latency.
+#
+# An incremental cleanup gates those model/arch-specific TUs behind explicit
+# CMake options so a slim build compiles only what a given hardware/model path
+# needs. This is COMPILE-TIME surface reduction only: it does not change kernel
+# math, launch params, dtype/dispatch policy, graph capture, or runtime
+# fallback. Default builds stay compatibility-oriented (broad set) until the
+# slim path is validated across SM89/SM120/Thor. See scripts/build_inventory.py
+# and tests/test_build_inventory.py for the measured per-target surface.
 pybind11_add_module(flash_rt_kernels
   csrc/gemm/gemm_runner.cu
   csrc/kernels/norm.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,24 @@ option(FLASHRT_ENABLE_MELBAND_ROFORMER
 # Enable explicitly on a Blackwell (sm_120) build.
 option(FLASHRT_ENABLE_OMNIVOICE
        "Build OmniVoice TTS RTX SM120 fused kernels in flash_rt_omnivoice" OFF)
+# ── Slim build for VLA deployments ──
+# OFF by default: the standard build keeps the broad, compatibility-oriented
+# kernel set it has today. Turn ON (-DFLASHRT_SLIM_BUILD=ON) to drop
+# model/architecture-specific translation units that a given hardware/model
+# path does not need, reducing flash_rt_kernels compile time on weaker
+# deployment machines. This is COMPILE-TIME surface reduction only; it never
+# changes kernel math, dispatch, graph capture, or runtime fallback. Each gated
+# group is guarded by its own internal FLASHRT_HAVE_* compile-def so the
+# corresponding bindings in csrc/bindings.cpp drop in lockstep with the sources
+# (a gated source whose binding stayed compiled would fail to link). See
+# scripts/build_inventory.py for the measured surface.
+option(FLASHRT_SLIM_BUILD
+       "Drop model/arch-specific kernels not needed by the target path" OFF)
+if(FLASHRT_SLIM_BUILD)
+  message(STATUS "Slim VLA build: ENABLED (model/arch-specific kernels gated out)")
+else()
+  message(STATUS "Slim VLA build: DISABLED (broad compatibility kernel set)")
+endif()
 if(FLASHRT_ENABLE_MOTUS)
   message(STATUS "Motus beta kernels: ENABLED")
 else()
@@ -1066,11 +1084,6 @@ pybind11_add_module(flash_rt_kernels
   csrc/quantize/wmma_probe.cu
   csrc/quantize/tq_dequant_cutlass.cu
   csrc/quantize/ada_layer_norm_fp8.cu
-  csrc/quantize/awq_quant_fp8_static_bf16.cu
-  csrc/quantize/bf16_ndhwc_to_ncdhw_transpose.cu
-  csrc/quantize/bf16_quant_fp8_ncdhw_to_ndhwc.cu
-  csrc/quantize/bf16_rms_silu_ncdhw.cu
-  csrc/quantize/bf16_rms_silu_quant_fp8_ncdhw_to_ndhwc_v4.cu
   csrc/quantize/bias_gelu_quantize_fp8.cu
   csrc/quantize/qkv_split_norm_rope_bf16.cu
   csrc/quantize/rope_apply_bf16.cu
@@ -1105,6 +1118,33 @@ pybind11_add_module(flash_rt_kernels
 set_target_properties(flash_rt_kernels PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
+
+# ── Motus VAE FP8 quantize kernels (slim-gated) ──
+# These 5 TUs are used only by the Motus VAE FP8 path (the *_ncdhw* /
+# upsample / per-tensor AWQ-FP8 quant helpers; see flash_rt/models/motus/*).
+# They compile unconditionally today even on SM89 where no Motus model runs,
+# so a slim VLA build drops them. The matching bindings in csrc/bindings.cpp
+# are guarded by FLASHRT_HAVE_MOTUS_VAE_FP8 so they drop in lockstep (a gated
+# source whose binding stayed compiled would fail to link). The Motus Python
+# frontend already probes these with hasattr(), so a missing binding degrades
+# clearly instead of crashing on import.
+#
+# NOTE: ada_layer_norm_fp8.cu and bias_gelu_quantize_fp8.cu are intentionally
+# NOT in this group — they are shared (ada_layer_norm_fp8 is used by GROOT N1.7,
+# bias_gelu_quantize_fp8_static_bf16 by Melband-RoFormer), so they stay always
+# compiled. Do not fold them in without splitting their shared symbols out.
+if(NOT FLASHRT_SLIM_BUILD)
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/quantize/awq_quant_fp8_static_bf16.cu
+    csrc/quantize/bf16_ndhwc_to_ncdhw_transpose.cu
+    csrc/quantize/bf16_quant_fp8_ncdhw_to_ndhwc.cu
+    csrc/quantize/bf16_rms_silu_ncdhw.cu
+    csrc/quantize/bf16_rms_silu_quant_fp8_ncdhw_to_ndhwc_v4.cu)
+  target_compile_definitions(flash_rt_kernels PRIVATE FLASHRT_HAVE_MOTUS_VAE_FP8=1)
+  message(STATUS "Motus VAE FP8 quantize kernels: ENABLED")
+else()
+  message(STATUS "Motus VAE FP8 quantize kernels: SKIPPED (slim build)")
+endif()
 
 # ── qwen3_5_moe family (Nex-N2 / Qwen3.6-35B-A3B) SM120 kernels ──
 # Gated: only compiled when explicitly enabled AND on a Blackwell (NVFP4)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1077,8 +1077,6 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/dit_bf16.cu
   csrc/kernels/attention_dit_bf16.cu
   csrc/quantize/fp8_block128_dequant.cu
-  csrc/quantize/fp8_block128_to_nvfp4_swizzled.cu
-  csrc/quantize/bf16_weight_to_nvfp4_swizzled.cu
   csrc/quantize/fp8_per_token_block_quant.cu
   csrc/quantize/tq_dequant_kv.cu
   csrc/quantize/wmma_probe.cu
@@ -1089,17 +1087,12 @@ pybind11_add_module(flash_rt_kernels
   csrc/quantize/rope_apply_bf16.cu
   csrc/gemm/fp8_block128_gemm.cu
   csrc/kernels/silu_mul_qwen36.cu
-  csrc/kernels/silu_mul_to_nvfp4_swizzled.cu
   csrc/kernels/embedding_lookup_bf16.cu
   # qwen3_5_moe-family RTX SM120 kernels are NOT listed here -- they are
   # gated into the module below (FLASHRT_ENABLE_QWEN35MOE), so SM89/87/110
   # and non-Nex-N2 builds never compile them. See the gated block after the
   # target definition.
   csrc/kernels/qwen3_qkv_post_proc.cu
-  csrc/kernels/fp4_w4a4_matvec_sm120.cu
-  csrc/kernels/fp4_w4a4_mma_sm120.cu
-  csrc/kernels/fp4_w4a4_mma_warpsplit_sm120.cu
-  csrc/kernels/fp4_w4a4_mma_warpsplit_mrows_sm120.cu
   csrc/kernels/bf16_matvec_qwen36.cu
   csrc/kernels/bf16_matmul_bf16.cu
   csrc/attention/fmha_dispatch.cu
@@ -1170,6 +1163,47 @@ if(NOT FLASHRT_SLIM_BUILD)
   message(STATUS "Qwen3.6 / linear-attention kernels: ENABLED")
 else()
   message(STATUS "Qwen3.6 / linear-attention kernels: SKIPPED (slim build)")
+endif()
+
+# ── SM120 / NVFP4-named kernels (slim-gated, arch-macro keyed) ──
+# These TUs are named/built for SM120 NVFP4 but today compile unconditionally,
+# wasting build time on SM89 where they are unreachable. Each group compiles
+# when "NOT slim build OR <its existing arch macro is ON>": this keeps the
+# default SM89 surface broad (compatibility), drops the kernels only in a slim
+# SM89 build, and GUARANTEES they stay compiled on any SM120/NVFP4 build (slim
+# or not) where the arch macro is ON.
+#
+# Group A — fp4_w4a4_* SM120 NVFP4 W4A16 GEMM/GEMV. Their bindings are already
+# inside #ifdef ENABLE_CUTLASS_SM120_NVFP4_W4A16 in bindings.cpp, so on SM89 the
+# Python symbols never exist; only the source was compiling. No bindings change.
+# Keyed on the SAME condition that defines that macro (GPU_ARCH 120/121, see the
+# ENABLE_CUTLASS_SM120_NVFP4_W4A16 block below) — the macro is a compile-def, not
+# a CMake variable, so it must not be tested as one here.
+if(NOT FLASHRT_SLIM_BUILD OR GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "121")
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/kernels/fp4_w4a4_matvec_sm120.cu
+    csrc/kernels/fp4_w4a4_mma_sm120.cu
+    csrc/kernels/fp4_w4a4_mma_warpsplit_sm120.cu
+    csrc/kernels/fp4_w4a4_mma_warpsplit_mrows_sm120.cu)
+  message(STATUS "SM120 NVFP4 W4A16 fp4_w4a4 kernels: ENABLED")
+else()
+  message(STATUS "SM120 NVFP4 W4A16 fp4_w4a4 kernels: SKIPPED (slim build)")
+endif()
+
+# Group B — NVFP4 swizzle/quantize helpers. Their bindings are unguarded today
+# (exposed on SM89 but runtime-unreachable: every Python loader self-gates on
+# has_nvfp4()). Gating the sources requires guarding their bindings + includes
+# in lockstep; FLASHRT_HAVE_NVFP4_SWIZZLE drives that guard and is defined on
+# the same "NOT slim OR ENABLE_NVFP4" condition.
+if(NOT FLASHRT_SLIM_BUILD OR ENABLE_NVFP4)
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/quantize/fp8_block128_to_nvfp4_swizzled.cu
+    csrc/quantize/bf16_weight_to_nvfp4_swizzled.cu
+    csrc/kernels/silu_mul_to_nvfp4_swizzled.cu)
+  target_compile_definitions(flash_rt_kernels PRIVATE FLASHRT_HAVE_NVFP4_SWIZZLE=1)
+  message(STATUS "NVFP4 swizzle/quantize kernels: ENABLED")
+else()
+  message(STATUS "NVFP4 swizzle/quantize kernels: SKIPPED (slim build)")
 endif()
 
 # ── qwen3_5_moe family (Nex-N2 / Qwen3.6-35B-A3B) SM120 kernels ──

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1088,17 +1088,9 @@ pybind11_add_module(flash_rt_kernels
   csrc/quantize/qkv_split_norm_rope_bf16.cu
   csrc/quantize/rope_apply_bf16.cu
   csrc/gemm/fp8_block128_gemm.cu
-  csrc/kernels/causal_conv1d_qwen36.cu
-  csrc/kernels/linear_attention/gated_delta_wy_bf16.cu
-  csrc/kernels/linear_attention/gated_delta_wy_bf16_mma_fla.cu
-  csrc/kernels/linear_attention/gated_delta_wy_output_o_mma_fla.cu
-  csrc/kernels/linear_attention/gated_delta_wy_recompute_wu_mma_fla.cu
-  csrc/kernels/gated_deltanet_qwen36.cu
-  csrc/kernels/rms_norm_gated_silu_qwen36.cu
   csrc/kernels/silu_mul_qwen36.cu
   csrc/kernels/silu_mul_to_nvfp4_swizzled.cu
   csrc/kernels/embedding_lookup_bf16.cu
-  csrc/kernels/qwen36_misc.cu
   # qwen3_5_moe-family RTX SM120 kernels are NOT listed here -- they are
   # gated into the module below (FLASHRT_ENABLE_QWEN35MOE), so SM89/87/110
   # and non-Nex-N2 builds never compile them. See the gated block after the
@@ -1110,8 +1102,6 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/fp4_w4a4_mma_warpsplit_mrows_sm120.cu
   csrc/kernels/bf16_matvec_qwen36.cu
   csrc/kernels/bf16_matmul_bf16.cu
-  csrc/kernels/bf16_matmul_qwen36.cu
-  csrc/kernels/bf16_matmul_qwen36_thor.cu
   csrc/attention/fmha_dispatch.cu
   csrc/bindings.cpp
 )
@@ -1144,6 +1134,42 @@ if(NOT FLASHRT_SLIM_BUILD)
   message(STATUS "Motus VAE FP8 quantize kernels: ENABLED")
 else()
   message(STATUS "Motus VAE FP8 quantize kernels: SKIPPED (slim build)")
+endif()
+
+# ── Qwen3.6 / linear-attention kernels (slim-gated) ──
+# These 10 TUs are used only by the Qwen3.6 family: Qwen3.6 dense/thor/spark
+# and Nex-N2 (the Qwen3.6-35B-A3B MoE). They cover causal-conv1d, the gated
+# DeltaNet / linear-attention WY stack, the Qwen3.6 fused RMSNorm-gated-SiLU,
+# Qwen3.6 misc helpers (partial-rope / argmax / tq-prepare / spec-accept /
+# legacy embedding wrapper), and the Qwen3.6 bf16 matmul (AB96 + legacy
+# wrapper + Thor MTP). A slim VLA build (Qwen3-VL etc.) needs none of them.
+# Their bindings in csrc/bindings.cpp are guarded by FLASHRT_HAVE_QWEN36_KERNELS
+# so they drop in lockstep (a gated source whose binding stayed compiled would
+# fail to link).
+#
+# NOTE: silu_mul_qwen36.cu and bf16_matvec_qwen36.cu are intentionally NOT in
+# this group — silu_mul_qwen36_bf16 is shared (Qwen3-dense / Higgs / Cosmos3)
+# and bf16_matvec_qwen36_bf16 is used by Higgs, so they stay always compiled.
+# The neutral helpers bf16_matmul_bf16.cu / embedding_lookup_bf16.cu also stay
+# (#112); only the legacy wrappers bf16_matmul_qwen36_bf16 /
+# qwen36_embedding_lookup_bf16 live inside the gated TUs. Do not fold the two
+# shared files in without splitting their shared symbols out.
+if(NOT FLASHRT_SLIM_BUILD)
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/kernels/causal_conv1d_qwen36.cu
+    csrc/kernels/linear_attention/gated_delta_wy_bf16.cu
+    csrc/kernels/linear_attention/gated_delta_wy_bf16_mma_fla.cu
+    csrc/kernels/linear_attention/gated_delta_wy_output_o_mma_fla.cu
+    csrc/kernels/linear_attention/gated_delta_wy_recompute_wu_mma_fla.cu
+    csrc/kernels/gated_deltanet_qwen36.cu
+    csrc/kernels/rms_norm_gated_silu_qwen36.cu
+    csrc/kernels/qwen36_misc.cu
+    csrc/kernels/bf16_matmul_qwen36.cu
+    csrc/kernels/bf16_matmul_qwen36_thor.cu)
+  target_compile_definitions(flash_rt_kernels PRIVATE FLASHRT_HAVE_QWEN36_KERNELS=1)
+  message(STATUS "Qwen3.6 / linear-attention kernels: ENABLED")
+else()
+  message(STATUS "Qwen3.6 / linear-attention kernels: SKIPPED (slim build)")
 endif()
 
 # ── qwen3_5_moe family (Nex-N2 / Qwen3.6-35B-A3B) SM120 kernels ──

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -138,7 +138,9 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #include "kernels/gated_deltanet_qwen36.cuh"
 #endif
 #include "kernels/qwen3_qkv_post_proc.cuh"
+#ifdef FLASHRT_HAVE_NVFP4_SWIZZLE
 #include "kernels/silu_mul_to_nvfp4_swizzled.cuh"
+#endif
 #ifdef FLASHRT_HAVE_QWEN36_KERNELS
 #include "kernels/rms_norm_gated_silu_qwen36.cuh"
 #endif
@@ -174,8 +176,10 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #include "kernels/fp4_w4a4_mma_warpsplit_sm120.cuh"
 #include "kernels/fp4_w4a4_mma_warpsplit_mrows_sm120.cuh"
 #include "quantize/fp8_block128_dequant.cuh"
+#ifdef FLASHRT_HAVE_NVFP4_SWIZZLE
 #include "quantize/fp8_block128_to_nvfp4_swizzled.cuh"
 #include "quantize/bf16_weight_to_nvfp4_swizzled.cuh"
+#endif
 #include "quantize/fp8_per_token_block_quant.cuh"
 #include "quantize/bias_gelu_quantize_fp8.cuh"
 #ifdef FLASHRT_HAVE_MOTUS_VAE_FP8
@@ -2396,6 +2400,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     // out_global_scale (1 fp32). out_global_scale is to be passed as the GEMM
     // alpha (= act_global * w_global; for per-token activation quant
     // act_global = 1 so alpha = w_global = out_global_scale).
+#ifdef FLASHRT_HAVE_NVFP4_SWIZZLE
     m.def("fp8_block128_to_nvfp4_swizzled_bf16",
         [](uintptr_t w_fp8, uintptr_t w_block_scale_fp32,
            uintptr_t nvfp4_packed, uintptr_t nvfp4_sf_swizzled,
@@ -2437,6 +2442,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("nvfp4_packed"), py::arg("nvfp4_sf_swizzled"),
         py::arg("scratch_global_amax"), py::arg("out_global_scale"),
         py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_NVFP4_SWIZZLE (fp8/bf16 weight -> nvfp4 swizzled)
 
     // ── TurboQuant unpack (Phase 3A B9 step S3) ───────────────────────
     // Packed B8 (4-bit K idx + 1-bit qjl + 4-bit V idx) → 3 BF16 outputs:
@@ -6451,6 +6457,7 @@ graph-replay safe) to fill the SMs on long K. M in 1..16; N%8==0; K%64==0;
         py::arg("n_q_heads"), py::arg("eps") = 1e-6f,
         py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_NVFP4_SWIZZLE
     m.def("silu_mul_to_nvfp4_swizzled_bf16",
         [](uintptr_t gate, uintptr_t up,
            uintptr_t packed, uintptr_t sf_swz,
@@ -6502,6 +6509,7 @@ graph-replay safe) to fill the SMs on long K. M in 1..16; N%8==0; K%64==0;
         py::arg("merged_gate_up"),
         py::arg("packed"), py::arg("sf_swz"),
         py::arg("rows"), py::arg("cols"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_NVFP4_SWIZZLE (silu_mul_to_nvfp4_swizzled)
 
     m.def("qwen3_k_norm_rope_kvwrite_bf16",
         [](uintptr_t k_pre, uintptr_t v_pre, uintptr_t k_norm_w,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -170,13 +170,17 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #include "quantize/bf16_weight_to_nvfp4_swizzled.cuh"
 #include "quantize/fp8_per_token_block_quant.cuh"
 #include "quantize/bias_gelu_quantize_fp8.cuh"
+#ifdef FLASHRT_HAVE_MOTUS_VAE_FP8
 #include "quantize/awq_quant_fp8_static_bf16.cuh"
+#endif
 #include "quantize/rope_apply_bf16.cuh"
 #include "quantize/ada_layer_norm_fp8.cuh"
+#ifdef FLASHRT_HAVE_MOTUS_VAE_FP8
 #include "quantize/bf16_rms_silu_quant_fp8_ncdhw_to_ndhwc_v4.cuh"
 #include "quantize/bf16_rms_silu_ncdhw.cuh"
 #include "quantize/bf16_ndhwc_to_ncdhw_transpose.cuh"
 #include "quantize/bf16_quant_fp8_ncdhw_to_ndhwc.cuh"
+#endif
 #include "quantize/qkv_split_norm_rope_bf16.cuh"
 #include "attention/fmha_dispatch.h"
 #ifdef ENABLE_MOTUS_SAGE2_RAW
@@ -2944,6 +2948,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
 
     // G7.23 v19 — bare BF16 -> FP8 quant with NCDHW -> NDHWC permute.
     // Used by the (1,1,1) shortcut conv FP8 path (no RMS / SiLU / gamma).
+#ifdef FLASHRT_HAVE_MOTUS_VAE_FP8
     m.def("bf16_quant_fp8_ncdhw_to_ndhwc",
         [](uintptr_t x_bf16, uintptr_t y_fp8,
            int B, int C, int T, int H, int W,
@@ -2992,6 +2997,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("x_bf16"), py::arg("gamma_bf16"), py::arg("y_fp8"),
         py::arg("B"), py::arg("C"), py::arg("T"), py::arg("H"), py::arg("W"),
         py::arg("act_scale"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_MOTUS_VAE_FP8
 
     // G7.23 v3 — v2 + uint32 vec smem read (eliminates 4-8 way bank conflict).
 
@@ -3023,6 +3029,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
 
     // G7.14 — Fused (per-K AWQ inv_s mul + per-tensor static FP8
     // quantize) for AWQ FP8 sites in action_expert + und_expert.
+#ifdef FLASHRT_HAVE_MOTUS_VAE_FP8
     m.def("awq_quant_fp8_static_bf16",
         [](uintptr_t in_bf16, uintptr_t inv_s_bf16, uintptr_t out_fp8,
            uintptr_t act_scale, long long M, int K, uintptr_t stream) {
@@ -3037,6 +3044,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("out_fp8"), py::arg("act_scale"),
         py::arg("M"), py::arg("K"),
         py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_MOTUS_VAE_FP8
 
     // Motus 205ms path bindings. These are the production fused kernels
     // used by the cleaned Motus frontend; probe/test kernels stay archived.
@@ -3196,6 +3204,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("seq_len"), py::arg("dim"),
         py::arg("eps") = 1e-6f, py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_MOTUS_VAE_FP8
     m.def("awq_quant2_fp8_static_bf16",
         [](uintptr_t in0_bf16, uintptr_t inv_s0_bf16, uintptr_t out0_fp8,
            uintptr_t act_scale0, long long M0, int K0,
@@ -3214,6 +3223,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("in1_bf16"), py::arg("inv_s1_bf16"),
         py::arg("out1_fp8"), py::arg("act_scale1"),
         py::arg("M1"), py::arg("K1"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_MOTUS_VAE_FP8
 
     m.def("layer_norm_no_affine_fp8_static_bf16",
         [](uintptr_t x, uintptr_t out, uintptr_t d_scale,
@@ -3449,6 +3459,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("gate"), py::arg("gate_scale"), py::arg("out"),
         py::arg("seq_len"), py::arg("dim"), py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_MOTUS_VAE_FP8
     m.def("bf16_rms_silu_ncdhw",
         [](uintptr_t x_bf16, uintptr_t gamma_bf16, uintptr_t y_bf16,
            uintptr_t prev_cache_bf16, uintptr_t next_cache_bf16,
@@ -3514,6 +3525,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("x_bf16"), py::arg("y_fp8"),
         py::arg("N"), py::arg("C"), py::arg("H"), py::arg("W"),
         py::arg("act_scale"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_MOTUS_VAE_FP8
 
     m.def("qkv_split_bias_norm_rope_v_bf16",
         [](uintptr_t packed_qkv, uintptr_t qkv_bias,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -132,15 +132,21 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #ifdef FLASHRT_HAVE_MELBAND_ROFORMER
 #include "kernels/mbr_kernels.cuh"
 #endif
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
 #include "kernels/causal_conv1d_qwen36.cuh"
 #include "kernels/linear_attention/gated_delta_wy_bf16.cuh"
 #include "kernels/gated_deltanet_qwen36.cuh"
+#endif
 #include "kernels/qwen3_qkv_post_proc.cuh"
 #include "kernels/silu_mul_to_nvfp4_swizzled.cuh"
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
 #include "kernels/rms_norm_gated_silu_qwen36.cuh"
+#endif
 #include "kernels/silu_mul_qwen36.cuh"
 #include "kernels/embedding_lookup_bf16.cuh"
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
 #include "kernels/qwen36_misc.cuh"
+#endif
 #ifdef FLASHRT_HAVE_QWEN35MOE
 #include "kernels/qwen35moe_layout.cuh"
 #include "kernels/moe_grouped_gemv_sm120.cuh"
@@ -159,8 +165,10 @@ extern "C" int cutlass_int8_rowwise_bf16out_t64x128(
 #endif  // FLASHRT_HAVE_QWEN35MOE
 #include "kernels/bf16_matvec_qwen36.cuh"
 #include "kernels/bf16_matmul_bf16.cuh"
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
 #include "kernels/bf16_matmul_qwen36.cuh"
 #include "kernels/bf16_matmul_qwen36_thor.cuh"
+#endif
 #include "kernels/fp4_w4a4_matvec_sm120.cuh"
 #include "kernels/fp4_w4a4_mma_sm120.cuh"
 #include "kernels/fp4_w4a4_mma_warpsplit_sm120.cuh"
@@ -4076,6 +4084,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("scratch_A_bf16"), py::arg("scratch_B_bf16"),
         py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
     // Phase 3.2 — causal_conv1d for Qwen3.6 linear-attention. SiLU
     // fused into the epilogue. Two variants for prefill / decode.
     m.def("causal_conv1d_qwen36_bf16",
@@ -4173,6 +4182,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("q16"), py::arg("k16"), py::arg("v48"), py::arg("state"),
         py::arg("B"), py::arg("S"), py::arg("conv_dim"), py::arg("k"),
         py::arg("apply_silu") = true, py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_QWEN36_KERNELS (causal_conv1d_qwen36)
 
     // Phase 4.4 — stream-invariant bf16 matvec for Qwen3.6 (replaces F.linear
     // / cuBLASLt for the small in_proj_a/b and the lm_head bf16 GEMM whose
@@ -4211,6 +4221,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("x"), py::arg("W"), py::arg("out"),
         py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
     m.def("bf16_matmul_qwen36_bf16",
         [](uintptr_t x, uintptr_t W, uintptr_t out,
            int M, int N, int K, uintptr_t stream) {
@@ -4286,6 +4297,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         },
         py::arg("x"), py::arg("W_ab"), py::arg("out_ab"),
         py::arg("M"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_QWEN36_KERNELS (bf16_matmul_qwen36 legacy + thor + ab96)
 
     // Neutral name for the model-neutral bf16 embedding lookup (#112). The
     // legacy qwen36_embedding_lookup_bf16 below is a thin wrapper over this
@@ -4303,6 +4315,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("token_ids"), py::arg("embed"), py::arg("out"),
         py::arg("rows"), py::arg("hidden"), py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
     m.def("qwen36_embedding_lookup_bf16",
         [](uintptr_t token_ids, uintptr_t embed, uintptr_t out,
            int rows, int hidden, uintptr_t stream) {
@@ -4395,6 +4408,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("accept_n"), py::arg("partial_vals"),
         py::arg("partial_idx"), py::arg("rows"), py::arg("vocab"),
         py::arg("spec_k"), py::arg("parts"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_QWEN36_KERNELS (qwen36_misc)
 
     // Phase 4.3 — SiLU-gate elementwise multiply for Qwen3.6 SwiGLU MLP.
     // out[i] = silu(gate[i]) * up[i], bf16 in/out, fp32 internal.
@@ -4424,6 +4438,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("n"), py::arg("stream") = 0);
 
     // Fused RMSNorm + weight + silu(gate) for Qwen3.6 linear-attn output.
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
     m.def("rms_norm_gated_silu_qwen36_bf16",
         [](uintptr_t x, uintptr_t gate, uintptr_t weight, uintptr_t out,
            int M, int dim, float eps, uintptr_t stream) {
@@ -4573,6 +4588,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         },
         py::arg("q_proj"), py::arg("q_pre"), py::arg("gate"),
         py::arg("S"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_QWEN36_KERNELS (gated_deltanet_qwen36 part 1)
 
 #ifdef FLASHRT_HAVE_QWEN35MOE
     m.def("qwen35moe_lin_split_qkv_broadcast_bf16",
@@ -4775,6 +4791,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("stream") = 0);
 #endif  // FLASHRT_HAVE_QWEN35MOE
 
+#ifdef FLASHRT_HAVE_QWEN36_KERNELS
     m.def("qwen36_gdn_gating_bf16",
         [](uintptr_t a, uintptr_t b,
            uintptr_t neg_exp_A_log, uintptr_t dt_bias,
@@ -5513,6 +5530,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
         py::arg("q16_l2"), py::arg("k16_l2"), py::arg("v_new"),
         py::arg("h0"), py::arg("g_cumsum"), py::arg("out"),
         py::arg("S"), py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_QWEN36_KERNELS (gated_deltanet + linear_attention WY)
 
 #ifdef ENABLE_CUTLASS_SM120_BLOCK_FP8
     // Path B: native CUTLASS block-128 FP8 GEMM on SM120a — no

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -126,6 +126,46 @@ cmake -B build -S . -DFA2_ARCH_NATIVE_ONLY=ON
 cmake --build build -j$(nproc)
 ```
 
+### 6.2 Slim VLA build (optional)
+
+The default build keeps FlashRT's broad compatibility surface. It compiles
+shared kernels plus several model- or architecture-specific translation units
+so existing model paths keep their historical bindings.
+
+For deployment builds that only need the current VLA-oriented surface, you can
+opt into a smaller compile surface:
+
+```bash
+cmake -B build -S . -DGPU_ARCH=<arch> -DFLASHRT_SLIM_BUILD=ON
+cmake --build build -j$(nproc) --target flash_rt_kernels
+```
+
+`FLASHRT_SLIM_BUILD` is OFF by default and only changes what is compiled into
+`flash_rt_kernels`. It does not change kernel math, launch parameters, dtype
+selection, graph capture, runtime routing, or fallback policy.
+
+In slim mode, the build drops kernel groups that the current VLA deployment
+surface does not need:
+
+- Motus VAE FP8 quantize kernels.
+- Qwen3.6 / linear-attention kernels and their legacy Qwen3.6 binding names.
+- SM120/NVFP4-named helper translation units on non-NVFP4 builds.
+
+Neutral shared helpers stay compiled in both modes, including
+`bf16_matmul_bf16` and `embedding_lookup_bf16`. Architecture-required kernels
+also stay compiled when their architecture macro is enabled; for example,
+SM120/NVFP4 builds retain NVFP4-required sources even with slim mode enabled.
+
+Do not use `FLASHRT_SLIM_BUILD=ON` for compatibility builds or for model paths
+that require the gated bindings, such as Qwen3.6 / Nex-N2, Motus FP8/VAE, or
+non-VLA NVFP4 conversion flows. Those paths should use the default build until
+they have their own documented build profile.
+
+This option is a first step toward explicit build profiles. It is not yet a
+general `vla` / `llm` / `vlm` / `tts` / `video` profile system; it is a
+conservative opt-in compile-time reduction with tests covering the exported
+binding surface.
+
 ## 7. Verify
 
 ```bash

--- a/scripts/build_inventory.py
+++ b/scripts/build_inventory.py
@@ -13,6 +13,16 @@ the target compiles directly. This is generator-agnostic (Makefiles or Ninja)
 and reflects the *configured* options (e.g. GPU_ARCH, FLASHRT_* gates), which
 is exactly the surface we want to shrink.
 
+A pybind module's *direct* sources are not its whole compile surface: object
+libraries (``add_library(... OBJECT ...)``) are compiled separately and linked
+in via ``$<TARGET_OBJECTS:...>``. Those TUs have their own DependInfo.cmake but
+are invisible in the consuming module's. This tool therefore reports both the
+direct-source count (``count``, where the slim-build source gates live) and the
+object-library TUs (``object_tu_count``), and attributes each object library to
+the module that links it when the linker manifest (``link.txt`` for Makefiles,
+``build.ninja`` for Ninja) is available. ``total_tu_count = count +
+object_tu_count`` is the honest full compile surface for the target.
+
 Usage:
     python scripts/build_inventory.py                 # default build dir: ./build
     python scripts/build_inventory.py --build out      # custom build dir
@@ -113,6 +123,55 @@ def target_sources(build_dir: Path, target: str) -> list[str] | None:
     return sorted(set(_SRC_RE.findall(text)))
 
 
+_OBJ_DIR_RE = re.compile(r"([A-Za-z0-9_]+_obj)\.dir")
+
+
+def object_libraries(build_dir: Path) -> dict[str, list[str]]:
+    """Map every configured object library (``*_obj``) to its csrc TUs.
+
+    Object libraries are compiled separately and linked into pybind modules via
+    ``$<TARGET_OBJECTS:...>``; their TUs never appear in a consuming module's
+    DependInfo.cmake. We read each ``<name>_obj.dir/DependInfo.cmake`` directly,
+    so this is generator-agnostic like ``target_sources``.
+    """
+    cmf = build_dir / "CMakeFiles"
+    libs: dict[str, list[str]] = {}
+    if not cmf.is_dir():
+        return libs
+    for d in sorted(cmf.glob("*_obj.dir")):
+        dep = d / "DependInfo.cmake"
+        if not dep.is_file():
+            continue
+        name = d.name[: -len(".dir")]
+        text = dep.read_text(encoding="utf-8", errors="replace")
+        libs[name] = sorted(set(_SRC_RE.findall(text)))
+    return libs
+
+
+def linked_object_libs(build_dir: Path, target: str) -> set[str] | None:
+    """Object libraries linked into ``target``, read from the linker manifest.
+
+    Makefiles write ``CMakeFiles/<target>.dir/link.txt``; Ninja writes one
+    ``build.ninja``. Both name the ``<obj>.dir/...`` object files on the link
+    line. Returns None when no manifest is found (attribution unavailable), so
+    callers can still report object-lib TUs globally without false attribution.
+    """
+    link_txt = build_dir / "CMakeFiles" / f"{target}.dir" / "link.txt"
+    if link_txt.is_file():
+        return set(_OBJ_DIR_RE.findall(link_txt.read_text(errors="replace")))
+    ninja = build_dir / "build.ninja"
+    if ninja.is_file():
+        # Find the build statement that produces this target's .so and read the
+        # object files listed as its inputs.
+        text = ninja.read_text(errors="replace")
+        found: set[str] = set()
+        for line in text.splitlines():
+            if line.startswith("build ") and target in line and ".so" in line:
+                found |= set(_OBJ_DIR_RE.findall(line))
+        return found or None
+    return None
+
+
 def categorize(sources: list[str]) -> dict[str, list[str]]:
     """Bucket a target's sources by the AGENTS.md layout groups."""
     known = {src: cat for cat, srcs in CATEGORIES.items() for src in srcs}
@@ -125,6 +184,8 @@ def categorize(sources: list[str]) -> dict[str, list[str]]:
 
 def collect(build_dir: Path) -> dict[str, object]:
     report: dict[str, object] = {"build_dir": str(build_dir), "targets": {}}
+    obj_libs = object_libraries(build_dir)
+    report["object_libraries"] = {n: len(v) for n, v in obj_libs.items()}
     for target in TARGETS:
         srcs = target_sources(build_dir, target)
         if srcs is None:
@@ -136,6 +197,14 @@ def collect(build_dir: Path) -> dict[str, object]:
             entry["categories"] = {c: len(v) for c, v in cats.items()}
             entry["category_sources"] = cats
         entry["sources"] = srcs
+        # Attribute object-library TUs to this target via the linker manifest.
+        linked = linked_object_libs(build_dir, target)
+        if linked is not None:
+            attributed = {n: len(obj_libs[n]) for n in sorted(linked) if n in obj_libs}
+            entry["object_libraries"] = attributed
+            obj_tu = sum(attributed.values())
+            entry["object_tu_count"] = obj_tu
+            entry["total_tu_count"] = len(srcs) + obj_tu
         report["targets"][target] = entry
     return report
 
@@ -154,6 +223,17 @@ def print_report(report: dict[str, object]) -> None:
         if cats:
             for cat, n in cats.items():
                 print(f"    {cat:<28} {n}")
+        objs = entry.get("object_libraries")
+        if objs:
+            print(f"    + object libraries ({entry['object_tu_count']} TUs):")
+            for name, n in objs.items():
+                print(f"        {name:<32} {n}")
+            print(f"    = {entry['total_tu_count']} total TUs (direct + object)")
+    obj_all = report.get("object_libraries")
+    if obj_all:
+        print(f"\nconfigured object libraries ({sum(obj_all.values())} TUs total):")
+        for name, n in obj_all.items():
+            print(f"    {name:<36} {n}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/build_inventory.py
+++ b/scripts/build_inventory.py
@@ -133,6 +133,10 @@ def object_libraries(build_dir: Path) -> dict[str, list[str]]:
     ``$<TARGET_OBJECTS:...>``; their TUs never appear in a consuming module's
     DependInfo.cmake. We read each ``<name>_obj.dir/DependInfo.cmake`` directly,
     so this is generator-agnostic like ``target_sources``.
+
+    Discovery relies on the repo convention that every CMake object library is
+    named ``<something>_obj`` (verified against CMakeLists.txt). An object
+    library that breaks this convention would be missed here.
     """
     cmf = build_dir / "CMakeFiles"
     libs: dict[str, list[str]] = {}
@@ -155,6 +159,8 @@ def linked_object_libs(build_dir: Path, target: str) -> set[str] | None:
     ``build.ninja``. Both name the ``<obj>.dir/...`` object files on the link
     line. Returns None when no manifest is found (attribution unavailable), so
     callers can still report object-lib TUs globally without false attribution.
+    An empty set means the manifest was found but the target links no object
+    library (distinct from None = no manifest).
     """
     link_txt = build_dir / "CMakeFiles" / f"{target}.dir" / "link.txt"
     if link_txt.is_file():
@@ -162,13 +168,19 @@ def linked_object_libs(build_dir: Path, target: str) -> set[str] | None:
     ninja = build_dir / "build.ninja"
     if ninja.is_file():
         # Find the build statement that produces this target's .so and read the
-        # object files listed as its inputs.
+        # object files listed as its inputs. Match the module filename
+        # (``<target>.cpython-...so``) rather than a bare substring so a longer
+        # target name that contains this one cannot be mis-attributed.
         text = ninja.read_text(errors="replace")
         found: set[str] = set()
+        seen_build_edge = False
         for line in text.splitlines():
-            if line.startswith("build ") and target in line and ".so" in line:
+            if line.startswith("build ") and f"{target}.cpython" in line and ".so" in line:
+                seen_build_edge = True
                 found |= set(_OBJ_DIR_RE.findall(line))
-        return found or None
+        # Empty set when the build edge was found but lists no object libs;
+        # None only when no build edge for this target exists at all.
+        return found if seen_build_edge else None
     return None
 
 

--- a/scripts/build_inventory.py
+++ b/scripts/build_inventory.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Report the CUDA/C++ translation units compiled into each FlashRT pybind
+module, read from a configured CMake build directory.
+
+This is a build-structure measurement tool for the VLA-deployment kernel-build
+split. It does NOT change anything at runtime; it only reports the current
+compile surface so source-gating work (slim builds) can be measured and
+reviewed unit by unit.
+
+Source of truth: ``<build>/CMakeFiles/<target>.dir/DependInfo.cmake``. CMake
+writes one of these per target after ``cmake`` configure, listing every source
+the target compiles directly. This is generator-agnostic (Makefiles or Ninja)
+and reflects the *configured* options (e.g. GPU_ARCH, FLASHRT_* gates), which
+is exactly the surface we want to shrink.
+
+Usage:
+    python scripts/build_inventory.py                 # default build dir: ./build
+    python scripts/build_inventory.py --build out      # custom build dir
+    python scripts/build_inventory.py --json           # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# pybind modules whose compile surface this cleanup cares about.
+TARGETS = (
+    "flash_rt_kernels",
+    "flash_rt_qwen3_vl_kernels",
+    "flash_rt_fa2",
+)
+
+# Categorization of the flash_rt_kernels flat source list, mirroring the
+# "Current Build Layout" groups in AGENTS.md. Used only to make the report
+# readable; gating decisions still live in CMakeLists.txt.
+CATEGORIES: dict[str, tuple[str, ...]] = {
+    "generic_shared": (
+        "csrc/gemm/gemm_runner.cu",
+        "csrc/kernels/norm.cu",
+        "csrc/kernels/activation.cu",
+        "csrc/kernels/rope.cu",
+        "csrc/kernels/elementwise.cu",
+        "csrc/kernels/fusion.cu",
+        "csrc/kernels/patch_embed.cu",
+        "csrc/kernels/softmax.cu",
+        "csrc/kernels/attention_cublas.cu",
+        "csrc/kernels/attention_mha.cu",
+        "csrc/kernels/attention_mha_causal.cu",
+        "csrc/kernels/decoder_fused.cu",
+        "csrc/kernels/embedding_lookup_bf16.cu",
+        "csrc/kernels/bf16_matmul_bf16.cu",
+        "csrc/attention/fmha_dispatch.cu",
+    ),
+    "qwen36_linear_attention": (
+        "csrc/kernels/causal_conv1d_qwen36.cu",
+        "csrc/kernels/linear_attention/gated_delta_wy_bf16.cu",
+        "csrc/kernels/linear_attention/gated_delta_wy_bf16_mma_fla.cu",
+        "csrc/kernels/linear_attention/gated_delta_wy_output_o_mma_fla.cu",
+        "csrc/kernels/linear_attention/gated_delta_wy_recompute_wu_mma_fla.cu",
+        "csrc/kernels/gated_deltanet_qwen36.cu",
+        "csrc/kernels/rms_norm_gated_silu_qwen36.cu",
+        "csrc/kernels/silu_mul_qwen36.cu",
+        "csrc/kernels/qwen36_misc.cu",
+        "csrc/kernels/bf16_matvec_qwen36.cu",
+        "csrc/kernels/bf16_matmul_qwen36.cu",
+        "csrc/kernels/bf16_matmul_qwen36_thor.cu",
+    ),
+    "sm120_nvfp4_named": (
+        "csrc/quantize/fp8_block128_to_nvfp4_swizzled.cu",
+        "csrc/quantize/bf16_weight_to_nvfp4_swizzled.cu",
+        "csrc/kernels/silu_mul_to_nvfp4_swizzled.cu",
+        "csrc/kernels/fp4_w4a4_matvec_sm120.cu",
+        "csrc/kernels/fp4_w4a4_mma_sm120.cu",
+        "csrc/kernels/fp4_w4a4_mma_warpsplit_sm120.cu",
+        "csrc/kernels/fp4_w4a4_mma_warpsplit_mrows_sm120.cu",
+    ),
+    "motus_video_fp8_history": (
+        "csrc/quantize/ada_layer_norm_fp8.cu",
+        "csrc/quantize/awq_quant_fp8_static_bf16.cu",
+        "csrc/quantize/bf16_ndhwc_to_ncdhw_transpose.cu",
+        "csrc/quantize/bf16_quant_fp8_ncdhw_to_ndhwc.cu",
+        "csrc/quantize/bf16_rms_silu_ncdhw.cu",
+        "csrc/quantize/bf16_rms_silu_quant_fp8_ncdhw_to_ndhwc_v4.cu",
+        "csrc/quantize/bias_gelu_quantize_fp8.cu",
+    ),
+    "dit_video": (
+        "csrc/kernels/dit_bf16.cu",
+        "csrc/kernels/attention_dit_bf16.cu",
+    ),
+    "qwen3_family": (
+        "csrc/kernels/rope_qwen3.cu",
+        "csrc/kernels/qwen3_qkv_post_proc.cu",
+    ),
+}
+
+_SRC_RE = re.compile(r"csrc/[A-Za-z0-9_/]+\.(?:cu|cpp)")
+
+
+def target_sources(build_dir: Path, target: str) -> list[str] | None:
+    """Return the sorted, de-duplicated csrc TUs a target compiles directly.
+
+    Returns None if the target's DependInfo.cmake is absent (target not
+    configured in this build dir).
+    """
+    dep = build_dir / "CMakeFiles" / f"{target}.dir" / "DependInfo.cmake"
+    if not dep.is_file():
+        return None
+    text = dep.read_text(encoding="utf-8", errors="replace")
+    return sorted(set(_SRC_RE.findall(text)))
+
+
+def categorize(sources: list[str]) -> dict[str, list[str]]:
+    """Bucket a target's sources by the AGENTS.md layout groups."""
+    known = {src: cat for cat, srcs in CATEGORIES.items() for src in srcs}
+    buckets: dict[str, list[str]] = {cat: [] for cat in CATEGORIES}
+    buckets["other"] = []
+    for src in sources:
+        buckets.setdefault(known.get(src, "other"), []).append(src)
+    return {cat: srcs for cat, srcs in buckets.items() if srcs}
+
+
+def collect(build_dir: Path) -> dict[str, object]:
+    report: dict[str, object] = {"build_dir": str(build_dir), "targets": {}}
+    for target in TARGETS:
+        srcs = target_sources(build_dir, target)
+        if srcs is None:
+            report["targets"][target] = {"configured": False}
+            continue
+        entry: dict[str, object] = {"configured": True, "count": len(srcs)}
+        if target == "flash_rt_kernels":
+            cats = categorize(srcs)
+            entry["categories"] = {c: len(v) for c, v in cats.items()}
+            entry["category_sources"] = cats
+        entry["sources"] = srcs
+        report["targets"][target] = entry
+    return report
+
+
+def print_report(report: dict[str, object]) -> None:
+    print(f"FlashRT build inventory  (build dir: {report['build_dir']})")
+    print("=" * 64)
+    targets: dict[str, dict] = report["targets"]  # type: ignore[assignment]
+    for target in TARGETS:
+        entry = targets[target]
+        if not entry.get("configured"):
+            print(f"\n{target}: NOT configured in this build dir")
+            continue
+        print(f"\n{target}: {entry['count']} directly-compiled TUs")
+        cats = entry.get("categories")
+        if cats:
+            for cat, n in cats.items():
+                print(f"    {cat:<28} {n}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--build", default="build", type=Path,
+                    help="configured CMake build directory (default: ./build)")
+    ap.add_argument("--json", action="store_true",
+                    help="emit machine-readable JSON instead of a table")
+    args = ap.parse_args(argv)
+
+    if not args.build.is_dir():
+        print(f"error: build dir '{args.build}' does not exist; run cmake "
+              f"configure first", file=sys.stderr)
+        return 2
+
+    report = collect(args.build)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_inventory.py
+++ b/tests/test_build_inventory.py
@@ -34,9 +34,9 @@ BUILD_DIR = Path(os.environ.get("FLASHRT_BUILD_DIR", REPO_ROOT / "build"))
 #   slim SM89   (FLASHRT_SLIM_BUILD=ON):     33 direct TUs (-22):
 #       -5 Motus VAE FP8 (Unit 1), -10 Qwen3.6/linear-attn (Unit 2),
 #       -7 SM120/NVFP4-named (Unit 3).
-# The slim breakdown is SM89-specific; a slim build on an arch whose macros keep
-# Group A/B (e.g. GPU_ARCH=120) would differ, so the slim asserts are limited to
-# the SM89 case below.
+# The direct-source breakdowns below are SM89-specific; other arches add/remove
+# arch-owned sources (for example SM120 adds nvfp4_sf_reshape_sm120.cu), so the
+# direct-count/category asserts are limited to SM89.
 COMPAT_KERNELS_TU = 55
 SLIM_SM89_KERNELS_TU = 33
 
@@ -139,8 +139,8 @@ def test_kernels_baseline_tu_count():
     a unit added/removed a TU from that mode's build; if intended, update the
     matching constant in the same commit.
     """
-    if _is_slim() and not _is_sm89():
-        pytest.skip("slim TU baseline is recorded for SM89 only")
+    if not _is_sm89():
+        pytest.skip("direct TU baseline is recorded for SM89 only")
     entry = _kernels_entry()
     expected = _expected_tu()
     assert entry["count"] == expected, (
@@ -152,8 +152,8 @@ def test_kernels_baseline_tu_count():
 
 def test_kernels_category_breakdown():
     """Per-group counts match AGENTS.md's Current Build Layout (mode-aware)."""
-    if _is_slim() and not _is_sm89():
-        pytest.skip("slim category baseline is recorded for SM89 only")
+    if not _is_sm89():
+        pytest.skip("category baseline is recorded for SM89 only")
     entry = _kernels_entry()
     assert entry["categories"] == _expected_categories()
 

--- a/tests/test_build_inventory.py
+++ b/tests/test_build_inventory.py
@@ -1,0 +1,107 @@
+"""Build-inventory baseline for the VLA-deployment kernel-build split.
+
+This test records the *current* compile surface of the FlashRT pybind modules
+so the source-gating units (slim builds) can be reviewed against a known
+baseline. It is a build-structure guardrail, not a CUDA behavior test: it reads
+the configured CMake build dir and asserts the directly-compiled translation
+unit counts per target.
+
+It skips cleanly when there is no configured build dir (e.g. CI without a CUDA
+toolchain), so it never blocks unrelated work.
+
+As each gating unit lands, the expected baseline below is updated in the same
+commit so the test keeps describing the real configured surface.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_DIR = Path(os.environ.get("FLASHRT_BUILD_DIR", REPO_ROOT / "build"))
+
+# Baseline captured on the local SM89 configure (GPU_ARCH=89,
+# FLASHRT_BUILD_QWEN3_VL=ON, FLASHRT_ENABLE_MOTUS=ON, QWEN35MOE/MELBAND OFF)
+# before any slim-build gating. Units 1-3 reduce flash_rt_kernels; when a unit
+# lands behind FLASHRT_SLIM_BUILD=OFF (compat default), the default-configure
+# count here is unchanged and the slim count is asserted separately.
+BASELINE_KERNELS_TU = 55
+
+# Category breakdown of flash_rt_kernels (mirrors AGENTS.md "Current Build
+# Layout"). These are the groups Units 1-3 gate.
+BASELINE_KERNELS_CATEGORIES = {
+    "generic_shared": 15,
+    "qwen36_linear_attention": 12,
+    "sm120_nvfp4_named": 7,
+    "motus_video_fp8_history": 7,
+    "dit_video": 2,
+    "qwen3_family": 2,
+    "other": 10,
+}
+
+
+def _load_inventory():
+    path = REPO_ROOT / "scripts" / "build_inventory.py"
+    spec = importlib.util.spec_from_file_location("build_inventory", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+inv = _load_inventory()
+
+
+def _require_build_dir():
+    if not BUILD_DIR.is_dir():
+        pytest.skip(f"no configured build dir at {BUILD_DIR}")
+
+
+def _kernels_entry():
+    _require_build_dir()
+    report = inv.collect(BUILD_DIR)
+    entry = report["targets"]["flash_rt_kernels"]
+    if not entry.get("configured"):
+        pytest.skip("flash_rt_kernels not configured in this build dir")
+    return entry
+
+
+def test_inventory_script_imports_and_collects():
+    """The inventory tooling itself must be importable and runnable."""
+    _require_build_dir()
+    report = inv.collect(BUILD_DIR)
+    assert "targets" in report
+    assert set(inv.TARGETS) <= set(report["targets"])
+
+
+def test_kernels_baseline_tu_count():
+    """flash_rt_kernels compile surface matches the recorded baseline.
+
+    A change here means a unit added/removed a TU from the default build. If
+    that is intended, update BASELINE_KERNELS_TU in the same commit.
+    """
+    entry = _kernels_entry()
+    assert entry["count"] == BASELINE_KERNELS_TU, (
+        f"flash_rt_kernels now compiles {entry['count']} TUs, baseline is "
+        f"{BASELINE_KERNELS_TU}. If this is an intended gating change, update "
+        f"the baseline in the same commit."
+    )
+
+
+def test_kernels_category_breakdown():
+    """Per-group counts match AGENTS.md's Current Build Layout."""
+    entry = _kernels_entry()
+    assert entry["categories"] == BASELINE_KERNELS_CATEGORIES
+
+
+def test_neutral_helpers_in_generic_core():
+    """The neutral helpers from #112 must stay in the generic core, never
+    gated behind a model-specific option."""
+    entry = _kernels_entry()
+    generic = set(entry["category_sources"]["generic_shared"])
+    assert "csrc/kernels/bf16_matmul_bf16.cu" in generic
+    assert "csrc/kernels/embedding_lookup_bf16.cu" in generic

--- a/tests/test_build_inventory.py
+++ b/tests/test_build_inventory.py
@@ -25,18 +25,24 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 BUILD_DIR = Path(os.environ.get("FLASHRT_BUILD_DIR", REPO_ROOT / "build"))
 
 # Baseline captured on the local SM89 configure (GPU_ARCH=89,
-# FLASHRT_BUILD_QWEN3_VL=ON, FLASHRT_ENABLE_MOTUS=ON, QWEN35MOE/MELBAND OFF)
-# before any slim-build gating. Units 1-3 gate model/arch-specific TUs behind
-# FLASHRT_SLIM_BUILD; with the compat default (OFF) the default-configure count
-# here is unchanged at 55. A slim SM89 build (FLASHRT_SLIM_BUILD=ON) drops 22 TUs
-# to 33: -5 Motus VAE FP8 (Unit 1), -10 Qwen3.6/linear-attn (Unit 2), -7
-# SM120/NVFP4-named (Unit 3). The slim count is build-dir specific and not
-# asserted here (CI configures the default build only).
-BASELINE_KERNELS_TU = 55
+# FLASHRT_BUILD_QWEN3_VL=ON, FLASHRT_ENABLE_MOTUS=ON, QWEN35MOE/MELBAND OFF).
+# Units 1-3 gate model/arch-specific TUs behind FLASHRT_SLIM_BUILD. This test is
+# build-mode aware: it reads FLASHRT_SLIM_BUILD from the configured build dir's
+# CMakeCache.txt and asserts the matching surface.
+#
+#   compat default (FLASHRT_SLIM_BUILD=OFF): 55 direct TUs, unchanged.
+#   slim SM89   (FLASHRT_SLIM_BUILD=ON):     33 direct TUs (-22):
+#       -5 Motus VAE FP8 (Unit 1), -10 Qwen3.6/linear-attn (Unit 2),
+#       -7 SM120/NVFP4-named (Unit 3).
+# The slim breakdown is SM89-specific; a slim build on an arch whose macros keep
+# Group A/B (e.g. GPU_ARCH=120) would differ, so the slim asserts are limited to
+# the SM89 case below.
+COMPAT_KERNELS_TU = 55
+SLIM_SM89_KERNELS_TU = 33
 
-# Category breakdown of flash_rt_kernels (mirrors AGENTS.md "Current Build
-# Layout"). These are the groups Units 1-3 gate.
-BASELINE_KERNELS_CATEGORIES = {
+# Per-group breakdown of flash_rt_kernels (mirrors AGENTS.md "Current Build
+# Layout"). categorize() drops empty groups, so slim omits sm120_nvfp4_named.
+COMPAT_KERNELS_CATEGORIES = {
     "generic_shared": 15,
     "qwen36_linear_attention": 12,
     "sm120_nvfp4_named": 7,
@@ -45,6 +51,51 @@ BASELINE_KERNELS_CATEGORIES = {
     "qwen3_family": 2,
     "other": 10,
 }
+SLIM_SM89_KERNELS_CATEGORIES = {
+    "generic_shared": 15,
+    "qwen36_linear_attention": 2,
+    "motus_video_fp8_history": 2,
+    "dit_video": 2,
+    "qwen3_family": 2,
+    "other": 10,
+}
+
+
+def _cache_bool(name: str) -> bool:
+    """Read a BOOL from the configured build dir's CMakeCache.txt."""
+    cache = BUILD_DIR / "CMakeCache.txt"
+    if not cache.is_file():
+        return False
+    for line in cache.read_text(errors="replace").splitlines():
+        if line.startswith(f"{name}:"):
+            return line.rsplit("=", 1)[-1].strip().upper() in ("ON", "TRUE", "1", "YES")
+    return False
+
+
+def _cache_value(name: str) -> str | None:
+    cache = BUILD_DIR / "CMakeCache.txt"
+    if not cache.is_file():
+        return None
+    for line in cache.read_text(errors="replace").splitlines():
+        if line.startswith(f"{name}:"):
+            return line.rsplit("=", 1)[-1].strip()
+    return None
+
+
+def _is_slim() -> bool:
+    return _cache_bool("FLASHRT_SLIM_BUILD")
+
+
+def _is_sm89() -> bool:
+    return (_cache_value("GPU_ARCH") or "").strip() == "89"
+
+
+def _expected_tu() -> int:
+    return SLIM_SM89_KERNELS_TU if _is_slim() else COMPAT_KERNELS_TU
+
+
+def _expected_categories() -> dict:
+    return SLIM_SM89_KERNELS_CATEGORIES if _is_slim() else COMPAT_KERNELS_CATEGORIES
 
 
 def _load_inventory():
@@ -82,23 +133,29 @@ def test_inventory_script_imports_and_collects():
 
 
 def test_kernels_baseline_tu_count():
-    """flash_rt_kernels compile surface matches the recorded baseline.
+    """flash_rt_kernels direct-source surface matches the recorded baseline.
 
-    A change here means a unit added/removed a TU from the default build. If
-    that is intended, update BASELINE_KERNELS_TU in the same commit.
+    Mode-aware: compat default expects 55, slim SM89 expects 33. A change means
+    a unit added/removed a TU from that mode's build; if intended, update the
+    matching constant in the same commit.
     """
+    if _is_slim() and not _is_sm89():
+        pytest.skip("slim TU baseline is recorded for SM89 only")
     entry = _kernels_entry()
-    assert entry["count"] == BASELINE_KERNELS_TU, (
-        f"flash_rt_kernels now compiles {entry['count']} TUs, baseline is "
-        f"{BASELINE_KERNELS_TU}. If this is an intended gating change, update "
-        f"the baseline in the same commit."
+    expected = _expected_tu()
+    assert entry["count"] == expected, (
+        f"flash_rt_kernels now compiles {entry['count']} direct TUs, "
+        f"{'slim' if _is_slim() else 'compat'} baseline is {expected}. If this "
+        f"is an intended gating change, update the baseline in the same commit."
     )
 
 
 def test_kernels_category_breakdown():
-    """Per-group counts match AGENTS.md's Current Build Layout."""
+    """Per-group counts match AGENTS.md's Current Build Layout (mode-aware)."""
+    if _is_slim() and not _is_sm89():
+        pytest.skip("slim category baseline is recorded for SM89 only")
     entry = _kernels_entry()
-    assert entry["categories"] == BASELINE_KERNELS_CATEGORIES
+    assert entry["categories"] == _expected_categories()
 
 
 def test_neutral_helpers_in_generic_core():
@@ -108,3 +165,24 @@ def test_neutral_helpers_in_generic_core():
     generic = set(entry["category_sources"]["generic_shared"])
     assert "csrc/kernels/bf16_matmul_bf16.cu" in generic
     assert "csrc/kernels/embedding_lookup_bf16.cu" in generic
+
+
+def test_object_libraries_counted_in_total():
+    """Object-library TUs linked via $<TARGET_OBJECTS:...> are not in a
+    module's direct sources; the inventory must account for them separately so
+    the reported compile surface is not understated.
+
+    flash_rt_fa2 compiles 1 direct TU but links the fa2_vendor_obj object
+    library; its total must exceed its direct count when attribution is
+    available (Makefile link.txt / Ninja build.ninja present).
+    """
+    _require_build_dir()
+    report = inv.collect(BUILD_DIR)
+    fa2 = report["targets"]["flash_rt_fa2"]
+    if not fa2.get("configured"):
+        pytest.skip("flash_rt_fa2 not configured in this build dir")
+    if "object_tu_count" not in fa2:
+        pytest.skip("no linker manifest in this build dir; attribution skipped")
+    assert fa2["object_tu_count"] >= 1
+    assert fa2["total_tu_count"] == fa2["count"] + fa2["object_tu_count"]
+    assert fa2["total_tu_count"] > fa2["count"]

--- a/tests/test_build_inventory.py
+++ b/tests/test_build_inventory.py
@@ -26,9 +26,12 @@ BUILD_DIR = Path(os.environ.get("FLASHRT_BUILD_DIR", REPO_ROOT / "build"))
 
 # Baseline captured on the local SM89 configure (GPU_ARCH=89,
 # FLASHRT_BUILD_QWEN3_VL=ON, FLASHRT_ENABLE_MOTUS=ON, QWEN35MOE/MELBAND OFF)
-# before any slim-build gating. Units 1-3 reduce flash_rt_kernels; when a unit
-# lands behind FLASHRT_SLIM_BUILD=OFF (compat default), the default-configure
-# count here is unchanged and the slim count is asserted separately.
+# before any slim-build gating. Units 1-3 gate model/arch-specific TUs behind
+# FLASHRT_SLIM_BUILD; with the compat default (OFF) the default-configure count
+# here is unchanged at 55. A slim SM89 build (FLASHRT_SLIM_BUILD=ON) drops 22 TUs
+# to 33: -5 Motus VAE FP8 (Unit 1), -10 Qwen3.6/linear-attn (Unit 2), -7
+# SM120/NVFP4-named (Unit 3). The slim count is build-dir specific and not
+# asserted here (CI configures the default build only).
 BASELINE_KERNELS_TU = 55
 
 # Category breakdown of flash_rt_kernels (mirrors AGENTS.md "Current Build

--- a/tests/test_generic_kernel_bindings.py
+++ b/tests/test_generic_kernel_bindings.py
@@ -1,18 +1,25 @@
-"""Binding-name regression net for the generic-kernel-helper cleanup (#112).
+"""Binding-name regression net for the generic-kernel-helper cleanup (#112)
+and the slim-build source gating (Units 1-3).
 
 This guards the ownership cleanup that moves model-neutral helpers out of
-Qwen3.6-named files into neutral files. The contract for that refactor is:
+Qwen3.6-named files into neutral files, and stays correct under both build
+modes. The contract is:
 
-- Legacy binding names MUST keep existing (we do not remove old Python
-  bindings in the cleanup PR), so existing call sites and external users do
-  not break.
-- As each neutral helper is introduced, its neutral binding name MUST also
-  exist on the same module, sharing one implementation with the legacy name.
+- Neutral binding names (``bf16_matmul_bf16``, ``embedding_lookup_bf16``) MUST
+  exist in EVERY build mode: they live in always-compiled neutral TUs, so the
+  slim gate never removes them. Existing call sites and external users rely on
+  them.
+- Legacy binding names (``bf16_matmul_qwen36_bf16``,
+  ``qwen36_embedding_lookup_bf16``) live inside Qwen3.6 TUs gated behind
+  ``FLASHRT_HAVE_QWEN36_KERNELS``. In the compat default build they MUST exist;
+  in a slim build (FLASHRT_SLIM_BUILD=ON) they are intentionally gated out, so
+  the test must NOT require them there.
 
-Unit 0 only asserts the legacy baseline (neutral names do not exist yet). The
-neutral-name assertions below are activated in the unit that introduces each
-neutral binding (Unit 1 for matmul, Unit 2 for embedding) by flipping the
-corresponding ``NEUTRAL_*_AVAILABLE`` switch.
+Because these assertions run against the imported ``.so`` (not a build dir), we
+detect the build mode from the module itself: a sentinel Qwen3.6 symbol that is
+gated under the same ``FLASHRT_HAVE_QWEN36_KERNELS`` macro as the legacy
+bindings. If the sentinel is absent, this is a slim build and the legacy names
+are expected to be absent too.
 
 These are CPU/import-friendly: importing the compiled ``.so`` does not require
 a CUDA device or any model checkpoint, only that the extension built.
@@ -24,11 +31,10 @@ import importlib
 
 import pytest
 
-# Cleanup progress switches. Each is flipped to True in the same commit that
-# introduces the corresponding neutral binding, which is also where the
-# matching neutral-name assertion starts being enforced.
-NEUTRAL_MATMUL_AVAILABLE = True  # Unit 1: bf16_matmul_bf16
-NEUTRAL_EMBEDDING_AVAILABLE = True  # Unit 2: embedding_lookup_bf16
+# A binding gated under FLASHRT_HAVE_QWEN36_KERNELS alongside the legacy helper
+# names. Present in the compat build, absent in slim. Used to detect build mode
+# from the compiled module without needing the source build dir.
+QWEN36_SENTINEL = "causal_conv1d_qwen36_bf16"
 
 
 def _import_kernels():
@@ -45,14 +51,33 @@ def _import_vl_kernels():
         pytest.skip(f"flash_rt_qwen3_vl_kernels not importable: {exc}")
 
 
+def _qwen36_kernels_built(m) -> bool:
+    """True if the module was built with the Qwen3.6 kernels (compat build)."""
+    return hasattr(m, QWEN36_SENTINEL)
+
+
 def test_legacy_matmul_bindings_exist():
+    """Compat build: legacy name present. Slim build: gated out by design."""
     m = _import_kernels()
-    assert hasattr(m, "bf16_matmul_qwen36_bf16")
+    if _qwen36_kernels_built(m):
+        assert hasattr(m, "bf16_matmul_qwen36_bf16")
+    else:
+        assert not hasattr(m, "bf16_matmul_qwen36_bf16"), (
+            "slim build still exposes legacy bf16_matmul_qwen36_bf16; the "
+            "Qwen3.6 TU gate did not drop it"
+        )
 
 
 def test_legacy_embedding_binding_exists():
+    """Compat build: legacy name present. Slim build: gated out by design."""
     m = _import_kernels()
-    assert hasattr(m, "qwen36_embedding_lookup_bf16")
+    if _qwen36_kernels_built(m):
+        assert hasattr(m, "qwen36_embedding_lookup_bf16")
+    else:
+        assert not hasattr(m, "qwen36_embedding_lookup_bf16"), (
+            "slim build still exposes legacy qwen36_embedding_lookup_bf16; the "
+            "Qwen3.6 TU gate did not drop it"
+        )
 
 
 def test_legacy_cublaslt_binding_exists_on_vl_module():
@@ -65,19 +90,13 @@ def test_legacy_cublaslt_binding_exists_on_vl_module():
     assert hasattr(m, "bf16_matmul_cublaslt_bf16")
 
 
-@pytest.mark.skipif(
-    not NEUTRAL_MATMUL_AVAILABLE,
-    reason="neutral bf16_matmul_bf16 binding introduced in Unit 1",
-)
 def test_neutral_matmul_binding_exists():
+    """Neutral helper must exist in every build mode (never gated)."""
     m = _import_kernels()
     assert hasattr(m, "bf16_matmul_bf16")
 
 
-@pytest.mark.skipif(
-    not NEUTRAL_EMBEDDING_AVAILABLE,
-    reason="neutral embedding_lookup_bf16 binding introduced in Unit 2",
-)
 def test_neutral_embedding_binding_exists():
+    """Neutral helper must exist in every build mode (never gated)."""
     m = _import_kernels()
     assert hasattr(m, "embedding_lookup_bf16")

--- a/tests/test_generic_kernel_bindings.py
+++ b/tests/test_generic_kernel_bindings.py
@@ -28,12 +28,17 @@ a CUDA device or any model checkpoint, only that the extension built.
 from __future__ import annotations
 
 import importlib
+import os
+from pathlib import Path
 
 import pytest
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_DIR = Path(os.environ.get("FLASHRT_BUILD_DIR", REPO_ROOT / "build"))
+
 # A binding gated under FLASHRT_HAVE_QWEN36_KERNELS alongside the legacy helper
-# names. Present in the compat build, absent in slim. Used to detect build mode
-# from the compiled module without needing the source build dir.
+# names. Present in the compat build, absent in slim. Used only as a consistency
+# check after the build mode is read from CMakeCache.txt.
 QWEN36_SENTINEL = "causal_conv1d_qwen36_bf16"
 
 
@@ -56,28 +61,68 @@ def _qwen36_kernels_built(m) -> bool:
     return hasattr(m, QWEN36_SENTINEL)
 
 
+def _cache_bool(name: str) -> bool:
+    """Read a BOOL from the configured build dir's CMakeCache.txt.
+
+    Do not infer the mode from exported symbols: that can hide compat-build
+    regressions where an entire binding group disappears.
+    """
+    cache = BUILD_DIR / "CMakeCache.txt"
+    if not cache.is_file():
+        pytest.skip(f"no CMakeCache.txt at {cache}; cannot determine build mode")
+    for line in cache.read_text(errors="replace").splitlines():
+        if line.startswith(f"{name}:"):
+            return line.rsplit("=", 1)[-1].strip().upper() in (
+                "ON",
+                "TRUE",
+                "1",
+                "YES",
+            )
+    pytest.skip(f"{name} not found in {cache}; cannot determine build mode")
+
+
+def _is_slim_build() -> bool:
+    return _cache_bool("FLASHRT_SLIM_BUILD")
+
+
 def test_legacy_matmul_bindings_exist():
     """Compat build: legacy name present. Slim build: gated out by design."""
     m = _import_kernels()
-    if _qwen36_kernels_built(m):
-        assert hasattr(m, "bf16_matmul_qwen36_bf16")
-    else:
+    if _is_slim_build():
+        assert not _qwen36_kernels_built(m), (
+            "slim build still exposes Qwen3.6 sentinel binding; the "
+            "FLASHRT_HAVE_QWEN36_KERNELS gate did not drop it"
+        )
         assert not hasattr(m, "bf16_matmul_qwen36_bf16"), (
             "slim build still exposes legacy bf16_matmul_qwen36_bf16; the "
             "Qwen3.6 TU gate did not drop it"
         )
+    else:
+        assert _qwen36_kernels_built(m), (
+            "compat build is missing Qwen3.6 sentinel binding; the "
+            "FLASHRT_HAVE_QWEN36_KERNELS gate may not have been enabled"
+        )
+        assert hasattr(m, "bf16_matmul_qwen36_bf16")
 
 
 def test_legacy_embedding_binding_exists():
     """Compat build: legacy name present. Slim build: gated out by design."""
     m = _import_kernels()
-    if _qwen36_kernels_built(m):
-        assert hasattr(m, "qwen36_embedding_lookup_bf16")
-    else:
+    if _is_slim_build():
+        assert not _qwen36_kernels_built(m), (
+            "slim build still exposes Qwen3.6 sentinel binding; the "
+            "FLASHRT_HAVE_QWEN36_KERNELS gate did not drop it"
+        )
         assert not hasattr(m, "qwen36_embedding_lookup_bf16"), (
             "slim build still exposes legacy qwen36_embedding_lookup_bf16; the "
             "Qwen3.6 TU gate did not drop it"
         )
+    else:
+        assert _qwen36_kernels_built(m), (
+            "compat build is missing Qwen3.6 sentinel binding; the "
+            "FLASHRT_HAVE_QWEN36_KERNELS gate may not have been enabled"
+        )
+        assert hasattr(m, "qwen36_embedding_lookup_bf16")
 
 
 def test_legacy_cublaslt_binding_exists_on_vl_module():


### PR DESCRIPTION
## Summary

Adds an opt-in `FLASHRT_SLIM_BUILD` CMake option (default **OFF**) that drops
model/architecture-specific CUDA translation units the target hardware/model
path does not need, reducing `flash_rt_kernels` compile time for VLA
deployments on weaker build machines.

This is **compile-time surface reduction only**. It does not change kernel math,
launch parameters, thresholds, dtype conversions, dispatch policy, graph-capture
behavior, Python API semantics, or runtime fallback. The default build keeps the
exact broad, compatibility-oriented kernel set it has today; slimming is fully
opt-in.

## How it works

Each gated group is guarded by its own internal `FLASHRT_HAVE_*` compile
definition so the corresponding pybind bindings in `csrc/bindings.cpp` drop in
**lockstep** with their sources — a gated source whose binding stayed compiled
would fail to link. Architecture-keyed groups reuse the existing arch macros
(`ENABLE_NVFP4`, `GPU_ARCH`) so real NVFP4/SM120 builds always retain them, slim
or not.

Gated groups (slim mode):
- **Motus VAE FP8** (5 TUs) — only the cleanly Motus-isolated quantize kernels.
  Shared FP8 helpers used by other models (GROOT AdaLN, MelBand GeLU-FFN) stay
  always-compiled.
- **Qwen3.6 / linear-attention** (10 TUs) — Qwen3.6-family-only kernels. Shared
  helpers reused by Qwen3-dense / Higgs / Cosmos3 stay always-compiled. Neutral
  helpers (`bf16_matmul_bf16`, `embedding_lookup_bf16`) are never gated.
- **SM120 / NVFP4-named** (7 TUs) — reuse `ENABLE_NVFP4` / `GPU_ARCH` so SM120
  and NVFP4 builds keep them in both modes.

## Tooling

- `scripts/build_inventory.py` reports the directly-compiled TUs per pybind
  target from the configured build dir (generator-agnostic, via
  `DependInfo.cmake`), categorizes the `flash_rt_kernels` set, and accounts for
  object-library TUs linked via `$<TARGET_OBJECTS:...>` so the reported compile
  surface is not understated.
- `tests/test_build_inventory.py` and `tests/test_generic_kernel_bindings.py`
  are build-mode aware: they read `FLASHRT_SLIM_BUILD` from `CMakeCache.txt` and
  assert the matching surface and binding contract. Compat asserts legacy +
  neutral bindings present; slim asserts the gated legacy bindings are absent
  while neutral bindings remain.

## Validation

**SM89 (RTX 4090):**
- Default `flash_rt_kernels`: 55 direct (+2 object) TUs.
- Slim `flash_rt_kernels`: 33 direct (+2 object) TUs (−22 direct).
- `flash_rt_qwen3_vl_kernels` (9) and `flash_rt_fa2` (1+20) unchanged.
- Binding tests pass in both modes; legacy Qwen3.6 bindings present in default,
  absent in slim; neutral bindings present in both.

**Thor (compute capability 11.0, `GPU_ARCH=110`):**
- Default `flash_rt_kernels`: 59 direct (+8 object) TUs.
- Slim `flash_rt_kernels`: 37 direct (+8 object) TUs (−22 direct).
- Slim removes exactly the same 22 direct TUs as SM89 and does **not** remove
  architecture-specific object libraries Thor requires.
- Binding checks match the intended contract in both modes.

Both architectures confirm: slim removes exactly the intended 22 direct TUs,
default compatibility builds retain the broad historical bindings, and no
architecture-specific object libraries needed at runtime are dropped.

## Scope notes

- Two mis-named-but-shared files per group (Motus and Qwen3.6) are intentionally
  kept always-compiled in this PR; neutralizing their ownership is deferred to a
  follow-up to avoid moving kernel bodies here.
- Default-ON / smarter hardware-profile defaults are intentionally deferred
  until more hardware/model paths are validated.
