### PR TITLE
Add RTC temporal fusion runtime

### DIFF
--- a/docs/rtc_temporal_fusion.md
+++ b/docs/rtc_temporal_fusion.md
@@ -1,0 +1,191 @@
+# RTC temporal fusion
+
+`flash_rt.runtime.rtc_temporal_fusion` provides an optional host-side runtime
+for action-chunk policies. It predicts the next chunk on one background worker
+while the foreground continues serving the active chunk, then fuses overlapping
+raw predictions on a controller-step timeline.
+
+This module is policy/runtime code. It does not change model kernels, CUDA graph
+capture, or the Pi0.5 decoder.
+
+## Timeline and fusion
+
+For an action rate `f`, the controller period is `dt = 1 / f`. A prediction
+started at time `t` receives a global start step
+
+```text
+start_step = floor((t - epoch) / dt)
+```
+
+Action `i` in that chunk addresses `start_step + i`. For a step covered by
+several raw chunks, at most `max_chunks` newest chunks are used. If `i_new` is
+the position in the newest chunk and `i_old` is the position in another chunk,
+its weight is
+
+```text
+w = exp(-decay * abs(i_old - i_new))
+```
+
+The fused action is the normalized weighted mean. Fusion never overwrites raw
+predictions. A raw chunk remains available until its final controller step has
+expired, allowing more than two predictions to contribute.
+
+## Basic use
+
+The adapter boundary deliberately matches `flash_rt.runtime.rtc`: it receives
+an observation and returns one numeric array shaped `[horizon, action_dim]`.
+
+```python
+import numpy as np
+
+from flash_rt.runtime import (
+    AsyncTemporalFusionRunner,
+    TemporalFusionConfig,
+)
+
+
+class Pi05Adapter:
+    def __init__(self, model, prompt):
+        self.model = model
+        self.prompt = prompt
+
+    def infer_actions(self, observation):
+        return np.asarray(self.model.predict(
+            images=observation["images"],
+            prompt=self.prompt,
+            state=observation.get("state"),
+        ))
+
+
+runner = AsyncTemporalFusionRunner(
+    Pi05Adapter(model, "pick up the red block"),
+    TemporalFusionConfig(
+        action_hz=20,
+        max_chunks=3,
+        decay=0.1,
+        start_next_at=25,
+        switch_mode="latency",
+    ),
+)
+
+observation = {"images": images}
+try:
+    while control_loop_running:
+        action = runner.next_action(observation)
+        robot.send_action(action)
+finally:
+    runner.close()
+```
+
+The first call is synchronous because no action exists yet. Later predictions
+run on a single background thread. The adapter/model must therefore permit
+inference from that worker thread. Only one model inference is in flight. Before
+submission, the default snapshotter recursively copies mappings, lists, tuples,
+and NumPy arrays so foreground camera/state updates cannot alter the in-flight
+observation. Pass `observation_snapshotter=` for custom device-buffer objects.
+
+`prediction_pending` and `prediction_ready` expose read-only worker state for
+monitoring without reaching into executor internals.
+
+## Chunk switching
+
+`switch_mode="latency"` selects the position corresponding to the foreground
+time at which the completed future is promoted. It accounts for both inference
+latency and a delayed foreground poll.
+
+`switch_mode="state"` selects the fused action whose estimated state is closest
+to the current robot state:
+
+- `action_representation="absolute"`: selected action dimensions are compared
+  directly with state.
+- `action_representation="delta"`: state is estimated from the state recorded
+  when prediction started. `delta_mode="cumulative"` cumulatively integrates
+  deltas; `"from_start"` treats each action as a displacement from that state.
+- `state_action_indices` maps state dimensions when action vectors contain
+  extra dimensions.
+- `distance_metric` selects L1 or L2 distance.
+
+Pass the latest state on every controller call when state switching is enabled:
+
+```python
+action = runner.next_action(observation, state=current_robot_state)
+```
+
+## Deadline policy
+
+The next prediction starts at `start_next_at`; the default is half of the
+active horizon. If the active chunk expires first:
+
+- `miss_policy="hold_last"` repeats the last served action;
+- `miss_policy="block"` waits for the pending prediction.
+
+`runner.stats` reports prediction counts, switches, misses, held actions,
+latency, and expired raw chunks.
+
+## Configuration summary
+
+| Option | Default | Meaning |
+|---|---:|---|
+| `action_hz` | required | Controller/action frequency |
+| `max_chunks` | `3` | Maximum overlapping raw chunks per fused action |
+| `decay` | `0.1` | Exponential position-difference decay |
+| `switch_mode` | `"latency"` | Latency- or state-based chunk switch |
+| `start_next_at` | half horizon | Active-chunk index that starts prediction |
+| `action_horizon` | model horizon | Optional maximum raw chunk length |
+| `miss_policy` | `"hold_last"` | Behavior when prediction misses the horizon |
+
+## Validation
+
+CPU-only mechanism tests:
+
+```bash
+PYTHONPATH=. python -m pytest tests/test_rtc_temporal_fusion.py -q
+```
+
+Reproduce the `3 x 50 x 32` host-side fusion microbenchmark with:
+
+```bash
+PYTHONPATH=. python tests/bench_rtc_temporal_fusion.py \
+  --warmup 100 --iterations 1000
+```
+
+The real Pi0.5 gate loads a checkpoint, executes the RTX SM89 model, predicts a
+second chunk on the background worker, and checks that two real model outputs
+are step-aligned and fused according to the exponential formula:
+
+```bash
+export CUDA_VISIBLE_DEVICES=7
+export PI05_CKPT=/path/to/pi05_libero_pytorch
+PYTHONPATH=. python -m pytest \
+  tests/test_rtc_temporal_fusion_pi05.py -q -s
+```
+
+On the FlashRT 4090 validation machine this was run with the same environment
+as `/home/yzb/flashrt/run_pi05_4090.sh`:
+
+```bash
+source /data/home/yzb/.bashrc
+conda activate flashrt-cu124-clean
+export CUDA_VISIBLE_DEVICES=7
+export PI05_CKPT=/data/home/yzb/yzh/pytorch_pi05_libero
+export LD_LIBRARY_PATH=/data/home/yzb/.conda/envs/pi0_env/lib:/usr/local/cuda-12.4/lib64:${LD_LIBRARY_PATH}
+PYTHONPATH=/home/yzb/flashrt/FlashRT:/home/yzb/flashrt/FlashRT-pr93 \
+  python -m pytest tests/test_rtc_temporal_fusion_pi05.py -q -s
+```
+
+The `FlashRT-pr93` entry is only used to reuse the already-built FA2 extension
+in that local environment; the temporal-fusion runtime itself is pure Python and
+is imported from the current checkout first.
+
+The test skips when CUDA or `PI05_CKPT` is unavailable. `RTC_PI05_AUTOTUNE`
+controls Pi0.5 autotune trials and defaults to `0` for a fast gate.
+It can also run without pytest, which is useful in minimal deployment Conda
+environments:
+
+```bash
+PYTHONPATH=. python tests/test_rtc_temporal_fusion_pi05.py
+```
+
+This gate validates model/runtime integration, not closed-loop task success.
+Before robot deployment, validate action cadence, camera/state freshness,
+deadline policy, and control quality in the target simulator or robot stack.

--- a/docs/rtc_temporal_fusion.md
+++ b/docs/rtc_temporal_fusion.md
@@ -160,22 +160,26 @@ PYTHONPATH=. python -m pytest \
   tests/test_rtc_temporal_fusion_pi05.py -q -s
 ```
 
-On the FlashRT 4090 validation machine this was run with the same environment
-as `/home/yzb/flashrt/run_pi05_4090.sh`:
+For a clean local SM89 validation environment, keep the current checkout first
+on `PYTHONPATH` and point `PI05_CKPT` at a local Pi0.5 PyTorch checkpoint:
 
 ```bash
-source /data/home/yzb/.bashrc
-conda activate flashrt-cu124-clean
-export CUDA_VISIBLE_DEVICES=7
-export PI05_CKPT=/data/home/yzb/yzh/pytorch_pi05_libero
-export LD_LIBRARY_PATH=/data/home/yzb/.conda/envs/pi0_env/lib:/usr/local/cuda-12.4/lib64:${LD_LIBRARY_PATH}
-PYTHONPATH=/home/yzb/flashrt/FlashRT:/home/yzb/flashrt/FlashRT-pr93 \
+cd "$FLASHRT_CHECKOUT"
+export PYTHONNOUSERSITE=1
+unset PYTHONPATH
+export CUDA_VISIBLE_DEVICES=0
+export PI05_CKPT=/path/to/pi05_libero_pytorch
+export CUDA_HOME=/path/to/cuda-12.x
+export CUDA_PATH="$CUDA_HOME"
+export LD_LIBRARY_PATH="$CUDA_HOME/lib64:$CUDA_HOME/targets/x86_64-linux/lib:$CONDA_PREFIX/lib"
+export FLASHRT_CUDART_PATH="$CUDA_HOME/lib64/libcudart.so.12"
+PYTHONPATH=$PWD \
   python -m pytest tests/test_rtc_temporal_fusion_pi05.py -q -s
 ```
 
-The `FlashRT-pr93` entry is only used to reuse the already-built FA2 extension
-in that local environment; the temporal-fusion runtime itself is pure Python and
-is imported from the current checkout first.
+This command imports FlashRT from the current checkout only. Build or install
+the required CUDA extensions in the active Conda environment before running the
+gate.
 
 The test skips when CUDA or `PI05_CKPT` is unavailable. `RTC_PI05_AUTOTUNE`
 controls Pi0.5 autotune trials and defaults to `0` for a fast gate.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -376,12 +376,31 @@ from flash_rt.runtime.rtc import (
     AsyncChunkRunner,
     RTCStats,
 )
+
+from flash_rt.runtime import (
+    AsyncTemporalFusionRunner,
+    FusedChunk,
+    ObservationSnapshotter,
+    PredictionTicket,
+    TemporalFusionBuffer,
+    TemporalFusionConfig,
+    TemporalFusionStats,
+    TimedActionChunk,
+)
 ```
 
 The legacy async chunk runner is a beta inference scheduling utility for action-chunk
 policies. It does not change model numerics or calibration; it only
 serves action chunks at a fixed controller rate while a background worker
 prepares the next chunk. See `docs/rtc_lite_design.md`.
+
+The temporal-fusion runner is an opt-in scheduling policy that retains raw
+predicted chunks, aligns them on the controller-step timeline, and fuses up to
+`TemporalFusionConfig.max_chunks` overlapping predictions with exponential
+position-difference weights. It supports latency- and state-based chunk
+switching without changing model kernels or calibration. See
+`docs/rtc_temporal_fusion.md` for the adapter contract, configuration, deadline
+behavior, and real Pi0.5 checkpoint gate.
 
 ### `flash_rt.flash_rt_fa2`
 

--- a/flash_rt/runtime/__init__.py
+++ b/flash_rt/runtime/__init__.py
@@ -8,6 +8,16 @@ from .rtc import (
     RTCConfig,
     RTCStats,
 )
+from .rtc_temporal_fusion import (
+    AsyncTemporalFusionRunner,
+    FusedChunk,
+    ObservationSnapshotter,
+    PredictionTicket,
+    TemporalFusionBuffer,
+    TemporalFusionConfig,
+    TemporalFusionStats,
+    TimedActionChunk,
+)
 
 __all__ = [
     "ActionChunkAdapter",
@@ -16,4 +26,12 @@ __all__ = [
     "ChunkResult",
     "RTCConfig",
     "RTCStats",
+    "AsyncTemporalFusionRunner",
+    "FusedChunk",
+    "ObservationSnapshotter",
+    "PredictionTicket",
+    "TemporalFusionBuffer",
+    "TemporalFusionConfig",
+    "TemporalFusionStats",
+    "TimedActionChunk",
 ]

--- a/flash_rt/runtime/rtc_temporal_fusion.py
+++ b/flash_rt/runtime/rtc_temporal_fusion.py
@@ -381,12 +381,15 @@ class AsyncTemporalFusionRunner:
         with self._lock:
             return self._pending is not None and self._pending.done()
 
-    def close(self) -> None:
+    def close(self, *, wait: bool = True) -> None:
         with self._lock:
             self._closed = True
             if self._pending is not None and not self._pending.done():
+                ticket = getattr(self._pending, "ticket", None)
+                if ticket is not None:
+                    self.buffer.cancel_prediction(ticket)
                 self._pending.cancel()
-        self._executor.shutdown(wait=False, cancel_futures=True)
+        self._executor.shutdown(wait=wait, cancel_futures=True)
 
     def __enter__(self) -> "AsyncTemporalFusionRunner":
         return self
@@ -449,12 +452,12 @@ class AsyncTemporalFusionRunner:
         self.stats.predictions_started += 1
         snapshot = self._observation_snapshotter(observation)
         self._pending = self._executor.submit(self._run, ticket, snapshot)
+        self._pending.ticket = ticket
 
     def _promote_ready(self, state: Any | None) -> bool:
         if self._pending is None or not self._pending.done():
             return False
-        output = self._pending.result()
-        self._pending = None
+        output = self._consume_pending_result_locked()
         fused = self.buffer.complete_prediction(
             output.ticket, output.actions,
             ready_at=output.ready_time_s, switch_at=self._clock(),
@@ -470,8 +473,7 @@ class AsyncTemporalFusionRunner:
         if self.config.miss_policy == "block":
             self._submit(observation, state)
             assert self._pending is not None
-            output = self._pending.result()
-            self._pending = None
+            output = self._consume_pending_result_locked()
             fused = self.buffer.complete_prediction(
                 output.ticket, output.actions,
                 ready_at=output.ready_time_s, switch_at=self._clock(),
@@ -488,6 +490,20 @@ class AsyncTemporalFusionRunner:
         self._active = FusedChunk(-1, held, self.buffer.step_at(now),
                                   np.asarray([now]), np.asarray([0]), 0, now, now)
         self._index = 0
+
+    def _consume_pending_result_locked(self) -> _PredictionOutput:
+        if self._pending is None:
+            raise RuntimeError("temporal fusion runner has no pending prediction")
+        try:
+            output = self._pending.result()
+        except BaseException:
+            ticket = getattr(self._pending, "ticket", None)
+            if ticket is not None:
+                self.buffer.cancel_prediction(ticket)
+            self._pending = None
+            raise
+        self._pending = None
+        return output
 
     def _activate(self, fused: FusedChunk) -> None:
         self._active = fused

--- a/flash_rt/runtime/rtc_temporal_fusion.py
+++ b/flash_rt/runtime/rtc_temporal_fusion.py
@@ -1,0 +1,529 @@
+"""Temporal fusion and asynchronous execution for action-chunk policies.
+
+Actions are aligned on a controller-step grid.  If a chunk starts at global
+step ``s``, action ``i`` addresses step ``s + i``.  Overlapping raw predictions
+are fused with ``exp(-decay * abs(old_index - latest_index))`` weights.  Fused
+values never replace raw predictions; raw chunks live until their final step
+expires.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+import math
+import threading
+import time
+from typing import Any, Callable, Literal, Mapping
+
+import numpy as np
+
+from .rtc import ActionChunkAdapter
+
+
+SwitchMode = Literal["latency", "state"]
+ObservationSnapshotter = Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class TemporalFusionConfig:
+    action_hz: float
+    max_chunks: int = 3
+    decay: float = 0.1
+    switch_mode: SwitchMode = "latency"
+    action_representation: Literal["absolute", "delta"] = "absolute"
+    delta_mode: Literal["cumulative", "from_start"] = "cumulative"
+    distance_metric: Literal["l1", "l2"] = "l1"
+    state_action_indices: tuple[int, ...] | None = None
+    start_next_at: int | None = None
+    action_horizon: int | None = None
+    miss_policy: Literal["hold_last", "block"] = "hold_last"
+    epoch_s: float | None = None
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.action_hz) or self.action_hz <= 0:
+            raise ValueError("action_hz must be positive and finite")
+        if self.max_chunks <= 0:
+            raise ValueError("max_chunks must be positive")
+        if not math.isfinite(self.decay) or self.decay < 0:
+            raise ValueError("decay must be non-negative and finite")
+        if self.switch_mode not in {"latency", "state"}:
+            raise ValueError("switch_mode must be 'latency' or 'state'")
+        if self.action_representation not in {"absolute", "delta"}:
+            raise ValueError("action_representation must be 'absolute' or 'delta'")
+        if self.delta_mode not in {"cumulative", "from_start"}:
+            raise ValueError("delta_mode must be 'cumulative' or 'from_start'")
+        if self.distance_metric not in {"l1", "l2"}:
+            raise ValueError("distance_metric must be 'l1' or 'l2'")
+        if self.start_next_at is not None and self.start_next_at < 0:
+            raise ValueError("start_next_at must be non-negative")
+        if self.action_horizon is not None and self.action_horizon <= 0:
+            raise ValueError("action_horizon must be positive")
+        if self.miss_policy not in {"hold_last", "block"}:
+            raise ValueError("miss_policy must be 'hold_last' or 'block'")
+        if self.epoch_s is not None and not math.isfinite(self.epoch_s):
+            raise ValueError("epoch_s must be finite")
+        if self.state_action_indices is not None:
+            indices = tuple(int(i) for i in self.state_action_indices)
+            if any(i < 0 for i in indices) or len(set(indices)) != len(indices):
+                raise ValueError("state_action_indices must be unique and non-negative")
+            object.__setattr__(self, "state_action_indices", indices)
+
+    @property
+    def period_s(self) -> float:
+        return 1.0 / self.action_hz
+
+
+@dataclass(frozen=True)
+class PredictionTicket:
+    prediction_id: int
+    started_time_s: float
+    start_step: int
+    start_state: np.ndarray | None = field(repr=False)
+
+
+@dataclass(frozen=True)
+class TimedActionChunk:
+    prediction_id: int
+    actions: np.ndarray = field(repr=False)
+    started_time_s: float
+    ready_time_s: float
+    start_step: int
+    start_state: np.ndarray | None = field(repr=False)
+
+    @property
+    def horizon(self) -> int:
+        return int(self.actions.shape[0])
+
+    @property
+    def action_dim(self) -> int:
+        return int(self.actions.shape[1])
+
+    @property
+    def end_step_exclusive(self) -> int:
+        return self.start_step + self.horizon
+
+    def covers(self, step: int) -> bool:
+        return self.start_step <= step < self.end_step_exclusive
+
+
+@dataclass(frozen=True)
+class FusedChunk:
+    prediction_id: int
+    actions: np.ndarray = field(repr=False)
+    start_step: int
+    expected_times_s: np.ndarray = field(repr=False)
+    source_counts: np.ndarray = field(repr=False)
+    switch_index: int
+    started_time_s: float
+    ready_time_s: float
+
+    @property
+    def horizon(self) -> int:
+        return int(self.actions.shape[0])
+
+
+@dataclass
+class TemporalFusionStats:
+    predictions_started: int = 0
+    predictions_completed: int = 0
+    actions_served: int = 0
+    chunk_switches: int = 0
+    deadline_misses: int = 0
+    held_actions: int = 0
+    raw_chunks_pruned: int = 0
+    last_latency_s: float = 0.0
+    max_latency_s: float = 0.0
+
+
+def _frozen_array(value: Any, ndim: int, name: str) -> np.ndarray:
+    array = np.asarray(value)
+    if array.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}D, got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number):
+        raise TypeError(f"{name} must have a numeric dtype")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    result = np.array(array, copy=True)
+    result.setflags(write=False)
+    return result
+
+
+class TemporalFusionBuffer:
+    """Record raw predictions and create step-aligned fused chunks."""
+
+    def __init__(self, config: TemporalFusionConfig, *,
+                 clock: Callable[[], float] = time.monotonic):
+        self.config = config
+        self._clock = clock
+        self._epoch_s = float(config.epoch_s) if config.epoch_s is not None else clock()
+        self._next_id = 0
+        self._pending: dict[int, PredictionTicket] = {}
+        self._chunks: list[TimedActionChunk] = []
+        self._latest: FusedChunk | None = None
+        self._total_pruned = 0
+        self._lock = threading.RLock()
+
+    @property
+    def epoch_s(self) -> float:
+        return self._epoch_s
+
+    @property
+    def raw_chunks(self) -> tuple[TimedActionChunk, ...]:
+        with self._lock:
+            return tuple(self._chunks)
+
+    @property
+    def latest(self) -> FusedChunk | None:
+        with self._lock:
+            return self._latest
+
+    @property
+    def total_pruned(self) -> int:
+        with self._lock:
+            return self._total_pruned
+
+    def step_at(self, timestamp_s: float) -> int:
+        value = float(timestamp_s)
+        if not math.isfinite(value):
+            raise ValueError("timestamp must be finite")
+        return math.floor((value - self._epoch_s) / self.config.period_s + 1e-9)
+
+    def time_at(self, step: int) -> float:
+        return self._epoch_s + int(step) * self.config.period_s
+
+    def begin_prediction(self, *, state: Any | None = None,
+                         started_at: float | None = None,
+                         start_step: int | None = None) -> PredictionTicket:
+        started = self._clock() if started_at is None else float(started_at)
+        if not math.isfinite(started):
+            raise ValueError("started_at must be finite")
+        step = self.step_at(started) if start_step is None else int(start_step)
+        start_state = None if state is None else _frozen_array(state, 1, "state")
+        with self._lock:
+            ticket = PredictionTicket(self._next_id, started, step, start_state)
+            self._next_id += 1
+            self._pending[ticket.prediction_id] = ticket
+            return ticket
+
+    def cancel_prediction(self, ticket: PredictionTicket) -> None:
+        with self._lock:
+            self._pending.pop(ticket.prediction_id, None)
+
+    def complete_prediction(self, ticket: PredictionTicket, actions: Any, *,
+                            ready_at: float | None = None,
+                            switch_at: float | None = None,
+                            current_state: Any | None = None,
+                            switch_mode: SwitchMode | None = None) -> FusedChunk:
+        ready = self._clock() if ready_at is None else float(ready_at)
+        if not math.isfinite(ready) or ready < ticket.started_time_s:
+            raise ValueError("ready_at must be finite and not precede started_at")
+        switch_time = ready if switch_at is None else float(switch_at)
+        if not math.isfinite(switch_time) or switch_time < ticket.started_time_s:
+            raise ValueError("switch_at must be finite and not precede started_at")
+        raw = _frozen_array(actions, 2, "actions")
+        if not raw.shape[0] or not raw.shape[1]:
+            raise ValueError("actions must have non-zero horizon and dimension")
+        if self.config.action_horizon is not None:
+            raw = _frozen_array(raw[:self.config.action_horizon], 2, "actions")
+
+        with self._lock:
+            registered = self._pending.pop(ticket.prediction_id, None)
+            if registered is not ticket:
+                raise ValueError("unknown, cancelled, or completed prediction ticket")
+            self._prune_locked(ready)
+            if self._chunks and self._chunks[-1].action_dim != raw.shape[1]:
+                raise ValueError("action dimension changed between predictions")
+            chunk = TimedActionChunk(ticket.prediction_id, raw,
+                                     ticket.started_time_s, ready,
+                                     ticket.start_step, ticket.start_state)
+            self._chunks.append(chunk)
+            fused, counts = self._fuse_locked(chunk)
+            index = self._switch_index(chunk, fused, switch_time,
+                                       current_state,
+                                       switch_mode or self.config.switch_mode)
+            times = np.array([self.time_at(chunk.start_step + i)
+                              for i in range(chunk.horizon)], dtype=np.float64)
+            for array in (fused, counts, times):
+                array.setflags(write=False)
+            result = FusedChunk(chunk.prediction_id, fused, chunk.start_step,
+                                times, counts, index,
+                                chunk.started_time_s, chunk.ready_time_s)
+            self._latest = result
+            return result
+
+    def prune_expired(self, *, now: float | None = None) -> int:
+        with self._lock:
+            return self._prune_locked(self._clock() if now is None else float(now))
+
+    def _prune_locked(self, now: float) -> int:
+        current = self.step_at(now)
+        before = len(self._chunks)
+        self._chunks[:] = [c for c in self._chunks if c.end_step_exclusive > current]
+        pruned = before - len(self._chunks)
+        self._total_pruned += pruned
+        return pruned
+
+    def _fuse_locked(self, latest: TimedActionChunk) -> tuple[np.ndarray, np.ndarray]:
+        fused = np.empty(latest.actions.shape,
+                         dtype=np.result_type(latest.actions.dtype, np.float32))
+        counts = np.empty(latest.horizon, dtype=np.int32)
+        newest_first = list(reversed(self._chunks))
+        for latest_i in range(latest.horizon):
+            step = latest.start_step + latest_i
+            candidates: list[tuple[TimedActionChunk, int]] = []
+            for chunk in newest_first:
+                if chunk.covers(step):
+                    candidates.append((chunk, step - chunk.start_step))
+                    if len(candidates) == self.config.max_chunks:
+                        break
+            weighted = np.zeros(latest.action_dim, dtype=np.float64)
+            weight_sum = 0.0
+            for chunk, source_i in candidates:
+                weight = math.exp(-self.config.decay * abs(source_i - latest_i))
+                weighted += weight * np.asarray(chunk.actions[source_i], dtype=np.float64)
+                weight_sum += weight
+            fused[latest_i] = weighted / weight_sum
+            counts[latest_i] = len(candidates)
+        return fused, counts
+
+    def _switch_index(self, latest: TimedActionChunk, fused: np.ndarray,
+                      switch_time: float, current_state: Any | None,
+                      mode: SwitchMode) -> int:
+        if mode == "latency":
+            return int(np.clip(self.step_at(switch_time) - latest.start_step,
+                               0, latest.horizon - 1))
+        if mode != "state":
+            raise ValueError(f"unknown switch mode {mode!r}")
+        if current_state is None:
+            raise ValueError("current_state is required for state switching")
+        state = np.asarray(current_state, dtype=np.float64)
+        if state.ndim != 1 or not state.size or not np.all(np.isfinite(state)):
+            raise ValueError("current_state must be a finite, non-empty 1D vector")
+        action_state = self._action_state(fused, state.size)
+        if self.config.action_representation == "absolute":
+            estimates = action_state
+        else:
+            if latest.start_state is None:
+                raise ValueError("prediction start state is required for delta actions")
+            base = np.asarray(latest.start_state, dtype=np.float64)
+            if base.shape != state.shape:
+                raise ValueError("prediction start state and current state shapes differ")
+            changes = (np.cumsum(action_state, axis=0)
+                       if self.config.delta_mode == "cumulative" else action_state)
+            estimates = base[None, :] + changes
+        delta = estimates - state[None, :]
+        distances = (np.sum(np.abs(delta), axis=1)
+                     if self.config.distance_metric == "l1"
+                     else np.linalg.norm(delta, axis=1))
+        return int(np.argmin(distances))
+
+    def _action_state(self, actions: np.ndarray, state_size: int) -> np.ndarray:
+        indices = self.config.state_action_indices
+        if indices is None:
+            if actions.shape[1] < state_size:
+                raise ValueError("action dimension is smaller than state dimension")
+            return np.asarray(actions[:, :state_size], dtype=np.float64)
+        if len(indices) != state_size or (indices and max(indices) >= actions.shape[1]):
+            raise ValueError("state_action_indices do not match state/action dimensions")
+        return np.asarray(actions[:, indices], dtype=np.float64)
+
+
+@dataclass(frozen=True)
+class _PredictionOutput:
+    ticket: PredictionTicket
+    actions: np.ndarray
+    ready_time_s: float
+
+
+class AsyncTemporalFusionRunner:
+    """Consume an active fused chunk while one worker predicts the next.
+
+    The default observation snapshotter recursively copies mappings, sequences,
+    and NumPy arrays before handing them to the worker. This prevents a camera
+    or state buffer updated by the foreground loop from changing an in-flight
+    prediction. Supply ``observation_snapshotter`` for custom observation types
+    such as device-buffer wrappers.
+    """
+
+    def __init__(self, adapter: ActionChunkAdapter, config: TemporalFusionConfig,
+                 *, clock: Callable[[], float] = time.monotonic,
+                 observation_snapshotter: ObservationSnapshotter | None = None):
+        self.adapter = adapter
+        self.config = config
+        self.buffer = TemporalFusionBuffer(config, clock=clock)
+        self.stats = TemporalFusionStats()
+        self._clock = clock
+        self._observation_snapshotter = (
+            observation_snapshotter or _snapshot_observation)
+        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._pending: Future[_PredictionOutput] | None = None
+        self._active: FusedChunk | None = None
+        self._index = 0
+        self._last_action: np.ndarray | None = None
+        self._closed = False
+        self._lock = threading.RLock()
+
+    @property
+    def active_chunk(self) -> FusedChunk | None:
+        with self._lock:
+            return self._active
+
+    @property
+    def prediction_pending(self) -> bool:
+        """Whether a background prediction has been submitted."""
+        with self._lock:
+            return self._pending is not None
+
+    @property
+    def prediction_ready(self) -> bool:
+        """Whether the submitted prediction can be promoted without blocking."""
+        with self._lock:
+            return self._pending is not None and self._pending.done()
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+            if self._pending is not None and not self._pending.done():
+                self._pending.cancel()
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def __enter__(self) -> "AsyncTemporalFusionRunner":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def reset(self, observation: Any, *, state: Any | None = None) -> None:
+        self._check_open()
+        ticket = self.buffer.begin_prediction(state=state)
+        self.stats.predictions_started += 1
+        try:
+            actions = self.adapter.infer_actions(observation)
+            ready = self._clock()
+            fused = self.buffer.complete_prediction(
+                ticket, actions, ready_at=ready, current_state=state)
+        except BaseException:
+            self.buffer.cancel_prediction(ticket)
+            raise
+        with self._lock:
+            self._activate(fused)
+            self._last_action = None
+            self._record_completion(ticket, ready, switched=False)
+
+    def next_action(self, observation: Any, *, state: Any | None = None,
+                    block_if_empty: bool = True) -> np.ndarray:
+        self._check_open()
+        if self._active is None:
+            if not block_if_empty:
+                raise RuntimeError("temporal fusion runner has no active chunk")
+            self.reset(observation, state=state)
+        with self._lock:
+            self._promote_ready(state)
+            active = self._active
+            assert active is not None
+            trigger = (min(self.config.start_next_at, active.horizon)
+                       if self.config.start_next_at is not None
+                       else max(1, active.horizon // 2))
+            if self._index >= trigger:
+                self._submit(observation, state)
+            if self._index >= active.horizon:
+                self._handle_exhausted(observation, state)
+                active = self._active
+                assert active is not None
+            action = np.asarray(active.actions[self._index]).copy()
+            self._index += 1
+            self._last_action = action
+            self.stats.actions_served += 1
+            return action
+
+    def _run(self, ticket: PredictionTicket, observation: Any) -> _PredictionOutput:
+        return _PredictionOutput(ticket,
+                                 np.asarray(self.adapter.infer_actions(observation)),
+                                 self._clock())
+
+    def _submit(self, observation: Any, state: Any | None) -> None:
+        if self._pending is not None:
+            return
+        ticket = self.buffer.begin_prediction(state=state)
+        self.stats.predictions_started += 1
+        snapshot = self._observation_snapshotter(observation)
+        self._pending = self._executor.submit(self._run, ticket, snapshot)
+
+    def _promote_ready(self, state: Any | None) -> bool:
+        if self._pending is None or not self._pending.done():
+            return False
+        output = self._pending.result()
+        self._pending = None
+        fused = self.buffer.complete_prediction(
+            output.ticket, output.actions,
+            ready_at=output.ready_time_s, switch_at=self._clock(),
+            current_state=state)
+        self._activate(fused)
+        self._record_completion(output.ticket, output.ready_time_s, switched=True)
+        return True
+
+    def _handle_exhausted(self, observation: Any, state: Any | None) -> None:
+        if self._promote_ready(state):
+            return
+        self.stats.deadline_misses += 1
+        if self.config.miss_policy == "block":
+            self._submit(observation, state)
+            assert self._pending is not None
+            output = self._pending.result()
+            self._pending = None
+            fused = self.buffer.complete_prediction(
+                output.ticket, output.actions,
+                ready_at=output.ready_time_s, switch_at=self._clock(),
+                current_state=state)
+            self._activate(fused)
+            self._record_completion(output.ticket, output.ready_time_s, switched=True)
+            return
+        if self._last_action is None:
+            raise RuntimeError("cannot hold before any action was served")
+        self.stats.held_actions += 1
+        now = self._clock()
+        held = np.asarray(self._last_action)[None, :].copy()
+        held.setflags(write=False)
+        self._active = FusedChunk(-1, held, self.buffer.step_at(now),
+                                  np.asarray([now]), np.asarray([0]), 0, now, now)
+        self._index = 0
+
+    def _activate(self, fused: FusedChunk) -> None:
+        self._active = fused
+        self._index = fused.switch_index
+
+    def _record_completion(self, ticket: PredictionTicket, ready: float,
+                           *, switched: bool) -> None:
+        latency = ready - ticket.started_time_s
+        self.stats.predictions_completed += 1
+        self.stats.chunk_switches += int(switched)
+        self.stats.last_latency_s = latency
+        self.stats.max_latency_s = max(self.stats.max_latency_s, latency)
+        self.buffer.prune_expired(now=ready)
+        self.stats.raw_chunks_pruned = self.buffer.total_pruned
+
+    def _check_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("temporal fusion runner is closed")
+
+
+def _snapshot_observation(value: Any) -> Any:
+    """Copy common mutable observation containers for worker ownership."""
+    if isinstance(value, np.ndarray):
+        return np.array(value, copy=True)
+    if isinstance(value, Mapping):
+        return {key: _snapshot_observation(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_snapshot_observation(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_snapshot_observation(item) for item in value)
+    return value
+
+
+__all__ = [
+    "ActionChunkAdapter", "AsyncTemporalFusionRunner", "FusedChunk",
+    "ObservationSnapshotter",
+    "PredictionTicket", "TemporalFusionBuffer", "TemporalFusionConfig",
+    "TemporalFusionStats", "TimedActionChunk",
+]

--- a/tests/bench_rtc_temporal_fusion.py
+++ b/tests/bench_rtc_temporal_fusion.py
@@ -1,0 +1,58 @@
+"""Microbenchmark three-way fusion of 50 x 32 action chunks."""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import numpy as np
+
+from flash_rt.runtime.rtc_temporal_fusion import (
+    TemporalFusionBuffer,
+    TemporalFusionConfig,
+)
+
+
+def _one_fusion(chunks: list[np.ndarray], config: TemporalFusionConfig) -> None:
+    buffer = TemporalFusionBuffer(config, clock=lambda: 0.0)
+    for index, actions in enumerate(chunks):
+        started = index * config.period_s
+        ticket = buffer.begin_prediction(started_at=started)
+        buffer.complete_prediction(ticket, actions, ready_at=started + 1e-4)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, default=1000)
+    parser.add_argument("--warmup", type=int, default=100)
+    args = parser.parse_args()
+    if args.iterations <= 0 or args.warmup < 0:
+        raise ValueError("iterations must be positive and warmup non-negative")
+
+    rng = np.random.default_rng(1234)
+    chunks = [rng.standard_normal((50, 32), dtype=np.float32)
+              for _ in range(3)]
+    config = TemporalFusionConfig(
+        action_hz=50, max_chunks=3, decay=0.1, epoch_s=0)
+
+    for _ in range(args.warmup):
+        _one_fusion(chunks, config)
+    samples_ms = []
+    for _ in range(args.iterations):
+        start = time.perf_counter_ns()
+        _one_fusion(chunks, config)
+        samples_ms.append((time.perf_counter_ns() - start) / 1e6)
+
+    ordered = sorted(samples_ms)
+    p95 = ordered[min(len(ordered) - 1, int(0.95 * len(ordered)))]
+    p99 = ordered[min(len(ordered) - 1, int(0.99 * len(ordered)))]
+    print("RTC temporal fusion: 3 chunks x 50 actions x 32 dims")
+    print(f"iterations={args.iterations} warmup={args.warmup}")
+    print(f"median_ms={statistics.median(samples_ms):.6f}")
+    print(f"p95_ms={p95:.6f} p99_ms={p99:.6f}")
+    print(f"mean_ms={statistics.fmean(samples_ms):.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rtc_temporal_fusion.py
+++ b/tests/test_rtc_temporal_fusion.py
@@ -3,6 +3,7 @@ import threading
 import time
 
 import numpy as np
+import pytest
 
 from flash_rt.runtime.rtc_temporal_fusion import (
     AsyncTemporalFusionRunner,
@@ -176,4 +177,81 @@ def test_async_runner_snapshots_mutable_observation():
         assert np.array_equal(seen[0][1], [1.0, 2.0])
     finally:
         release.set()
+        runner.close()
+
+
+def test_async_runner_close_waits_for_running_worker_by_default():
+    class Adapter:
+        def __init__(self):
+            self.calls = 0
+            self.started = threading.Event()
+            self.release = threading.Event()
+
+        def infer_actions(self, observation):
+            call = self.calls
+            self.calls += 1
+            if call == 0:
+                return np.arange(2, dtype=np.float32)[:, None]
+            self.started.set()
+            self.release.wait(timeout=2.0)
+            return np.arange(10, 12, dtype=np.float32)[:, None]
+
+    adapter = Adapter()
+    runner = AsyncTemporalFusionRunner(
+        adapter, TemporalFusionConfig(action_hz=10, start_next_at=0))
+    try:
+        runner.reset({"chunk": 0})
+        assert runner.next_action({"chunk": 1}).item() == 0
+        assert adapter.started.wait(timeout=1.0)
+
+        close_done = threading.Event()
+
+        def close_runner():
+            runner.close()
+            close_done.set()
+
+        close_thread = threading.Thread(target=close_runner)
+        close_thread.start()
+        assert not close_done.wait(timeout=0.05)
+        adapter.release.set()
+        close_thread.join(timeout=1.0)
+        assert close_done.is_set()
+    finally:
+        adapter.release.set()
+        runner.close(wait=False)
+
+
+def test_async_runner_clears_failed_pending_future_and_ticket():
+    class Adapter:
+        def __init__(self):
+            self.calls = 0
+
+        def infer_actions(self, observation):
+            call = self.calls
+            self.calls += 1
+            if call == 0:
+                return np.arange(2, dtype=np.float32)[:, None]
+            if call == 1:
+                raise RuntimeError("worker failed")
+            return np.arange(10, 12, dtype=np.float32)[:, None]
+
+    runner = AsyncTemporalFusionRunner(
+        Adapter(), TemporalFusionConfig(action_hz=10, start_next_at=0))
+    try:
+        runner.reset({"chunk": 0})
+        assert runner.next_action({"chunk": 1}).item() == 0
+        assert runner.prediction_pending
+        deadline = time.monotonic() + 1.0
+        while not runner.prediction_ready and time.monotonic() < deadline:
+            time.sleep(0.001)
+        assert runner.prediction_ready
+
+        with pytest.raises(RuntimeError, match="worker failed"):
+            runner.next_action({"chunk": 2})
+        assert not runner.prediction_pending
+        assert not runner.buffer._pending
+
+        assert runner.next_action({"chunk": 3}).item() == 1
+        assert runner.prediction_pending
+    finally:
         runner.close()

--- a/tests/test_rtc_temporal_fusion.py
+++ b/tests/test_rtc_temporal_fusion.py
@@ -1,0 +1,179 @@
+import math
+import threading
+import time
+
+import numpy as np
+
+from flash_rt.runtime.rtc_temporal_fusion import (
+    AsyncTemporalFusionRunner,
+    TemporalFusionBuffer,
+    TemporalFusionConfig,
+)
+
+
+def test_fusion_aligns_actions_by_controller_step():
+    cfg = TemporalFusionConfig(action_hz=10, decay=0.5, epoch_s=0)
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    one = buf.begin_prediction(started_at=0.0)
+    buf.complete_prediction(one, [[0.0], [1.0], [2.0], [3.0]], ready_at=0.01)
+    two = buf.begin_prediction(started_at=0.2)
+    fused = buf.complete_prediction(two, [[10.0], [11.0], [12.0], [13.0]], ready_at=0.21)
+
+    old_weight = math.exp(-1.0)  # old index 2 vs latest index 0
+    assert np.isclose(fused.actions[0, 0], (10 + old_weight * 2) / (1 + old_weight))
+    assert np.isclose(fused.actions[1, 0], (11 + old_weight * 3) / (1 + old_weight))
+    assert np.array_equal(fused.source_counts, [2, 2, 1, 1])
+    assert np.allclose(fused.expected_times_s, [0.2, 0.3, 0.4, 0.5])
+
+
+def test_fusion_uses_up_to_three_raw_chunks():
+    cfg = TemporalFusionConfig(action_hz=10, max_chunks=3,
+                               decay=0.2, epoch_s=0)
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    for start, value in ((0.0, 0.0), (0.1, 10.0)):
+        ticket = buf.begin_prediction(started_at=start)
+        buf.complete_prediction(ticket, np.full((5, 1), value),
+                                ready_at=start + 0.01)
+    ticket = buf.begin_prediction(started_at=0.2)
+    fused = buf.complete_prediction(ticket, np.full((5, 1), 20.0),
+                                    ready_at=0.21)
+
+    w_oldest = math.exp(-0.4)
+    w_previous = math.exp(-0.2)
+    expected = (20 + w_previous * 10) / (1 + w_previous + w_oldest)
+    assert np.isclose(fused.actions[0, 0], expected)
+    assert fused.source_counts[0] == 3
+
+
+def test_raw_chunks_are_immutable_and_expire_after_last_step():
+    cfg = TemporalFusionConfig(action_hz=10, epoch_s=0)
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    source = np.array([[1.0], [2.0], [3.0]])
+    ticket = buf.begin_prediction(started_at=0)
+    buf.complete_prediction(ticket, source, ready_at=0.01)
+    source[:] = 99
+
+    assert np.array_equal(buf.raw_chunks[0].actions[:, 0], [1, 2, 3])
+    assert buf.prune_expired(now=0.2) == 0
+    assert buf.prune_expired(now=0.3) == 1
+    assert buf.total_pruned == 1
+
+
+def test_completion_counts_chunks_pruned_before_fusion():
+    cfg = TemporalFusionConfig(action_hz=10, epoch_s=0)
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    first = buf.begin_prediction(started_at=0)
+    buf.complete_prediction(first, np.ones((2, 1)), ready_at=0.01)
+
+    second = buf.begin_prediction(started_at=0.3)
+    buf.complete_prediction(second, np.ones((2, 1)), ready_at=0.31)
+
+    assert buf.total_pruned == 1
+
+
+def test_latency_switch_uses_elapsed_step_count():
+    cfg = TemporalFusionConfig(action_hz=10, epoch_s=0,
+                               switch_mode="latency")
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    ticket = buf.begin_prediction(started_at=0)
+    fused = buf.complete_prediction(ticket, np.arange(5)[:, None],
+                                    ready_at=0.25)
+    assert fused.switch_index == 2
+
+
+def test_latency_switch_can_use_later_foreground_poll_time():
+    cfg = TemporalFusionConfig(action_hz=10, epoch_s=0,
+                               switch_mode="latency")
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    ticket = buf.begin_prediction(started_at=0)
+    fused = buf.complete_prediction(ticket, np.arange(5)[:, None],
+                                    ready_at=0.15, switch_at=0.32)
+    assert fused.switch_index == 3
+
+
+def test_absolute_state_switch_chooses_nearest_action():
+    cfg = TemporalFusionConfig(action_hz=10, epoch_s=0,
+                               switch_mode="state")
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    ticket = buf.begin_prediction(state=[0.0], started_at=0)
+    fused = buf.complete_prediction(ticket, [[1.0], [5.0], [9.0]],
+                                    ready_at=0.01, current_state=[5.2])
+    assert fused.switch_index == 1
+
+
+def test_delta_state_switch_integrates_from_prediction_start_state():
+    cfg = TemporalFusionConfig(action_hz=10, epoch_s=0,
+                               switch_mode="state",
+                               action_representation="delta",
+                               delta_mode="cumulative")
+    buf = TemporalFusionBuffer(cfg, clock=lambda: 0.0)
+    ticket = buf.begin_prediction(state=[10.0], started_at=0)
+    fused = buf.complete_prediction(ticket, [[1.0], [2.0], [-1.0]],
+                                    ready_at=0.01, current_state=[12.9])
+    # Estimated post-action states are [11, 13, 12].
+    assert fused.switch_index == 1
+
+
+def test_async_runner_consumes_old_chunk_during_prediction():
+    class Adapter:
+        def infer_actions(self, observation):
+            if observation["chunk"]:
+                time.sleep(0.01)
+            base = observation["chunk"] * 10
+            return np.arange(base, base + 4, dtype=np.float32)[:, None]
+
+    runner = AsyncTemporalFusionRunner(
+        Adapter(),
+        TemporalFusionConfig(action_hz=1000, start_next_at=2,
+                             decay=100),
+    )
+    try:
+        runner.reset({"chunk": 0})
+        assert runner.next_action({"chunk": 1}).item() == 0
+        assert runner.next_action({"chunk": 1}).item() == 1
+        assert runner.next_action({"chunk": 1}).item() == 2
+        time.sleep(0.02)
+        assert runner.next_action({"chunk": 2}).item() >= 10
+        assert runner.stats.chunk_switches >= 1
+    finally:
+        runner.close()
+
+
+def test_async_runner_snapshots_mutable_observation():
+    started = threading.Event()
+    release = threading.Event()
+    seen = []
+
+    class Adapter:
+        def __init__(self):
+            self.calls = 0
+
+        def infer_actions(self, observation):
+            self.calls += 1
+            if self.calls > 1:
+                started.set()
+                assert release.wait(timeout=1)
+                seen.append((observation["step"], observation["image"].copy()))
+            return np.arange(4, dtype=np.float32)[:, None]
+
+    runner = AsyncTemporalFusionRunner(
+        Adapter(), TemporalFusionConfig(action_hz=10, start_next_at=0))
+    observation = {"step": 1, "image": np.array([1.0, 2.0])}
+    try:
+        runner.reset(observation)
+        runner.next_action(observation)
+        assert started.wait(timeout=1)
+        observation["step"] = 2
+        observation["image"][:] = 9
+        release.set()
+        deadline = time.monotonic() + 1
+        while not runner.prediction_ready and time.monotonic() < deadline:
+            time.sleep(0.001)
+        assert runner.prediction_pending
+        assert runner.prediction_ready
+        runner.next_action(observation)
+        assert seen[0][0] == 1
+        assert np.array_equal(seen[0][1], [1.0, 2.0])
+    finally:
+        release.set()
+        runner.close()

--- a/tests/test_rtc_temporal_fusion_pi05.py
+++ b/tests/test_rtc_temporal_fusion_pi05.py
@@ -1,0 +1,128 @@
+"""Real-checkpoint gate for Pi0.5 with asynchronous temporal fusion.
+
+Set ``PI05_CKPT`` to a Pi0.5 PyTorch checkpoint and run on an SM89 GPU. The
+default test suite skips this module when the checkpoint or CUDA is absent.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+import unittest
+
+import numpy as np
+import torch
+
+from flash_rt.runtime.rtc_temporal_fusion import (
+    AsyncTemporalFusionRunner,
+    TemporalFusionConfig,
+)
+
+
+_CHECKPOINT = os.environ.get("PI05_CKPT")
+_HAS_CHECKPOINT = bool(_CHECKPOINT and os.path.isdir(_CHECKPOINT))
+
+
+class _Pi05Adapter:
+    def __init__(self, model, prompt: str):
+        self.model = model
+        self.prompt = prompt
+
+    def infer_actions(self, observation):
+        return np.asarray(self.model.predict(
+            images=observation["images"], prompt=self.prompt))
+
+
+def _validate_pi05_checkpoint_async_temporal_fusion():
+    import flash_rt
+
+    capability = torch.cuda.get_device_capability()
+    if capability != (8, 9):
+        raise unittest.SkipTest(
+            f"RTX SM89 gate requires compute capability 8.9, got {capability}")
+
+    rng = np.random.RandomState(7)
+    image = rng.randint(0, 255, (224, 224, 3), dtype=np.uint8)
+    observation = {"images": [image, image.copy()]}
+    prompt = "pick up the red block"
+    model = flash_rt.load_model(
+        checkpoint=_CHECKPOINT,
+        framework="torch",
+        config="pi05",
+        hardware="rtx_sm89",
+        num_views=2,
+        autotune=int(os.environ.get("RTC_PI05_AUTOTUNE", "0")),
+        use_fp8=True,
+    )
+
+    # Complete calibration/capture before constructing the controller clock.
+    baseline = np.asarray(model.predict(
+        images=observation["images"], prompt=prompt))
+    assert baseline.ndim == 2 and baseline.shape[0] > 1 and baseline.shape[1] > 0
+    assert np.all(np.isfinite(baseline))
+
+    config = TemporalFusionConfig(
+        action_hz=20,
+        max_chunks=3,
+        decay=0.1,
+        switch_mode="latency",
+        start_next_at=1,
+        miss_policy="block",
+    )
+    runner = AsyncTemporalFusionRunner(_Pi05Adapter(model, prompt), config)
+    try:
+        runner.reset(observation)
+        initial = runner.active_chunk
+        assert initial is not None
+        assert initial.actions.shape == baseline.shape
+        assert np.all(np.isfinite(initial.actions))
+
+        # Serve action zero, then action one while the next real model inference
+        # runs on the worker. The active prediction must not switch yet.
+        runner.next_action(observation)
+        initial_id = runner.active_chunk.prediction_id
+        runner.next_action(observation)
+        assert runner.active_chunk.prediction_id == initial_id
+
+        deadline = time.monotonic() + 10.0
+        while not runner.prediction_ready and time.monotonic() < deadline:
+            time.sleep(0.001)
+        assert runner.prediction_pending and runner.prediction_ready, (
+            "background Pi0.5 inference did not finish within 10 seconds")
+
+        served = runner.next_action(observation)
+        fused = runner.active_chunk
+        assert fused is not None and fused.prediction_id != initial_id
+        assert served.shape == (baseline.shape[1],)
+        assert np.all(np.isfinite(served))
+        assert int(np.max(fused.source_counts)) >= 2
+
+        raw = runner.buffer.raw_chunks
+        assert len(raw) >= 2
+        previous, latest = raw[-2], raw[-1]
+        source_i = latest.start_step - previous.start_step
+        assert 0 <= source_i < previous.horizon
+        weight = math.exp(-config.decay * abs(source_i))
+        expected = (np.asarray(latest.actions[0], dtype=np.float64)
+                    + weight * np.asarray(previous.actions[source_i],
+                                          dtype=np.float64)) / (1.0 + weight)
+        assert np.allclose(fused.actions[0], expected, rtol=1e-5, atol=1e-6)
+        assert runner.stats.predictions_completed >= 2
+        assert runner.stats.chunk_switches >= 1
+    finally:
+        runner.close()
+        del model
+        torch.cuda.empty_cache()
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA GPU required")
+@unittest.skipUnless(
+    _HAS_CHECKPOINT, "set PI05_CKPT to a Pi0.5 PyTorch checkpoint")
+class Pi05TemporalFusionCheckpointTest(unittest.TestCase):
+    def test_async_prediction_is_temporally_fused(self):
+        _validate_pi05_checkpoint_async_temporal_fusion()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add a host-side RTC temporal-fusion runtime for action-chunk policies.

This introduces an `AsyncTemporalFusionRunner` and `TemporalFusionBuffer` that:
- run the next policy prediction on a background worker while serving the active chunk
- align raw action chunks on controller-step time
- fuse overlapping predictions with exponential position-decay weights
- support latency-based and state-based chunk switching
- expose runner stats and worker readiness state for monitoring

The PR also documents the adapter contract, configuration knobs, deadline behavior, CPU validation, benchmark command, and the real Pi0.5 checkpoint gate. The checkpoint validation command is PR-safe and uses generic local paths instead of machine-specific paths.

## Validation

- `PYTHONPATH=. python -m pytest tests/test_rtc_temporal_fusion.py -q`
  - `10 passed in 0.18s`
- Real Pi0.5 checkpoint gate on SM89:
  - `PYTHONPATH=$PWD python -m pytest tests/test_rtc_temporal_fusion_pi05.py -q -s`
  - `1 passed, 2 warnings in 23.36s`