### PR TITLE
Add VLASH async runner

### DIFF
--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -376,12 +376,23 @@ from flash_rt.runtime.rtc import (
     AsyncChunkRunner,
     RTCStats,
 )
+from flash_rt.runtime.vlash import (
+    AsyncVLAShRunner,
+    VLAShChunkResult,
+    VLAShConfig,
+    VLAShStats,
+)
 ```
 
 The legacy async chunk runner is a beta inference scheduling utility for action-chunk
 policies. It does not change model numerics or calibration; it only
 serves action chunks at a fixed controller rate while a background worker
 prepares the next chunk. See `docs/rtc_lite_design.md`.
+
+`AsyncVLAShRunner` is an optional host-side runtime for projected-state
+action-chunk scheduling. It estimates a future robot state from the active
+chunk, injects that state into the next observation, and activates the completed
+chunk from index zero. See `docs/vlash.md`.
 
 ### `flash_rt.flash_rt_fa2`
 

--- a/docs/vlash.md
+++ b/docs/vlash.md
@@ -1,0 +1,125 @@
+# VLASh runtime
+
+`flash_rt.runtime.vlash` provides an optional host-side runtime for action-chunk
+policies that condition the next prediction on a projected future robot state.
+It does not change model kernels, CUDA graph capture, or decoder numerics.
+
+While the foreground consumes the active chunk, one background worker predicts
+the next chunk. Before starting that worker, VLASh estimates the robot state
+after the next `lookahead_steps` actions from the active chunk:
+
+```text
+projected_state = measured_state + sum(active_actions[i : i + lookahead_steps])
+```
+
+The projected state is inserted into a copied observation and passed to the
+adapter. For Pi0.5, the adapter normally forwards it to
+`model.predict(..., state=projected_state)`, so the state is rendered into the
+prompt before the context graph runs. When the background chunk is ready, VLASh
+activates it from action index zero. There is no temporal fusion and no
+latency-based index skip.
+
+## Basic use
+
+The adapter boundary matches the existing action-chunk runtime: it receives an
+observation and returns a numeric array shaped `[horizon, action_dim]`.
+
+```python
+import numpy as np
+
+from flash_rt.runtime import AsyncVLAShRunner, VLAShConfig
+
+
+class Pi05Adapter:
+    def __init__(self, model, prompt):
+        self.model = model
+        self.prompt = prompt
+
+    def infer_actions(self, observation):
+        return np.asarray(self.model.predict(
+            images=observation["images"],
+            prompt=self.prompt,
+            state=observation["state"],
+        ))
+
+
+runner = AsyncVLAShRunner(
+    Pi05Adapter(model, "pick up the red block"),
+    VLAShConfig(
+        action_hz=20,
+        lookahead_steps=2,
+        start_next_at=25,
+        state_action_indices=tuple(range(7)),
+    ),
+)
+
+observation = {"images": images}
+try:
+    runner.reset(observation, state=current_robot_state)
+    while control_loop_running:
+        action = runner.next_action(observation, state=current_robot_state)
+        robot.send_action(action)
+finally:
+    runner.close()
+```
+
+Actions used for projection must be deltas in the same units as the measured
+robot state. If an action vector has extra dimensions such as gripper commands,
+set `state_action_indices` to choose the action dimensions that correspond to
+state dimensions.
+
+## Action quantization
+
+Set `action_quantization_enabled=True` to store every consecutive group of
+`action_quantization_granularity` actions as a summed delta. This reduces the
+stored horizon and makes `lookahead_steps`, `start_next_at`, and
+`action_horizon` count quantized actions. This is appropriate only for additive
+delta actions; absolute targets and discrete commands need a task-specific
+aggregation rule.
+
+## Pi0.5 subgraph plan
+
+The Pi0.5 `vlash` stage plan reuses the existing `context -> decode_only` graph
+split. The upper runtime performs the state projection before context replay;
+the subgraph helper only enables the required context/action graph capture.
+For live state prompts, use a state-prompt mode whose shapes are graph-safe,
+such as `state_prompt_mode="fixed"` or prewarmed exact buckets.
+
+## Validation
+
+CPU-only mechanism tests:
+
+```bash
+PYTHONPATH=. python -m pytest tests/test_vlash.py -q
+```
+
+Real Pi0.5 checkpoint gate on an SM89 GPU:
+
+```bash
+export CUDA_VISIBLE_DEVICES=0
+export PI05_CKPT=/path/to/pi05_libero_pytorch
+PYTHONPATH=. python -m pytest tests/test_vlash_pi05.py -q -s
+```
+
+For a clean local SM89 validation environment, keep the current checkout first
+on `PYTHONPATH` and point `PI05_CKPT` at a local Pi0.5 PyTorch checkpoint:
+
+```bash
+cd "$FLASHRT_CHECKOUT"
+export PYTHONNOUSERSITE=1
+unset PYTHONPATH
+export CUDA_VISIBLE_DEVICES=0
+export PI05_CKPT=/path/to/pi05_libero_pytorch
+export CUDA_HOME=/path/to/cuda-12.x
+export CUDA_PATH="$CUDA_HOME"
+export LD_LIBRARY_PATH="$CUDA_HOME/lib64:$CUDA_HOME/targets/x86_64-linux/lib:$CONDA_PREFIX/lib"
+export FLASHRT_CUDART_PATH="$CUDA_HOME/lib64/libcudart.so.12"
+PYTHONPATH=$PWD \
+  python -m pytest tests/test_vlash_pi05.py -q -s
+```
+
+The checkpoint gate skips when CUDA or `PI05_CKPT` is unavailable. It validates
+model/runtime integration, projected-state injection, asynchronous worker
+completion, and index-zero chunk activation. It does not measure closed-loop
+task success; validate cadence, state freshness, and control quality in the
+target simulator or robot stack before deployment.

--- a/docs/vlash.md
+++ b/docs/vlash.md
@@ -19,6 +19,11 @@ prompt before the context graph runs. When the background chunk is ready, VLASh
 activates it from action index zero. There is no temporal fusion and no
 latency-based index skip.
 
+Background submissions snapshot mapping, list, tuple, and NumPy-array
+observation values before state injection. Deployments that own immutable or
+device-resident buffers can pass a custom `observation_snapshotter` to
+`AsyncVLAShRunner`.
+
 ## Basic use
 
 The adapter boundary matches the existing action-chunk runtime: it receives an

--- a/flash_rt/runtime/__init__.py
+++ b/flash_rt/runtime/__init__.py
@@ -8,6 +8,12 @@ from .rtc import (
     RTCConfig,
     RTCStats,
 )
+from .vlash import (
+    AsyncVLAShRunner,
+    VLAShChunkResult,
+    VLAShConfig,
+    VLAShStats,
+)
 
 __all__ = [
     "ActionChunkAdapter",
@@ -16,4 +22,8 @@ __all__ = [
     "ChunkResult",
     "RTCConfig",
     "RTCStats",
+    "AsyncVLAShRunner",
+    "VLAShChunkResult",
+    "VLAShConfig",
+    "VLAShStats",
 ]

--- a/flash_rt/runtime/vlash.py
+++ b/flash_rt/runtime/vlash.py
@@ -24,11 +24,12 @@ aggregation rule instead.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 import threading
 import time
-from typing import Any, Callable, Mapping
+from typing import Any, Callable
 
 import numpy as np
 
@@ -36,6 +37,20 @@ from .rtc import ActionChunkAdapter
 
 
 StateSetter = Callable[[Any, np.ndarray], Any]
+ObservationSnapshotter = Callable[[Any], Any]
+
+
+def _snapshot_observation(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.copy()
+    if isinstance(value, Mapping):
+        return {key: _snapshot_observation(item)
+                for key, item in value.items()}
+    if isinstance(value, list):
+        return [_snapshot_observation(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_snapshot_observation(item) for item in value)
+    return value
 
 
 @dataclass(frozen=True)
@@ -126,11 +141,14 @@ class AsyncVLAShRunner:
 
     def __init__(self, adapter: ActionChunkAdapter, config: VLAShConfig, *,
                  state_setter: StateSetter | None = None,
+                 observation_snapshotter: ObservationSnapshotter | None = None,
                  clock: Callable[[], float] = time.monotonic):
         self.adapter = adapter
         self.config = config
         self.stats = VLAShStats()
         self._state_setter = state_setter or self._set_state_on_mapping
+        self._observation_snapshotter = (
+            observation_snapshotter or _snapshot_observation)
         self._clock = clock
         self._executor = ThreadPoolExecutor(max_workers=1)
         self._lock = threading.RLock()
@@ -140,10 +158,10 @@ class AsyncVLAShRunner:
         self._last_action: np.ndarray | None = None
         self._closed = False
 
-    def close(self) -> None:
+    def close(self, *, wait: bool = True) -> None:
         with self._lock:
             self._closed = True
-        self._executor.shutdown(wait=False, cancel_futures=True)
+        self._executor.shutdown(wait=wait, cancel_futures=True)
 
     def __enter__(self) -> "AsyncVLAShRunner":
         return self
@@ -207,7 +225,8 @@ class AsyncVLAShRunner:
             raise RuntimeError("cannot project state without an active chunk")
         projected, count = self.project_state(
             state, current.actions, start_index=self._idx)
-        prepared = self._state_setter(observation, projected)
+        snapshot = self._observation_snapshotter(observation)
+        prepared = self._state_setter(snapshot, projected)
         self.stats.chunks_started += 1
         self.stats.state_projections += 1
         self._pending = self._executor.submit(
@@ -291,15 +310,7 @@ class AsyncVLAShRunner:
     def _promote_ready_locked(self) -> bool:
         if self._pending is None or not self._pending.done():
             return False
-        result = self._pending.result()
-        self._pending = None
-        self._current = result
-        self._idx = 0  # VLASh trajectory starts at prediction completion.
-        self.stats.chunks_completed += 1
-        self.stats.swaps += 1
-        self.stats.last_latency_s = result.latency_s
-        self.stats.max_latency_s = max(
-            self.stats.max_latency_s, result.latency_s)
+        self._activate_pending_result_locked()
         return True
 
     def _handle_exhausted_locked(self, observation: Any,
@@ -311,12 +322,7 @@ class AsyncVLAShRunner:
             self._submit_locked(observation, state)
             if self._pending is None:
                 raise RuntimeError("failed to submit recovery chunk")
-            result = self._pending.result()
-            self._pending = None
-            self._current = result
-            self._idx = 0
-            self.stats.chunks_completed += 1
-            self.stats.swaps += 1
+            self._activate_pending_result_locked()
             return
         if self._last_action is None:
             raise RuntimeError("cannot hold before any action was served")
@@ -328,6 +334,27 @@ class AsyncVLAShRunner:
             start_state=state.copy(), projected_state=state.copy(),
             projected_action_count=0, metadata={"held": True})
         self._idx = 0
+
+    def _activate_pending_result_locked(self) -> None:
+        result = self._consume_pending_result_locked()
+        self._current = result
+        self._idx = 0  # VLASh trajectory starts at prediction completion.
+        self.stats.chunks_completed += 1
+        self.stats.swaps += 1
+        self.stats.last_latency_s = result.latency_s
+        self.stats.max_latency_s = max(
+            self.stats.max_latency_s, result.latency_s)
+
+    def _consume_pending_result_locked(self) -> VLAShChunkResult:
+        if self._pending is None:
+            raise RuntimeError("VLASh runner has no pending chunk")
+        try:
+            result = self._pending.result()
+        except BaseException:
+            self._pending = None
+            raise
+        self._pending = None
+        return result
 
     def _state_deltas(self, actions: np.ndarray,
                       state_dim: int) -> np.ndarray:
@@ -385,6 +412,7 @@ class AsyncVLAShRunner:
 
 __all__ = [
     "AsyncVLAShRunner",
+    "ObservationSnapshotter",
     "StateSetter",
     "VLAShChunkResult",
     "VLAShConfig",

--- a/flash_rt/runtime/vlash.py
+++ b/flash_rt/runtime/vlash.py
@@ -1,0 +1,392 @@
+"""Lightweight asynchronous VLASh execution for action-chunk policies.
+
+While the foreground consumes one action chunk, one background worker predicts
+the next.  At prediction start, the runner estimates the robot state after the
+next ``lookahead_steps`` actions from the active chunk::
+
+    projected_state = start_state + sum(active_actions[i:i+t])
+
+The projected state is inserted into a copy of the observation passed to the
+model.  Because the new trajectory is conditioned on the estimated state at
+prediction completion, a completed chunk is activated from index zero.  There
+is deliberately no temporal fusion and no latency/state index search here.
+
+Actions supplied by the adapter must be state deltas in the same units as the
+robot state.  Use ``state_action_indices`` when action vectors contain extra
+dimensions such as a gripper command.
+
+Optional action quantization reduces the temporal horizon by summing every
+``k`` consecutive delta actions.  Once enabled, horizon/index configuration is
+expressed in quantized actions.  Summing is appropriate only for additive
+delta actions; absolute targets and discrete commands need a task-specific
+aggregation rule instead.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+import threading
+import time
+from typing import Any, Callable, Mapping
+
+import numpy as np
+
+from .rtc import ActionChunkAdapter
+
+
+StateSetter = Callable[[Any, np.ndarray], Any]
+
+
+@dataclass(frozen=True)
+class VLAShConfig:
+    """Configuration for asynchronous projected-state chunk generation."""
+
+    action_hz: float
+    lookahead_steps: int
+    action_horizon: int | None = None
+    start_next_at: int | None = None
+    miss_policy: str = "hold_last"
+    state_key: str = "state"
+    state_action_indices: tuple[int, ...] | None = None
+    action_quantization_enabled: bool = False
+    action_quantization_granularity: int = 1
+
+    def __post_init__(self) -> None:
+        if not np.isfinite(self.action_hz) or self.action_hz <= 0:
+            raise ValueError("action_hz must be positive and finite")
+        if self.lookahead_steps < 0:
+            raise ValueError("lookahead_steps must be non-negative")
+        if self.action_horizon is not None and self.action_horizon <= 0:
+            raise ValueError("action_horizon must be positive")
+        if self.start_next_at is not None and self.start_next_at < 0:
+            raise ValueError("start_next_at must be non-negative")
+        if self.miss_policy not in {"hold_last", "block"}:
+            raise ValueError("miss_policy must be 'hold_last' or 'block'")
+        if not self.state_key:
+            raise ValueError("state_key must be non-empty")
+        if not isinstance(self.action_quantization_enabled, (bool, np.bool_)):
+            raise TypeError("action_quantization_enabled must be a boolean")
+        if (isinstance(self.action_quantization_granularity, (bool, np.bool_))
+                or not isinstance(self.action_quantization_granularity,
+                                  (int, np.integer))):
+            raise TypeError(
+                "action_quantization_granularity must be an integer")
+        if self.action_quantization_granularity <= 0:
+            raise ValueError(
+                "action_quantization_granularity must be positive")
+        object.__setattr__(self, "action_quantization_granularity",
+                           int(self.action_quantization_granularity))
+        if self.state_action_indices is not None:
+            indices = tuple(int(i) for i in self.state_action_indices)
+            if any(i < 0 for i in indices) or len(set(indices)) != len(indices):
+                raise ValueError(
+                    "state_action_indices must be unique and non-negative")
+            object.__setattr__(self, "state_action_indices", indices)
+
+    @property
+    def period_s(self) -> float:
+        return 1.0 / self.action_hz
+
+
+@dataclass(frozen=True)
+class VLAShChunkResult:
+    actions: np.ndarray = field(repr=False)
+    latency_s: float
+    observation_time_s: float
+    ready_time_s: float
+    start_state: np.ndarray = field(repr=False)
+    projected_state: np.ndarray = field(repr=False)
+    projected_action_count: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class VLAShStats:
+    chunks_started: int = 0
+    chunks_completed: int = 0
+    actions_served: int = 0
+    state_projections: int = 0
+    deadline_misses: int = 0
+    held_actions: int = 0
+    swaps: int = 0
+    last_latency_s: float = 0.0
+    max_latency_s: float = 0.0
+
+
+class AsyncVLAShRunner:
+    """Consume actions while one worker predicts from a projected state.
+
+    Call :meth:`next_action` once per robot tick with the latest observation
+    and measured robot state.  The first call blocks for the initial chunk.
+    Later calls launch prediction at ``start_next_at`` and continue serving the
+    active chunk.  When the prediction completes, its action zero is served
+    next.
+    """
+
+    def __init__(self, adapter: ActionChunkAdapter, config: VLAShConfig, *,
+                 state_setter: StateSetter | None = None,
+                 clock: Callable[[], float] = time.monotonic):
+        self.adapter = adapter
+        self.config = config
+        self.stats = VLAShStats()
+        self._state_setter = state_setter or self._set_state_on_mapping
+        self._clock = clock
+        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._lock = threading.RLock()
+        self._current: VLAShChunkResult | None = None
+        self._pending: Future[VLAShChunkResult] | None = None
+        self._idx = 0
+        self._last_action: np.ndarray | None = None
+        self._closed = False
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def __enter__(self) -> "AsyncVLAShRunner":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    @property
+    def current_chunk(self) -> VLAShChunkResult | None:
+        with self._lock:
+            return self._current
+
+    def reset(self, observation: Any, *, state: Any) -> None:
+        """Synchronously generate the initial chunk from the measured state."""
+        self._raise_if_closed()
+        measured = self._validate_state(state)
+        prepared = self._state_setter(observation, measured)
+        result = self._run_inference(
+            prepared, start_state=measured, projected_state=measured,
+            projected_count=0)
+        with self._lock:
+            self._current = result
+            self._pending = None
+            self._idx = 0
+            self._last_action = None
+
+    def next_action(self, observation: Any, *, state: Any,
+                    block_if_empty: bool = True) -> np.ndarray:
+        """Return one action while preparing the next VLASh chunk."""
+        self._raise_if_closed()
+        measured = self._validate_state(state)
+        if self._current is None:
+            if not block_if_empty:
+                raise RuntimeError("VLASh runner has no current chunk")
+            self.reset(observation, state=measured)
+
+        with self._lock:
+            self._promote_ready_locked()
+            current = self._current
+            if current is None:
+                raise RuntimeError("VLASh runner failed to initialize")
+            horizon = self._horizon(current.actions)
+            if self._idx >= self._start_next_at(horizon):
+                self._submit_locked(observation, measured)
+            if self._idx >= horizon:
+                self._handle_exhausted_locked(observation, measured)
+                current = self._current
+                if current is None:
+                    raise RuntimeError("VLASh runner has no chunk after exhaustion")
+            action = np.asarray(current.actions[self._idx]).copy()
+            self._idx += 1
+            self._last_action = action
+            self.stats.actions_served += 1
+            return action
+
+    def _submit_locked(self, observation: Any, state: np.ndarray) -> None:
+        if self._pending is not None:
+            return
+        current = self._current
+        if current is None:
+            raise RuntimeError("cannot project state without an active chunk")
+        projected, count = self.project_state(
+            state, current.actions, start_index=self._idx)
+        prepared = self._state_setter(observation, projected)
+        self.stats.chunks_started += 1
+        self.stats.state_projections += 1
+        self._pending = self._executor.submit(
+            self._run_inference, prepared,
+            start_state=state.copy(), projected_state=projected,
+            projected_count=count)
+
+    def project_state(self, state: Any, actions: Any, *,
+                      start_index: int) -> tuple[np.ndarray, int]:
+        """Integrate the next ``t`` stored action deltas into measured state.
+
+        With action quantization enabled, each stored action is already the sum
+        of up to ``action_quantization_granularity`` model actions, and ``t``
+        therefore counts quantized actions.
+        """
+        measured = self._validate_state(state)
+        chunk = np.asarray(actions)
+        if chunk.ndim != 2:
+            raise ValueError("actions must be [horizon, action_dim]")
+        begin = max(0, int(start_index))
+        end = min(chunk.shape[0], begin + self.config.lookahead_steps)
+        selected = chunk[begin:end]
+        deltas = self._state_deltas(selected, measured.size)
+        projected = measured + np.sum(deltas, axis=0, dtype=np.float64)
+        return projected.astype(measured.dtype, copy=False), end - begin
+
+    def _run_inference(self, observation: Any, *, start_state: np.ndarray,
+                       projected_state: np.ndarray,
+                       projected_count: int) -> VLAShChunkResult:
+        t0 = self._clock()
+        actions = np.asarray(self.adapter.infer_actions(observation))
+        t1 = self._clock()
+        if actions.ndim == 3 and actions.shape[0] == 1:
+            actions = actions[0]
+        if actions.ndim != 2 or not actions.shape[0] or not actions.shape[1]:
+            raise ValueError(
+                f"expected action chunk [horizon, action_dim], got {actions.shape}")
+        original_action_count = int(actions.shape[0])
+        actions = self.quantize_actions(actions)
+        return VLAShChunkResult(
+            actions=actions,
+            latency_s=t1 - t0,
+            observation_time_s=t0,
+            ready_time_s=t1,
+            start_state=start_state.copy(),
+            projected_state=projected_state.copy(),
+            projected_action_count=projected_count,
+            metadata={
+                "action_quantization_enabled":
+                    bool(self.config.action_quantization_enabled),
+                "action_quantization_granularity":
+                    self.config.action_quantization_granularity,
+                "original_action_count": original_action_count,
+                "stored_action_count": int(actions.shape[0]),
+            },
+        )
+
+    def quantize_actions(self, actions: Any) -> np.ndarray:
+        """Return a chunk with every consecutive ``k`` actions summed.
+
+        The final group is retained even when it contains fewer than ``k``
+        actions.  Quantization is applied along the horizon axis only, so the
+        action dimension is unchanged.  A copy is returned when quantization
+        is disabled, keeping model-owned output buffers isolated from runtime
+        mutation.
+        """
+        chunk = np.asarray(actions)
+        if chunk.ndim != 2 or not chunk.shape[0] or not chunk.shape[1]:
+            raise ValueError(
+                f"expected action chunk [horizon, action_dim], got {chunk.shape}")
+        if not self.config.action_quantization_enabled:
+            return np.array(chunk, copy=True)
+
+        granularity = self.config.action_quantization_granularity
+        groups = [
+            np.sum(chunk[start:start + granularity], axis=0)
+            for start in range(0, chunk.shape[0], granularity)
+        ]
+        return np.stack(groups, axis=0)
+
+    def _promote_ready_locked(self) -> bool:
+        if self._pending is None or not self._pending.done():
+            return False
+        result = self._pending.result()
+        self._pending = None
+        self._current = result
+        self._idx = 0  # VLASh trajectory starts at prediction completion.
+        self.stats.chunks_completed += 1
+        self.stats.swaps += 1
+        self.stats.last_latency_s = result.latency_s
+        self.stats.max_latency_s = max(
+            self.stats.max_latency_s, result.latency_s)
+        return True
+
+    def _handle_exhausted_locked(self, observation: Any,
+                                 state: np.ndarray) -> None:
+        if self._promote_ready_locked():
+            return
+        self.stats.deadline_misses += 1
+        if self.config.miss_policy == "block":
+            self._submit_locked(observation, state)
+            if self._pending is None:
+                raise RuntimeError("failed to submit recovery chunk")
+            result = self._pending.result()
+            self._pending = None
+            self._current = result
+            self._idx = 0
+            self.stats.chunks_completed += 1
+            self.stats.swaps += 1
+            return
+        if self._last_action is None:
+            raise RuntimeError("cannot hold before any action was served")
+        self.stats.held_actions += 1
+        now = self._clock()
+        self._current = VLAShChunkResult(
+            actions=self._last_action[None, :].copy(), latency_s=0.0,
+            observation_time_s=now, ready_time_s=now,
+            start_state=state.copy(), projected_state=state.copy(),
+            projected_action_count=0, metadata={"held": True})
+        self._idx = 0
+
+    def _state_deltas(self, actions: np.ndarray,
+                      state_dim: int) -> np.ndarray:
+        indices = self.config.state_action_indices
+        if indices is None:
+            if actions.shape[1] < state_dim:
+                raise ValueError(
+                    f"action dimension {actions.shape[1]} is smaller than "
+                    f"state dimension {state_dim}")
+            return np.asarray(actions[:, :state_dim], dtype=np.float64)
+        if len(indices) != state_dim:
+            raise ValueError(
+                "state_action_indices length must equal state dimension")
+        if indices and max(indices) >= actions.shape[1]:
+            raise ValueError("state_action_indices exceed action dimension")
+        return np.asarray(actions[:, indices], dtype=np.float64)
+
+    def _set_state_on_mapping(self, observation: Any,
+                              state: np.ndarray) -> Any:
+        if not isinstance(observation, Mapping):
+            raise TypeError(
+                "default VLASh state injection requires a mapping "
+                "observation; pass state_setter for custom types")
+        copied = dict(observation)
+        copied[self.config.state_key] = state.copy()
+        return copied
+
+    @staticmethod
+    def _validate_state(state: Any) -> np.ndarray:
+        result = np.asarray(state)
+        if result.ndim != 1 or not result.size:
+            raise ValueError("state must be a non-empty 1D vector")
+        if not np.issubdtype(result.dtype, np.number):
+            raise TypeError("state must have a numeric dtype")
+        if not np.all(np.isfinite(result)):
+            raise ValueError("state must contain only finite values")
+        dtype = result.dtype if np.issubdtype(result.dtype, np.floating) else np.float64
+        return np.array(result, dtype=dtype, copy=True)
+
+    def _horizon(self, actions: np.ndarray) -> int:
+        horizon = int(actions.shape[0])
+        if self.config.action_horizon is not None:
+            horizon = min(horizon, self.config.action_horizon)
+        return horizon
+
+    def _start_next_at(self, horizon: int) -> int:
+        if self.config.start_next_at is not None:
+            return min(self.config.start_next_at, horizon)
+        return max(1, horizon // 2)
+
+    def _raise_if_closed(self) -> None:
+        if self._closed:
+            raise RuntimeError("VLASh runner is closed")
+
+
+__all__ = [
+    "AsyncVLAShRunner",
+    "StateSetter",
+    "VLAShChunkResult",
+    "VLAShConfig",
+    "VLAShStats",
+]

--- a/flash_rt/subgraphs/pi05/stage_plans.py
+++ b/flash_rt/subgraphs/pi05/stage_plans.py
@@ -52,6 +52,23 @@ def context_rtc_vjp_guided_action(**_) -> StagePlan:
     })
 
 
+def vlash(*, lookahead_steps: int = 1, **_) -> StagePlan:
+    """Context/action cut conditioned on an upper-runtime projected state."""
+    steps = int(lookahead_steps)
+    if steps < 0:
+        raise ValueError("lookahead_steps must be >= 0")
+    return StagePlan((
+        Stage("context", graph="context"),
+        Stage("action", graph="decode_only", after=("context",)),
+    ), name="vlash", metadata={
+        "granularity": "context/vlash_action",
+        "context": "prompt_copy+vision_encoder+transformer_encoder",
+        "action": "transformer_decoder",
+        "state_projection": "start_state+sum(next_actions)",
+        "lookahead_steps": steps,
+    })
+
+
 register_stage_plan("full", full, model="pi05", replace=True)
 register_stage_plan("context_action", context_action, model="pi05",
                     replace=True)
@@ -60,6 +77,7 @@ register_stage_plan("context_rtc_prefix_action", context_rtc_prefix_action,
 register_stage_plan("context_rtc_vjp_guided_action",
                     context_rtc_vjp_guided_action, model="pi05",
                     replace=True)
+register_stage_plan("vlash", vlash, model="pi05", replace=True)
 
 
 __all__ = [
@@ -67,4 +85,5 @@ __all__ = [
     "context_action",
     "context_rtc_prefix_action",
     "context_rtc_vjp_guided_action",
+    "vlash",
 ]

--- a/flash_rt/subgraphs/pi05/vlash.py
+++ b/flash_rt/subgraphs/pi05/vlash.py
@@ -1,0 +1,29 @@
+"""Pi0.5 VLASh context/action cut.
+
+VLASh does not modify the decoder graph.  Before context replay, the upper
+runtime projects the robot state forward with the actions expected to execute
+during inference.  Pi0.5 renders that projected state into its prompt, so the
+normal ``context -> decode_only`` graphs consume the updated prompt embedding.
+
+Call :func:`enable` before graph capture.  For live state updates, the frontend
+must use a state-prompt mode whose shapes have been prewarmed (or fixed mode);
+this module cannot make variable token lengths graph-safe by itself.
+"""
+
+from __future__ import annotations
+
+
+def enable(target: object) -> None:
+    """Enable the graphs required by ``stage_plan="vlash"``.
+
+    The actual state projection and asynchronous scheduling live in
+    :mod:`flash_rt.runtime.vlash`; capture only needs the existing separate
+    context and decoder graphs.
+    """
+    from flash_rt.subgraphs.pi05.context_action import enable as enable_context
+    from flash_rt.subgraphs.pi05 import stage_plans as _stage_plans  # noqa: F401
+
+    enable_context(target)
+
+
+__all__ = ["enable"]

--- a/tests/test_vlash.py
+++ b/tests/test_vlash.py
@@ -1,3 +1,4 @@
+import threading
 import time
 
 import numpy as np
@@ -175,6 +176,140 @@ def test_async_vlash_conditions_next_prediction_and_switches_at_zero():
         assert np.array_equal(original_observation["state"], [-1.0])
         assert runner.current_chunk.projected_action_count == 2
     finally:
+        runner.close()
+
+
+def test_async_vlash_close_waits_for_running_worker_by_default():
+    class BlockingAdapter:
+        def __init__(self):
+            self.calls = 0
+            self.started = threading.Event()
+            self.release = threading.Event()
+
+        def infer_actions(self, observation):
+            call = self.calls
+            self.calls += 1
+            if call == 0:
+                return np.array([[1.0], [2.0]])
+            self.started.set()
+            self.release.wait(timeout=2.0)
+            return np.array([[10.0], [11.0]])
+
+    adapter = BlockingAdapter()
+    runner = AsyncVLAShRunner(
+        adapter,
+        VLAShConfig(action_hz=20, lookahead_steps=1, start_next_at=0),
+    )
+    try:
+        runner.reset({"state": np.array([0.0])}, state=[0.0])
+        assert runner.next_action({"state": np.array([0.0])}, state=[0.0]).item() == 1
+        assert adapter.started.wait(timeout=1.0)
+
+        close_done = threading.Event()
+
+        def close_runner():
+            runner.close()
+            close_done.set()
+
+        close_thread = threading.Thread(target=close_runner)
+        close_thread.start()
+        assert not close_done.wait(timeout=0.05)
+        adapter.release.set()
+        close_thread.join(timeout=1.0)
+        assert close_done.is_set()
+    finally:
+        adapter.release.set()
+        runner.close(wait=False)
+
+
+def test_async_vlash_clears_failed_pending_future_and_can_resubmit():
+    class FlakyAdapter:
+        def __init__(self):
+            self.calls = 0
+
+        def infer_actions(self, observation):
+            call = self.calls
+            self.calls += 1
+            if call == 0:
+                return np.array([[1.0], [2.0]])
+            if call == 1:
+                raise RuntimeError("worker failed")
+            return np.array([[10.0], [11.0]])
+
+    adapter = FlakyAdapter()
+    runner = AsyncVLAShRunner(
+        adapter,
+        VLAShConfig(action_hz=20, lookahead_steps=1, start_next_at=0),
+    )
+    try:
+        runner.reset({"state": np.array([0.0])}, state=[0.0])
+        assert runner.next_action({"state": np.array([0.0])}, state=[0.0]).item() == 1
+        assert runner._pending is not None
+        for _ in range(100):
+            if runner._pending.done():
+                break
+            time.sleep(0.001)
+        assert runner._pending.done()
+
+        with pytest.raises(RuntimeError, match="worker failed"):
+            runner.next_action({"state": np.array([0.0])}, state=[0.0])
+        assert runner._pending is None
+
+        assert runner.next_action({"state": np.array([0.0])}, state=[0.0]).item() == 2
+        assert runner._pending is not None
+    finally:
+        runner.close()
+
+
+def test_async_vlash_snapshots_background_observation_before_mutation():
+    class SnapshotAdapter:
+        def __init__(self):
+            self.calls = 0
+            self.started = threading.Event()
+            self.read_allowed = threading.Event()
+            self.images = []
+            self.tags = []
+
+        def infer_actions(self, observation):
+            call = self.calls
+            self.calls += 1
+            if call == 0:
+                return np.array([[1.0], [2.0]])
+            self.started.set()
+            self.read_allowed.wait(timeout=2.0)
+            self.images.append(observation["images"][0].copy())
+            self.tags.append(observation["meta"]["tags"][0])
+            return np.array([[10.0], [11.0]])
+
+    adapter = SnapshotAdapter()
+    image = np.array([[1.0, 2.0]], dtype=np.float32)
+    observation = {
+        "state": np.array([0.0]),
+        "images": [image],
+        "meta": {"tags": ["original"]},
+    }
+    runner = AsyncVLAShRunner(
+        adapter,
+        VLAShConfig(action_hz=20, lookahead_steps=1, start_next_at=0),
+    )
+    try:
+        runner.reset(observation, state=[0.0])
+        assert runner.next_action(observation, state=[0.0]).item() == 1
+        assert adapter.started.wait(timeout=1.0)
+
+        image[...] = 99.0
+        observation["images"].append(np.array([[5.0]], dtype=np.float32))
+        observation["meta"]["tags"][0] = "mutated"
+        adapter.read_allowed.set()
+
+        for _ in range(100):
+            if adapter.images:
+                break
+            time.sleep(0.001)
+        assert np.array_equal(adapter.images[0], [[1.0, 2.0]])
+        assert adapter.tags == ["original"]
+    finally:
+        adapter.read_allowed.set()
         runner.close()
 
 

--- a/tests/test_vlash.py
+++ b/tests/test_vlash.py
@@ -1,0 +1,186 @@
+import time
+
+import numpy as np
+import pytest
+
+from flash_rt.runtime.vlash import AsyncVLAShRunner, VLAShConfig
+from flash_rt.subgraphs.pi05.stage_plans import vlash
+
+
+class RecordingAdapter:
+    def __init__(self):
+        self.states = []
+        self.calls = 0
+
+    def infer_actions(self, observation):
+        self.states.append(np.asarray(observation["state"]).copy())
+        call = self.calls
+        self.calls += 1
+        if call:
+            time.sleep(0.01)
+            return np.array([[100.0], [101.0], [102.0], [103.0]])
+        return np.array([[1.0], [2.0], [3.0], [4.0]])
+
+
+def test_vlash_projects_state_with_next_t_actions():
+    runner = AsyncVLAShRunner(
+        RecordingAdapter(), VLAShConfig(action_hz=20, lookahead_steps=2))
+    try:
+        projected, count = runner.project_state(
+            np.array([10.0]),
+            np.array([[1.0], [2.0], [3.0], [4.0]]),
+            start_index=1,
+        )
+        assert count == 2
+        assert np.array_equal(projected, [15.0])  # 10 + 2 + 3
+    finally:
+        runner.close()
+
+
+def test_vlash_does_not_truncate_float_deltas_for_integer_state():
+    runner = AsyncVLAShRunner(
+        RecordingAdapter(), VLAShConfig(action_hz=20, lookahead_steps=1))
+    try:
+        projected, _ = runner.project_state(
+            np.array([10], dtype=np.int32), np.array([[0.5]]), start_index=0)
+        assert projected.dtype == np.float64
+        assert np.array_equal(projected, [10.5])
+    finally:
+        runner.close()
+
+
+def test_vlash_projection_supports_state_action_dimension_mapping():
+    runner = AsyncVLAShRunner(
+        RecordingAdapter(),
+        VLAShConfig(action_hz=20, lookahead_steps=2,
+                    state_action_indices=(0, 2)),
+    )
+    try:
+        projected, count = runner.project_state(
+            np.array([10.0, 20.0]),
+            np.array([[1.0, 99.0, 2.0], [3.0, 99.0, 4.0]]),
+            start_index=0,
+        )
+        assert count == 2
+        assert np.array_equal(projected, [14.0, 26.0])
+    finally:
+        runner.close()
+
+
+def test_vlash_uses_available_actions_when_fewer_than_t_remain():
+    runner = AsyncVLAShRunner(
+        RecordingAdapter(), VLAShConfig(action_hz=20, lookahead_steps=5))
+    try:
+        projected, count = runner.project_state(
+            np.array([10.0]), np.array([[1.0], [2.0], [3.0]]),
+            start_index=2)
+        assert count == 1
+        assert np.array_equal(projected, [13.0])
+    finally:
+        runner.close()
+
+
+def test_vlash_action_quantization_is_disabled_by_default():
+    runner = AsyncVLAShRunner(
+        RecordingAdapter(), VLAShConfig(action_hz=20, lookahead_steps=1))
+    actions = np.arange(10, dtype=np.float32).reshape(5, 2)
+    try:
+        quantized = runner.quantize_actions(actions)
+        assert np.array_equal(quantized, actions)
+        assert quantized is not actions
+    finally:
+        runner.close()
+
+
+def test_vlash_action_quantization_sums_groups_and_keeps_tail():
+    runner = AsyncVLAShRunner(
+        RecordingAdapter(),
+        VLAShConfig(
+            action_hz=20,
+            lookahead_steps=1,
+            action_quantization_enabled=True,
+            action_quantization_granularity=2,
+        ),
+    )
+    actions = np.array([
+        [1.0, 10.0],
+        [2.0, 20.0],
+        [3.0, 30.0],
+        [4.0, 40.0],
+        [5.0, 50.0],
+    ])
+    try:
+        quantized = runner.quantize_actions(actions)
+        assert np.array_equal(quantized, [
+            [3.0, 30.0],
+            [7.0, 70.0],
+            [5.0, 50.0],
+        ])
+    finally:
+        runner.close()
+
+
+@pytest.mark.parametrize("granularity", [0, -1])
+def test_vlash_rejects_non_positive_quantization_granularity(granularity):
+    with pytest.raises(ValueError, match="granularity must be positive"):
+        VLAShConfig(
+            action_hz=20,
+            lookahead_steps=1,
+            action_quantization_granularity=granularity,
+        )
+
+
+def test_async_vlash_stores_and_serves_quantized_actions():
+    adapter = RecordingAdapter()
+    runner = AsyncVLAShRunner(
+        adapter,
+        VLAShConfig(
+            action_hz=20,
+            lookahead_steps=1,
+            action_quantization_enabled=True,
+            action_quantization_granularity=2,
+        ),
+    )
+    try:
+        runner.reset({"state": np.array([0.0])}, state=[0.0])
+        assert np.array_equal(runner.current_chunk.actions, [[3.0], [7.0]])
+        assert runner.current_chunk.metadata["original_action_count"] == 4
+        assert runner.current_chunk.metadata["stored_action_count"] == 2
+        assert runner.next_action({"state": np.array([0.0])}, state=[0.0]).item() == 3
+        assert runner.next_action({"state": np.array([0.0])}, state=[0.0]).item() == 7
+    finally:
+        runner.close()
+
+
+def test_async_vlash_conditions_next_prediction_and_switches_at_zero():
+    adapter = RecordingAdapter()
+    original_observation = {"state": np.array([-1.0]), "frame": "frame"}
+    runner = AsyncVLAShRunner(
+        adapter,
+        VLAShConfig(action_hz=20, lookahead_steps=2, start_next_at=1),
+    )
+    try:
+        runner.reset(original_observation, state=np.array([0.0]))
+        assert runner.next_action(original_observation, state=[0.0]).item() == 1
+
+        # Submission happens before action index 1 is served.  The projected
+        # state is current state 10 + old actions[1:3] = 10 + 2 + 3 = 15.
+        assert runner.next_action(original_observation, state=[10.0]).item() == 2
+        time.sleep(0.02)
+
+        # VLASh starts the new trajectory at index zero; it does not skip by
+        # measured inference latency.
+        assert runner.next_action(original_observation, state=[15.0]).item() == 100
+        assert np.array_equal(adapter.states[1], [15.0])
+        assert np.array_equal(original_observation["state"], [-1.0])
+        assert runner.current_chunk.projected_action_count == 2
+    finally:
+        runner.close()
+
+
+def test_vlash_stage_plan_reuses_context_and_plain_decoder():
+    plan = vlash(lookahead_steps=3)
+    assert [stage.graph_name() for stage in plan.stages] == [
+        "context", "decode_only"]
+    assert plan.stages[1].after == ("context",)
+    assert plan.metadata["lookahead_steps"] == 3

--- a/tests/test_vlash_pi05.py
+++ b/tests/test_vlash_pi05.py
@@ -1,0 +1,140 @@
+"""Real-checkpoint gate for Pi0.5 with asynchronous VLASh.
+
+Set ``PI05_CKPT`` to a Pi0.5 PyTorch checkpoint and run on an SM89 GPU. The
+normal test suite skips this module when the checkpoint or CUDA is absent.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import unittest
+
+import numpy as np
+import torch
+
+from flash_rt.runtime.vlash import AsyncVLAShRunner, VLAShConfig
+
+
+_CHECKPOINT = (os.environ.get("PI05_CKPT")
+               or os.environ.get("PI05_LIBERO_PYTORCH_CHECKPOINT"))
+_HAS_CHECKPOINT = bool(_CHECKPOINT and os.path.isdir(_CHECKPOINT))
+
+
+class _Pi05VLAShAdapter:
+    def __init__(self, model, prompt: str):
+        self.model = model
+        self.prompt = prompt
+        self.states: list[np.ndarray] = []
+        self._lock = threading.Lock()
+
+    def infer_actions(self, observation):
+        state = np.asarray(observation["state"], dtype=np.float32)
+        with self._lock:
+            self.states.append(state.copy())
+        return np.asarray(self.model.predict(
+            images=observation["images"], prompt=self.prompt, state=state))
+
+    def recorded_states(self) -> list[np.ndarray]:
+        with self._lock:
+            return [s.copy() for s in self.states]
+
+
+class Pi05VLAShCheckpointTest(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA GPU required")
+    @unittest.skipUnless(
+        _HAS_CHECKPOINT, "set PI05_CKPT to a Pi0.5 PyTorch checkpoint")
+    def test_async_prediction_uses_projected_state(self):
+        import flash_rt
+
+        capability = torch.cuda.get_device_capability()
+        if capability != (8, 9):
+            raise unittest.SkipTest(
+                "RTX SM89 gate requires compute capability 8.9, "
+                f"got {capability}")
+
+        rng = np.random.RandomState(11)
+        image = rng.randint(0, 255, (224, 224, 3), dtype=np.uint8)
+        observation = {"images": [image, image.copy()]}
+        prompt = "pick up the red block"
+        state_dim = 7
+        state0 = np.zeros(state_dim, dtype=np.float32)
+        measured = np.linspace(-0.2, 0.2, state_dim).astype(np.float32)
+
+        model = flash_rt.load_model(
+            checkpoint=_CHECKPOINT,
+            framework="torch",
+            config="pi05",
+            hardware="rtx_sm89",
+            num_views=2,
+            autotune=int(os.environ.get("VLASH_PI05_AUTOTUNE", "0")),
+            use_fp8=True,
+            state_prompt_mode="fixed",
+        )
+        adapter = _Pi05VLAShAdapter(model, prompt)
+        runner = AsyncVLAShRunner(
+            adapter,
+            VLAShConfig(
+                action_hz=20,
+                lookahead_steps=1,
+                start_next_at=1,
+                miss_policy="block",
+                state_action_indices=tuple(range(state_dim)),
+            ),
+        )
+        try:
+            runner.reset(observation, state=state0)
+            initial = runner.current_chunk
+            self.assertIsNotNone(initial)
+            assert initial is not None
+            self.assertEqual(initial.actions.ndim, 2)
+            self.assertGreater(initial.actions.shape[0], 1)
+            self.assertGreaterEqual(initial.actions.shape[1], state_dim)
+            self.assertTrue(np.all(np.isfinite(initial.actions)))
+
+            first = runner.next_action(observation, state=state0)
+            self.assertTrue(np.all(np.isfinite(first)))
+
+            expected_projected = measured + initial.actions[1, :state_dim]
+            second = runner.next_action(observation, state=measured)
+            self.assertTrue(np.all(np.isfinite(second)))
+
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                states = adapter.recorded_states()
+                pending = getattr(runner, "_pending", None)
+                if len(states) >= 2 and pending is not None and pending.done():
+                    break
+                time.sleep(0.001)
+            states = adapter.recorded_states()
+            self.assertGreaterEqual(
+                len(states), 2,
+                "background Pi0.5 inference did not start within 10 seconds")
+            np.testing.assert_allclose(states[0], state0, rtol=0, atol=0)
+            np.testing.assert_allclose(
+                states[1], expected_projected.astype(np.float32),
+                rtol=1e-5, atol=1e-5)
+
+            served = runner.next_action(observation, state=expected_projected)
+            current = runner.current_chunk
+            self.assertIsNotNone(current)
+            assert current is not None
+            self.assertTrue(np.all(np.isfinite(served)))
+            self.assertEqual(current.projected_action_count, 1)
+            np.testing.assert_allclose(
+                current.start_state, measured, rtol=1e-6, atol=1e-6)
+            np.testing.assert_allclose(
+                current.projected_state, expected_projected,
+                rtol=1e-5, atol=1e-5)
+            self.assertGreaterEqual(runner.stats.chunks_started, 1)
+            self.assertGreaterEqual(runner.stats.chunks_completed, 1)
+            self.assertGreaterEqual(runner.stats.swaps, 1)
+        finally:
+            runner.close()
+            del model
+            torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add VLASh as an independent host-side runtime for action-chunk policies.

VLASh predicts the next chunk asynchronously while the foreground consumes the current chunk. Before launching the background prediction, it projects the measured robot state forward using the next `lookahead_steps` delta actions from the active chunk, injects that projected state into the observation, and starts the next trajectory from action index zero when ready.

This PR includes:
- `AsyncVLAShRunner` and `VLAShConfig`
- projected-state scheduling and deadline handling
- optional additive action quantization
- Pi0.5 `vlash` stage-plan registration
- Pi0.5 subgraph enable helper
- user-facing VLASh docs and stable API docs
- CPU mechanism tests and a real Pi0.5 checkpoint gate

## Validation

- `PYTHONPATH=. python -m pytest tests/test_vlash.py -q`
  - `11 passed in 0.19s`

- `python -m py_compile flash_rt/runtime/vlash.py flash_rt/subgraphs/pi05/vlash.py tests/test_vlash.py tests/test_vlash_pi05.py`
  - passed

- Real Pi0.5 checkpoint gate on RTX 4090 / SM89, CUDA 12.4:
  - `PYTHONPATH=$PWD python -m pytest tests/test_vlash_pi05.py -q -s`
  - `1 passed, 2 warnings in 22.57s`

- Pi0.5 RTX SM89 quickstart, CUDA 12.4:
  - `PYTHONPATH=$PWD python examples/quickstart.py --checkpoint "$PI05_CKPT" --config pi05 --framework torch --hardware rtx_sm89 --num_views 2 --benchmark 20 --warmup 20`
  - `actions: shape=(10, 7)`
  - `sanity: PASS`
  - `reuse prompt: shape=(10, 7) OK`
  - `P50: 41.0 ms (24 Hz)`
  - `min: 38.4, mean: 41.8, max: 45.8 ms`
