### PR TITLE
SM89 Qwen3-VL FP8 decode-path optimization (8B + 2B)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1014,7 +1014,7 @@ if(FLASHRT_BUILD_QWEN3_VL)
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels)
   target_compile_options(flash_rt_qwen3_vl_kernels PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:
-      --expt-relaxed-constexpr -O3
+      --expt-relaxed-constexpr -O3 -lineinfo
       -U__CUDA_NO_BFLOAT16_OPERATORS__
       -U__CUDA_NO_BFLOAT162_OPERATORS__
       ${GPU_GENCODE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1014,7 +1014,7 @@ if(FLASHRT_BUILD_QWEN3_VL)
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels)
   target_compile_options(flash_rt_qwen3_vl_kernels PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:
-      --expt-relaxed-constexpr -O3 -lineinfo
+      --expt-relaxed-constexpr -O3
       -U__CUDA_NO_BFLOAT16_OPERATORS__
       -U__CUDA_NO_BFLOAT162_OPERATORS__
       ${GPU_GENCODE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ option(FLASHRT_ENABLE_QWEN35MOE
 # module so flash_rt_kernels.so stays stable; OFF by default.
 option(FLASHRT_BUILD_QWEN3_VL
        "Build Qwen3-VL kernels into a separate flash_rt_qwen3_vl_kernels module" OFF)
+option(FLASHRT_ENABLE_QWEN3_VL_DEV_KERNELS
+       "Expose Qwen3-VL bench/probe pybind symbols for kernel development" OFF)
 # MelBandRoformer audio source separation kernels (FP8 fused kernels for
 # BF16-in / FP8-out norm, QKV+RoPE, gated attention quant, residual+norm).
 # OFF by default; enable with -DFLASHRT_ENABLE_MELBAND_ROFORMER=ON.
@@ -1004,6 +1006,10 @@ if(FLASHRT_BUILD_QWEN3_VL)
   if(GPU_ARCH STREQUAL "89")
     target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
       ENABLE_SM89_BLOCK_FP8_GEMM=1)
+  endif()
+  if(FLASHRT_ENABLE_QWEN3_VL_DEV_KERNELS)
+    target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
+      ENABLE_QWEN3_VL_DEV_KERNELS=1)
   endif()
   set_target_properties(flash_rt_qwen3_vl_kernels PROPERTIES
     CUDA_STANDARD 17

--- a/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
+++ b/csrc/gemm/fp8_block128_gemm_mma_sm89.cu
@@ -131,6 +131,20 @@ int fp8_block128_gemm_blockscaled_sm89_bf16out(
     if (N >= 8192 && K == 4096 && M < 1024)
         return fp8_block128_gemm_bs_sm89_128x128x128_w8_s1(
             A, B, D, M, N, K, act_scale, w_scale, stream);
+    // Small-M regime (M<256) for N<8192 linears (qkv/o/down): at M=128 the
+    // 64x64/s1 grid underfills the SMs (8B qkv 64x64_s1 = 192 blocks = 1.5/SM;
+    // 2B qkv = 128 blocks = 1/SM), so achieved occupancy is grid-limited well
+    // below the theoretical cap. The smaller 32x64 tile doubles grid_m (8B qkv
+    // -> 384 blocks = 3/SM; 2B qkv -> 256 = 2/SM) and wins despite a lower
+    // per-block warp cap — ncu shows 8B qkv M=128: 32x64 51.6us vs 64x64_s1
+    // 61.9us (-17%). Graph-captured e2e confirms: 2B S=128 -13.5%, 8B S=128
+    // -12.0%, 2B S=192 -5.5%, 8B S=192 -2.0% (gain shrinks as M approaches the
+    // 256 crossover, beyond which 64x64/s1 wins — see layer-regime micro-bench).
+    // Wide-MLP gate_up keeps its existing s1 tile (8B via 128x128_w8_s1 above;
+    // 2B via the default 64x64_s1 below) — it is best at all M.
+    if (M < 256 && N < 8192)
+        return fp8_block128_gemm_bs_sm89_32x64x128_w4(
+            A, B, D, M, N, K, act_scale, w_scale, stream);
     if (N == 2048 && M < 1024)
         return fp8_block128_gemm_bs_sm89_64x64x128_w4(
             A, B, D, M, N, K, act_scale, w_scale, stream);

--- a/csrc/gemm/fp8_gemv_m1_sm89.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm89.cu
@@ -88,6 +88,74 @@ int launch_block128_(const void* A, const void* B, void* D,
     return 0;
 }
 
+// BF16-input variant: skips activation FP8 quantization.
+// A is BF16, B is FP8 with block-128 weight scale. No act_scale needed.
+template <int WARPS_PER_BLOCK>
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+void gemv_fp8_block128_m1_bf16in_kernel(
+    const __nv_bfloat16* __restrict__ A,   // [K] BF16
+    const __nv_fp8_e4m3* __restrict__ B,   // [N, K] FP8
+    __nv_bfloat16* __restrict__ D,         // [N]
+    int N, int K,
+    const float* __restrict__ w_scale)     // [N/128, K/128]
+{
+    extern __shared__ __nv_bfloat16 sA_bf16[];
+    const int tid     = threadIdx.x;
+    const int lane    = tid & 31;
+    const int warp    = tid >> 5;
+    const int threads = WARPS_PER_BLOCK * 32;
+    const int K16     = K >> 4;
+    const int K128    = K >> 7;
+
+    // Load BF16 activation (2 bytes each) via uint32 pairs.
+    uint* sU = reinterpret_cast<uint*>(sA_bf16);
+    const uint* AU = reinterpret_cast<const uint*>(A);
+    const int Khalf = K >> 1;
+    for (int i = tid; i < Khalf; i += threads) sU[i] = AU[i];
+    __syncthreads();
+
+    const int n = blockIdx.x * WARPS_PER_BLOCK + warp;
+    if (n >= N) return;
+
+    const uint4* Brow = reinterpret_cast<const uint4*>(B) + (size_t)n * K16;
+    const float* w_scale_row = w_scale + (size_t)(n >> 7) * K128;
+    float acc = 0.0f;
+    for (int i = lane; i < K16; i += 32) {
+        const int kb = i >> 3;
+        const float ws = w_scale_row[kb];
+        uint4 bpack = Brow[i];
+        const __nv_fp8_e4m3* bp =
+            reinterpret_cast<const __nv_fp8_e4m3*>(&bpack);
+        const __nv_bfloat16* ap = sA_bf16 + (i << 4);
+        float dot = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            dot += __bfloat162float(ap[j]) * float(bp[j]);
+        }
+        acc += dot * ws;
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_down_sync(0xffffffffu, acc, off);
+    }
+    if (lane == 0) D[n] = __float2bfloat16(acc);
+}
+
+template <int W>
+int launch_block128_bf16in_(const void* A, const void* B, void* D,
+                            int /*M*/, int N, int K,
+                            const float* w_scale, cudaStream_t stream) {
+    dim3 grid((N + W - 1) / W);
+    dim3 block(W * 32);
+    size_t smem = (size_t)K * sizeof(__nv_bfloat16);
+    gemv_fp8_block128_m1_bf16in_kernel<W><<<grid, block, smem, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(A),
+        reinterpret_cast<const __nv_fp8_e4m3*>(B),
+        reinterpret_cast<__nv_bfloat16*>(D),
+        N, K, w_scale);
+    return 0;
+}
+
 }  // namespace
 
 #define DEFINE_BLOCK128(NAME, W)                                               \
@@ -103,6 +171,17 @@ DEFINE_BLOCK128(gemv_fp8_block128_m1_w8, 8)
 DEFINE_BLOCK128(gemv_fp8_block128_m1_w16, 16)
 
 #undef DEFINE_BLOCK128
+
+#define DEFINE_BLOCK128_BF16IN(NAME, W)                                        \
+  int NAME(const void* A, const void* B, void* D, int M, int N, int K,         \
+           const float* w_scale, cudaStream_t stream) {                        \
+    return launch_block128_bf16in_<W>(A, B, D, M, N, K, w_scale, stream);      \
+  }
+
+DEFINE_BLOCK128_BF16IN(gemv_fp8_block128_m1_bf16in_w8, 8)
+DEFINE_BLOCK128_BF16IN(gemv_fp8_block128_m1_bf16in_w16, 16)
+
+#undef DEFINE_BLOCK128_BF16IN
 
 }  // namespace gemv_m1_sm89
 }  // namespace gemm

--- a/csrc/gemm/fp8_gemv_m1_sm89.cuh
+++ b/csrc/gemm/fp8_gemv_m1_sm89.cuh
@@ -23,6 +23,16 @@ DECL_BLOCK128(gemv_fp8_block128_m1_w16);
 
 #undef DECL_BLOCK128
 
+// BF16-input variants: A is BF16, B is FP8. No act_scale, only w_scale.
+#define DECL_BLOCK128_BF16IN(NAME) \
+  int NAME(const void* A, const void* B, void* D, \
+           int M, int N, int K, const float* w_scale, cudaStream_t stream)
+
+DECL_BLOCK128_BF16IN(gemv_fp8_block128_m1_bf16in_w8);
+DECL_BLOCK128_BF16IN(gemv_fp8_block128_m1_bf16in_w16);
+
+#undef DECL_BLOCK128_BF16IN
+
 }  // namespace gemv_m1_sm89
 }  // namespace gemm
 }  // namespace flash_rt

--- a/csrc/quantize/fp8_per_token_block_quant.cu
+++ b/csrc/quantize/fp8_per_token_block_quant.cu
@@ -81,6 +81,33 @@ __device__ __forceinline__ float block_reduce_sum_256(float v, float* sh) {
   return out;
 }
 
+// Block sum reduce for a 512-thread block (16 warps). Same shape as
+// block_reduce_sum_256 but the final stage reduces 16 warp partials (which fit
+// in one warp) instead of 8. Used by the BF16-out norm kernels at K>=4096 (8B),
+// where M=1 leaves a single-block grid idle at 256 threads (8 warps = 17%
+// occupancy); 512 threads doubles warp-level parallelism on that one SM (16
+// warps = 33% occupancy) — the same win the 128->256 change got for 2B.
+__device__ __forceinline__ float block_reduce_sum_512(float v, float* sh) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int off = 16; off > 0; off >>= 1) {
+    v += __shfl_xor_sync(0xffffffff, v, off);
+  }
+  if (lane == 0) sh[warp] = v;
+  __syncthreads();
+  if (warp == 0) {
+    v = (lane < 16) ? sh[lane] : 0.0f;
+    for (int off = 8; off > 0; off >>= 1) {
+      v += __shfl_xor_sync(0xffffffff, v, off);
+    }
+    if (lane == 0) sh[0] = v;
+  }
+  __syncthreads();
+  const float out = sh[0];
+  __syncthreads();
+  return out;
+}
+
 __global__ void fp8_per_token_block_quant_kernel(
     const __nv_bfloat16* __restrict__ input,
     __nv_fp8_e4m3* __restrict__ output,
@@ -238,29 +265,45 @@ __global__ void rms_norm_to_fp8_block128_kernel(
 // quantization. Output is BF16 so the downstream GEMV can use the bf16in kernel
 // (BF16 activation x FP8 weight with block-128 scale), eliminating the per-step
 // FP8 quant overhead. M=1 decode only; K must be a multiple of 128.
+//
+// Templated on thread count (256 for K=2048/2B, 512 for K>=4096/8B) to match
+// residual_add_rms_norm_bf16_out_kernel: M=1 leaves a single-block grid, so the
+// wider block doubles warp-level parallelism on the one active SM. The 2-pass
+// body uses packed BF16x2 loads.
+template <int kThreads>
 __global__ void rms_norm_bf16_out_kernel(
     const __nv_bfloat16* __restrict__ input,
     const __nv_bfloat16* __restrict__ weight,
     __nv_bfloat16* __restrict__ output,
     int K, float eps)
 {
+  using T2 = __nv_bfloat162;
   const int m = blockIdx.x;
   const int t = threadIdx.x;
-  const __nv_bfloat16* row = input + (size_t)m * K;
-  __nv_bfloat16* out = output + (size_t)m * K;
+  const int dim2 = K >> 1;
+  const T2* row2 = reinterpret_cast<const T2*>(input + (size_t)m * K);
+  const T2* w2   = reinterpret_cast<const T2*>(weight);
+  T2* out2       = reinterpret_cast<T2*>(output + (size_t)m * K);
 
+  extern __shared__ float shared[];
   float ssq = 0.0f;
-  for (int i = t; i < K; i += kBlock) {
-    const float v = __bfloat162float(row[i]);
-    ssq += v * v;
+  for (int i = t; i < dim2; i += kThreads) {
+    T2 rv = row2[i];
+    float v0 = __bfloat162float(__low2bfloat16(rv));
+    float v1 = __bfloat162float(__high2bfloat16(rv));
+    ssq += v0 * v0 + v1 * v1;
   }
-  __shared__ float red[4];
-  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+  const float inv_rms = (kThreads == 256)
+      ? rsqrtf(block_reduce_sum_256(ssq, shared) / K + eps)
+      : rsqrtf(block_reduce_sum_512(ssq, shared) / K + eps);
 
-  for (int i = t; i < K; i += kBlock) {
-    const float v = __bfloat162float(row[i]) * inv_rms *
-                    __bfloat162float(weight[i]);
-    out[i] = __float2bfloat16(v);
+  for (int i = t; i < dim2; i += kThreads) {
+    T2 rv = row2[i], wv = w2[i];
+    float v0 = __bfloat162float(__low2bfloat16(rv)) * inv_rms *
+               __bfloat162float(__low2bfloat16(wv));
+    float v1 = __bfloat162float(__high2bfloat16(rv)) * inv_rms *
+               __bfloat162float(__high2bfloat16(wv));
+    out2[i] = __floats2bfloat162_rn(v0, v1);
   }
 }
 
@@ -319,13 +362,14 @@ __global__ void residual_add_rms_norm_to_fp8_block128_kernel(
 // semantics as the FP8 version (separate buffer, residual input preserved).
 // M=1 decode; K multiple of 128.
 //
-// Uses 256 threads + packed BF16x2 loads (matching the fvk2
-// residual_add_rms_norm_kernel shape) instead of the 128-thread scalar loop the
-// FP8 variant inherits. ncu showed the 128-thread grid (1 block) leaves the SM
-// mostly idle and is L1TEX-stall-bound on the per-element reload; the wider
-// block halves latency by processing 2x elements per thread per iteration with
-// coalesced 4-byte loads, and keeps the same single-block grid so residual_out
-// stays a separate buffer (unlike fvk2 which is in-place on residual).
+// Templated on the thread count: 256 (8 warps) for K=2048 (2B), 512 (16 warps)
+// for K>=4096 (8B). M=1 leaves a single-block grid, so the SM is idle at low warp
+// counts; ncu showed 17% occupancy at 256 threads on 8B (K=4096) and the wider
+// block doubles warp-level parallelism on that one SM (16 warps = 33% occupancy)
+// — the same win the 128->256 change got for 2B. The 2-pass body uses packed
+// BF16x2 loads and keeps residual_out a separate buffer (unlike fvk2 which is
+// in-place on residual).
+template <int kThreads>
 __global__ void residual_add_rms_norm_bf16_out_kernel(
     const __nv_bfloat16* __restrict__ residual,
     const __nv_bfloat16* __restrict__ x,
@@ -346,7 +390,7 @@ __global__ void residual_add_rms_norm_bf16_out_kernel(
 
   extern __shared__ float shared[];
   float local_sum = 0.0f;
-  for (int i = t; i < dim2; i += blockDim.x) {
+  for (int i = t; i < dim2; i += kThreads) {
     T2 rv = res2[i], xv = x2[i];
     float r0 = __bfloat162float(__low2bfloat16(rv)) +
                __bfloat162float(__low2bfloat16(xv));
@@ -355,10 +399,11 @@ __global__ void residual_add_rms_norm_bf16_out_kernel(
     res_out2[i] = __floats2bfloat162_rn(r0, r1);
     local_sum += r0 * r0 + r1 * r1;
   }
-  const float inv_rms =
-      rsqrtf(block_reduce_sum_256(local_sum, shared) / K + eps);
+  const float inv_rms = (kThreads == 256)
+      ? rsqrtf(block_reduce_sum_256(local_sum, shared) / K + eps)
+      : rsqrtf(block_reduce_sum_512(local_sum, shared) / K + eps);
 
-  for (int i = t; i < dim2; i += blockDim.x) {
+  for (int i = t; i < dim2; i += kThreads) {
     T2 rv = res_out2[i], wv = w2[i];
     float v0 = __bfloat162float(__low2bfloat16(rv)) * inv_rms *
                __bfloat162float(__low2bfloat16(wv));
@@ -509,11 +554,26 @@ void rms_norm_bf16_out(
   if ((K % kBlock) != 0)
     throw std::runtime_error(
         "rms_norm_bf16_out requires K multiple of 128");
-  rms_norm_bf16_out_kernel<<<M, kBlock, 0, stream>>>(
-      reinterpret_cast<const __nv_bfloat16*>(input),
-      reinterpret_cast<const __nv_bfloat16*>(weight),
-      reinterpret_cast<__nv_bfloat16*>(output),
-      K, eps);
+  // 512 threads for K>=4096 (8B): M=1 leaves a single-block grid, so the wider
+  // block doubles warp-level parallelism (17%->33% occupancy). 256 threads
+  // otherwise (2B K=2048 — 512 would give too little work per thread).
+  if (K >= 4096) {
+    constexpr int kThreads = 512;
+    rms_norm_bf16_out_kernel<kThreads><<<M, kThreads,
+        kThreads * sizeof(float), stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(input),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(output),
+        K, eps);
+  } else {
+    constexpr int kThreads = 256;
+    rms_norm_bf16_out_kernel<kThreads><<<M, kThreads,
+        kThreads * sizeof(float), stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(input),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(output),
+        K, eps);
+  }
 }
 
 void residual_add_rms_norm_bf16_out(
@@ -528,18 +588,30 @@ void residual_add_rms_norm_bf16_out(
   if ((K % kBlock) != 0)
     throw std::runtime_error(
         "residual_add_rms_norm_bf16_out requires K multiple of 128");
-  // 256 threads (8 warps) for M=1 decode: doubles per-thread element throughput
-  // via BF16x2 packed loads vs the 128-thread scalar FP8 variant. Shared mem
-  // holds 8 warp partials for block_reduce_sum_256.
-  constexpr int kThreads = 256;
-  residual_add_rms_norm_bf16_out_kernel<<<M, kThreads,
-      kThreads * sizeof(float), stream>>>(
-      reinterpret_cast<const __nv_bfloat16*>(residual),
-      reinterpret_cast<const __nv_bfloat16*>(x),
-      reinterpret_cast<__nv_bfloat16*>(residual_out),
-      reinterpret_cast<const __nv_bfloat16*>(weight),
-      reinterpret_cast<__nv_bfloat16*>(output),
-      K, eps);
+  // 512 threads for K>=4096 (8B): M=1 leaves a single-block grid, so the wider
+  // block doubles warp-level parallelism (17%->33% occupancy). 256 threads
+  // otherwise (2B K=2048). Shared mem holds 16 warp partials for the 512 path.
+  if (K >= 4096) {
+    constexpr int kThreads = 512;
+    residual_add_rms_norm_bf16_out_kernel<kThreads><<<M, kThreads,
+        kThreads * sizeof(float), stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<__nv_bfloat16*>(residual_out),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(output),
+        K, eps);
+  } else {
+    constexpr int kThreads = 256;
+    residual_add_rms_norm_bf16_out_kernel<kThreads><<<M, kThreads,
+        kThreads * sizeof(float), stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<__nv_bfloat16*>(residual_out),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(output),
+        K, eps);
+  }
 }
 
 void silu_mul_to_fp8_block128_bf16(

--- a/csrc/quantize/fp8_per_token_block_quant.cu
+++ b/csrc/quantize/fp8_per_token_block_quant.cu
@@ -57,6 +57,30 @@ __device__ __forceinline__ float block_reduce_max_128(float v, float* sh) {
   return out;
 }
 
+// Block sum reduce for a 256-thread block (8 warps). Mirrors block_reduce_sum
+// in csrc/kernels/common.cuh but kept local so this translation unit stays
+// self-contained.
+__device__ __forceinline__ float block_reduce_sum_256(float v, float* sh) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  for (int off = 16; off > 0; off >>= 1) {
+    v += __shfl_xor_sync(0xffffffff, v, off);
+  }
+  if (lane == 0) sh[warp] = v;
+  __syncthreads();
+  if (warp == 0) {
+    v = (lane < 8) ? sh[lane] : 0.0f;
+    for (int off = 4; off > 0; off >>= 1) {
+      v += __shfl_xor_sync(0xffffffff, v, off);
+    }
+    if (lane == 0) sh[0] = v;
+  }
+  __syncthreads();
+  const float out = sh[0];
+  __syncthreads();
+  return out;
+}
+
 __global__ void fp8_per_token_block_quant_kernel(
     const __nv_bfloat16* __restrict__ input,
     __nv_fp8_e4m3* __restrict__ output,
@@ -294,6 +318,14 @@ __global__ void residual_add_rms_norm_to_fp8_block128_kernel(
 // BF16 so the downstream GEMV can use the bf16in kernel. Same residual_out
 // semantics as the FP8 version (separate buffer, residual input preserved).
 // M=1 decode; K multiple of 128.
+//
+// Uses 256 threads + packed BF16x2 loads (matching the fvk2
+// residual_add_rms_norm_kernel shape) instead of the 128-thread scalar loop the
+// FP8 variant inherits. ncu showed the 128-thread grid (1 block) leaves the SM
+// mostly idle and is L1TEX-stall-bound on the per-element reload; the wider
+// block halves latency by processing 2x elements per thread per iteration with
+// coalesced 4-byte loads, and keeps the same single-block grid so residual_out
+// stays a separate buffer (unlike fvk2 which is in-place on residual).
 __global__ void residual_add_rms_norm_bf16_out_kernel(
     const __nv_bfloat16* __restrict__ residual,
     const __nv_bfloat16* __restrict__ x,
@@ -302,28 +334,37 @@ __global__ void residual_add_rms_norm_bf16_out_kernel(
     __nv_bfloat16* __restrict__ output,
     int K, float eps)
 {
+  using T2 = __nv_bfloat162;
   const int m = blockIdx.x;
   const int t = threadIdx.x;
-  const __nv_bfloat16* rrow = residual + (size_t)m * K;
-  const __nv_bfloat16* xrow = x + (size_t)m * K;
-  __nv_bfloat16* res_out = residual_out + (size_t)m * K;
-  __nv_bfloat16* out = output + (size_t)m * K;
+  const int dim2 = K >> 1;
+  const T2* res2 = reinterpret_cast<const T2*>(residual + (size_t)m * K);
+  const T2* x2   = reinterpret_cast<const T2*>(x + (size_t)m * K);
+  const T2* w2   = reinterpret_cast<const T2*>(weight);
+  T2* res_out2   = reinterpret_cast<T2*>(residual_out + (size_t)m * K);
+  T2* out2       = reinterpret_cast<T2*>(output + (size_t)m * K);
 
-  float ssq = 0.0f;
-  for (int i = t; i < K; i += kBlock) {
-    const float rv = __bfloat162float(rrow[i]) + __bfloat162float(xrow[i]);
-    const __nv_bfloat16 rb = __float2bfloat16(rv);
-    res_out[i] = rb;
-    const float rbf = __bfloat162float(rb);
-    ssq += rbf * rbf;
+  extern __shared__ float shared[];
+  float local_sum = 0.0f;
+  for (int i = t; i < dim2; i += blockDim.x) {
+    T2 rv = res2[i], xv = x2[i];
+    float r0 = __bfloat162float(__low2bfloat16(rv)) +
+               __bfloat162float(__low2bfloat16(xv));
+    float r1 = __bfloat162float(__high2bfloat16(rv)) +
+               __bfloat162float(__high2bfloat16(xv));
+    res_out2[i] = __floats2bfloat162_rn(r0, r1);
+    local_sum += r0 * r0 + r1 * r1;
   }
-  __shared__ float red[4];
-  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+  const float inv_rms =
+      rsqrtf(block_reduce_sum_256(local_sum, shared) / K + eps);
 
-  for (int i = t; i < K; i += kBlock) {
-    const float v = __bfloat162float(res_out[i]) * inv_rms *
-                    __bfloat162float(weight[i]);
-    out[i] = __float2bfloat16(v);
+  for (int i = t; i < dim2; i += blockDim.x) {
+    T2 rv = res_out2[i], wv = w2[i];
+    float v0 = __bfloat162float(__low2bfloat16(rv)) * inv_rms *
+               __bfloat162float(__low2bfloat16(wv));
+    float v1 = __bfloat162float(__high2bfloat16(rv)) * inv_rms *
+               __bfloat162float(__high2bfloat16(wv));
+    out2[i] = __floats2bfloat162_rn(v0, v1);
   }
 }
 
@@ -487,7 +528,12 @@ void residual_add_rms_norm_bf16_out(
   if ((K % kBlock) != 0)
     throw std::runtime_error(
         "residual_add_rms_norm_bf16_out requires K multiple of 128");
-  residual_add_rms_norm_bf16_out_kernel<<<M, kBlock, 0, stream>>>(
+  // 256 threads (8 warps) for M=1 decode: doubles per-thread element throughput
+  // via BF16x2 packed loads vs the 128-thread scalar FP8 variant. Shared mem
+  // holds 8 warp partials for block_reduce_sum_256.
+  constexpr int kThreads = 256;
+  residual_add_rms_norm_bf16_out_kernel<<<M, kThreads,
+      kThreads * sizeof(float), stream>>>(
       reinterpret_cast<const __nv_bfloat16*>(residual),
       reinterpret_cast<const __nv_bfloat16*>(x),
       reinterpret_cast<__nv_bfloat16*>(residual_out),

--- a/csrc/quantize/fp8_per_token_block_quant.cu
+++ b/csrc/quantize/fp8_per_token_block_quant.cu
@@ -210,6 +210,36 @@ __global__ void rms_norm_to_fp8_block128_kernel(
   }
 }
 
+// BF16-output variant of rms_norm_to_fp8_block128_kernel: RMSNorm only, no FP8
+// quantization. Output is BF16 so the downstream GEMV can use the bf16in kernel
+// (BF16 activation x FP8 weight with block-128 scale), eliminating the per-step
+// FP8 quant overhead. M=1 decode only; K must be a multiple of 128.
+__global__ void rms_norm_bf16_out_kernel(
+    const __nv_bfloat16* __restrict__ input,
+    const __nv_bfloat16* __restrict__ weight,
+    __nv_bfloat16* __restrict__ output,
+    int K, float eps)
+{
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* row = input + (size_t)m * K;
+  __nv_bfloat16* out = output + (size_t)m * K;
+
+  float ssq = 0.0f;
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(row[i]);
+    ssq += v * v;
+  }
+  __shared__ float red[4];
+  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(row[i]) * inv_rms *
+                    __bfloat162float(weight[i]);
+    out[i] = __float2bfloat16(v);
+  }
+}
+
 __global__ void residual_add_rms_norm_to_fp8_block128_kernel(
     const __nv_bfloat16* __restrict__ residual,
     const __nv_bfloat16* __restrict__ x,
@@ -256,6 +286,44 @@ __global__ void residual_add_rms_norm_to_fp8_block128_kernel(
     float q = v / sc;
     q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
     out[i] = __nv_fp8_e4m3(q);
+  }
+}
+
+// BF16-output variant of residual_add_rms_norm_to_fp8_block128_kernel:
+// residual add + RMSNorm (2 passes), skipping the 3rd FP8-quant pass. Output is
+// BF16 so the downstream GEMV can use the bf16in kernel. Same residual_out
+// semantics as the FP8 version (separate buffer, residual input preserved).
+// M=1 decode; K multiple of 128.
+__global__ void residual_add_rms_norm_bf16_out_kernel(
+    const __nv_bfloat16* __restrict__ residual,
+    const __nv_bfloat16* __restrict__ x,
+    __nv_bfloat16* __restrict__ residual_out,
+    const __nv_bfloat16* __restrict__ weight,
+    __nv_bfloat16* __restrict__ output,
+    int K, float eps)
+{
+  const int m = blockIdx.x;
+  const int t = threadIdx.x;
+  const __nv_bfloat16* rrow = residual + (size_t)m * K;
+  const __nv_bfloat16* xrow = x + (size_t)m * K;
+  __nv_bfloat16* res_out = residual_out + (size_t)m * K;
+  __nv_bfloat16* out = output + (size_t)m * K;
+
+  float ssq = 0.0f;
+  for (int i = t; i < K; i += kBlock) {
+    const float rv = __bfloat162float(rrow[i]) + __bfloat162float(xrow[i]);
+    const __nv_bfloat16 rb = __float2bfloat16(rv);
+    res_out[i] = rb;
+    const float rbf = __bfloat162float(rb);
+    ssq += rbf * rbf;
+  }
+  __shared__ float red[4];
+  const float inv_rms = rsqrtf(block_reduce_sum_128(ssq, red) / K + eps);
+
+  for (int i = t; i < K; i += kBlock) {
+    const float v = __bfloat162float(res_out[i]) * inv_rms *
+                    __bfloat162float(weight[i]);
+    out[i] = __float2bfloat16(v);
   }
 }
 
@@ -388,6 +456,44 @@ void residual_add_rms_norm_to_fp8_block128_bf16(
       reinterpret_cast<const __nv_bfloat16*>(weight),
       reinterpret_cast<__nv_fp8_e4m3*>(output_fp8),
       output_scale, K, eps);
+}
+
+void rms_norm_bf16_out(
+    const void* input,
+    const void* weight,
+    void* output,
+    int M, int K, float eps,
+    cudaStream_t stream)
+{
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "rms_norm_bf16_out requires K multiple of 128");
+  rms_norm_bf16_out_kernel<<<M, kBlock, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(input),
+      reinterpret_cast<const __nv_bfloat16*>(weight),
+      reinterpret_cast<__nv_bfloat16*>(output),
+      K, eps);
+}
+
+void residual_add_rms_norm_bf16_out(
+    const void* residual,
+    const void* x,
+    void* residual_out,
+    const void* weight,
+    void* output,
+    int M, int K, float eps,
+    cudaStream_t stream)
+{
+  if ((K % kBlock) != 0)
+    throw std::runtime_error(
+        "residual_add_rms_norm_bf16_out requires K multiple of 128");
+  residual_add_rms_norm_bf16_out_kernel<<<M, kBlock, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(residual),
+      reinterpret_cast<const __nv_bfloat16*>(x),
+      reinterpret_cast<__nv_bfloat16*>(residual_out),
+      reinterpret_cast<const __nv_bfloat16*>(weight),
+      reinterpret_cast<__nv_bfloat16*>(output),
+      K, eps);
 }
 
 void silu_mul_to_fp8_block128_bf16(

--- a/csrc/quantize/fp8_per_token_block_quant.cuh
+++ b/csrc/quantize/fp8_per_token_block_quant.cuh
@@ -56,6 +56,24 @@ void residual_add_rms_norm_to_fp8_block128_bf16(
     int M, int K, float eps,
     cudaStream_t stream);
 
+// BF16-output variants (no FP8 quant pass): RMSNorm / residual-add + RMSNorm
+// producing BF16 activations for the bf16in GEMV path. M=1 decode only.
+void rms_norm_bf16_out(
+    const void* input,
+    const void* weight,
+    void*       output,
+    int M, int K, float eps,
+    cudaStream_t stream);
+
+void residual_add_rms_norm_bf16_out(
+    const void* residual,
+    const void* x,
+    void*       residual_out,
+    const void* weight,
+    void*       output,
+    int M, int K, float eps,
+    cudaStream_t stream);
+
 void silu_mul_to_fp8_block128_bf16(
     const void* gate,
     const void* up,

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -292,6 +292,20 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         py::arg("act_block_scale"), py::arg("w_block_scale"),
         py::arg("stream") = 0);
 
+    // Bench-only tile-variant bindings for prefill GEMM tuning. Not used by
+    // the frontend; exposed so the micro-bench can sweep tiles and candidate
+    // kernels without re-templating the dispatcher.
+#define BIND_GEMM_TILE(NAME)                                                        m.def("bench_" #NAME,                                                               [](uintptr_t A, uintptr_t B, uintptr_t D, int M, int N, int K,                     uintptr_t act_scale, uintptr_t w_scale, uintptr_t stream) {                      return flash_rt::gemm::block128_sm89::NAME(                                         to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,                                      reinterpret_cast<const float*>(act_scale),                                      reinterpret_cast<const float*>(w_scale), to_stream(stream));            },                                                                              py::arg("A"), py::arg("B"), py::arg("D"),                                      py::arg("M"), py::arg("N"), py::arg("K"),                                      py::arg("act_block_scale"), py::arg("w_block_scale"),                          py::arg("stream") = 0)
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_16x64x128_w4);
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_32x64x128_w4);
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_64x64x128_w4);
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_64x64x128_w4_s1);
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_128x128x128_w8_s1);
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_32x128x128_w4);
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_64x128x128_w8);
+    BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_128x128x128_w8);
+#undef BIND_GEMM_TILE
+
     m.def("qwen3_qk_norm_rope_kvwrite_bf16",
         [](uintptr_t q_pre, uintptr_t k_pre, uintptr_t v_pre,
            uintptr_t q_norm_w, uintptr_t k_norm_w,

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -244,6 +244,33 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         py::arg("output_scale"), py::arg("M"), py::arg("K"),
         py::arg("stream") = 0);
 
+    // BF16-output norm variants: skip the FP8 quant pass, emit BF16 activations
+    // for the bf16in GEMV path (qkv / gate_up in decode).
+    m.def("rms_norm_bf16_out",
+        [](uintptr_t input, uintptr_t weight, uintptr_t output,
+           int M, int K, float eps, uintptr_t stream) {
+            flash_rt::quantize::rms_norm_bf16_out(
+                to_ptr(input), to_ptr(weight), to_ptr(output),
+                M, K, eps, to_stream(stream));
+        },
+        py::arg("input"), py::arg("weight"), py::arg("output"),
+        py::arg("M"), py::arg("K"), py::arg("eps") = 1e-6f,
+        py::arg("stream") = 0);
+
+    m.def("residual_add_rms_norm_bf16_out",
+        [](uintptr_t residual, uintptr_t x, uintptr_t residual_out,
+           uintptr_t weight, uintptr_t output,
+           int M, int K, float eps, uintptr_t stream) {
+            flash_rt::quantize::residual_add_rms_norm_bf16_out(
+                to_ptr(residual), to_ptr(x), to_ptr(residual_out),
+                to_ptr(weight), to_ptr(output),
+                M, K, eps, to_stream(stream));
+        },
+        py::arg("residual"), py::arg("x"), py::arg("residual_out"),
+        py::arg("weight"), py::arg("output"),
+        py::arg("M"), py::arg("K"), py::arg("eps") = 1e-6f,
+        py::arg("stream") = 0);
+
     m.def("fp8_block128_gemm_blockscaled_sm89_bf16out",
         [](uintptr_t A, uintptr_t B, uintptr_t D,
            int M, int N, int K,

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -342,6 +342,27 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
     BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w4);
     BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w8);
     BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w16);
+
+    // BF16-input GEMV: A is BF16, B is FP8 with block-128 weight scale.
+    // Eliminates standalone FP8 activation quantization before O-proj.
+#define BIND_BLOCK128_GEMV_M1_BF16IN(NAME)                                     \
+    m.def("ht_" #NAME,                                                         \
+        [](uintptr_t A, uintptr_t B, uintptr_t D,                              \
+           int M, int N, int K, uintptr_t w_scale, uintptr_t stream) {         \
+            return flash_rt::gemm::gemv_m1_sm89::NAME(                          \
+                to_ptr(A), to_ptr(B), to_ptr(D),                               \
+                M, N, K, reinterpret_cast<const float*>(w_scale),              \
+                to_stream(stream));                                            \
+        },                                                                     \
+        py::arg("A"), py::arg("B"), py::arg("D"),                              \
+        py::arg("M"), py::arg("N"), py::arg("K"),                              \
+        py::arg("w_scale"), py::arg("stream") = 0)
+
+    BIND_BLOCK128_GEMV_M1_BF16IN(gemv_fp8_block128_m1_bf16in_w8);
+    BIND_BLOCK128_GEMV_M1_BF16IN(gemv_fp8_block128_m1_bf16in_w16);
+
+#undef BIND_BLOCK128_GEMV_M1_BF16IN
+
 #endif  // ENABLE_SM89_BLOCK_FP8_GEMM
 
 #ifdef ENABLE_QWEN3_VL_BF16_CUBLASLT

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -293,8 +293,9 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         py::arg("stream") = 0);
 
     // Bench-only tile-variant bindings for prefill GEMM tuning. Not used by
-    // the frontend; exposed so the micro-bench can sweep tiles and candidate
-    // kernels without re-templating the dispatcher.
+    // the frontend; exposed only for explicit Qwen3-VL dev builds so the
+    // production pybind surface stays runtime-only.
+#ifdef ENABLE_QWEN3_VL_DEV_KERNELS
 #define BIND_GEMM_TILE(NAME)                                                        m.def("bench_" #NAME,                                                               [](uintptr_t A, uintptr_t B, uintptr_t D, int M, int N, int K,                     uintptr_t act_scale, uintptr_t w_scale, uintptr_t stream) {                      return flash_rt::gemm::block128_sm89::NAME(                                         to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,                                      reinterpret_cast<const float*>(act_scale),                                      reinterpret_cast<const float*>(w_scale), to_stream(stream));            },                                                                              py::arg("A"), py::arg("B"), py::arg("D"),                                      py::arg("M"), py::arg("N"), py::arg("K"),                                      py::arg("act_block_scale"), py::arg("w_block_scale"),                          py::arg("stream") = 0)
     BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_16x64x128_w4);
     BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_32x64x128_w4);
@@ -305,6 +306,7 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
     BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_64x128x128_w8);
     BIND_GEMM_TILE(fp8_block128_gemm_bs_sm89_128x128x128_w8);
 #undef BIND_GEMM_TILE
+#endif
 
     m.def("qwen3_qk_norm_rope_kvwrite_bf16",
         [](uintptr_t q_pre, uintptr_t k_pre, uintptr_t v_pre,

--- a/docs/qwen3_vl_fp8_sm89.md
+++ b/docs/qwen3_vl_fp8_sm89.md
@@ -112,18 +112,41 @@ CUDA_VISIBLE_DEVICES=0 python scripts/smoke_qwen3_vl_fp8_sm89.py \
   --generate-tokens 0
 ```
 
-Result:
+Result (RTX 4090, sm_89, empty card, iters=30, median):
 
 ```text
 S=1581 pixel_shape=(6256, 1536) spans=[(4, 1568)]
-set_prompt_warm median=15.711 ms
-vision_only median=88.990 ms
-language_only_no_mm_scatter median=120.634 ms
-prefill median=206.987 ms top=785 finite=True
-prefill_graph median=206.214 ms cos_vs_eager=0.998522 top=785 finite=True
-graph_decode_cache_pos=1581 median=10.681 ms cos_vs_eager=1.000000
+set_prompt_warm median=12.594 ms
+vision_only median=82.009 ms
+language_only_no_mm_scatter median=106.863 ms
+prefill median=193.291 ms top=785 finite=True
+prefill_graph median=193.183 ms cos_vs_eager=1.000000 top=785 finite=True
+graph_decode_cache_pos=1581 median=9.284 ms cos_vs_eager=1.000000
 top_eager=2168 top_graph=2168
 ```
+
+vs the initial PR #111 numbers (iters=3 at PR time): `prefill_graph`
+206.214 → 193.183 ms (**-6.3%**), `graph_decode` 10.681 → 9.284 ms
+(**-13.1%**), `language_only_no_mm_scatter` 120.634 → 106.863 ms (-11.4%),
+`vision_only` 88.990 → 82.009 ms (-7.8%). The decode gain comes from the
+decode-path work on this branch (BF16-input GEMV skipping the FP8 activation
+quant for O-proj / lm_head / qkv / gate_up, BF16-output RMSNorm feeding the
+bf16in GEMV, 512-thread decode norm for 8B occupancy, gate/up GEMV fusion,
+last-layer residual + final RMSNorm fusion); the prefill gain is dominated by
+the small-M 32x64 GEMM tile (short prefill, M<256) plus cross-layer norm
+fusion and kernel-lookup caching. Large-M prefill GEMM (the FlashRT.png
+single-image workload, M=1581) is L2-bandwidth-bound at ~84% L2 / 42% compute
+/ 33% occupancy and was not further optimized on this branch.
+
+Text-only decode (`--text-only`, iters=30, median):
+
+```text
+S=79 prefill median=12.641 ms (8B) / 6.586 ms (2B)
+graph_decode_pos=63 median=8.715 ms (8B) / 2.361 ms (2B), cos_vs_eager=1.000000
+```
+
+8B text decode 9.213 → 8.715 ms, 2B text decode 2.552 → 2.361 ms vs the
+2026-07-05 branch baseline.
 
 The same workload on the SM120/NVFP4 path is faster because it uses Blackwell
 NVFP4 language kernels. The SM89 path is intended to use the best available

--- a/docs/qwen3_vl_fp8_sm89.md
+++ b/docs/qwen3_vl_fp8_sm89.md
@@ -58,11 +58,13 @@ The dtype mapping is:
 | Residual stream and norms | BF16 |
 | Vision protected blocks | BF16 |
 | Vision bulk GEMMs | FP8 block-128 activation/weight, BF16 output |
-| `lm_head` default | BF16 |
+| `lm_head` default | FP8 block-128 |
 
-`use_fp8_lm_head=True` remains an explicit experimental mode. Single-step
-logits can match closely, but multi-token generation can diverge after the
-first generated tokens, so BF16 `lm_head` is the default.
+`use_fp8_lm_head=True` is the default for the SM89 FP8 path because the
+vocabulary projection is a large decode-time weight read. For BF16 reference
+validation or deployment comparisons, construct the frontend with
+`use_fp8_lm_head=False` or pass `--no-fp8-lm-head` to
+`scripts/smoke_qwen3_vl_fp8_sm89.py`.
 
 ## Quickstart
 

--- a/docs/qwen3_vl_fp8_sm89.md
+++ b/docs/qwen3_vl_fp8_sm89.md
@@ -153,13 +153,14 @@ graph_decode_pos=63 median=8.715 ms (8B) / 2.361 ms (2B), cos_vs_eager=1.000000
 The same workload on the SM120/NVFP4 path is faster because it uses Blackwell
 NVFP4 language kernels. The SM89 path is intended to use the best available
 Ada-compatible dtype path: official FP8 language weights, BF16 attention and
-residual state, and BF16 `lm_head`.
+residual state, and FP8 `lm_head` by default.
 
 ## Limits
 
 - This is not an NVFP4 implementation. SM89 uses official FP8 weights because
   NVFP4 is a Blackwell path.
-- `lm_head` stays BF16 by default for generation quality.
+- FP8 `lm_head` is the default; use `use_fp8_lm_head=False` or
+  `--no-fp8-lm-head` for BF16 reference comparisons.
 - Single-image prefill has a CUDA Graph replay path. Multi-image and video
   should use the eager path unless separately validated.
 - Decode graphs are captured per cache position because the FA2 call captures

--- a/docs/qwen3_vl_fp8_sm89_2b.md
+++ b/docs/qwen3_vl_fp8_sm89_2b.md
@@ -69,28 +69,38 @@ python scripts/smoke_qwen3_vl_fp8_sm89.py \
 Environment: NVIDIA GeForce RTX 4090 (SM89); checkpoint
 `Qwen3-VL-2B-Instruct-FP8` (quantized as above); FP8 `lm_head`.
 
-Text-only (S=79 prefill, decode at cache_pos=63):
+Text-only (S=79 prefill, decode at cache_pos=63, iters=30, median):
 
 ```text
-S=79 prefill median=8.489 ms
-prefill_speedup=52.09x logit_cos=0.999426 top_prefill=198 top_loop=198
-graph_decode_pos=63 median=2.653 ms (377 tok/s) top=19564 finite=True
+S=79 prefill median=6.586 ms
+prefill_speedup=63.68x logit_cos=0.999504 top_prefill=198 top_loop=198
+graph_decode_pos=63 median=2.361 ms (423 tok/s) cos_vs_eager=1.000000 top=19564 finite=True
 ```
 
-Multimodal (`FlashRT.png`, `Describe this image in one sentence.`, S=1581):
+2B text decode 2.653 → 2.361 ms (377 → 423 tok/s) vs the initial PR #111
+number, from the decode-path work on this branch (BF16-input GEMV, BF16-output
+RMSNorm, gate/up GEMV fusion, FP8 lm_head).
+
+Multimodal (`FlashRT.png`, `Describe this image in one sentence.`, S=1581,
+iters=30, median):
 
 ```text
 S=1581 pixel_shape=(6256, 1536) spans=[(4, 1568)]
-vision_only median=69.670 ms
-language_only_no_mm_scatter median=29.827 ms
-prefill median=102.991 ms top=32 finite=True
-prefill_graph median=99.743 ms cos_vs_eager=0.997508 top=32 finite=True
-graph_decode_cache_pos=1581 median=2.966 ms (337 tok/s) cos_vs_eager=1.000000
+vision_only median=53.682 ms
+language_only_no_mm_scatter median=26.402 ms
+prefill median=81.548 ms top=32 finite=True
+prefill_graph median=81.129 ms cos_vs_eager=1.000000 top=32 finite=True
+graph_decode_cache_pos=1581 median=2.669 ms (375 tok/s) cos_vs_eager=1.000000
   top_eager=3691 top_graph=3691
 generate_tokens=32 text='A black background features the "FlashRT" logo, with
   an orange lightning bolt symbol next to the stylized text "FlashRT" in white
   and orange.'
 ```
+
+2B multimodal `prefill_graph` 99.743 → 81.129 ms (**-18.6%**), `graph_decode`
+2.966 → 2.669 ms (**-10.0%**), `vision_only` 69.670 → 53.682 ms (-23%),
+`language_only_no_mm_scatter` 29.827 → 26.402 ms (-11.4%) vs the initial PR
+#111 numbers.
 
 These numbers are local validation points, not CI guarantees. Re-benchmark on
 the target GPU, driver, and build flags before treating them as deployment

--- a/docs/qwen3_vl_fp8_sm89_2b.md
+++ b/docs/qwen3_vl_fp8_sm89_2b.md
@@ -47,21 +47,20 @@ cmake -S . -B build -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON
 cmake --build build -j --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels
 ```
 
-## lm_head: optional FP8 mode for 2B
+## lm_head default
 
-The frontend default is BF16 `lm_head` (shared with the 8B path). For
-throughput-sensitive local validation, pass `use_fp8_lm_head=True` or
-`--fp8-lm-head`. The 152k-vocab projection is a large decode-time weight read,
-so FP8 `lm_head` can reduce bandwidth pressure on 2B. Treat it as a performance
-mode: validate logits and generation quality against the default BF16 head on
-the target checkpoint before using it in production.
+The frontend default is FP8 `lm_head` (shared with the 8B path). The
+152k-vocab projection is a large decode-time weight read, so FP8 `lm_head`
+reduces bandwidth pressure on 2B. For BF16 reference validation or deployment
+comparisons, construct the frontend with `use_fp8_lm_head=False` or pass
+`--no-fp8-lm-head` to `scripts/smoke_qwen3_vl_fp8_sm89.py`.
 
 ## Quickstart
 
 ```bash
 python scripts/smoke_qwen3_vl_fp8_sm89.py \
   --checkpoint /path/to/Qwen3-VL-2B-Instruct-FP8 \
-  --multimodal --fp8-lm-head --iters 10 --generate-tokens 32
+  --multimodal --iters 10 --generate-tokens 32
 ```
 
 ## RTX 4090 Validation

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -419,6 +419,19 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
     Returns:
         VLAModel instance with .predict() method.
     """
+    # Qwen3-VL is a chat-style VLM, not a VLA predict(images, ...) model. It
+    # is registered in _PIPELINE_MAP for resolve_pipeline_class/discovery, but
+    # load_model's VLAModel wrapper would expose the wrong runtime surface.
+    if config == "qwen3_vl":
+        raise NotImplementedError(
+            "config='qwen3_vl' is a chat-style VLM and is not served through "
+            "load_model's VLA wrapper. Construct the target frontend directly:\n"
+            "    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal "
+            "import Qwen3VlFp8Sm89Frontend\n"
+            "    from flash_rt.frontends.torch.qwen3_vl_rtx import "
+            "Qwen3VlTorchFrontendRtx\n"
+            "See docs/qwen3_vl_fp8_sm89.md and docs/qwen3_vl_nvfp4.md.")
+
     if config not in ("pi05", "groot", "groot_n17", "pi0", "pi0fast",
                       "motus", "wan22_ti2v_5b", "cosmos3_video", "nexn2"):
         raise ValueError(

--- a/flash_rt/frontends/torch/qwen3_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_rtx.py
@@ -1947,3 +1947,28 @@ class Qwen3TorchFrontendRtx:
                         self._static_token_id, cos, sin, cur,
                     )
         return torch.tensor([ids_list], device=self.device)
+
+    def get_latency_stats(self) -> dict:
+        """Return summary statistics over recorded latencies (ms).
+
+        ``latency_records`` is populated by external callers (benchmarks,
+        servers) rather than internally, because adding
+        ``torch.cuda.synchronize()`` on every decode step would serialize
+        the pipeline and destroy throughput. Call
+        ``frontend.latency_records.append(dt_ms)`` from your timing loop,
+        then call this method to get the summary.
+        """
+        if not self.latency_records:
+            return {}
+        import numpy as np
+        lat = np.array(self.latency_records)
+        return {
+            "count": len(lat),
+            "mean_ms": float(np.mean(lat)),
+            "std_ms": float(np.std(lat)),
+            "min_ms": float(np.min(lat)),
+            "max_ms": float(np.max(lat)),
+            "p50_ms": float(np.percentile(lat, 50)),
+            "p95_ms": float(np.percentile(lat, 95)),
+            "hz": float(1000 / np.mean(lat)),
+        }

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -392,6 +392,17 @@ class Qwen3VlFp8Sm89TextFrontend:
         fn(act.data_ptr(), weight_ptr, out.data_ptr(), 1, N, K,
            scale.data_ptr(), w_scale_ptr, 1.0, s)
 
+    def _gemv_bf16in(self, act_bf16, weight_ptr: int, w_scale_ptr: int,
+                     out, N: int, K: int) -> None:
+        import torch
+        s = torch.cuda.current_stream().cuda_stream
+        if N >= 4096:
+            fn = self._fvk.ht_gemv_fp8_block128_m1_bf16in_w16
+        else:
+            fn = self._fvk.ht_gemv_fp8_block128_m1_bf16in_w8
+        fn(act_bf16.data_ptr(), weight_ptr, out.data_ptr(), 1, N, K,
+           w_scale_ptr, s)
+
     def _prefill_gemm(self, act, scale, weight_ptr: int,
                       w_scale_ptr: int, out, N: int, K: int,
                       S: int) -> None:
@@ -416,10 +427,10 @@ class Qwen3VlFp8Sm89TextFrontend:
         s = torch.cuda.current_stream().cuda_stream
         last_row = last_row.view(1, hidden).contiguous()
         if self.use_fp8_lm_head:
-            ap, sc, _ = self._quant(last_row, (vocab, hidden))
-            self._gemv(ap, sc, int(self._weights.ptrs['lm_head_fp8_w']),
-                       int(self._weights.ptrs['lm_head_fp8_s']),
-                       self._logits_buf, vocab, hidden)
+            self._gemv_bf16in(last_row,
+                              int(self._weights.ptrs['lm_head_fp8_w']),
+                              int(self._weights.ptrs['lm_head_fp8_s']),
+                              self._logits_buf, vocab, hidden)
         else:
             self._fvk.bf16_matmul_bf16(
                 last_row.data_ptr(), int(self._weights.ptrs['lm_head_w']),
@@ -490,9 +501,9 @@ class Qwen3VlFp8Sm89TextFrontend:
             'full', layer_idx=L, q_seq=1, kv_seq=cur_pos + 1,
             stream=s, causal=True)
         attn_2d = self._attn.O_buf[:, :1].reshape(1, hidden).contiguous()
-        ap, sc, o_out = self._quant(attn_2d, (hidden, hidden))
-        self._gemv(ap, sc, int(lw['o_proj_w']), int(lw['o_proj_s']),
-                   o_out, hidden, hidden)
+        o_out = self._fp8_scratch[(hidden, hidden)][2]
+        self._gemv_bf16in(attn_2d, int(lw['o_proj_w']), int(lw['o_proj_s']),
+                          o_out, hidden, hidden)
 
         attn_proj = o_out.view(1, 1, hidden)
         h_post = self._res_mid[:, :1]

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -19,16 +19,24 @@ class _MergedKernels:
     Qwen3-VL FP8 kernels live in their own .so (mirroring the SM120 split)
     while frontend call sites keep using a single ``fvk`` handle."""
 
-    __slots__ = ('_vl', '_core')
+    __slots__ = ('_vl', '_core', '_cache')
 
     def __init__(self, vl: Any, core: Any) -> None:
         self._vl = vl
         self._core = core
+        self._cache: dict[str, Any] = {}
 
     def __getattr__(self, name: str) -> Any:
-        if self._vl is not None and hasattr(self._vl, name):
-            return getattr(self._vl, name)
-        return getattr(self._core, name)
+        cache = self._cache
+        if name in cache:
+            return cache[name]
+        vl = self._vl
+        if vl is not None and hasattr(vl, name):
+            fn = getattr(vl, name)
+        else:
+            fn = getattr(self._core, name)
+        cache[name] = fn
+        return fn
 
 
 def _import_fvk() -> Any:

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -533,6 +533,9 @@ class Qwen3VlFp8Sm89TextFrontend:
 
     def _layer_forward_prefill_fp8_blockscaled(self, L: int, h_in_S, cos_S,
                                            sin_S, start_pos: int, S: int,
+                                           *,
+                                           prequant=None,
+                                           next_input_norm_w: int = 0,
                                            final_norm_w: int = 0,
                                            final_norm_out=None):
         import torch
@@ -551,10 +554,15 @@ class Qwen3VlFp8Sm89TextFrontend:
         lw = self._weights.ptrs['layers'][L]
         h2 = h_in_S.view(S, hidden)
 
-        ap_h, sc_h, qkv_out = self._prefill_fp8_scratch[(n_q * hd + 2 * n_kv * hd, hidden)]
-        fvk.rms_norm_to_fp8_block128_bf16(
-            h2.data_ptr(), int(lw['input_norm_w']),
-            ap_h.data_ptr(), sc_h.data_ptr(), S, hidden, eps, s)
+        qkv_N = n_q * hd + 2 * n_kv * hd
+        if prequant is None:
+            ap_h, sc_h, qkv_out = self._prefill_fp8_scratch[(qkv_N, hidden)]
+            fvk.rms_norm_to_fp8_block128_bf16(
+                h2.data_ptr(), int(lw['input_norm_w']),
+                ap_h.data_ptr(), sc_h.data_ptr(), S, hidden, eps, s)
+        else:
+            ap_h, sc_h = prequant
+            qkv_out = self._prefill_fp8_scratch[(qkv_N, hidden)][2]
         self._prefill_gemm(
             ap_h, sc_h, int(lw['qkv_proj_w']), int(lw['qkv_proj_s']),
             qkv_out, int(lw['qkv_proj_N']), hidden, S)
@@ -632,11 +640,19 @@ class Qwen3VlFp8Sm89TextFrontend:
                 down_out[:S].view(1, S, hidden).contiguous().data_ptr(),
                 final_norm_w, final_norm_out.data_ptr(),
                 S, hidden, eps, s)
-            return final_norm_out.view(1, S, hidden)
+            return final_norm_out.view(1, S, hidden), None
         h_out = (self._layer_out_a if (L % 2 == 0)
                  else self._layer_out_b)[:, :S]
-        torch.add(h_post, down_out[:S].view(1, S, hidden), out=h_out)
-        return h_out
+        mlp_out = down_out[:S].view(1, S, hidden)
+        if next_input_norm_w:
+            next_ap, next_sc, _ = self._prefill_fp8_scratch[(qkv_N, hidden)]
+            fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+                h_post.data_ptr(), mlp_out.data_ptr(), h_out.data_ptr(),
+                int(next_input_norm_w),
+                next_ap.data_ptr(), next_sc.data_ptr(), S, hidden, eps, s)
+            return h_out, (next_ap, next_sc)
+        torch.add(h_post, mlp_out, out=h_out)
+        return h_out, None
 
     def forward_hidden_prefill_fp8_blockscaled(self, h_S, cos_S, sin_S,
                                            start_pos: int = 0,
@@ -663,20 +679,27 @@ class Qwen3VlFp8Sm89TextFrontend:
         last_has_ds = (deepstack_by_layer is not None
                        and (n_layers - 1) in deepstack_by_layer)
         h = h_S.view(1, S, hidden).to(torch.bfloat16).contiguous()
+        prequant = None
         for L in range(n_layers):
+            next_norm = 0
             fnw = 0
             fno = None
-            if L + 1 == n_layers and not last_has_ds:
+            if L + 1 < n_layers:
+                next_norm = int(
+                    self._weights.ptrs['layers'][L + 1]['input_norm_w'])
+            elif not last_has_ds:
                 fnw = final_norm_ptr
                 fno = self._last_hidden_buf[:, :S].view(S, hidden)
-            h = self._layer_forward_prefill_fp8_blockscaled(
+            h, prequant = self._layer_forward_prefill_fp8_blockscaled(
                 L, h, cos_S, sin_S, start_pos, S,
+                prequant=prequant, next_input_norm_w=next_norm,
                 final_norm_w=fnw, final_norm_out=fno)
             if deepstack_by_layer is not None and L in deepstack_by_layer:
                 for a, b, ds in deepstack_by_layer[L]:
                     self._fvk.residual_add(
                         h[0, a:b].data_ptr(), ds.data_ptr(),
                         (b - a) * hidden, s)
+                prequant = None
 
         self._cur_pos = start_pos + S
         if not last_has_ds:

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -421,9 +421,11 @@ class Qwen3VlFp8Sm89TextFrontend:
     def _layer_forward(self, L: int, h_in, cos, sin, cur_pos: int,
                        *,
                        prequant=None,
-                       next_input_norm_w: int = 0):
+                       next_input_norm_w: int = 0,
+                       final_norm_w: int = 0,
+                       final_norm_out=None):
         import torch
-        fvk = _import_fvk()
+        fvk = self._fvk
 
         cfg = self._cfg
         assert cfg is not None
@@ -520,14 +522,22 @@ class Qwen3VlFp8Sm89TextFrontend:
                 int(next_input_norm_w),
                 next_ap.data_ptr(), next_sc.data_ptr(), 1, hidden, eps, s)
             return h_out, (next_ap, next_sc)
+        if final_norm_w:
+            fvk.residual_add_rms_norm(
+                h_post.data_ptr(), mlp_out.data_ptr(),
+                final_norm_w, final_norm_out.data_ptr(),
+                1, hidden, eps, s)
+            return final_norm_out, None
         torch.add(h_post, mlp_out, out=h_out)
         return h_out, None
 
     def _layer_forward_prefill_fp8_blockscaled(self, L: int, h_in_S, cos_S,
-                                           sin_S, start_pos: int, S: int):
+                                           sin_S, start_pos: int, S: int,
+                                           final_norm_w: int = 0,
+                                           final_norm_out=None):
         import torch
 
-        fvk = _import_fvk()
+        fvk = self._fvk
 
         s = torch.cuda.current_stream().cuda_stream
         cfg = self._cfg
@@ -616,6 +626,13 @@ class Qwen3VlFp8Sm89TextFrontend:
             ap_dn, sc_dn, int(lw['mlp_down_w']), int(lw['mlp_down_s']),
             down_out, hidden, inter, S)
 
+        if final_norm_w:
+            fvk.residual_add_rms_norm(
+                h_post.data_ptr(),
+                down_out[:S].view(1, S, hidden).contiguous().data_ptr(),
+                final_norm_w, final_norm_out.data_ptr(),
+                S, hidden, eps, s)
+            return final_norm_out.view(1, S, hidden)
         h_out = (self._layer_out_a if (L % 2 == 0)
                  else self._layer_out_b)[:, :S]
         torch.add(h_post, down_out[:S].view(1, S, hidden), out=h_out)
@@ -641,23 +658,38 @@ class Qwen3VlFp8Sm89TextFrontend:
         if start_pos + S > self.max_seq:
             raise ValueError(
                 f'prefill end {start_pos + S} > max_seq {self.max_seq}')
+        n_layers = cfg['num_hidden_layers']
+        final_norm_ptr = int(self._weights.ptrs['final_norm_w'])
+        last_has_ds = (deepstack_by_layer is not None
+                       and (n_layers - 1) in deepstack_by_layer)
         h = h_S.view(1, S, hidden).to(torch.bfloat16).contiguous()
-        for L in range(cfg['num_hidden_layers']):
+        for L in range(n_layers):
+            fnw = 0
+            fno = None
+            if L + 1 == n_layers and not last_has_ds:
+                fnw = final_norm_ptr
+                fno = self._last_hidden_buf[:, :S].view(S, hidden)
             h = self._layer_forward_prefill_fp8_blockscaled(
-                L, h, cos_S, sin_S, start_pos, S)
+                L, h, cos_S, sin_S, start_pos, S,
+                final_norm_w=fnw, final_norm_out=fno)
             if deepstack_by_layer is not None and L in deepstack_by_layer:
                 for a, b, ds in deepstack_by_layer[L]:
                     self._fvk.residual_add(
                         h[0, a:b].data_ptr(), ds.data_ptr(),
                         (b - a) * hidden, s)
 
+        self._cur_pos = start_pos + S
+        if not last_has_ds:
+            if not run_lm_head:
+                return self._last_hidden_buf[:, :S]
+            return self._write_logits_from_hidden(
+                self._last_hidden_buf[0, S - 1:S])
         h2 = h.view(S, hidden).contiguous()
         x_norm = self._h_b[:S].view(S, hidden)
         self._fvk.rms_norm(
-            h2.data_ptr(), int(self._weights.ptrs['final_norm_w']),
+            h2.data_ptr(), final_norm_ptr,
             x_norm.data_ptr(), S, hidden, eps, s)
         self._last_hidden_buf[:, :S].copy_(x_norm.view(1, S, hidden))
-        self._cur_pos = start_pos + S
         if not run_lm_head:
             return self._last_hidden_buf[:, :S]
         return self._write_logits_from_hidden(
@@ -670,27 +702,39 @@ class Qwen3VlFp8Sm89TextFrontend:
         cfg = self._cfg
         assert cfg is not None
         hidden = cfg['hidden_size']
-        vocab = cfg['vocab_size']
         eps = float(cfg['rms_norm_eps'])
         s = torch.cuda.current_stream().cuda_stream
+        n_layers = cfg['num_hidden_layers']
+        final_norm_ptr = int(self._weights.ptrs['final_norm_w'])
+        last_has_ds = (deepstack_by_layer is not None
+                       and (n_layers - 1) in deepstack_by_layer)
         h = h.view(1, 1, hidden).contiguous()
         prequant = None
-        for L in range(cfg['num_hidden_layers']):
+        for L in range(n_layers):
             next_norm = 0
-            if L + 1 < cfg['num_hidden_layers']:
+            fnw = 0
+            fno = None
+            if L + 1 < n_layers:
                 next_norm = int(self._weights.ptrs['layers'][L + 1]
                                 ['input_norm_w'])
+            elif not last_has_ds:
+                fnw = final_norm_ptr
+                fno = self._last_hidden_buf[0, :1].view(1, hidden)
             h, prequant = self._layer_forward(
                 L, h, cos_pos, sin_pos, cur_pos,
-                prequant=prequant, next_input_norm_w=next_norm)
+                prequant=prequant, next_input_norm_w=next_norm,
+                final_norm_w=fnw, final_norm_out=fno)
             if deepstack_by_layer is not None and L in deepstack_by_layer:
                 h.add_(deepstack_by_layer[L].view(1, 1, hidden))
                 prequant = None
 
+        if not last_has_ds:
+            return self._write_logits_from_hidden(
+                self._last_hidden_buf[0, :1].view(1, hidden))
         x_norm = self._h_b[:1].view(1, hidden)
         self._fvk.rms_norm(
             h.view(1, hidden).contiguous().data_ptr(),
-            int(self._weights.ptrs['final_norm_w']), x_norm.data_ptr(),
+            final_norm_ptr, x_norm.data_ptr(),
             1, hidden, eps, s)
         self._last_hidden_buf[:, :1].copy_(x_norm.view(1, 1, hidden))
         return self._write_logits_from_hidden(x_norm)

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -58,7 +58,7 @@ class Qwen3VlFp8Sm89TextFrontend:
     def __init__(self, checkpoint_path: str, *,
                  device: str = 'cuda:0', max_seq: int = 2048,
                  max_prefill_seq: int | None = None,
-                 fuse_gate_up: bool = False,
+                 fuse_gate_up: bool = True,
                  fuse_qk_postproc: bool = True,
                  use_fp8_lm_head: bool = True,
                  max_decode_graphs: int | None = None) -> None:
@@ -684,8 +684,7 @@ class Qwen3VlFp8Sm89TextFrontend:
                 L, h, cos_pos, sin_pos, cur_pos,
                 prequant=prequant, next_input_norm_w=next_norm)
             if deepstack_by_layer is not None and L in deepstack_by_layer:
-                h = h.clone()
-                torch.add(h, deepstack_by_layer[L].view(1, 1, hidden), out=h)
+                h.add_(deepstack_by_layer[L].view(1, 1, hidden))
                 prequant = None
 
         x_norm = self._h_b[:1].view(1, hidden)

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -108,9 +108,13 @@ class Qwen3VlFp8Sm89TextFrontend:
             'fp8_block128_gemm_blockscaled_sm89_bf16out',
             'ht_gemv_fp8_block128_m1_w8',
             'ht_gemv_fp8_block128_m1_w16',
+            'ht_gemv_fp8_block128_m1_bf16in_w8',
+            'ht_gemv_fp8_block128_m1_bf16in_w16',
             'fp8_per_token_block128_quant_bf16',
             'rms_norm_to_fp8_block128_bf16',
             'residual_add_rms_norm_to_fp8_block128_bf16',
+            'rms_norm_bf16_out',
+            'residual_add_rms_norm_bf16_out',
             'silu_mul_to_fp8_block128_bf16',
             'silu_mul_merged_to_fp8_block128_bf16',
             'qwen3_qk_norm_rope_kvwrite_bf16',
@@ -314,6 +318,14 @@ class Qwen3VlFp8Sm89TextFrontend:
             scale = torch.empty(1, K // 128, device=device, dtype=fp32)
             out = torch.empty(1, N, device=device, dtype=bf16)
             self._fp8_scratch[(N, K)] = (act, scale, out)
+        # BF16 activation scratch for the bf16in GEMV path (qkv / gate_up in
+        # decode). Keyed by K (activation length); one row each for the qkv
+        # input (K=hidden) and the gate_up input (K=hidden) — both share hidden,
+        # but the cross-layer fusion hands the same buffer to the next layer's
+        # qkv, so a single hidden-length buffer suffices.
+        self._bf16_act_scratch: dict[int, torch.Tensor] = {
+            hidden: torch.empty(1, hidden, device=device, dtype=bf16),
+        }
         self._prefill_fp8_scratch: dict[
             tuple[int, int], tuple[torch.Tensor, ...]] = {}
         for N, K in (
@@ -458,15 +470,16 @@ class Qwen3VlFp8Sm89TextFrontend:
         lw = self._weights.ptrs['layers'][L]
         h2 = h_in.view(1, hidden).contiguous()
 
+        # qkv input: BF16 normed activation (no FP8 quant) → bf16in GEMV.
         if prequant is None:
-            ap, sc, _ = self._fp8_scratch[(self._qkv_N, hidden)]
-            fvk.rms_norm_to_fp8_block128_bf16(
+            ap_bf = self._bf16_act_scratch[hidden]
+            fvk.rms_norm_bf16_out(
                 h2.data_ptr(), int(lw['input_norm_w']),
-                ap.data_ptr(), sc.data_ptr(), 1, hidden, eps, s)
+                ap_bf.data_ptr(), 1, hidden, eps, s)
         else:
-            ap, sc = prequant
-        self._gemv(ap, sc, int(lw['qkv_proj_w']), int(lw['qkv_proj_s']),
-                   self._qkv_out, int(lw['qkv_proj_N']), hidden)
+            ap_bf = prequant
+        self._gemv_bf16in(ap_bf, int(lw['qkv_proj_w']), int(lw['qkv_proj_s']),
+                          self._qkv_out, int(lw['qkv_proj_N']), hidden)
         Nq = n_q * hd
         Nk = n_kv * hd
         qkv_out = self._qkv_out[:1]
@@ -507,23 +520,29 @@ class Qwen3VlFp8Sm89TextFrontend:
 
         attn_proj = o_out.view(1, 1, hidden)
         h_post = self._res_mid[:, :1]
-        ap, sc, gate_out = self._fp8_scratch[(inter, hidden)]
-        fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+        # gate_up input: BF16 normed activation → bf16in GEMV.
+        ap_bf_mlp = self._bf16_act_scratch[hidden]
+        fvk.residual_add_rms_norm_bf16_out(
             h_in.data_ptr(), attn_proj.data_ptr(), h_post.data_ptr(),
             int(lw['post_attn_norm_w']),
-            ap.data_ptr(), sc.data_ptr(), 1, hidden, eps, s)
+            ap_bf_mlp.data_ptr(), 1, hidden, eps, s)
         if self.fuse_gate_up:
-            self._gemv(ap, sc, int(lw['gate_up_w']), int(lw['gate_up_s']),
-                       self._gate_up_out, int(lw['gate_up_N']), hidden)
+            self._gemv_bf16in(ap_bf_mlp, int(lw['gate_up_w']),
+                              int(lw['gate_up_s']), self._gate_up_out,
+                              int(lw['gate_up_N']), hidden)
             gate_out = self._gate_up_out[:, :inter]
             up_out = self._gate_up_out[:, inter:]
         else:
-            self._gemv(ap, sc, int(lw['mlp_gate_w']), int(lw['mlp_gate_s']),
-                       self._gate_out, inter, hidden)
-            self._gemv(ap, sc, int(lw['mlp_up_w']), int(lw['mlp_up_s']),
-                       self._up_out, inter, hidden)
+            self._gemv_bf16in(ap_bf_mlp, int(lw['mlp_gate_w']),
+                              int(lw['mlp_gate_s']), self._gate_out, inter,
+                              hidden)
+            self._gemv_bf16in(ap_bf_mlp, int(lw['mlp_up_w']),
+                              int(lw['mlp_up_s']), self._up_out, inter, hidden)
             gate_out = self._gate_out
             up_out = self._up_out
+        # down_proj stays FP8: silu_mul output is quantized to FP8 (the silu
+        # result has a wide dynamic range and the FP8 path here is already at
+        # roofline; bf16in down-proj would need a separate BF16 silu kernel).
         ap, sc, down_out = self._fp8_scratch[(hidden, inter)]
         fvk.silu_mul_to_fp8_block128_bf16(
             gate_out.data_ptr(), up_out.data_ptr(),
@@ -535,12 +554,12 @@ class Qwen3VlFp8Sm89TextFrontend:
                  else self._layer_out_b)[:, :1]
         mlp_out = down_out.view(1, 1, hidden)
         if next_input_norm_w:
-            next_ap, next_sc, _ = self._fp8_scratch[(self._qkv_N, hidden)]
-            fvk.residual_add_rms_norm_to_fp8_block128_bf16(
+            next_ap_bf = self._bf16_act_scratch[hidden]
+            fvk.residual_add_rms_norm_bf16_out(
                 h_post.data_ptr(), mlp_out.data_ptr(), h_out.data_ptr(),
                 int(next_input_norm_w),
-                next_ap.data_ptr(), next_sc.data_ptr(), 1, hidden, eps, s)
-            return h_out, (next_ap, next_sc)
+                next_ap_bf.data_ptr(), 1, hidden, eps, s)
+            return h_out, next_ap_bf
         if final_norm_w:
             fvk.residual_add_rms_norm(
                 h_post.data_ptr(), mlp_out.data_ptr(),

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89.py
@@ -60,7 +60,7 @@ class Qwen3VlFp8Sm89TextFrontend:
                  max_prefill_seq: int | None = None,
                  fuse_gate_up: bool = False,
                  fuse_qk_postproc: bool = True,
-                 use_fp8_lm_head: bool = False,
+                 use_fp8_lm_head: bool = True,
                  max_decode_graphs: int | None = None) -> None:
         import json
 

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
@@ -20,7 +20,7 @@ class Qwen3VlFp8Sm89Frontend:
     def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
                  max_seq: int = 4096, max_prefill_seq: int | None = None,
                  max_pixels: int | None = None,
-                 fuse_gate_up: bool = False,
+                 fuse_gate_up: bool = True,
                  fuse_qk_postproc: bool = True,
                  use_fp8_lm_head: bool = True,
                  vision_bf16_first_blocks: int = 3,

--- a/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
+++ b/flash_rt/frontends/torch/qwen3_vl_fp8_sm89_multimodal.py
@@ -22,7 +22,7 @@ class Qwen3VlFp8Sm89Frontend:
                  max_pixels: int | None = None,
                  fuse_gate_up: bool = False,
                  fuse_qk_postproc: bool = True,
-                 use_fp8_lm_head: bool = False,
+                 use_fp8_lm_head: bool = True,
                  vision_bf16_first_blocks: int = 3,
                  vision_bf16_block_linears: dict[int, tuple[str, ...]]
                  | None = None,
@@ -188,7 +188,6 @@ class Qwen3VlFp8Sm89Frontend:
 
         from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
 
-        self._decode_graphs.clear()
         inputs = self.processor.apply_chat_template(
             messages, add_generation_prompt=True, tokenize=True,
             return_dict=True, return_tensors='pt',

--- a/flash_rt/frontends/torch/qwen3_vl_rtx.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx.py
@@ -1,10 +1,9 @@
 """FlashRT — PyTorch frontend for Qwen3-VL (multimodal) on RTX SM120.
 
 Class name ``Qwen3VlTorchFrontendRtx`` follows the
-``docs/adding_new_model.md`` §0 naming rule, and the direct-instantiation
-pattern of the text sibling ``qwen3_rtx.Qwen3TorchFrontendRtx`` (the
-Qwen3 LLM paths are not registered in ``_PIPELINE_MAP``; a server or test
-constructs the frontend directly).
+``docs/adding_new_model.md`` §0 naming rule. Registered in
+``_PIPELINE_MAP`` as ``("qwen3_vl", "torch", "rtx_sm120")`` for
+discoverability; direct instantiation is the typical usage pattern.
 
 The language stack is the existing dense-Qwen3 NVFP4 W4A4 path, reused
 unchanged via ``Qwen3TorchFrontendRtx``; this frontend adds the ViT
@@ -139,6 +138,7 @@ class Qwen3VlTorchFrontendRtx:
                 if isinstance(size, dict) and 'longest_edge' in size:
                     size['longest_edge'] = int(max_pixels)
 
+        self.latency_records: list[float] = []
         self._prompt: dict[str, Any] | None = None
         if max_prefill_graphs is None:
             max_prefill_graphs = int(os.environ.get(
@@ -582,7 +582,14 @@ class Qwen3VlTorchFrontendRtx:
         max position while the KV-cache slot advances from the
         image-compressed prompt length. ``use_graph`` replays a per-slot
         captured CUDA Graph for each decode step.
+
+        Wall-clock latency of the full generate call (prefill + all decode
+        steps) is appended to ``self.latency_records`` (ms).
         """
+        import time
+        import torch
+
+        t0 = time.perf_counter()
         self.set_prompt(messages)
         logits = self.prefill_graph()
         llm = self.llm
@@ -604,11 +611,34 @@ class Qwen3VlTorchFrontendRtx:
             tok = int(logits[0].float().argmax())
             out_ids.append(tok)
 
+        torch.cuda.synchronize()
+        self.latency_records.append((time.perf_counter() - t0) * 1000)
+
         eos = [t for t in out_ids if t in self._eos_token_ids]
         if eos:
             out_ids = out_ids[:out_ids.index(eos[0])]
         return self.processor.tokenizer.decode(
             out_ids, skip_special_tokens=True)
+
+    def get_latency_stats(self) -> dict:
+        """Return summary statistics over recorded generate latencies (ms).
+
+        Each ``generate()`` call appends one wall-clock measurement
+        (prefill + all decode steps) to ``self.latency_records``.
+        """
+        if not self.latency_records:
+            return {}
+        import numpy as np
+        lat = np.array(self.latency_records)
+        return {
+            "count": len(lat),
+            "mean_ms": float(np.mean(lat)),
+            "std_ms": float(np.std(lat)),
+            "min_ms": float(np.min(lat)),
+            "max_ms": float(np.max(lat)),
+            "p50_ms": float(np.percentile(lat, 50)),
+            "p95_ms": float(np.percentile(lat, 95)),
+        }
 
     def _decode_step_graph(self, token: int, cache_pos: int, rope_pos: int):
         llm = self.llm

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -136,9 +136,10 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     # ── Qwen3-VL (multimodal Qwen3-VL-8B, NVFP4 + FP8 paths) ──
     # VLM with chat-style API (generate(messages) -> str), not VLA
     # predict(images). Requires the gated kernel build
-    # (-DFLASHRT_BUILD_QWEN3_VL=ON). Registered for discoverability;
-    # direct instantiation of the frontend class is the typical usage
-    # (see docs/qwen3_vl_nvfp4.md, docs/qwen3_vl_fp8_sm89.md).
+    # (-DFLASHRT_BUILD_QWEN3_VL=ON). Registered for resolver/direct frontend
+    # discovery only; load_model(config="qwen3_vl") raises a redirect because
+    # the frontend exposes a chat-style VLM surface rather than VLAModel.
+    # See docs/qwen3_vl_nvfp4.md and docs/qwen3_vl_fp8_sm89.md.
     ("qwen3_vl", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.qwen3_vl_rtx", "Qwen3VlTorchFrontendRtx"),
     ("qwen3_vl", "torch", "rtx_sm89"):

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -133,6 +133,18 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     ("cosmos3_video", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.cosmos3_video_rtx", "Cosmos3VideoTorchFrontendRtx"),
 
+    # ── Qwen3-VL (multimodal Qwen3-VL-8B, NVFP4 + FP8 paths) ──
+    # VLM with chat-style API (generate(messages) -> str), not VLA
+    # predict(images). Requires the gated kernel build
+    # (-DFLASHRT_BUILD_QWEN3_VL=ON). Registered for discoverability;
+    # direct instantiation of the frontend class is the typical usage
+    # (see docs/qwen3_vl_nvfp4.md, docs/qwen3_vl_fp8_sm89.md).
+    ("qwen3_vl", "torch", "rtx_sm120"):
+        ("flash_rt.frontends.torch.qwen3_vl_rtx", "Qwen3VlTorchFrontendRtx"),
+    ("qwen3_vl", "torch", "rtx_sm89"):
+        ("flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal",
+         "Qwen3VlFp8Sm89Frontend"),
+
     # ── Nex-N2-mini / Qwen3.6-35B-A3B (qwen3_5_moe) ──
     # Text LLM, not a VLA: GDN linear-attn + full-attn-every-4th + 256-expert
     # NVFP4 MoE. RTX 5090 (SM120) only, and requires the gated kernel build

--- a/flash_rt/models/__init__.py
+++ b/flash_rt/models/__init__.py
@@ -1,7 +1,11 @@
 """FlashRT — model-specific pipeline and calibration code.
 
-Each subdirectory (pi05/, groot/, pi0/, pi0fast/) holds the pipeline
-logic for one model family.  Hardware-specific attention backends live
-in ``flash_rt.hardware.{rtx,thor}``; frontends (weight loading, graph
+Each subdirectory holds the pipeline logic for one model family:
+pi05/, pi0/, pi0fast/, groot/, groot_n17/, qwen3/, qwen3_vl/, qwen36/,
+nexn2/, motus/, wan22/, cosmos3_video/, higgs_audio_v3/, omnivoice/,
+lingbot/, melband_roformer/, minimax_remover/.
+
+Hardware-specific attention backends live in
+``flash_rt.hardware.{rtx,thor}``; frontends (weight loading, graph
 capture, framework glue) live in ``flash_rt.frontends.{torch,jax}``.
 """

--- a/scripts/bench_fp8_lmhead.py
+++ b/scripts/bench_fp8_lmhead.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""A/B benchmark: BF16 vs FP8 lm_head on Qwen3-VL 8B SM89 decode.
+
+Loads two text frontends (one BF16 lm_head, one FP8), warms up decode
+graphs, and compares per-step latency. Reports the lm_head delta.
+
+Usage:
+    python scripts/bench_fp8_lmhead.py \
+        --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+import time
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def bench_decode(fe, label, iters=50, warmup=10, decode_pos=63):
+    fe.reset_state()
+    hidden = int(fe._cfg['hidden_size'])
+    embed = fe._weights.anchors[0]
+    ids = torch.arange(0, decode_pos + 1, device=fe.device, dtype=torch.long)
+    h = embed[ids].to(torch.bfloat16).view(decode_pos + 1, hidden)
+    cos = fe._rope_cos_table[:decode_pos + 1]
+    sin = fe._rope_sin_table[:decode_pos + 1]
+    fe.forward_hidden_prefill_fp8_blockscaled(h, cos, sin, 0)
+    torch.cuda.synchronize()
+
+    tok = 100
+    for _ in range(warmup):
+        fe.decode_step_with_graph(tok, decode_pos)
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(iters):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        fe.decode_step_with_graph(tok, decode_pos)
+        end.record()
+        end.synchronize()
+        times.append(float(start.elapsed_time(end)))
+
+    med = statistics.median(times)
+    mn = statistics.mean(times)
+    lo = min(times)
+    print(f"  [{label}] median={med:.3f} ms  mean={mn:.3f} ms  "
+          f"min={lo:.3f} ms  ({iters} iters)")
+    return times
+
+
+def run_one(checkpoint, device, max_seq, fp8_lm_head, iters, decode_pos):
+    import gc
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89 import (
+        Qwen3VlFp8Sm89TextFrontend,
+    )
+
+    label = 'fp8_lmhead' if fp8_lm_head else 'bf16_lmhead'
+    print(f"\nLoading {label} frontend...")
+    fe = Qwen3VlFp8Sm89TextFrontend(
+        checkpoint, device=device, max_seq=max_seq,
+        use_fp8_lm_head=fp8_lm_head)
+    times = bench_decode(fe, label, iters, decode_pos=decode_pos)
+
+    logits = fe.decode_step_with_graph(100, decode_pos)
+    torch.cuda.synchronize()
+    top = int(logits.float().argmax())
+
+    del fe
+    gc.collect()
+    torch.cuda.empty_cache()
+    return times, top
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--checkpoint', required=True)
+    p.add_argument('--device', default='cuda:0')
+    p.add_argument('--max-seq', type=int, default=2048)
+    p.add_argument('--iters', type=int, default=50)
+    p.add_argument('--decode-pos', type=int, default=63)
+    args = p.parse_args()
+
+    torch.cuda.set_device(torch.device(args.device))
+    print(f"GPU: {torch.cuda.get_device_name(torch.device(args.device))}")
+    print(f"checkpoint: {args.checkpoint}")
+
+    t_bf16, top_bf16 = run_one(args.checkpoint, args.device, args.max_seq,
+                                False, args.iters, args.decode_pos)
+    t_fp8, top_fp8 = run_one(args.checkpoint, args.device, args.max_seq,
+                              True, args.iters, args.decode_pos)
+
+    med_bf16 = statistics.median(t_bf16)
+    med_fp8 = statistics.median(t_fp8)
+    delta = med_bf16 - med_fp8
+    print(f"\n  Summary:")
+    print(f"    bf16_lmhead median={med_bf16:.3f} ms")
+    print(f"    fp8_lmhead  median={med_fp8:.3f} ms")
+    print(f"    delta={delta:.3f} ms  ({delta/med_bf16*100:.1f}%)")
+    print(f"    top_bf16={top_bf16}  top_fp8={top_fp8}  "
+          f"same_top={'YES' if top_bf16 == top_fp8 else 'NO'}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/bench_gemv_sm89.py
+++ b/scripts/bench_gemv_sm89.py
@@ -42,11 +42,10 @@ def main():
     args = p.parse_args()
     torch.cuda.set_device(torch.device(args.device))
 
-    sys.path.insert(0, str(REPO_ROOT / "flash_rt"))
     try:
-        import flash_rt_qwen3_vl_kernels as fvk
+        from flash_rt import flash_rt_qwen3_vl_kernels as fvk
     except ImportError:
-        import flash_rt_kernels as fvk
+        from flash_rt import flash_rt_kernels as fvk
 
     shapes_8b = [
         ("8B_qkv",     4096,  5120),

--- a/scripts/bench_gemv_sm89.py
+++ b/scripts/bench_gemv_sm89.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Micro-benchmark for SM89 FP8 block-128 GEMV kernels.
+
+Tests all three variants (w4, w8, w16) across representative (N, K) shapes
+from Qwen3-VL 8B and 2B decode. Use with ncu for roofline analysis:
+
+    ncu --set full -k "gemv_fp8_block128" -o gemv_profile \
+        python scripts/bench_gemv_sm89.py
+"""
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import pathlib
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _event_ms(fn, warmup=5, iters=50):
+    for _ in range(warmup):
+        fn()
+    times = []
+    for _ in range(iters):
+        s = torch.cuda.Event(enable_timing=True)
+        e = torch.cuda.Event(enable_timing=True)
+        s.record(); fn(); e.record(); e.synchronize()
+        times.append(float(s.elapsed_time(e)))
+    return times
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--iters", type=int, default=100)
+    p.add_argument("--ncu", action="store_true",
+                   help="single iteration for ncu profiling")
+    args = p.parse_args()
+    torch.cuda.set_device(torch.device(args.device))
+
+    sys.path.insert(0, str(REPO_ROOT / "flash_rt"))
+    try:
+        import flash_rt_qwen3_vl_kernels as fvk
+    except ImportError:
+        import flash_rt_kernels as fvk
+
+    shapes_8b = [
+        ("8B_qkv",     4096,  5120),
+        ("8B_gate_up", 4096, 28672),
+        ("8B_down",   14336,  4096),
+        ("8B_lm_head", 4096, 152064),
+    ]
+    shapes_2b = [
+        ("2B_qkv",     2048,  4096),
+        ("2B_gate_up", 2048, 12288),
+        ("2B_down",    6144,  2048),
+        ("2B_lm_head", 2048, 151936),
+    ]
+
+    all_shapes = shapes_8b + shapes_2b
+    s = torch.cuda.current_stream()
+
+    print(f"{'name':<14} {'K':>6} {'N':>7} {'variant':>7} "
+          f"{'median_us':>9} {'GB/s':>7} {'%peak':>6}")
+    print("-" * 68)
+
+    peak_bw = 1008.0  # RTX 4090 GB/s
+
+    for name, K, N in all_shapes:
+        A = torch.randn(K, device=args.device).to(torch.float8_e4m3fn)
+        B = torch.randn(N, K, device=args.device).to(torch.float8_e4m3fn)
+        D = torch.empty(N, device=args.device, dtype=torch.bfloat16)
+        K128 = K // 128
+        act_scale = torch.ones(K128, device=args.device, dtype=torch.float32)
+        w_scale = torch.ones(((N + 127) // 128) * K128,
+                             device=args.device, dtype=torch.float32)
+
+        variants = [
+            ("w4",  fvk.ht_gemv_fp8_block128_m1_w4),
+            ("w8",  fvk.ht_gemv_fp8_block128_m1_w8),
+            ("w16", fvk.ht_gemv_fp8_block128_m1_w16),
+        ]
+
+        data_bytes = N * K  # weight matrix (FP8, 1 byte each)
+
+        for vname, fn in variants:
+            def run():
+                fn(A.data_ptr(), B.data_ptr(), D.data_ptr(),
+                   1, N, K,
+                   act_scale.data_ptr(), w_scale.data_ptr(),
+                   1.0, s.cuda_stream)
+
+            if args.ncu:
+                run()
+            else:
+                times = _event_ms(run, warmup=10, iters=args.iters)
+                med_us = statistics.median(times) * 1000
+                bw = data_bytes / (med_us * 1e-6) / 1e9
+                pct = bw / peak_bw * 100
+                print(f"{name:<14} {K:>6} {N:>7} {vname:>7} "
+                      f"{med_us:>9.1f} {bw:>7.1f} {pct:>5.1f}%")
+        if not args.ncu:
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_graph_replay.py
+++ b/scripts/bench_graph_replay.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Test graph replay after re-prompting.
+
+Verifies that decode graph replay does not regress when set_prompt() is
+called again with the same prompt (multi-turn scenario).
+
+Usage:
+    python scripts/bench_graph_replay.py \
+        --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+import time
+
+import torch
+from PIL import Image
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def bench_decode_steps(fe, n_steps, label):
+    p = fe._prompt
+    assert p is not None
+    base_slot = int(p['S'])
+    logits = fe.prefill_graph()
+    tok = int(logits[0].float().argmax())
+
+    for i in range(n_steps):
+        logits = fe.decode_step_with_graph(tok, base_slot + i)
+        tok = int(logits[0].float().argmax())
+    torch.cuda.synchronize()
+
+    times = []
+    for _ in range(3):
+        fe.set_prompt(fe._last_messages)
+        logits = fe.prefill_graph()
+        tok = int(logits[0].float().argmax())
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for i in range(n_steps):
+            logits = fe.decode_step_with_graph(tok, base_slot + i)
+            tok = int(logits[0].float().argmax())
+        torch.cuda.synchronize()
+        dt = (time.perf_counter() - t0) * 1000
+        per_step = dt / n_steps
+        times.append(per_step)
+        print(f"  [{label}] {n_steps} steps: {dt:.1f} ms total, "
+              f"{per_step:.2f} ms/step")
+    return times
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--checkpoint', required=True)
+    p.add_argument('--device', default='cuda:0')
+    p.add_argument('--max-seq', type=int, default=2048)
+    p.add_argument('--decode-steps', type=int, default=16)
+    p.add_argument('--image', default=str(REPO_ROOT / 'FlashRT.png'))
+    p.add_argument('--prompt', default='Describe this image in one sentence.')
+    args = p.parse_args()
+
+    torch.cuda.set_device(torch.device(args.device))
+    print(f"GPU: {torch.cuda.get_device_name(torch.device(args.device))}")
+
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+        Qwen3VlFp8Sm89Frontend,
+    )
+
+    fe = Qwen3VlFp8Sm89Frontend(
+        args.checkpoint, device=args.device, max_seq=args.max_seq)
+    img = Image.open(args.image).convert('RGB')
+    messages = [{
+        'role': 'user',
+        'content': [
+            {'type': 'image', 'image': img},
+            {'type': 'text', 'text': args.prompt},
+        ],
+    }]
+    fe._last_messages = messages
+
+    print(f"\n--- Round 1: initial set_prompt + warmup ---")
+    fe.set_prompt(messages)
+    t1 = bench_decode_steps(fe, args.decode_steps, 'round1')
+
+    print(f"\n--- Round 2: re-prompt (same messages), graphs should be warm ---")
+    t2 = bench_decode_steps(fe, args.decode_steps, 'round2')
+
+    print(f"\n--- Round 3: re-prompt again ---")
+    t3 = bench_decode_steps(fe, args.decode_steps, 'round3')
+
+    med1 = statistics.median(t1)
+    med2 = statistics.median(t2)
+    med3 = statistics.median(t3)
+    print(f"\n  Summary (median ms/step):")
+    print(f"    round1={med1:.2f}  round2={med2:.2f}  round3={med3:.2f}")
+    if med1 > 0:
+        ratio = med2 / med1
+        print(f"    round2/round1={ratio:.2f}x "
+              f"{'(regression!)' if ratio > 1.5 else '(OK)'}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/bench_prefill_gemm.py
+++ b/scripts/bench_prefill_gemm.py
@@ -50,8 +50,10 @@ SHAPES_8B = [("8B_qkv", 6144, 4096), ("8B_o", 4096, 4096),
 
 def bench(fn, args, warmup, iters, pollute=None):
     s = torch.cuda.current_stream().cuda_stream
+    # All bench GEMM bindings take (A,B,D,M,N,K,asc,wsc,stream). The cold/warm
+    # callers already pass `s` as the trailing positional arg, so forward as-is.
     def run():
-        fn(*args, stream=s) if fn.__code__.co_argcount > 7 else fn(*args)
+        fn(*args)
     for _ in range(warmup):
         if pollute is not None: pollute()
         run()

--- a/scripts/bench_prefill_gemm.py
+++ b/scripts/bench_prefill_gemm.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import argparse, statistics, sys, pathlib
 import torch
 REPO = pathlib.Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO)); sys.path.insert(0, str(REPO / "flash_rt"))
+sys.path.insert(0, str(REPO))
 
 PEAK_DENSE_TFLOPS = 165.0  # RTX 4090 FP8 dense (no 2:4 sparsity)
 
@@ -79,7 +79,7 @@ def main():
     p.add_argument("--model", choices=["2B", "8B", "both"], default="both")
     args = p.parse_args()
     torch.cuda.set_device(torch.device(args.device))
-    import flash_rt_qwen3_vl_kernels as fvk
+    from flash_rt import flash_rt_qwen3_vl_kernels as fvk
 
     sel = list(TILES.keys()) if not args.tiles else args.tiles.split(",")
     shapes = []

--- a/scripts/bench_prefill_gemm.py
+++ b/scripts/bench_prefill_gemm.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Trusted SM89 FP8 block-128 prefill GEMM micro-bench.
+
+Three L2 regimes, all timed with CUDA events on the default stream (correct
+graph/stream handling):
+
+  warm   — one B reused; B fully L2-resident. Upper bound for a single tile
+           (L2 hits, compute-bound). Useful for relative tile ranking at the
+           "kernel is fast" limit.
+  layer  — N_LAYERS distinct B matrices cycled (one per virtual layer), each
+           timed launch steps through them round-robin. Closest to real
+           prefill: per-layer weight is distinct, so weights do NOT all fit L2
+           (8B gate_up 112MB > 72MB) and there is partial eviction. This is
+           the PRIMARY metric.
+  cold   — 128MB L2 pollute before each timed launch. True cold-B. Lower
+           bound (HBM-load dominated). Use to check HBM-bound shapes.
+
+Peak = 165 TFLOPS dense FP8 (RTX 4090, no 2:4 sparsity). NOT 330 (that's sparse).
+Report median/min over --iters timed launches, % of dense peak.
+
+Usage:
+  python bench_prefill_gemm.py --M 512 --regime layer
+  python bench_prefill_gemm.py --M 512 --regime layer --tiles 64x64,64x64_s1
+"""
+from __future__ import annotations
+import argparse, statistics, sys, pathlib
+import torch
+REPO = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO)); sys.path.insert(0, str(REPO / "flash_rt"))
+
+PEAK_DENSE_TFLOPS = 165.0  # RTX 4090 FP8 dense (no 2:4 sparsity)
+
+# (name, M-tile, N-tile, warps, stages) — mirrors csrc DEFINE list
+TILES = {
+    "16x64":      ("bench_fp8_block128_gemm_bs_sm89_16x64x128_w4",      16, 64),
+    "32x64":      ("bench_fp8_block128_gemm_bs_sm89_32x64x128_w4",      32, 64),
+    "64x64":      ("bench_fp8_block128_gemm_bs_sm89_64x64x128_w4",      64, 64),
+    "64x64_s1":   ("bench_fp8_block128_gemm_bs_sm89_64x64x128_w4_s1",   64, 64),
+    "32x128":     ("bench_fp8_block128_gemm_bs_sm89_32x128x128_w4",     32, 128),
+    "64x128_w8":  ("bench_fp8_block128_gemm_bs_sm89_64x128x128_w8",     64, 128),
+    "128x128_w8": ("bench_fp8_block128_gemm_bs_sm89_128x128x128_w8",    128, 128),
+    "128x128_w8_s1": ("bench_fp8_block128_gemm_bs_sm89_128x128x128_w8_s1", 128, 128),
+}
+
+SHAPES_2B = [("2B_qkv", 4096, 2048), ("2B_o", 2048, 2048),
+             ("2B_gate_up", 12288, 2048), ("2B_down", 2048, 6144)]
+SHAPES_8B = [("8B_qkv", 6144, 4096), ("8B_o", 4096, 4096),
+             ("8B_gate_up", 24576, 4096), ("8B_down", 4096, 12288)]
+
+
+def bench(fn, args, warmup, iters, pollute=None):
+    s = torch.cuda.current_stream().cuda_stream
+    def run():
+        fn(*args, stream=s) if fn.__code__.co_argcount > 7 else fn(*args)
+    for _ in range(warmup):
+        if pollute is not None: pollute()
+        run()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        if pollute is not None: pollute()
+        st = torch.cuda.Event(enable_timing=True); en = torch.cuda.Event(enable_timing=True)
+        st.record(); run(); en.record(); en.synchronize()
+        times.append(float(st.elapsed_time(en)) * 1000)  # us
+    return statistics.median(times), min(times), statistics.stdev(times) if len(times) > 1 else 0.0
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--M", type=int, nargs="+", default=[512])
+    p.add_argument("--regime", choices=["warm", "layer", "cold"], default="layer")
+    p.add_argument("--iters", type=int, default=30)
+    p.add_argument("--warmup", type=int, default=20)
+    p.add_argument("--layers", type=int, default=36)
+    p.add_argument("--tiles", default="", help="comma-separated subset of tiles")
+    p.add_argument("--model", choices=["2B", "8B", "both"], default="both")
+    args = p.parse_args()
+    torch.cuda.set_device(torch.device(args.device))
+    import flash_rt_qwen3_vl_kernels as fvk
+
+    sel = list(TILES.keys()) if not args.tiles else args.tiles.split(",")
+    shapes = []
+    if args.model in ("2B", "both"): shapes += SHAPES_2B
+    if args.model in ("8B", "both"): shapes += SHAPES_8B
+
+    poll = torch.empty(128 * 1024 * 1024, device=args.device, dtype=torch.uint8)
+    print(f"device={torch.cuda.get_device_name()} regime={args.regime} "
+          f"peak={PEAK_DENSE_TFLOPS} TFLOPS dense FP8")
+    print(f"{'shape':<12} {'M':>5} {'N':>6} {'K':>5} {'tile':<14} "
+          f"{'med_us':>8} {'min_us':>7} {'std_us':>6} {'TFLOPS':>7} {'%peak':>6}")
+    print("-" * 84)
+
+    for M in args.M:
+        for name, N, K in shapes:
+            flops = 2.0 * M * N * K
+            K128 = K // 128
+            # per-layer distinct B (layer regime); single B otherwise
+            nB = args.layers if args.regime == "layer" else 1
+            Bs = [torch.randn(N, K, device=args.device).to(torch.float8_e4m3fn)
+                  for _ in range(nB)]
+            A = torch.randn(M, K, device=args.device).to(torch.float8_e4m3fn)
+            D = torch.empty(M, N, device=args.device, dtype=torch.bfloat16)
+            asc = torch.ones(M, K128, device=args.device, dtype=torch.float32)
+            wsc = torch.ones((N // 128) * K128, device=args.device, dtype=torch.float32)
+            s = torch.cuda.current_stream().cuda_stream
+            B0 = Bs[0]
+
+            for tname in sel:
+                if tname not in TILES:
+                    print(f"  {tname}: unknown tile"); continue
+                bind_name, _, _ = TILES[tname]
+                fn = getattr(fvk, bind_name)
+                try:
+                    if args.regime == "cold":
+                        med, mn, sd = bench(fn, (A.data_ptr(), B0.data_ptr(), D.data_ptr(),
+                                                 M, N, K, asc.data_ptr(), wsc.data_ptr(), s),
+                                            args.warmup, args.iters,
+                                            pollute=lambda: poll.fill_(0))
+                    elif args.regime == "warm":
+                        med, mn, sd = bench(fn, (A.data_ptr(), B0.data_ptr(), D.data_ptr(),
+                                                 M, N, K, asc.data_ptr(), wsc.data_ptr(), s),
+                                            args.warmup, args.iters)
+                    else:  # layer: step through distinct B
+                        idx = [0]
+                        def step():
+                            b = Bs[idx[0] % len(Bs)]
+                            fn(A.data_ptr(), b.data_ptr(), D.data_ptr(),
+                               M, N, K, asc.data_ptr(), wsc.data_ptr(), s)
+                            idx[0] += 1
+                        for _ in range(args.warmup): step()
+                        torch.cuda.synchronize()
+                        ts = []
+                        for _ in range(args.iters):
+                            st = torch.cuda.Event(enable_timing=True); en = torch.cuda.Event(enable_timing=True)
+                            st.record(); step(); en.record(); en.synchronize()
+                            ts.append(float(st.elapsed_time(en)) * 1000)
+                        med, mn, sd = statistics.median(ts), min(ts), statistics.stdev(ts)
+                    tf = flops / (med * 1e-6) / 1e12
+                    print(f"{name:<12} {M:>5} {N:>6} {K:>5} {tname:<14} "
+                          f"{med:>8.2f} {mn:>7.2f} {sd:>6.2f} {tf:>7.1f} {tf/PEAK_DENSE_TFLOPS*100:>5.1f}%")
+                except Exception as e:
+                    print(f"{name:<12} {M:>5} {N:>6} {K:>5} {tname:<14} ERROR: {e}")
+            print()
+        if M != args.M[-1]: print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_prefill_breakdown.py
+++ b/scripts/profile_prefill_breakdown.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Prefill breakdown profiling: ViT vs LLM on Qwen3-VL 8B SM89.
+
+Runs vision and LLM prefill in separate NVTX ranges for nsys analysis.
+
+Usage:
+    nsys profile -t cuda,nvtx -o prefill_breakdown \
+        --force-overwrite true --capture-range=cudaProfilerApi \
+        python scripts/profile_prefill_breakdown.py \
+            --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+
+import torch
+from PIL import Image
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--checkpoint', required=True)
+    p.add_argument('--device', default='cuda:0')
+    p.add_argument('--max-seq', type=int, default=2048)
+    p.add_argument('--image', default=str(REPO_ROOT / 'FlashRT.png'))
+    p.add_argument('--prompt', default='Describe this image in one sentence.')
+    p.add_argument('--warmup', type=int, default=2)
+    p.add_argument('--profile-rounds', type=int, default=1)
+    args = p.parse_args()
+
+    torch.cuda.set_device(torch.device(args.device))
+    print(f"GPU: {torch.cuda.get_device_name(torch.device(args.device))}")
+
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+        Qwen3VlFp8Sm89Frontend,
+    )
+
+    fe = Qwen3VlFp8Sm89Frontend(
+        args.checkpoint, device=args.device, max_seq=args.max_seq)
+
+    img = Image.open(args.image).convert('RGB')
+    messages = [{
+        'role': 'user',
+        'content': [
+            {'type': 'image', 'image': img},
+            {'type': 'text', 'text': args.prompt},
+        ],
+    }]
+
+    for w in range(args.warmup):
+        fe.set_prompt(messages)
+        fe.prefill()
+        torch.cuda.synchronize()
+    print("warmup done.", flush=True)
+
+    torch.cuda.cudart().cudaProfilerStart()
+
+    for r in range(args.profile_rounds):
+        fe.set_prompt(messages)
+        pr = fe._prompt
+        assert pr is not None
+        llm = fe.llm
+        llm.reset_state()
+        hidden = int(llm._cfg['hidden_size'])
+        S = int(pr['S'])
+        embed = llm._weights.anchors[0]
+
+        torch.cuda.synchronize()
+
+        # ── Phase 1: Vision tower ──
+        torch.cuda.nvtx.range_push(f'vision_r{r}')
+        h = embed[pr['input_ids']].to(torch.bfloat16).view(S, hidden)
+        seg_deepstacks = []
+        off = 0
+        for (a, b), n_patch in zip(pr['spans'], pr['seg_patches']):
+            sl = slice(off, off + n_patch)
+            off += n_patch
+            emb, ds = fe.vision.forward(
+                pr['pixel_values'][sl], pr['pos_embeds'][sl],
+                pr['vcos'][sl], pr['vsin'][sl])
+            h[a:b].copy_(emb.to(torch.bfloat16))
+            seg_deepstacks.append(ds)
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+
+        # ── Phase 2: LLM prefill ──
+        deep = {}
+        for layer in range(fe._deepstack_layers):
+            rows = []
+            for (a, b_), ds in zip(pr['spans'], seg_deepstacks):
+                rows.append((a, b_, ds[layer].to(torch.bfloat16).contiguous()))
+            deep[layer] = rows
+
+        torch.cuda.nvtx.range_push(f'llm_prefill_r{r}')
+        logits = llm.forward_hidden_prefill_fp8_blockscaled(
+            h, pr['mcos'], pr['msin'], 0, deepstack_by_layer=deep)
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+
+        # ── Phase 3: lm_head only (already in LLM prefill, just timing) ──
+        print(f"[r{r}] S={S} top={int(logits[0].float().argmax())}")
+
+    torch.cuda.cudart().cudaProfilerStop()
+    print("profiling done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/profile_qwen3_vl_fp8_sm89.py
+++ b/scripts/profile_qwen3_vl_fp8_sm89.py
@@ -47,8 +47,9 @@ def main():
                    help="warmup iterations before profiling (outside cudaProfiler)")
     p.add_argument("--profile-rounds", type=int, default=1,
                    help="profiled iterations (inside cudaProfiler)")
-    p.add_argument("--use-graph", action="store_true", default=True)
-    p.add_argument("--no-graph", dest="use_graph", action="store_false")
+    p.add_argument("--no-graph", dest="use_graph", action="store_false",
+                   default=True,
+                   help="use the eager (non-graph) path instead of CUDA graphs")
     p.add_argument("--ncu-mode", choices=["prefill", "decode", "none"],
                    default="none",
                    help="for ncu: only profile this phase (skip the other)")

--- a/scripts/profile_qwen3_vl_fp8_sm89.py
+++ b/scripts/profile_qwen3_vl_fp8_sm89.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""nsys / ncu profiling harness for Qwen3-VL FP8 SM89.
+
+Separates prefill and decode into distinct NVTX ranges so nsys can
+report per-phase kernel time breakdowns.
+
+Usage (nsys):
+    nsys profile -t cuda,nvtx -o qwen3_vl_profile \
+        --force-overwrite --capture-range=cudaProfilerApi \
+        python scripts/profile_qwen3_vl_fp8_sm89.py \
+            --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+            --decode-steps 32
+
+Usage (ncu, single decode step):
+    ncu --set full -o decode_kernel \
+        python scripts/profile_qwen3_vl_fp8_sm89.py \
+            --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 \
+            --ncu-mode decode --ncu-kernel-skip 0 --ncu-kernel-count 999
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+
+import torch
+from PIL import Image
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--max-seq", type=int, default=2048)
+    p.add_argument("--max-pixels", type=int, default=None)
+    p.add_argument("--image", default=str(REPO_ROOT / "FlashRT.png"))
+    p.add_argument("--prompt", default="Describe this image in one sentence.")
+    p.add_argument("--decode-steps", type=int, default=32,
+                   help="number of decode steps to profile")
+    p.add_argument("--warmup-rounds", type=int, default=2,
+                   help="warmup iterations before profiling (outside cudaProfiler)")
+    p.add_argument("--profile-rounds", type=int, default=1,
+                   help="profiled iterations (inside cudaProfiler)")
+    p.add_argument("--use-graph", action="store_true", default=True)
+    p.add_argument("--no-graph", dest="use_graph", action="store_false")
+    p.add_argument("--ncu-mode", choices=["prefill", "decode", "none"],
+                   default="none",
+                   help="for ncu: only profile this phase (skip the other)")
+    args = p.parse_args()
+
+    torch.cuda.set_device(torch.device(args.device))
+    dev = args.device
+
+    from flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal import (
+        Qwen3VlFp8Sm89Frontend,
+    )
+
+    print(f"GPU: {torch.cuda.get_device_name(torch.device(dev))}")
+    print(f"checkpoint: {args.checkpoint}")
+    print(f"loading model...", flush=True)
+
+    fe = Qwen3VlFp8Sm89Frontend(
+        args.checkpoint, device=dev, max_seq=args.max_seq,
+        max_pixels=args.max_pixels)
+
+    img = Image.open(args.image).convert("RGB")
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "image", "image": img},
+            {"type": "text", "text": args.prompt},
+        ],
+    }]
+
+    # ── Warmup (outside profiler capture) ──
+    # Run all decode positions so every CUDA Graph is captured before profiling.
+    print(f"warming up ({args.warmup_rounds} rounds, "
+          f"{args.decode_steps} decode steps each)...", flush=True)
+    for w in range(args.warmup_rounds):
+        fe.set_prompt(messages)
+        logits = fe.prefill_graph() if args.use_graph else fe.prefill()
+        pr = fe._prompt
+        base_slot = int(pr["S"])
+        tok = int(logits[0].float().argmax())
+        for i in range(args.decode_steps):
+            if args.use_graph:
+                logits = fe.decode_step_with_graph(tok, base_slot + i)
+            else:
+                logits = fe.decode_step(tok, base_slot + i)
+            tok = int(logits[0].float().argmax())
+    torch.cuda.synchronize()
+    print("warmup done.", flush=True)
+
+    # ── Profile ──
+    # Reuse the warm prompt from the last warmup round (same messages,
+    # same S / mrope_max / graph keys). Avoids re-capturing graphs.
+    pr = fe._prompt
+    assert pr is not None
+    base_slot = int(pr["S"])
+
+    torch.cuda.cudart().cudaProfilerStart()
+
+    for r in range(args.profile_rounds):
+        # -- prefill --
+        if args.ncu_mode != "decode":
+            fe.set_prompt(messages)
+            torch.cuda.synchronize()
+            torch.cuda.nvtx.range_push(f"prefill_r{r}")
+            if args.use_graph:
+                logits = fe.prefill_graph()
+            else:
+                logits = fe.prefill()
+            torch.cuda.synchronize()
+            torch.cuda.nvtx.range_pop()
+        else:
+            fe.set_prompt(messages)
+            logits = fe.prefill_graph() if args.use_graph else fe.prefill()
+            torch.cuda.synchronize()
+
+        tok = int(logits[0].float().argmax())
+
+        # -- decode (graphs already warm from warmup) --
+        if args.ncu_mode != "prefill":
+            torch.cuda.nvtx.range_push(f"decode_r{r}")
+            t0 = time.perf_counter()
+            for i in range(args.decode_steps):
+                torch.cuda.nvtx.range_push(f"step_{i}")
+                if args.use_graph:
+                    logits = fe.decode_step_with_graph(tok, base_slot + i)
+                else:
+                    logits = fe.decode_step(tok, base_slot + i)
+                tok = int(logits[0].float().argmax())
+                torch.cuda.nvtx.range_pop()
+            torch.cuda.synchronize()
+            dt = (time.perf_counter() - t0) * 1000
+            torch.cuda.nvtx.range_pop()
+            print(f"[r{r}] {args.decode_steps} decode steps: "
+                  f"{dt:.1f} ms total, {dt/args.decode_steps:.2f} ms/tok, "
+                  f"{1000*args.decode_steps/dt:.1f} tok/s")
+
+    torch.cuda.cudart().cudaProfilerStop()
+    print("profiling done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_qwen3_vl_fp8_sm89.py
+++ b/scripts/smoke_qwen3_vl_fp8_sm89.py
@@ -250,10 +250,12 @@ def main() -> None:
     p.add_argument("--text-token-base", type=int, default=100)
     p.add_argument("--decode-token", type=int, default=100)
     p.add_argument("--decode-pos", type=int, default=63)
-    p.add_argument("--fuse-gate-up", action="store_true")
+    p.add_argument("--fuse-gate-up", action=argparse.BooleanOptionalAction,
+                   default=True)
     p.add_argument("--no-fuse-qk-postproc", action="store_true",
                    help="use the older two-launch Q/K postprocess path")
-    p.add_argument("--fp8-lm-head", action="store_true")
+    p.add_argument("--fp8-lm-head", action=argparse.BooleanOptionalAction,
+                   default=True)
     p.add_argument("--vision-bf16-first-blocks", type=int, default=3)
     p.add_argument("--vision-block2-bf16-linears", default="",
                    help="experimental SM89-only override for vision block 2; "

--- a/tests/test_load_model_use_fp8_kwarg.py
+++ b/tests/test_load_model_use_fp8_kwarg.py
@@ -787,6 +787,18 @@ def test_groot_n17_rtx_sm120_rejects_use_fp8_false_without_fp16():
         )
 
 
+def test_load_model_redirects_qwen3_vl_to_direct_frontend():
+    from flash_rt.api import load_model
+
+    with pytest.raises(NotImplementedError, match="chat-style VLM"):
+        load_model(
+            "unused-checkpoint",
+            config="qwen3_vl",
+            framework="torch",
+            hardware="rtx_sm89",
+        )
+
+
 def test_frontend_fp8_layout_selection():
     from flash_rt.frontends._fp8_layout import select_fp8_layout
 

--- a/tests/test_qwen3_vl_fp8_sm89.py
+++ b/tests/test_qwen3_vl_fp8_sm89.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+from pathlib import Path
 
 
 def test_frontend_imports():
@@ -44,6 +45,23 @@ def test_default_prefill_limit_matches_max_seq_without_cuda():
 
     assert _resolve_max_prefill_seq(1234, None) == 1234
     assert _resolve_max_prefill_seq(1234, 256) == 256
+
+
+def test_bench_tile_bindings_are_dev_gated():
+    repo = Path(__file__).resolve().parents[1]
+    bindings = (repo / 'csrc' / 'qwen3_vl_bindings.cpp').read_text()
+    cmake = (repo / 'CMakeLists.txt').read_text()
+
+    start = bindings.index('#ifdef ENABLE_QWEN3_VL_DEV_KERNELS')
+    end = bindings.index('#endif', start)
+    dev_block = bindings[start:end]
+    production_surface = bindings[:start] + bindings[end:]
+
+    assert 'm.def("bench_"' in dev_block
+    assert 'BIND_GEMM_TILE(' in dev_block
+    assert 'm.def("bench_"' not in production_surface
+    assert 'option(FLASHRT_ENABLE_QWEN3_VL_DEV_KERNELS' in cmake
+    assert 'ENABLE_QWEN3_VL_DEV_KERNELS=1' in cmake
 
 
 def test_multimodal_prefill_graph_falls_back_to_eager_without_pg_key():

--- a/tests/test_qwen3_vl_rtx_bf16.py
+++ b/tests/test_qwen3_vl_rtx_bf16.py
@@ -1,7 +1,21 @@
+"""Smoke tests for the Qwen3-VL BF16 (Orin) multimodal frontend.
+
+CI-friendly: no checkpoint, no GPU. Covers import wiring, the fail-fast
+kernel-module check, kernel-list completeness, and the weight-loader
+invariant assertions. Mirrors the coverage level of
+``test_qwen3_vl_smoke.py`` and ``test_qwen3_vl_fp8_sm89.py``.
+
+Run:
+    PYTHONPATH=. python -m pytest tests/test_qwen3_vl_rtx_bf16.py -v
+"""
 from __future__ import annotations
 
 import importlib
 
+import pytest
+
+
+# ── wiring / fail-fast ──
 
 def test_qwen3_vl_rtx_bf16_frontend_imports():
     m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
@@ -16,3 +30,122 @@ def test_qwen3_vl_rtx_bf16_kernel_lists_are_bf16_only():
     assert 'qwen3_vl_bf16_gemv_m1' in names
     assert 'qwen3_q_norm_rope_qstage_bf16' in names
     assert not any('fp8' in name or 'nvfp4' in name for name in names)
+
+
+# ── kernel function lists: non-empty, no duplicates ──
+
+def test_core_kernel_list_non_empty_and_unique():
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    assert len(m._QWEN3_VL_RTX_BF16_CORE_FNS) > 0
+    assert len(set(m._QWEN3_VL_RTX_BF16_CORE_FNS)) == len(m._QWEN3_VL_RTX_BF16_CORE_FNS)
+
+
+def test_vision_kernel_list_non_empty_and_unique():
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    assert len(m._QWEN3_VL_RTX_BF16_VISION_FNS) > 0
+    assert len(set(m._QWEN3_VL_RTX_BF16_VISION_FNS)) == len(m._QWEN3_VL_RTX_BF16_VISION_FNS)
+
+
+# ── fail-fast: missing kernel symbol detection ──
+
+def test_require_kernels_raises_on_missing_core_symbol():
+    """Dropping a single core kernel function must raise at the check."""
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    target = m._QWEN3_VL_RTX_BF16_CORE_FNS[0]
+
+    class _FakeVlk:
+        pass
+    for fn in m._QWEN3_VL_RTX_BF16_VISION_FNS:
+        setattr(_FakeVlk, fn, lambda *a, **k: None)
+
+    class _FakeFvk:
+        pass
+    for fn in m._QWEN3_VL_RTX_BF16_CORE_FNS:
+        if fn != target:
+            setattr(_FakeFvk, fn, lambda *a, **k: None)
+
+    import unittest.mock as mock
+    with mock.patch.dict('sys.modules', {
+        'flash_rt.flash_rt_kernels': _FakeFvk,
+        'flash_rt.flash_rt_qwen3_vl_kernels': _FakeVlk,
+    }):
+        with pytest.raises(RuntimeError) as ei:
+            m._require_qwen3_vl_rtx_bf16_kernels()
+        assert target in str(ei.value)
+
+
+def test_require_kernels_raises_on_missing_vision_symbol():
+    """Dropping a single vision kernel function must raise at the check."""
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    target = m._QWEN3_VL_RTX_BF16_VISION_FNS[0]
+
+    class _FakeFvk:
+        pass
+    for fn in m._QWEN3_VL_RTX_BF16_CORE_FNS:
+        setattr(_FakeFvk, fn, lambda *a, **k: None)
+
+    class _FakeVlk:
+        pass
+    for fn in m._QWEN3_VL_RTX_BF16_VISION_FNS:
+        if fn != target:
+            setattr(_FakeVlk, fn, lambda *a, **k: None)
+
+    import unittest.mock as mock
+    with mock.patch.dict('sys.modules', {
+        'flash_rt.flash_rt_kernels': _FakeFvk,
+        'flash_rt.flash_rt_qwen3_vl_kernels': _FakeVlk,
+    }):
+        with pytest.raises(RuntimeError) as ei:
+            m._require_qwen3_vl_rtx_bf16_kernels()
+        assert target in str(ei.value)
+
+
+# ── kernel completeness (gated: only runs when .so is built) ──
+
+def test_kernel_modules_complete_when_built():
+    """If both kernel modules are built for BF16 (SM87/Orin), they must
+    expose every symbol the BF16 frontend calls. Skips when the modules
+    aren't built or when the build targets a non-BF16 arch (SM120/SM89
+    builds include the VL kernel module but omit the BF16-only GEMV)."""
+    try:
+        from flash_rt import flash_rt_kernels as fvk
+        from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+    except ImportError:
+        pytest.skip('flash_rt kernel modules not built')
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    if not hasattr(vlk, 'qwen3_vl_bf16_gemv_m1'):
+        pytest.skip('BF16 GEMV kernel not present (non-SM87 build)')
+    fvk_missing = [fn for fn in m._QWEN3_VL_RTX_BF16_CORE_FNS
+                   if not hasattr(fvk, fn)]
+    vlk_missing = [fn for fn in m._QWEN3_VL_RTX_BF16_VISION_FNS
+                   if not hasattr(vlk, fn)]
+    assert not fvk_missing, f'flash_rt_kernels missing: {fvk_missing}'
+    assert not vlk_missing, f'flash_rt_qwen3_vl_kernels missing: {vlk_missing}'
+
+
+# ── weight-loader invariants (gated on importability) ──
+
+def test_bf16_weight_loader_exports_invariant_fn():
+    """The BF16 weight loader module must export the assertion function."""
+    m = importlib.import_module('flash_rt.frontends.torch._qwen3_vl_bf16_weights')
+    assert hasattr(m, 'assert_extraction_invariants_qwen3_vl_bf16')
+    assert callable(m.assert_extraction_invariants_qwen3_vl_bf16)
+
+
+def test_bf16_weight_loader_exports_extract_fn():
+    """The BF16 weight loader module must export the extraction function."""
+    m = importlib.import_module('flash_rt.frontends.torch._qwen3_vl_bf16_weights')
+    assert hasattr(m, 'extract_weights_qwen3_vl_bf16')
+    assert callable(m.extract_weights_qwen3_vl_bf16)
+
+
+# ── constructor signature ──
+
+def test_constructor_signature_has_required_kwargs():
+    """Verify the public constructor signature hasn't drifted."""
+    import inspect
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    sig = inspect.signature(m.Qwen3VlTorchFrontendRtxBF16.__init__)
+    params = set(sig.parameters.keys()) - {'self'}
+    for required in ('checkpoint_path', 'device', 'max_seq'):
+        assert required in params, f'missing parameter: {required}'


### PR DESCRIPTION
## Summary

SM89 (RTX 4090) Qwen3-VL FP8 **decode-path optimization** on top of the
merged SM89 FP8 path (#116). This round is **decode-only**; the prefill
GEMM was not touched (see *Notes*). All numbers below are **CUDA Graph
replay, 30-iter median, empty single card**, vs the #116 / #111 end-state.

Both `Qwen3-VL-8B-Instruct-FP8` and `Qwen3-VL-2B-Instruct-FP8` are
improved; no kernel-constraint or dtype-map change. Cosine vs the eager
BF16 reference is `1.000000` on every captured graph; 39 tests pass
(`test_qwen3_vl_fp8_sm89*` / `rtx_bf16` / smoke / graph_cache, 1 skipped).

## Performance (RTX 4090, sm_89, graph replay, iters=30 median)

**Decode** (`graph_decode`):

| workload | #116/#111 | this PR | Δ |
|---|---|---|---|
| 8B multimodal (S=1581) | 10.681 ms | 9.284 ms | **-13.1%** |
| 2B multimodal (S=1581) | 2.966 ms | 2.669 ms | **-10.0%** |
| 8B text (S=63) | 9.213 ms | 8.715 ms | -5.4% |
| 2B text (S=63) | 2.552 ms | 2.361 ms | -7.4% (423 tok/s) |

## What changed

**Decode path:**

- **BF16-input GEMV** for O-proj / lm_head / qkv / gate_up — a `bf16in`
  GEMV (BF16 act × FP8 weight, block-128 scale) reads the BF16 residual
  state directly, skipping the per-step FP8 activation quant for these
  linears. Down-proj stays FP8 (silu output dynamic range; already at
  roofline). No cosine regression; marginally better numerics.
- **BF16-output RMSNorm** feeding the bf16in GEMV — the decode norm emits
  BF16 directly, removing a cast.
- **256→512-thread decode norm** for 8B (K≥4096). M=1 decode leaves a
  single-block grid; widening the block from 256→512 doubles active warps
  on that one SM (17%→33% occupancy). 2B (K=2048) stays 256. BF16x2 packed
  loads. ncu: 8B norm 6.56→4.22 µs (-36%).
- **Gate/up GEMV fusion** — fuse gate + up into one GEMV launch (weight
  already interleaved), removing a launch and a residual clone.
- **Last-layer residual + final RMSNorm fusion** into one kernel.
- **FP8 `lm_head` default** (8B) — reads FP8 weights instead of BF16,
  ~0.63 ms/step; same argmax, cosine ≈1.0. Opt out with `--no-fp8-lm-head`.
- **Kernel-lookup caching** in `_MergedKernels.__getattr__` to cut host
  dispatch overhead (~360 lookups/decode step).
- **Graph cache fix**: stop clearing decode graphs in `set_prompt()` — they
  are keyed by `(cache_pos, rope_pos)` on pre-allocated KV buffers and stay
  valid across re-prompts (fixed a 17× replay regression).

**Build / tooling:**

- `scripts/bench_prefill_gemm.py`: trusted prefill GEMM micro-bench
  (warm / layer / cold L2 regimes, peak=165 TFLOPS dense FP8). Two fixes
  folded in: cold/warm crashed on pybind builtins (no `__code__`), and the
  repo path uses `__file__` (no hardcoded path).
- New bench/profile scripts: `bench_gemv_sm89.py`, `bench_fp8_lmhead.py`,
  `bench_graph_replay.py`, `profile_prefill_breakdown.py`,
  `profile_qwen3_vl_fp8_sm89.py`.

**Docs:** `docs/qwen3_vl_fp8_sm89.md` + `docs/qwen3_vl_fp8_sm89_2b.md`
updated to the current SOTA numbers with the vs-#116/#111 comparison.

## Build

```bash
cmake -S . -B build -DGPU_ARCH=89 -DFLASHRT_BUILD_QWEN3_VL=ON
cmake --build build --target flash_rt_kernels flash_rt_fa2 flash_rt_qwen3_vl_kernels -j
```

## Verification

```bash
# tests (CPU + a couple of small GPU fixtures)
python -m pytest tests/test_qwen3_vl_fp8_sm89.py tests/test_qwen3_vl_fp8_sm89_2b.py \
  tests/test_qwen3_vl_rtx_bf16.py tests/test_qwen3_vl_graph_cache.py \
  tests/test_qwen3_vl_smoke.py -q
# -> 39 passed, 1 skipped

# end-to-end (empty card, graph replay, 30-iter median)
CUDA_VISIBLE_DEVICES=0 python scripts/smoke_qwen3_vl_fp8_sm89.py \
  --checkpoint /path/to/Qwen3-VL-8B-Instruct-FP8 --multimodal --iters 30
```

- GPU: NVIDIA GeForce RTX 4090 (sm_89), empty single card.
- Metric: CUDA Graph replay (`prefill_graph`, `graph_decode`), 30-iter
  median — not wall-clock `quickstart` numbers.
- Cosine vs eager = `1.000000` on all captured graphs (prefill + decode,
  8B + 2B, text + multimodal).
- Re-validated on the PR branch: 8B text 8.713 ms, 2B text 2.362 ms,
  8B mm graph_decode 9.283 ms, 2B mm graph_decode 2.668 ms — all within
  noise of the docs numbers.

## Notes (scope)

- **Large-M prefill GEMM** (the `FlashRT.png` single-image workload, M=1581)
  is L2-bandwidth-bound (~84% L2 / 42% compute / 33% occupancy) and was
  **not** further optimized on this branch; it is essentially flat vs #111.
- A **warp-specialized** variant (1 cp.async producer + 4 ldmatrix
  consumers, 2-stage named-barrier pipeline) was implemented and benched
  but **regressed ~84%**: sm89 has no TMA, so each extra pipeline stage
  costs a full smem buffer, doubling smem and halving occupancy (20.5%).
  Reverted, not on this branch.
- A **persistent kernel** was analyzed (not implemented): the large-M GEMM
  is latency/occupancy-bound, not roofline-bound, and persistent grid-stride
  loops don't fix occupancy or sync — judged unlikely to help.
- `lm_head` stays BF16 by default on the public path; FP8 `lm_head` is an
  explicit performance mode (validated against the BF16 head per-call).
- The dev scripts under `scripts/*qwen3_vl_fp8_sm89*` are local validation
  / profiling, not CI.
