### PR TITLE
fix(groot_n17): repair SM89 FP8 DiT graph path

### DIFF
--- a/docs/benchmark_comparison.md
+++ b/docs/benchmark_comparison.md
@@ -39,6 +39,86 @@ NVIDIA Isaac GR00T reports **GR00T-N1.6-3B** with 4 denoising steps.
 | T=50, 2-view, **13.08 ms** | RTX 5090 | torch.compile | 37 ms | **2.83x** |
 | T=50, 2-view, **13.08 ms** | RTX 5090 | TensorRT | 31 ms | **2.37x** |
 
+### Local RTX 4090 Baselines
+
+Local FlashRT measurements below were taken on **July 2-3, 2026** on one
+idle **RTX 4090 (SM89)** using the in-repo RTX frontends, not TensorRT.
+Unless noted otherwise, the latency number of interest is the
+**steady-state** replay path (capture / graph-build cost excluded). Do not
+compare these rows directly with the RTX 5090 / TensorRT table above
+unless the model, harness, and warmup path match.
+
+`groot` is the repo config name for the current **GR00T-N1.6-3B** path.
+There is no separate third local checkpoint beyond `GR00T-N1.6-3B` and
+`GR00T-N1.7-3B`.
+
+| Config / Checkpoint | Hardware | Harness | Init | set_prompt | First infer | Steady-state | Notes | Output |
+|---|---|---|---:|---:|---:|---:|---|---|
+| `groot` | RTX 4090 (SM89) | repo config name for `GR00T-N1.6-3B`; 2-view, synthetic obs, `T=50`, FP8, `fp8_layout=nk` | 6182.18 ms | 2847.41 ms | 1070.17 ms | **18.39 ms p50** / 18.50 ms mean | July 2 local baseline; warm replay only | `(50, 128)` finite |
+| `GR00T-N1.6-3B` | RTX 4090 (SM89) | same runtime path as `groot`; 2-view, synthetic obs, `T=50`, FP8, `fp8_layout=nk` | 6182.18 ms | 2847.41 ms | 1070.17 ms | **18.39 ms p50** / 18.50 ms mean | Alias row for the same local baseline | `(50, 128)` finite |
+| `GR00T-N1.6-3B` | RTX 4090 (SM89) | local re-check; 2-view `FlashRT.png` duplicated to `image` + `wrist_image`, prompt=`pick up the red block`, `state=zeros(128)`, FP8, `fp8_layout=nk` | - | - | first call excluded | **18.60 ms mean** over 5 steady-state replays | July 3 local steady-state-only re-check; samples: 19.53 / 18.86 / 18.25 / 18.18 / 18.20 ms | `(50, 128)` finite |
+| `groot_n17` / `GR00T-N1.7-3B` | RTX 4090 (SM89) | real 2-view fixture, `T=40`, FP8, `fp8_layout=nk`, `use_dit_graph=False` | 7689.45 ms | 910.33 ms | 31.92 ms | **32.60 ms p50** / 33.50 ms mean | July 2 local eager baseline | `(1, 40, 132)` finite |
+| `groot_n17` / `GR00T-N1.7-3B` | RTX 4090 (SM89) | same real 2-view fixture, `T=40`, FP8, fixed SM89 DiT graph path, `use_dit_graph=True` | - | - | first graph capture excluded (`252.98 ms`) | **9.98 ms mean** over steady-state replays | July 3 local graph hot path before extra fusion; measured replays: 10.06 / 9.89 ms after capture | `(1, 40, 132)` finite |
+| `groot_n17` / `GR00T-N1.7-3B` | RTX 4090 (SM89) | same real 2-view fixture, `T=40`, FP8, same graph path plus existing fused `bias_gelu_quantize_fp8_static_bf16` on the DiT FFN up->down handoff | - | - | first graph capture excluded | **9.69 ms mean** over steady-state replays | July 3 local fused re-check; measured replays: 9.74 / 9.68 / 9.67 / 9.67 ms | `(1, 40, 132)` finite |
+
+### N1.7 SM89 Steady-State Hot Replay Profile
+
+Local Nsight Systems capture on **July 3, 2026** used the same real
+2-view N1.7 fixture as the steady-state row above and captured exactly
+one hot replay after graph build with
+`--capture-range=cudaProfilerApi --cuda-graph-trace=node`. The summed GPU
+kernel time inside that replay was **10.404 ms**, slightly above the
+**9.98 ms** CUDA-event steady-state mean because of profiler overhead.
+
+| Category | Share of summed kernel time | Notes |
+|---|---:|---|
+| FP8 GEMM (+ split-K reduce) | **44.05%** | dominant `sm89_xmma_gemm_e4m3...` cuBLASLt kernels plus split-K reduction |
+| Elementwise / layout / norm | **21.86%** | `add_bias_bf16`, residual add, layout copy, layer norm, GELU, AdaLN |
+| BF16 CUTLASS GEMM+ReLU | **19.06%** | `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn_align8` |
+| FA2 attention | **9.12%** | vendored `flash_fwd_kernel` |
+| FP8 quantize | **3.00%** | `quantize_fp8_kernel_generic` |
+| BF16 cuBLAS GEMM | **2.51%** | remaining non-FP8 GEMM work |
+
+Top individual kernels from that hot replay:
+
+| Kernel | Share | Instances | Avg |
+|---|---:|---:|---:|
+| `sm89_xmma_gemm_e4m3bf16_e4m3f32_f32_tn_n_tilesize64x64x64_stage4...` | **31.63%** | 256 | 12.85 us |
+| `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn_align8` | **19.06%** | 212 | 9.35 us |
+| `flash_fwd_kernel` | **9.12%** | 128 | 7.41 us |
+| `add_bias_bf16_kernel` | **8.11%** | 570 | 1.48 us |
+| `sm89_xmma_gemm_e4m3bf16_e4m3f32_f32_tn_n_tilesize32x64x64_stage5...` | **6.48%** | 64 | 10.53 us |
+| `quantize_fp8_kernel_generic` | **3.00%** | 256 | 1.22 us |
+
+### N1.7 SM89 Steady-State Hot Replay Profile After Reusing Existing Fused Kernel
+
+After replacing the DiT FP8 FFN handoff chain
+`add_bias_bf16 + gelu_inplace + quantize_fp8_static` with the existing
+`bias_gelu_quantize_fp8_static_bf16` kernel, the same hot-replay-only
+Nsight Systems capture reported **10.115 ms** summed GPU kernel time.
+Local CUDA-event timing over the same graph steady state was
+**9.69 ms mean**.
+
+| Category | Share of summed kernel time | Notes |
+|---|---:|---|
+| FP8 GEMM (+ split-K reduce) | **45.32%** | essentially unchanged; still the main cost |
+| Elementwise / layout / norm | **21.41%** | now includes the fused `bias_gelu_quantize_fp8_static_bf16` kernel |
+| BF16 CUTLASS GEMM+ReLU | **19.56%** | unchanged FFN / projector GEMM family |
+| FA2 attention | **9.31%** | unchanged attention share |
+| BF16 cuBLAS GEMM | **2.59%** | unchanged |
+| FP8 quantize | **1.40%** | reduced after fusing the FFN up-output quantize |
+
+Top individual kernels after this reuse:
+
+| Kernel | Share | Instances | Avg |
+|---|---:|---:|---:|
+| `sm89_xmma_gemm_e4m3bf16_e4m3f32_f32_tn_n_tilesize64x64x64_stage4...` | **32.56%** | 256 | 12.86 us |
+| `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn_align8` | **19.56%** | 212 | 9.33 us |
+| `flash_fwd_kernel` | **9.31%** | 128 | 7.36 us |
+| `sm89_xmma_gemm_e4m3bf16_e4m3f32_f32_tn_n_tilesize32x64x64_stage5...` | **6.63%** | 64 | 10.48 us |
+| `add_bias_bf16_kernel` | **5.97%** | 442 | 1.37 us |
+| `bias_gelu_quantize_fp8_static_bf16_kernel` | **3.15%** | 128 | 2.49 us |
+
 ## LingBot-VLA
 
 LingBot model cleanup baseline:

--- a/flash_rt/frontends/_fp8_layout.py
+++ b/flash_rt/frontends/_fp8_layout.py
@@ -1,0 +1,32 @@
+"""Shared FP8 layout selection for frontends."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def select_fp8_layout(hardware: Optional[str], fp8_layout: Optional[str]) -> str:
+    """Choose the FP8 weight layout used by RTX frontend kernels.
+
+    ``kn`` is the existing SM120 path: weights are stored as [K,N] and use
+    ``fp8_nn_dev``. ``nk`` is the SM89-compatible path: weights are stored
+    as [N,K] and use ``fp8_nt_dev``.
+    """
+    if fp8_layout is not None:
+        if fp8_layout not in ("kn", "nk"):
+            raise ValueError(f"fp8_layout must be 'kn' or 'nk', got {fp8_layout!r}")
+        return fp8_layout
+    if hardware == "rtx_sm89":
+        return "nk"
+    if hardware == "rtx_sm120":
+        return "kn"
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            major, minor = torch.cuda.get_device_capability()
+            if major == 8 and minor == 9:
+                return "nk"
+    except Exception:
+        pass
+    return "kn"

--- a/flash_rt/frontends/jax/pi05_rtx.py
+++ b/flash_rt/frontends/jax/pi05_rtx.py
@@ -49,8 +49,8 @@ from flash_rt.frontends.torch.pi05_rtx import (
     Pi05TorchFrontendRtx,
     _interleave_qk,
     _resolve_effective_hardware,
-    _select_fp8_layout,
 )
+from flash_rt.frontends._fp8_layout import select_fp8_layout
 from flash_rt.core.utils.hardware import supports_fp8
 
 logger = logging.getLogger(__name__)
@@ -479,7 +479,7 @@ class Pi05JaxFrontendRtx(Pi05TorchFrontendRtx):
                 f"got {self._vision_num_layers}")
         self.use_fp8 = bool(use_fp8)
         self.hardware = _resolve_effective_hardware(hardware)
-        self.fp8_layout = _select_fp8_layout(hardware, fp8_layout)
+        self.fp8_layout = select_fp8_layout(hardware, fp8_layout)
 
         self.latency_records: list[float] = []
         self.calibrated = False

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -25,6 +25,8 @@ from typing import Optional
 
 import torch
 
+from flash_rt.frontends._fp8_layout import select_fp8_layout
+
 
 class GrootN17TorchFrontendThor:
     """N1.7 Thor inference frontend.
@@ -621,9 +623,7 @@ class GrootN17TorchFrontendThor:
                 act_fc2[li] = max(act_fc2[li], float(ff_t[:Sa].abs().max().item()))
             post_fwd(step, 0)
 
-        from flash_rt.frontends.torch.pi05_rtx import _select_fp8_layout
-
-        fp8_layout = _select_fp8_layout(getattr(self, "hardware", None), None)
+        fp8_layout = select_fp8_layout(getattr(self, "hardware", None), None)
 
         # Quantize FFN weights to FP8 (per-tensor). The SM120-safe path keeps
         # the legacy descale+epilogue contract; the SM89 path carries explicit

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -621,7 +621,13 @@ class GrootN17TorchFrontendThor:
                 act_fc2[li] = max(act_fc2[li], float(ff_t[:Sa].abs().max().item()))
             post_fwd(step, 0)
 
-        # Quantize FFN weights to FP8 (per-tensor) + compose alphas/act-scales.
+        from flash_rt.frontends.torch.pi05_rtx import _select_fp8_layout
+
+        fp8_layout = _select_fp8_layout(getattr(self, "hardware", None), None)
+
+        # Quantize FFN weights to FP8 (per-tensor). The SM120-safe path keeps
+        # the legacy descale+epilogue contract; the SM89 path carries explicit
+        # act/weight scales and dispatches the GEMM by layout.
         FP8_MAX = 448.0
         f8 = torch.float8_e4m3fn
         self._k_xn_fp8 = torch.empty(Sa, 1536, dtype=f8, device=dev)
@@ -633,15 +639,19 @@ class GrootN17TorchFrontendThor:
         proj_fp8, down_fp8, projb16 = [], [], []
         proj_ws, down_fp8_nt, down_ws = [], [], []
         a_fc1, a_fc2, s_fc1, s_fc2 = [], [], [], []
+        w_fc1, w_fc2 = [], []
         for li in range(32):
             pw = self._dit_ff_proj_w[li].float()
             dw = self._dit_ff_down_w[li].float()
             ws_p = pw.abs().max().item() / FP8_MAX
             ws_d = dw.abs().max().item() / FP8_MAX
+            if (not use_sm120_safe) and fp8_layout == "nk":
+                pw = pw.t().contiguous()
+                dw = dw.t().contiguous()
             pf = (pw / ws_p).to(f8).contiguous()
             df = (dw / ws_d).to(f8).contiguous()
-            # fp8_nn_gelu_bias outputs fp16 → its bias must be fp16.
-            pb = self._dit_ff_proj_b[li].half().contiguous()
+            pb = (self._dit_ff_proj_b[li].half().contiguous() if use_sm120_safe
+                  else self._dit_ff_proj_b[li].bfloat16().contiguous())
             sf1 = torch.tensor([act_fc1[li] / FP8_MAX], dtype=torch.float32, device=dev)
             sf2 = torch.tensor([act_fc2[li] / FP8_MAX], dtype=torch.float32, device=dev)
             self._dit_ff_fp8_keep += [pf, df, pb, sf1, sf2]
@@ -656,6 +666,13 @@ class GrootN17TorchFrontendThor:
                 proj_ws.append(sw_p.data_ptr())
                 down_fp8_nt.append(df_nt.data_ptr())
                 down_ws.append(sw_d.data_ptr())
+            else:
+                self._dit_ff_fp8_keep += [
+                    torch.tensor([ws_p], dtype=torch.float32, device=dev),
+                    torch.tensor([ws_d], dtype=torch.float32, device=dev),
+                ]
+                w_fc1.append(self._dit_ff_fp8_keep[-2].data_ptr())
+                w_fc2.append(self._dit_ff_fp8_keep[-1].data_ptr())
             a_fc1.append((act_fc1[li] / FP8_MAX) * ws_p)
             a_fc2.append((act_fc2[li] / FP8_MAX) * ws_d)
         # Fused FP8 QKV for the 16 self-attn layers: concat q/k/v ([D,D] each)
@@ -663,11 +680,14 @@ class GrootN17TorchFrontendThor:
         self._k_qkv_buf = torch.empty(Sa, 3 * 1536, dtype=torch.bfloat16, device=dev)
         self._k_qkv_xn_fp8 = torch.empty(Sa, 1536, dtype=f8, device=dev)
         qkv_fp8, qkv_fp8_nt, qkv_b, a_qkv, s_qkv, qkv_ws = [], [], [], [], [], []
+        w_qkv = []
         for j in range(16):
             li = 2 * j + 1
             qw = torch.cat([self._dit_q_w[li], self._dit_k_w[li], self._dit_v_w[li]], dim=1).float()
             qb = torch.cat([self._dit_q_b[li], self._dit_k_b[li], self._dit_v_b[li]]).to(torch.bfloat16).contiguous()
             ws_q = qw.abs().max().item() / FP8_MAX
+            if (not use_sm120_safe) and fp8_layout == "nk":
+                qw = qw.t().contiguous()
             qf = (qw / ws_q).to(f8).contiguous()
             sq = torch.tensor([act_qkv[j] / FP8_MAX], dtype=torch.float32, device=dev)
             self._dit_ff_fp8_keep += [qf, qb, sq]
@@ -678,6 +698,10 @@ class GrootN17TorchFrontendThor:
                 self._dit_ff_fp8_keep += [qf_nt, sw_q]
                 qkv_fp8_nt.append(qf_nt.data_ptr())
                 qkv_ws.append(sw_q.data_ptr())
+            else:
+                wq = torch.tensor([ws_q], dtype=torch.float32, device=dev)
+                self._dit_ff_fp8_keep.append(wq)
+                w_qkv.append(wq.data_ptr())
             a_qkv.append((act_qkv[j] / FP8_MAX) * ws_q)
         for step in range(num_inference_timesteps):
             if use_sm120_safe:
@@ -696,11 +720,13 @@ class GrootN17TorchFrontendThor:
             else:
                 step_weights[step].update(
                     ff_proj_w_fp8=proj_fp8, ff_down_w_fp8=down_fp8,
-                    ff_proj_b=projb16,  # fp16 bias for the GELU epilogue
-                    alpha_fc1=a_fc1, alpha_fc2=a_fc2,
+                    ff_proj_b=projb16,
                     act_fc1_scale=s_fc1, act_fc2_scale=s_fc2,
+                    w_fc1_scale=w_fc1, w_fc2_scale=w_fc2,
+                    ff_fp8_layout=fp8_layout,
                     qkv_w_fp8=qkv_fp8, qkv_b=qkv_b,
-                    alpha_qkv=a_qkv, act_qkv_scale=s_qkv)
+                    act_qkv_scale=s_qkv, w_qkv_scale=w_qkv,
+                    qkv_fp8_layout=fp8_layout)
         bp.update(xn_fp8=self._k_xn_fp8.data_ptr(),
                   ff_fp16=self._k_ff_fp16.data_ptr(),
                   ff_fp8=self._k_ff_fp8.data_ptr(),

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -33,6 +33,7 @@ import torch
 import torch.nn.functional as F
 
 from flash_rt.core.utils.actions import unnormalize_actions, LIBERO_ACTION_DIM
+from flash_rt.frontends._fp8_layout import select_fp8_layout
 from flash_rt.hardware.rtx.attn_backend import RtxFlashAttnBackend
 from flash_rt.models.pi05.pipeline_rtx import (
     Pi05Pipeline,
@@ -349,31 +350,6 @@ def _quantize_fp8_e4m3(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor
     return w_fp8, scale_tensor
 
 
-def _select_fp8_layout(hardware: Optional[str], fp8_layout: Optional[str]) -> str:
-    """Choose the Pi0.5 FP8 weight layout.
-
-    ``kn`` is the existing SM120 path: weights are stored as [K,N] and use
-    ``fp8_nn_dev``. ``nk`` is the SM89-compatible path: weights are stored
-    as [N,K] and use ``fp8_nt_dev``.
-    """
-    if fp8_layout is not None:
-        if fp8_layout not in ("kn", "nk"):
-            raise ValueError(f"fp8_layout must be 'kn' or 'nk', got {fp8_layout!r}")
-        return fp8_layout
-    if hardware == "rtx_sm89":
-        return "nk"
-    if hardware == "rtx_sm120":
-        return "kn"
-    try:
-        if torch.cuda.is_available():
-            major, minor = torch.cuda.get_device_capability()
-            if major == 8 and minor == 9:
-                return "nk"
-    except Exception:
-        pass
-    return "kn"
-
-
 def _resolve_effective_hardware(hardware: Optional[str]) -> Optional[str]:
     """Resolve the RTX hardware tag used by lower-level policy decisions."""
     if hardware is not None:
@@ -542,7 +518,7 @@ class Pi05TorchFrontendRtx:
         # _use_int8_vision_static is set after _force_int8_decoder below
         self.use_fp8 = bool(use_fp8)
         self.hardware = _resolve_effective_hardware(hardware)
-        self.fp8_layout = _select_fp8_layout(hardware, fp8_layout)
+        self.fp8_layout = select_fp8_layout(hardware, fp8_layout)
 
         self.latency_records: list[float] = []
         self.calibrated = False

--- a/flash_rt/frontends/torch/pi05_rtx_fp16.py
+++ b/flash_rt/frontends/torch/pi05_rtx_fp16.py
@@ -33,6 +33,7 @@ import torch
 import torch.nn.functional as F
 
 from flash_rt.core.utils.actions import unnormalize_actions, LIBERO_ACTION_DIM
+from flash_rt.frontends._fp8_layout import select_fp8_layout
 from flash_rt.hardware.rtx.attn_backend import RtxFlashAttnBackend
 from flash_rt.models.pi05.pipeline_rtx_fp16 import (
     Pi05PipelineFP16 as Pi05Pipeline,
@@ -354,31 +355,6 @@ def _quantize_fp8_e4m3(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor
     return w_fp8, scale_tensor
 
 
-def _select_fp8_layout(hardware: Optional[str], fp8_layout: Optional[str]) -> str:
-    """Choose the Pi0.5 FP8 weight layout.
-
-    ``kn`` is the existing SM120 path: weights are stored as [K,N] and use
-    ``fp8_nn_dev``. ``nk`` is the SM89-compatible path: weights are stored
-    as [N,K] and use ``fp8_nt_dev``.
-    """
-    if fp8_layout is not None:
-        if fp8_layout not in ("kn", "nk"):
-            raise ValueError(f"fp8_layout must be 'kn' or 'nk', got {fp8_layout!r}")
-        return fp8_layout
-    if hardware == "rtx_sm89":
-        return "nk"
-    if hardware == "rtx_sm120":
-        return "kn"
-    try:
-        if torch.cuda.is_available():
-            major, minor = torch.cuda.get_device_capability()
-            if major == 8 and minor == 9:
-                return "nk"
-    except Exception:
-        pass
-    return "kn"
-
-
 def _precompute_decoder_styles(ckpt: dict, chunk_size: int,
                                num_steps: int = NUM_STEPS_DEFAULT) -> dict:
     """Pre-compute the time-MLP + per-layer style modulations in torch.
@@ -519,7 +495,7 @@ class Pi05TorchFrontendRtxFP16:
                 f"got {self._vision_num_layers}")
         # This experimental frontend is intentionally full FP16 only.
         self.use_fp8 = False
-        self.fp8_layout = _select_fp8_layout(hardware, fp8_layout)
+        self.fp8_layout = select_fp8_layout(hardware, fp8_layout)
 
         self.latency_records: list[float] = []
         self.calibrated = False

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -879,10 +879,22 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             # so one [D, 3D] GEMM (compute-bound, unlike 3 launch-bound D→D
             # GEMMs) + a strided split into the Q/K/V slots. Cross-attn keeps
             # a single Q GEMM (K/V come from the backbone-projected cross-KV).
-            gemm.fp8_nn_bias_bf16(
-                int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8"][j_self]),
+            qkv_fp8_layout = str(weights.get("qkv_fp8_layout", "kn"))
+            if qkv_fp8_layout == "nk":
+                gemm.fp8_nt_dev(
+                    int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8"][j_self]),
+                    int(bufs["qkv_buf"]), Sa, 3 * D, D,
+                    int(weights["act_qkv_scale"][j_self]),
+                    int(weights["w_qkv_scale"][j_self]), int(stream))
+            else:
+                gemm.fp8_run_dev(
+                    int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8"][j_self]),
+                    int(bufs["qkv_buf"]), Sa, 3 * D, D,
+                    int(weights["act_qkv_scale"][j_self]),
+                    int(weights["w_qkv_scale"][j_self]), int(stream))
+            fvk.add_bias_bf16(
                 int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
-                Sa, 3 * D, D, float(weights["alpha_qkv"][j_self]), int(stream))
+                Sa, 3 * D, int(stream))
             fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
             fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
             fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
@@ -950,20 +962,40 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_bf16(o_out_ptr, int(weights["ff_down_b"][li]),
                               Sa, D, int(stream))
         elif "ff_proj_w_fp8" in weights:
+            ff_fp8_layout = str(weights.get("ff_fp8_layout", "kn"))
             fvk.quantize_fp8_static(
                 xn_ptr, int(bufs["xn_fp8"]),
                 int(weights["act_fc1_scale"][li]), Sa * D, int(stream))
-            gemm.fp8_nn_gelu_bias(
-                int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8"][li]),
-                int(bufs["ff_fp16"]), int(weights["ff_proj_b"][li]),
-                Sa, FF, D, float(weights["alpha_fc1"][li]), int(stream))
-            fvk.quantize_fp8_static_fp16(
-                int(bufs["ff_fp16"]), int(bufs["ff_fp8"]),
-                int(weights["act_fc2_scale"][li]), Sa * FF, int(stream))
-            gemm.fp8_nn_bias_bf16(
-                int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8"][li]),
-                o_out_ptr, int(weights["ff_down_b"][li]),
-                Sa, D, FF, float(weights["alpha_fc2"][li]), int(stream))
+            if ff_fp8_layout == "nk":
+                gemm.fp8_nt_dev(
+                    int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8"][li]),
+                    ff_out_ptr, Sa, FF, D,
+                    int(weights["act_fc1_scale"][li]),
+                    int(weights["w_fc1_scale"][li]), int(stream))
+            else:
+                gemm.fp8_run_dev(
+                    int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8"][li]),
+                    ff_out_ptr, Sa, FF, D,
+                    int(weights["act_fc1_scale"][li]),
+                    int(weights["w_fc1_scale"][li]), int(stream))
+            fvk.bias_gelu_quantize_fp8_static_bf16(
+                ff_out_ptr, int(weights["ff_proj_b"][li]),
+                int(bufs["ff_fp8"]), int(weights["act_fc2_scale"][li]),
+                Sa, FF, int(stream))
+            if ff_fp8_layout == "nk":
+                gemm.fp8_nt_dev(
+                    int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8"][li]),
+                    o_out_ptr, Sa, D, FF,
+                    int(weights["act_fc2_scale"][li]),
+                    int(weights["w_fc2_scale"][li]), int(stream))
+            else:
+                gemm.fp8_run_dev(
+                    int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8"][li]),
+                    o_out_ptr, Sa, D, FF,
+                    int(weights["act_fc2_scale"][li]),
+                    int(weights["w_fc2_scale"][li]), int(stream))
+            fvk.add_bias_bf16(o_out_ptr, int(weights["ff_down_b"][li]),
+                              Sa, D, int(stream))
         else:
             gemm.bf16_nn(xn_ptr, int(weights["ff_proj_w"][li]),
                           ff_out_ptr, Sa, FF, D, int(stream))

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -887,7 +887,7 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
                     int(weights["act_qkv_scale"][j_self]),
                     int(weights["w_qkv_scale"][j_self]), int(stream))
             else:
-                gemm.fp8_run_dev(
+                gemm.fp8_nn_dev(
                     int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8"][j_self]),
                     int(bufs["qkv_buf"]), Sa, 3 * D, D,
                     int(weights["act_qkv_scale"][j_self]),
@@ -973,7 +973,7 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
                     int(weights["act_fc1_scale"][li]),
                     int(weights["w_fc1_scale"][li]), int(stream))
             else:
-                gemm.fp8_run_dev(
+                gemm.fp8_nn_dev(
                     int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8"][li]),
                     ff_out_ptr, Sa, FF, D,
                     int(weights["act_fc1_scale"][li]),
@@ -989,7 +989,7 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
                     int(weights["act_fc2_scale"][li]),
                     int(weights["w_fc2_scale"][li]), int(stream))
             else:
-                gemm.fp8_run_dev(
+                gemm.fp8_nn_dev(
                     int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8"][li]),
                     o_out_ptr, Sa, D, FF,
                     int(weights["act_fc2_scale"][li]),

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -787,12 +787,12 @@ def test_groot_n17_rtx_sm120_rejects_use_fp8_false_without_fp16():
         )
 
 
-def test_pi05_rtx_fp8_layout_selection():
-    from flash_rt.frontends.torch.pi05_rtx import _select_fp8_layout
+def test_frontend_fp8_layout_selection():
+    from flash_rt.frontends._fp8_layout import select_fp8_layout
 
-    assert _select_fp8_layout("rtx_sm89", None) == "nk"
-    assert _select_fp8_layout("rtx_sm120", None) == "kn"
-    assert _select_fp8_layout("rtx_sm120", "nk") == "nk"
+    assert select_fp8_layout("rtx_sm89", None) == "nk"
+    assert select_fp8_layout("rtx_sm120", None) == "kn"
+    assert select_fp8_layout("rtx_sm120", "nk") == "nk"
 
 
 def test_vla_frontend_constructors_accept_use_fp8():

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -868,7 +868,8 @@ def test_pi05_jax_rtx_frontend_mirrors_runtime_knobs():
         assert attr in assigned
 
 
-def test_groot_n17_dit_fp8_kn_layout_dispatches_nn_dev():
+def _make_dit_fp8_fixtures(fp8_layout):
+    """Build minimal Mock/dict fixtures for ``dit_forward`` FP8 dispatch tests."""
     from flash_rt.models.groot_n17 import pipeline_thor
 
     class DummyAttn:
@@ -883,54 +884,49 @@ def test_groot_n17_dit_fp8_kn_layout_dispatches_nn_dev():
     attn = DummyAttn()
     dims = {"Sa": 2, "D": 4, "FF": 8, "Skv_text": 1, "Skv_image": 1}
     bufs = {
-        "h": 1,
-        "xn": 2,
-        "o_proj_out": 3,
-        "ff_proj_out": 4,
-        "qkv_xn_fp8": 5,
-        "qkv_buf": 6,
-        "xn_fp8": 7,
-        "ff_fp8": 8,
+        "h": 1, "xn": 2, "o_proj_out": 3, "ff_proj_out": 4,
+        "qkv_xn_fp8": 5, "qkv_buf": 6, "xn_fp8": 7, "ff_fp8": 8,
     }
     weights = {
-        "scale_msa": [11] * 32,
-        "shift_msa": [12] * 32,
-        "q_w": [13] * 32,
-        "q_b": [14] * 32,
-        "k_w": [15] * 32,
-        "k_b": [16] * 32,
-        "v_w": [17] * 32,
-        "v_b": [18] * 32,
-        "o_w": [19] * 32,
-        "o_b": [20] * 32,
-        "ff_proj_w": [21] * 32,
-        "ff_proj_b": [22] * 32,
-        "ff_down_w": [23] * 32,
-        "ff_down_b": [24] * 32,
-        "qkv_w_fp8": [25] * 16,
-        "qkv_b": [26] * 16,
-        "act_qkv_scale": [27] * 16,
-        "w_qkv_scale": [28] * 16,
-        "qkv_fp8_layout": "kn",
-        "ff_proj_w_fp8": [29] * 32,
-        "ff_down_w_fp8": [30] * 32,
-        "act_fc1_scale": [41] * 32,
-        "act_fc2_scale": [42] * 32,
-        "w_fc1_scale": [43] * 32,
-        "w_fc2_scale": [44] * 32,
-        "ff_fp8_layout": "kn",
+        "scale_msa": [11] * 32, "shift_msa": [12] * 32,
+        "q_w": [13] * 32, "q_b": [14] * 32,
+        "k_w": [15] * 32, "k_b": [16] * 32,
+        "v_w": [17] * 32, "v_b": [18] * 32,
+        "o_w": [19] * 32, "o_b": [20] * 32,
+        "ff_proj_w": [21] * 32, "ff_proj_b": [22] * 32,
+        "ff_down_w": [23] * 32, "ff_down_b": [24] * 32,
+        "qkv_w_fp8": [25] * 16, "qkv_b": [26] * 16,
+        "act_qkv_scale": [27] * 16, "w_qkv_scale": [28] * 16,
+        "qkv_fp8_layout": fp8_layout,
+        "ff_proj_w_fp8": [29] * 32, "ff_down_w_fp8": [30] * 32,
+        "act_fc1_scale": [41] * 32, "act_fc2_scale": [42] * 32,
+        "w_fc1_scale": [43] * 32, "w_fc2_scale": [44] * 32,
+        "ff_fp8_layout": fp8_layout,
     }
+    return pipeline_thor, gemm, fvk, bufs, weights, dims, attn
+
+
+def test_groot_n17_dit_fp8_kn_layout_dispatches_nn_dev():
+    pipeline_thor, gemm, fvk, bufs, weights, dims, attn = _make_dit_fp8_fixtures("kn")
 
     pipeline_thor.dit_forward(
-        gemm=gemm,
-        fvk=fvk,
-        bufs=bufs,
-        weights=weights,
-        dims=dims,
-        attn=attn,
-        layers_subset=[1],
+        gemm=gemm, fvk=fvk, bufs=bufs, weights=weights,
+        dims=dims, attn=attn, layers_subset=[1],
     )
 
     assert gemm.fp8_nn_dev.call_count == 3
     gemm.fp8_run_dev.assert_not_called()
     gemm.fp8_nt_dev.assert_not_called()
+
+
+def test_groot_n17_dit_fp8_nk_layout_dispatches_nt_dev():
+    pipeline_thor, gemm, fvk, bufs, weights, dims, attn = _make_dit_fp8_fixtures("nk")
+
+    pipeline_thor.dit_forward(
+        gemm=gemm, fvk=fvk, bufs=bufs, weights=weights,
+        dims=dims, attn=attn, layers_subset=[1],
+    )
+
+    assert gemm.fp8_nt_dev.call_count == 3
+    gemm.fp8_nn_dev.assert_not_called()
+    gemm.fp8_run_dev.assert_not_called()

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -2,7 +2,7 @@ import ast
 from pathlib import Path
 import sys
 import types
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -866,3 +866,71 @@ def test_pi05_jax_rtx_frontend_mirrors_runtime_knobs():
         "_int8_weight_scales",
     ):
         assert attr in assigned
+
+
+def test_groot_n17_dit_fp8_kn_layout_dispatches_nn_dev():
+    from flash_rt.models.groot_n17 import pipeline_thor
+
+    class DummyAttn:
+        def get_slot_ptrs(self, site, layer_idx):
+            return {"Q": 31, "K": 32, "V": 33, "O": 34}
+
+        def run(self, site, layer_idx, q_seq, *, kv_seq=None, stream=0, state_nk=None):
+            return None
+
+    gemm = Mock()
+    fvk = Mock()
+    attn = DummyAttn()
+    dims = {"Sa": 2, "D": 4, "FF": 8, "Skv_text": 1, "Skv_image": 1}
+    bufs = {
+        "h": 1,
+        "xn": 2,
+        "o_proj_out": 3,
+        "ff_proj_out": 4,
+        "qkv_xn_fp8": 5,
+        "qkv_buf": 6,
+        "xn_fp8": 7,
+        "ff_fp8": 8,
+    }
+    weights = {
+        "scale_msa": [11] * 32,
+        "shift_msa": [12] * 32,
+        "q_w": [13] * 32,
+        "q_b": [14] * 32,
+        "k_w": [15] * 32,
+        "k_b": [16] * 32,
+        "v_w": [17] * 32,
+        "v_b": [18] * 32,
+        "o_w": [19] * 32,
+        "o_b": [20] * 32,
+        "ff_proj_w": [21] * 32,
+        "ff_proj_b": [22] * 32,
+        "ff_down_w": [23] * 32,
+        "ff_down_b": [24] * 32,
+        "qkv_w_fp8": [25] * 16,
+        "qkv_b": [26] * 16,
+        "act_qkv_scale": [27] * 16,
+        "w_qkv_scale": [28] * 16,
+        "qkv_fp8_layout": "kn",
+        "ff_proj_w_fp8": [29] * 32,
+        "ff_down_w_fp8": [30] * 32,
+        "act_fc1_scale": [41] * 32,
+        "act_fc2_scale": [42] * 32,
+        "w_fc1_scale": [43] * 32,
+        "w_fc2_scale": [44] * 32,
+        "ff_fp8_layout": "kn",
+    }
+
+    pipeline_thor.dit_forward(
+        gemm=gemm,
+        fvk=fvk,
+        bufs=bufs,
+        weights=weights,
+        dims=dims,
+        attn=attn,
+        layers_subset=[1],
+    )
+
+    assert gemm.fp8_nn_dev.call_count == 3
+    gemm.fp8_run_dev.assert_not_called()
+    gemm.fp8_nt_dev.assert_not_called()


### PR DESCRIPTION
## Summary
- repair the GROOT N1.7 SM89 DiT FP8 graph path by carrying explicit act/weight scales and honoring FP8 layout for the inherited Thor action-head code
- keep the existing SM120-safe branch intact while fixing the non-SM120 path used by the SM89 frontend
- document the local SM89 steady-state and hot-replay measurements for GR00T-N1.6-3B and GR00T-N1.7-3B

## What Changed
- `flash_rt/frontends/torch/groot_n17_thor.py`
  - select the runtime FP8 layout from hardware
  - for the non-`sm120_safe` path, materialize DiT FFN and self-attention QKV weights/scales in the layout expected by SM89 (`nk` on RTX SM89)
  - pass explicit activation and weight scales into the step weights instead of relying on the older fused-alpha contract
- `flash_rt/models/groot_n17/pipeline_thor.py`
  - route self-attention QKV through layout-aware FP8 GEMMs and explicit bias add on the non-SM120 path
  - route the DiT FFN through layout-aware FP8 GEMMs and reuse the existing `bias_gelu_quantize_fp8_static_bf16` kernel for the up->down handoff
  - preserve the existing `sm120_safe` branch unchanged
- `docs/benchmark_comparison.md`
  - add local RTX 4090 SM89 steady-state rows for GR00T-N1.6-3B and GR00T-N1.7-3B
  - add the N1.7 hot-replay kernel-share breakdown before and after reusing the fused FFN handoff kernel

## Validation
Environment:
- GPU: NVIDIA GeForce RTX 4090 (SM89)
- Driver: 550.54.14
- Python: `conda` env `flashrt`
- PyTorch: 2.6.0+cu124
- CUDA: 12.4

Tests:
- `python -m pytest tests/test_load_model_use_fp8_kwarg.py -q -k 'groot_n17_rtx_sm89'`
  - passed (`4 passed, 27 deselected`)

Local runtime results captured in `docs/benchmark_comparison.md`:
- GR00T-N1.7-3B eager baseline: `33.50 ms` mean steady-state
- GR00T-N1.7-3B fixed SM89 DiT graph path: `9.98 ms` mean steady-state
- GR00T-N1.7-3B fixed path plus reused fused `bias_gelu_quantize_fp8_static_bf16`: `9.69 ms` mean steady-state
- GR00T-N1.6-3B steady-state re-check: `18.60 ms` mean over 5 warm replays
