### PR TITLE
feat(minimax-remover): add NVFP4 kernelized video inpainting pipeline

### DIFF
--- a/docs/minimax_remover_usage.md
+++ b/docs/minimax_remover_usage.md
@@ -23,11 +23,11 @@ NVFP4 surface is compiled in automatically (internally gated by
 flag users pass). Then install the runtime extras:
 
 ```bash
-pip install -e ".[minimax-remover]"   # diffusers + einops + sageattention
+pip install -e ".[minimax-remover]"   # diffusers + einops + scipy + sageattention
 ```
 
 Importing `flash_rt.models.minimax_remover` always succeeds — it needs
-**none** of `diffusers` / `einops` / `triton` / `sageattention`. The
+**none** of `diffusers` / `einops` / `scipy` / `triton` / `sageattention`. The
 kernel surface is validated lazily in
 `MiniMaxRemoverPipeline.__init__` via `_load_kernels()`, and the runtime
 deps are resolved at construction via `_import_runtime()`. If a required

--- a/docs/minimax_remover_usage.md
+++ b/docs/minimax_remover_usage.md
@@ -1,0 +1,153 @@
+# MiniMax-Remover — FlashRT Inference Pipeline
+
+MiniMax-Remover video inpainting (subtitle / object removal) with NVFP4
+(W4A4) kernelized inference on Blackwell SM120.
+
+## Build
+
+The pipeline reuses the **generic** FlashRT SM120 NVFP4 kernels — it
+ships **no model-specific CUDA operators**. It requires those generic
+kernels to be compiled in. Build FlashRT on a Blackwell host with the
+NVFP4 build option enabled so the NVFP4 quantise / W4A4 GEMM /
+fused-bias-gelu kernels are present in `flash_rt_kernels.so`:
+
+```bash
+cd FlashRT
+mkdir build && cd build
+cmake .. -DENABLE_CUTLASS_SM120_NVFP4_W4A16=ON
+make -j$(nproc)
+pip install -e ..
+```
+
+Importing `flash_rt.models.minimax_remover` always succeeds; the kernel
+surface is validated lazily in `MiniMaxRemoverPipeline.__init__` via
+`_load_kernels()`. If any required symbol is missing the constructor
+raises a clear `RuntimeError` listing the missing names, so a non-NVFP4
+build fails fast instead of crashing mid-quantisation. The required
+generic symbols are:
+
+| Symbol | Role |
+|--------|------|
+| `nvfp4_sf_swizzled_bytes` | block-scale-factor byte layout helper |
+| `bf16_weight_to_nvfp4_swizzled` | one-shot weight -> NVFP4 quantise |
+| `quantize_bf16_to_nvfp4_swizzled` | per-call dynamic activation quantise |
+| `fp4_w4a16_gemm_sm120_bf16out_pingpong` | SM120-native W4A4 MMA -> bf16 |
+| `add_bias_bf16` | in-place bias add on bf16 GEMM output |
+| `fp4_w4a16_gemm_bias_gelu_fp4out_sm120` | fused FFN-up GEMM + bias + GELU -> FP4 |
+
+The attention backend (`FLASHRT_ATTN_MODE`) optionally pulls in
+`sageattention` (Sage) or `triton_flash_attn` (Triton FA); `fa2` uses
+the vendored `flash_rt_fa2.so`. The fused norm / RoPE / Euler-step
+elementwise kernels are self-contained Triton JIT kernels shipped in the
+package (`_kernels.py`) and need no build step.
+
+## Pipeline
+
+`flash_rt/models/minimax_remover/pipeline.py` — `MiniMaxRemoverPipeline`.
+It wraps a loaded diffusers MiniMax-Remover `pipe` and consumes it in
+place:
+
+- every eligible transformer Linear -> NVFP4 W4A4 GEMM (weight quantised
+  once at load time; activation quantised **dynamically** per call with
+  per-16-element UE4M3 block scales computed on-GPU — no offline
+  calibration, no CPU sync);
+- transformer switched to bf16 (NVFP4-native, eliminates the fp16<->bf16
+  cast pair);
+- RoPE freqs cached as complex<float>;
+- `torch.nn.functional.scaled_dot_product_attention` -> FA2 / SageAttention;
+- per-block LayerNorm + adaLN modulation + gate-residual fused into a
+  single fp32-stat Triton kernel;
+- the N-step flow-matching denoise loop replaced by a manual, graph-
+  capturable pointer-based loop (`ManualRemoverPipeline`). QKV quantises
+  the norm output **once** and reuses it for all three projections; the
+  FFN-up GEMM fuses bias + GELU straight to FP4 output so the FFN-down
+  projection skips re-quantisation. With `FLASHRT_MANUAL_GRAPH=1` the
+  whole N-step x N-block loop is captured as a single CUDA Graph;
+  inside the captured graph there are **zero** torch elementwise ops —
+  every operation is a kernel launch.
+
+The VAE encode / decode run unchanged from the loaded diffusers model
+(one-shot per segment, outside the graph). No MiniMax-Remover source is
+imported; the `pipe` is duck-typed through `.transformer` / `.vae` /
+`.scheduler` / `.video_processor` and the `expand_masks` / `resize`
+helpers.
+
+## Performance (RTX 5060 Ti, SM120, CUDA 13)
+
+### End-to-end (123 frames, 3 segments, fp16 reference baseline)
+
+| Stack | Wall time | Speedup | PSNR vs fp16 |
+|-------|-----------|---------|--------------|
+| fp16 reference (diffusers) | 30.7 s | 1.0× | — |
+| FlashRT NVFP4 (this pipeline) | 11.9 s | **2.6×** | 52.0 / 45.2 dB |
+
+At 24 fps the 123-frame clip is 5.1 s, so the FlashRT stack runs at
+**RTF ≈ 2.3** (processing-time / clip-duration); the fp16 reference is
+RTF ≈ 6.0.
+
+### Transformer GEMM (NVFP4 vs fp16 matmul, single layer)
+
+| Linear | fp16 matmul | NVFP4 W4A4 | per-layer speedup |
+|--------|-------------|------------|-------------------|
+| FFN up [5120 -> 13824] | 1.095 ms | 0.840 ms | 1.30× |
+| FFN down [13824 -> 5120] | 1.020 ms | 0.864 ms | 1.18× |
+| QKV / out [5120 -> 5120] | 0.409 ms | 0.359 ms | 1.14× |
+
+Including cast + quantise overhead, the isolated FP4 GEMM is 4–9× faster
+than the fp16 matmul on the large FFN projections (e.g. ffn_up
+3.95 ms -> 0.47 ms). NVFP4 is also 1.14–1.30× faster per layer than the
+static-quant FP8 GEMM.
+
+### Precision specification
+
+The pipeline keeps the math reference-equivalent on the precision-critical
+path (fp32-stat LayerNorm / RMSNorm, interleaved RoPE) and confines the
+loss to the quantised GEMMs and the attention backend.
+
+| Component | Metric | Value |
+|-----------|--------|-------|
+| Attention — SageAttention QK-int8 PV-fp8 (`sage_fp8`, default) | cosine vs SDPA | 0.9993 |
+| Attention — SageAttention QK-int8 PV-fp16 (`sage_fp16`) | cosine vs SDPA | 0.9999 |
+| NVFP4 W4A4 GEMM | cosine vs fp16 matmul | >= 0.999 |
+| End-to-end (full pipeline) | PSNR vs fp16 | 52.0 dB (mean) / 45.2 dB (worst frame) |
+| End-to-end (full pipeline) | max abs diff vs fp16 | bounded by the FP4 grid; per-block relative, scales with activation magnitude (median per-pixel deviation < 2 / 255 on 8-bit output) |
+
+The default `sage_fp8` attention gives the best latency at cosine 0.9993;
+switch to `FLASHRT_ATTN_MODE=sage_fp16` for cosine 0.9999 at a small
+latency cost. NVFP4 needs no calibration, so the first call is already
+in the steady state (no warm-up / calibration pass).
+
+## Environment variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `FLASHRT_ATTN_MODE` | `sage_fp8` | attention backend (`sage_fp8`/`sage_fp16`/`sage`/`fa2`) |
+| `FLASHRT_FP4_GEMM` | `pingpong` | GEMM kernel variant (`pingpong`/`plain`/`widen`) |
+| `FLASHRT_FUSED_BLOCK` | `1` | fused QKV-quant-once + fused FFN-up GEMM+bias+gelu block (`0` = per-projection re-quant debug path) |
+| `FLASHRT_MANUAL_GRAPH` | `0` | capture the whole denoise loop as one CUDA Graph |
+| `FLASHRT_NUM_STEPS` | unset | override the denoise step count (default 12) |
+
+## Usage
+
+```python
+from flash_rt.models.minimax_remover import MiniMaxRemoverPipeline
+
+# `pipe` is a loaded diffusers Minimax_Remover_Pipeline (transformer +
+# vae + scheduler). The FlashRT pipeline consumes it in place.
+pipeline = MiniMaxRemoverPipeline(pipe)
+output = pipeline(
+    images=frames,        # [F, H, W, 3] uint8/np, 0..255
+    masks=masks,          # [F, H, W, 1] np, 0/1
+    num_frames=len(frames),
+    height=720, width=1280,
+    num_inference_steps=12,
+)
+video = output.frames
+```
+
+## Model weights
+
+MiniMax-Remover checkpoint + the `Transformer3DModel` / `AutoencoderKLWan`
+definitions are loaded by the reference project (unmodified, via the
+loaded diffusers `pipe`). This FlashRT pipeline module imports no
+MiniMax-Remover source.

--- a/docs/minimax_remover_usage.md
+++ b/docs/minimax_remover_usage.md
@@ -6,25 +6,35 @@ MiniMax-Remover video inpainting (subtitle / object removal) with NVFP4
 ## Build
 
 The pipeline reuses the **generic** FlashRT SM120 NVFP4 kernels — it
-ships **no model-specific CUDA operators**. It requires those generic
-kernels to be compiled in. Build FlashRT on a Blackwell host with the
-NVFP4 build option enabled so the NVFP4 quantise / W4A4 GEMM /
-fused-bias-gelu kernels are present in `flash_rt_kernels.so`:
+ships **no model-specific CUDA operators**. Building for Blackwell
+auto-enables the NVFP4 kernels (the NVFP4 quantise / W4A4 GEMM /
+fused-bias-gelu entry points land in `flash_rt_kernels.so`):
 
 ```bash
 cd FlashRT
-mkdir build && cd build
-cmake .. -DENABLE_CUTLASS_SM120_NVFP4_W4A16=ON
-make -j$(nproc)
-pip install -e ..
+cmake -S . -B build -DGPU_ARCH=120 -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j --target flash_rt_kernels
+pip install -e ".[torch,minimax-remover]"
 ```
 
-Importing `flash_rt.models.minimax_remover` always succeeds; the kernel
-surface is validated lazily in `MiniMaxRemoverPipeline.__init__` via
-`_load_kernels()`. If any required symbol is missing the constructor
-raises a clear `RuntimeError` listing the missing names, so a non-NVFP4
-build fails fast instead of crashing mid-quantisation. The required
-generic symbols are:
+`GPU_ARCH=120` (RTX 5090) or `121` selects the Blackwell target; the
+NVFP4 surface is compiled in automatically (internally gated by
+`ENABLE_CUTLASS_SM120_NVFP4_W4A16`, which is set from `GPU_ARCH`, not a
+flag users pass). Then install the runtime extras:
+
+```bash
+pip install -e ".[minimax-remover]"   # diffusers + einops + sageattention
+```
+
+Importing `flash_rt.models.minimax_remover` always succeeds — it needs
+**none** of `diffusers` / `einops` / `triton` / `sageattention`. The
+kernel surface is validated lazily in
+`MiniMaxRemoverPipeline.__init__` via `_load_kernels()`, and the runtime
+deps are resolved at construction via `_import_runtime()`. If a required
+symbol or dep is missing the constructor raises a clear `RuntimeError`
+with the rebuild/install hint, so a non-NVFP4 build or a bare
+environment fails fast instead of crashing mid-run. The required generic
+symbols are:
 
 | Symbol | Role |
 |--------|------|
@@ -36,8 +46,8 @@ generic symbols are:
 | `fp4_w4a16_gemm_bias_gelu_fp4out_sm120` | fused FFN-up GEMM + bias + GELU -> FP4 |
 
 The attention backend (`FLASHRT_ATTN_MODE`) optionally pulls in
-`sageattention` (Sage) or `triton_flash_attn` (Triton FA); `fa2` uses
-the vendored `flash_rt_fa2.so`. The fused norm / RoPE / Euler-step
+`sageattention` (Sage); `fa2` uses the vendored `flash_rt_fa2.so` and is
+the dependency-light fallback. The fused norm / RoPE / Euler-step
 elementwise kernels are self-contained Triton JIT kernels shipped in the
 package (`_kernels.py`) and need no build step.
 

--- a/examples/minimax_remover_quickstart.py
+++ b/examples/minimax_remover_quickstart.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""MiniMax-Remover full-frame mask removal -- FlashRT NVFP4 quickstart.
+
+End-to-end demo of the FlashRT-accelerated MiniMax-Remover video mask
+removal pipeline. Every frame (plus its binary mask) is fed to the model
+at once -- no segmentation, no bbox cropping. Mask pixels above the
+threshold mark the region to inpaint; the rest of the frame is preserved.
+
+This is a FlashRT optimization of the upstream project:
+    https://github.com/zibojia/MiniMax-Remover
+
+It wraps a loaded diffusers MiniMax-Remover pipeline with
+``flash_rt.models.minimax_remover.MiniMaxRemoverPipeline``, which rewrites
+the transformer denoise path onto NVFP4 (W4A4) GEMMs, fused fp32-stat
+Triton norm/RoPE, kernel attention and a graph-capturable manual
+flow-matching loop.
+
+------------------------------------------------------------------
+Test data
+------------------------------------------------------------------
+Sample frames + masks (numeric filenames, aligned by frame number):
+
+    git clone https://github.com/chenping9999/object_removal_data.git
+
+------------------------------------------------------------------
+Model weights
+------------------------------------------------------------------
+Download the VAE / transformer / scheduler once:
+
+    huggingface-cli download zibojia/minimax-remover \
+        --include vae transformer scheduler --local-dir ./minimax-remover
+
+------------------------------------------------------------------
+Build
+------------------------------------------------------------------
+FlashRT must be built for Blackwell so the generic SM120 NVFP4 kernels
+are compiled in (GPU_ARCH=120 / 121 auto-enables them):
+
+    cmake -S . -B build -DGPU_ARCH=120 -DCMAKE_BUILD_TYPE=Release
+    cmake --build build -j --target flash_rt_kernels
+    pip install -e ".[torch,minimax-remover]"
+
+------------------------------------------------------------------
+Run
+------------------------------------------------------------------
+    python3 examples/minimax_remover_quickstart.py \
+        --model-dir ./minimax-remover \
+        --frames-dir ./object_removal_data/<frames> \
+        --masks-dir  ./object_removal_data/<masks> \
+        --output-dir ./out
+
+------------------------------------------------------------------
+Precision note
+------------------------------------------------------------------
+NVFP4 (W4A4) is calibrated for the model's large GEMMs. The fused
+norm/RoPE kernels keep the precision-critical path fp32-stat. For
+large full-frame latents, 4-bit weight/activation quantisation can
+accumulate small per-block error; if you observe colour drift on a
+high-resolution full-frame job, prefer the bbox-cropped regime (crop
+to the mask region before inference) where the quantisation grid is
+tighter. The provided test data is sized for this path.
+
+The VAE temporal compression factor is 4, so the input frame count
+should be 4k+1 for a lossless round trip; trailing frames that the VAE
+does not decode are copied from the source so the output frame count
+always matches the input. Width/height not divisible by 16 are padded
+bottom/right and cropped back on output.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import shutil
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+import numpy as np
+import scipy
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from PIL import Image
+
+# Make the flash_rt package importable when run directly from the repo root.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# diffusers model plumbing (vendored here so this demo depends only on pip
+# packages -- no MiniMax-Remover source is imported).
+from diffusers.configuration_utils import ConfigMixin, register_to_config
+from diffusers.models import AutoencoderKLWan
+from diffusers.models.attention import FeedForward
+from diffusers.models.attention_processor import Attention
+from diffusers.models.embeddings import (PixArtAlphaTextProjection,
+                                         TimestepEmbedding, Timesteps,
+                                         get_1d_rotary_pos_embed)
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+from diffusers.models.modeling_utils import ModelMixin
+from diffusers.models.normalization import FP32LayerNorm
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+from diffusers.pipelines.wan.pipeline_output import WanPipelineOutput
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.video_processor import VideoProcessor
+from einops import rearrange
+
+DEVICE = torch.device("cuda:0")
+MASK_THRESHOLD = 127
+NUM_INFERENCE_STEPS = 12
+PIPE_ITERATIONS = 6
+RANDOM_SEED = 42
+
+
+# =====================================================================
+# Reference model definition (self-contained).
+#
+# The Transformer3DModel below mirrors the upstream MiniMax-Remover
+# architecture verbatim so the released checkpoint loads without pulling
+# in the upstream source tree. FlashRT then patches its forward path.
+# =====================================================================
+
+class AttnProcessor2_0:
+    """Reference SDPA attention processor (replaced by FlashRT at runtime)."""
+
+    def __init__(self):
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError(
+                "AttnProcessor2_0 requires PyTorch 2.0+.")
+
+    def __call__(self, attn: Attention, hidden_states: torch.Tensor,
+                 rotary_emb: Optional[torch.Tensor] = None,
+                 attention_mask: Optional[torch.Tensor] = None,
+                 encoder_hidden_states: Optional[torch.Tensor] = None
+                 ) -> torch.Tensor:
+        encoder_hidden_states = hidden_states
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        query = query.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+        key = key.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+        value = value.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+
+        if rotary_emb is not None:
+            def apply_rotary_emb(hidden_states: torch.Tensor, freqs: torch.Tensor):
+                x_rotated = torch.view_as_complex(
+                    hidden_states.to(torch.float64).unflatten(3, (-1, 2)))
+                x_out = torch.view_as_real(x_rotated * freqs).flatten(3, 4)
+                return x_out.type_as(hidden_states)
+
+            query = apply_rotary_emb(query, rotary_emb)
+            key = apply_rotary_emb(key, rotary_emb)
+
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False)
+        hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
+        hidden_states = hidden_states.type_as(query)
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        return hidden_states
+
+
+class TimeEmbedding(nn.Module):
+    def __init__(self, dim: int, time_freq_dim: int, time_proj_dim: int):
+        super().__init__()
+        self.timesteps_proj = Timesteps(num_channels=time_freq_dim,
+                                        flip_sin_to_cos=True, downscale_freq_shift=0)
+        self.time_embedder = TimestepEmbedding(in_channels=time_freq_dim,
+                                               time_embed_dim=dim)
+        self.act_fn = nn.SiLU()
+        self.time_proj = nn.Linear(dim, time_proj_dim)
+
+    def forward(self, timestep: torch.Tensor):
+        timestep = self.timesteps_proj(timestep)
+        time_embedder_dtype = next(iter(self.time_embedder.parameters())).dtype
+        if timestep.dtype != time_embedder_dtype and time_embedder_dtype != torch.int8:
+            timestep = timestep.to(time_embedder_dtype)
+        temb = self.time_embedder(timestep).type_as(self.time_proj.weight.data)
+        timestep_proj = self.time_proj(self.act_fn(temb))
+        return temb, timestep_proj
+
+
+class RotaryPosEmbed(nn.Module):
+    def __init__(self, attention_head_dim: int, patch_size: Tuple[int, int, int],
+                 max_seq_len: int, theta: float = 10000.0):
+        super().__init__()
+        self.attention_head_dim = attention_head_dim
+        self.patch_size = patch_size
+        self.max_seq_len = max_seq_len
+
+        h_dim = w_dim = 2 * (attention_head_dim // 6)
+        t_dim = attention_head_dim - h_dim - w_dim
+
+        freqs = []
+        for dim in [t_dim, h_dim, w_dim]:
+            freq = get_1d_rotary_pos_embed(
+                dim, max_seq_len, theta, use_real=False,
+                repeat_interleave_real=False, freqs_dtype=torch.float64)
+            freqs.append(freq)
+        self.freqs = torch.cat(freqs, dim=1)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.patch_size
+        ppf, pph, ppw = num_frames // p_t, height // p_h, width // p_w
+
+        self.freqs = self.freqs.to(hidden_states.device)
+        freqs = self.freqs.split_with_sizes(
+            [self.attention_head_dim // 2 - 2 * (self.attention_head_dim // 6),
+             self.attention_head_dim // 6,
+             self.attention_head_dim // 6], dim=1)
+
+        freqs_f = freqs[0][:ppf].view(ppf, 1, 1, -1).expand(ppf, pph, ppw, -1)
+        freqs_h = freqs[1][:pph].view(1, pph, 1, -1).expand(ppf, pph, ppw, -1)
+        freqs_w = freqs[2][:ppw].view(1, 1, ppw, -1).expand(ppf, pph, ppw, -1)
+        freqs = torch.cat([freqs_f, freqs_h, freqs_w], dim=-1).reshape(
+            1, 1, ppf * pph * ppw, -1)
+        return freqs
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, dim: int, ffn_dim: int, num_heads: int,
+                 qk_norm: str = "rms_norm_across_heads", cross_attn_norm: bool = False,
+                 eps: float = 1e-6, added_kv_proj_dim: Optional[int] = None):
+        super().__init__()
+        self.norm1 = FP32LayerNorm(dim, eps, elementwise_affine=False)
+        self.attn1 = Attention(
+            query_dim=dim, heads=num_heads, kv_heads=num_heads,
+            dim_head=dim // num_heads, qk_norm=qk_norm, eps=eps, bias=True,
+            cross_attention_dim=None, out_bias=True,
+            processor=AttnProcessor2_0())
+        self.ffn = FeedForward(dim, inner_dim=ffn_dim, activation_fn="gelu-approximate")
+        self.norm2 = FP32LayerNorm(dim, eps, elementwise_affine=False)
+        self.scale_shift_table = nn.Parameter(torch.randn(1, 6, dim) / dim ** 0.5)
+
+    def forward(self, hidden_states: torch.Tensor, temb: torch.Tensor,
+                rotary_emb: torch.Tensor) -> torch.Tensor:
+        shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
+            self.scale_shift_table + temb.float()).chunk(6, dim=1)
+        norm_hidden_states = (self.norm1(hidden_states.float())
+                              * (1 + scale_msa) + shift_msa).type_as(hidden_states)
+        attn_output = self.attn1(hidden_states=norm_hidden_states, rotary_emb=rotary_emb)
+        hidden_states = (hidden_states.float()
+                         + attn_output * gate_msa).type_as(hidden_states)
+        norm_hidden_states = (self.norm2(hidden_states.float())
+                              * (1 + c_scale_msa) + c_shift_msa).type_as(hidden_states)
+        ff_output = self.ffn(norm_hidden_states)
+        hidden_states = (hidden_states.float()
+                         + ff_output.float() * c_gate_msa).type_as(hidden_states)
+        return hidden_states
+
+
+class Transformer3DModel(ModelMixin, ConfigMixin):
+    """MiniMax-Remover Transformer (patch-embed + N adaLN blocks + proj_out).
+
+    Loaded from the released checkpoint; its forward is then patched by
+    the FlashRT pipeline onto NVFP4 GEMMs + fused kernels.
+    """
+
+    _skip_layerwise_casting_patterns = ["patch_embedding", "condition_embedder", "norm"]
+    _no_split_modules = ["TransformerBlock"]
+    _keep_in_fp32_modules = ["time_embedder", "scale_shift_table", "norm1", "norm2"]
+
+    @register_to_config
+    def __init__(self, patch_size: Tuple[int] = (1, 2, 2),
+                 num_attention_heads: int = 40, attention_head_dim: int = 128,
+                 in_channels: int = 16, out_channels: int = 16,
+                 freq_dim: int = 256, ffn_dim: int = 13824, num_layers: int = 40,
+                 cross_attn_norm: bool = True,
+                 qk_norm: Optional[str] = "rms_norm_across_heads",
+                 eps: float = 1e-6, added_kv_proj_dim: Optional[int] = None,
+                 rope_max_seq_len: int = 1024) -> None:
+        super().__init__()
+        inner_dim = num_attention_heads * attention_head_dim
+        out_channels = out_channels or in_channels
+
+        self.rope = RotaryPosEmbed(attention_head_dim, patch_size, rope_max_seq_len)
+        self.patch_embedding = nn.Conv3d(
+            in_channels, inner_dim, kernel_size=patch_size, stride=patch_size)
+
+        self.condition_embedder = TimeEmbedding(
+            dim=inner_dim, time_freq_dim=freq_dim, time_proj_dim=inner_dim * 6)
+
+        self.blocks = nn.ModuleList([
+            TransformerBlock(inner_dim, ffn_dim, num_attention_heads, qk_norm,
+                             cross_attn_norm, eps, added_kv_proj_dim)
+            for _ in range(num_layers)])
+
+        self.norm_out = FP32LayerNorm(inner_dim, eps, elementwise_affine=False)
+        self.proj_out = nn.Linear(inner_dim, out_channels * math.prod(patch_size))
+        self.scale_shift_table = nn.Parameter(torch.randn(1, 2, inner_dim) / inner_dim ** 0.5)
+
+    def forward(self, hidden_states: torch.Tensor,
+                timestep: torch.LongTensor) -> Union[torch.Tensor, dict]:
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.config.patch_size
+        post_patch_num_frames = num_frames // p_t
+        post_patch_height = height // p_h
+        post_patch_width = width // p_w
+
+        rotary_emb = self.rope(hidden_states)
+        hidden_states = self.patch_embedding(hidden_states)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+        temb, timestep_proj = self.condition_embedder(timestep)
+        timestep_proj = timestep_proj.unflatten(1, (6, -1))
+
+        for block in self.blocks:
+            hidden_states = block(hidden_states, timestep_proj, rotary_emb)
+
+        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+        hidden_states = (self.norm_out(hidden_states.float())
+                         * (1 + scale) + shift).type_as(hidden_states)
+        hidden_states = self.proj_out(hidden_states)
+
+        hidden_states = hidden_states.reshape(
+            batch_size, post_patch_num_frames, post_patch_height, post_patch_width,
+            p_t, p_h, p_w, -1)
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+        return Transformer2DModelOutput(sample=output)
+
+
+# =====================================================================
+# Reference diffusers pipeline (self-contained).
+#
+# Constructs the pipe (transformer + vae + scheduler). Its __call__ is
+# the reference flow-matching loop; FlashRT replaces it at runtime with
+# the NVFP4 manual denoise pipeline.
+# =====================================================================
+
+class MinimaxRemoverPipeline(DiffusionPipeline):
+    """diffusers pipeline wrapping the MiniMax-Remover transformer + VAE.
+
+    Uses FlowMatchEulerDiscreteScheduler: the FlashRT manual denoise loop
+    advances the latent with sigma-based Euler steps, which matches
+    flow-matching semantics exactly.
+    """
+
+    model_cpu_offload_seq = "transformer->vae"
+    _callback_tensor_inputs = ["latents"]
+
+    def __init__(self, transformer: Transformer3DModel, vae: AutoencoderKLWan,
+                 scheduler: FlowMatchEulerDiscreteScheduler):
+        super().__init__()
+        self.register_modules(vae=vae, transformer=transformer, scheduler=scheduler)
+        self.vae_scale_factor_temporal = (
+            2 ** sum(self.vae.temperal_downsample) if getattr(self, "vae", None) else 4)
+        self.vae_scale_factor_spatial = (
+            2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8)
+        self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
+
+    def expand_masks(self, masks, iterations):
+        masks = masks.cpu().detach().numpy()
+        masks2 = []
+        for i in range(len(masks)):
+            mask = masks[i]
+            mask = mask > 0
+            mask = scipy.ndimage.binary_dilation(mask, iterations=iterations)
+            masks2.append(mask)
+        masks = np.array(masks2).astype(np.float32)
+        masks = torch.from_numpy(masks)
+        masks = masks.repeat(1, 1, 1, 3)
+        masks = rearrange(masks, "f h w c -> c f h w")
+        masks = masks[None, ...]
+        return masks
+
+    def resize(self, images, w, h):
+        bsz, _, _, _, _ = images.shape
+        images = rearrange(images, "b c f w h -> (b f) c w h")
+        images = F.interpolate(images, (w, h), mode="bilinear")
+        images = rearrange(images, "(b f) c w h -> b c f w h", b=bsz)
+        return images
+
+    @torch.no_grad()
+    def __call__(self, height: int = 720, width: int = 1280, num_frames: int = 81,
+                 num_inference_steps: int = 50, generator=None,
+                 images: Optional[torch.Tensor] = None,
+                 masks: Optional[torch.Tensor] = None,
+                 latents: Optional[torch.Tensor] = None,
+                 output_type: Optional[str] = "np", iterations: int = 16):
+        device = self._execution_device
+        batch_size = 1
+        transformer_dtype = torch.float16
+
+        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        timesteps = self.scheduler.timesteps
+        num_channels_latents = 16
+        num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
+
+        shape = (batch_size, num_channels_latents, num_latent_frames,
+                 int(height) // self.vae_scale_factor_spatial,
+                 int(width) // self.vae_scale_factor_spatial)
+        latents = randn_tensor(shape, generator=generator, device=device, dtype=torch.float16)
+
+        masks = self.expand_masks(masks, iterations)
+        masks = self.resize(masks, height, width).to("cuda:0").half()
+        masks[masks > 0] = 1
+        images = rearrange(images, "f h w c -> c f h w")
+        images = self.resize(images[None, ...], height, width).to("cuda:0").half()
+        masked_images = images * (1 - masks)
+
+        latents_mean = (torch.tensor(self.vae.config.latents_mean)
+                        .view(1, self.vae.config.z_dim, 1, 1, 1)
+                        .to(self.vae.device, torch.float16))
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(
+            1, self.vae.config.z_dim, 1, 1, 1).to(self.vae.device, torch.float16)
+
+        with torch.no_grad():
+            masked_latents = self.vae.encode(masked_images.half()).latent_dist.mode()
+            masks_latents = self.vae.encode(2 * masks.half() - 1.0).latent_dist.mode()
+            masked_latents = (masked_latents - latents_mean) * latents_std
+            masks_latents = (masks_latents - latents_mean) * latents_std
+
+        self._num_timesteps = len(timesteps)
+        for i, t in enumerate(timesteps):
+            latent_model_input = latents.to(transformer_dtype)
+            latent_model_input = torch.cat(
+                [latent_model_input, masked_latents, masks_latents], dim=1)
+            timestep = t.expand(latents.shape[0])
+            noise_pred = self.transformer(
+                hidden_states=latent_model_input.half(), timestep=timestep)[0]
+            latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+
+        latents = latents.half() / latents_std + latents_mean
+        video = self.vae.decode(latents, return_dict=False)[0]
+        video = self.video_processor.postprocess_video(video, output_type=output_type)
+        return WanPipelineOutput(frames=video)
+
+
+def build_pipeline(model_dir: Path) -> MinimaxRemoverPipeline:
+    """Load VAE / transformer / scheduler and assemble the diffusers pipe."""
+    vae = AutoencoderKLWan.from_pretrained(model_dir / "vae", torch_dtype=torch.float16)
+    transformer = Transformer3DModel.from_pretrained(
+        model_dir / "transformer", torch_dtype=torch.float16)
+    scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(model_dir / "scheduler")
+    pipe = MinimaxRemoverPipeline(transformer=transformer, vae=vae, scheduler=scheduler)
+    pipe.to(DEVICE)
+    return pipe
+
+
+# =====================================================================
+# Frame / mask IO helpers (self-contained).
+# =====================================================================
+
+def collect_frame_files(frames_dir: Path) -> List[Path]:
+    """Collect numeric-named image files, sorted by frame number."""
+    supported = ["*.png", "*.jpg", "*.jpeg", "*.PNG", "*.JPG", "*.JPEG"]
+    frame_files: Dict[int, Path] = {}
+    for pattern in supported:
+        for file in frames_dir.glob(pattern):
+            try:
+                frame_files.setdefault(int(file.stem), file)
+            except ValueError:
+                continue
+    if not frame_files:
+        raise ValueError(
+            f"No frames found in {frames_dir} "
+            "(numeric-named png/jpg/jpeg expected).")
+    return [p for _, p in sorted(frame_files.items(), key=lambda x: x[0])]
+
+
+def build_frame_path_map(paths: List[Path]) -> Dict[int, Path]:
+    return {int(p.stem): p for p in paths}
+
+
+def load_frames(image_paths: List[Path], num_workers: int = 8) -> np.ndarray:
+    img0 = Image.open(image_paths[0]).convert("RGB")
+    base_width, base_height = img0.size
+    img0_np = np.array(img0, dtype=np.uint8)
+    if len(image_paths) == 1:
+        return np.stack([img0_np], axis=0)
+    results: List[Optional[np.ndarray]] = [img0_np] + [None] * (len(image_paths) - 1)
+    max_workers = max(1, min(num_workers, (os.cpu_count() or 4), len(image_paths)))
+
+    def _load_one(idx, path):
+        img = Image.open(path).convert("RGB")
+        if img.size != (base_width, base_height):
+            img = img.resize((base_width, base_height), Image.Resampling.BILINEAR)
+        return idx, np.array(img, dtype=np.uint8)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        futures = [ex.submit(_load_one, idx, path)
+                   for idx, path in enumerate(image_paths[1:], start=1)]
+        for fut in as_completed(futures):
+            idx, arr = fut.result()
+            results[idx] = arr
+    return np.stack([r for r in results if r is not None], axis=0)
+
+
+def _load_single_mask(path: Optional[Path], orig_width: int,
+                      orig_height: int) -> Tuple[np.ndarray, bool]:
+    if path is None:
+        return np.zeros((orig_height, orig_width, 1), dtype=np.float32), False
+    img = Image.open(path).convert("L")
+    if img.size != (orig_width, orig_height):
+        img = img.resize((orig_width, orig_height), Image.Resampling.NEAREST)
+    arr = np.array(img, dtype=np.uint8)
+    mask = (arr > MASK_THRESHOLD).astype(np.float32)[..., None]
+    return mask, bool(mask.any())
+
+
+def load_masks(seg_paths: List[Path], mask_path_map: Dict[int, Path],
+               orig_width: int, orig_height: int,
+               num_workers: int = 8) -> Tuple[np.ndarray, List[bool]]:
+    n = len(seg_paths)
+    masks = np.zeros((n, orig_height, orig_width, 1), dtype=np.float32)
+    has_region: List[bool] = [False] * n
+    if n == 0:
+        return masks, has_region
+    masks[0], has_region[0] = _load_single_mask(
+        mask_path_map.get(int(seg_paths[0].stem)), orig_width, orig_height)
+    if n == 1:
+        return masks, has_region
+    max_workers = max(1, min(num_workers, (os.cpu_count() or 4), n))
+
+    def _load_one(local_i, frame_no):
+        mask, has = _load_single_mask(mask_path_map.get(frame_no), orig_width, orig_height)
+        return local_i, mask, has
+
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        futures = [ex.submit(_load_one, i, int(seg_paths[i].stem)) for i in range(1, n)]
+        for fut in as_completed(futures):
+            local_i, mask, has = fut.result()
+            masks[local_i] = mask
+            has_region[local_i] = has
+    return masks, has_region
+
+
+def pad_hw_to_multiple_of_16(height: int, width: int) -> Tuple[int, int, int, int]:
+    ph = (16 - height % 16) % 16
+    pw = (16 - width % 16) % 16
+    return ph, pw, height + ph, width + pw
+
+
+def pad_frames_bottom_right(frames: np.ndarray, ph: int, pw: int) -> np.ndarray:
+    if ph == 0 and pw == 0:
+        return frames
+    return np.pad(frames, ((0, 0), (0, ph), (0, pw), (0, 0)), mode="edge")
+
+
+def pad_masks_bottom_right(masks: np.ndarray, ph: int, pw: int) -> np.ndarray:
+    if ph == 0 and pw == 0:
+        return masks
+    return np.pad(masks, ((0, 0), (0, ph), (0, pw), (0, 0)),
+                  mode="constant", constant_values=0.0)
+
+
+# =====================================================================
+# Demo entry point.
+# =====================================================================
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="MiniMax-Remover full-frame mask removal (FlashRT NVFP4).")
+    p.add_argument("--model-dir", type=str, required=True,
+                   help="MiniMax-Remover checkpoint dir (vae/ transformer/ scheduler/).")
+    p.add_argument("--frames-dir", type=str, required=True,
+                   help="Input video frames dir (numeric filenames).")
+    p.add_argument("--masks-dir", type=str, required=True,
+                   help="Mask frames dir (numeric filenames, aligned with frames).")
+    p.add_argument("--output-dir", type=str, required=True, help="Output frames dir.")
+    p.add_argument("--iterations", type=int, default=PIPE_ITERATIONS,
+                   help="Mask dilation iterations inside the pipeline (default 6).")
+    p.add_argument("--num-inference-steps", type=int, default=NUM_INFERENCE_STEPS,
+                   help="Denoise steps (default 12).")
+    p.add_argument("--no-flashrt", action="store_true",
+                   help="Run the reference diffusers path instead of FlashRT (for diffing).")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    frames_dir = Path(args.frames_dir)
+    masks_dir = Path(args.masks_dir)
+    output_dir = Path(args.output_dir)
+    model_dir = Path(args.model_dir)
+
+    if not frames_dir.is_dir():
+        raise ValueError(f"frames dir does not exist: {frames_dir}")
+    if not masks_dir.is_dir():
+        raise ValueError(f"masks dir does not exist: {masks_dir}")
+    if not (model_dir / "transformer").is_dir():
+        raise ValueError(
+            f"model dir missing transformer/: {model_dir}\n"
+            "Download with: huggingface-cli download zibojia/minimax-remover "
+            "--include vae transformer scheduler --local-dir <model-dir>")
+
+    print("=" * 60)
+    print("MiniMax-Remover full-frame mask removal (FlashRT NVFP4 W4A4)")
+    print("=" * 60)
+
+    image_paths = collect_frame_files(frames_dir)
+    mask_paths = collect_frame_files(masks_dir)
+    mask_path_map = build_frame_path_map(mask_paths)
+
+    first = Image.open(image_paths[0]).convert("RGB")
+    orig_w, orig_h = first.size
+    first.close()
+
+    ph, pw, pad_h, pad_w = pad_hw_to_multiple_of_16(orig_h, orig_w)
+    print(f"  resolution: {orig_w}x{orig_h} -> padded {pad_w}x{pad_h} "
+          f"(bottom +{ph}, right +{pw})")
+
+    n = len(image_paths)
+    print(f"  frames: {n}; steps={args.num_inference_steps}, iterations={args.iterations}")
+
+    frames = load_frames(image_paths)
+    masks, has_region = load_masks(image_paths, mask_path_map, orig_w, orig_h)
+
+    if not any(has_region):
+        print("  no removal region detected (masks empty); copying all source frames.")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for src in image_paths:
+            shutil.copy2(src, output_dir / src.name)
+        return
+
+    frames_padded = pad_frames_bottom_right(frames, ph, pw)
+    masks_padded = pad_masks_bottom_right(masks, ph, pw)
+
+    pipe = build_pipeline(model_dir)
+
+    if args.no_flashrt:
+        runner = pipe
+        tag = "reference (diffusers fp16)"
+    else:
+        from flash_rt.models.minimax_remover import MiniMaxRemoverPipeline
+        runner = MiniMaxRemoverPipeline(pipe)
+        tag = "FlashRT NVFP4 W4A4"
+
+    t, h, w, _ = frames_padded.shape
+    images_tensor = torch.from_numpy(frames_padded).to(device=DEVICE, dtype=torch.float16)
+    images_tensor = images_tensor / 127.5 - 1.0
+    masks_infer = torch.from_numpy(masks_padded.astype(np.float32))
+
+    print(f"  running inference [{tag}] (all frames at once)...")
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.empty_cache()
+    t0 = time.time()
+    out = runner(
+        images=images_tensor, masks=masks_infer, num_frames=t,
+        height=h, width=w, num_inference_steps=args.num_inference_steps,
+        generator=torch.Generator(device=DEVICE).manual_seed(RANDOM_SEED),
+        iterations=args.iterations).frames[0]
+    torch.cuda.synchronize()
+    elapsed = time.time() - t0
+    print(f"  inference wall time: {elapsed:.2f}s")
+
+    out_u8 = (np.array(out, dtype=np.float32) * 255.0).clip(0, 255).astype(np.uint8)
+    proc_len = out_u8.shape[0]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    saved = inpainted = uncovered = 0
+    for local_i, path in enumerate(image_paths):
+        dst = output_dir / path.name
+        if local_i < proc_len and has_region[local_i]:
+            crop = out_u8[local_i, :orig_h, :orig_w, :]
+            Image.fromarray(crop, mode="RGB").save(dst)
+            inpainted += 1
+        elif local_i >= proc_len and has_region[local_i]:
+            Image.fromarray(frames[local_i], mode="RGB").save(dst)
+            uncovered += 1
+        else:
+            Image.fromarray(frames[local_i], mode="RGB").save(dst)
+        saved += 1
+
+    peak_alloc = torch.cuda.max_memory_allocated() / 1024 ** 3
+    peak_reserved = torch.cuda.max_memory_reserved() / 1024 ** 3
+    print(f"  saved {saved}/{n} frames to {output_dir} ({inpainted} inpainted)")
+    if uncovered > 0:
+        print(f"  note: {uncovered} trailing frame(s) kept from source "
+              f"(VAE temporal factor 4; pad input to 4k+1 frames to avoid).")
+    print(f"  peak VRAM: allocated {peak_alloc:.2f} GB / reserved {peak_reserved:.2f} GB")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_rt/models/minimax_remover/__init__.py
+++ b/flash_rt/models/minimax_remover/__init__.py
@@ -1,0 +1,18 @@
+"""FlashRT -- MiniMax-Remover video inpainting pipeline.
+
+MiniMax-Remover is a flow-matching video inpainting Transformer used for
+subtitle / object removal. This package ships the NVFP4 (W4A4)
+kernelized inference pipeline (``MiniMaxRemoverPipeline``): the
+transformer Linears are rewritten as NVFP4 GEMMs over the generic
+FlashRT SM120 kernels, the per-block norm / gate / residual / gelu ops
+become fused Triton kernels, attention moves to FA2 / SageAttention, and
+the N-step flow-matching loop is captured as a single CUDA Graph. The VAE
+encode / decode run unchanged from the loaded diffusers model.
+"""
+
+from flash_rt.models.minimax_remover.pipeline import (
+    MiniMaxRemoverPipeline,
+    _load_kernels,
+)
+
+__all__ = ["MiniMaxRemoverPipeline"]

--- a/flash_rt/models/minimax_remover/_attention.py
+++ b/flash_rt/models/minimax_remover/_attention.py
@@ -1,0 +1,150 @@
+"""FlashRT -- MiniMax-Remover kernel attention processor.
+
+Replaces ``torch.nn.functional.scaled_dot_product_attention`` in every
+attention block with a pointer-based kernel backend:
+
+* ``FlashRTFA2Processor.__call__`` runs the QKV projection (through the
+  NVFP4 Linears installed by ``_nvfp4_linear``), Q/K RMSNorm
+  (fp32-stat Triton), interleaved RoPE on the native [B, S, H, D]
+  layout (no transpose / copy), then the chosen attention kernel.
+
+The attention backend is selected by ``FLASHRT_ATTN_MODE``:
+
+  * ``sage`` / ``sage_auto``    -- SageAttention auto-dispatcher.
+  * ``sage_fp8`` / ``sage2``    -- SageAttention QK-int8 + PV-fp8 CUDA
+                                   (default; ~5x vs FA2, cos ~0.9993).
+  * ``sage_fp16`` / ``sage1``   -- SageAttention QK-int8 + PV-fp16 CUDA.
+  * ``sage_triton``             -- SageAttention QK-int8 + PV-fp16 Triton.
+  * ``fa2``                     -- FlashRT FA2 (``flash_rt_fa2.fwd_fp16``).
+
+``sageattention`` is an optional third-party dependency (pip); only the
+selected backend is imported lazily. ``fa2`` uses FlashRT's own vendored
+``flash_rt_fa2.so``. No MiniMax-Remover imports -- tensors only.
+"""
+
+import math
+import os
+
+import torch
+
+from ._kernels import rms_norm_fp32stat, rope_apply_bshd, freqs_to_cos_sin
+
+try:
+    _NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
+except Exception:
+    _NUM_SMS = 0
+
+
+def _attention_mode():
+    return os.environ.get("FLASHRT_ATTN_MODE", "sage_fp8").lower()
+
+
+_SAGE = None
+
+
+def _get_sage():
+    global _SAGE
+    if _SAGE is None:
+        import sageattention as _m
+        _SAGE = _m
+    return _SAGE
+
+
+def _sage_attn(q, k, v, scale, mode):
+    """Dispatch to the requested SageAttention variant.
+
+    All variants accept and return [B, S, H, D] (NHD) fp16.
+    """
+    sa = _get_sage()
+    kw = dict(tensor_layout="NHD", is_causal=False, sm_scale=scale)
+    if mode in ("sage", "sage_auto"):
+        return sa.sageattn(q, k, v, **kw)
+    if mode in ("sage_fp8", "sage2"):
+        return sa.sageattn_qk_int8_pv_fp8_cuda(q, k, v, **kw)
+    if mode in ("sage_fp16", "sage1"):
+        return sa.sageattn_qk_int8_pv_fp16_cuda(q, k, v, **kw)
+    if mode == "sage_triton":
+        return sa.sageattn_qk_int8_pv_fp16_triton(q, k, v, **kw)
+    return sa.sageattn(q, k, v, **kw)
+
+
+class FlashRTFA2Processor:
+    """Kernel attention processor for the native [B, S, H, D] layout.
+
+    QKV projection goes through the installed NVFP4 Linears; Q/K
+    RMSNorm uses the fp32-stat Triton kernel; RoPE is applied in place
+    on the native layout (zero transpose / copy); the attention backend
+    is chosen by ``FLASHRT_ATTN_MODE``. Per-shape cos/sin RoPE tables
+    and FA2 log-sum-exp buffers are cached.
+    """
+
+    def __init__(self):
+        self._lse_bufs = {}
+        self._cos_sin = {}
+
+    def __call__(self, attn, hidden_states, rotary_emb=None,
+                 attention_mask=None, encoder_hidden_states=None):
+        mode = _attention_mode()
+        B, S, _ = hidden_states.shape
+        H = attn.heads
+        Dd = attn.inner_dim // H
+        scale = 1.0 / math.sqrt(float(Dd))
+
+        q = attn.to_q(hidden_states)
+        k = attn.to_k(hidden_states)
+        v = attn.to_v(hidden_states)
+        if attn.norm_q is not None:
+            q = rms_norm_fp32stat(q, attn.norm_q.weight, attn.norm_q.eps)
+        if attn.norm_k is not None:
+            k = rms_norm_fp32stat(k, attn.norm_k.weight, attn.norm_k.eps)
+
+        q = q.view(B, S, H, Dd)
+        k = k.view(B, S, H, Dd)
+        v = v.view(B, S, H, Dd)
+
+        if rotary_emb is not None:
+            cs = self._cos_sin.get(S)
+            if cs is None:
+                cs = freqs_to_cos_sin(rotary_emb)
+                self._cos_sin[S] = cs
+            rope_apply_bshd(q, cs[0], cs[1])
+            rope_apply_bshd(k, cs[0], cs[1])
+
+        if not q.is_contiguous():
+            q = q.contiguous()
+        if not k.is_contiguous():
+            k = k.contiguous()
+        if not v.is_contiguous():
+            v = v.contiguous()
+
+        if mode.startswith("sage"):
+            out = _sage_attn(q, k, v, scale, mode)
+        else:
+            out = torch.empty_like(q)
+            lse = self._lse_bufs.get((B, S, H))
+            if lse is None:
+                lse = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
+                self._lse_bufs[(B, S, H)] = lse
+            from flash_rt import flash_rt_fa2 as fa2
+            qs, ks, vs, os_ = (q.stride(), k.stride(), v.stride(), out.stride())
+            fa2.fwd_fp16(
+                q.data_ptr(), k.data_ptr(), v.data_ptr(), out.data_ptr(),
+                lse.data_ptr(), 0, 0,
+                B, S, S, H, H, Dd,
+                (qs[0], qs[1], qs[2]), (ks[0], ks[1], ks[2]), (vs[0], vs[1], vs[2]),
+                (os_[0], os_[1], os_[2]),
+                scale, _NUM_SMS, torch.cuda.current_stream().cuda_stream)
+
+        hidden_states = out.view(B, S, H * Dd)
+        hidden_states = attn.to_out[0](hidden_states)
+        return hidden_states
+
+
+def install_attention(transformer):
+    """Install the kernel attention processor on every transformer block."""
+    proc = FlashRTFA2Processor()
+    n = 0
+    for block in transformer.blocks:
+        block.attn1.processor = proc
+        n += 1
+    return n

--- a/flash_rt/models/minimax_remover/_attention.py
+++ b/flash_rt/models/minimax_remover/_attention.py
@@ -76,6 +76,37 @@ def _sage_attn(q, k, v, scale, mode):
     return sa.sageattn(q, k, v, **kw)
 
 
+def _fa2_attn(q, k, v, scale, lse_cache=None):
+    """Run FlashRT's vendored FA2 backend on [B, S, H, D] fp16 tensors."""
+    B, S, H, Dd = q.shape
+    out = torch.empty_like(q)
+    if lse_cache is None:
+        lse = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
+    else:
+        lse = lse_cache.get((B, S, H))
+        if lse is None:
+            lse = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
+            lse_cache[(B, S, H)] = lse
+    from flash_rt import flash_rt_fa2 as fa2
+    qs, ks, vs, os_ = (q.stride(), k.stride(), v.stride(), out.stride())
+    fa2.fwd_fp16(
+        q.data_ptr(), k.data_ptr(), v.data_ptr(), out.data_ptr(),
+        lse.data_ptr(), 0, 0,
+        B, S, S, H, H, Dd,
+        (qs[0], qs[1], qs[2]), (ks[0], ks[1], ks[2]), (vs[0], vs[1], vs[2]),
+        (os_[0], os_[1], os_[2]),
+        scale, _NUM_SMS, torch.cuda.current_stream().cuda_stream)
+    return out
+
+
+def attention_forward(q, k, v, scale, mode=None, *, lse_cache=None):
+    """Dispatch MiniMax-Remover attention without importing unused backends."""
+    mode = _attention_mode() if mode is None else str(mode).lower()
+    if mode.startswith("sage"):
+        return _sage_attn(q, k, v, scale, mode)
+    return _fa2_attn(q, k, v, scale, lse_cache)
+
+
 class FlashRTFA2Processor:
     """Kernel attention processor for the native [B, S, H, D] layout.
 
@@ -125,23 +156,8 @@ class FlashRTFA2Processor:
         if not v.is_contiguous():
             v = v.contiguous()
 
-        if mode.startswith("sage"):
-            out = _sage_attn(q, k, v, scale, mode)
-        else:
-            out = torch.empty_like(q)
-            lse = self._lse_bufs.get((B, S, H))
-            if lse is None:
-                lse = torch.empty(B, H, S, device=q.device, dtype=torch.float32)
-                self._lse_bufs[(B, S, H)] = lse
-            from flash_rt import flash_rt_fa2 as fa2
-            qs, ks, vs, os_ = (q.stride(), k.stride(), v.stride(), out.stride())
-            fa2.fwd_fp16(
-                q.data_ptr(), k.data_ptr(), v.data_ptr(), out.data_ptr(),
-                lse.data_ptr(), 0, 0,
-                B, S, S, H, H, Dd,
-                (qs[0], qs[1], qs[2]), (ks[0], ks[1], ks[2]), (vs[0], vs[1], vs[2]),
-                (os_[0], os_[1], os_[2]),
-                scale, _NUM_SMS, torch.cuda.current_stream().cuda_stream)
+        out = attention_forward(q, k, v, scale, mode,
+                                lse_cache=self._lse_bufs)
 
         hidden_states = out.view(B, S, H * Dd)
         hidden_states = attn.to_out[0](hidden_states)

--- a/flash_rt/models/minimax_remover/_attention.py
+++ b/flash_rt/models/minimax_remover/_attention.py
@@ -45,7 +45,15 @@ _SAGE = None
 def _get_sage():
     global _SAGE
     if _SAGE is None:
-        import sageattention as _m
+        try:
+            import sageattention as _m
+        except ImportError as e:
+            raise RuntimeError(
+                "FLASHRT_ATTN_MODE=sage_* requires the 'sageattention' package "
+                "(the default attention backend). Install the model extra:\n"
+                "    pip install -e \".[minimax-remover]\"\n"
+                "or switch to the dependency-light FlashRT FA2 backend:\n"
+                "    FLASHRT_ATTN_MODE=fa2") from e
         _SAGE = _m
     return _SAGE
 

--- a/flash_rt/models/minimax_remover/_kernels.py
+++ b/flash_rt/models/minimax_remover/_kernels.py
@@ -1,0 +1,282 @@
+"""FlashRT -- MiniMax-Remover fused Triton kernels.
+
+Self-contained Triton JIT kernels used by the MiniMax-Remover denoise
+loop. They are the precision-critical elementwise / normalisation ops
+of the Transformer3DModel block forward and the flow-matching step:
+
+* ``ada_layernorm_fp16_io`` -- fp32-stat LayerNorm + adaLN modulation
+  fused into one kernel, fp16/bf16 in/out. The FlashRT generic
+  ``ada_layer_norm_fp16`` loses precision on real diffusion latents;
+  this kernel matches the reference FP32LayerNorm path bit-for-bit by
+  accumulating mean/var in fp32 across three passes.
+* ``rms_norm_fp32stat``      -- RMSNorm with fp32 statistics + affine
+  weight, used for attention norm_q / norm_k.
+* ``gate_mul_residual_bcast``-- in-place ``residual += x * gate`` with a
+  broadcast gate vector (avoids the [S, D] expand copy).
+* ``rope_apply_bshd`` / ``freqs_to_cos_sin`` -- interleaved RoPE applied
+  in-place on the native [B, S, H, D] layout (no transpose / copy).
+* ``euler_step_inplace``     -- in-place Euler flow-matching step with
+  fp32 accumulation, used every denoise step.
+* ``mask_mul`` / ``latent_affine`` -- fused host-side elementwise ops
+  (masked-image build and latent (de)normalisation).
+
+Every kernel here is dtype-generic on fp16 / bf16 and dispatches on the
+input dtype at call time. No model-class imports -- tensors only.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+def _io_dtype(x):
+    return tl.bfloat16 if x.dtype == torch.bfloat16 else tl.float16
+
+
+# ── adaLayerNorm: fp32-stat LayerNorm + (1 + scale) * x_norm + shift ──────
+
+@triton.jit
+def _ada_layernorm_io_kernel(X, SCALE, SHIFT, OUT, M, N, sM_x, sM_o, eps,
+                             BLOCK_N: tl.constexpr, IO_DTYPE: tl.constexpr):
+    row = tl.program_id(0)
+    x_ptr = X + row * sM_x
+    o_ptr = OUT + row * sM_o
+    _mean = tl.zeros([BLOCK_N], dtype=tl.float32)
+    for off in tl.range(0, N, BLOCK_N):
+        cols = off + tl.arange(0, BLOCK_N)
+        mask = cols < N
+        x = tl.load(x_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        _mean += tl.sum(x)
+    mean = _mean / N
+    _var = tl.zeros([BLOCK_N], dtype=tl.float32)
+    for off in tl.range(0, N, BLOCK_N):
+        cols = off + tl.arange(0, BLOCK_N)
+        mask = cols < N
+        x = tl.load(x_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        d = x - mean
+        _var += tl.sum(d * d)
+    rstd = 1.0 / tl.sqrt(_var / N + eps)
+    for off in tl.range(0, N, BLOCK_N):
+        cols = off + tl.arange(0, BLOCK_N)
+        mask = cols < N
+        x = tl.load(x_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        x_norm = (x - mean) * rstd
+        scale = tl.load(SCALE + cols, mask=mask, other=0.0)
+        shift = tl.load(SHIFT + cols, mask=mask, other=0.0)
+        y = x_norm * (1.0 + scale) + shift
+        tl.store(o_ptr + cols, y.to(IO_DTYPE), mask=mask)
+
+
+def ada_layernorm_fp16_io(x, scale, shift, eps=1e-6):
+    """LayerNorm(x) * (1 + scale) + shift -> same dtype as x.
+
+    ``x`` is contiguous [S, D] or [B, S, D] fp16/bf16; scale/shift are
+    [D] vectors. Statistics accumulated in fp32 (reference-equivalent).
+    """
+    orig_shape = x.shape
+    if x.dim() == 3:
+        x = x.reshape(orig_shape[0] * orig_shape[1], orig_shape[2])
+    S, D = x.shape
+    assert x.is_contiguous(), "ada_layernorm_fp16_io: x must be contiguous"
+    scale = scale.contiguous().to(torch.float32).view(-1)
+    shift = shift.contiguous().to(torch.float32).view(-1)
+    out = torch.empty_like(x)
+    BLOCK_N = triton.next_power_of_2(min(D, 2048))
+    num_warps = 8 if D >= 1024 else 4
+    _ada_layernorm_io_kernel[(S,)](
+        x, scale, shift, out, S, D, x.stride(0), out.stride(0), eps,
+        BLOCK_N=BLOCK_N, num_warps=num_warps, IO_DTYPE=_io_dtype(x))
+    return out.reshape(orig_shape)
+
+
+# ── RMSNorm with fp32 statistics + affine weight ─────────────────────────
+
+@triton.jit
+def _rmsnorm_affine_kernel(X, WEIGHT, OUT, Npts, D, EPS, BLOCK_D: tl.constexpr,
+                           IO_DTYPE: tl.constexpr):
+    pt = tl.program_id(0)
+    xp = X + pt * D
+    op = OUT + pt * D
+    _sum = tl.zeros([BLOCK_D], dtype=tl.float32)
+    for off in tl.range(0, D, BLOCK_D):
+        cols = off + tl.arange(0, BLOCK_D)
+        mask = cols < D
+        x = tl.load(xp + cols, mask=mask, other=0.0).to(tl.float32)
+        _sum += tl.sum(x * x)
+    inv_rms = 1.0 / tl.sqrt(_sum / D + EPS)
+    for off in tl.range(0, D, BLOCK_D):
+        cols = off + tl.arange(0, BLOCK_D)
+        mask = cols < D
+        x = tl.load(xp + cols, mask=mask, other=0.0).to(tl.float32)
+        w = tl.load(WEIGHT + cols, mask=mask, other=0.0).to(tl.float32)
+        tl.store(op + cols, (x * inv_rms * w).to(IO_DTYPE), mask=mask)
+
+
+def rms_norm_fp32stat(x, weight, eps):
+    """RMSNorm (fp32 statistics + affine weight[D]). x[.., D] -> same dtype."""
+    D = x.shape[-1]
+    orig_shape = x.shape
+    x2 = x.reshape(-1, D).contiguous()
+    Npts = x2.shape[0]
+    out = torch.empty_like(x2)
+    w = weight.contiguous().to(torch.float32).view(-1)
+    BLOCK_D = 16
+    while BLOCK_D < D and BLOCK_D < 2048:
+        BLOCK_D <<= 1
+    _rmsnorm_affine_kernel[(Npts,)](
+        x2, w, out, Npts, D, float(eps), BLOCK_D=BLOCK_D,
+        num_warps=8 if D >= 256 else 4, IO_DTYPE=_io_dtype(x2))
+    return out.reshape(orig_shape)
+
+
+# ── in-place residual += x * gate (broadcast gate vector) ────────────────
+
+@triton.jit
+def _gate_mul_res_bcast_kernel(RES, X, GATE, Nrow, D, BLOCK_D: tl.constexpr,
+                               IO_DTYPE: tl.constexpr):
+    r = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_D)
+    mask = cols < D
+    rp = RES + r * D
+    x = tl.load(rp + cols, mask=mask).to(tl.float32)
+    xv = tl.load(X + r * D + cols, mask=mask).to(tl.float32)
+    g = tl.load(GATE + cols, mask=mask).to(tl.float32)
+    tl.store(rp + cols, (x + xv * g).to(IO_DTYPE), mask=mask)
+
+
+def gate_mul_residual_bcast(residual, x, gate):
+    """In-place residual[S, D] += x[S, D] * gate[D] (gate broadcast)."""
+    D = residual.shape[-1]
+    res2 = residual.reshape(-1, D)
+    x2 = x.reshape(-1, D)
+    Nrow = res2.shape[0]
+    g = gate.contiguous().to(residual.dtype).view(-1)
+    BLOCK_D = 16
+    while BLOCK_D < D and BLOCK_D < 2048:
+        BLOCK_D <<= 1
+    _gate_mul_res_bcast_kernel[(Nrow,)](res2, x2, g, Nrow, D, BLOCK_D=BLOCK_D,
+                                        num_warps=4, IO_DTYPE=_io_dtype(residual))
+    return residual
+
+
+# ── interleaved RoPE on native [B, S, H, D] layout (in-place) ────────────
+
+@triton.jit
+def _rope_bshd_kernel(X, COS, SIN, Nrows, S, H, Dhalf,
+                      BLOCK_D: tl.constexpr, IO_DTYPE: tl.constexpr):
+    r = tl.program_id(0)
+    s = (r // H) % S
+    x_ptr = X + r * (2 * Dhalf)
+    cos_ptr = COS + s * Dhalf
+    sin_ptr = SIN + s * Dhalf
+    offs = tl.arange(0, BLOCK_D)
+    mask = offs < Dhalf
+    cos = tl.load(cos_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    sin = tl.load(sin_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    x0 = tl.load(x_ptr + 2 * offs, mask=mask, other=0.0).to(tl.float32)
+    x1 = tl.load(x_ptr + 2 * offs + 1, mask=mask, other=0.0).to(tl.float32)
+    tl.store(x_ptr + 2 * offs, (x0 * cos - x1 * sin).to(IO_DTYPE), mask=mask)
+    tl.store(x_ptr + 2 * offs + 1, (x0 * sin + x1 * cos).to(IO_DTYPE), mask=mask)
+
+
+def rope_apply_bshd(x, cos, sin):
+    """In-place interleaved RoPE on contiguous [B, S, H, D].
+
+    cos/sin are [S, D // 2] fp32 tables. Returns x (modified in place).
+    """
+    assert x.is_contiguous(), "rope_apply_bshd: x must be contiguous"
+    B, S, H, D = x.shape
+    Dhalf = D // 2
+    Nrows = B * S * H
+    BLOCK_D = max(16, 1 << max(0, (Dhalf - 1).bit_length()))
+    _rope_bshd_kernel[(Nrows,)](
+        x, cos.contiguous().to(torch.float32), sin.contiguous().to(torch.float32),
+        Nrows, S, H, Dhalf, BLOCK_D=BLOCK_D, num_warps=4, IO_DTYPE=_io_dtype(x))
+    return x
+
+
+def freqs_to_cos_sin(freqs):
+    """complex [1, 1, S, D // 2] -> (cos[S, D // 2] fp32, sin[S, D // 2] fp32)."""
+    f = freqs.squeeze().to(torch.complex64)
+    return f.real.contiguous().to(torch.float32), f.imag.contiguous().to(torch.float32)
+
+
+# ── denoise-loop elementwise kernels (fp32 accumulation, in-place) ───────
+
+@triton.jit
+def _euler_kernel(latents_ptr, noise_ptr, n_elements, dt,
+                  BLOCK: tl.constexpr, IO_DTYPE: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n_elements
+    lat = tl.load(latents_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    noise = tl.load(noise_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    tl.store(latents_ptr + offs, (lat + dt * noise).to(IO_DTYPE), mask=mask)
+
+
+def euler_step_inplace(latents, noise_pred, dt):
+    """In-place Euler flow-matching step: latents += dt * noise_pred."""
+    n = latents.numel()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]),)
+    _euler_kernel[grid](latents, noise_pred, n, float(dt),
+                        BLOCK=2048, IO_DTYPE=_io_dtype(latents))
+
+
+@triton.jit
+def _mask_mul_kernel(a_ptr, b_ptr, out_ptr, n, BLOCK: tl.constexpr,
+                     IO_DTYPE: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    a = tl.load(a_ptr + offs, mask=mask).to(tl.float32)
+    b = tl.load(b_ptr + offs, mask=mask).to(tl.float32)
+    tl.store(out_ptr + offs, (a * (1.0 - b)).to(IO_DTYPE), mask=mask)
+
+
+def mask_mul(a, b):
+    """out = a * (1 - b), same dtype as a. Replaces torch elementwise."""
+    out = torch.empty_like(a)
+    n = a.numel()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]),)
+    _mask_mul_kernel[grid](a, b, out, n, BLOCK=4096, IO_DTYPE=_io_dtype(a))
+    return out
+
+
+@triton.jit
+def _latent_affine_kernel(x_ptr, param_ptr, out_ptr, n, scale, is_sub_mul,
+                          BLOCK: tl.constexpr, IO_DTYPE: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+    p = tl.load(param_ptr + offs, mask=mask).to(tl.float32)
+    if is_sub_mul:
+        result = (x - p) * scale
+    else:
+        result = x * scale + p
+    tl.store(out_ptr + offs, result.to(IO_DTYPE), mask=mask)
+
+
+def latent_normalize(x, mean_param, inv_std_param):
+    """out = (x - mean) * inv_std. Replaces torch elementwise."""
+    out = torch.empty_like(x)
+    inv_std = 1.0 / float(inv_std_param.max())
+    n = x.numel()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]),)
+    _latent_affine_kernel[grid](x, mean_param, out, n, inv_std, True,
+                                BLOCK=4096, IO_DTYPE=_io_dtype(x))
+    return out
+
+
+def latent_denormalize(x, mean_param, inv_std_param):
+    """out = x / inv_std + mean = x * (1/inv_std) + mean.
+
+    inv_std_param stores 1/std; mean_param stores latents_mean.
+    """
+    out = torch.empty_like(x)
+    inv_std_val = float(inv_std_param.max())
+    n = x.numel()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK"]),)
+    _latent_affine_kernel[grid](x, mean_param, out, n, inv_std_val, False,
+                                BLOCK=4096, IO_DTYPE=_io_dtype(x))
+    return out

--- a/flash_rt/models/minimax_remover/_manual_denoise.py
+++ b/flash_rt/models/minimax_remover/_manual_denoise.py
@@ -43,7 +43,7 @@ from ._kernels import (ada_layernorm_fp16_io, gate_mul_residual_bcast,
                        rms_norm_fp32stat, rope_apply_bshd, freqs_to_cos_sin,
                        euler_step_inplace, mask_mul,
                        latent_normalize, latent_denormalize)
-from ._attention import _sage_attn, _attention_mode
+from ._attention import attention_forward, _attention_mode
 
 _USE_FUSED_BLOCK = os.environ.get("FLASHRT_FUSED_BLOCK", "1") == "1"
 
@@ -116,7 +116,7 @@ def block_forward_fused(block, hidden_states, mod, rotary_emb, eps, kern,
     k = k.contiguous()
     v = v.contiguous()
     scale = 1.0 / math.sqrt(float(Dd))
-    out = _sage_attn(q, k, v, scale, _attention_mode())
+    out = attention_forward(q, k, v, scale, _attention_mode())
     attn_out = attn.to_out[0](out.view(1, S, D)).view(S, D)
     gate_mul_residual_bcast(hs, attn_out, mod[2])
 

--- a/flash_rt/models/minimax_remover/_manual_denoise.py
+++ b/flash_rt/models/minimax_remover/_manual_denoise.py
@@ -1,0 +1,413 @@
+"""FlashRT -- MiniMax-Remover manual pointer-based denoise pipeline.
+
+Replaces the diffusers ``Minimax_Remover_Pipeline.__call__`` denoise
+loop with a pointer-based, graph-capturable implementation that mirrors
+the FlashRT frontend pattern:
+
+1. Pre-compute ALL step time embeddings BEFORE graph capture (the
+   condition embedder's ``Timesteps`` uses ``torch.arange`` -- a CPU op
+   that breaks capture).
+2. Pre-compute ALL modulation vectors (``scale_shift_table + temb``) for
+   every step x every block + norm_out, eliminating all ``.float()``
+   casts, additions and chunk ops from the hot path.
+3. Pre-compute RoPE freqs (fixed for a given latent shape).
+4. Pre-compute the Euler flow-matching ``dt`` values.
+5. Manual block forward (``block_forward_fused``): only kernel calls --
+   Triton adaLN, kernel attention, NVFP4 GEMM, Triton gate-mul, FlashRT
+   gelu. QKV quantises the norm output ONCE and reuses it for all three
+   projections; the FFN up GEMM fuses bias + gelu straight to FP4 output
+   so the FFN-down projection skips re-quantisation.
+6. Manual norm_out: Triton adaLN (replaces FP32LayerNorm + mul + add).
+7. CUDA Graph captures the ENTIRE N-step x N-block denoise loop as ONE
+   graph (``FLASHRT_MANUAL_GRAPH=1``).
+8. Euler step via the fp32-accumulating Triton kernel.
+9. VAE encode / decode stay outside the graph (one-shot per segment).
+
+Inside the captured graph there are ZERO torch elementwise ops -- every
+operation is a kernel launch.
+
+No MiniMax-Remover imports: the loaded diffusers ``pipe`` is duck-typed
+through ``pipe.transformer`` / ``pipe.vae`` / ``pipe.scheduler``. The
+``flash_rt_kernels`` module is passed in (``kern``) so importing this
+module never requires the compiled extension.
+"""
+
+import math
+import os
+
+import torch
+from einops import rearrange
+from diffusers.utils.torch_utils import randn_tensor
+
+from ._kernels import (ada_layernorm_fp16_io, gate_mul_residual_bcast,
+                       rms_norm_fp32stat, rope_apply_bshd, freqs_to_cos_sin,
+                       euler_step_inplace, mask_mul,
+                       latent_normalize, latent_denormalize)
+from ._attention import _sage_attn, _attention_mode
+
+_USE_FUSED_BLOCK = os.environ.get("FLASHRT_FUSED_BLOCK", "1") == "1"
+
+
+def _fp4_gemm_raw(a_packed, a_sfa, linear, m, device, kern):
+    """FP4 GEMM from a pre-quantised packed input (no re-quantisation)."""
+    k, n = linear.in_features, linear.out_features
+    out = torch.empty(m, n, dtype=torch.bfloat16, device=device)
+    stream = torch.cuda.current_stream().cuda_stream
+    linear._gemm(
+        a_packed.data_ptr(), linear.weight_packed.data_ptr(), out.data_ptr(),
+        m, n, k, a_sfa.data_ptr(), linear.weight_sfb.data_ptr(),
+        linear.weight_alpha, stream)
+    if linear.bias is not None:
+        kern.add_bias_bf16(out.data_ptr(), linear.bias.data_ptr(), m, n, stream)
+    return out
+
+
+def _quant_to_nvfp4(x_bf16, kern):
+    """Quantise bf16 [S, D] -> (packed [S, D/2], swizzled SF) for FP4 GEMM."""
+    m, k = x_bf16.shape
+    packed = torch.empty(m, k // 2, dtype=torch.uint8, device=x_bf16.device)
+    sfa = torch.empty(kern.nvfp4_sf_swizzled_bytes(m, k), dtype=torch.uint8,
+                      device=x_bf16.device)
+    stream = torch.cuda.current_stream().cuda_stream
+    kern.quantize_bf16_to_nvfp4_swizzled(
+        x_bf16.data_ptr(), packed.data_ptr(), sfa.data_ptr(), m, k, stream)
+    return packed, sfa
+
+
+def block_forward_fused(block, hidden_states, mod, rotary_emb, eps, kern,
+                        cos_sin=None):
+    """Block forward with pre-computed fp32 modulation; fused QKV + FFN.
+
+    ``mod`` is [6, D] fp32: (shift_msa, scale_msa, gate_msa,
+    shift_ffn, scale_ffn, gate_ffn). Only kernel calls remain.
+    """
+    _, S, D = hidden_states.shape
+    hs = hidden_states.contiguous().view(S, D)
+    stream = torch.cuda.current_stream().cuda_stream
+    device = hs.device
+
+    # ── Self-attention sub-layer ──
+    norm1 = ada_layernorm_fp16_io(hs, mod[1], mod[0], eps)
+    packed1, sfa1 = _quant_to_nvfp4(norm1, kern)
+
+    attn = block.attn1
+    H = attn.heads
+    Dd = D // H
+    q = _fp4_gemm_raw(packed1, sfa1, attn.to_q, S, device, kern)
+    k = _fp4_gemm_raw(packed1, sfa1, attn.to_k, S, device, kern)
+    v = _fp4_gemm_raw(packed1, sfa1, attn.to_v, S, device, kern)
+
+    if attn.norm_q is not None:
+        q = rms_norm_fp32stat(q, attn.norm_q.weight, attn.norm_q.eps)
+    if attn.norm_k is not None:
+        k = rms_norm_fp32stat(k, attn.norm_k.weight, attn.norm_k.eps)
+
+    q = q.view(1, S, H, Dd)
+    k = k.view(1, S, H, Dd)
+    v = v.view(1, S, H, Dd)
+
+    if rotary_emb is not None:
+        if cos_sin is None:
+            cos_sin = freqs_to_cos_sin(rotary_emb)
+        rope_apply_bshd(q, cos_sin[0], cos_sin[1])
+        rope_apply_bshd(k, cos_sin[0], cos_sin[1])
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    scale = 1.0 / math.sqrt(float(Dd))
+    out = _sage_attn(q, k, v, scale, _attention_mode())
+    attn_out = attn.to_out[0](out.view(1, S, D)).view(S, D)
+    gate_mul_residual_bcast(hs, attn_out, mod[2])
+
+    # ── FFN sub-layer ──
+    norm2 = ada_layernorm_fp16_io(hs, mod[4], mod[3], eps)
+    packed2, sfa2 = _quant_to_nvfp4(norm2, kern)
+
+    ffn_up = block.ffn.net[0].proj
+    n_inner = ffn_up.out_features
+    up_packed = torch.empty(S, n_inner // 2, dtype=torch.uint8, device=device)
+    up_sfd = torch.empty(kern.nvfp4_sf_swizzled_bytes(S, n_inner),
+                         dtype=torch.uint8, device=device)
+    bias_ptr = ffn_up.bias.data_ptr() if ffn_up.bias is not None else 0
+    kern.fp4_w4a16_gemm_bias_gelu_fp4out_sm120(
+        packed2.data_ptr(), ffn_up.weight_packed.data_ptr(),
+        sfa2.data_ptr(), ffn_up.weight_sfb.data_ptr(),
+        bias_ptr, up_packed.data_ptr(), up_sfd.data_ptr(),
+        S, n_inner, D, ffn_up.weight_alpha, stream)
+
+    ff_out = _fp4_gemm_raw(up_packed, up_sfd, block.ffn.net[2], S, device, kern)
+    gate_mul_residual_bcast(hs, ff_out, mod[5])
+
+    return hs.view(1, S, D)
+
+
+def block_forward_mod(block, hidden_states, mod, rotary_emb, eps, kern,
+                      cos_sin=None):
+    """Non-fused block forward (debug fallback): per-projection re-quant."""
+    _, S, D = hidden_states.shape
+    hs = hidden_states.contiguous().view(S, D)
+
+    norm1 = ada_layernorm_fp16_io(hs, mod[1], mod[0], eps)
+    attn_out = block.attn1(
+        hidden_states=norm1.view(1, S, D), rotary_emb=rotary_emb).view(S, D)
+    gate_mul_residual_bcast(hs, attn_out, mod[2])
+
+    norm2 = ada_layernorm_fp16_io(hs, mod[4], mod[3], eps)
+    up = block.ffn.net[0].proj(norm2.view(1, S, D))
+    inner = up.shape[-1]
+    stream = torch.cuda.current_stream().cuda_stream
+    _gelu_fn = kern.gelu_inplace if up.dtype == torch.bfloat16 else kern.gelu_inplace_fp16
+    _gelu_fn(up.data_ptr(), S * inner, stream)
+    ff_out = block.ffn.net[2](up).view(S, D)
+    gate_mul_residual_bcast(hs, ff_out, mod[5])
+
+    return hs.view(1, S, D)
+
+
+def transformer_forward_mod(transformer, hidden_states, mod_blocks_step,
+                            mod_out_step, rotary_emb, eps, kern):
+    """Transformer forward with pre-computed modulation; no torch elementwise."""
+    B, C_in, T, H, W = hidden_states.shape
+    p_t, p_h, p_w = transformer.config.patch_size
+    post_t, post_h, post_w = T // p_t, H // p_h, W // p_w
+
+    hs = transformer.patch_embedding(hidden_states)
+    hs = hs.flatten(2).transpose(1, 2)
+
+    cos_sin = freqs_to_cos_sin(rotary_emb) if rotary_emb is not None else None
+    block_fn = block_forward_fused if _USE_FUSED_BLOCK else block_forward_mod
+
+    for blk_idx, block in enumerate(transformer.blocks):
+        hs = block_fn(block, hs, mod_blocks_step[blk_idx], rotary_emb, eps, kern, cos_sin)
+
+    S, D = hs.shape[1], hs.shape[2]
+    hs_2d = hs.contiguous().view(S, D)
+    hs_2d = ada_layernorm_fp16_io(hs_2d, mod_out_step[1], mod_out_step[0], eps)
+    hs = transformer.proj_out(hs_2d.view(1, S, D))
+
+    hs = hs.reshape(B, post_t, post_h, post_w, p_t, p_h, p_w, -1)
+    hs = hs.permute(0, 7, 1, 4, 2, 5, 3, 6)
+    return hs.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+
+class ManualRemoverPipeline:
+    """Pointer-based, graph-capturable replacement for ``pipe.__call__``.
+
+    Captures the full N-step denoise loop as one CUDA Graph (when
+    ``FLASHRT_MANUAL_GRAPH=1``) and replays it on subsequent calls with
+    the same latent shape. Inside the captured graph: zero torch
+    elementwise ops -- every operation is a kernel launch.
+
+    The class reads everything it needs off the loaded ``pipe`` (its
+    transformer, vae, scheduler, video processor, expand_masks / resize
+    helpers and VAE scale factors); it imports no MiniMax-Remover code.
+    ``kern`` is the validated ``flash_rt_kernels`` module.
+    """
+
+    def __init__(self, pipe, kern):
+        self.kern = kern
+        self.pipe = pipe
+        self.transformer = pipe.transformer
+        self.vae = pipe.vae
+        self.scheduler = pipe.scheduler
+        self.device = pipe._execution_device
+        self.video_processor = pipe.video_processor
+        self.eps = float(pipe.transformer.config.eps)
+        self.num_blocks = len(pipe.transformer.blocks)
+        self.inner_dim = (pipe.transformer.config.num_attention_heads *
+                          pipe.transformer.config.attention_head_dim)
+        self._dtype = next(pipe.transformer.parameters()).dtype
+        self._vae_dtype = next(pipe.vae.parameters()).dtype
+
+        self._graphs = {}
+        self._mod_cache = None
+        self._rope_cache = {}
+
+    @property
+    def vae_scale_factor_temporal(self):
+        return self.pipe.vae_scale_factor_temporal
+
+    @property
+    def vae_scale_factor_spatial(self):
+        return self.pipe.vae_scale_factor_spatial
+
+    def expand_masks(self, masks, iterations):
+        return self.pipe.expand_masks(masks, iterations)
+
+    def resize(self, images, w, h):
+        return self.pipe.resize(images, w, h)
+
+    def _precompute_modulation(self, temb_all, tproj_all, num_steps):
+        """Pre-compute all modulation vectors for steps x blocks + norm_out."""
+        D = self.inner_dim
+        nb = self.num_blocks
+        tr = self.transformer
+        device = self.device
+
+        mod_blocks = torch.empty(num_steps, nb, 6, D, dtype=torch.float32, device=device)
+        mod_out = torch.empty(num_steps, 2, D, dtype=torch.float32, device=device)
+
+        with torch.no_grad():
+            for step in range(num_steps):
+                tproj = tproj_all[step].float()
+                for blk_idx, block in enumerate(tr.blocks):
+                    mod_blocks[step, blk_idx] = (block.scale_shift_table + tproj).squeeze(0)
+                temb = temb_all[step].float().unsqueeze(1)
+                mod_out[step] = (tr.scale_shift_table + temb).squeeze(0)
+
+        self._mod_cache = (num_steps, mod_blocks, mod_out)
+        return mod_blocks, mod_out
+
+    def __call__(self, images, masks, num_frames, height, width,
+                 num_inference_steps=12, generator=None, iterations=16,
+                 output_type="np"):
+        device = self.device
+        kern = self.kern
+
+        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        timesteps = self.scheduler.timesteps
+        sigmas = self.scheduler.sigmas
+        dt_all = [float(sigmas[i + 1] - sigmas[i]) for i in range(num_inference_steps)]
+
+        vae_t = self.vae_scale_factor_temporal
+        vae_s = self.vae_scale_factor_spatial
+        num_latent_frames = (num_frames - 1) // vae_t + 1
+        lat_shape = (1, 16, num_latent_frames, height // vae_s, width // vae_s)
+        latents = randn_tensor(lat_shape, generator=generator,
+                               device=device, dtype=self._dtype)
+
+        masks_t = self.expand_masks(masks, iterations)
+        masks_t = self.resize(masks_t, height, width).to(device).to(self._vae_dtype)
+        masks_t[masks_t > 0] = 1
+        images_t = rearrange(images, "f h w c -> c f h w")
+        images_t = self.resize(images_t[None, ...], height, width).to(device).to(self._vae_dtype)
+        masked_images = mask_mul(images_t, masks_t)
+
+        latents_mean = (torch.tensor(self.vae.config.latents_mean)
+                        .view(1, self.vae.config.z_dim, 1, 1, 1)
+                        .to(device, self._vae_dtype))
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(
+            1, self.vae.config.z_dim, 1, 1, 1).to(device, self._vae_dtype)
+
+        with torch.no_grad():
+            masked_latents = self.vae.encode(masked_images.to(self._vae_dtype)).latent_dist.mode()
+            masks_latents = self.vae.encode((2 * masks_t - 1.0).to(self._vae_dtype)).latent_dist.mode()
+            masked_latents = latent_normalize(masked_latents, latents_mean, latents_std).to(self._dtype)
+            masks_latents = latent_normalize(masks_latents, latents_mean, latents_std).to(self._dtype)
+
+        if self._mod_cache is None or self._mod_cache[0] != num_inference_steps:
+            with torch.no_grad():
+                temb_all, tproj_all = [], []
+                for i in range(num_inference_steps):
+                    t_step = timesteps[i:i + 1]
+                    temb_i, tproj_i = self.transformer.condition_embedder(t_step)
+                    tproj_i = tproj_i.unflatten(1, (6, -1))
+                    temb_all.append(temb_i)
+                    tproj_all.append(tproj_i)
+            mod_blocks, mod_out = self._precompute_modulation(
+                temb_all, tproj_all, num_inference_steps)
+        else:
+            mod_blocks, mod_out = self._mod_cache[1], self._mod_cache[2]
+
+        rope_key = tuple(latents.shape)
+        rotary_emb = self._rope_cache.get(rope_key)
+        if rotary_emb is None:
+            with torch.no_grad():
+                rotary_emb = self.transformer.rope(latents)
+            self._rope_cache[rope_key] = rotary_emb
+
+        use_graph = os.environ.get("FLASHRT_MANUAL_GRAPH", "0") == "1"
+        shape_key = tuple(latents.shape)
+        entry = self._graphs.get(shape_key)
+
+        if use_graph:
+            if entry is None:
+                entry = self._capture_graph(
+                    latents, masked_latents, masks_latents,
+                    mod_blocks, mod_out, dt_all, rotary_emb, num_inference_steps)
+                self._graphs[shape_key] = entry
+            graph, lat_buf, masked_buf, masks_buf = entry
+            lat_buf.copy_(latents)
+            masked_buf.copy_(masked_latents)
+            masks_buf.copy_(masks_latents)
+            graph.replay()
+            torch.cuda.synchronize()
+            result_latents = lat_buf.clone()
+        else:
+            result_latents = self._denoise_eager(
+                latents, masked_latents, masks_latents,
+                mod_blocks, mod_out, dt_all, rotary_emb, num_inference_steps)
+
+        result_latents = latent_denormalize(result_latents.to(self._vae_dtype),
+                                            latents_mean, latents_std)
+        with torch.no_grad():
+            video = self.vae.decode(result_latents, return_dict=False)[0]
+            video = self.video_processor.postprocess_video(video, output_type=output_type)
+
+        from diffusers.pipelines.wan.pipeline_output import WanPipelineOutput
+        return WanPipelineOutput(frames=video)
+
+    def _denoise_eager(self, latents, masked_latents, masks_latents,
+                       mod_blocks, mod_out, dt_all, rotary_emb, num_steps):
+        device = latents.device
+        kern = self.kern
+        C = latents.shape[1]
+        concat_buf = torch.empty(latents.shape[0], 3 * C, *latents.shape[2:],
+                                 dtype=self._dtype, device=device)
+        lat_buf = latents.clone()
+        tr = self.transformer
+        eps = self.eps
+
+        for step in range(num_steps):
+            concat_buf[:, :C].copy_(lat_buf)
+            concat_buf[:, C:2 * C].copy_(masked_latents)
+            concat_buf[:, 2 * C:3 * C].copy_(masks_latents)
+            noise_pred = transformer_forward_mod(
+                tr, concat_buf, mod_blocks[step], mod_out[step], rotary_emb, eps, kern)
+            euler_step_inplace(lat_buf, noise_pred, dt_all[step])
+
+        return lat_buf
+
+    def _capture_graph(self, latents, masked_latents, masks_latents,
+                       mod_blocks, mod_out, dt_all, rotary_emb, num_steps):
+        """Capture the entire N-step denoise loop as one CUDA Graph."""
+        device = latents.device
+        kern = self.kern
+        C = latents.shape[1]
+        B, _, T, H, W = latents.shape
+
+        lat_buf = latents.clone()
+        masked_buf = masked_latents.clone()
+        masks_buf = masks_latents.clone()
+        concat_buf = torch.empty(B, 3 * C, T, H, W, dtype=self._dtype, device=device)
+
+        tr = self.transformer
+        eps = self.eps
+
+        def denoise():
+            for step in range(num_steps):
+                concat_buf[:, :C].copy_(lat_buf)
+                concat_buf[:, C:2 * C].copy_(masked_buf)
+                concat_buf[:, 2 * C:3 * C].copy_(masks_buf)
+                noise_pred = transformer_forward_mod(
+                    tr, concat_buf, mod_blocks[step], mod_out[step], rotary_emb, eps, kern)
+                euler_step_inplace(lat_buf, noise_pred, dt_all[step])
+
+        s = torch.cuda.Stream()
+        with torch.cuda.stream(s):
+            concat_buf[:, :C].copy_(lat_buf)
+            concat_buf[:, C:2 * C].copy_(masked_buf)
+            concat_buf[:, 2 * C:3 * C].copy_(masks_buf)
+            noise_pred = transformer_forward_mod(
+                tr, concat_buf, mod_blocks[0], mod_out[0], rotary_emb, eps, kern)
+            euler_step_inplace(lat_buf, noise_pred, dt_all[0])
+            torch.cuda.current_stream().wait_stream(s)
+        torch.cuda.synchronize()
+        lat_buf.copy_(latents)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=s):
+            denoise()
+
+        return (graph, lat_buf, masked_buf, masks_buf)

--- a/flash_rt/models/minimax_remover/_nvfp4_linear.py
+++ b/flash_rt/models/minimax_remover/_nvfp4_linear.py
@@ -1,0 +1,236 @@
+"""FlashRT -- MiniMax-Remover NVFP4 (W4A4) Linear layer.
+
+Replaces every eligible ``nn.Linear`` in the Transformer3DModel with a
+NVFP4 W4A4 GEMM backed by the generic FlashRT NVFP4 kernels:
+
+* Weights are quantised once at load time to NVFP4 via
+  ``bf16_weight_to_nvfp4_swizzled`` (packed [N, K/2] e2m1 + tile-swizzled
+  block-scale factors + a host-scalar global ``alpha``).
+* Activations are quantised dynamically per call via
+  ``quantize_bf16_to_nvfp4_swizzled`` (per-16-element UE4M3 block scales
+  computed on-GPU, no CPU sync, no offline calibration -- this is the
+  key difference from the static FP8 path).
+* The GEMM ``fp4_w4a16_gemm_sm120_bf16out`` is the SM120-native W4A4
+  MMA producing a bf16 output (the kernel name keeps the legacy
+  ``w4a16`` token but both operands are FP4).
+
+Shape constraints (SM120 FP4 MMA): K >= 64, K % 16 == 0, N % 16 == 0.
+All MiniMax-Remover Linears (K in {5120, 13824}, N in {64, 5120, 13824})
+satisfy this; ineligible layers (none in practice) keep the original
+Linear. NVFP4 needs no calibration, so the calibration shims below are
+no-ops kept only for API compatibility.
+"""
+
+import os
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+_BF16 = torch.bfloat16
+_FP16 = torch.float16
+
+_FP4_MIN_K = 64
+_FP4_ALIGN = 16
+
+
+def _sf_swizzled_bytes(rows, dim, kern):
+    return kern.nvfp4_sf_swizzled_bytes(rows, dim)
+
+
+def _quantize_weight_nvfp4(w, kern):
+    """Quantise an [N, K] bf16 weight to NVFP4.
+
+    Returns ``(packed[N, K/2] uint8, sfb uint8, alpha python float)``.
+    """
+    assert w.dtype == _BF16, f"FP4 weight quant requires bf16, got {w.dtype}"
+    N, K = w.shape
+    assert K % _FP4_ALIGN == 0 and N % _FP4_ALIGN == 0 and K >= _FP4_MIN_K, (
+        f"FP4 weight shape unsupported N={N} K={K} "
+        f"(need K>=64, N%16==0, K%16==0)")
+    w = w.contiguous()
+    packed = torch.empty(N, K // 2, dtype=torch.uint8, device=w.device)
+    sfb = torch.empty(_sf_swizzled_bytes(N, K, kern), dtype=torch.uint8, device=w.device)
+    scratch_amax = torch.empty(1, dtype=torch.float32, device=w.device)
+    out_global = torch.empty(1, dtype=torch.float32, device=w.device)
+    kern.bf16_weight_to_nvfp4_swizzled(
+        w.data_ptr(), packed.data_ptr(), sfb.data_ptr(),
+        scratch_amax.data_ptr(), out_global.data_ptr(), N, K, 0)
+    torch.cuda.synchronize(w.device)
+    alpha = float(out_global.item())
+    return packed, sfb, alpha
+
+
+def _pick_gemm(kern):
+    mode = os.environ.get("FLASHRT_FP4_GEMM", "pingpong").lower()
+    if mode == "plain":
+        return kern.fp4_w4a16_gemm_sm120_bf16out
+    if mode == "widen":
+        return kern.fp4_w4a16_gemm_sm120_bf16out_widen
+    return kern.fp4_w4a16_gemm_sm120_bf16out_pingpong
+
+
+class FlashRTNvfp4Linear(nn.Module):
+    """Linear layer backed by the FlashRT NVFP4 (W4A4) GEMM.
+
+    Computes ``y = x @ weight^T + bias`` where the weight is stored as
+    NVFP4 and the activation is quantised to NVFP4 dynamically per call.
+    The SM120 FP4 kernels are bf16-native; the residual stream is fp16,
+    so this layer casts fp16 -> bf16 on entry and bf16 -> fp16 on exit
+    (two large-tensor casts, memory-bound, ~0.04 ms/layer).
+    """
+
+    def __init__(self, in_features, out_features, bias=True,
+                 device=None, dtype=torch.float16, kern=None):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self._kern = kern
+
+        self.weight_packed = nn.Parameter(
+            torch.empty(out_features, in_features // 2, dtype=torch.uint8, device=device),
+            requires_grad=False)
+        self.weight_sfb = nn.Parameter(
+            torch.empty(_sf_swizzled_bytes(out_features, in_features, kern),
+                        dtype=torch.uint8, device=device),
+            requires_grad=False)
+        self.weight_alpha = 1.0
+        self.register_buffer(
+            "weight_alpha_buf", torch.ones(1, dtype=torch.float32, device=device),
+            persistent=False)
+
+        if bias:
+            self.bias = nn.Parameter(
+                torch.zeros(out_features, dtype=_BF16, device=device),
+                requires_grad=False)
+        else:
+            self.register_parameter("bias", None)
+
+        self.calibrating = False
+        self._gemm = _pick_gemm(kern)
+
+    @property
+    def weight(self):
+        return self.weight_packed
+
+    @classmethod
+    def from_linear(cls, linear, kern):
+        in_f, out_f = linear.weight.shape[1], linear.weight.shape[0]
+        layer = cls(in_f, out_f, bias=linear.bias is not None,
+                    device=linear.weight.device, dtype=_FP16, kern=kern)
+        w_bf16 = linear.weight.data.to(_BF16)
+        packed, sfb, alpha = _quantize_weight_nvfp4(w_bf16, kern)
+        layer.weight_packed.data = packed
+        layer.weight_sfb.data = sfb
+        layer.weight_alpha = alpha
+        layer.weight_alpha_buf.data = torch.tensor([alpha], dtype=torch.float32,
+                                                   device=w_bf16.device)
+        if linear.bias is not None:
+            layer.bias.data = linear.bias.data.to(_BF16)
+        return layer
+
+    def forward(self, x):
+        kern = self._kern
+        in_dtype = x.dtype
+        if x.dtype != _BF16:
+            x = x.to(_BF16)
+
+        orig_shape = x.shape
+        x2d = x.reshape(-1, self.in_features)
+        if x2d.stride(0) != self.in_features or x2d.stride(1) != 1:
+            x2d = x2d.contiguous()
+        m = x2d.shape[0]
+        k, n = self.in_features, self.out_features
+        stream = torch.cuda.current_stream().cuda_stream
+
+        a_packed = torch.empty(m, k // 2, dtype=torch.uint8, device=x2d.device)
+        a_sfa = torch.empty(_sf_swizzled_bytes(m, k, kern), dtype=torch.uint8, device=x2d.device)
+        kern.quantize_bf16_to_nvfp4_swizzled(
+            x2d.data_ptr(), a_packed.data_ptr(), a_sfa.data_ptr(), m, k, stream)
+
+        out = torch.empty(m, n, dtype=_BF16, device=x2d.device)
+        self._gemm(
+            a_packed.data_ptr(), self.weight_packed.data_ptr(), out.data_ptr(),
+            m, n, k, a_sfa.data_ptr(), self.weight_sfb.data_ptr(),
+            self.weight_alpha, stream)
+        if self.bias is not None:
+            kern.add_bias_bf16(out.data_ptr(), self.bias.data_ptr(), m, n, stream)
+        out = out.view(*orig_shape[:-1], n)
+
+        if in_dtype != _BF16:
+            out = out.to(in_dtype)
+        return out
+
+    def freeze_act_scale(self, margin=1.0):
+        pass
+
+
+def _is_nvfp4_eligible(linear):
+    if not isinstance(linear, nn.Linear):
+        return False
+    in_f, out_f = linear.weight.shape[1], linear.weight.shape[0]
+    return (in_f % _FP4_ALIGN == 0 and out_f % _FP4_ALIGN == 0
+            and in_f >= _FP4_MIN_K)
+
+
+def install_flashrt_nvfp4(model, kern, verbose=False, target="all"):
+    """Recursively replace eligible Linears in ``model`` with NVFP4 layers.
+
+    ``target``:
+      * ``"all"`` (default) -- every attention / ffn / proj Linear.
+      * ``"ffn_only"``      -- only the FFN up/down projections (higher
+        precision, the speedup comes from the large GEMMs anyway).
+    Timestep / condition embedders are always skipped (precision
+    sensitive and small). Returns the number of replaced layers.
+    """
+    replaced = 0
+    skipped_shape = 0
+    skip_substr = ("time_embedder", "condition_embedder")
+
+    if target == "ffn_only":
+        include_patterns = ("ffn.net.0.proj", "ffn.net.2")
+    else:
+        include_patterns = ()
+
+    def _should_replace(name):
+        if any(s in name for s in skip_substr):
+            return False
+        if include_patterns:
+            return any(p in name for p in include_patterns)
+        return True
+
+    targets = []
+    for name, module in model.named_modules():
+        if not isinstance(module, nn.Linear):
+            continue
+        if not _should_replace(name):
+            continue
+        targets.append((name, module))
+
+    for name, linear in targets:
+        if not _is_nvfp4_eligible(linear):
+            skipped_shape += 1
+            continue
+        parent = model
+        for p in name.split(".")[:-1]:
+            parent = getattr(parent, p)
+        attr = name.split(".")[-1]
+        setattr(parent, attr, FlashRTNvfp4Linear.from_linear(linear, kern))
+        replaced += 1
+
+    return replaced
+
+
+def set_calibration(model, on):
+    for module in model.modules():
+        if isinstance(module, FlashRTNvfp4Linear):
+            module.calibrating = on
+
+
+def freeze_calibration(model, margin=1.0):
+    n = 0
+    for module in model.modules():
+        if isinstance(module, FlashRTNvfp4Linear):
+            module.freeze_act_scale(margin)
+            n += 1
+    return n

--- a/flash_rt/models/minimax_remover/pipeline.py
+++ b/flash_rt/models/minimax_remover/pipeline.py
@@ -35,15 +35,12 @@ import types
 
 import torch
 
-from ._nvfp4_linear import install_flashrt_nvfp4
-from ._attention import install_attention
-from ._manual_denoise import ManualRemoverPipeline
-
 logger = logging.getLogger(__name__)
 
 # Core generic SM120 NVFP4 kernel surface required by this pipeline. All of
-# these are gated by the Blackwell NVFP4 build option; if any is missing the
-# pipeline cannot run and _load_kernels raises a clear RuntimeError.
+# these are compiled in automatically on a Blackwell (sm_120a / sm_121a)
+# build; if any is missing the pipeline cannot run and _load_kernels raises
+# a clear RuntimeError.
 _REQUIRED_NVFP4_SYMBOLS = (
     "nvfp4_sf_swizzled_bytes",
     "bf16_weight_to_nvfp4_swizzled",
@@ -52,6 +49,41 @@ _REQUIRED_NVFP4_SYMBOLS = (
     "add_bias_bf16",
     "fp4_w4a16_gemm_bias_gelu_fp4out_sm120",
 )
+
+# Optional third-party packages pulled in only when the pipeline is actually
+# constructed. Importing this model package never touches them, so
+# `import flash_rt.models.minimax_remover` succeeds in a bare environment.
+_RUNTIME_DEPS = ("diffusers", "einops", "triton")
+
+
+def _import_runtime():
+    """Lazily import the optional runtime deps + the pipeline submodules.
+
+    Importing ``flash_rt.models.minimax_remover`` does not require any of
+    the optional dependencies; they are only resolved here, at pipeline
+    construction time. Raises ``RuntimeError`` with an install hint if any
+    optional dep is missing instead of a low-level ``ModuleNotFoundError``.
+
+    Returns ``(install_flashrt_nvfp4, install_attention, ManualRemoverPipeline)``.
+    """
+    missing = []
+    for dep in _RUNTIME_DEPS:
+        try:
+            __import__(dep)
+        except ImportError:
+            missing.append(dep)
+    if missing:
+        raise RuntimeError(
+            "MiniMax-Remover runtime requires "
+            f"{', '.join(missing)} which {'is' if len(missing) == 1 else 'are'} "
+            "not installed. Install the model extra:\n"
+            "    pip install -e \".[minimax-remover]\"\n"
+            "('triton' normally ships with torch on CUDA; 'diffusers' and "
+            "'einops' are in the extra.)")
+    from ._nvfp4_linear import install_flashrt_nvfp4
+    from ._attention import install_attention
+    from ._manual_denoise import ManualRemoverPipeline
+    return install_flashrt_nvfp4, install_attention, ManualRemoverPipeline
 
 
 def _load_kernels():
@@ -75,9 +107,12 @@ def _load_kernels():
     if missing:
         raise RuntimeError(
             "MiniMax-Remover requires the SM120 NVFP4 kernels which are not "
-            "compiled into flash_rt_kernels. Rebuild with the Blackwell NVFP4 "
-            "build option enabled (ENABLE_CUTLASS_SM120_NVFP4_W4A16) so the "
-            "NVFP4 quantise / GEMM / fused-bias-gelu kernels are present.\n"
+            "compiled into flash_rt_kernels. Build FlashRT for Blackwell, which "
+            "auto-enables the NVFP4 kernels:\n"
+            "    cmake -S . -B build -DGPU_ARCH=120 -DCMAKE_BUILD_TYPE=Release\n"
+            "    cmake --build build -j --target flash_rt_kernels\n"
+            "(sm_120a / sm_121a, i.e. GPU_ARCH=120/121). The internal compile "
+            "flag is ENABLE_CUTLASS_SM120_NVFP4_W4A16.\n"
             f"Missing symbols: {', '.join(missing)}")
     return fvk
 
@@ -122,6 +157,10 @@ class MiniMaxRemoverPipeline:
     def __init__(self, pipe, num_inference_steps=12, fp4_target="all",
                  use_bf16=True, use_manual_pipeline=True):
         self.fvk = _load_kernels()
+        # Optional runtime deps (diffusers / einops / triton) and the pipeline
+        # submodules are resolved here, at construction time -- importing the
+        # model package never touches them.
+        install_flashrt_nvfp4, install_attention, ManualRemoverPipeline = _import_runtime()
         self.pipe = pipe
         self.transformer = pipe.transformer
         self.num_inference_steps = num_inference_steps

--- a/flash_rt/models/minimax_remover/pipeline.py
+++ b/flash_rt/models/minimax_remover/pipeline.py
@@ -1,0 +1,207 @@
+"""FlashRT -- MiniMax-Remover NVFP4 kernelized inference pipeline.
+
+MiniMax-Remover is a flow-matching video inpainting model (a
+Transformer3DModel + an AutoencoderKLWan VAE). This pipeline rewrites the
+transformer denoise path onto NVFP4 (W4A4) GEMMs driven by the generic
+FlashRT kernels, fused fp32-stat Triton norm/RoPE, kernel attention and
+a graph-capturable manual N-step flow-matching loop.
+
+What is replaced (vs the diffusers reference ``Minimax_Remover_Pipeline``):
+
+* every eligible transformer Linear -> NVFP4 W4A4 GEMM (weight quantised
+  once at load time, activation quantised dynamically per call -- no
+  offline calibration).
+* per-block norm/gate/residual/gelu elementwise -> single fused kernels.
+* ``torch.nn.functional.scaled_dot_product_attention`` -> FA2 / SageAttention.
+* the N-step Python denoise loop -> a single captured CUDA Graph
+  (``FLASHRT_MANUAL_GRAPH=1``); inside the graph there are zero torch
+  elementwise ops, only kernel launches.
+
+The loaded diffusers ``pipe`` is consumed in place: it is duck-typed
+(``.transformer`` / ``.vae`` / ``.scheduler`` / ``.video_processor`` and
+the ``expand_masks`` / ``resize`` helpers). No MiniMax-Remover source is
+imported -- the VAE encode / decode run unchanged from the loaded model.
+
+The pipeline requires the generic SM120 NVFP4 kernels in
+``flash_rt_kernels``. They are gated by the Blackwell NVFP4 build option
+(``ENABLE_CUTLASS_SM120_NVFP4_W4A16``); ``_load_kernels`` validates them
+and raises a clear ``RuntimeError`` if they are absent, so a non-NVFP4
+build fails fast instead of crashing mid-quantisation.
+"""
+
+import logging
+import os
+import types
+
+import torch
+
+from ._nvfp4_linear import install_flashrt_nvfp4
+from ._attention import install_attention
+from ._manual_denoise import ManualRemoverPipeline
+
+logger = logging.getLogger(__name__)
+
+# Core generic SM120 NVFP4 kernel surface required by this pipeline. All of
+# these are gated by the Blackwell NVFP4 build option; if any is missing the
+# pipeline cannot run and _load_kernels raises a clear RuntimeError.
+_REQUIRED_NVFP4_SYMBOLS = (
+    "nvfp4_sf_swizzled_bytes",
+    "bf16_weight_to_nvfp4_swizzled",
+    "quantize_bf16_to_nvfp4_swizzled",
+    "fp4_w4a16_gemm_sm120_bf16out_pingpong",
+    "add_bias_bf16",
+    "fp4_w4a16_gemm_bias_gelu_fp4out_sm120",
+)
+
+
+def _load_kernels():
+    """Import ``flash_rt_kernels`` and validate the required NVFP4 surface.
+
+    Returns the raw ``flash_rt_kernels`` module. Raises ``RuntimeError``
+    if any required symbol is missing (i.e. the build was not configured
+    with the Blackwell NVFP4 kernels enabled).
+    """
+    try:
+        from flash_rt import flash_rt_kernels as fvk
+    except ImportError:
+        try:
+            import flash_rt_kernels as fvk  # type: ignore
+        except ImportError:
+            raise RuntimeError(
+                "flash_rt_kernels is not available. Build FlashRT with "
+                "'pip install -e .' and ensure the compiled .so is on the path.")
+
+    missing = [s for s in _REQUIRED_NVFP4_SYMBOLS if not hasattr(fvk, s)]
+    if missing:
+        raise RuntimeError(
+            "MiniMax-Remover requires the SM120 NVFP4 kernels which are not "
+            "compiled into flash_rt_kernels. Rebuild with the Blackwell NVFP4 "
+            "build option enabled (ENABLE_CUTLASS_SM120_NVFP4_W4A16) so the "
+            "NVFP4 quantise / GEMM / fused-bias-gelu kernels are present.\n"
+            f"Missing symbols: {', '.join(missing)}")
+    return fvk
+
+
+class _FrozenMarker:
+    """NVFP4 needs no calibration (per-call dynamic quantisation).
+
+    This marker reports ``is_frozen() == True`` so a smart ``__call__``
+    routes straight to the manual graph pipeline on the first call.
+    """
+
+    def __init__(self):
+        self._frozen = True
+
+    def is_frozen(self):
+        return self._frozen
+
+
+class MiniMaxRemoverPipeline:
+    """NVFP4 kernelized inference pipeline for MiniMax-Remover.
+
+    Wraps a loaded diffusers MiniMax-Remover ``pipe`` and rewrites the
+    transformer denoise path onto NVFP4 GEMMs, fused Triton norm/RoPE,
+    kernel attention and a graph-capturable manual flow-matching loop.
+    The pipe is consumed in place; transformer Linears referenced by the
+    patched path are quantised to NVFP4 and the original weights deleted.
+
+    Args:
+        pipe: a loaded diffusers pipeline exposing ``.transformer``,
+            ``.vae``, ``.scheduler``, ``.video_processor``,
+            ``_execution_device``, ``expand_masks``, ``resize`` and the
+            ``vae_scale_factor_temporal`` / ``vae_scale_factor_spatial``
+            properties.
+        num_inference_steps: default denoise step count (12).
+        fp4_target: ``"all"`` (default, every attention/ffn/proj Linear)
+            or ``"ffn_only"`` (FFN up/down only).
+        use_bf16: run the transformer in bf16 (NVFP4-native, no cast).
+        use_manual_pipeline: install the graph-capturable manual denoise
+            loop (default ``True``).
+    """
+
+    def __init__(self, pipe, num_inference_steps=12, fp4_target="all",
+                 use_bf16=True, use_manual_pipeline=True):
+        self.fvk = _load_kernels()
+        self.pipe = pipe
+        self.transformer = pipe.transformer
+        self.num_inference_steps = num_inference_steps
+
+        n_lin = install_flashrt_nvfp4(self.transformer, self.fvk,
+                                      verbose=False, target=fp4_target)
+        logger.info("MiniMax-Remover: target=%r, %d Linears -> NVFP4 W4A4 GEMM",
+                    fp4_target, n_lin)
+
+        if use_bf16:
+            self.transformer.to(torch.bfloat16)
+            logger.info("MiniMax-Remover: transformer -> bf16 (NVFP4-native)")
+
+        self._optimize_rope()
+
+        n_attn = install_attention(self.transformer)
+        logger.info("MiniMax-Remover: %d attention blocks -> kernel backend", n_attn)
+
+        pipe._flashrt_wrapper = _FrozenMarker()
+
+        self._manual = None
+        if use_manual_pipeline:
+            self._manual = ManualRemoverPipeline(pipe, self.fvk)
+            self._install_smart_call()
+            logger.info("MiniMax-Remover: manual denoise pipeline installed "
+                        "(CUDA-graph capturable, NVFP4 dynamic quant -- no calibration)")
+
+    def _optimize_rope(self):
+        """Cache the RoPE freqs as complex<float>.
+
+        The reference caches complex128/float64 which is slow on consumer
+        GPUs. Patched on the loaded rope module's class (no model import).
+        """
+        rope_module = getattr(self.transformer, "rope", None)
+        if rope_module is None:
+            return
+        rope_cls = type(rope_module)
+        orig = rope_cls.forward
+
+        def rope_fwd_c64(self, hidden_states):
+            out = orig(self, hidden_states)
+            return out.to(torch.complex64) if out.dtype == torch.complex128 else out
+
+        rope_cls.forward = rope_fwd_c64
+
+    def _install_smart_call(self):
+        """Route ``pipe.__call__`` to the manual pipeline (frozen, no calibration)."""
+        _orig_call = self.pipe.__class__.__call__
+
+        @torch.no_grad()
+        def _smart_call(self, *args, **kwargs):
+            w = getattr(self, "_flashrt_wrapper", None)
+            m = getattr(self, "_manual_pipeline", None)
+            ns = os.environ.get("FLASHRT_NUM_STEPS")
+            if ns:
+                kwargs["num_inference_steps"] = int(ns)
+            if w is not None and w.is_frozen() and m is not None:
+                return m(*args, **kwargs)
+            return _orig_call(self, *args, **kwargs)
+
+        self.pipe.__class__.__call__ = _smart_call
+        self.pipe._manual_pipeline = self._manual
+
+    def __call__(self, images, masks, num_frames, height, width,
+                 num_inference_steps=None, generator=None, iterations=16,
+                 output_type="np"):
+        """Run the NVFP4 denoise loop.
+
+        Delegates to the manual pipeline when installed (the optimised
+        path), otherwise to the patched diffusers ``pipe.__call__``.
+        """
+        if num_inference_steps is None:
+            num_inference_steps = self.num_inference_steps
+        if self._manual is not None:
+            return self._manual(
+                images, masks, num_frames, height, width,
+                num_inference_steps=num_inference_steps, generator=generator,
+                iterations=iterations, output_type=output_type)
+        return self.pipe(
+            images=images, masks=masks, num_frames=num_frames,
+            height=height, width=width,
+            num_inference_steps=num_inference_steps, generator=generator,
+            iterations=iterations, output_type=output_type)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ torch = ["torch", "safetensors", "sentencepiece"]
 jax = ["jax", "jaxlib", "ml_dtypes", "orbax-checkpoint", "flax"]
 server = ["fastapi", "uvicorn"]
 eval = ["opencv-python", "tqdm"]
+# MiniMax-Remover NVFP4 video-inpainting pipeline. Optional: only needed to
+# construct/run flash_rt.models.minimax_remover (importing the package needs
+# none of these). diffusers + einops are the runtime model deps; sageattention
+# is the default attention backend (FLASHRT_ATTN_MODE=sage_fp8) -- switch to
+# FLASHRT_ATTN_MODE=fa2 to drop it. triton ships with torch on CUDA.
+minimax-remover = ["diffusers", "einops", "sageattention"]
 # Optional. Required only for the legacy upstream attention path
 # (FVK_RTX_FA2=0 / FVK_RTX_FA2_SITES=...) and the GROOT N1.6/N1.7
 # backend. Default RTX Pi0 / Pi0.5 inference uses the vendored
@@ -35,7 +41,7 @@ flash-attn = ["flash-attn"]
 # (flash_rt/hardware/thor/fa4_backend.py) sets CUTE_DSL_ARCH=sm_101a.
 # Requires an editable / source-tree install (pip install -e). pip install ".[thor-fa4]".
 thor-fa4 = ["nvidia-cutlass-dsl==4.5.1", "quack-kernels==0.4.1"]
-all = ["flash-rt[torch,jax,server,eval]"]
+all = ["flash-rt[torch,jax,server,eval,minimax-remover]"]
 
 [tool.setuptools.packages.find]
 include = ["flash_rt*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,11 @@ server = ["fastapi", "uvicorn"]
 eval = ["opencv-python", "tqdm"]
 # MiniMax-Remover NVFP4 video-inpainting pipeline. Optional: only needed to
 # construct/run flash_rt.models.minimax_remover (importing the package needs
-# none of these). diffusers + einops are the runtime model deps; sageattention
-# is the default attention backend (FLASHRT_ATTN_MODE=sage_fp8) -- switch to
-# FLASHRT_ATTN_MODE=fa2 to drop it. triton ships with torch on CUDA.
-minimax-remover = ["diffusers", "einops", "sageattention"]
+# none of these). diffusers + einops are the runtime model deps; scipy is used
+# by the quickstart mask helpers; sageattention is the default attention backend
+# (FLASHRT_ATTN_MODE=sage_fp8) -- switch to FLASHRT_ATTN_MODE=fa2 to drop it.
+# triton ships with torch on CUDA.
+minimax-remover = ["diffusers", "einops", "scipy", "sageattention"]
 # Optional. Required only for the legacy upstream attention path
 # (FVK_RTX_FA2=0 / FVK_RTX_FA2_SITES=...) and the GROOT N1.6/N1.7
 # backend. Default RTX Pi0 / Pi0.5 inference uses the vendored

--- a/tests/test_minimax_remover_smoke.py
+++ b/tests/test_minimax_remover_smoke.py
@@ -1,0 +1,170 @@
+"""Smoke tests for MiniMax-Remover FlashRT integration.
+
+These tests run in **any** build configuration:
+  - default build (SM120 NVFP4 kernels absent): import succeeds,
+    ``_load_kernels`` raises ``RuntimeError``, pipeline construction
+    fails fast.
+  - gated build (SM120 NVFP4 kernels present): the required NVFP4
+    symbols are present and callable.
+
+No GPU, no model checkpoint, no MiniMax-Remover source tree is required.
+"""
+import pytest
+
+
+# ── 1. Package import always succeeds ──
+
+def test_package_import():
+    """Importing the model package must not require flash_rt_kernels."""
+    from flash_rt.models.minimax_remover import MiniMaxRemoverPipeline
+    assert MiniMaxRemoverPipeline is not None
+
+
+def test_pipeline_module_import():
+    """The pipeline module imports cleanly without flash_rt_kernels."""
+    from flash_rt.models.minimax_remover import pipeline
+    assert hasattr(pipeline, "MiniMaxRemoverPipeline")
+    assert hasattr(pipeline, "_load_kernels")
+    assert hasattr(pipeline, "_REQUIRED_NVFP4_SYMBOLS")
+    assert "nvfp4_sf_swizzled_bytes" in pipeline._REQUIRED_NVFP4_SYMBOLS
+
+
+# ── 2. _load_kernels validates the NVFP4 surface ──
+
+def test_load_kernels_raises_when_symbols_absent():
+    """Without the NVFP4 kernels, _load_kernels raises a clear RuntimeError."""
+    from flash_rt.models.minimax_remover import pipeline
+
+    class _NoNvfp4:
+        # Module stub exposing none of the required symbols.
+        pass
+
+    import sys
+    import types
+
+    fake_mod = types.ModuleType("flash_rt.flash_rt_kernels")
+    sys.modules["flash_rt.flash_rt_kernels"] = fake_mod
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            pipeline._load_kernels()
+        msg = str(excinfo.value)
+        assert "NVFP4" in msg
+        assert "Missing symbols" in msg
+        assert "nvfp4_sf_swizzled_bytes" in msg
+    finally:
+        del sys.modules["flash_rt.flash_rt_kernels"]
+
+
+def test_load_kernels_succeeds_when_symbols_present():
+    """With all required symbols, _load_kernels returns the kernels module."""
+    from flash_rt.models.minimax_remover import pipeline
+
+    import sys
+    import types
+
+    fake_mod = types.ModuleType("flash_rt.flash_rt_kernels")
+    for s in pipeline._REQUIRED_NVFP4_SYMBOLS:
+        setattr(fake_mod, s, lambda *a, **k: None)
+    sys.modules["flash_rt.flash_rt_kernels"] = fake_mod
+    try:
+        fvk = pipeline._load_kernels()
+        assert fvk is fake_mod
+    finally:
+        del sys.modules["flash_rt.flash_rt_kernels"]
+
+
+# ── 3. Pipeline construction validates kernel availability ──
+
+class _FakePipe:
+    """Minimal stub matching the diffusers pipeline contract.
+
+    Construction must fail at _load_kernels before any pipe attribute is
+    touched, so the stub is never actually read.
+    """
+
+
+def test_pipeline_constructor_validates_kernels(monkeypatch):
+    """Pipeline construction must fail before touching model internals."""
+    from flash_rt.models.minimax_remover import pipeline
+
+    def _raise_missing():
+        raise RuntimeError(
+            "MiniMax-Remover requires the SM120 NVFP4 kernels which are not "
+            "compiled into flash_rt_kernels. Rebuild with the Blackwell NVFP4 "
+            "build option enabled.")
+
+    monkeypatch.setattr(pipeline, "_load_kernels", _raise_missing)
+    with pytest.raises(RuntimeError, match="NVFP4"):
+        pipeline.MiniMaxRemoverPipeline(_FakePipe())
+
+
+def test_pipeline_constructor_calls_load_kernels(monkeypatch):
+    """_load_kernels is invoked exactly once during construction."""
+    from flash_rt.models.minimax_remover import pipeline
+
+    calls = []
+
+    def _fake_load():
+        calls.append(1)
+        raise RuntimeError("stop construction here")
+
+    monkeypatch.setattr(pipeline, "_load_kernels", _fake_load)
+    with pytest.raises(RuntimeError, match="stop construction"):
+        pipeline.MiniMaxRemoverPipeline(_FakePipe())
+    assert len(calls) == 1
+
+
+# ── 4. Gated build: required NVFP4 symbols present and callable ──
+
+def test_nvfp4_symbols_present_when_gated():
+    """In a gated build, every required NVFP4 symbol is present & callable."""
+    try:
+        from flash_rt import flash_rt_kernels as fvk
+    except ImportError:
+        try:
+            import flash_rt_kernels as fvk  # type: ignore
+        except ImportError:
+            pytest.skip("flash_rt_kernels not built")
+
+    from flash_rt.models.minimax_remover.pipeline import _REQUIRED_NVFP4_SYMBOLS
+    missing = [s for s in _REQUIRED_NVFP4_SYMBOLS if not hasattr(fvk, s)]
+    if missing:
+        pytest.skip(f"SM120 NVFP4 kernels not compiled (missing: {', '.join(missing)})")
+
+    for sym in _REQUIRED_NVFP4_SYMBOLS:
+        assert callable(getattr(fvk, sym)), f"{sym} is not callable"
+
+
+def test_nvfp4_symbols_absent_in_default_build():
+    """In a default (non-NVFP4) build, _load_kernels documents the gap.
+
+    This documents the 'compile option OFF' case end-to-end: if any
+    required symbol is missing the pipeline refuses to construct.
+    """
+    try:
+        from flash_rt import flash_rt_kernels as fvk
+    except ImportError:
+        pytest.skip("flash_rt_kernels not built (treated as missing)")
+    from flash_rt.models.minimax_remover.pipeline import _REQUIRED_NVFP4_SYMBOLS
+
+    missing = [s for s in _REQUIRED_NVFP4_SYMBOLS if not hasattr(fvk, s)]
+    if not missing:
+        pytest.skip("this build has the NVFP4 kernels (gated build) — covered elsewhere")
+
+    # Verify _load_kernels raises and names the missing symbols.
+    import sys
+    import types
+
+    fake_mod = types.ModuleType("flash_rt.flash_rt_kernels")
+    for s in _REQUIRED_NVFP4_SYMBOLS:
+        if hasattr(fvk, s):
+            setattr(fake_mod, s, getattr(fvk, s))
+    sys.modules["flash_rt.flash_rt_kernels"] = fake_mod
+    try:
+        from flash_rt.models.minimax_remover import pipeline
+        with pytest.raises(RuntimeError) as excinfo:
+            pipeline._load_kernels()
+        for s in missing:
+            assert s in str(excinfo.value)
+    finally:
+        del sys.modules["flash_rt.flash_rt_kernels"]

--- a/tests/test_minimax_remover_smoke.py
+++ b/tests/test_minimax_remover_smoke.py
@@ -29,6 +29,52 @@ def test_pipeline_module_import():
     assert "nvfp4_sf_swizzled_bytes" in pipeline._REQUIRED_NVFP4_SYMBOLS
 
 
+def test_attention_forward_fa2_does_not_import_sageattention(monkeypatch):
+    """The documented fa2 fallback must not require sageattention."""
+    import sys
+    import types
+
+    import torch
+
+    import flash_rt
+    from flash_rt.models.minimax_remover import _attention
+
+    calls = []
+    fake_fa2 = types.SimpleNamespace(
+        fwd_fp16=lambda *args: calls.append(args))
+    monkeypatch.setattr(flash_rt, "flash_rt_fa2", fake_fa2, raising=False)
+    monkeypatch.setitem(sys.modules, "flash_rt.flash_rt_fa2", fake_fa2)
+    monkeypatch.setattr(
+        _attention, "_get_sage",
+        lambda: pytest.fail("fa2 mode must not import sageattention"))
+
+    class _FakeStream:
+        cuda_stream = 0
+
+    monkeypatch.setattr(torch.cuda, "current_stream",
+                        lambda: _FakeStream(), raising=False)
+
+    q = torch.empty(1, 2, 1, 4, dtype=torch.float16)
+    k = torch.empty_like(q)
+    v = torch.empty_like(q)
+    out = _attention.attention_forward(q, k, v, 0.5, "fa2")
+
+    assert out.shape == q.shape
+    assert calls
+
+
+def test_manual_fused_block_uses_shared_attention_forward():
+    """The manual fused block must respect FLASHRT_ATTN_MODE."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "flash_rt/models/minimax_remover/_manual_denoise.py").read_text()
+
+    assert "from ._attention import attention_forward" in src
+    assert "_sage_attn" not in src
+    assert "attention_forward(q, k, v, scale, _attention_mode())" in src
+
+
 # ── 2. _load_kernels validates the NVFP4 surface ──
 
 def test_load_kernels_raises_when_symbols_absent():


### PR DESCRIPTION
Performance highlights (RTX 5060 Ti, SM120, CUDA 13):
- End-to-end: 2.6x speedup (30.7s -> 11.9s for 123 frames, 3 segments)
- RTF improvement: 6.0 -> 2.3 (processing-time / clip-duration)
- Per-layer GEMM: 1.14-1.30x speedup vs fp16 matmul
- FP4 GEMM with quantize overhead: 4-9x faster than fp16 on large FFN projections
- Precision: PSNR 52.0 dB (mean) / 45.2 dB (worst frame) vs fp16

Optimizations:
- NVFP4 W4A4 quantization with dynamic per-call activation (no offline calibration)
- Fused LayerNorm + adaLN + gate-residual in single fp32-stat Triton kernel
- Fused FFN-up GEMM + bias + GELU -> FP4 output (skip re-quantization for FFN-down)
- QKV quantize-once optimization (reuse quantized norm output for Q/K/V projections)
- Manual graph-capturable denoise loop with CUDA Graph support
- BF16 transformer (NVFP4-native, eliminates fp16<->bf16 casts)
- SageAttention / FA2 backend integration
- Shared attention dispatch for installed processors and the manual fused block, so `FLASHRT_ATTN_MODE=fa2` uses the dependency-light FA2 path without importing `sageattention`

Validation:
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_minimax_remover_smoke.py`: 8 passed, 2 skipped
- `python -m compileall -q flash_rt/models/minimax_remover tests/test_minimax_remover_smoke.py examples/minimax_remover_quickstart.py`: passed
- `git diff --check`: passed
- Import check for `flash_rt`, `flash_rt.models.minimax_remover`, `_kernels`, and `pipeline`: passed
- `FLASHRT_ATTN_MODE=fa2` dispatch check with a stub `flash_rt_fa2`: passed without touching SageAttention
