### PR TITLE
fix(qwen3-vl): bound CUDA graph caches

### DIFF
--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -8,6 +8,8 @@ route. The hot linears use block-scaled M=1 FP8 GEMV against the checkpoint's
 """
 from __future__ import annotations
 
+import collections
+import os
 from typing import Any
 
 
@@ -58,9 +60,9 @@ class Qwen3VlFp8Sm89TextFrontend:
                  max_prefill_seq: int | None = None,
                  fuse_gate_up: bool = False,
                  fuse_qk_postproc: bool = True,
-                 use_fp8_lm_head: bool = False) -> None:
+                 use_fp8_lm_head: bool = False,
+                 max_decode_graphs: int | None = None) -> None:
         import json
-        import os
 
         self.checkpoint_path = str(checkpoint_path)
         self.device = device
@@ -75,7 +77,12 @@ class Qwen3VlFp8Sm89TextFrontend:
         self._cfg: dict | None = None
         self._attn = None
         self._cur_pos = 0
-        self._decode_graphs: dict[int, Any] = {}
+        if max_decode_graphs is None:
+            max_decode_graphs = int(os.environ.get(
+                'FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX', '256'))
+        self.max_decode_graphs = int(max_decode_graphs)
+        self._decode_graphs: collections.OrderedDict[int, Any] = (
+            collections.OrderedDict())
 
         import torch
         fvk = _import_fvk()
@@ -155,6 +162,31 @@ class Qwen3VlFp8Sm89TextFrontend:
         self._load_fp8_path()
         self._alloc_buffers()
         self._build_rope_table()
+
+    def _graph_cache_get(self, cache, key):
+        graph = cache.get(key)
+        if graph is not None and isinstance(cache, collections.OrderedDict):
+            cache.move_to_end(key)
+        return graph
+
+    def _trim_lru_graph_cache(self, cache, max_entries: int) -> None:
+        if max_entries <= 0 or not isinstance(cache, collections.OrderedDict):
+            return
+        while len(cache) > max_entries:
+            cache.popitem(last=False)
+
+    def clear_graphs(self) -> None:
+        if self._decode_graphs:
+            self._decode_graphs.clear()
+
+    def graph_cache_stats(self) -> dict[str, Any]:
+        return {
+            'decode': {
+                'max_graphs': self.max_decode_graphs,
+                'graph_count': len(self._decode_graphs),
+                'graph_keys': list(self._decode_graphs.keys()),
+            },
+        }
 
     def _load_fp8_path(self) -> None:
         from transformers import AutoTokenizer
@@ -691,7 +723,10 @@ class Qwen3VlFp8Sm89TextFrontend:
     def _ensure_decode_graph(self, cur_pos: int):
         import torch
 
-        graph = self._decode_graphs.get(cur_pos)
+        if not isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs = collections.OrderedDict(
+                self._decode_graphs)
+        graph = self._graph_cache_get(self._decode_graphs, cur_pos)
         if graph is not None:
             return graph
         cos, sin = self._rope_cos_sin(cur_pos)
@@ -709,6 +744,10 @@ class Qwen3VlFp8Sm89TextFrontend:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
         self._decode_graphs[cur_pos] = graph
+        if isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs.move_to_end(cur_pos)
+        self._trim_lru_graph_cache(
+            self._decode_graphs, self.max_decode_graphs)
         return graph
 
     def decode_step_with_graph(self, token_id, cur_pos: int):

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
@@ -9,6 +9,8 @@ Decode remains owned by ``Qwen3VlFp8Sm89TextFrontend``.
 """
 from __future__ import annotations
 
+import collections
+import os
 from typing import Any
 
 
@@ -23,9 +25,10 @@ class Qwen3VlFp8Sm89Frontend:
                  use_fp8_lm_head: bool = False,
                  vision_bf16_first_blocks: int = 3,
                  vision_bf16_block_linears: dict[int, tuple[str, ...]]
-                 | None = None) -> None:
+                 | None = None,
+                 max_prefill_graphs: int | None = None,
+                 max_decode_graphs: int | None = None) -> None:
         import json
-        import os
 
         from transformers import AutoProcessor
 
@@ -46,12 +49,21 @@ class Qwen3VlFp8Sm89Frontend:
         _require_qwen3_vl_kernels()
         self.max_prefill_seq = _resolve_max_prefill_seq(
             self.max_seq, max_prefill_seq)
+        if max_prefill_graphs is None:
+            max_prefill_graphs = int(os.environ.get(
+                'FLASHRT_QWEN3_VL_PREFILL_GRAPH_CACHE_MAX', '256'))
+        if max_decode_graphs is None:
+            max_decode_graphs = int(os.environ.get(
+                'FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX', '256'))
+        self.max_prefill_graphs = int(max_prefill_graphs)
+        self.max_decode_graphs = int(max_decode_graphs)
         self.llm = Qwen3VlFp8Sm89TextFrontend(
             checkpoint_path, device=device, max_seq=max_seq,
             max_prefill_seq=self.max_prefill_seq,
             fuse_gate_up=fuse_gate_up,
             fuse_qk_postproc=fuse_qk_postproc,
-            use_fp8_lm_head=use_fp8_lm_head)
+            use_fp8_lm_head=use_fp8_lm_head,
+            max_decode_graphs=self.max_decode_graphs)
         self.arch = 'sm89'
         cfg = json.load(open(os.path.join(checkpoint_path, 'config.json')))
         vcfg = dict(cfg['vision_config'])
@@ -98,24 +110,78 @@ class Qwen3VlFp8Sm89Frontend:
                 if isinstance(size, dict) and 'longest_edge' in size:
                     size['longest_edge'] = int(max_pixels)
         self._prompt: dict[str, Any] | None = None
-        self._decode_graphs: dict[tuple[int, int], Any] = {}
-        self._prefill_graphs: dict = {}
-        self._pg_buffers: dict = {}
+        self._decode_graphs: collections.OrderedDict[tuple[int, int], Any] = (
+            collections.OrderedDict())
+        self._prefill_graphs: collections.OrderedDict = (
+            collections.OrderedDict())
+        self._pg_buffers: collections.OrderedDict = collections.OrderedDict()
 
     _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
                 'vcos', 'vsin', 'mcos', 'msin')
 
+    def _graph_cache_get(self, cache, key):
+        graph = cache.get(key)
+        if graph is not None and isinstance(cache, collections.OrderedDict):
+            cache.move_to_end(key)
+        return graph
+
+    def _trim_lru_graph_cache(self, cache, max_entries: int,
+                              on_evict=None) -> None:
+        if max_entries <= 0 or not isinstance(cache, collections.OrderedDict):
+            return
+        while len(cache) > max_entries:
+            old_key, _ = cache.popitem(last=False)
+            if on_evict is not None:
+                on_evict(old_key)
+
     def _stage_prefill_inputs(self, P: int, S: int, span):
         p = self._prompt
         key = (P, S, span[0], span[1])
+        if not isinstance(self._pg_buffers, collections.OrderedDict):
+            self._pg_buffers = collections.OrderedDict(self._pg_buffers)
+        if not isinstance(self._prefill_graphs, collections.OrderedDict):
+            self._prefill_graphs = collections.OrderedDict(
+                self._prefill_graphs)
         bufs = self._pg_buffers.get(key)
         if bufs is None:
+            cap = self.max_prefill_graphs
+            while cap > 0 and len(self._pg_buffers) >= cap:
+                old_key, _ = self._pg_buffers.popitem(last=False)
+                self._prefill_graphs.pop(old_key, None)
             bufs = {k: p[k].clone() for k in self._PG_KEYS}
             self._pg_buffers[key] = bufs
         else:
+            self._pg_buffers.move_to_end(key)
             for k in self._PG_KEYS:
                 bufs[k].copy_(p[k])
         return key
+
+    def clear_graphs(self) -> None:
+        for attr in ('_prefill_graphs', '_decode_graphs', '_pg_buffers'):
+            cache = getattr(self, attr, None)
+            if cache:
+                cache.clear()
+        if hasattr(self.llm, 'clear_graphs'):
+            self.llm.clear_graphs()
+
+    def graph_cache_stats(self) -> dict[str, Any]:
+        stats = {
+            'prefill': {
+                'max_graphs': self.max_prefill_graphs,
+                'graph_count': len(self._prefill_graphs),
+                'buffer_count': len(self._pg_buffers),
+                'graph_keys': list(self._prefill_graphs.keys()),
+                'buffer_keys': list(self._pg_buffers.keys()),
+            },
+            'decode': {
+                'max_graphs': self.max_decode_graphs,
+                'graph_count': len(self._decode_graphs),
+                'graph_keys': list(self._decode_graphs.keys()),
+            },
+        }
+        if hasattr(self.llm, 'graph_cache_stats'):
+            stats['text'] = self.llm.graph_cache_stats()
+        return stats
 
     def set_prompt(self, messages: list) -> None:
         import torch
@@ -280,11 +346,24 @@ class Qwen3VlFp8Sm89Frontend:
             return self.prefill()
 
         P, S, a, b = key
-        st = self._pg_buffers[key]
-        graph = self._prefill_graphs.get(key)
+        st = self._pg_buffers.get(key)
+        if st is None:
+            self._prefill_graphs.pop(key, None)
+            self._stage_prefill_inputs(P, S, (a, b))
+            st = self._pg_buffers[key]
+        graph = self._graph_cache_get(self._prefill_graphs, key)
         if graph is None:
             graph = self._capture_prefill_graph(st, P, S, a, b)
             self._prefill_graphs[key] = graph
+            if isinstance(self._prefill_graphs, collections.OrderedDict):
+                self._prefill_graphs.move_to_end(key)
+            if isinstance(self._pg_buffers, collections.OrderedDict):
+                self._pg_buffers.move_to_end(key)
+            self._trim_lru_graph_cache(
+                self._prefill_graphs, self.max_prefill_graphs,
+                lambda old_key: self._pg_buffers.pop(old_key, None))
+        elif isinstance(self._pg_buffers, collections.OrderedDict):
+            self._pg_buffers.move_to_end(key)
         graph.replay()
         logits = self.llm._write_logits_from_hidden(
             self.llm._last_hidden_buf[0, S - 1:S])
@@ -304,7 +383,10 @@ class Qwen3VlFp8Sm89Frontend:
         import torch
 
         key = (int(cache_pos), int(rope_pos))
-        graph = self._decode_graphs.get(key)
+        if not isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs = collections.OrderedDict(
+                self._decode_graphs)
+        graph = self._graph_cache_get(self._decode_graphs, key)
         if graph is not None:
             return graph
         llm = self.llm
@@ -323,6 +405,10 @@ class Qwen3VlFp8Sm89Frontend:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
         self._decode_graphs[key] = graph
+        if isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs.move_to_end(key)
+        self._trim_lru_graph_cache(
+            self._decode_graphs, self.max_decode_graphs)
         return graph
 
     def decode_step_with_graph(self, token_id, cache_pos: int):

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -20,6 +20,7 @@ by ``_qwen3_vl_geometry``; the forward itself runs only kernels.
 """
 from __future__ import annotations
 
+import collections
 import json
 import os
 from typing import Any
@@ -64,13 +65,18 @@ class Qwen3VlTorchFrontendRtx:
     """Qwen3-VL-8B-class multimodal inference frontend (RTX SM120, NVFP4).
 
     Public surface:
-      __init__(checkpoint_path, *, device='cuda:0', max_seq=4096)
+      __init__(checkpoint_path, *, device='cuda:0', max_seq=4096,
+               max_prefill_graphs=None, max_decode_graphs=None)
       set_prompt(messages)   -- preprocess image+text, build geometry
       prefill()              -- multimodal prefill, returns next-token logits
+      clear_graphs()         -- drop captured prefill/decode graphs
+      graph_cache_stats()    -- inspect captured graph-cache buckets
     """
 
     def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
-                 max_seq: int = 4096, max_pixels: int | None = None) -> None:
+                 max_seq: int = 4096, max_pixels: int | None = None,
+                 max_prefill_graphs: int | None = None,
+                 max_decode_graphs: int | None = None) -> None:
         from transformers import AutoProcessor
 
         from flash_rt.frontends.torch._qwen3_vl_vision_rtx import (
@@ -134,14 +140,25 @@ class Qwen3VlTorchFrontendRtx:
                     size['longest_edge'] = int(max_pixels)
 
         self._prompt: dict[str, Any] | None = None
+        if max_prefill_graphs is None:
+            max_prefill_graphs = int(os.environ.get(
+                'FLASHRT_QWEN3_VL_PREFILL_GRAPH_CACHE_MAX', '256'))
+        if max_decode_graphs is None:
+            max_decode_graphs = int(os.environ.get(
+                'FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX', '256'))
+        self.max_prefill_graphs = int(max_prefill_graphs)
+        self.max_decode_graphs = int(max_decode_graphs)
+
         # cache-slot -> captured decode CUDA Graph (rope baked at the
         # MRoPE-continuation position, which differs from the slot).
-        self._decode_graphs: dict[int, Any] = {}
+        self._decode_graphs: collections.OrderedDict[int, Any] = (
+            collections.OrderedDict())
         # Captured single-image prefill: (P,S,a,b) -> graph, plus the static
         # input buffers set_prompt stages into and the persistent output
         # buffers the replay + eager lm_head write.
-        self._prefill_graphs: dict = {}
-        self._pg_buffers: dict = {}
+        self._prefill_graphs: collections.OrderedDict = (
+            collections.OrderedDict())
+        self._pg_buffers: collections.OrderedDict = collections.OrderedDict()
         import torch as _torch
         hidden = self.llm._cfg['hidden_size']
         vocab = self.llm._cfg['vocab_size']
@@ -247,20 +264,69 @@ class Qwen3VlTorchFrontendRtx:
     _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
                 'vcos', 'vsin', 'mcos', 'msin')
 
+    def _graph_cache_get(self, cache, key):
+        graph = cache.get(key)
+        if graph is not None and isinstance(cache, collections.OrderedDict):
+            cache.move_to_end(key)
+        return graph
+
+    def _trim_lru_graph_cache(self, cache, max_entries: int,
+                              on_evict=None) -> None:
+        if max_entries <= 0 or not isinstance(cache, collections.OrderedDict):
+            return
+        while len(cache) > max_entries:
+            old_key, _ = cache.popitem(last=False)
+            if on_evict is not None:
+                on_evict(old_key)
+
     def _stage_prefill_inputs(self, P: int, S: int, span):
         """Copy the per-prompt tensors into persistent static buffers keyed by
         (P, S, a, b). The captured prefill graph reads only from these, so the
         replay path needs no torch copy. Returns the key."""
         p = self._prompt
         key = (P, S, span[0], span[1])
+        if not isinstance(self._pg_buffers, collections.OrderedDict):
+            self._pg_buffers = collections.OrderedDict(self._pg_buffers)
+        if not isinstance(self._prefill_graphs, collections.OrderedDict):
+            self._prefill_graphs = collections.OrderedDict(
+                self._prefill_graphs)
         bufs = self._pg_buffers.get(key)
         if bufs is None:
+            cap = self.max_prefill_graphs
+            while cap > 0 and len(self._pg_buffers) >= cap:
+                old_key, _ = self._pg_buffers.popitem(last=False)
+                self._prefill_graphs.pop(old_key, None)
             bufs = {k: p[k].clone() for k in self._PG_KEYS}
             self._pg_buffers[key] = bufs
         else:
+            self._pg_buffers.move_to_end(key)
             for k in self._PG_KEYS:
                 bufs[k].copy_(p[k])
         return key
+
+    def clear_graphs(self) -> None:
+        """Drop captured Qwen3-VL prefill/decode CUDA Graphs and buffers."""
+        for attr in ('_prefill_graphs', '_decode_graphs', '_pg_buffers'):
+            cache = getattr(self, attr, None)
+            if cache:
+                cache.clear()
+
+    def graph_cache_stats(self) -> dict[str, Any]:
+        """Return lightweight Qwen3-VL CUDA Graph cache diagnostics."""
+        return {
+            'prefill': {
+                'max_graphs': self.max_prefill_graphs,
+                'graph_count': len(self._prefill_graphs),
+                'buffer_count': len(self._pg_buffers),
+                'graph_keys': list(self._prefill_graphs.keys()),
+                'buffer_keys': list(self._pg_buffers.keys()),
+            },
+            'decode': {
+                'max_graphs': self.max_decode_graphs,
+                'graph_count': len(self._decode_graphs),
+                'graph_keys': list(self._decode_graphs.keys()),
+            },
+        }
 
     # ── Forward ──
 
@@ -424,15 +490,28 @@ class Qwen3VlTorchFrontendRtx:
         S = p['S']
         key = p['pg_key']
         P, _, a, b = key
-        st = self._pg_buffers[key]            # already staged by set_prompt
+        st = self._pg_buffers.get(key)
+        if st is None:
+            self._prefill_graphs.pop(key, None)
+            self._stage_prefill_inputs(P, S, (a, b))
+            st = self._pg_buffers[key]
         # No reset_state: the captured layers write K/V[0:S] (which is all the
         # causal prefill reads), and the subsequent decode overwrites
         # K/V[>=S] before reading it (same as qwen3_rtx.prefill_with_graph).
 
-        graph = self._prefill_graphs.get(key)
+        graph = self._graph_cache_get(self._prefill_graphs, key)
         if graph is None:
             graph = self._capture_prefill_graph(st, P, S, a, b)
             self._prefill_graphs[key] = graph
+            if isinstance(self._prefill_graphs, collections.OrderedDict):
+                self._prefill_graphs.move_to_end(key)
+            if isinstance(self._pg_buffers, collections.OrderedDict):
+                self._pg_buffers.move_to_end(key)
+            self._trim_lru_graph_cache(
+                self._prefill_graphs, self.max_prefill_graphs,
+                lambda old_key: self._pg_buffers.pop(old_key, None))
+        elif isinstance(self._pg_buffers, collections.OrderedDict):
+            self._pg_buffers.move_to_end(key)
 
         # Hot path: pure-kernel graph replay + eager lm_head (one buffer, no
         # per-request torch alloc/copy).
@@ -456,7 +535,10 @@ class Qwen3VlTorchFrontendRtx:
         import torch
 
         llm = self.llm
-        g = self._decode_graphs.get(cache_pos)
+        if not isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs = collections.OrderedDict(
+                self._decode_graphs)
+        g = self._graph_cache_get(self._decode_graphs, cache_pos)
         if g is not None:
             return g
         cos, sin = llm._rope_cos_sin(rope_pos)
@@ -474,6 +556,10 @@ class Qwen3VlTorchFrontendRtx:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
         self._decode_graphs[cache_pos] = g
+        if isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs.move_to_end(cache_pos)
+        self._trim_lru_graph_cache(
+            self._decode_graphs, self.max_decode_graphs)
         return g
 
     def warmup_decode_graphs(self, n_tokens: int) -> None:

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -149,9 +149,9 @@ class Qwen3VlTorchFrontendRtx:
         self.max_prefill_graphs = int(max_prefill_graphs)
         self.max_decode_graphs = int(max_decode_graphs)
 
-        # cache-slot -> captured decode CUDA Graph (rope baked at the
-        # MRoPE-continuation position, which differs from the slot).
-        self._decode_graphs: collections.OrderedDict[int, Any] = (
+        # (cache-slot, rope-pos) -> captured decode CUDA Graph. The RoPE slice
+        # is baked into capture and can differ across prompts for one slot.
+        self._decode_graphs: collections.OrderedDict[tuple[int, int], Any] = (
             collections.OrderedDict())
         # Captured single-image prefill: (P,S,a,b) -> graph, plus the static
         # input buffers set_prompt stages into and the persistent output
@@ -535,10 +535,11 @@ class Qwen3VlTorchFrontendRtx:
         import torch
 
         llm = self.llm
+        key = (int(cache_pos), int(rope_pos))
         if not isinstance(self._decode_graphs, collections.OrderedDict):
             self._decode_graphs = collections.OrderedDict(
                 self._decode_graphs)
-        g = self._graph_cache_get(self._decode_graphs, cache_pos)
+        g = self._graph_cache_get(self._decode_graphs, key)
         if g is not None:
             return g
         cos, sin = llm._rope_cos_sin(rope_pos)
@@ -555,9 +556,9 @@ class Qwen3VlTorchFrontendRtx:
                 llm._static_token_id, cos, sin, cache_pos)
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
-        self._decode_graphs[cache_pos] = g
+        self._decode_graphs[key] = g
         if isinstance(self._decode_graphs, collections.OrderedDict):
-            self._decode_graphs.move_to_end(cache_pos)
+            self._decode_graphs.move_to_end(key)
         self._trim_lru_graph_cache(
             self._decode_graphs, self.max_decode_graphs)
         return g

--- a/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
@@ -15,6 +15,7 @@ checkpoint path for correctness bring-up and unsupported quantized targets.
 """
 from __future__ import annotations
 
+import collections
 import json
 import os
 from typing import Any
@@ -77,7 +78,9 @@ class Qwen3VlTorchFrontendRtxBF16:
     """
 
     def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
-                 max_seq: int = 2048, max_pixels: int | None = None) -> None:
+                 max_seq: int = 2048, max_pixels: int | None = None,
+                 max_prefill_graphs: int | None = None,
+                 max_decode_graphs: int | None = None) -> None:
         import torch
         from transformers import AutoProcessor
 
@@ -97,9 +100,21 @@ class Qwen3VlTorchFrontendRtxBF16:
         self.max_seq = int(max_seq)
         self.max_pixels = max_pixels
         self._prompt: dict[str, Any] | None = None
-        self._decode_graphs: dict[tuple[int, int], Any] = {}
-        self._prefill_graphs: dict[tuple[int, int, int, int], Any] = {}
-        self._pg_buffers: dict[tuple[int, int, int, int], dict[str, Any]] = {}
+        if max_prefill_graphs is None:
+            max_prefill_graphs = int(os.environ.get(
+                'FLASHRT_QWEN3_VL_PREFILL_GRAPH_CACHE_MAX', '256'))
+        if max_decode_graphs is None:
+            max_decode_graphs = int(os.environ.get(
+                'FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX', '256'))
+        self.max_prefill_graphs = int(max_prefill_graphs)
+        self.max_decode_graphs = int(max_decode_graphs)
+        self._decode_graphs: collections.OrderedDict[tuple[int, int], Any] = (
+            collections.OrderedDict())
+        self._prefill_graphs: collections.OrderedDict[
+            tuple[int, int, int, int], Any] = collections.OrderedDict()
+        self._pg_buffers: collections.OrderedDict[
+            tuple[int, int, int, int], dict[str, Any]] = (
+                collections.OrderedDict())
 
         device_obj = torch.device(device)
         if device_obj.type != 'cuda' or not torch.cuda.is_available():
@@ -180,6 +195,21 @@ class Qwen3VlTorchFrontendRtxBF16:
     _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
                 'vcos', 'vsin', 'mcos', 'msin')
 
+    def _graph_cache_get(self, cache, key):
+        graph = cache.get(key)
+        if graph is not None and isinstance(cache, collections.OrderedDict):
+            cache.move_to_end(key)
+        return graph
+
+    def _trim_lru_graph_cache(self, cache, max_entries: int,
+                              on_evict=None) -> None:
+        if max_entries <= 0 or not isinstance(cache, collections.OrderedDict):
+            return
+        while len(cache) > max_entries:
+            old_key, _ = cache.popitem(last=False)
+            if on_evict is not None:
+                on_evict(old_key)
+
     def _alloc_buffers(self) -> None:
         import torch
 
@@ -226,14 +256,48 @@ class Qwen3VlTorchFrontendRtxBF16:
         p = self._prompt
         assert p is not None
         key = (int(P), int(S), int(span[0]), int(span[1]))
+        if not isinstance(self._pg_buffers, collections.OrderedDict):
+            self._pg_buffers = collections.OrderedDict(self._pg_buffers)
+        if not isinstance(self._prefill_graphs, collections.OrderedDict):
+            self._prefill_graphs = collections.OrderedDict(
+                self._prefill_graphs)
         bufs = self._pg_buffers.get(key)
         if bufs is None:
+            cap = self.max_prefill_graphs
+            while cap > 0 and len(self._pg_buffers) >= cap:
+                old_key, _ = self._pg_buffers.popitem(last=False)
+                self._prefill_graphs.pop(old_key, None)
             bufs = {k: p[k].clone() for k in self._PG_KEYS}
             self._pg_buffers[key] = bufs
         else:
+            self._pg_buffers.move_to_end(key)
             for k in self._PG_KEYS:
                 bufs[k].copy_(p[k])
         return key
+
+    def clear_graphs(self) -> None:
+        """Drop captured Qwen3-VL BF16 prefill/decode CUDA Graphs."""
+        for attr in ('_prefill_graphs', '_decode_graphs', '_pg_buffers'):
+            cache = getattr(self, attr, None)
+            if cache:
+                cache.clear()
+
+    def graph_cache_stats(self) -> dict[str, Any]:
+        """Return lightweight BF16 CUDA Graph cache diagnostics."""
+        return {
+            'prefill': {
+                'max_graphs': self.max_prefill_graphs,
+                'graph_count': len(self._prefill_graphs),
+                'buffer_count': len(self._pg_buffers),
+                'graph_keys': list(self._prefill_graphs.keys()),
+                'buffer_keys': list(self._pg_buffers.keys()),
+            },
+            'decode': {
+                'max_graphs': self.max_decode_graphs,
+                'graph_count': len(self._decode_graphs),
+                'graph_keys': list(self._decode_graphs.keys()),
+            },
+        }
 
     def set_prompt(self, messages: list) -> None:
         """Preprocess a single-image Qwen3-VL chat prompt."""
@@ -537,10 +601,30 @@ class Qwen3VlTorchFrontendRtxBF16:
         key = self._prompt.get('pg_key')
         if key is None:
             return self.prefill()
-        graph = self._prefill_graphs.get(key)
+        if not isinstance(self._pg_buffers, collections.OrderedDict):
+            self._pg_buffers = collections.OrderedDict(self._pg_buffers)
+        if not isinstance(self._prefill_graphs, collections.OrderedDict):
+            self._prefill_graphs = collections.OrderedDict(
+                self._prefill_graphs)
+        st = self._pg_buffers.get(key)
+        if st is None:
+            self._prefill_graphs.pop(key, None)
+            P, S, a, b = key
+            self._stage_prefill_inputs(P, S, (a, b))
+            st = self._pg_buffers[key]
+        graph = self._graph_cache_get(self._prefill_graphs, key)
         if graph is None:
-            graph = self._capture_prefill_graph(self._pg_buffers[key], key)
+            graph = self._capture_prefill_graph(st, key)
             self._prefill_graphs[key] = graph
+            if isinstance(self._prefill_graphs, collections.OrderedDict):
+                self._prefill_graphs.move_to_end(key)
+            if isinstance(self._pg_buffers, collections.OrderedDict):
+                self._pg_buffers.move_to_end(key)
+            self._trim_lru_graph_cache(
+                self._prefill_graphs, self.max_prefill_graphs,
+                lambda old_key: self._pg_buffers.pop(old_key, None))
+        elif isinstance(self._pg_buffers, collections.OrderedDict):
+            self._pg_buffers.move_to_end(key)
         graph.replay()
         self._cur_pos = int(key[1])
         return self._logits
@@ -582,7 +666,10 @@ class Qwen3VlTorchFrontendRtxBF16:
         import torch
 
         key = (int(cache_pos), int(rope_pos))
-        graph = self._decode_graphs.get(key)
+        if not isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs = collections.OrderedDict(
+                self._decode_graphs)
+        graph = self._graph_cache_get(self._decode_graphs, key)
         if graph is not None:
             return graph
         gs = self._graph_stream
@@ -600,6 +687,10 @@ class Qwen3VlTorchFrontendRtxBF16:
         gs.synchronize()
         torch.cuda.current_stream().wait_stream(gs)
         self._decode_graphs[key] = graph
+        if isinstance(self._decode_graphs, collections.OrderedDict):
+            self._decode_graphs.move_to_end(key)
+        self._trim_lru_graph_cache(
+            self._decode_graphs, self.max_decode_graphs)
         return graph
 
     def decode_step_with_graph(self, token_id: int, *, cache_pos: int,

--- a/tests/test_qwen3_vl_fp8_sm89.py
+++ b/tests/test_qwen3_vl_fp8_sm89.py
@@ -15,6 +15,7 @@ def test_frontend_imports():
     text_cls = m.Qwen3VlFp8Sm89TextFrontend
     assert hasattr(m, 'Qwen3VlFp8Sm89TextFrontend')
     assert 'max_prefill_seq' in inspect.signature(text_cls).parameters
+    assert 'max_decode_graphs' in inspect.signature(text_cls).parameters
     assert 'run_lm_head' in inspect.signature(
         text_cls.forward_hidden_prefill_fp8_blockscaled).parameters
     mm = importlib.import_module(
@@ -24,11 +25,13 @@ def test_frontend_imports():
     assert 'max_prefill_seq' in inspect.signature(
         cls).parameters
     for name in ('fuse_gate_up', 'fuse_qk_postproc', 'use_fp8_lm_head',
-                 'vision_bf16_first_blocks'):
+                 'vision_bf16_first_blocks', 'max_prefill_graphs',
+                 'max_decode_graphs'):
         assert name in inspect.signature(cls).parameters
     for name in (
         'prefill_graph', 'decode_step_with_graph',
-        'warmup_decode_graphs', 'generate',
+        'warmup_decode_graphs', 'clear_graphs', 'graph_cache_stats',
+        'generate',
     ):
         assert hasattr(cls, name)
 

--- a/tests/test_qwen3_vl_graph_cache.py
+++ b/tests/test_qwen3_vl_graph_cache.py
@@ -1,0 +1,340 @@
+"""Regression tests for Qwen3-VL CUDA Graph cache management.
+
+These tests avoid checkpoints and real CUDA Graph capture. They patch the small
+``torch.cuda`` surface used by ``Qwen3VlTorchFrontendRtx._ensure_decode_graph``
+so the test can drive graph-cache bookkeeping in CI.
+"""
+from __future__ import annotations
+
+import collections
+import contextlib
+import sys
+import types
+
+
+class _TensorStub:
+    def __init__(self, name):
+        self.name = name
+        self.copied_from = []
+
+    def clone(self):
+        return _TensorStub(self.name + "_clone")
+
+    def copy_(self, other):
+        self.copied_from.append(other)
+        return self
+
+
+def test_qwen3_vl_decode_graph_cache_is_lru_bounded(monkeypatch):
+    """Distinct decode positions must not grow the graph cache forever."""
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+
+    class _FakeStream:
+        cuda_stream = 0
+
+        def wait_stream(self, _other):
+            pass
+
+        def synchronize(self):
+            pass
+
+    class _FakeGraph:
+        def replay(self):
+            pass
+
+    class _FakeLLM:
+        def __init__(self):
+            self._graph_stream = _FakeStream()
+            self._static_token_id = object()
+            self.calls = []
+
+        def _rope_cos_sin(self, rope_pos):
+            return object(), object()
+
+        def forward_own_decode_nvfp4(self, token, cos, sin, cache_pos):
+            self.calls.append((token, cos, sin, cache_pos))
+
+    monkeypatch.setattr(torch.cuda, "current_stream",
+                        lambda: _FakeStream(), raising=False)
+    monkeypatch.setattr(torch.cuda, "stream",
+                        lambda _stream: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "graph",
+                        lambda _graph, stream=None: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "CUDAGraph",
+                        lambda: _FakeGraph(), raising=False)
+
+    fe = Qwen3VlTorchFrontendRtx.__new__(Qwen3VlTorchFrontendRtx)
+    fe.llm = _FakeLLM()
+    fe.max_decode_graphs = 2
+    fe._decode_graphs = collections.OrderedDict()
+
+    for cache_pos in range(5):
+        fe._ensure_decode_graph(cache_pos, rope_pos=100 + cache_pos)
+
+    assert len(fe._decode_graphs) == fe.max_decode_graphs
+    assert list(fe._decode_graphs) == [3, 4]
+
+
+def test_qwen3_vl_prefill_graph_cache_eviction_drops_static_buffers():
+    """Prefill graph eviction must also drop that graph's staged inputs."""
+    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+
+    fe = Qwen3VlTorchFrontendRtx.__new__(Qwen3VlTorchFrontendRtx)
+    fe.max_prefill_graphs = 2
+    fe._prefill_graphs = collections.OrderedDict()
+    fe._pg_buffers = collections.OrderedDict()
+
+    for i in range(3):
+        fe._prompt = {k: _TensorStub(f"{k}_{i}") for k in fe._PG_KEYS}
+        key = fe._stage_prefill_inputs(P=10 + i, S=20 + i, span=(i, i + 10))
+        fe._prefill_graphs[key] = object()
+        fe._trim_lru_graph_cache(
+            fe._prefill_graphs, fe.max_prefill_graphs,
+            lambda old_key: fe._pg_buffers.pop(old_key, None))
+
+    assert len(fe._prefill_graphs) == fe.max_prefill_graphs
+    assert len(fe._pg_buffers) == fe.max_prefill_graphs
+    assert list(fe._prefill_graphs) == list(fe._pg_buffers)
+    assert list(fe._prefill_graphs) == [(11, 21, 1, 11), (12, 22, 2, 12)]
+
+
+def test_qwen3_vl_prefill_graph_restages_after_clear(monkeypatch):
+    """clear_graphs() should not force callers to rerun set_prompt()."""
+    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+
+    fe = Qwen3VlTorchFrontendRtx.__new__(Qwen3VlTorchFrontendRtx)
+    fe.max_prefill_graphs = 2
+    fe._prefill_graphs = collections.OrderedDict()
+    fe._pg_buffers = collections.OrderedDict()
+    fe._decode_graphs = collections.OrderedDict()
+    fe._prompt = {k: _TensorStub(k) for k in fe._PG_KEYS}
+    fe._prompt.update({"S": 20, "pg_key": (10, 20, 3, 13)})
+
+    stale_graph = object()
+    fe._stage_prefill_inputs(P=10, S=20, span=(3, 13))
+    fe._prefill_graphs[(10, 20, 3, 13)] = stale_graph
+    fe.clear_graphs()
+    fe._prefill_graphs[(10, 20, 3, 13)] = stale_graph
+
+    class _FakeGraph:
+        def replay(self):
+            pass
+
+    graph = _FakeGraph()
+    monkeypatch.setattr(
+        Qwen3VlTorchFrontendRtx, "_capture_prefill_graph",
+        lambda self, st, P, S, a, b: graph)
+
+    class _FakeLLM:
+        _cfg = {"hidden_size": 1, "vocab_size": 1}
+        _weights = type(
+            "Weights", (), {"ptrs": {"lm_head_w": 0}})()
+
+    class _FakeTensor:
+        def __getitem__(self, _key):
+            return self
+
+        def contiguous(self):
+            return self
+
+        def data_ptr(self):
+            return 0
+
+    class _FakeStream:
+        cuda_stream = 0
+
+    fake_fvk = types.SimpleNamespace(
+        bf16_matmul_bf16=lambda *args: None,
+        bf16_matmul_qwen36_bf16=lambda *args: None)
+    import flash_rt
+    monkeypatch.setitem(sys.modules, "flash_rt.flash_rt_kernels", fake_fvk)
+    monkeypatch.setattr(flash_rt, "flash_rt_kernels", fake_fvk, raising=False)
+    import torch
+    monkeypatch.setattr(torch.cuda, "current_stream",
+                        lambda: _FakeStream(), raising=False)
+    monkeypatch.setattr(torch.cuda, "synchronize",
+                        lambda: None, raising=False)
+
+    fe.llm = _FakeLLM()
+    fe._pg_last_hidden = _FakeTensor()
+    fe._pg_logits = _FakeTensor()
+
+    assert fe.prefill_graph() is fe._pg_logits
+    assert list(fe._pg_buffers) == [(10, 20, 3, 13)]
+    assert list(fe._prefill_graphs) == [(10, 20, 3, 13)]
+    assert fe._prefill_graphs[(10, 20, 3, 13)] is graph
+
+
+def test_qwen3_vl_graph_cache_stats_and_clear_graphs():
+    from flash_rt.frontends.torch.qwen3_vl_rtx import Qwen3VlTorchFrontendRtx
+
+    fe = Qwen3VlTorchFrontendRtx.__new__(Qwen3VlTorchFrontendRtx)
+    fe.max_prefill_graphs = 7
+    fe.max_decode_graphs = 5
+    fe._prefill_graphs = collections.OrderedDict([(("p0",), object())])
+    fe._pg_buffers = collections.OrderedDict([(("p0",), object())])
+    fe._decode_graphs = collections.OrderedDict([(3, object()), (4, object())])
+
+    stats = fe.graph_cache_stats()
+    assert stats["prefill"]["max_graphs"] == 7
+    assert stats["prefill"]["graph_count"] == 1
+    assert stats["prefill"]["buffer_count"] == 1
+    assert stats["prefill"]["graph_keys"] == [("p0",)]
+    assert stats["decode"]["max_graphs"] == 5
+    assert stats["decode"]["graph_count"] == 2
+    assert stats["decode"]["graph_keys"] == [3, 4]
+
+    fe.clear_graphs()
+
+    assert fe._prefill_graphs == collections.OrderedDict()
+    assert fe._pg_buffers == collections.OrderedDict()
+    assert fe._decode_graphs == collections.OrderedDict()
+
+
+def test_qwen3_vl_sm89_text_decode_graph_cache_is_lru_bounded(monkeypatch):
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+        Qwen3VlFp8Sm89TextFrontend,
+    )
+
+    class _FakeStream:
+        cuda_stream = 0
+
+        def wait_stream(self, _other):
+            pass
+
+        def synchronize(self):
+            pass
+
+    class _FakeGraph:
+        def replay(self):
+            pass
+
+    monkeypatch.setattr(torch.cuda, "current_stream",
+                        lambda: _FakeStream(), raising=False)
+    monkeypatch.setattr(torch.cuda, "stream",
+                        lambda _stream: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "graph",
+                        lambda _graph, stream=None: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "CUDAGraph",
+                        lambda: _FakeGraph(), raising=False)
+    monkeypatch.setattr(torch, "inference_mode",
+                        lambda: contextlib.nullcontext())
+
+    fe = Qwen3VlFp8Sm89TextFrontend.__new__(
+        Qwen3VlFp8Sm89TextFrontend)
+    fe.max_decode_graphs = 2
+    fe._decode_graphs = collections.OrderedDict()
+    fe._graph_stream = _FakeStream()
+    fe._static_token_id = object()
+    fe._rope_cos_sin = lambda pos: (object(), object())
+    fe.forward_own_decode_fp8 = lambda token, cos, sin, pos: None
+
+    for cur_pos in range(5):
+        fe._ensure_decode_graph(cur_pos)
+
+    assert len(fe._decode_graphs) == fe.max_decode_graphs
+    assert list(fe._decode_graphs) == [3, 4]
+    stats = fe.graph_cache_stats()
+    assert stats["decode"]["graph_count"] == 2
+    fe.clear_graphs()
+    assert fe._decode_graphs == collections.OrderedDict()
+
+
+def test_qwen3_vl_sm89_multimodal_graph_caches_are_lru_bounded(monkeypatch):
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+        Qwen3VlFp8Sm89Frontend,
+    )
+
+    class _FakeStream:
+        cuda_stream = 0
+
+        def wait_stream(self, _other):
+            pass
+
+        def synchronize(self):
+            pass
+
+    class _FakeGraph:
+        def replay(self):
+            pass
+
+    class _FakeLLM:
+        def __init__(self):
+            self._graph_stream = _FakeStream()
+            self._static_token_id = object()
+            self._logits_buf = object()
+            self.clear_count = 0
+
+        def _rope_cos_sin(self, rope_pos):
+            return object(), object()
+
+        def forward_own_decode_fp8(self, token, cos, sin, cache_pos):
+            pass
+
+        def clear_graphs(self):
+            self.clear_count += 1
+
+        def graph_cache_stats(self):
+            return {"decode": {"graph_count": 0}}
+
+    monkeypatch.setattr(torch.cuda, "current_stream",
+                        lambda: _FakeStream(), raising=False)
+    monkeypatch.setattr(torch.cuda, "stream",
+                        lambda _stream: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "graph",
+                        lambda _graph, stream=None: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "CUDAGraph",
+                        lambda: _FakeGraph(), raising=False)
+    monkeypatch.setattr(torch, "inference_mode",
+                        lambda: contextlib.nullcontext())
+
+    fe = Qwen3VlFp8Sm89Frontend.__new__(Qwen3VlFp8Sm89Frontend)
+    fe.max_prefill_graphs = 2
+    fe.max_decode_graphs = 2
+    fe._prefill_graphs = collections.OrderedDict()
+    fe._pg_buffers = collections.OrderedDict()
+    fe._decode_graphs = collections.OrderedDict()
+    fe.llm = _FakeLLM()
+
+    for i in range(3):
+        fe._prompt = {k: _TensorStub(f"{k}_{i}") for k in fe._PG_KEYS}
+        key = fe._stage_prefill_inputs(P=10 + i, S=20 + i, span=(i, i + 10))
+        fe._prefill_graphs[key] = object()
+        fe._trim_lru_graph_cache(
+            fe._prefill_graphs, fe.max_prefill_graphs,
+            lambda old_key: fe._pg_buffers.pop(old_key, None))
+
+    assert len(fe._prefill_graphs) == fe.max_prefill_graphs
+    assert len(fe._pg_buffers) == fe.max_prefill_graphs
+    assert list(fe._prefill_graphs) == list(fe._pg_buffers)
+    assert list(fe._prefill_graphs) == [(11, 21, 1, 11), (12, 22, 2, 12)]
+
+    for i in range(5):
+        fe._ensure_decode_graph(cache_pos=i, rope_pos=100 + i)
+
+    assert len(fe._decode_graphs) == fe.max_decode_graphs
+    assert list(fe._decode_graphs) == [(3, 103), (4, 104)]
+    stats = fe.graph_cache_stats()
+    assert stats["prefill"]["graph_count"] == 2
+    assert stats["prefill"]["buffer_count"] == 2
+    assert stats["decode"]["graph_count"] == 2
+    assert stats["text"]["decode"]["graph_count"] == 0
+
+    fe.clear_graphs()
+
+    assert fe._prefill_graphs == collections.OrderedDict()
+    assert fe._pg_buffers == collections.OrderedDict()
+    assert fe._decode_graphs == collections.OrderedDict()
+    assert fe.llm.clear_count == 1

--- a/tests/test_qwen3_vl_graph_cache.py
+++ b/tests/test_qwen3_vl_graph_cache.py
@@ -76,7 +76,7 @@ def test_qwen3_vl_decode_graph_cache_is_lru_bounded(monkeypatch):
         fe._ensure_decode_graph(cache_pos, rope_pos=100 + cache_pos)
 
     assert len(fe._decode_graphs) == fe.max_decode_graphs
-    assert list(fe._decode_graphs) == [3, 4]
+    assert list(fe._decode_graphs) == [(3, 103), (4, 104)]
 
 
 def test_qwen3_vl_prefill_graph_cache_eviction_drops_static_buffers():
@@ -177,7 +177,8 @@ def test_qwen3_vl_graph_cache_stats_and_clear_graphs():
     fe.max_decode_graphs = 5
     fe._prefill_graphs = collections.OrderedDict([(("p0",), object())])
     fe._pg_buffers = collections.OrderedDict([(("p0",), object())])
-    fe._decode_graphs = collections.OrderedDict([(3, object()), (4, object())])
+    fe._decode_graphs = collections.OrderedDict([
+        ((3, 103), object()), ((4, 104), object())])
 
     stats = fe.graph_cache_stats()
     assert stats["prefill"]["max_graphs"] == 7
@@ -186,7 +187,7 @@ def test_qwen3_vl_graph_cache_stats_and_clear_graphs():
     assert stats["prefill"]["graph_keys"] == [("p0",)]
     assert stats["decode"]["max_graphs"] == 5
     assert stats["decode"]["graph_count"] == 2
-    assert stats["decode"]["graph_keys"] == [3, 4]
+    assert stats["decode"]["graph_keys"] == [(3, 103), (4, 104)]
 
     fe.clear_graphs()
 

--- a/tests/test_qwen3_vl_graph_cache.py
+++ b/tests/test_qwen3_vl_graph_cache.py
@@ -338,3 +338,191 @@ def test_qwen3_vl_sm89_multimodal_graph_caches_are_lru_bounded(monkeypatch):
     assert fe._pg_buffers == collections.OrderedDict()
     assert fe._decode_graphs == collections.OrderedDict()
     assert fe.llm.clear_count == 1
+
+
+def test_qwen3_vl_rtx_bf16_graph_caches_are_lru_bounded(monkeypatch):
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_rtx_bf16 import (
+        Qwen3VlTorchFrontendRtxBF16,
+    )
+
+    class _FakeStream:
+        cuda_stream = 0
+
+        def wait_stream(self, _other):
+            pass
+
+        def synchronize(self):
+            pass
+
+    class _FakeGraph:
+        def replay(self):
+            pass
+
+    monkeypatch.setattr(torch.cuda, "current_stream",
+                        lambda: _FakeStream(), raising=False)
+    monkeypatch.setattr(torch.cuda, "stream",
+                        lambda _stream: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "graph",
+                        lambda _graph, stream=None: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "CUDAGraph",
+                        lambda: _FakeGraph(), raising=False)
+    monkeypatch.setattr(torch, "inference_mode",
+                        lambda: contextlib.nullcontext())
+    monkeypatch.setattr(
+        Qwen3VlTorchFrontendRtxBF16, "_decode_token_tensor",
+        lambda self, token, *, cache_pos, rope_pos: None)
+
+    fe = Qwen3VlTorchFrontendRtxBF16.__new__(
+        Qwen3VlTorchFrontendRtxBF16)
+    fe.max_prefill_graphs = 2
+    fe.max_decode_graphs = 2
+    fe._prefill_graphs = collections.OrderedDict()
+    fe._pg_buffers = collections.OrderedDict()
+    fe._decode_graphs = collections.OrderedDict()
+    fe._graph_stream = _FakeStream()
+    fe._static_token_id = object()
+
+    for i in range(3):
+        fe._prompt = {k: _TensorStub(f"{k}_{i}") for k in fe._PG_KEYS}
+        key = fe._stage_prefill_inputs(P=10 + i, S=20 + i, span=(i, i + 10))
+        fe._prefill_graphs[key] = object()
+        fe._trim_lru_graph_cache(
+            fe._prefill_graphs, fe.max_prefill_graphs,
+            lambda old_key: fe._pg_buffers.pop(old_key, None))
+
+    assert len(fe._prefill_graphs) == fe.max_prefill_graphs
+    assert len(fe._pg_buffers) == fe.max_prefill_graphs
+    assert list(fe._prefill_graphs) == list(fe._pg_buffers)
+    assert list(fe._prefill_graphs) == [(11, 21, 1, 11), (12, 22, 2, 12)]
+
+    for i in range(5):
+        fe._ensure_decode_graph(cache_pos=i, rope_pos=100 + i)
+
+    assert len(fe._decode_graphs) == fe.max_decode_graphs
+    assert list(fe._decode_graphs) == [(3, 103), (4, 104)]
+    stats = fe.graph_cache_stats()
+    assert stats["prefill"]["graph_count"] == 2
+    assert stats["prefill"]["buffer_count"] == 2
+    assert stats["decode"]["graph_count"] == 2
+
+    fe.clear_graphs()
+
+    assert fe._prefill_graphs == collections.OrderedDict()
+    assert fe._pg_buffers == collections.OrderedDict()
+    assert fe._decode_graphs == collections.OrderedDict()
+
+
+def test_qwen3_vl_rtx_bf16_prefill_graph_restages_after_clear(monkeypatch):
+    from flash_rt.frontends.torch.qwen3_vl_rtx_bf16 import (
+        Qwen3VlTorchFrontendRtxBF16,
+    )
+
+    fe = Qwen3VlTorchFrontendRtxBF16.__new__(
+        Qwen3VlTorchFrontendRtxBF16)
+    fe.max_prefill_graphs = 2
+    fe.max_decode_graphs = 2
+    fe._prefill_graphs = collections.OrderedDict()
+    fe._pg_buffers = collections.OrderedDict()
+    fe._decode_graphs = collections.OrderedDict()
+    fe._prompt = {k: _TensorStub(k) for k in fe._PG_KEYS}
+    fe._prompt.update({"S": 20, "pg_key": (10, 20, 3, 13)})
+    fe._logits = object()
+    fe._cur_pos = 0
+
+    stale_graph = object()
+    fe._stage_prefill_inputs(P=10, S=20, span=(3, 13))
+    fe._prefill_graphs[(10, 20, 3, 13)] = stale_graph
+    fe.clear_graphs()
+    fe._prefill_graphs[(10, 20, 3, 13)] = stale_graph
+
+    class _FakeGraph:
+        def replay(self):
+            pass
+
+    graph = _FakeGraph()
+    monkeypatch.setattr(
+        Qwen3VlTorchFrontendRtxBF16, "_capture_prefill_graph",
+        lambda self, st, key: graph)
+
+    assert fe.prefill_graph() is fe._logits
+    assert list(fe._pg_buffers) == [(10, 20, 3, 13)]
+    assert list(fe._prefill_graphs) == [(10, 20, 3, 13)]
+    assert fe._prefill_graphs[(10, 20, 3, 13)] is graph
+    assert fe._cur_pos == 20
+
+
+def test_qwen3_vl_rtx_bf16_graph_cache_init_surface(monkeypatch):
+    import importlib.machinery
+    import inspect
+
+    from flash_rt.frontends.torch.qwen3_vl_rtx_bf16 import (
+        Qwen3VlTorchFrontendRtxBF16,
+    )
+
+    sig = inspect.signature(Qwen3VlTorchFrontendRtxBF16)
+    assert "max_prefill_graphs" in sig.parameters
+    assert "max_decode_graphs" in sig.parameters
+
+    monkeypatch.setenv("FLASHRT_QWEN3_VL_PREFILL_GRAPH_CACHE_MAX", "17")
+    monkeypatch.setenv("FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX", "19")
+
+    fe = Qwen3VlTorchFrontendRtxBF16.__new__(
+        Qwen3VlTorchFrontendRtxBF16)
+
+    class _StopInit(Exception):
+        pass
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", None)
+    fake_torch.bfloat16 = object()
+    fake_torch.long = object()
+
+    class _FakeCuda:
+        @staticmethod
+        def is_available():
+            return True
+
+        @staticmethod
+        def get_device_capability(_device):
+            raise _StopInit
+
+    fake_torch.cuda = _FakeCuda
+    fake_torch.device = lambda device: types.SimpleNamespace(
+        type="cuda", value=device)
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers.AutoProcessor = object
+    fake_weights = types.ModuleType(
+        "flash_rt.frontends.torch._qwen3_vl_bf16_weights")
+    fake_weights.assert_extraction_invariants_qwen3_vl_bf16 = lambda *_: None
+    fake_weights.extract_weights_qwen3_vl_bf16 = lambda *_args, **_kwargs: None
+    fake_vision = types.ModuleType(
+        "flash_rt.frontends.torch._qwen3_vl_vision_rtx")
+    fake_vision.Qwen3VlVisionRtx = object
+    fake_attn = types.ModuleType(
+        "flash_rt.hardware.rtx.attn_backend_qwen3")
+    fake_attn.RtxFlashAttnBackendQwen3 = object
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    monkeypatch.setitem(
+        sys.modules, "flash_rt.frontends.torch._qwen3_vl_bf16_weights",
+        fake_weights)
+    monkeypatch.setitem(
+        sys.modules, "flash_rt.frontends.torch._qwen3_vl_vision_rtx",
+        fake_vision)
+    monkeypatch.setitem(
+        sys.modules, "flash_rt.hardware.rtx.attn_backend_qwen3", fake_attn)
+    try:
+        Qwen3VlTorchFrontendRtxBF16.__init__(fe, "checkpoint")
+    except _StopInit:
+        pass
+
+    assert fe.max_prefill_graphs == 17
+    assert fe.max_decode_graphs == 19
+    assert fe._prefill_graphs == collections.OrderedDict()
+    assert fe._pg_buffers == collections.OrderedDict()
+    assert fe._decode_graphs == collections.OrderedDict()


### PR DESCRIPTION
## Summary

Fixes #122.

This PR adds bounded CUDA Graph cache management for all current Qwen3-VL frontends in the repo:

- `Qwen3VlTorchFrontendRtx` (SM120/NVFP4 multimodal path)
- `Qwen3VlTorchFrontendRtxBF16` (Orin SM87 BF16 multimodal path)
- `Qwen3VlFp8Sm89TextFrontend` (SM89 FP8 text path)
- `Qwen3VlFp8Sm89Frontend` (SM89 FP8 multimodal wrapper)

The change replaces unbounded process-local graph dictionaries with LRU-bounded `OrderedDict` caches, adds public `clear_graphs()` APIs, and exposes lightweight `graph_cache_stats()` bucket diagnostics. Prefill graph eviction also drops the corresponding staged/static input buffers so graph entries and buffer residency stay in sync.

Decode graph caches that bake a prompt-dependent RoPE position now key by `(cache_pos, rope_pos)`, avoiding reuse of a graph captured for a different MRoPE continuation position.

The default cap is 256 entries per cache. It can be overridden with:

- `FLASHRT_QWEN3_VL_PREFILL_GRAPH_CACHE_MAX`
- `FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX`

Values <= 0 preserve legacy unbounded behavior for callers that intentionally want it.

## Scope

Runtime graph-cache bookkeeping only. This does not change model numerics, kernels, dtype policy, dispatch policy, graph-capture bodies, launch parameters, CMake, or pybind bindings.

## Validation

Environment:

- Python test environment with FlashRT dependencies installed
- Python tests only; no real checkpoint required for the graph-cache regression coverage

Commands:

```bash
PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q \
  tests/test_qwen3_vl_graph_cache.py \
  tests/test_qwen3_vl_rtx_bf16.py \
  tests/test_qwen3_vl_fp8_sm89.py \
  tests/test_qwen3_vl_fp8_sm89_2b.py \
  tests/test_qwen3_vl_smoke.py
python -m compileall -q \
  flash_rt/frontends/torch/qwen3_vl_rtx.py \
  flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py \
  flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py \
  flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py \
  tests/test_qwen3_vl_graph_cache.py \
  tests/test_qwen3_vl_rtx_bf16.py \
  tests/test_qwen3_vl_fp8_sm89.py \
  tests/test_qwen3_vl_fp8_sm89_2b.py \
  tests/test_qwen3_vl_smoke.py
git diff --check
rg -n "_decode_graphs\\s*:\\s*dict|_prefill_graphs\\s*:\\s*dict|_pg_buffers\\s*:\\s*dict|_decode_graphs\\s*=\\s*\\{\\}|_prefill_graphs\\s*=\\s*\\{\\}|_pg_buffers\\s*=\\s*\\{\\}" flash_rt/frontends/torch/qwen3_vl*.py tests/test_qwen3_vl_graph_cache.py
```

Results:

- Qwen3-VL Python tests above: 31 passed, 1 skipped
- `compileall`: passed
- `git diff --check`: passed
- Plain unbounded Qwen3-VL graph-cache dict declaration scan: no matches

## Not Run

- Real-checkpoint SM87 BF16 Qwen3-VL smoke.
- Real-checkpoint SM89 Qwen3-VL smoke.
- Real-checkpoint SM120/NVFP4 Qwen3-VL smoke.

Those are useful integration checks for CUDA Graph capture/replay on hardware, but the regression tests in this PR intentionally isolate the cache-management bug without requiring checkpoints or real CUDA Graph capture.
