### PR TITLE
feat(qwen3-vl): add Orin BF16 frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,30 +952,55 @@ endif()
 if(FLASHRT_BUILD_QWEN3_VL)
   # SM120 (RTX 5090): NVFP4/FP8 ViT helpers. SM89 (Ada): native FP8 block-128
   # GEMM/GEMV + fused act/norm-quant + QK norm-rope kernels for the official
-  # FP8 Qwen3-VL path. Both build into the same separate module so neither
-  # bloats the central flash_rt_kernels.so.
-  if(NOT (GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89"))
+  # FP8 Qwen3-VL path. SM87 (Jetson Orin): BF16 ViT helper module only; the
+  # language path reuses the generic flash_rt_kernels BF16 Qwen3 helpers.
+  # All build into a separate module so neither bloats flash_rt_kernels.so.
+  if(NOT (GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89" OR
+          GPU_ARCH STREQUAL "87"))
     message(FATAL_ERROR
       "FLASHRT_BUILD_QWEN3_VL requires GPU_ARCH=120 (RTX 5090 / sm_120) or "
-      "GPU_ARCH=89 (Ada / sm_89); got '${GPU_ARCH}'.")
+      "GPU_ARCH=89 (Ada / sm_89) or GPU_ARCH=87 (Jetson Orin / sm_87); "
+      "got '${GPU_ARCH}'.")
   endif()
+
   set(QWEN3_VL_SOURCES
     csrc/qwen3_vl_bindings.cpp
     csrc/kernels/rope_neox_qk_bf16.cu
-    csrc/kernels/norm_act_to_fp8_block128.cu
     csrc/kernels/bias_epilogue_bf16.cu)
-  if(GPU_ARCH STREQUAL "89")
+
+  if(GPU_ARCH STREQUAL "120")
+    list(APPEND QWEN3_VL_SOURCES
+      csrc/kernels/norm_act_to_fp8_block128.cu)
+  elseif(GPU_ARCH STREQUAL "89")
     # Ada has no TMA / no warp-specialized CUTLASS collective, so these are
     # hand-written cp.async + ldmatrix + block-128 scaling kernels (see
     # docs/qwen3_vl_fp8_sm89.md for why the SM120a CUTLASS path does not port).
     list(APPEND QWEN3_VL_SOURCES
+      csrc/kernels/norm_act_to_fp8_block128.cu
       csrc/gemm/fp8_block128_gemm_mma_sm89.cu
       csrc/gemm/fp8_gemv_m1_sm89.cu
       csrc/quantize/fp8_per_token_block_quant.cu
       csrc/kernels/qwen3_qkv_post_proc.cu
       csrc/kernels/bf16_matmul_bf16.cu)
+  elseif(GPU_ARCH STREQUAL "87")
+    list(APPEND QWEN3_VL_SOURCES
+      csrc/kernels/bf16_matmul_bf16.cu
+      csrc/kernels/qwen3_vl_bf16_gemv_m1.cu)
   endif()
+
   pybind11_add_module(flash_rt_qwen3_vl_kernels ${QWEN3_VL_SOURCES})
+  if(GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89")
+    target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
+      ENABLE_QWEN3_VL_FP8_ACT=1)
+  endif()
+  if(GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "89")
+    target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
+      ENABLE_QWEN3_VL_BF16_CUBLASLT=1)
+  endif()
+  if(GPU_ARCH STREQUAL "87")
+    target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
+      ENABLE_QWEN3_VL_BF16_GEMV_M1=1)
+  endif()
   if(GPU_ARCH STREQUAL "89")
     target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
       ENABLE_SM89_BLOCK_FP8_GEMM=1)
@@ -995,8 +1020,8 @@ if(FLASHRT_BUILD_QWEN3_VL)
       ${GPU_GENCODE}
     >)
   target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cudart)
-  if(GPU_ARCH STREQUAL "89")
-    # bf16_matmul_bf16 (ViT bf16 linears on SM89) uses cuBLASLt.
+  if(GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "89")
+    # bf16_matmul_bf16 (ViT/language bf16 linears) uses cuBLASLt.
     target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cublasLt)
   endif()
   install(TARGETS flash_rt_qwen3_vl_kernels

--- a/csrc/kernels/bf16_matmul_bf16.cu
+++ b/csrc/kernels/bf16_matmul_bf16.cu
@@ -10,10 +10,14 @@
 #include "bf16_matmul_bf16.cuh"
 
 #include <cublasLt.h>
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
 #include <mutex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace flash_rt::kernels {
 
@@ -39,6 +43,7 @@ struct Bf16LtPlan {
     cublasLtMatrixLayout_t b_desc = nullptr;
     cublasLtMatrixLayout_t c_desc = nullptr;
     cublasLtMatmulAlgo_t algo{};
+    bool autotuned = false;
 };
 
 struct Bf16LtKey {
@@ -66,6 +71,17 @@ static size_t g_bf16_workspace_size = 32 * 1024 * 1024;
 static std::mutex g_bf16_mu;
 static std::unordered_map<Bf16LtKey, Bf16LtPlan, Bf16LtKeyHash>
     g_bf16_plans;
+
+static int get_bf16_autotune_algos() {
+    const char* env = std::getenv("FLASHRT_BF16_CUBLASLT_AUTOTUNE_ALGOS");
+    if (!env || !*env) return 8;
+    return std::clamp(std::atoi(env), 1, 32);
+}
+
+static bool get_bf16_autotune_verbose() {
+    const char* env = std::getenv("FLASHRT_BF16_CUBLASLT_AUTOTUNE_VERBOSE");
+    return env && std::atoi(env) != 0;
+}
 
 static void ensure_bf16_lt() {
     if (g_bf16_lt) return;
@@ -133,6 +149,150 @@ static Bf16LtPlan& get_bf16_lt_plan(int M, int N, int K) {
 
     auto [inserted, _] = g_bf16_plans.emplace(key, plan);
     return inserted->second;
+}
+
+static void autotune_bf16_lt_plan(
+    Bf16LtPlan& plan,
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int M,
+    int N,
+    int K,
+    cudaStream_t stream) {
+    if (plan.autotuned) return;
+    const int num_algos = get_bf16_autotune_algos();
+    if (num_algos <= 1) {
+        plan.autotuned = true;
+        return;
+    }
+    cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+    cudaError_t capture_err = cudaStreamIsCapturing(stream, &capture_status);
+    if (capture_err == cudaSuccess && capture_status != cudaStreamCaptureStatusNone) {
+        return;
+    }
+
+    cublasLtMatmulPreference_t pref;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceCreate(&pref));
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulPreferenceSetAttribute(
+        pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+        &g_bf16_workspace_size, sizeof(g_bf16_workspace_size)));
+
+    std::vector<cublasLtMatmulHeuristicResult_t> heuristics(num_algos);
+    int returned = 0;
+    FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmulAlgoGetHeuristic(
+        g_bf16_lt, plan.desc, plan.a_desc, plan.b_desc,
+        plan.c_desc, plan.c_desc, pref, num_algos, heuristics.data(),
+        &returned));
+    cublasLtMatmulPreferenceDestroy(pref);
+    if (returned <= 1) {
+        plan.autotuned = true;
+        return;
+    }
+
+    cudaEvent_t start, stop;
+    cudaError_t err = cudaEventCreate(&start);
+    if (err != cudaSuccess) {
+        throw std::runtime_error(std::string("cudaEventCreate failed: ") +
+                                 cudaGetErrorString(err));
+    }
+    err = cudaEventCreate(&stop);
+    if (err != cudaSuccess) {
+        cudaEventDestroy(start);
+        throw std::runtime_error(std::string("cudaEventCreate failed: ") +
+                                 cudaGetErrorString(err));
+    }
+
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    constexpr int kWarmup = 1;
+    constexpr int kBench = 3;
+    float best_ms = 1.0e30f;
+    int best_idx = -1;
+
+    for (int i = 0; i < returned; ++i) {
+        bool ok = true;
+        for (int w = 0; w < kWarmup; ++w) {
+            cublasStatus_t st = cublasLtMatmul(
+                g_bf16_lt, plan.desc, &alpha,
+                x, plan.a_desc,
+                W, plan.b_desc,
+                &beta,
+                out, plan.c_desc,
+                out, plan.c_desc,
+                &heuristics[i].algo, g_bf16_workspace,
+                g_bf16_workspace_size, stream);
+            if (st != CUBLAS_STATUS_SUCCESS) {
+                ok = false;
+                break;
+            }
+        }
+        if (!ok) continue;
+
+        err = cudaEventRecord(start, stream);
+        if (err != cudaSuccess) {
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            throw std::runtime_error(std::string("cudaEventRecord failed: ") +
+                                     cudaGetErrorString(err));
+        }
+        for (int b = 0; b < kBench; ++b) {
+            cublasStatus_t st = cublasLtMatmul(
+                g_bf16_lt, plan.desc, &alpha,
+                x, plan.a_desc,
+                W, plan.b_desc,
+                &beta,
+                out, plan.c_desc,
+                out, plan.c_desc,
+                &heuristics[i].algo, g_bf16_workspace,
+                g_bf16_workspace_size, stream);
+            if (st != CUBLAS_STATUS_SUCCESS) {
+                ok = false;
+                break;
+            }
+        }
+        if (!ok) continue;
+        err = cudaEventRecord(stop, stream);
+        if (err != cudaSuccess) {
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            throw std::runtime_error(std::string("cudaEventRecord failed: ") +
+                                     cudaGetErrorString(err));
+        }
+        err = cudaEventSynchronize(stop);
+        if (err != cudaSuccess) {
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            throw std::runtime_error(std::string("cudaEventSynchronize failed: ") +
+                                     cudaGetErrorString(err));
+        }
+        float ms = 0.0f;
+        err = cudaEventElapsedTime(&ms, start, stop);
+        if (err != cudaSuccess) {
+            cudaEventDestroy(start);
+            cudaEventDestroy(stop);
+            throw std::runtime_error(std::string("cudaEventElapsedTime failed: ") +
+                                     cudaGetErrorString(err));
+        }
+        ms /= static_cast<float>(kBench);
+        if (ms < best_ms) {
+            best_ms = ms;
+            best_idx = i;
+        }
+    }
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(stop);
+    if (best_idx >= 0) {
+        plan.algo = heuristics[best_idx].algo;
+    }
+    plan.autotuned = true;
+    if (best_idx >= 0 && get_bf16_autotune_verbose()) {
+        std::cout << "  bf16_matmul_cublaslt autotune: shape=("
+                  << M << "," << N << "," << K << ") tested=" << returned
+                  << " best=" << best_idx << " (" << best_ms * 1000.0f
+                  << " us)" << std::endl;
+    }
 }
 
 // Vectorized: each thread reads 8 bf16 = 16 bytes per iter via int4.
@@ -253,7 +413,7 @@ void bf16_matmul_bf16(
     dim3 grid((N + kWarpsPerBlock - 1) / kWarpsPerBlock, M);
     // Specialization set must match the bf16_matvec sibling so the
     // M=1 reference and the M=K test produce bit-identical reductions
-    // (different chunking → different fma order → bf16 drift). matvec
+    // (different chunking -> different fma order -> bf16 drift). matvec
     // specializes K=5120 and K=4096; everything else (incl. K=6144 for
     // lin_K out_proj) falls to the generic chunked path.
     if (K == 5120) {
@@ -277,6 +437,10 @@ void bf16_matmul_cublaslt_bf16(
     cudaStream_t stream) {
     if (M <= 0 || N <= 0 || K <= 0) return;
     Bf16LtPlan& plan = get_bf16_lt_plan(M, N, K);
+    if (!plan.autotuned) {
+        std::lock_guard<std::mutex> lock(g_bf16_mu);
+        autotune_bf16_lt_plan(plan, x, W, out, M, N, K, stream);
+    }
     const float alpha = 1.0f;
     const float beta = 0.0f;
     FLASHRT_BF16_MATMUL_CUBLASLT_CHECK(cublasLtMatmul(

--- a/csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
@@ -1,0 +1,87 @@
+#include "qwen3_vl_bf16_gemv_m1.cuh"
+
+#include <stdexcept>
+#include <string>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kWarpsPerBlock = 8;
+constexpr int kThreads = kWarpsPerBlock * 32;
+
+template<int K_FIXED>
+__global__ void qwen3_vl_bf16_gemv_m1_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ W,
+    __nv_bfloat16* __restrict__ out,
+    int N) {
+    __shared__ __nv_bfloat16 x_sh[K_FIXED];
+
+    const int4* x_i4 = reinterpret_cast<const int4*>(x);
+    int4* x_sh_i4 = reinterpret_cast<int4*>(x_sh);
+    constexpr int K_INT4 = K_FIXED / 8;
+    #pragma unroll 1
+    for (int j = threadIdx.x; j < K_INT4; j += kThreads) {
+        x_sh_i4[j] = x_i4[j];
+    }
+    __syncthreads();
+
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x & 31;
+    const int n = blockIdx.x * kWarpsPerBlock + warp_id;
+    if (n >= N) return;
+
+    const int4* w_row_i4 = reinterpret_cast<const int4*>(W + n * K_FIXED);
+
+    float acc = 0.0f;
+    #pragma unroll 1
+    for (int i4 = lane; i4 < K_INT4; i4 += 32) {
+        int4 wv = w_row_i4[i4];
+        int4 xv = x_sh_i4[i4];
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            __nv_bfloat162 wb = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&wv)[k]));
+            __nv_bfloat162 xb = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&xv)[k]));
+            float2 wf = __bfloat1622float2(wb);
+            float2 xf = __bfloat1622float2(xb);
+            acc = fmaf(xf.x, wf.x, acc);
+            acc = fmaf(xf.y, wf.y, acc);
+        }
+    }
+
+    #pragma unroll
+    for (int off = 16; off > 0; off /= 2) {
+        acc += __shfl_xor_sync(0xffffffff, acc, off);
+    }
+    if (lane == 0) {
+        out[n] = __float2bfloat16(acc);
+    }
+}
+
+}  // namespace
+
+void qwen3_vl_bf16_gemv_m1(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int N,
+    int K,
+    cudaStream_t stream) {
+    dim3 grid((N + kWarpsPerBlock - 1) / kWarpsPerBlock);
+    if (K == 2048) {
+        qwen3_vl_bf16_gemv_m1_kernel<2048>
+            <<<grid, kThreads, 0, stream>>>(x, W, out, N);
+    } else if (K == 6144) {
+        qwen3_vl_bf16_gemv_m1_kernel<6144>
+            <<<grid, kThreads, 0, stream>>>(x, W, out, N);
+    } else {
+        throw std::runtime_error(
+            "qwen3_vl_bf16_gemv_m1 supports only K=2048 or K=6144, got K=" +
+            std::to_string(K));
+    }
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_bf16_gemv_m1.cuh
+++ b/csrc/kernels/qwen3_vl_bf16_gemv_m1.cuh
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace flash_rt::kernels {
+
+void qwen3_vl_bf16_gemv_m1(
+    const __nv_bfloat16* x,
+    const __nv_bfloat16* W,
+    __nv_bfloat16* out,
+    int N,
+    int K,
+    cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -22,22 +22,28 @@
 #include <cstdint>
 
 #include <cuda_bf16.h>
+#ifdef ENABLE_QWEN3_VL_FP8_ACT
 #include <cuda_fp8.h>
+#endif
 #include <cuda_runtime.h>
 
 // SM89 Qwen3-VL FP8 kernels (block-128 GEMM/GEMV + fused act/norm quant +
 // fused QK norm-rope-kvwrite). Bound here so the SM89 path imports them from
 // this dedicated module, just like the SM120 ViT helpers below, instead of
 // bloating the central flash_rt_kernels bindings.
+#if defined(ENABLE_SM89_BLOCK_FP8_GEMM) || defined(ENABLE_QWEN3_VL_BF16_CUBLASLT)
+#include "kernels/bf16_matmul_bf16.cuh"
+#endif
+
+#ifdef ENABLE_QWEN3_VL_BF16_GEMV_M1
+#include "kernels/qwen3_vl_bf16_gemv_m1.cuh"
+#endif
+
 #ifdef ENABLE_SM89_BLOCK_FP8_GEMM
 #include "gemm/fp8_block128_gemm_mma_sm89.cuh"
 #include "gemm/fp8_gemv_m1_sm89.cuh"
 #include "quantize/fp8_per_token_block_quant.cuh"
 #include "kernels/qwen3_qkv_post_proc.cuh"
-// Only bf16_matmul_cublaslt_bf16 is needed here; it lives in the neutral
-// matmul translation unit (#112), so the Qwen3-VL module no longer has to
-// pull in the Qwen3.6 AB96 matmul file.
-#include "kernels/bf16_matmul_bf16.cuh"
 #endif
 
 namespace py = pybind11;
@@ -50,6 +56,13 @@ void rope_neox_qk_bf16(
     __nv_bfloat16* q_out, __nv_bfloat16* k_out,
     int rows, int q_heads, int k_heads, int head_dim, cudaStream_t stream);
 
+#ifdef ENABLE_QWEN3_VL_BF16_GEMV_M1
+void qwen3_vl_bf16_gemv_m1(
+    const __nv_bfloat16* x, const __nv_bfloat16* W, __nv_bfloat16* out,
+    int N, int K, cudaStream_t stream);
+#endif
+
+#ifdef ENABLE_QWEN3_VL_FP8_ACT
 void layer_norm_to_fp8_block128_bf16(
     const __nv_bfloat16* x, const __nv_bfloat16* gamma,
     const __nv_bfloat16* beta, __nv_fp8_e4m3* out, float* scale,
@@ -62,6 +75,7 @@ void gelu_tanh_to_fp8_block128_bf16(
 void gelu_tanh_bias_to_fp8_block128_bf16(
     const __nv_bfloat16* x, const __nv_bfloat16* bias, __nv_fp8_e4m3* out,
     float* scale, int rows, int dim, cudaStream_t stream);
+#endif
 
 void residual_add_bias_bf16(
     __nv_bfloat16* residual, const __nv_bfloat16* x,
@@ -108,6 +122,7 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         py::arg("q_heads"), py::arg("k_heads"), py::arg("head_dim"),
         py::arg("stream") = 0);
 
+#ifdef ENABLE_QWEN3_VL_FP8_ACT
     m.def(
         "layer_norm_to_fp8_block128_bf16",
         [](uintptr_t x, uintptr_t gamma, uintptr_t beta, uintptr_t out,
@@ -145,6 +160,7 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         },
         py::arg("x"), py::arg("bias"), py::arg("out"), py::arg("scale"),
         py::arg("rows"), py::arg("dim"), py::arg("stream") = 0);
+#endif
 
     m.def(
         "residual_add_bias_bf16",
@@ -326,9 +342,11 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
     BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w4);
     BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w8);
     BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w16);
+#endif  // ENABLE_SM89_BLOCK_FP8_GEMM
 
-    // BF16 cuBLASLt matmul for the ViT bf16 linears on SM89 (the SM120 path
-    // uses w16a16_gemm_sm120_bf16 from flash_rt_kernels instead).
+#ifdef ENABLE_QWEN3_VL_BF16_CUBLASLT
+    // BF16 cuBLASLt matmul for Qwen3-VL BF16 linears on SM87/SM89. SM120
+    // uses w16a16_gemm_sm120_bf16 from flash_rt_kernels instead.
     m.def("bf16_matmul_cublaslt_bf16",
         [](uintptr_t x, uintptr_t W, uintptr_t out,
            int M, int N, int K, uintptr_t stream) {
@@ -340,5 +358,19 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         },
         py::arg("x"), py::arg("W"), py::arg("out"),
         py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0);
-#endif  // ENABLE_SM89_BLOCK_FP8_GEMM
+
+#ifdef ENABLE_QWEN3_VL_BF16_GEMV_M1
+    m.def("qwen3_vl_bf16_gemv_m1",
+        [](uintptr_t x, uintptr_t W, uintptr_t out,
+           int N, int K, uintptr_t stream) {
+            flash_rt::kernels::qwen3_vl_bf16_gemv_m1(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const __nv_bfloat16*>(W),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("W"), py::arg("out"),
+        py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+#endif
+#endif
 }

--- a/docs/qwen3_vl_rtx_bf16.md
+++ b/docs/qwen3_vl_rtx_bf16.md
@@ -1,0 +1,245 @@
+# Qwen3-VL official BF16 on Jetson Orin (SM87)
+
+This path brings up Qwen3-VL on Jetson Orin using the official BF16
+checkpoint weights. It is the SM87 baseline counterpart to the optimized
+SM89 FP8 and SM120 NVFP4 Qwen3-VL paths: the model stays in BF16, while the
+runtime still uses FlashRT fixed-shape CUDA Graph replay and a small set of
+Orin-friendly BF16 kernels.
+
+The fully validated target for this path is `Qwen3-VL-2B-Instruct` on Jetson
+AGX Orin 32G. The frontend is config-driven and can load
+`Qwen3-VL-8B-Instruct`, but practical memory headroom is tight on Orin 32G;
+8B has only been checked with a constrained low-resolution 1-token smoke test.
+
+## Checkpoint
+
+Use an official BF16 checkpoint:
+
+```text
+Qwen3-VL-2B-Instruct
+Qwen3-VL-8B-Instruct
+```
+
+The language stack tensors are stored under `model.language_model.layers.*`.
+Linear weights remain BF16. Sharded and single-file safetensors checkpoints
+are both supported. For checkpoints with tied embeddings, such as the 2B
+release, the BF16 loader synthesizes `lm_head` from `embed_tokens` when no
+separate `lm_head.weight` exists.
+
+## Build
+
+Build the regular FlashRT kernels, FlashAttention module, and Qwen3-VL helper
+module for SM87:
+
+```bash
+cmake -B build -S . \
+  -DGPU_ARCH=87 \
+  -DFA2_ARCH_NATIVE_ONLY=ON \
+  -DFLASHRT_BUILD_QWEN3_VL=ON
+cmake --build build -j4 \
+  --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels
+```
+
+On SM87, `flash_rt_qwen3_vl_kernels` provides BF16 Qwen3-VL helper kernels.
+It does not build the SM89 FP8 activation-quantization sources.
+
+## Runtime Architecture
+
+The runtime frontend is:
+
+```python
+flash_rt.frontends.torch.qwen3_vl_rtx_bf16.Qwen3VlTorchFrontendRtxBF16
+```
+
+The dtype mapping is:
+
+| Component | SM87 BF16 path |
+|---|---|
+| Language weights | Official BF16 |
+| Language activations | BF16 |
+| Language GEMM output | BF16 |
+| Attention Q/K/V cache | BF16 |
+| Attention backend | BF16 FA2 |
+| Residual stream and norms | BF16 |
+| Vision tower | BF16 |
+| `lm_head` | BF16 |
+
+The language stack uses the generic FlashRT BF16 Qwen3 helpers:
+`bf16_matmul_bf16`, `rms_norm`, `residual_add_rms_norm`,
+`silu_mul_qwen36_bf16`, and fused Q/K norm + RoPE + KV-write kernels.
+
+The vision tower reuses `Qwen3VlVisionRtx` in BF16 mode. On SM87, Qwen3-VL
+BF16 prefill GEMMs use a cuBLASLt helper from `flash_rt_qwen3_vl_kernels`.
+Decode-time `M=1` language GEMMs use a Qwen3-VL-specific BF16 GEMV helper for
+the 2B model's dominant `K=2048` and `K=6144` projections.
+
+The cuBLASLt autotune change is limited to callers of
+`bf16_matmul_cublaslt_bf16`; the regular `bf16_matmul_bf16`, INT8, FP8, and
+NVFP4 kernels are unchanged. Autotuning is skipped during CUDA Graph capture.
+
+The BF16 frontend currently supports single-image chat prompts and greedy
+generation. It stages single-image prompt tensors into fixed buffers, captures
+one prefill graph per `(patch_count, seq_len, image_span)` bucket, and captures
+decode graphs per `(cache_pos, rope_pos)` bucket.
+
+## Quickstart
+
+```bash
+python examples/orin/qwen3_vl_quickstart.py \
+  --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+  --image FlashRT.png \
+  --prompt "Describe this image in one sentence." \
+  --max-new-tokens 32
+```
+
+Use `--no-graph` to run the eager correctness path without CUDA Graph replay.
+
+For the full-resolution comparison workload used by the existing Qwen3-VL
+FP8/NVFP4 reports:
+
+```bash
+python examples/orin/qwen3_vl_quickstart.py \
+  --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+  --image FlashRT.png \
+  --prompt "Describe this image in one sentence." \
+  --max-new-tokens 4 \
+  --benchmark 3
+```
+
+`FlashRT.png` at full resolution produces 6256 vision patches and 1581 prompt
+tokens. Pass `--max-pixels` only when deliberately trading visual resolution
+for latency; the BF16 frontend forwards this through the Qwen3-VL processor's
+smart-resize policy rather than manually resizing the image.
+
+## Jetson Orin Validation
+
+Environment:
+
+- Device: Jetson AGX Orin 32G, SM87
+- L4T: R36.4.7
+- CUDA Toolkit: 12.6.68
+- PyTorch: 2.8.0 + CUDA 12.6
+- Checkpoint: `/root/models/Qwen3-VL-2B-Instruct`
+- Workload: `FlashRT.png`, prompt `Describe this image in one sentence.`
+
+Local checks:
+
+```bash
+python -m py_compile \
+  flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py \
+  examples/orin/qwen3_vl_quickstart.py
+python -m pytest tests/test_qwen3_vl_rtx_bf16.py tests/test_build_inventory.py -q
+git diff --check
+```
+
+Runtime smoke validation compared the same prompt through HuggingFace BF16,
+FlashRT BF16 eager (`--no-graph`), and FlashRT BF16 graph paths. FlashRT eager
+and graph produced the same short continuation on the small smoke prompt.
+
+Full-resolution Orin BF16 result with cuBLASLt autotuning and the M=1 BF16
+GEMV decode helper enabled:
+
+```text
+vision patches: 6256
+prompt tokens: 1581
+max_new_tokens: 4
+generate latency: 5768.0 ms cold / 1050.5 ms warm
+prefill graph P50: 927.5 ms
+decode throughput (warm graph): 36.8 tok/s
+```
+
+With cuBLASLt autotuning disabled via
+`FLASHRT_BF16_CUBLASLT_AUTOTUNE_ALGOS=1`, the same binary measured:
+
+```text
+generate latency: 4973.0 ms cold / 1066.7 ms warm
+prefill graph P50: 953.8 ms
+decode throughput (warm graph): 36.7 tok/s
+```
+
+The decode throughput improvement over the earlier generic M=1 BF16 GEMM
+bring-up comes from the Qwen3-VL `K=2048/6144` M=1 BF16 GEMV path. The
+cuBLASLt autotune mainly affects M>1 prefill replay.
+
+### Resolution knob
+
+Resolution capping is an explicit deployment knob. It reduces both vision
+patches and LLM prefill tokens:
+
+| `max_pixels` | vision patches | prompt tokens | warm generate | prefill graph P50 | decode throughput |
+|---|---:|---:|---:|---:|---:|
+| none | 6256 | 1581 | 1050.5 ms | 927.5 ms | 36.8 tok/s |
+| 1.0 M | 3888 | 989 | 600.2 ms | 503.6 ms | 41.4 tok/s |
+| 0.5 M | 1824 | 473 | 317.3 ms | 216.1 ms | 39.0 tok/s |
+| 0.25 M | 972 | 260 | 234.6 ms | 127.2 ms | 39.6 tok/s |
+
+These capped-resolution numbers are not the full-resolution baseline. They
+only show the expected prefill scaling when the processor emits fewer visual
+tokens.
+
+### 8B support
+
+The same BF16 frontend can load `Qwen3-VL-8B-Instruct`. On Jetson AGX Orin
+32G, memory headroom is tight, so validation was limited to a low-resolution
+1-token smoke:
+
+```text
+max_pixels: 250000
+max_seq: 2048
+max_new_tokens: 1
+latency: 2790.9 ms
+```
+
+This confirms the checkpoint path is loadable, but the validated target for
+this BF16 path remains Qwen3-VL-2B on Orin 32G. Orin configurations with more
+memory should have more room for larger `max_pixels`, longer sequences, and
+more decode tokens.
+
+## Profiling Notes
+
+A replay-only Nsight profile was collected on the full-resolution workload
+after graph capture and warmup:
+
+```bash
+nsys profile --trace=cuda \
+  --capture-range=cudaProfilerApi --capture-range-end=stop \
+  --cuda-graph-trace=node \
+  -o /root/qwen3_vl_bf16_prefill_replay \
+  python ...
+```
+
+The captured range replayed the full-resolution prefill graph three times.
+Top GPU kernel groups were:
+
+| Kernel group | Time share |
+|---|---:|
+| FA2 BF16 prefill attention, vision tower | 32.9% |
+| cuBLASLt BF16 GEMM, 128x128 family | 23.7% |
+| cuBLASLt BF16 GEMM, 128x256 family | 12.7% |
+| cuBLASLt BF16 GEMM, 256x128 family | 6.3% |
+| QKV split / bias | 4.0% |
+| BF16 bias+GELU | 3.3% |
+| copy / staging elementwise | 2.8% |
+| residual+bias | 2.6% |
+| FA2 BF16 prefill attention, language stack | 2.1% |
+| SiLU multiply | 2.0% |
+
+The remaining full-resolution prefill bottleneck is split between attention
+and large BF16 GEMMs. Another one-off elementwise fusion is unlikely to move
+the full path much; larger future work would need to target attention/prefill
+structure, larger-grain BF16 GEMM scheduling, or a separate Orin-friendly
+quantized path.
+
+## Limits
+
+- The first fully validated target is Qwen3-VL-2B on Jetson Orin / SM87.
+- Qwen3-VL-8B is supported by the config-driven BF16 path, but Orin 32G was
+  only validated with a constrained low-resolution smoke because memory
+  pressure is high.
+- Single-image prompts are supported. Multi-image and video are not part of
+  this BF16 bring-up.
+- The frontend is instantiated directly; server integration and `load_model()`
+  registration are not included.
+- The path is BF16-only. It is a correctness and portability baseline for
+  official checkpoints, not a replacement for the optimized FP8/NVFP4 paths.
+- Decode graphs are captured per cache position and RoPE position.

--- a/docs/qwen3_vl_rtx_bf16.md
+++ b/docs/qwen3_vl_rtx_bf16.md
@@ -157,9 +157,16 @@ prefill graph P50: 953.8 ms
 decode throughput (warm graph): 36.7 tok/s
 ```
 
-The decode throughput improvement over the earlier generic M=1 BF16 GEMM
-bring-up comes from the Qwen3-VL `K=2048/6144` M=1 BF16 GEMV path. The
-cuBLASLt autotune mainly affects M>1 prefill replay.
+The two optimization effects were measured separately:
+
+| Change | Before | After |
+|---|---:|---:|
+| M=1 BF16 GEMV decode helper | ~16.2 tok/s | 36.8 tok/s |
+| cuBLASLt autotune for M>1 prefill GEMMs | 953.8 ms prefill P50 | 927.5 ms prefill P50 |
+
+The fixed-K M=1 GEMV helper provides the larger decode win. The cuBLASLt
+autotune mainly affects M>1 prefill replay; it has little effect on decode
+throughput once the M=1 GEMV helper is enabled.
 
 ### Resolution knob
 

--- a/examples/orin/qwen3_vl_quickstart.py
+++ b/examples/orin/qwen3_vl_quickstart.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Qwen3-VL quickstart for Jetson Orin.
+
+Example:
+  python examples/orin/qwen3_vl_quickstart.py \
+    --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+    --image FlashRT.png \
+    --prompt "Describe this image in one sentence." \
+    --max-new-tokens 32
+"""
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument('--checkpoint', default='/root/models/Qwen3-VL-2B-Instruct')
+    p.add_argument('--image', required=True)
+    p.add_argument('--prompt', default='Describe this image in one sentence.')
+    p.add_argument('--max-new-tokens', type=int, default=32)
+    p.add_argument('--max-seq', type=int, default=2048)
+    p.add_argument('--max-pixels', type=int, default=None)
+    p.add_argument('--device', default='cuda:0')
+    p.add_argument('--precision', default='bf16',
+                   help='runtime precision path; currently implemented: bf16')
+    p.add_argument('--reps', type=int, default=1,
+                   help=('repeat generation in one process; useful for '
+                         'graph warm replay timing'))
+    p.add_argument('--benchmark', type=int, default=0,
+                   help=('if >0, separately time graph prefill and warm '
+                         'graph decode'))
+    p.add_argument('--no-graph', action='store_true',
+                   help='disable CUDA Graph replay for prefill/decode')
+    return p.parse_args()
+
+
+def main() -> None:
+    from PIL import Image
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_rtx_bf16 import (
+        Qwen3VlTorchFrontendRtxBF16,
+    )
+
+    args = parse_args()
+    if args.precision != 'bf16':
+        raise ValueError(
+            f'unsupported Qwen3-VL Orin precision {args.precision!r}; '
+            'currently implemented: bf16')
+    with Image.open(args.image) as im:
+        image = im.convert('RGB')
+    messages = [{
+        'role': 'user',
+        'content': [
+            {'type': 'image', 'image': image},
+            {'type': 'text', 'text': args.prompt},
+        ],
+    }]
+
+    model = Qwen3VlTorchFrontendRtxBF16(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_pixels=args.max_pixels)
+    text = ''
+    lat_ms = []
+    for _ in range(max(1, args.reps)):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        text = model.generate(
+            messages, max_new_tokens=args.max_new_tokens,
+            use_graph=not args.no_graph)
+        torch.cuda.synchronize()
+        lat_ms.append((time.perf_counter() - t0) * 1000.0)
+    print(text)
+    print('\nlatency_ms: ' + ', '.join(f'{v:.1f}' for v in lat_ms))
+    if len(lat_ms) > 1:
+        print(f'warm_latency_ms: {lat_ms[-1]:.1f}')
+
+    if args.benchmark > 0:
+        if args.no_graph:
+            raise ValueError('--benchmark requires CUDA Graph replay')
+        model.set_prompt(messages)
+        p = model._prompt
+        assert p is not None
+        torch.cuda.synchronize()
+
+        # Capture once, then measure steady graph replay.
+        model.prefill_graph()
+        torch.cuda.synchronize()
+        ttft = []
+        for _ in range(args.benchmark):
+            t0 = time.perf_counter()
+            model.prefill_graph()
+            torch.cuda.synchronize()
+            ttft.append((time.perf_counter() - t0) * 1000.0)
+        prefill_p50 = statistics.median(ttft)
+
+        n_dec = max(1, args.max_new_tokens)
+        model.warmup_decode_graphs(n_dec)
+        torch.cuda.synchronize()
+        base_slot = int(p['S'])
+        base_rope = int(p['mrope_max']) + 1
+        t0 = time.perf_counter()
+        for j in range(n_dec):
+            model.decode_step_with_graph(
+                0, cache_pos=base_slot + j, rope_pos=base_rope + j)
+        torch.cuda.synchronize()
+        dt = time.perf_counter() - t0
+
+        print('\n--- benchmark ---')
+        print(f'vision patches               : {int(p["patches"])}')
+        print(f'prompt tokens (incl. vision) : {int(p["S"])}')
+        print(f'prefill graph P50            : {prefill_p50:.1f} ms')
+        print(f'decode throughput (warm graph): {n_dec / dt:.1f} tok/s '
+              f'({n_dec} tok in {dt * 1000.0:.1f} ms)')
+
+
+if __name__ == '__main__':
+    main()

--- a/flash_rt/frontends/torch/_qwen3_vl_bf16_weights.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_bf16_weights.py
@@ -1,0 +1,182 @@
+"""Loader for official BF16 Qwen3-VL language weights.
+
+The Orin bring-up path keeps the checkpoint in its original BF16 layout and
+records raw device pointers for the generic FlashRT Qwen3 BF16 kernels. It is
+intentionally separate from the SM89 FP8 loader so the precision contracts do
+not get mixed.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+
+import torch
+
+
+@dataclass
+class WeightHandles:
+    ptrs: dict = field(default_factory=dict)
+    anchors: list = field(default_factory=list)
+
+
+def _anchor(handles: WeightHandles, t: torch.Tensor) -> int:
+    handles.anchors.append(t)
+    return int(t.data_ptr())
+
+
+def _open_shards(ckpt_dir: str):
+    from safetensors import safe_open
+
+    idx_path = os.path.join(ckpt_dir, 'model.safetensors.index.json')
+    if os.path.isfile(idx_path):
+        with open(idx_path) as f:
+            wmap = json.load(f)['weight_map']
+        handles_d = {
+            shard: safe_open(os.path.join(ckpt_dir, shard), framework='pt',
+                             device='cpu')
+            for shard in set(wmap.values())
+        }
+        return handles_d, wmap
+    single = os.path.join(ckpt_dir, 'model.safetensors')
+    if not os.path.isfile(single):
+        raise RuntimeError(
+            f'Qwen3-VL BF16 ckpt missing both index and model.safetensors: '
+            f'{ckpt_dir}')
+    h = safe_open(single, framework='pt', device='cpu')
+    wmap = {key: 'model.safetensors' for key in h.keys()}
+    return {'model.safetensors': h}, wmap
+
+
+def _get_tensor(handles_d, wmap, key: str) -> torch.Tensor:
+    if key not in wmap:
+        raise KeyError(f'tensor {key!r} not in weight_map')
+    return handles_d[wmap[key]].get_tensor(key)
+
+
+def _to_bf16(t: torch.Tensor, device: str) -> torch.Tensor:
+    return t.to(torch.bfloat16).to(device).contiguous()
+
+
+def _load_bf16_linear(handles: WeightHandles, out: dict, short: str,
+                      base: str, handles_d, wmap, device: str) -> None:
+    out[short + '_w'] = _anchor(
+        handles, _to_bf16(_get_tensor(handles_d, wmap, base + '.weight'),
+                          device))
+
+
+def extract_weights_qwen3_vl_bf16(ckpt_dir: str,
+                                  device: str = 'cuda:0') -> WeightHandles:
+    cfg_path = os.path.join(ckpt_dir, 'config.json')
+    if not os.path.isfile(cfg_path):
+        raise RuntimeError(f'Qwen3-VL BF16 ckpt missing config: {cfg_path}')
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+    text_cfg = cfg['text_config']
+
+    num_layers = int(text_cfg['num_hidden_layers'])
+    hidden = int(text_cfg['hidden_size'])
+    vocab = int(text_cfg['vocab_size'])
+    head_dim = int(text_cfg.get('head_dim') or
+                   (hidden // int(text_cfg['num_attention_heads'])))
+    n_q = int(text_cfg['num_attention_heads'])
+    n_kv = int(text_cfg['num_key_value_heads'])
+    inter = int(text_cfg['intermediate_size'])
+    rms_eps = float(text_cfg.get('rms_norm_eps', 1e-6))
+    rope_scaling = text_cfg.get('rope_scaling') or cfg.get('rope_scaling') or {}
+    rope_theta = float(text_cfg.get('rope_theta') or cfg.get('rope_theta') or
+                       rope_scaling.get('rope_theta') or 1_000_000.0)
+
+    handles = WeightHandles()
+    handles_d, wmap = _open_shards(ckpt_dir)
+
+    embed_key = 'model.language_model.embed_tokens.weight'
+    embed = _to_bf16(_get_tensor(handles_d, wmap, embed_key), device)
+    handles.ptrs['embed_w'] = _anchor(handles, embed)
+    final_norm = _to_bf16(
+        _get_tensor(handles_d, wmap, 'model.language_model.norm.weight'),
+        device)
+    handles.ptrs['final_norm_w'] = _anchor(handles, final_norm)
+
+    tied = bool(cfg.get('tie_word_embeddings',
+                        text_cfg.get('tie_word_embeddings', False)))
+    if 'lm_head.weight' in wmap:
+        lm_head_cpu = _get_tensor(handles_d, wmap, 'lm_head.weight')
+    elif tied:
+        lm_head_cpu = _get_tensor(handles_d, wmap, embed_key)
+    else:
+        raise RuntimeError(
+            'Qwen3-VL BF16 ckpt has neither lm_head.weight nor '
+            'tie_word_embeddings=true')
+    handles.ptrs['lm_head_w'] = _anchor(handles, _to_bf16(lm_head_cpu, device))
+
+    per_layer: list[dict] = [None] * num_layers   # type: ignore[list-item]
+    for L in range(num_layers):
+        base = f'model.language_model.layers.{L}.'
+        ld: dict = {'type': 'full_attention', 'quant_format': 'bf16'}
+        ld['input_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, base + 'input_layernorm.weight'),
+            device))
+        ld['post_attn_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap,
+                        base + 'post_attention_layernorm.weight'),
+            device))
+        sa = base + 'self_attn.'
+        q = _to_bf16(_get_tensor(handles_d, wmap, sa + 'q_proj.weight'),
+                     device)
+        k = _to_bf16(_get_tensor(handles_d, wmap, sa + 'k_proj.weight'),
+                     device)
+        v = _to_bf16(_get_tensor(handles_d, wmap, sa + 'v_proj.weight'),
+                     device)
+        qkv = torch.cat([q, k, v], dim=0).contiguous()
+        ld['qkv_proj_w'] = _anchor(handles, qkv)
+        ld['qkv_proj_N'] = int(qkv.shape[0])
+        _load_bf16_linear(handles, ld, 'o_proj', sa + 'o_proj',
+                          handles_d, wmap, device)
+        ld['q_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, sa + 'q_norm.weight'), device))
+        ld['k_norm_w'] = _anchor(handles, _to_bf16(
+            _get_tensor(handles_d, wmap, sa + 'k_norm.weight'), device))
+
+        mp = base + 'mlp.'
+        gate = _to_bf16(_get_tensor(handles_d, wmap, mp + 'gate_proj.weight'),
+                        device)
+        up = _to_bf16(_get_tensor(handles_d, wmap, mp + 'up_proj.weight'),
+                      device)
+        gate_up = torch.cat([gate, up], dim=0).contiguous()
+        ld['gate_up_w'] = _anchor(handles, gate_up)
+        ld['gate_up_N'] = int(gate_up.shape[0])
+        _load_bf16_linear(handles, ld, 'mlp_down', mp + 'down_proj',
+                          handles_d, wmap, device)
+        per_layer[L] = ld
+
+    handles.ptrs.update({
+        'vocab_size': vocab,
+        'hidden': hidden,
+        'head_dim': head_dim,
+        'num_q_heads': n_q,
+        'num_kv_heads': n_kv,
+        'intermediate': inter,
+        'num_layers': num_layers,
+        'layer_types': ['full_attention'] * num_layers,
+        'rms_norm_eps': rms_eps,
+        'rope_theta': rope_theta,
+        'rope_scaling': rope_scaling,
+        'quant_format': 'bf16',
+        'ckpt_dir': ckpt_dir,
+        'layers': per_layer,
+    })
+    return handles
+
+
+def assert_extraction_invariants_qwen3_vl_bf16(
+        handles: WeightHandles) -> None:
+    p = handles.ptrs
+    if p.get('quant_format') != 'bf16':
+        raise AssertionError('expected quant_format=bf16')
+    if int(p['head_dim']) != 128:
+        raise AssertionError('Qwen3 fused q/k norm RoPE kernels require head_dim=128')
+    if int(p['num_q_heads']) % int(p['num_kv_heads']) != 0:
+        raise AssertionError('num_q_heads must be a multiple of num_kv_heads')
+    if len(p['layers']) != int(p['num_layers']):
+        raise AssertionError('layer count mismatch')

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -70,8 +70,19 @@ class Qwen3VlVisionRtx:
         import os
         index_path = os.path.join(
             checkpoint_path, 'model.safetensors.index.json')
-        wmap = json.load(open(index_path))['weight_map']
         shards: dict[str, Any] = {}
+        if os.path.isfile(index_path):
+            with open(index_path) as f:
+                wmap = json.load(f)['weight_map']
+        else:
+            single = os.path.join(checkpoint_path, 'model.safetensors')
+            if not os.path.isfile(single):
+                raise RuntimeError(
+                    f'Qwen3-VL ckpt missing both index and model.safetensors: '
+                    f'{checkpoint_path}')
+            h = safe_open(single, framework='pt', device='cpu')
+            shards['model.safetensors'] = h
+            wmap = {key: 'model.safetensors' for key in h.keys()}
 
         def _w(key: str):
             shard = wmap[key]
@@ -199,8 +210,12 @@ class Qwen3VlVisionRtx:
                 fvk.w16a16_gemm_sm120_bf16(
                     x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K, 1.0,
                     stream)
-            else:
+            elif hasattr(self._vlk, 'bf16_matmul_cublaslt_bf16'):
                 self._vlk.bf16_matmul_cublaslt_bf16(
+                    x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K,
+                    stream)
+            else:
+                fvk.bf16_matmul_bf16(
                     x.data_ptr(), ws.data_ptr(), y.data_ptr(), M, N, K,
                     stream)
         else:                                           # FP8 block-128 W8A8
@@ -547,5 +562,6 @@ def _load_merger(load_fn, lin_fn, prefix: str) -> dict:
 def _read_vision_config(checkpoint_path: str) -> dict:
     import json
     import os
-    cfg = json.load(open(os.path.join(checkpoint_path, 'config.json')))
+    with open(os.path.join(checkpoint_path, 'config.json')) as f:
+        cfg = json.load(f)
     return cfg['vision_config']

--- a/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
@@ -1,0 +1,646 @@
+"""Qwen3-VL official-BF16 multimodal frontend for the RTX-family backend.
+
+First bring-up target:
+  * official BF16 Qwen3-VL-2B-Instruct checkpoint
+  * single-image chat prompt
+  * greedy generation
+  * CUDA Graph replay for fixed-shape prefill/decode buckets
+  * no server/load_model registration yet
+
+The vision tower reuses ``Qwen3VlVisionRtx`` in its BF16 mode. The language
+stack is a direct BF16 Qwen3 decoder over generic FlashRT kernels.
+This mirrors the project's precision-variant pattern: the optimized
+NVFP4/FP8 frontends remain separate, while this file keeps an official BF16
+checkpoint path for correctness bring-up and unsupported quantized targets.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+_QWEN3_VL_RTX_BF16_VISION_FNS = (
+    'rope_neox_qk_bf16',
+    'residual_add_bias_bf16',
+    'qkv_split_bias_bf16',
+    'bf16_matmul_cublaslt_bf16',
+    'qwen3_vl_bf16_gemv_m1',
+)
+
+_QWEN3_VL_RTX_BF16_CORE_FNS = (
+    'embedding_lookup_bf16',
+    'bf16_matmul_bf16',
+    'rms_norm',
+    'residual_add',
+    'residual_add_rms_norm',
+    'silu_mul_qwen36_bf16',
+    'qwen3_q_norm_rope_qstage_bf16',
+    'qwen3_k_norm_rope_kvwrite_bf16',
+    'qwen3_q_norm_rope_qstage_prefill_bf16',
+    'qwen3_k_norm_rope_kvwrite_prefill_bf16',
+)
+
+
+def _require_qwen3_vl_rtx_bf16_kernels():
+    try:
+        from flash_rt import flash_rt_kernels as fvk
+        from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+    except ImportError as e:
+        raise RuntimeError(
+            'Qwen3VlTorchFrontendRtxBF16 requires flash_rt_kernels and '
+            'flash_rt_qwen3_vl_kernels. Configure with '
+            '-DGPU_ARCH=87 -DFLASHRT_BUILD_QWEN3_VL=ON and build '
+            'flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels.'
+        ) from e
+    missing_core = [name for name in _QWEN3_VL_RTX_BF16_CORE_FNS
+                    if not hasattr(fvk, name)]
+    missing_vl = [name for name in _QWEN3_VL_RTX_BF16_VISION_FNS
+                  if not hasattr(vlk, name)]
+    if missing_core or missing_vl:
+        pieces = []
+        if missing_core:
+            pieces.append('flash_rt_kernels: ' + ', '.join(missing_core))
+        if missing_vl:
+            pieces.append('flash_rt_qwen3_vl_kernels: ' + ', '.join(missing_vl))
+        raise RuntimeError(
+            'Qwen3-VL RTX BF16 kernels are incomplete: ' + '; '.join(pieces))
+    return fvk, vlk
+
+
+class Qwen3VlTorchFrontendRtxBF16:
+    """Batch-1 Qwen3-VL image+text inference with official BF16 weights.
+
+    This is the BF16 precision variant for the RTX-family backend. The first
+    validated target is Jetson Orin SM87, where the FP8/NVFP4 Qwen3-VL paths
+    are not available.
+    """
+
+    def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
+                 max_seq: int = 2048, max_pixels: int | None = None) -> None:
+        import torch
+        from transformers import AutoProcessor
+
+        from flash_rt.frontends.torch._qwen3_vl_bf16_weights import (
+            assert_extraction_invariants_qwen3_vl_bf16,
+            extract_weights_qwen3_vl_bf16,
+        )
+        from flash_rt.frontends.torch._qwen3_vl_vision_rtx import (
+            Qwen3VlVisionRtx,
+        )
+        from flash_rt.hardware.rtx.attn_backend_qwen3 import (
+            RtxFlashAttnBackendQwen3,
+        )
+
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+        self.max_pixels = max_pixels
+        self._prompt: dict[str, Any] | None = None
+        self._decode_graphs: dict[tuple[int, int], Any] = {}
+        self._prefill_graphs: dict[tuple[int, int, int, int], Any] = {}
+        self._pg_buffers: dict[tuple[int, int, int, int], dict[str, Any]] = {}
+
+        device_obj = torch.device(device)
+        if device_obj.type != 'cuda' or not torch.cuda.is_available():
+            raise RuntimeError('Qwen3VlTorchFrontendRtxBF16 requires CUDA')
+        cap = torch.cuda.get_device_capability(device_obj)
+        if cap != (8, 7):
+            raise RuntimeError(
+                'Qwen3VlTorchFrontendRtxBF16 targets SM87 currently; '
+                f'got sm_{cap[0]}{cap[1]} on {device}')
+
+        self._fvk, self._vlk = _require_qwen3_vl_rtx_bf16_kernels()
+        with open(os.path.join(self.checkpoint_path, 'config.json')) as f:
+            self._cfg_raw = json.load(f)
+        cfg = self._cfg_raw
+        text_cfg = cfg['text_config']
+        self._cfg = {
+            'rms_norm_eps': float(text_cfg.get('rms_norm_eps', 1e-6)),
+            'head_dim': int(text_cfg.get('head_dim') or
+                            text_cfg['hidden_size'] //
+                            text_cfg['num_attention_heads']),
+            'hidden_size': int(text_cfg['hidden_size']),
+            'vocab_size': int(text_cfg['vocab_size']),
+            'num_hidden_layers': int(text_cfg['num_hidden_layers']),
+            'num_q_heads': int(text_cfg['num_attention_heads']),
+            'num_kv_heads': int(text_cfg['num_key_value_heads']),
+            'intermediate': int(text_cfg['intermediate_size']),
+            'rope_theta': float(text_cfg.get('rope_theta')
+                                or cfg.get('rope_theta') or 1_000_000.0),
+        }
+        self._head_dim = self._cfg['head_dim']
+        if self._head_dim != 128:
+            raise RuntimeError(
+                f'BF16 path requires head_dim=128, got {self._head_dim}')
+        self._image_token_id = int(cfg['image_token_id'])
+        self._video_token_id = int(cfg['video_token_id'])
+        self._vision_start_token_id = int(cfg['vision_start_token_id'])
+        vc = cfg['vision_config']
+        self._merge = int(vc['spatial_merge_size'])
+        self._vis_head_dim = int(vc['hidden_size']) // int(vc['num_heads'])
+        self._num_grid_per_side = int(vc['num_position_embeddings'] ** 0.5)
+        self._deepstack_layers = len(vc['deepstack_visual_indexes'])
+        rope_scaling = text_cfg.get('rope_scaling') or cfg.get('rope_scaling')
+        if not rope_scaling or 'mrope_section' not in rope_scaling:
+            raise RuntimeError('Qwen3-VL config missing rope_scaling.mrope_section')
+        self._mrope_section = tuple(rope_scaling['mrope_section'])
+        eos = cfg.get('eos_token_id', text_cfg.get('eos_token_id'))
+        if eos is None:
+            self._eos_token_ids: set[int] = set()
+        else:
+            self._eos_token_ids = set(eos if isinstance(eos, list) else [eos])
+
+        self.processor = AutoProcessor.from_pretrained(self.checkpoint_path)
+        self._processor_kwargs = {'device': self.device}
+        if max_pixels is not None:
+            size = getattr(getattr(self.processor, 'image_processor', None),
+                           'size', {})
+            shortest = int(size.get('shortest_edge', 65536))
+            self._processor_kwargs['size'] = {
+                'shortest_edge': shortest,
+                'longest_edge': int(max_pixels),
+            }
+
+        self._weights = extract_weights_qwen3_vl_bf16(
+            self.checkpoint_path, device=self.device)
+        assert_extraction_invariants_qwen3_vl_bf16(self._weights)
+        self.vision = Qwen3VlVisionRtx(
+            self.checkpoint_path, device=device, config=vc)
+        self._attn = RtxFlashAttnBackendQwen3(
+            max_seq=self.max_seq, max_q_seq=self.max_seq, dtype=torch.bfloat16,
+            num_layers=self._cfg['num_hidden_layers'],
+            num_q_heads=self._cfg['num_q_heads'],
+            num_kv_heads=self._cfg['num_kv_heads'],
+            head_dim=self._cfg['head_dim'],
+            device=self.device)
+        self._alloc_buffers()
+        self._build_mrope_caches()
+
+    _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
+                'vcos', 'vsin', 'mcos', 'msin')
+
+    def _alloc_buffers(self) -> None:
+        import torch
+
+        cfg = self._cfg
+        d = torch.device(self.device)
+        bf16 = torch.bfloat16
+        S = self.max_seq
+        H = cfg['hidden_size']
+        I = cfg['intermediate']
+        NQ = cfg['num_q_heads']
+        NKV = cfg['num_kv_heads']
+        HD = cfg['head_dim']
+        qkv_n = (NQ + 2 * NKV) * HD
+        self._qkv_N = qkv_n
+        self._h_a = torch.empty(1, S, H, device=d, dtype=bf16)
+        self._h_b = torch.empty(1, S, H, device=d, dtype=bf16)
+        self._qkv_out = torch.empty(S, qkv_n, device=d, dtype=bf16)
+        self._gate_up = torch.empty(S, 2 * I, device=d, dtype=bf16)
+        self._gate_tmp = torch.empty(S, I, device=d, dtype=bf16)
+        self._up_tmp = torch.empty(S, I, device=d, dtype=bf16)
+        self._mlp_act = torch.empty(S, I, device=d, dtype=bf16)
+        self._tmp_hidden = torch.empty(S, H, device=d, dtype=bf16)
+        self._norm_buf = torch.empty(S, H, device=d, dtype=bf16)
+        self._logits = torch.empty(1, cfg['vocab_size'], device=d, dtype=bf16)
+        self._static_token_id = torch.zeros(1, 1, device=d, dtype=torch.long)
+        self._graph_stream = torch.cuda.Stream(device=d)
+
+    def _build_mrope_caches(self) -> None:
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+        self._mrope_cos_cache, self._mrope_sin_cache = geo.build_mrope_cache(
+            max_pos=self.max_seq + self._num_grid_per_side,
+            head_dim=self._head_dim, rope_theta=self._cfg['rope_theta'],
+            device=self.device)
+        self._vision_rope_cos_cache, self._vision_rope_sin_cache = (
+            geo.build_vision_rope_cache(
+                max_hw=self.max_seq * self._merge,
+                head_dim=self._vis_head_dim, device=self.device))
+
+    def reset_state(self) -> None:
+        self._attn.reset_cache()
+
+    def _stage_prefill_inputs(self, P: int, S: int, span):
+        p = self._prompt
+        assert p is not None
+        key = (int(P), int(S), int(span[0]), int(span[1]))
+        bufs = self._pg_buffers.get(key)
+        if bufs is None:
+            bufs = {k: p[k].clone() for k in self._PG_KEYS}
+            self._pg_buffers[key] = bufs
+        else:
+            for k in self._PG_KEYS:
+                bufs[k].copy_(p[k])
+        return key
+
+    def set_prompt(self, messages: list) -> None:
+        """Preprocess a single-image Qwen3-VL chat prompt."""
+        import torch
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+        inputs = self.processor.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=True,
+            return_dict=True, return_tensors='pt',
+            processor_kwargs=self._processor_kwargs).to(self.device)
+        input_ids = inputs['input_ids'][0]
+        S = int(input_ids.shape[0])
+        if S > self.max_seq:
+            raise ValueError(
+                f'prompt length {S} exceeds max_seq {self.max_seq}')
+
+        image_grid = inputs.get('image_grid_thw')
+        video_grid = inputs.get('video_grid_thw')
+        if video_grid is not None and len(video_grid):
+            raise ValueError('Qwen3VlTorchFrontendRtxBF16 v1 supports images, not video')
+        pix_img = inputs.get('pixel_values')
+        if pix_img is None:
+            raise ValueError('Qwen3VlTorchFrontendRtxBF16 requires one image')
+        pix_img = pix_img.to(torch.bfloat16)
+
+        segs = geo.vision_segments(
+            input_ids.cpu(), image_grid, None,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
+            spatial_merge_size=self._merge)
+        if len(segs) != 1:
+            raise ValueError(
+                f'Qwen3VlTorchFrontendRtxBF16 v1 supports exactly one image; '
+                f'got {len(segs)} vision segments')
+        sg = segs[0]
+        n_patch = int(sg['patches'])
+        pixel_values = pix_img[:n_patch].contiguous()
+        seg_grid = torch.tensor([sg['grid']], dtype=torch.long)
+        pos_ids = geo.mrope_position_ids(
+            input_ids.cpu(), image_grid.cpu(), None,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
+            vision_start_token_id=self._vision_start_token_id,
+            spatial_merge_size=self._merge)
+        mcos, msin = geo.mrope_cos_sin_cached(
+            pos_ids, self._mrope_cos_cache, self._mrope_sin_cache,
+            mrope_section=self._mrope_section)
+        vcos, vsin = geo.vision_rope_cos_sin_cached(
+            seg_grid, self._vision_rope_cos_cache, self._vision_rope_sin_cache,
+            spatial_merge_size=self._merge)
+        pos_embeds = geo.vision_pos_embeds(
+            seg_grid, self.vision.pos_embed,
+            num_grid_per_side=self._num_grid_per_side,
+            spatial_merge_size=self._merge, device=self.device)
+
+        self._prompt = {
+            'input_ids': input_ids.contiguous(),
+            'pixel_values': pixel_values,
+            'span': sg['span'],
+            'patches': n_patch,
+            'mcos': mcos,
+            'msin': msin,
+            'vcos': vcos,
+            'vsin': vsin,
+            'pos_embeds': pos_embeds,
+            'S': S,
+            'mrope_max': int(pos_ids.max()),
+        }
+        self._prompt['pg_key'] = self._stage_prefill_inputs(n_patch, S, sg['span'])
+
+    def _bf16_gemm(self, x, weight_ptr: int, out, M: int, N: int, K: int,
+                   stream: int) -> None:
+        if (M == 1 and K in (2048, 6144)
+                and hasattr(self._vlk, 'qwen3_vl_bf16_gemv_m1')):
+            self._vlk.qwen3_vl_bf16_gemv_m1(
+                x.data_ptr(), int(weight_ptr), out.data_ptr(), N, K, stream)
+            return
+        if M > 1 and hasattr(self._vlk, 'bf16_matmul_cublaslt_bf16'):
+            self._vlk.bf16_matmul_cublaslt_bf16(
+                x.data_ptr(), int(weight_ptr), out.data_ptr(), M, N, K, stream)
+            return
+        self._fvk.bf16_matmul_bf16(
+            x.data_ptr(), int(weight_ptr), out.data_ptr(), M, N, K, stream)
+
+    def _layer_forward_prefill(self, L: int, h, cos_S, sin_S,
+                               start_pos: int, S: int):
+        import torch
+
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        I = cfg['intermediate']
+        NQ = cfg['num_q_heads']
+        NKV = cfg['num_kv_heads']
+        HD = cfg['head_dim']
+        Nq = NQ * HD
+        Nk = NKV * HD
+        eps = cfg['rms_norm_eps']
+        stream = torch.cuda.current_stream().cuda_stream
+        lw = self._weights.ptrs['layers'][L]
+        h2 = h.view(S, H).contiguous()
+        xn = self._norm_buf[:S]
+        fvk.rms_norm(
+            h2.data_ptr(), int(lw['input_norm_w']), xn.data_ptr(),
+            S, H, eps, stream)
+
+        qkv = self._qkv_out[:S]
+        self._bf16_gemm(
+            xn, int(lw['qkv_proj_w']), qkv, S, int(lw['qkv_proj_N']), H,
+            stream)
+        fvk.qwen3_q_norm_rope_qstage_prefill_bf16(
+            qkv[:, :Nq].data_ptr(), int(lw['q_norm_w']),
+            cos_S.data_ptr(), sin_S.data_ptr(),
+            self._attn.Q_buf[:, :S].data_ptr(),
+            NQ, S, int(qkv.stride(0)), int(self._attn.Q_buf[:, :S].stride(1)),
+            eps, stream)
+        fvk.qwen3_k_norm_rope_kvwrite_prefill_bf16(
+            qkv[:, Nq:Nq + Nk].data_ptr(), qkv[:, Nq + Nk:].data_ptr(),
+            int(lw['k_norm_w']), cos_S.data_ptr(), sin_S.data_ptr(),
+            self._attn.K_cache[L, start_pos:start_pos + S].data_ptr(),
+            self._attn.V_cache[L, start_pos:start_pos + S].data_ptr(),
+            NKV, S, int(qkv.stride(0)),
+            int(self._attn.K_cache[L, start_pos:start_pos + S].stride(0)),
+            eps, stream)
+
+        self._attn.run(
+            'full', layer_idx=L, q_seq=S, kv_seq=start_pos + S,
+            stream=stream, causal=True)
+        attn_2d = self._attn.O_buf[:, :S].reshape(S, H).contiguous()
+        attn_out = self._tmp_hidden[:S]
+        self._bf16_gemm(
+            attn_2d, int(lw['o_proj_w']), attn_out, S, H, H, stream)
+
+        xn2 = self._norm_buf[:S]
+        fvk.residual_add_rms_norm(
+            h.data_ptr(), attn_out.view(1, S, H).data_ptr(),
+            int(lw['post_attn_norm_w']), xn2.data_ptr(), S, H, eps, stream)
+
+        gate_up = self._gate_up[:S]
+        self._bf16_gemm(
+            xn2, int(lw['gate_up_w']), gate_up, S, int(lw['gate_up_N']), H,
+            stream)
+        gate = self._gate_tmp[:S]
+        up = self._up_tmp[:S]
+        gate.copy_(gate_up[:, :I])
+        up.copy_(gate_up[:, I:])
+        fvk.silu_mul_qwen36_bf16(
+            gate.data_ptr(), up.data_ptr(),
+            self._mlp_act[:S].data_ptr(), S * I, stream)
+        down = self._tmp_hidden[:S]
+        self._bf16_gemm(
+            self._mlp_act[:S], int(lw['mlp_down_w']), down, S, H, I, stream)
+
+        h_out = (self._h_a if (L % 2 == 0) else self._h_b)[:, :S]
+        torch.add(h, down.view(1, S, H), out=h_out)
+        return h_out
+
+    def _layer_forward_decode(self, L: int, h, cos, sin, cur_pos: int):
+        import torch
+
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        I = cfg['intermediate']
+        NQ = cfg['num_q_heads']
+        NKV = cfg['num_kv_heads']
+        HD = cfg['head_dim']
+        Nq = NQ * HD
+        Nk = NKV * HD
+        eps = cfg['rms_norm_eps']
+        stream = torch.cuda.current_stream().cuda_stream
+        lw = self._weights.ptrs['layers'][L]
+        h2 = h.view(1, H).contiguous()
+        xn = self._norm_buf[:1]
+        fvk.rms_norm(
+            h2.data_ptr(), int(lw['input_norm_w']), xn.data_ptr(),
+            1, H, eps, stream)
+        qkv = self._qkv_out[:1]
+        self._bf16_gemm(
+            xn, int(lw['qkv_proj_w']), qkv, 1, int(lw['qkv_proj_N']), H,
+            stream)
+        kv_layer_stride = self._attn.kv_layer_stride_bytes
+        kv_row_stride = self._attn.kv_row_stride_bytes
+        kv_slot_off = L * kv_layer_stride + cur_pos * kv_row_stride
+        fvk.qwen3_q_norm_rope_qstage_bf16(
+            qkv[:, :Nq].data_ptr(), int(lw['q_norm_w']),
+            cos.data_ptr(), sin.data_ptr(), self._attn.Q_buf[:, :1].data_ptr(),
+            NQ, eps, stream)
+        fvk.qwen3_k_norm_rope_kvwrite_bf16(
+            qkv[:, Nq:Nq + Nk].data_ptr(), qkv[:, Nq + Nk:].data_ptr(),
+            int(lw['k_norm_w']), cos.data_ptr(), sin.data_ptr(),
+            self._attn.K_cache.data_ptr() + kv_slot_off,
+            self._attn.V_cache.data_ptr() + kv_slot_off,
+            NKV, eps, stream)
+        self._attn.run(
+            'full', layer_idx=L, q_seq=1, kv_seq=cur_pos + 1,
+            stream=stream, causal=True)
+        attn_2d = self._attn.O_buf[:, :1].reshape(1, H).contiguous()
+        attn_out = self._tmp_hidden[:1]
+        self._bf16_gemm(
+            attn_2d, int(lw['o_proj_w']), attn_out, 1, H, H, stream)
+
+        xn2 = self._norm_buf[:1]
+        fvk.residual_add_rms_norm(
+            h.data_ptr(), attn_out.view(1, 1, H).data_ptr(),
+            int(lw['post_attn_norm_w']), xn2.data_ptr(), 1, H, eps, stream)
+        gate_up = self._gate_up[:1]
+        self._bf16_gemm(
+            xn2, int(lw['gate_up_w']), gate_up, 1, int(lw['gate_up_N']), H,
+            stream)
+        gate = self._gate_tmp[:1]
+        up = self._up_tmp[:1]
+        gate.copy_(gate_up[:, :I])
+        up.copy_(gate_up[:, I:])
+        fvk.silu_mul_qwen36_bf16(
+            gate.data_ptr(), up.data_ptr(), self._mlp_act[:1].data_ptr(),
+            I, stream)
+        down = self._tmp_hidden[:1]
+        self._bf16_gemm(
+            self._mlp_act[:1], int(lw['mlp_down_w']), down, 1, H, I, stream)
+        h_out = (self._h_a if (L % 2 == 0) else self._h_b)[:, :1]
+        torch.add(h, down.view(1, 1, H), out=h_out)
+        return h_out
+
+    def _prefill_body(self, p: dict[str, Any], *, use_vision_graph: bool):
+        import torch
+
+        self.reset_state()
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        S = p['S']
+        if S > self.max_seq:
+            raise ValueError(f'prompt length {S} exceeds max_seq {self.max_seq}')
+        stream = torch.cuda.current_stream().cuda_stream
+        h = self._h_a[:, :S]
+        fvk.embedding_lookup_bf16(
+            p['input_ids'].view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']),
+            h.data_ptr(), S, H, stream)
+        a, b = p['span']
+        if use_vision_graph:
+            emb, deepstack = self.vision.forward_graph(
+                p['pixel_values'], p['pos_embeds'], p['vcos'], p['vsin'])
+        else:
+            emb, deepstack = self.vision.forward(
+                p['pixel_values'], p['pos_embeds'], p['vcos'], p['vsin'])
+        h[0, a:b].copy_(emb.to(torch.bfloat16))
+
+        cur = h
+        for L in range(cfg['num_hidden_layers']):
+            cur = self._layer_forward_prefill(
+                L, cur, p['mcos'], p['msin'], 0, S)
+            if L < self._deepstack_layers:
+                fvk.residual_add(
+                    cur[0, a:b].data_ptr(),
+                    deepstack[L].to(torch.bfloat16).data_ptr(),
+                    (b - a) * H, stream)
+
+        x = cur.view(S, H)[S - 1:S].contiguous()
+        xn = self._norm_buf[:1]
+        fvk.rms_norm(
+            x.data_ptr(), int(self._weights.ptrs['final_norm_w']),
+            xn.data_ptr(), 1, H, cfg['rms_norm_eps'], stream)
+        self._bf16_gemm(
+            xn, int(self._weights.ptrs['lm_head_w']), self._logits,
+            1, cfg['vocab_size'], H, stream)
+        self._cur_pos = S
+        return self._logits
+
+    def prefill(self):
+        """Run multimodal prefill eagerly and return next-token logits."""
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill()')
+        return self._prefill_body(self._prompt, use_vision_graph=True)
+
+    def _capture_prefill_graph(self, st: dict[str, Any], key):
+        import torch
+
+        P, S, a, b = key
+        st = dict(st)
+        st['S'] = int(S)
+        st['span'] = (int(a), int(b))
+        gs = self._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.inference_mode():
+            for _ in range(2):
+                self._prefill_body(st, use_vision_graph=False)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.inference_mode():
+            self._prefill_body(st, use_vision_graph=False)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        return graph
+
+    def prefill_graph(self):
+        """Run multimodal prefill through a fixed-shape CUDA Graph bucket."""
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill_graph()')
+        key = self._prompt.get('pg_key')
+        if key is None:
+            return self.prefill()
+        graph = self._prefill_graphs.get(key)
+        if graph is None:
+            graph = self._capture_prefill_graph(self._pg_buffers[key], key)
+            self._prefill_graphs[key] = graph
+        graph.replay()
+        self._cur_pos = int(key[1])
+        return self._logits
+
+    def _decode_token_tensor(self, token, *, cache_pos: int, rope_pos: int):
+        import torch
+
+        cfg = self._cfg
+        H = cfg['hidden_size']
+        stream = torch.cuda.current_stream().cuda_stream
+        h = self._h_a[:, :1]
+        self._fvk.embedding_lookup_bf16(
+            token.view(-1).data_ptr(), int(self._weights.ptrs['embed_w']),
+            h.data_ptr(), 1, H, stream)
+        cos = self._mrope_cos_cache[rope_pos:rope_pos + 1]
+        sin = self._mrope_sin_cache[rope_pos:rope_pos + 1]
+        cur = h
+        for L in range(cfg['num_hidden_layers']):
+            cur = self._layer_forward_decode(L, cur, cos, sin, cache_pos)
+        xn = self._norm_buf[:1]
+        self._fvk.rms_norm(
+            cur.view(1, H).contiguous().data_ptr(),
+            int(self._weights.ptrs['final_norm_w']),
+            xn.data_ptr(), 1, H, cfg['rms_norm_eps'], stream)
+        self._bf16_gemm(
+            xn, int(self._weights.ptrs['lm_head_w']), self._logits,
+            1, cfg['vocab_size'], H, stream)
+        return self._logits
+
+    def decode_step(self, token_id: int, *, cache_pos: int, rope_pos: int):
+        import torch
+
+        token = torch.tensor([[int(token_id)]], dtype=torch.long,
+                             device=self.device)
+        return self._decode_token_tensor(
+            token, cache_pos=cache_pos, rope_pos=rope_pos)
+
+    def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
+        import torch
+
+        key = (int(cache_pos), int(rope_pos))
+        graph = self._decode_graphs.get(key)
+        if graph is not None:
+            return graph
+        gs = self._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.inference_mode():
+            for _ in range(2):
+                self._decode_token_tensor(
+                    self._static_token_id,
+                    cache_pos=cache_pos, rope_pos=rope_pos)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.inference_mode():
+            self._decode_token_tensor(
+                self._static_token_id, cache_pos=cache_pos, rope_pos=rope_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._decode_graphs[key] = graph
+        return graph
+
+    def decode_step_with_graph(self, token_id: int, *, cache_pos: int,
+                               rope_pos: int):
+        self._static_token_id.fill_(int(token_id))
+        self._ensure_decode_graph(cache_pos, rope_pos).replay()
+        return self._logits
+
+    def warmup_decode_graphs(self, n_tokens: int) -> None:
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before warmup_decode_graphs()')
+        base_slot = int(self._prompt['S'])
+        base_rope = int(self._prompt['mrope_max']) + 1
+        for i in range(int(n_tokens)):
+            self._ensure_decode_graph(base_slot + i, base_rope + i)
+
+    def generate(self, messages: list, *, max_new_tokens: int = 64,
+                 use_graph: bool = True) -> str:
+        """Greedy single-image generation."""
+        self.set_prompt(messages)
+        logits = self.prefill_graph() if use_graph else self.prefill()
+        p = self._prompt
+        assert p is not None
+        base_slot = int(p['S'])
+        base_rope = int(p['mrope_max']) + 1
+        tok = int(logits[0].float().argmax())
+        out_ids = [tok]
+        for i in range(max_new_tokens - 1):
+            if tok in self._eos_token_ids:
+                break
+            if use_graph:
+                logits = self.decode_step_with_graph(
+                    tok, cache_pos=base_slot + i, rope_pos=base_rope + i)
+            else:
+                logits = self.decode_step(
+                    tok, cache_pos=base_slot + i, rope_pos=base_rope + i)
+            tok = int(logits[0].float().argmax())
+            out_ids.append(tok)
+
+        eos = [t for t in out_ids if t in self._eos_token_ids]
+        if eos:
+            out_ids = out_ids[:out_ids.index(eos[0])]
+        return self.processor.tokenizer.decode(
+            out_ids, skip_special_tokens=True)

--- a/tests/test_qwen3_vl_rtx_bf16.py
+++ b/tests/test_qwen3_vl_rtx_bf16.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_qwen3_vl_rtx_bf16_frontend_imports():
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    assert hasattr(m, 'Qwen3VlTorchFrontendRtxBF16')
+    assert hasattr(m, '_require_qwen3_vl_rtx_bf16_kernels')
+
+
+def test_qwen3_vl_rtx_bf16_kernel_lists_are_bf16_only():
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    names = set(m._QWEN3_VL_RTX_BF16_CORE_FNS) | set(m._QWEN3_VL_RTX_BF16_VISION_FNS)
+    assert 'bf16_matmul_bf16' in names
+    assert 'qwen3_vl_bf16_gemv_m1' in names
+    assert 'qwen3_q_norm_rope_qstage_bf16' in names
+    assert not any('fp8' in name or 'nvfp4' in name for name in names)


### PR DESCRIPTION
## Summary

This PR adds a Qwen3-VL BF16 frontend for Jetson Orin / SM87.

The goal is to provide a baseline path for official BF16 Qwen3-VL checkpoints
on Orin, where the existing Qwen3-VL FP8/NVFP4 paths are not available. The
fully validated target is `Qwen3-VL-2B-Instruct`; the frontend is
config-driven and can load the 8B checkpoint as well, but 8B on Orin 32G is
only practical as a constrained smoke test.

## What Changed

- Added `Qwen3VlTorchFrontendRtxBF16`.
- Added a BF16 Qwen3-VL language weight loader for official safetensors
  checkpoints.
- Reused `Qwen3VlVisionRtx` in BF16 mode for the vision tower.
- Enabled `FLASHRT_BUILD_QWEN3_VL=ON` for `GPU_ARCH=87`.
- Added SM87 Qwen3-VL BF16 helper module support:
  - BF16 cuBLASLt matmul helper for prefill GEMMs.
  - Qwen3-VL-specific M=1 BF16 GEMV helper for dominant 2B decode shapes
    (`K=2048` and `K=6144`).
- Added an Orin quickstart script:
  - `examples/orin/qwen3_vl_quickstart.py`
  - The script exposes `--precision bf16` and is named as an Orin entry point
    so a future INT8 path can be added without introducing another
    hardware-specific quickstart.
- Added documentation:
  - `docs/qwen3_vl_rtx_bf16.md`
- Added a lightweight import/kernel-list test:
  - `tests/test_qwen3_vl_rtx_bf16.py`

The only shared-kernel behavior change is cuBLASLt autotuning inside
`bf16_matmul_cublaslt_bf16`. It affects only paths that explicitly call this
helper; the regular `bf16_matmul_bf16`, INT8, FP8, and NVFP4 kernels are
unchanged. Autotuning is skipped during CUDA Graph capture.

## Scope

Included:

- Jetson Orin / SM87.
- Official BF16 Qwen3-VL checkpoints.
- Single-image chat prompt.
- Greedy generation.
- Fixed-shape CUDA Graph replay for prefill/decode buckets.
- Direct frontend instantiation.

Not included:

- FP8 / NVFP4.
- INT8. The quickstart keeps a precision selector for future Orin INT8 work,
  but this PR implements and validates only BF16.
- Multi-image or video prompts.
- Server integration.
- `load_model()` registration.

## Build

Validated on Jetson AGX Orin 32G:

```bash
cd /root/FlashRT
source /root/pi0.5/bin/activate
cmake -B build -S . \
  -DGPU_ARCH=87 \
  -DFA2_ARCH_NATIVE_ONLY=ON \
  -DFLASHRT_BUILD_QWEN3_VL=ON
cmake --build build -j4 \
  --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels
```

## Validation

Local checks:

```bash
python -m py_compile \
  flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py \
  examples/orin/qwen3_vl_quickstart.py
python -m pytest tests/test_qwen3_vl_rtx_bf16.py tests/test_build_inventory.py -q
git diff --check
```

Jetson Orin runtime checks:

```bash
python examples/orin/qwen3_vl_quickstart.py \
  --checkpoint /root/models/Qwen3-VL-2B-Instruct \
  --image FlashRT.png \
  --prompt "Describe this image in one sentence." \
  --max-new-tokens 4 \
  --benchmark 3
```

Representative 2B full-resolution generation output from the current branch:

```text
output: A black background features
latency_ms: 5881.7, 1105.6
warm_latency_ms: 1105.6
```

The full-resolution Qwen3-VL-2B BF16 benchmark workload was:

```text
image: FlashRT.png
prompt: Describe this image in one sentence.
vision patches: 6256
prompt tokens: 1581
max_new_tokens: 4
```

Current full-resolution result:

| Path | Cold generate | Warm generate | Prefill graph P50 | Decode throughput |
|---|---:|---:|---:|---:|
| Full-res, cuBLASLt autotune enabled + M=1 BF16 GEMV | 5768.0 ms | 1050.5 ms | 927.5 ms | 36.8 tok/s |

Cold generation includes one-time graph capture and autotune effects, so the
warm and replay-only numbers are the more meaningful steady-state comparison.

The two optimization effects were measured separately:

| Change | Before | After |
|---|---:|---:|
| M=1 BF16 GEMV decode helper | ~16.2 tok/s | 36.8 tok/s |
| cuBLASLt autotune for M>1 prefill GEMMs | 953.8 ms prefill P50 | 927.5 ms prefill P50 |

The fixed-K M=1 GEMV helper provides the larger decode win. The cuBLASLt
autotune mainly improves M>1 prefill replay; it has little effect on decode
throughput once the M=1 GEMV helper is enabled.

Resolution capping is also exposed as an explicit deployment knob through the
Qwen3-VL processor's smart-resize path:

| `max_pixels` | Vision patches | Prompt tokens | Warm generate | Prefill graph P50 | Decode throughput |
|---|---:|---:|---:|---:|---:|
| none | 6256 | 1581 | 1050.5 ms | 927.5 ms | 36.8 tok/s |
| 1.0 M | 3888 | 989 | 600.2 ms | 503.6 ms | 41.4 tok/s |
| 0.5 M | 1824 | 473 | 317.3 ms | 216.1 ms | 39.0 tok/s |
| 0.25 M | 972 | 260 | 234.6 ms | 127.2 ms | 39.6 tok/s |

Qwen3-VL-8B low-resolution smoke:

```bash
python examples/orin/qwen3_vl_quickstart.py \
  --checkpoint /root/models/Qwen3-VL-8B-Instruct \
  --image FlashRT.png \
  --prompt "Describe this image in one sentence." \
  --max-new-tokens 1 \
  --max-seq 2048 \
  --max-pixels 250000 \
  --reps 1
```

```text
checkpoint: /root/models/Qwen3-VL-8B-Instruct
max_pixels: 250000
max_seq: 2048
max_new_tokens: 1
output: The
latency: 2790.9 ms
```

The 8B smoke completed successfully, but memory pressure is high on Orin 32G,
so Qwen3-VL-2B remains the fully validated target for this PR.

## Profiling

Replay-only Nsight profiling on the full-resolution 2B workload shows the
remaining BF16 prefill bottleneck is split between attention and large BF16
GEMMs:

| Kernel group | Time share |
|---|---:|
| FA2 BF16 prefill attention, vision tower | 32.9% |
| cuBLASLt BF16 GEMM, 128x128 family | 23.7% |
| cuBLASLt BF16 GEMM, 128x256 family | 12.7% |
| cuBLASLt BF16 GEMM, 256x128 family | 6.3% |

This suggests future work should target attention/prefill structure,
larger-grain BF16 GEMM scheduling, or an Orin-friendly quantized path rather
than more one-off elementwise fusion.
