### PR TITLE
runtime(pi05): enable Thor model-runtime export

### DIFF
--- a/docs/cpp_runtime_design.md
+++ b/docs/cpp_runtime_design.md
@@ -49,6 +49,35 @@ Rule of altitude: `modalities/` knows pixels and tensors, never models;
 binds names and constants, never re-implements a transform. Nothing under
 `cpp/` is ABI — the struct in `runtime/` is the deployment surface.
 
+## Model and hardware binding
+
+The model boundary and the hardware boundary are intentionally different.
+
+The **model** is selected by the native overlay/factory that the host loads:
+`cpp/models/pi05/` exports `frt_pi05_model_runtime_create_over`, a future
+GROOT runtime would export its own model factory, and so on. That code owns the
+model's hot-path transforms: image normalization, state packing, action
+postprocess, and the names/shapes of public ports it supports.
+
+The **hardware** is selected before the C++ runtime sees the model: the Python
+or native setup producer chooses the hardware pipeline, captures the graphs,
+allocates live buffers, calibrates precision-specific paths, and writes the
+canonical identity/fingerprint. The C++ overlay then inherits those graph,
+stream, stage, and buffer declarations with `frt_model_runtime_override_verbs`.
+
+So the expected setup shape is:
+
+1. The hardware-specific pipeline builds a ready model instance.
+2. `flash_rt/models/<model>/runtime_export.py` exports that instance as the
+   model family's standard `frt_model_runtime_v1` face.
+3. `cpp/models/<model>/` overlays native hot verbs on that exact declaration.
+4. Nexus or a robot loop consumes only the resulting model-runtime handle.
+
+If two hardware pipelines expose the same logical ports and stage DAG, they can
+share one native C++ overlay. If their visible contract differs, the difference
+must be represented in the producer identity and handled with a distinct plan,
+model key, or overlay; it should not leak into Nexus as ad hoc hardware logic.
+
 ## The production tick
 
 Ports declare the update class; the class decides the lane:

--- a/docs/model_runtime_api.md
+++ b/docs/model_runtime_api.md
@@ -138,6 +138,38 @@ identity is unchanged.
 `flash_rt.runtime.export.build_model_runtime`) and the native Pi0.5 verb
 overlay `frt_pi05_model_runtime_create_over` (`cpp/models/pi05/`).
 
+## Producer layout: model contract vs hardware pipeline
+
+The clean default is one export module per logical model family contract:
+
+```
+flash_rt/models/<model>/runtime_export.py     ports, stages, identity, export helpers
+flash_rt/models/<model>/pipeline_rtx.py       RTX graph capture and live buffers
+flash_rt/models/<model>/pipeline_thor.py      Thor graph capture and live buffers
+cpp/models/<model>/                           native hot-path verb overlay
+```
+
+`runtime_export.py` is not the hardware implementation. It is the shared
+contract that lowers a ready pipeline into `frt_model_runtime_v1`: declared
+ports, graph/stage descriptors, stream placement, identity fields, and optional
+stage-plan selection. Each hardware pipeline owns its graph capture, buffers,
+kernel choices, calibration, and setup policy, then delegates
+`export_model_runtime(...)` to that model export module.
+
+The C++ runtime consumes the resulting declaration. It distinguishes the model
+by the native factory/overlay it loads (`cpp/models/<model>/...`) and by the
+declared port schema it implements; it should not branch on hardware unless a
+real input/output transform differs. Hardware identity comes from the producer:
+the graph handles, stream table, buffer descriptors, pipeline class, precision,
+architecture, and other setup fields included in the canonical identity and
+fingerprint.
+
+This means an RTX Pi0.5 producer and a Thor Pi0.5 producer may both feed the
+same native Pi0.5 C++ runtime if they expose the same logical model-runtime
+contract. If a hardware path needs incompatible graph names, stage cuts, port
+shapes, or hot-input semantics, it is a different deployment identity and must
+either use distinct stage-plan names/model keys or a separate native overlay.
+
 Pi0.5 export knobs:
 
 - `stage_plan="full"` exports one `infer` stage.

--- a/flash_rt/frontends/jax/pi05_thor.py
+++ b/flash_rt/frontends/jax/pi05_thor.py
@@ -131,14 +131,15 @@ class Pi05JaxFrontendThor:
         if fmha_path is None:
             # Search order matches the torch Thor frontends: ckpt-adjacent,
             # ``flash_rt/`` package dir (pip / editable install target),
-            # fresh cmake ``build/`` output, docker ``/workspace/``.
+            # fresh cmake ``build/`` output. Use FLASHRT_FMHA_LIBRARY for an
+            # explicit out-of-tree location.
             _here = pathlib.Path(__file__)
-            for c in [str(checkpoint_dir.parent / 'libfmha_fp16_strided.so'),
+            for c in [os.environ.get('FLASHRT_FMHA_LIBRARY', ''),
+                      str(checkpoint_dir.parent / 'libfmha_fp16_strided.so'),
                       str(_here.parent.parent.parent / 'libfmha_fp16_strided.so'),
                       str(_here.parent.parent.parent.parent / 'build'
-                          / 'libfmha_fp16_strided.so'),
-                      '/workspace/libfmha_fp16_strided.so']:
-                if os.path.exists(c):
+                          / 'libfmha_fp16_strided.so')]:
+                if c and os.path.exists(c):
                     fmha_path = c
                     break
         if fmha_path:

--- a/flash_rt/frontends/jax/pi05_thor.py
+++ b/flash_rt/frontends/jax/pi05_thor.py
@@ -29,6 +29,7 @@ from flash_rt.hardware.thor.shared_primitives import (
     encoder_forward_calibrate,
 )
 from flash_rt.models.pi05.pipeline_thor import (
+    Pi05ThorPipeline,
     decoder_forward,
     decoder_forward_calibrate,
 )
@@ -82,6 +83,12 @@ class Pi05JaxFrontendThor:
 
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         self.use_fp8 = bool(use_fp8)
+        self.pipeline = Pi05ThorPipeline(batch_size=1)
+        self.pipeline.bind_runtime_owner(self)
+        self._model_runtime_full_graph = None
+        self._runtime_rtc_prev_action_chunk = None
+        self._runtime_rtc_prefix_weights = None
+        self._runtime_rtc_guidance_weight = None
         mode = os.environ.get("FLASHRT_PI05_STATE_PROMPT_MODE",
                               state_prompt_mode)
         if mode not in ("exact", "fixed"):
@@ -1286,7 +1293,81 @@ class Pi05JaxFrontendThor:
         _run(stream_int)
         self.enc_ae_graph.end_capture(stream)
         _cudart.cudaStreamSynchronize(stream)
+        self._model_runtime_full_graph = None
         logger.info(f"Enc+AE CUDA Graph captured (Se={self.Se})")
+
+    def _capture_model_runtime_full_graph(self) -> None:
+        """Capture one full Pi0.5 Thor graph for model-runtime export."""
+        from flash_rt.core.cuda_graph import CUDAGraph
+
+        stream = self._stream
+        cudart = self._cudart
+        stream_int = stream.value or 0
+        (sig_bufs, sig_weights, sig_dims,
+         postln_bufs, postln_weights, postln_dims) = (
+            self._build_siglip_call_specs())
+        enc_bufs, enc_weights, enc_dims = self._build_enc_dicts(stream_int)
+        ae_bufs, ae_weights, ae_dims = self._build_ae_dicts(stream_int)
+
+        def _run(st):
+            self._run_siglip(st, sig_bufs, sig_weights, sig_dims,
+                             postln_bufs, postln_weights, postln_dims)
+            self.Kc.zero_(stream)
+            self.Vc.zero_(stream)
+            encoder_forward(self._gemm, self._fvk, enc_bufs, enc_weights,
+                            enc_dims, st, attn=self._attn)
+            decoder_forward(self._ctx, self._fvk, ae_bufs, ae_weights,
+                            ae_dims, st, attn=self._attn)
+
+        for _ in range(3):
+            _run(stream_int)
+        cudart.cudaStreamSynchronize(stream)
+
+        graph = CUDAGraph()
+        graph.begin_capture(stream)
+        _run(stream_int)
+        graph.end_capture(stream)
+        cudart.cudaStreamSynchronize(stream)
+        self._model_runtime_full_graph = graph
+        logger.info("JAX Pi0.5 Thor model-runtime full graph captured (Se=%d)",
+                    self.Se)
+
+    def _ensure_model_runtime_export(self) -> None:
+        if not hasattr(self, "enc_ae_graph"):
+            raise RuntimeError(
+                "Pi0.5 Thor export requires set_prompt()/predict() first")
+        if self._model_runtime_full_graph is None:
+            self._capture_model_runtime_full_graph()
+        if self._runtime_rtc_prev_action_chunk is None:
+            CB = self._CudaBuffer
+            self._runtime_rtc_prev_action_chunk = CB.device_empty(
+                self.Sa * 32, np.float16)
+            self._runtime_rtc_prefix_weights = CB.device_empty(
+                self.Sa, np.float32)
+            self._runtime_rtc_guidance_weight = CB.device_empty(
+                1, np.float32)
+
+        bufs = {
+            "observation_images_normalized": self.img_buf,
+            "diffusion_noise": self.g_noise,
+            "encoder_x": self.enc_x,
+            "rtc_prev_action_chunk": self._runtime_rtc_prev_action_chunk,
+            "rtc_prefix_weights": self._runtime_rtc_prefix_weights,
+            "rtc_guidance_weight": self._runtime_rtc_guidance_weight,
+        }
+        self.pipeline.bind_runtime_export(
+            graph=self._model_runtime_full_graph,
+            graph_stream=self._stream,
+            bufs=bufs,
+            decoder_only_graph=None,
+            num_views=self.num_views,
+            max_prompt_len=getattr(self, "S_lang", 0),
+            chunk_size=self.Sa,
+            norm_stats=getattr(self, "norm_stats", {}),
+            use_fp8=self.use_fp8,
+            tensor_dtype="f16",
+            hardware="thor_sm110",
+        )
 
     # -----------------------------------------------------------------------
     # B=N batched inference (JAX side — Stage 2/3 parallel to torch)

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -25,6 +25,7 @@ from flash_rt.hardware.thor.shared_primitives import (
     encoder_forward_calibrate,
 )
 from flash_rt.models.pi05.pipeline_thor import (
+    Pi05ThorPipeline,
     decoder_forward,
     decoder_forward_calibrate,
 )
@@ -60,6 +61,49 @@ _cudart = ctypes.CDLL("libcudart.so")
 # ---------------------------------------------------------------------------
 
 from flash_rt.core.thor_frontend_utils import embed_prompt_torch as embed_prompt  # noqa: E402
+
+
+class _TorchTensorBuffer:
+    """CudaBuffer-compatible view over a stable CUDA torch.Tensor."""
+
+    def __init__(self, tensor: torch.Tensor):
+        if not tensor.is_cuda:
+            raise ValueError("runtime-export tensor buffer must be CUDA")
+        self.tensor = tensor.contiguous()
+        self.ptr = ctypes.c_void_p(int(self.tensor.data_ptr()))
+        self.nbytes = self.tensor.numel() * self.tensor.element_size()
+
+    def upload(self, arr: np.ndarray) -> None:
+        arr = np.ascontiguousarray(arr)
+        if arr.nbytes != self.nbytes:
+            raise ValueError(
+                f"upload size mismatch: {arr.nbytes} != {self.nbytes}")
+        _cudart.cudaMemcpy(
+            self.ptr, ctypes.c_void_p(arr.ctypes.data), self.nbytes, 1)
+
+    def download(self, arr: np.ndarray) -> None:
+        if arr.nbytes > self.nbytes:
+            raise ValueError(
+                f"download size mismatch: {arr.nbytes} > {self.nbytes}")
+        _cudart.cudaDeviceSynchronize()
+        _cudart.cudaMemcpy(
+            ctypes.c_void_p(arr.ctypes.data), self.ptr, arr.nbytes, 2)
+
+    def download_new(self, shape, dtype) -> np.ndarray:
+        arr = np.empty(shape, dtype=dtype)
+        self.download(arr)
+        return arr
+
+
+class _TorchGraphExport:
+    """Expose torch CUDAGraph with the field shape used by runtime_export."""
+
+    def __init__(self, graph: torch.cuda.CUDAGraph):
+        self._graph = graph
+        self._graph_exec = ctypes.c_void_p(int(graph.raw_cuda_graph_exec()))
+
+    def replay(self, stream=None):
+        self._graph.replay()
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +164,14 @@ class Pi05TorchFrontendThor:
         self.latency_records = []
         self.calibrated = False
         self.graph_captured = False
+        self.pipeline = Pi05ThorPipeline(batch_size=1)
+        self.pipeline.bind_runtime_owner(self)
+        self._model_runtime_full_graph = None
+        self._model_runtime_graph_stream = None
+        self._model_runtime_torch_stream = None
+        self._runtime_rtc_prev_action_chunk = None
+        self._runtime_rtc_prefix_weights = None
+        self._runtime_rtc_guidance_weight = None
         self._real_data_calibrated = False
         self.current_prompt_len = 0
         self._fixed_shape_active = False
@@ -1529,7 +1581,161 @@ class Pi05TorchFrontendThor:
                             use_fp8=self.use_fp8)
             self._enc_ae_graph.capture_end()
         torch.cuda.synchronize()
+        self._model_runtime_full_graph = None
         logger.info("Enc+AE CUDA graph captured (Se=%d)", Se)
+
+    def _capture_model_runtime_full_graph(self) -> None:
+        """Capture one full Pi0.5 Thor graph for model-runtime export."""
+        Se = self.Se
+        total_keys = self.total_keys
+        Le = self.Le; La = self.La; De = self.De; He = self.He
+        NHe = self.NHe; HDe = self.HDe
+        Sa = self.Sa; Da = self.Da; Ha = self.Ha
+
+        enc_bufs = {
+            'x':       self._enc_x.data_ptr(),
+            'x_fp8':   self._enc_x_fp8.data_ptr(),
+            'qkv':     self._enc_qkv_buf.data_ptr(),
+            'logits':  self._enc_logits.data_ptr(),
+            'attn_out': self._enc_attn.data_ptr(),
+            'o_fp8':   self._enc_o_fp8.data_ptr(),
+            'gate':    self._enc_gate.data_ptr(),
+            'hidden':  self._enc_hidden.data_ptr(),
+            'hid_fp8': self._enc_hid_fp8.data_ptr(),
+            'fg':      self._enc_fg.data_ptr(),
+            'ctx':     self._ctx,
+            'x_norm':  self._enc_attn.data_ptr(),
+            'ones':    (self._enc_ones_fp16.data_ptr()
+                        if self._enc_ones_fp16 is not None else 0),
+        }
+        enc_weights = {
+            'qkv_w':     [w.data_ptr() for w in self._enc_qkv_w],
+            'o_w':       [w.data_ptr() for w in self._enc_o_w],
+            'gate_w':    [w.data_ptr() for w in self._enc_gu_w],
+            'down_w':    [w.data_ptr() for w in self._enc_d_w],
+            'rope':      self._enc_rope.data_ptr(),
+            'Kc':        self._Kc.reshape(-1).data_ptr(),
+            'Vc':        self._Vc.reshape(-1).data_ptr(),
+            'act_scales':  self._enc_calib_scales.data_ptr(),
+            'alpha_host':  self._enc_alpha_host,
+        }
+        enc_dims = {
+            'Se': Se, 'D': De, 'H': He, 'NH': NHe, 'HD': HDe,
+            'L': Le, 'total_keys': total_keys,
+        }
+
+        ae_bufs = {
+            'noise':   self._g_noise.data_ptr(),
+            'x':       self._ae_x.data_ptr(),
+            'xn':      self._ae_xn.data_ptr(),
+            'gate':    self._ae_gate.data_ptr(),
+            'qkv':     self._ae_qkv.data_ptr(),
+            'logits':  self._ae_logits.data_ptr(),
+            'attn_out': self._ae_attn.data_ptr(),
+            'hid':     self._ae_hid.data_ptr(),
+            'fg':      self._ae_fg.data_ptr(),
+            'action_f32': self._ae_action_f32.data_ptr(),
+            'xn_fp8':  self._ae_xn_fp8.data_ptr(),
+            'hid_fp8': self._ae_hid_fp8.data_ptr(),
+            'ctx_fp8': self._ae_ctx_fp8.data_ptr(),
+        }
+        ae_weights = {
+            'ain_w':      self._ain_w.data_ptr(),
+            'ain_b':      self._ain_b.data_ptr(),
+            'sa':         self._sa_all.data_ptr(),
+            'qw':         self._dec_qkv_flat.data_ptr(),
+            'Kc':         self._Kc.reshape(-1).data_ptr(),
+            'Vc':         self._Vc.reshape(-1).data_ptr(),
+            'dec_devpos': self._attn.dec_devpos.data_ptr(),
+            'ow':         self._dec_o_flat.data_ptr(),
+            'sf':         self._sf_all.data_ptr(),
+            'gw':         self._dec_gu_flat.data_ptr(),
+            'dw':         self._dec_d_flat.data_ptr(),
+            'aow':        self._aow.data_ptr(),
+            'aob':        self._aob.data_ptr(),
+            'aob_dt':     self._aob_dt.data_ptr(),
+            'dt':         self._ae_dt,
+            'fs':         self._fs_all.data_ptr(),
+            'rope':       self._dec_rope.data_ptr(),
+            'w_scales':   self._ae_w_dev.data_ptr(),
+            'act_scales': self._ae_calib_scales.data_ptr(),
+        }
+        ae_dims = {
+            'S': Sa, 'D': Da, 'H': Ha, 'NH': 8, 'HD': 256,
+            'steps': 10, 'layers': La, 'enc_seq': Se,
+            'total_keys': total_keys,
+            'fixed_shape': self._fixed_shape_active,
+        }
+
+        def _run(stream_int):
+            self._patch_embed_ops(stream_int)
+            siglip_forward(self._gemm, fvk, self._sig_bufs,
+                           self._sig_weights, self._sig_dims,
+                           stream=stream_int, attn=self._attn,
+                           use_fp8=self.use_fp8)
+            self._postln_project_ops(stream_int)
+            self._Kc.zero_()
+            self._Vc.zero_()
+            encoder_forward(self._gemm, fvk, enc_bufs, enc_weights,
+                            enc_dims, stream=stream_int, attn=self._attn,
+                            use_fp8=self.use_fp8)
+            decoder_forward(self._ctx, fvk, ae_bufs, ae_weights,
+                            ae_dims, stream=stream_int, attn=self._attn,
+                            use_fp8=self.use_fp8)
+
+        for _ in range(3):
+            _run(0)
+        torch.cuda.synchronize()
+
+        stream = torch.cuda.Stream()
+        graph = torch.cuda.CUDAGraph()
+        stream_int = stream.cuda_stream
+        with torch.cuda.stream(stream):
+            graph.capture_begin()
+            _run(stream_int)
+            graph.capture_end()
+        torch.cuda.synchronize()
+
+        self._model_runtime_torch_stream = stream
+        self._model_runtime_graph_stream = ctypes.c_void_p(stream_int)
+        self._model_runtime_full_graph = _TorchGraphExport(graph)
+        logger.info("Pi0.5 Thor model-runtime full graph captured (Se=%d)", Se)
+
+    def _ensure_model_runtime_export(self) -> None:
+        if not self.graph_captured:
+            raise RuntimeError(
+                "Pi0.5 Thor export requires set_prompt()/predict() first")
+        if self._model_runtime_full_graph is None:
+            self._capture_model_runtime_full_graph()
+        if self._runtime_rtc_prev_action_chunk is None:
+            self._runtime_rtc_prev_action_chunk = CudaBuffer.device_empty(
+                self.Sa * 32, np.float16)
+            self._runtime_rtc_prefix_weights = CudaBuffer.device_empty(
+                self.Sa, np.float32)
+            self._runtime_rtc_guidance_weight = CudaBuffer.device_empty(
+                1, np.float32)
+
+        bufs = {
+            "observation_images_normalized": self._img_buf,
+            "diffusion_noise": _TorchTensorBuffer(self._g_noise),
+            "encoder_x": _TorchTensorBuffer(self._enc_x),
+            "rtc_prev_action_chunk": self._runtime_rtc_prev_action_chunk,
+            "rtc_prefix_weights": self._runtime_rtc_prefix_weights,
+            "rtc_guidance_weight": self._runtime_rtc_guidance_weight,
+        }
+        self.pipeline.bind_runtime_export(
+            graph=self._model_runtime_full_graph,
+            graph_stream=self._model_runtime_graph_stream,
+            bufs=bufs,
+            decoder_only_graph=None,
+            num_views=self.num_views,
+            max_prompt_len=getattr(self, "_S_lang", self.current_prompt_len),
+            chunk_size=self.Sa,
+            norm_stats=self.norm_stats,
+            use_fp8=self.use_fp8,
+            tensor_dtype="f16",
+            hardware="thor_sm110",
+        )
 
     def _capture_enc_ae_graph_b2(self):
         """Capture B=N encoder + decoder as a CUDA graph (Stage 2).

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -203,20 +203,19 @@ class Pi05TorchFrontendThor:
         self._gemm = fvk.GemmRunner()
 
         # ---- Load CUTLASS FMHA (compiled from csrc/attention/) ----
-        # Search order: next to the checkpoint, then the installed
-        # ``flash_rt/`` package dir (pip + editable installs land here via
-        # the ``package-data = ["*.so"]`` glob in pyproject.toml), then the
-        # uncopied ``build/`` output of a fresh cmake run, then the docker
-        # container convention ``/workspace/``.
+        # Search order: explicit override, next to the checkpoint, then the
+        # installed ``flash_rt/`` package dir (pip + editable installs land
+        # here via the ``package-data = ["*.so"]`` glob in pyproject.toml),
+        # then the uncopied ``build/`` output of a fresh cmake run.
         fmha_paths = [
+            os.environ.get("FLASHRT_FMHA_LIBRARY", ""),
             str(checkpoint_dir.parent / "libfmha_fp16_strided.so"),
             str(pathlib.Path(__file__).parent.parent.parent / "libfmha_fp16_strided.so"),
             str(pathlib.Path(__file__).parent.parent.parent.parent / "build" / "libfmha_fp16_strided.so"),
-            "/workspace/libfmha_fp16_strided.so",
         ]
         fmha_loaded = False
         for p in fmha_paths:
-            if pathlib.Path(p).exists():
+            if p and pathlib.Path(p).exists():
                 ret = fvk.load_fmha_strided_library(p)
                 if ret == 0:
                     fmha_loaded = True
@@ -250,10 +249,17 @@ class Pi05TorchFrontendThor:
             checkpoint_dir / "assets" / "physical-intelligence" / "libero" / "norm_stats.json",
             checkpoint_dir.parent / "pi05_libero" / "assets" / "physical-intelligence" / "libero" / "norm_stats.json",
             checkpoint_dir / "norm_stats.json",
-            pathlib.Path("/root/.cache/openpi/openpi-assets/checkpoints/pi05_libero/"
-                         "assets/physical-intelligence/libero/norm_stats.json"),
             *lerobot_candidates(checkpoint_dir),
         ]
+        openpi_assets_dir = os.environ.get("OPENPI_ASSETS_DIR")
+        if openpi_assets_dir:
+            root = pathlib.Path(openpi_assets_dir)
+            candidates.extend([
+                root / "checkpoints" / "pi05_libero" / "assets"
+                / "physical-intelligence" / "libero" / "norm_stats.json",
+                root / "pi05_libero" / "assets" / "physical-intelligence"
+                / "libero" / "norm_stats.json",
+            ])
         self.norm_stats = load_norm_stats(
             candidates, checkpoint_dir=checkpoint_dir)
 

--- a/flash_rt/frontends/torch/pi05_thor.py
+++ b/flash_rt/frontends/torch/pi05_thor.py
@@ -167,8 +167,13 @@ class Pi05TorchFrontendThor:
         self.pipeline = Pi05ThorPipeline(batch_size=1)
         self.pipeline.bind_runtime_owner(self)
         self._model_runtime_full_graph = None
+        self._model_runtime_context_graph = None
+        self._model_runtime_decode_only_graph = None
+        self._model_runtime_rtc_prefix_graphs = {}
         self._model_runtime_graph_stream = None
         self._model_runtime_torch_stream = None
+        self._model_runtime_context_stream = None
+        self._model_runtime_decode_only_stream = None
         self._runtime_rtc_prev_action_chunk = None
         self._runtime_rtc_prefix_weights = None
         self._runtime_rtc_guidance_weight = None
@@ -1582,7 +1587,192 @@ class Pi05TorchFrontendThor:
             self._enc_ae_graph.capture_end()
         torch.cuda.synchronize()
         self._model_runtime_full_graph = None
+        self._model_runtime_context_graph = None
+        self._model_runtime_decode_only_graph = None
+        self._model_runtime_rtc_prefix_graphs = {}
+        self.pipeline._decoder_only_graph = None
         logger.info("Enc+AE CUDA graph captured (Se=%d)", Se)
+
+    def _runtime_encoder_spec(self):
+        Se = self.Se
+        total_keys = self.total_keys
+        Le = self.Le; De = self.De; He = self.He
+        NHe = self.NHe; HDe = self.HDe
+        enc_bufs = {
+            'x':       self._enc_x.data_ptr(),
+            'x_fp8':   self._enc_x_fp8.data_ptr(),
+            'qkv':     self._enc_qkv_buf.data_ptr(),
+            'logits':  self._enc_logits.data_ptr(),
+            'attn_out': self._enc_attn.data_ptr(),
+            'o_fp8':   self._enc_o_fp8.data_ptr(),
+            'gate':    self._enc_gate.data_ptr(),
+            'hidden':  self._enc_hidden.data_ptr(),
+            'hid_fp8': self._enc_hid_fp8.data_ptr(),
+            'fg':      self._enc_fg.data_ptr(),
+            'ctx':     self._ctx,
+            'x_norm':  self._enc_attn.data_ptr(),
+            'ones':    (self._enc_ones_fp16.data_ptr()
+                        if self._enc_ones_fp16 is not None else 0),
+        }
+        enc_weights = {
+            'qkv_w':     [w.data_ptr() for w in self._enc_qkv_w],
+            'o_w':       [w.data_ptr() for w in self._enc_o_w],
+            'gate_w':    [w.data_ptr() for w in self._enc_gu_w],
+            'down_w':    [w.data_ptr() for w in self._enc_d_w],
+            'rope':      self._enc_rope.data_ptr(),
+            'Kc':        self._Kc.reshape(-1).data_ptr(),
+            'Vc':        self._Vc.reshape(-1).data_ptr(),
+            'act_scales': self._enc_calib_scales.data_ptr(),
+            'alpha_host': self._enc_alpha_host,
+        }
+        enc_dims = {
+            'Se': Se, 'D': De, 'H': He, 'NH': NHe, 'HD': HDe,
+            'L': Le, 'total_keys': total_keys,
+        }
+        return enc_bufs, enc_weights, enc_dims
+
+    def _runtime_decoder_spec(self):
+        Se = self.Se
+        total_keys = self.total_keys
+        La = self.La
+        Sa = self.Sa; Da = self.Da; Ha = self.Ha
+        ae_bufs = {
+            'noise':   self._g_noise.data_ptr(),
+            'x':       self._ae_x.data_ptr(),
+            'xn':      self._ae_xn.data_ptr(),
+            'gate':    self._ae_gate.data_ptr(),
+            'qkv':     self._ae_qkv.data_ptr(),
+            'logits':  self._ae_logits.data_ptr(),
+            'attn_out': self._ae_attn.data_ptr(),
+            'hid':     self._ae_hid.data_ptr(),
+            'fg':      self._ae_fg.data_ptr(),
+            'action_f32': self._ae_action_f32.data_ptr(),
+            'xn_fp8':  self._ae_xn_fp8.data_ptr(),
+            'hid_fp8': self._ae_hid_fp8.data_ptr(),
+            'ctx_fp8': self._ae_ctx_fp8.data_ptr(),
+        }
+        if self._runtime_rtc_prev_action_chunk is not None:
+            ae_bufs['rtc_prev_action_chunk'] = (
+                self._runtime_rtc_prev_action_chunk.ptr.value)
+        ae_weights = {
+            'ain_w':      self._ain_w.data_ptr(),
+            'ain_b':      self._ain_b.data_ptr(),
+            'sa':         self._sa_all.data_ptr(),
+            'qw':         self._dec_qkv_flat.data_ptr(),
+            'Kc':         self._Kc.reshape(-1).data_ptr(),
+            'Vc':         self._Vc.reshape(-1).data_ptr(),
+            'dec_devpos': self._attn.dec_devpos.data_ptr(),
+            'ow':         self._dec_o_flat.data_ptr(),
+            'sf':         self._sf_all.data_ptr(),
+            'gw':         self._dec_gu_flat.data_ptr(),
+            'dw':         self._dec_d_flat.data_ptr(),
+            'aow':        self._aow.data_ptr(),
+            'aob':        self._aob.data_ptr(),
+            'aob_dt':     self._aob_dt.data_ptr(),
+            'dt':         self._ae_dt,
+            'fs':         self._fs_all.data_ptr(),
+            'rope':       self._dec_rope.data_ptr(),
+            'w_scales':   self._ae_w_dev.data_ptr(),
+            'act_scales': self._ae_calib_scales.data_ptr(),
+        }
+        ae_dims = {
+            'S': Sa, 'D': Da, 'H': Ha, 'NH': 8, 'HD': 256,
+            'steps': 10, 'layers': La, 'enc_seq': Se,
+            'total_keys': total_keys,
+            'fixed_shape': self._fixed_shape_active,
+        }
+        return ae_bufs, ae_weights, ae_dims
+
+    def _capture_runtime_graph(self, body, *, log_name: str):
+        for _ in range(3):
+            body(0)
+        torch.cuda.synchronize()
+
+        stream = torch.cuda.Stream()
+        graph = torch.cuda.CUDAGraph()
+        stream_int = stream.cuda_stream
+        with torch.cuda.stream(stream):
+            graph.capture_begin()
+            body(stream_int)
+            graph.capture_end()
+        torch.cuda.synchronize()
+        logger.info("Pi0.5 Thor model-runtime %s graph captured", log_name)
+        return stream, _TorchGraphExport(graph)
+
+    def _run_model_runtime_context(self, stream_int: int, enc_bufs,
+                                   enc_weights, enc_dims) -> None:
+        self._patch_embed_ops(stream_int)
+        siglip_forward(self._gemm, fvk, self._sig_bufs,
+                       self._sig_weights, self._sig_dims,
+                       stream=stream_int, attn=self._attn,
+                       use_fp8=self.use_fp8)
+        self._postln_project_ops(stream_int)
+        self._Kc.zero_()
+        self._Vc.zero_()
+        encoder_forward(self._gemm, fvk, enc_bufs, enc_weights,
+                        enc_dims, stream=stream_int, attn=self._attn,
+                        use_fp8=self.use_fp8)
+
+    def _run_model_runtime_decode(self, stream_int: int, ae_bufs,
+                                  ae_weights, ae_dims,
+                                  rtc_prefix_len: int = 0) -> None:
+        decoder_forward(self._ctx, fvk, ae_bufs, ae_weights,
+                        ae_dims, stream=stream_int, attn=self._attn,
+                        use_fp8=self.use_fp8,
+                        rtc_prefix_len=rtc_prefix_len)
+
+    def _capture_model_runtime_context_action_graphs(
+            self, pipeline, stream_handle, stream_int) -> None:
+        del stream_handle, stream_int
+        if getattr(self, "_model_runtime_context_graph", None) is None:
+            enc_bufs, enc_weights, enc_dims = self._runtime_encoder_spec()
+            stream, graph = self._capture_runtime_graph(
+                lambda s: self._run_model_runtime_context(
+                    s, enc_bufs, enc_weights, enc_dims),
+                log_name="context")
+            self._model_runtime_context_stream = stream
+            self._model_runtime_context_graph = graph
+            from flash_rt.subgraphs.capture import register_captured_graph
+            register_captured_graph(
+                pipeline, "context", graph, exec_name="pi05_thor_context",
+                stream="main", variants=(0,))
+
+        if getattr(self, "_model_runtime_decode_only_graph", None) is None:
+            ae_bufs, ae_weights, ae_dims = self._runtime_decoder_spec()
+            stream, graph = self._capture_runtime_graph(
+                lambda s: self._run_model_runtime_decode(
+                    s, ae_bufs, ae_weights, ae_dims),
+                log_name="decode_only")
+            self._model_runtime_decode_only_stream = stream
+            self._model_runtime_decode_only_graph = graph
+        pipeline._decoder_only_graph = self._model_runtime_decode_only_graph
+
+    def _capture_model_runtime_rtc_prefix_graph(
+            self, pipeline, stream_handle, stream_int, prefix_len: int) -> None:
+        del stream_handle, stream_int
+        prefix = int(prefix_len)
+        if prefix < 0:
+            raise ValueError("prefix_len must be >= 0")
+        if prefix > int(self.Sa):
+            raise ValueError(
+                f"prefix_len {prefix} exceeds chunk_size {self.Sa}")
+        cached = getattr(self, "_model_runtime_rtc_prefix_graphs", None)
+        if cached is None:
+            cached = {}
+            self._model_runtime_rtc_prefix_graphs = cached
+        if prefix in cached:
+            return
+        ae_bufs, ae_weights, ae_dims = self._runtime_decoder_spec()
+        stream, graph = self._capture_runtime_graph(
+            lambda s: self._run_model_runtime_decode(
+                s, ae_bufs, ae_weights, ae_dims, rtc_prefix_len=prefix),
+            log_name=f"decode_rtc_prefix_{prefix}")
+        cached[prefix] = (stream, graph)
+        from flash_rt.subgraphs.capture import register_captured_graph
+        register_captured_graph(
+            pipeline, "decode_rtc_prefix", graph,
+            exec_name=f"pi05_thor_decode_rtc_prefix_{prefix}",
+            stream="main", variants=(0,))
 
     def _capture_model_runtime_full_graph(self) -> None:
         """Capture one full Pi0.5 Thor graph for model-runtime export."""

--- a/flash_rt/models/pi05/pipeline_thor.py
+++ b/flash_rt/models/pi05/pipeline_thor.py
@@ -23,6 +23,7 @@ Classes:
     Pi05ThorPipeline           — B=1 facade for SigLIP + enc_ae replay
 """
 
+import ctypes
 import math
 
 from flash_rt.hardware.thor.shared_primitives import (
@@ -530,6 +531,7 @@ class Pi05ThorPipeline:
                 f"Pi05ThorPipeline base class supports only B=1; got "
                 f"B={batch_size}. Use Pi05ThorBatchedPipeline for B>1.")
         self.batch_size = int(batch_size)
+        self._runtime_owner = None
 
     def run_pipeline(self, *, replay_siglip, replay_enc_ae) -> None:
         """Replay the captured SigLIP graph followed by enc_ae graph.
@@ -543,3 +545,96 @@ class Pi05ThorPipeline:
         """
         replay_siglip()
         replay_enc_ae()
+
+    def bind_runtime_owner(self, owner: object) -> None:
+        """Attach the frontend that owns Thor buffers and graph capture."""
+        self._runtime_owner = owner
+
+    def bind_runtime_export(
+            self, *, graph: object, graph_stream: object, bufs: dict,
+            decoder_only_graph: object | None = None,
+            num_views: int, max_prompt_len: int, chunk_size: int,
+            norm_stats=None, use_fp8: bool = True,
+            tensor_dtype: str = "f16", hardware: str = "thor_sm110") -> None:
+        """Bind the standard Pi0.5 runtime-export surface.
+
+        Thor frontends own the actual storage/capture. This facade exposes the
+        same producer attributes as the RTX pipeline so the shared
+        ``runtime_export.py`` contract can lower either hardware path without
+        hardware branches in C++ or Nexus.
+        """
+        self._graph = graph
+        self._decoder_only_graph = decoder_only_graph
+        self._graph_stream = graph_stream
+        self.bufs = dict(bufs)
+        self.num_views = int(num_views)
+        self.max_prompt_len = int(max_prompt_len)
+        self.chunk_size = int(chunk_size)
+        self.norm_stats = norm_stats or {}
+        self.use_fp8 = bool(use_fp8)
+        self.use_int8_decoder = False
+        self.tensor_dtype = str(tensor_dtype)
+        self.hardware = str(hardware)
+        self._cudart = ctypes.CDLL("libcudart.so")
+
+    def _ensure_runtime_export_ready(self) -> None:
+        owner = getattr(self, "_runtime_owner", None)
+        if owner is not None and hasattr(owner, "_ensure_model_runtime_export"):
+            owner._ensure_model_runtime_export()
+        if getattr(self, "_graph", None) is None:
+            raise RuntimeError(
+                "Pi05 Thor runtime export requires a captured full graph; "
+                "call set_prompt()/predict() before export")
+
+    @property
+    def input_images_buf(self):
+        return self.bufs["observation_images_normalized"]
+
+    @property
+    def input_noise_buf(self):
+        return self.bufs["diffusion_noise"]
+
+    @property
+    def input_encoder_x_buf(self):
+        return self.bufs["encoder_x"]
+
+    @property
+    def input_rtc_prev_action_chunk_buf(self):
+        return self.bufs["rtc_prev_action_chunk"]
+
+    @property
+    def input_rtc_prefix_weights_buf(self):
+        return self.bufs["rtc_prefix_weights"]
+
+    @property
+    def input_rtc_guidance_weight_buf(self):
+        return self.bufs["rtc_guidance_weight"]
+
+    def forward(self) -> int:
+        self._ensure_runtime_export_ready()
+        if getattr(self, "_use_exec", False):
+            rc = self._exec_full.replay(0, self._exec_gs_id)
+            if rc != 0:
+                raise RuntimeError(f"frt pi05 thor infer replay rc={rc}")
+        else:
+            self._graph.replay(self._graph_stream)
+        self._cudart.cudaStreamSynchronize(self._graph_stream)
+        return self.bufs["diffusion_noise"].ptr.value
+
+    def export_runtime(self, identity=None, extra_regions=None):
+        """Package the captured Thor pipeline as ``frt_runtime_export_v1``."""
+        self._ensure_runtime_export_ready()
+        from flash_rt.models.pi05.runtime_export import export_runtime
+        return export_runtime(self, identity=identity,
+                              extra_regions=extra_regions)
+
+    def export_model_runtime(self, identity=None, extra_regions=None,
+                             stage_plan="full", io="python",
+                             stage_plan_kwargs=None):
+        """Package the captured Thor pipeline as ``frt_model_runtime_v1``."""
+        self._ensure_runtime_export_ready()
+        from flash_rt.models.pi05.runtime_export import export_model_runtime
+        return export_model_runtime(self, identity=identity,
+                                    extra_regions=extra_regions,
+                                    stage_plan=stage_plan, io=io,
+                                    stage_plan_kwargs=stage_plan_kwargs)

--- a/flash_rt/models/pi05/pipeline_thor.py
+++ b/flash_rt/models/pi05/pipeline_thor.py
@@ -56,8 +56,20 @@ def _action_update_fp16(ctx, fvk, xn, aow, aob, noise, rows, cols, dim,
 # Decoder (18 layers, 10 diffusion steps, static FP8)
 # ══════════════════════════════════════════════════════════════════
 
+def _copy_rtc_prefix(bufs, dims, stream: int, prefix_len: int) -> None:
+    if prefix_len <= 0:
+        return
+    if prefix_len > int(dims["S"]):
+        raise ValueError(
+            f"rtc prefix_len {prefix_len} exceeds chunk_size {dims['S']}")
+    prev = bufs.get("rtc_prev_action_chunk")
+    if not prev:
+        raise ValueError("rtc_prev_action_chunk buffer is required")
+    _gpu_copy(bufs["noise"], prev, int(prefix_len) * 32 * 2, stream)
+
+
 def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None,
-                    use_fp8=True):
+                    use_fp8=True, rtc_prefix_len: int = 0):
     """Full AE decoder forward pass ≡ pi05 ae_forward_static.
 
     Args:
@@ -78,10 +90,15 @@ def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None,
             FP8 norm/quantize kernels are split into their FP16
             equivalents (``adarms_fp16``, ``gate_res_fp16``,
             ``gate_geglu_merged_fp16``). Used for FP16 baseline runs.
+        rtc_prefix_len: Optional prefix length for RTC prefix-lock action
+            graphs. When non-zero, the prefix rows of ``noise`` are restored
+            from ``bufs['rtc_prev_action_chunk']`` before each denoise step and
+            after each action update.
     """
     if not use_fp8:
         return _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream,
-                                      attn=attn)
+                                      attn=attn,
+                                      rtc_prefix_len=rtc_prefix_len)
     S = dims['S']
     D = dims['D']
     H = dims['H']
@@ -133,8 +150,10 @@ def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None,
     rope = weights['rope']
     w_scales = weights['w_scales']
     act_scales = weights['act_scales']
+    rtc_prefix_len = int(rtc_prefix_len or 0)
 
     for s in range(steps):
+        _copy_rtc_prefix(bufs, dims, stream, rtc_prefix_len)
         step_scale_base = s * layers * 4
         # ── Action input: noise → x ──
         fvk.gmm_fp16(ctx, noise, ain_w, x, S, D, 32, 0.0, stream)
@@ -226,13 +245,15 @@ def decoder_forward(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None,
 
         _action_update_fp16(ctx, fvk, xn, aow, aob, noise, S, 32, D,
                             stream, dt, action_f32, aob_dt)
+        _copy_rtc_prefix(bufs, dims, stream, rtc_prefix_len)
 
 
 # ══════════════════════════════════════════════════════════════════
 # FP16 decoder path (no quantization, FP16 weights, baseline only)
 # ══════════════════════════════════════════════════════════════════
 
-def _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None):
+def _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream=0, *,
+                          attn=None, rtc_prefix_len: int = 0):
     """FP16-only decoder forward. Structure mirrors the FP8 path; every
     GEMM is ``fvk.gmm_fp16`` and the fused FP8 norm kernels are split.
 
@@ -266,8 +287,10 @@ def _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None)
     aob_dt = weights.get('aob_dt')
     dt = weights.get('dt')
     fs = weights['fs']; rope = weights['rope']
+    rtc_prefix_len = int(rtc_prefix_len or 0)
 
     for s in range(steps):
+        _copy_rtc_prefix(bufs, dims, stream, rtc_prefix_len)
         fvk.gmm_fp16(ctx, noise, ain_w, x, S, D, 32, 0.0, stream)
         fvk.add_bias_fp16(x, ain_b, S, D, stream)
 
@@ -336,6 +359,7 @@ def _decoder_forward_fp16(ctx, fvk, bufs, weights, dims, stream=0, *, attn=None)
         fvk.adarms_fp16(x, fs_ptr, xn, gate, S, D, stream)
         _action_update_fp16(ctx, fvk, xn, aow, aob, noise, S, 32, D,
                             stream, dt, action_f32, aob_dt)
+        _copy_rtc_prefix(bufs, dims, stream, rtc_prefix_len)
 
 
 # ══════════════════════════════════════════════════════════════════
@@ -576,6 +600,10 @@ class Pi05ThorPipeline:
         self.tensor_dtype = str(tensor_dtype)
         self.hardware = str(hardware)
         self._cudart = ctypes.CDLL("libcudart.so")
+        from flash_rt.subgraphs.capture import run_capture_hooks
+        run_capture_hooks(
+            self, self._graph_stream,
+            int(getattr(self._graph_stream, "value", self._graph_stream) or 0))
 
     def _ensure_runtime_export_ready(self) -> None:
         owner = getattr(self, "_runtime_owner", None)
@@ -609,6 +637,23 @@ class Pi05ThorPipeline:
     @property
     def input_rtc_guidance_weight_buf(self):
         return self.bufs["rtc_guidance_weight"]
+
+    def capture_context_action_graphs(self, stream_handle, stream_int) -> None:
+        owner = getattr(self, "_runtime_owner", None)
+        if owner is None or not hasattr(
+                owner, "_capture_model_runtime_context_action_graphs"):
+            raise RuntimeError("Pi05 Thor owner cannot capture context_action")
+        owner._capture_model_runtime_context_action_graphs(
+            self, stream_handle, stream_int)
+
+    def capture_rtc_prefix_graph(self, stream_handle, stream_int,
+                                 prefix_len: int) -> None:
+        owner = getattr(self, "_runtime_owner", None)
+        if owner is None or not hasattr(
+                owner, "_capture_model_runtime_rtc_prefix_graph"):
+            raise RuntimeError("Pi05 Thor owner cannot capture rtc_prefix")
+        owner._capture_model_runtime_rtc_prefix_graph(
+            self, stream_handle, stream_int, prefix_len)
 
     def forward(self) -> int:
         self._ensure_runtime_export_ready()

--- a/flash_rt/models/pi05/runtime_export.py
+++ b/flash_rt/models/pi05/runtime_export.py
@@ -19,10 +19,13 @@ def exec_enable(pl) -> None:
     pl._exec_ctx = _frt.Ctx()
     pl._exec_gs_id = pl._exec_ctx.wrap_stream(int(pl._graph_stream.value))
     pl._exec_full = pl._exec_ctx.graph("pi05_infer", 1)
-    pl._exec_dec = pl._exec_ctx.graph("pi05_decode_only", 1)
+    has_decode_only = getattr(pl, "_decoder_only_graph", None) is not None
+    pl._exec_dec = (
+        pl._exec_ctx.graph("pi05_decode_only", 1)
+        if has_decode_only else None)
     if getattr(pl, "_graph", None) is not None:
         pl._exec_full.adopt(0, pl._graph._graph_exec.value)
-    if getattr(pl, "_decoder_only_graph", None) is not None:
+    if has_decode_only:
         pl._exec_dec.adopt(0, pl._decoder_only_graph._graph_exec.value)
     from flash_rt.subgraphs.capture import materialize_captured_graphs
     materialize_captured_graphs(pl)
@@ -207,6 +210,9 @@ def export_model_runtime(pl, identity=None, extra_regions=None,
 
 def _tensor_dtype(pl):
     """Device tensor dtype for Pi0.5 IO buffers."""
+    dtype = getattr(pl, "tensor_dtype", None)
+    if dtype:
+        return str(dtype)
     if type(pl).__name__.endswith("FP16"):
         return "f16"
     return "bf16"
@@ -244,10 +250,9 @@ def _parts(pl, identity, extra_regions):
     streams = [_rt.StreamSpec(
         "main", pl._exec_gs_id,
         native_handle=int(pl._graph_stream.value or 0))]
-    graphs = [
-        _rt.GraphSpec("infer", pl._exec_full, 0, (0,)),
-        _rt.GraphSpec("decode_only", pl._exec_dec, 0, (0,)),
-    ]
+    graphs = [_rt.GraphSpec("infer", pl._exec_full, 0, (0,))]
+    if getattr(pl, "_decoder_only_graph", None) is not None:
+        graphs.append(_rt.GraphSpec("decode_only", pl._exec_dec, 0, (0,)))
     from flash_rt.subgraphs.capture import export_graph_records
     for rec in export_graph_records(pl):
         graphs.append(_rt.GraphSpec(
@@ -280,10 +285,15 @@ def _parts(pl, identity, extra_regions):
     ident = {
         "model": "pi05",
         "pipeline": type(pl).__name__,
+        "hardware": str(getattr(pl, "hardware", "")),
+        "tensor_dtype": _tensor_dtype(pl),
         "use_fp8": str(bool(getattr(pl, "use_fp8", False))),
         "use_int8_decoder": str(bool(getattr(pl, "use_int8_decoder", False))),
         "num_views": str(getattr(pl, "num_views", "")),
         "max_prompt_len": str(getattr(pl, "max_prompt_len", "")),
+        "chunk_size": str(getattr(pl, "chunk_size", "")),
+        "model_action_dim": "32",
+        "robot_action_dim": str(_robot_action_dim(pl)),
     }
     ident.update({str(k): str(v) for k, v in (identity or {}).items()})
 

--- a/flash_rt/subgraphs/pi05/context_action.py
+++ b/flash_rt/subgraphs/pi05/context_action.py
@@ -50,6 +50,10 @@ def _run_context(pl: object, stream: int) -> None:
 
 def _capture_context_graph(pl: object, stream_handle: object,
                            stream_int: int) -> None:
+    capture = getattr(pl, "capture_context_action_graphs", None)
+    if capture is not None:
+        capture(stream_handle, stream_int)
+        return
     if getattr(pl, "_context_graph", None) is not None:
         return
     graph = capture_graph(

--- a/flash_rt/subgraphs/pi05/rtc_prefix.py
+++ b/flash_rt/subgraphs/pi05/rtc_prefix.py
@@ -52,6 +52,10 @@ def _install_pipeline(pipeline: object, prefix_len: int) -> None:
 
 def _capture_rtc_prefix_graph(pl: object, stream_handle: object,
                               stream_int: int, prefix_len: int) -> None:
+    capture = getattr(pl, "capture_rtc_prefix_graph", None)
+    if capture is not None:
+        capture(stream_handle, stream_int, prefix_len)
+        return
     if getattr(pl, "_decode_rtc_prefix_graph", None) is not None:
         return
     if int(prefix_len) > int(getattr(pl, "chunk_size", 0)):


### PR DESCRIPTION
## Summary
- document the model-runtime split between model contracts, hardware producers, and native C++ overlays
- expose Pi0.5 Thor pipelines through the shared `runtime_export.py` model-runtime contract
- add Thor export readiness hooks for full, context/action, and RTC-prefix subgraph exports

## Validation
- `git diff --check origin/main..HEAD`
- Python AST parse for the touched Thor/export/subgraph files
- `PYTHONPATH=.:exec/build:runtime/build pytest -q runtime/tests/test_runtime_export.py runtime/tests/test_model_runtime_py.py`
- `cmake --build runtime/build -j && ./runtime/build/test_model_runtime`
- `cmake --build cpp/build -j && ctest --test-dir cpp/build --output-on-failure`
- RTX/Pi0.5 FP16 real gate with system libstdc++ preload: `LD_PRELOAD=/path/to/system/libstdc++.so.6 PYTHONPATH=.:exec/build:runtime/build:cpp/build python cpp/tests/gate_pi05_model_runtime_export.py --checkpoint $PI05_CHECKPOINT --steps 10`
  - py vs full raw exact: true
  - full vs split raw exact: true
  - rtc prefix exact: true

## Notes
- The RTX path needed no follow-up changes after the Thor export additions.
- Thor real-hardware validation was run on the Thor side before pushing this branch; this host only validates the shared ABI/C++ runtime and RTX real-model path.
- The added runtime identity fields (`hardware`, `tensor_dtype`, `chunk_size`, `model_action_dim`, `robot_action_dim`) intentionally change Pi0.5 runtime fingerprints; existing exported artifacts should be regenerated.