### PR TITLE
fix(groot_n17): implement latency stats, populate __init__.py, clean up stale docstrings

### DIFF
--- a/flash_rt/frontends/torch/groot_n17_rtx_fp16.py
+++ b/flash_rt/frontends/torch/groot_n17_rtx_fp16.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import math
 import os
 import glob
+import time
 
 import torch
 
@@ -367,6 +368,7 @@ class GrootN17TorchFrontendRtxFP16(GrootN17TorchFrontendRtx):
             self._warmup_infer()
         except Exception as e:  # noqa: BLE001
             warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+        self.latency_records.clear()
 
     def _run_kernel_backbone(self, aux: dict) -> "torch.Tensor":
         """Run ViT → DeepStack → LLM → vlln → VL-self-attn through FP16 kernels.
@@ -572,6 +574,8 @@ class GrootN17TorchFrontendRtxFP16(GrootN17TorchFrontendRtx):
     ) -> torch.Tensor:
         if not hasattr(self, "_backbone_features"):
             raise RuntimeError("call set_prompt before infer")
+
+        t0 = time.perf_counter()
         if not hasattr(self, "_dit_cross_K"):
             self._precompute_dit_cross_kv()
 
@@ -640,6 +644,8 @@ class GrootN17TorchFrontendRtxFP16(GrootN17TorchFrontendRtx):
             velocity = self._run_action_decode(h_out[:, -action_horizon:])
             actions = actions + (dt * velocity).to(actions.dtype)
 
+        torch.cuda.synchronize()
+        self.latency_records.append((time.perf_counter() - t0) * 1000)
         return actions.float()
 
     def _warmup_infer(self) -> None:

--- a/flash_rt/frontends/torch/groot_n17_rtx_fp8.py
+++ b/flash_rt/frontends/torch/groot_n17_rtx_fp8.py
@@ -158,6 +158,7 @@ class _GrootN17FP8BackboneMixin:
             self._warmup_infer()
         except Exception as e:  # noqa: BLE001
             warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+        self.latency_records.clear()
 
     # ── FP8 kernel backbone: ViT → DeepStack → LLM → vlln → VL-self-attn ──
     def _run_kernel_backbone_fp8(self, aux: dict) -> "torch.Tensor":

--- a/flash_rt/frontends/torch/groot_n17_rtx_sm89.py
+++ b/flash_rt/frontends/torch/groot_n17_rtx_sm89.py
@@ -227,6 +227,7 @@ class _GrootN17FP8BackboneMixin:
             self._warmup_infer()
         except Exception as e:  # noqa: BLE001
             warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+        self.latency_records.clear()
 
     def _run_kernel_backbone_fp8(self, aux: dict) -> "torch.Tensor":
         import flash_rt.flash_rt_kernels as fvk

--- a/flash_rt/frontends/torch/groot_n17_rtx_sm89_fp16.py
+++ b/flash_rt/frontends/torch/groot_n17_rtx_sm89_fp16.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import math
 import os
 import glob
+import time
 
 import torch
 
@@ -364,6 +365,7 @@ class GrootN17TorchFrontendRtxSm89FP16(GrootN17TorchFrontendRtx):
             self._warmup_infer()
         except Exception as e:  # noqa: BLE001
             warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+        self.latency_records.clear()
 
     def _run_kernel_backbone(self, aux: dict) -> "torch.Tensor":
         """Run ViT → DeepStack → LLM → vlln → VL-self-attn through FP16 kernels.
@@ -569,6 +571,8 @@ class GrootN17TorchFrontendRtxSm89FP16(GrootN17TorchFrontendRtx):
     ) -> torch.Tensor:
         if not hasattr(self, "_backbone_features"):
             raise RuntimeError("call set_prompt before infer")
+
+        t0 = time.perf_counter()
         if not hasattr(self, "_dit_cross_K"):
             self._precompute_dit_cross_kv()
 
@@ -637,6 +641,8 @@ class GrootN17TorchFrontendRtxSm89FP16(GrootN17TorchFrontendRtx):
             velocity = self._run_action_decode(h_out[:, -action_horizon:])
             actions = actions + (dt * velocity).to(actions.dtype)
 
+        torch.cuda.synchronize()
+        self.latency_records.append((time.perf_counter() - t0) * 1000)
         return actions.float()
 
     def _warmup_infer(self) -> None:

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -4,15 +4,11 @@ Public surface mirrors ``GrootTorchFrontendThor`` (N1.6):
 
 * ``__init__(checkpoint_path, num_views, embodiment_tag, ...)``
 * ``set_prompt(prompt: str, embodiment_tag: str | None = None)``
-* ``infer(observation: dict) -> np.ndarray``  # (action_horizon=40, 132)
+* ``infer(state_normalized) -> torch.Tensor``  # (1, action_horizon, 132)
 * ``predict(...)`` — alias kept for API parity
-* ``get_latency_stats()``
-
-
-This commit (Phase 3c.a) lands the foundation: ``__init__`` +
-``_load_weights`` driven by ``MultiSafetensorsSource`` and the
-declarative ``WEIGHT_SPEC`` (Phase 3a). ``set_prompt``/``infer`` are
-still stubbed.
+* ``normalize_state(state_dict) -> torch.Tensor``
+* ``denormalize_action(action_normed, state_dict) -> dict``
+* ``get_latency_stats() -> dict``
 """
 
 from __future__ import annotations
@@ -20,6 +16,7 @@ from __future__ import annotations
 import glob
 import os
 import pathlib
+import time
 import warnings
 from typing import Optional
 
@@ -31,14 +28,10 @@ from flash_rt.frontends._fp8_layout import select_fp8_layout
 class GrootN17TorchFrontendThor:
     """N1.7 Thor inference frontend.
 
-    Phase 3c lands in 4 stages:
-      a. ``_load_weights`` (this commit) — full WEIGHT_SPEC across 2 ckpt
-         shards via MultiSafetensorsSource; per-embodiment slot slicing
-         on the dense (32, ·, ·) tensors.
-      b. ``set_prompt`` — Qwen3-VL processor, M-RoPE cos/sin (mrope_table),
-         timestep emb, DiT cross-KV precompute, calibration cache.
-      c. eager ``infer`` (no graphs).
-      d. CUDA Graph capture for vit / llm / vl_self_attn / dit-per-step.
+    Loads weights from a GR00T-N1.7-3B checkpoint via ``MultiSafetensorsSource``
+    and the declarative ``WEIGHT_SPEC``. Supports per-embodiment slot slicing,
+    FP8 activation calibration, CUDA Graph captured DiT, and fully-kernelized
+    backbone + DiT graph replay.
     """
 
     # Run the DiT action head's compute-bound GEMMs (FFN + self-attn QKV) in
@@ -79,8 +72,10 @@ class GrootN17TorchFrontendThor:
 
         self._load_weights()
 
+        self.latency_records: list[float] = []
+
     # ────────────────────────────────────────────────────────────────
-    # Weight loading (Phase 3c.a)
+    # Weight loading
     # ────────────────────────────────────────────────────────────────
 
     def _load_fmha_strided(self) -> None:
@@ -229,11 +224,7 @@ class GrootN17TorchFrontendThor:
         self._fp16_shadow_weights = shadow
 
     # ────────────────────────────────────────────────────────────────
-    # Phase 3c.b/c/d — pending
-    # ────────────────────────────────────────────────────────────────
-
-    # ────────────────────────────────────────────────────────────────
-    # Phase 3c.b2 — set_prompt
+    # Prompt setup
     # ────────────────────────────────────────────────────────────────
 
     def set_prompt(
@@ -244,8 +235,8 @@ class GrootN17TorchFrontendThor:
     ) -> None:
         """Run the calibration shadow + bake FP8 alphas + cache.
 
-        For 3c.b2 ``aux`` is the bundle of HF-derived setup tensors (the
-        same shape produced by ``tests/_helpers/groot_n17/capture_llm_aux.py``):
+        ``aux`` is the bundle of HF-derived setup tensors (the same shape
+        produced by ``tests/_helpers/groot_n17/capture_llm_aux.py``):
 
           * ``input_ids``           — (1, S)  int64
           * ``visual_pos_masks``    — (1, S)  bool
@@ -254,11 +245,6 @@ class GrootN17TorchFrontendThor:
           * ``llm_input_embeds``    — (1, S, 2048) fp32 (input to truncated LLM)
           * ``pixel_features``      — (S_vit=1024, 1024) fp32 (post-patch_embed+pos_embed)
           * ``grid_thw``            — (num_views, 3) int64
-
-        A future revision (3c.c+) will derive ``aux`` end-to-end from raw
-        ``(prompt, sample_obs)`` via the HF Qwen3VL processor + vision
-        model. For 3c.b2 we accept the pre-captured form so the calibration
-        path can land independently of the production preprocessing path.
 
         After this call, the frontend has:
 
@@ -347,6 +333,7 @@ class GrootN17TorchFrontendThor:
             self._warmup_infer()
         except Exception as e:
             warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+        self.latency_records.clear()
 
     def _warmup_infer(self) -> None:
         """Single dry-run infer to prime cuBLAS / lazy-init DiT attn."""
@@ -356,7 +343,7 @@ class GrootN17TorchFrontendThor:
         _ = self.infer(warm_state, initial_noise=warm_noise)
 
     # ────────────────────────────────────────────────────────────────
-    # Phase 3c.d — CUDA Graph capture of the 32-layer DiT inner loop
+    # CUDA Graph capture
     # ────────────────────────────────────────────────────────────────
 
     def _precompute_diffusion_modulators(
@@ -1209,7 +1196,7 @@ class GrootN17TorchFrontendThor:
         return spec
 
     # ────────────────────────────────────────────────────────────────
-    # Phase 3c.c — eager infer (4-step flow-matching diffusion loop)
+    # Inference (4-step flow-matching diffusion loop)
     # ────────────────────────────────────────────────────────────────
 
     def infer(
@@ -1232,6 +1219,7 @@ class GrootN17TorchFrontendThor:
         if not hasattr(self, "_backbone_features"):
             raise RuntimeError("call set_prompt before infer")
 
+        t0 = time.perf_counter()
         device = self.device
         D = 1536
         action_dim = 132
@@ -1263,6 +1251,9 @@ class GrootN17TorchFrontendThor:
                     self._k_actions.copy_(torch.randn(
                         action_horizon, action_dim, dtype=torch.bfloat16, device=device))
                 self._k_dit_graph.replay()
+                torch.cuda.synchronize()
+                self.latency_records.append(
+                    (time.perf_counter() - t0) * 1000)
                 return self._k_actions.float().view(1, action_horizon, action_dim)
 
         # Eager fallback: torch cross-KV from backbone (graph path refreshes
@@ -1368,10 +1359,12 @@ class GrootN17TorchFrontendThor:
             # ── Euler step ──────────────────────────────────────────────
             actions = actions + (dt * velocity).to(actions.dtype)
 
+        torch.cuda.synchronize()
+        self.latency_records.append((time.perf_counter() - t0) * 1000)
         return actions.float()
 
     # ────────────────────────────────────────────────────────────────
-    # Internal helpers (eager; will be CUDA-graph wrapped in 3c.d)
+    # Internal helpers
     # ────────────────────────────────────────────────────────────────
 
     def _precompute_dit_cross_kv(self) -> None:
@@ -1538,9 +1531,7 @@ class GrootN17TorchFrontendThor:
         return shifts, scales
 
     def _run_state_encode(self, state_flat: torch.Tensor) -> torch.Tensor:
-        """state (1, 1, 132) → state_features (1, 1, 1536) bf16. Pure PyTorch
-        for 3c.c eager mode (small MLP; perf-irrelevant). bf16 matches the
-        ckpt's native dtype and the DiT main path."""
+        """state (1, 1, 132) → state_features (1, 1, 1536) bf16."""
         x = state_flat.view(1, 132).float()
         h = x @ self._st_enc_l1_W.float() + self._st_enc_l1_b.float()
         h = torch.nn.functional.relu(h)
@@ -1863,5 +1854,18 @@ class GrootN17TorchFrontendThor:
     def predict(self, *args, **kwargs):
         return self.infer(*args, **kwargs)
 
-    def get_latency_stats(self):
-        raise NotImplementedError("Phase 3c.d: latency stats")
+    def get_latency_stats(self) -> dict:
+        if not self.latency_records:
+            return {}
+        import numpy as np
+        lat = np.array(self.latency_records)
+        return {
+            "count": len(lat),
+            "mean_ms": float(np.mean(lat)),
+            "std_ms": float(np.std(lat)),
+            "min_ms": float(np.min(lat)),
+            "max_ms": float(np.max(lat)),
+            "p50_ms": float(np.percentile(lat, 50)),
+            "p95_ms": float(np.percentile(lat, 95)),
+            "hz": float(1000 / np.mean(lat)),
+        }

--- a/flash_rt/frontends/torch/groot_n17_thor_fp8.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp8.py
@@ -207,6 +207,7 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
             self._warmup_infer()
         except Exception as e:  # noqa: BLE001
             warnings.warn(f"set_prompt warmup failed (non-fatal): {e!r}")
+        self.latency_records.clear()
 
     # ── Patch embed (image → ViT input), kernelized ───────────────────────
     def _fast_pos_embed_interpolate(self, grid_thw) -> "torch.Tensor":

--- a/flash_rt/models/groot_n17/__init__.py
+++ b/flash_rt/models/groot_n17/__init__.py
@@ -1,6 +1,50 @@
 """GR00T N1.7 model package.
 
-Pi0.5/Pi0/GROOT-N1.6 sibling. Architecture: Qwen3-VL-2B (Cosmos-Reason2-2B)
-backbone with M-RoPE + DeepStack + 4-layer vl_self_attention + 32-layer
-AlternateVLDiT action head. State/action dim 132, action horizon 40.
+Architecture: Qwen3-VL-2B (Cosmos-Reason2-2B) backbone with M-RoPE +
+DeepStack + 4-layer vl_self_attention + 32-layer AlternateVLDiT action
+head. State/action dim 132, action horizon 40.
+
+Per the unified pipeline_<hw>.py contract:
+    pipeline_thor.py      - Thor SM110 pointer-only forward functions
+    pipeline_rtx.py       - RTX SM120 (re-exports dit_forward from Thor)
+    pipeline_rtx_fp8.py   - RTX SM120 FP8 backbone forwards
+    pipeline_rtx_fp16.py  - RTX full-FP16 reference forwards
+    pipeline_rtx_sm89.py  - RTX SM89 FP8 backbone forwards
+
+The embodiment mapping is re-exported eagerly (no heavy deps). All other
+symbols (calibration, M-RoPE tables, pipeline forwards) are available via
+their submodules and are listed in ``__all__`` for discoverability but
+imported lazily so that ``import flash_rt.models.groot_n17`` does not
+pull in torch.
 """
+from __future__ import annotations
+
+from flash_rt.models.groot_n17.embodiments import (
+    EMBODIMENT_NUM_VIEWS,
+    EMBODIMENT_TAG_TO_INDEX,
+)
+
+__all__ = [
+    "EMBODIMENT_TAG_TO_INDEX",
+    "EMBODIMENT_NUM_VIEWS",
+    "calibrate_pipeline_amax",
+    "amax_to_dev_scale",
+    "RopeConfig",
+    "build_cos_sin_tables",
+    "build_position_ids_for_segments",
+    "dit_forward",
+]
+
+
+def __getattr__(name: str):
+    if name in ("calibrate_pipeline_amax", "amax_to_dev_scale"):
+        from flash_rt.models.groot_n17 import calibration
+        return getattr(calibration, name)
+    if name in ("RopeConfig", "build_cos_sin_tables",
+                "build_position_ids_for_segments"):
+        from flash_rt.models.groot_n17 import mrope_table
+        return getattr(mrope_table, name)
+    if name == "dit_forward":
+        from flash_rt.models.groot_n17 import pipeline_rtx
+        return pipeline_rtx.dit_forward
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

- **Implement `get_latency_stats()`** across all N1.7 frontends (Thor, RTX, FP8, FP16, SM89). Previously a `NotImplementedError` stub — now records wall-clock inference latency per `infer()` call and reports count / mean / std / min / max / p50 / p95 / Hz, matching the Pi0.5 and Groot N1.6 API contract.

- **Clear `latency_records` after warmup** in every `set_prompt()` path so `get_latency_stats()` reflects only user-visible steady-state inference, not graph-capture or cuBLAS-priming cost.

- **Populate `groot_n17/__init__.py`** with public re-exports. Embodiment mappings (`EMBODIMENT_TAG_TO_INDEX`, `EMBODIMENT_NUM_VIEWS`) are imported eagerly (pure dicts, no heavy deps). Calibration, M-RoPE table, and pipeline symbols are lazy-loaded via `__getattr__` so that `import flash_rt.models.groot_n17` does not pull in torch.

- **Remove stale Phase 3c comments** and docstrings that referenced `set_prompt` / `infer` as "still stubbed".

## Files changed

| File | Change |
|------|--------|
| `groot_n17_thor.py` | `latency_records` init, timing in `infer()` (both graph + eager paths), `get_latency_stats()` impl, warmup clear, docstring cleanup |
| `groot_n17_rtx_fp16.py` | Timing in overridden `infer()`, warmup clear |
| `groot_n17_rtx_sm89_fp16.py` | Timing in overridden `infer()`, warmup clear |
| `groot_n17_rtx_fp8.py` | Warmup clear |
| `groot_n17_rtx_sm89.py` | Warmup clear |
| `groot_n17_thor_fp8.py` | Warmup clear |
| `groot_n17/__init__.py` | Lazy public re-exports |

## Validation

```python
# __init__.py does not pull torch eagerly
>>> import sys; mods_before = set(sys.modules)
>>> import flash_rt.models.groot_n17
>>> any('torch' in m for m in set(sys.modules) - mods_before)
False

# Lazy symbols resolve correctly
>>> from flash_rt.models.groot_n17 import calibrate_pipeline_amax, dit_forward
>>> calibrate_pipeline_amax is not None and dit_forward is not None
True

# get_latency_stats is no longer a stub
>>> import inspect
>>> 'NotImplementedError' not in inspect.getsource(
...     flash_rt.frontends.torch.groot_n17_thor.GrootN17TorchFrontendThor.get_latency_stats)
True
```

No GPU / checkpoint required for this change — all edits are Python-level API plumbing with no change to runtime kernels, calibration, or graph capture behavior.

## Test plan

- [x] Verify `import flash_rt.models.groot_n17` does not import torch
- [x] Verify lazy attribute access resolves `calibrate_pipeline_amax`, `RopeConfig`, `dit_forward`
- [x] Verify `get_latency_stats()` source contains no `NotImplementedError`
- [x] Verify `infer()` in Thor base and both FP16 subclasses contains `time.perf_counter` + `latency_records.append`
- [ ] (requires GPU) Run `test_groot_n17_e2e.py` — confirm `get_latency_stats()` returns non-empty dict after inference
- [ ] (requires GPU) Confirm `latency_records` is empty immediately after `set_prompt()` (warmup cleared)