### PR TITLE
Add sm_120 INT4 (E0M3) W4A4 GEMV kernel and OMMA unlock tool

### DIFF
--- a/csrc/kernels/int4_w4a4_mma_sm120.cu
+++ b/csrc/kernels/int4_w4a4_mma_sm120.cu
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tensor-core INT4 (E0M3) W4A4 GEMV + quantizer for sm_120. See the
+// header (int4_w4a4_mma_sm120.cuh) for the format contract and the
+// mandatory OMMA bit-patch post-build step. Fragment layout notes
+// live in fp4_w4a4_mma_sm120.cu — this TU uses the identical layout,
+// expressed as raw PTX so the file stays free of CUTLASS includes
+// (self-contained for the llama.cpp backend build).
+
+#include "int4_w4a4_mma_sm120.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt {
+namespace gemm {
+
+namespace {
+
+// ── Block-scaled MMA (compiled e2m1, patched to E0M3) ─────────────
+//
+// Same operand order as cute SM120_16x8x64_TN_VS<..., VS=16>::fma.
+// scale_vec::4X — each lane's sfa/sfb u32 carries the 4 UE4M3 bytes
+// for its fragment rows/cols across the 4 K-groups of this K-tile.
+
+__device__ __forceinline__ void int4_mma_16x8x64(
+    float& d0, float& d1, float& d2, float& d3,
+    uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
+    uint32_t b0, uint32_t b1,
+    float c0, float c1, float c2, float c3,
+    uint32_t sfa, uint32_t sfb) {
+  constexpr uint16_t bid = 0, tid = 0;
+  asm volatile(
+      "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64"
+      ".row.col.f32.e2m1.e2m1.f32.ue4m3 "
+      "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},"
+      "{%14},{%15,%16},{%17},{%18,%19};\n"
+      : "=f"(d0), "=f"(d1), "=f"(d2), "=f"(d3)
+      : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+        "f"(c0), "f"(c1), "f"(c2), "f"(c3),
+        "r"(sfa), "h"(bid), "h"(tid),
+        "r"(sfb), "h"(bid), "h"(tid));
+}
+
+// ── UE4M3 helpers (same semantics as the NVFP4 quantizers) ────────
+
+__device__ __forceinline__ uint8_t fp32_to_ue4m3_ceil(float v) {
+  if (v <= 0.0f) return 0;
+  if (v > 240.0f) return 0xFE;
+  uint32_t bits = __float_as_uint(v);
+  int float_exp = ((bits >> 23) & 0xFF) - 127;
+  uint32_t frac = bits & 0x7FFFFF;
+  int ue_exp = float_exp + 7;
+  if (ue_exp <= 0) {
+    float scaled = v * 512.0f;
+    int m = (int)ceilf(scaled);
+    if (m > 7) return (1 << 3) | 0;
+    if (m < 1) m = 1;
+    return (uint8_t)m;
+  }
+  if (ue_exp >= 15) return 0xFE;
+  int m = (int)(frac >> 20);
+  if (frac & 0xFFFFF) m++;
+  if (m >= 8) { m = 0; ue_exp++; }
+  if (ue_exp >= 15) return 0xFE;
+  return (uint8_t)((ue_exp << 3) | m);
+}
+
+__device__ __forceinline__ float ue4m3_to_fp32(uint8_t v) {
+  int e = (v >> 3) & 0xF;
+  int m = v & 0x7;
+  if (e == 0) return ldexpf((float)m / 8.0f, -6);
+  return ldexpf(1.0f + (float)m / 8.0f, e - 7);
+}
+
+// ── INT4 (E0M3) element encode ────────────────────────────────────
+// nibble = (sign<<3) | mag, value = (-1)^sign * mag, mag 0..7.
+// Round-to-nearest-even on the integer grid, clamp to 7.
+
+__device__ __forceinline__ uint8_t fp32_to_int4_nibble(float x) {
+  float q = rintf(fabsf(x));
+  int mag = (int)fminf(q, 7.0f);
+  return (uint8_t)(((x < 0.0f) ? 8 : 0) | mag);
+}
+
+// ── SF swizzle addressing ─────────────────────────────────────────
+// nvfp4_sf_linear_to_swizzled scheme (see fp4_w4a4_mma_sm120.cu):
+// for row r, K-group b (16 elements each):
+//   rb = r>>7, ri = r&127, cb = b>>2, ci = b&3
+//   off = (rb * n_col_super + cb) * 512 + (ri&31)*16 + ((ri>>5)&3)*4 + ci
+// n_col_super = ceil(K_groups / 4). One 64-K tile = 4 consecutive bytes.
+
+__device__ __forceinline__ int sf_swizzled_off(
+    int row, int kgroup, int n_col_super) {
+  int rb = row >> 7, ri = row & 127;
+  int cb = kgroup >> 2, ci = kgroup & 3;
+  return (rb * n_col_super + cb) * 512 +
+         (ri & 31) * 16 + ((ri >> 5) & 3) * 4 + ci;
+}
+
+// ── Quantizer kernel ──────────────────────────────────────────────
+// One block per row; threads stride over the row's 16-element groups.
+
+__global__ void int4_quantize_bf16_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    uint8_t* __restrict__ out_packed,
+    uint8_t* __restrict__ out_sf,
+    const float* __restrict__ global_scale,
+    int rows, int K) {
+  int row = blockIdx.x;
+  if (row >= rows) return;
+  const float g = *global_scale;
+  const float inv_g = (g > 0.f) ? (1.f / g) : 0.f;
+  const int K_groups = K / 16;
+  const int n_col_super = (K_groups + 3) / 4;
+  const __nv_bfloat16* xr = x + (long long)row * K;
+  uint8_t* pr = out_packed + (long long)row * (K / 2);
+
+  for (int gidx = threadIdx.x; gidx < K_groups; gidx += blockDim.x) {
+    float v[16];
+    float bmax = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 16; ++i) {
+      v[i] = __bfloat162float(xr[gidx * 16 + i]);
+      bmax = fmaxf(bmax, fabsf(v[i]));
+    }
+    uint8_t sf_byte = fp32_to_ue4m3_ceil((bmax / 7.0f) * inv_g);
+    out_sf[sf_swizzled_off(row, gidx, n_col_super)] = sf_byte;
+    float s = ue4m3_to_fp32(sf_byte) * g;
+    float inv_s = (s > 0.f) ? (1.f / s) : 0.f;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+      uint8_t lo = fp32_to_int4_nibble(v[2 * i] * inv_s);
+      uint8_t hi = fp32_to_int4_nibble(v[2 * i + 1] * inv_s);
+      pr[gidx * 8 + i] = (uint8_t)(lo | (hi << 4));
+    }
+  }
+}
+
+__global__ void int4_global_scale_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    float* __restrict__ scale_out,
+    long long numel) {
+  float local = 0.f;
+  for (long long i = blockIdx.x * (long long)blockDim.x + threadIdx.x;
+       i < numel; i += (long long)gridDim.x * blockDim.x) {
+    local = fmaxf(local, fabsf(__bfloat162float(x[i])));
+  }
+  #pragma unroll
+  for (int off = 16; off > 0; off >>= 1) {
+    local = fmaxf(local, __shfl_down_sync(0xffffffffu, local, off));
+  }
+  if ((threadIdx.x & 31) == 0 && local > 0.f) {
+    // amax / (INT4_MAX * UE4M3_MAX); atomicMax on non-negative floats
+    // via int reinterpretation.
+    atomicMax(reinterpret_cast<int*>(scale_out),
+              __float_as_int(local / (7.0f * 448.0f)));
+  }
+}
+
+// ── GEMV kernel (twin of fp4 full_n_kernel; layout notes there) ───
+
+constexpr int INT4_WARPS_PER_BLOCK = 1;
+constexpr int INT4_THREADS_PER_BLOCK = INT4_WARPS_PER_BLOCK * 32;
+constexpr int INT4_COLS_PER_WARP = 8;
+constexpr int INT4_COLS_PER_BLOCK =
+    INT4_WARPS_PER_BLOCK * INT4_COLS_PER_WARP;
+
+__device__ __forceinline__ uint32_t fast_load_a(
+    const uint8_t* sA, int t0, int t1, int reg_idx) {
+  int row_off = ((reg_idx & 1) ? (t1 + 8) : t1) * 32;
+  int col_off = t0 * 4 + ((reg_idx >> 1) & 1) * 16;
+  return *reinterpret_cast<const uint32_t*>(sA + row_off + col_off);
+}
+
+__device__ __forceinline__ uint32_t fast_load_b(
+    const uint8_t* sB, int t0, int t1, int reg_idx) {
+  int col_off = t0 * 4 + reg_idx * 16;
+  return *reinterpret_cast<const uint32_t*>(sB + t1 * 32 + col_off);
+}
+
+__device__ __forceinline__ void cp_async_4(
+    uint8_t* smem_dst, const uint8_t* gmem_src) {
+  uint32_t smem_int = __cvta_generic_to_shared(smem_dst);
+  asm volatile(
+      "cp.async.ca.shared.global.L2::128B [%0], [%1], 4;\n"
+      :: "r"(smem_int), "l"(gmem_src));
+}
+
+__device__ __forceinline__ void cp_async_commit_group() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+__device__ __forceinline__ void cp_async_wait_1() {
+  asm volatile("cp.async.wait_group 1;\n" ::);
+}
+
+__device__ __forceinline__ void cp_async_wait_0() {
+  asm volatile("cp.async.wait_group 0;\n" ::);
+}
+
+__global__ void int4_full_n_kernel(
+    const uint8_t* __restrict__ A_packed,    // (K/2,)
+    const uint8_t* __restrict__ B_packed,    // (N, K/2)
+    const uint8_t* __restrict__ SFA,         // swizzled, 1 row
+    const uint8_t* __restrict__ SFB,         // swizzled, N rows
+    __nv_bfloat16* __restrict__ D,           // (N,)
+    float alpha,
+    int N, int K) {
+  __shared__ alignas(16) uint8_t s_A[2][16 * 32];
+  __shared__ alignas(16) uint8_t s_SFA[2][16 * 4];
+  __shared__ alignas(16) uint8_t s_B_all[2][INT4_WARPS_PER_BLOCK * 8 * 32];
+  __shared__ alignas(16) uint8_t s_SFB_all[2][INT4_WARPS_PER_BLOCK * 8 * 4];
+
+  int tid = threadIdx.x;
+  int warp = tid >> 5;
+  int lane = tid & 31;
+
+  int block_n_off = blockIdx.x * INT4_COLS_PER_BLOCK;
+  int my_n_off = block_n_off + warp * INT4_COLS_PER_WARP;
+  if (my_n_off >= N) return;
+
+  int t0 = lane & 3;
+  int t1 = lane >> 2;
+  int sfa_unique_row = (lane & 1) * 8 + (lane >> 2);
+  int sfb_unique_col = lane >> 2;
+
+  float c0 = 0.f, c1 = 0.f, c2 = 0.f, c3 = 0.f;
+
+  const int K_iters = K / 64;
+  const int K_half = K / 2;
+
+  // M=1 padding: zero rows 1..15 of A and SFA in both banks once.
+  if (lane < 16) {
+    int row = lane;
+    if (row >= 1) {
+      int4* a0_v = reinterpret_cast<int4*>(s_A[0]);
+      int4* a1_v = reinterpret_cast<int4*>(s_A[1]);
+      int4 z; z.x = 0; z.y = 0; z.z = 0; z.w = 0;
+      a0_v[row * 2 + 0] = z; a0_v[row * 2 + 1] = z;
+      a1_v[row * 2 + 0] = z; a1_v[row * 2 + 1] = z;
+    }
+  }
+  if (lane < 4) {
+    for (int i = 4 + lane; i < 64; i += 4) {
+      s_SFA[0][i] = 0;
+      s_SFA[1][i] = 0;
+    }
+  }
+
+  const int K_blocks = K / 16;
+  const int n_col_super = (K_blocks + 3) / 4;
+
+  auto issue_async_load = [&](int buf, int kt) {
+    int byte_off = kt * 32;
+    if (lane < 8) {
+      cp_async_4(s_A[buf] + lane * 4, A_packed + byte_off + lane * 4);
+    }
+    if (lane == 0) {
+      cp_async_4(s_SFA[buf] + 0, SFA + kt * 512);
+    }
+    {
+      uint8_t* my_s_B = s_B_all[buf] + warp * (8 * 32);
+      for (int c = 0; c < 2; ++c) {
+        int chunk = lane + c * 32;
+        int col = chunk >> 3;
+        int off = chunk & 7;
+        cp_async_4(
+            my_s_B + chunk * 4,
+            B_packed + (long long)(my_n_off + col) * K_half +
+                byte_off + off * 4);
+      }
+    }
+    if (lane < 8) {
+      uint8_t* my_s_SFB = s_SFB_all[buf] + warp * (8 * 4);
+      int col = my_n_off + lane;
+      int rb = col >> 7;
+      int ri = col & 127;
+      int super_idx = rb * n_col_super + kt;
+      int inner_base = (ri & 31) * 16 + ((ri >> 5) & 3) * 4;
+      cp_async_4(
+          my_s_SFB + lane * 4,
+          SFB + (long long)super_idx * 512 + inner_base);
+    }
+  };
+
+  issue_async_load(0, 0);
+  cp_async_commit_group();
+  if (K_iters > 1) {
+    issue_async_load(1, 1);
+    cp_async_commit_group();
+  }
+
+  for (int kt = 0; kt < K_iters; ++kt) {
+    int curr_buf = kt & 1;
+    if (kt + 1 < K_iters) {
+      cp_async_wait_1();
+    } else {
+      cp_async_wait_0();
+    }
+    __syncwarp();
+
+    uint32_t a0 = fast_load_a(s_A[curr_buf], t0, t1, 0);
+    uint32_t a1 = fast_load_a(s_A[curr_buf], t0, t1, 1);
+    uint32_t a2 = fast_load_a(s_A[curr_buf], t0, t1, 2);
+    uint32_t a3 = fast_load_a(s_A[curr_buf], t0, t1, 3);
+    uint8_t* my_s_B = s_B_all[curr_buf] + warp * (8 * 32);
+    uint8_t* my_s_SFB = s_SFB_all[curr_buf] + warp * (8 * 4);
+    uint32_t b0 = fast_load_b(my_s_B, t0, t1, 0);
+    uint32_t b1 = fast_load_b(my_s_B, t0, t1, 1);
+    uint32_t sfa = *reinterpret_cast<const uint32_t*>(
+        s_SFA[curr_buf] + sfa_unique_row * 4);
+    uint32_t sfb = *reinterpret_cast<const uint32_t*>(
+        my_s_SFB + sfb_unique_col * 4);
+
+    float d0, d1, d2, d3;
+    int4_mma_16x8x64(d0, d1, d2, d3,
+                     a0, a1, a2, a3, b0, b1,
+                     c0, c1, c2, c3, sfa, sfb);
+    c0 = d0; c1 = d1; c2 = d2; c3 = d3;
+
+    if (kt + 2 < K_iters) {
+      issue_async_load(curr_buf, kt + 2);
+      cp_async_commit_group();
+    }
+  }
+
+  int q = lane >> 2;
+  int r = lane & 3;
+  if (q == 0) {
+    int col0 = my_n_off + r * 2;
+    int col1 = col0 + 1;
+    if (col0 < N) D[col0] = __float2bfloat16(c0 * alpha);
+    if (col1 < N) D[col1] = __float2bfloat16(c1 * alpha);
+  }
+}
+
+// ── Codebook canary ───────────────────────────────────────────────
+// A = nibble 0x7 broadcast, B = nibble 0x1 broadcast, SF = 1.0.
+// Every output element = 64 * dec(0x7) * dec(0x1):
+//   E0M3 (patched):   64 * 7 * 1   = 448
+//   E2M1 (unpatched): 64 * 6 * 0.5 = 192
+// One warp, one MMA; lane 0 writes the verdict.
+
+__global__ void int4_codebook_canary_kernel(int* __restrict__ verdict) {
+  uint32_t a = 0x77777777u, b = 0x11111111u, sf = 0x38383838u;
+  float d0, d1, d2, d3;
+  int4_mma_16x8x64(d0, d1, d2, d3, a, a, a, a, b, b,
+                   0.f, 0.f, 0.f, 0.f, sf, sf);
+  if (threadIdx.x == 0) {
+    *verdict = (d0 == 448.0f) ? 0 : ((d0 == 192.0f) ? 1 : 2);
+  }
+}
+
+}  // namespace
+
+// ── Host dispatch ─────────────────────────────────────────────────
+
+int int4_w4a4_mma_sm120_full_n_bf16out(
+    const void*  A_packed,
+    const void*  B_packed,
+    void*        D_bf16,
+    int          N,
+    int          K,
+    const void*  SFA,
+    const void*  SFB,
+    float        alpha,
+    cudaStream_t stream) {
+  if (!A_packed || !B_packed || !D_bf16 || !SFA || !SFB) return 1;
+  if (K <= 0 || (K % 64) != 0) return 2;
+  if (N <= 0 || (N % INT4_COLS_PER_BLOCK) != 0) return 3;
+
+  dim3 block(INT4_THREADS_PER_BLOCK);
+  dim3 grid((N + INT4_COLS_PER_BLOCK - 1) / INT4_COLS_PER_BLOCK);
+  int4_full_n_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const uint8_t*>(A_packed),
+      reinterpret_cast<const uint8_t*>(B_packed),
+      reinterpret_cast<const uint8_t*>(SFA),
+      reinterpret_cast<const uint8_t*>(SFB),
+      reinterpret_cast<__nv_bfloat16*>(D_bf16),
+      alpha, N, K);
+  return 0;
+}
+
+int int4_quantize_bf16_sm120(
+    const void*  x_bf16,
+    void*        out_packed,
+    void*        out_sf_swizzled,
+    const void*  global_scale,
+    int          rows,
+    int          K,
+    cudaStream_t stream) {
+  if (!x_bf16 || !out_packed || !out_sf_swizzled || !global_scale) return 1;
+  if (K <= 0 || (K % 64) != 0 || rows <= 0) return 2;
+  dim3 block(128);
+  dim3 grid(rows);
+  int4_quantize_bf16_kernel<<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(x_bf16),
+      reinterpret_cast<uint8_t*>(out_packed),
+      reinterpret_cast<uint8_t*>(out_sf_swizzled),
+      reinterpret_cast<const float*>(global_scale),
+      rows, K);
+  return 0;
+}
+
+int int4_global_scale_bf16_sm120(
+    const void*  x_bf16,
+    void*        scale_out,
+    long long    numel,
+    cudaStream_t stream) {
+  if (!x_bf16 || !scale_out || numel <= 0) return 1;
+  int blocks = (int)((numel + 255) / 256);
+  if (blocks > 1024) blocks = 1024;
+  int4_global_scale_kernel<<<blocks, 256, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16*>(x_bf16),
+      reinterpret_cast<float*>(scale_out),
+      numel);
+  return 0;
+}
+
+int int4_w4a4_sm120_codebook_canary(cudaStream_t stream) {
+  int* d_verdict = nullptr;
+  if (cudaMalloc(&d_verdict, sizeof(int)) != cudaSuccess) return -1;
+  int4_codebook_canary_kernel<<<1, 32, 0, stream>>>(d_verdict);
+  int verdict = -2;
+  cudaError_t err = cudaMemcpyAsync(&verdict, d_verdict, sizeof(int),
+                                    cudaMemcpyDeviceToHost, stream);
+  if (err == cudaSuccess) err = cudaStreamSynchronize(stream);
+  cudaFree(d_verdict);
+  if (err != cudaSuccess) return -1;
+  return verdict;
+}
+
+}  // namespace gemm
+}  // namespace flash_rt
+
+// ── extern "C" wrappers (ctypes / non-C++ backends, e.g. GGML) ────
+
+extern "C" {
+
+int int4_w4a4_full_n_bf16out(
+    const void* A, const void* B, void* D, int N, int K,
+    const void* SFA, const void* SFB, float alpha, void* stream) {
+  return flash_rt::gemm::int4_w4a4_mma_sm120_full_n_bf16out(
+      A, B, D, N, K, SFA, SFB, alpha,
+      reinterpret_cast<cudaStream_t>(stream));
+}
+
+int int4_quantize_bf16(
+    const void* x, void* out_packed, void* out_sf,
+    const void* global_scale, int rows, int K, void* stream) {
+  return flash_rt::gemm::int4_quantize_bf16_sm120(
+      x, out_packed, out_sf, global_scale, rows, K,
+      reinterpret_cast<cudaStream_t>(stream));
+}
+
+int int4_global_scale_bf16(
+    const void* x, void* scale_out, long long numel, void* stream) {
+  return flash_rt::gemm::int4_global_scale_bf16_sm120(
+      x, scale_out, numel, reinterpret_cast<cudaStream_t>(stream));
+}
+
+int int4_codebook_canary(void* stream) {
+  return flash_rt::gemm::int4_w4a4_sm120_codebook_canary(
+      reinterpret_cast<cudaStream_t>(stream));
+}
+
+}  // extern "C"

--- a/csrc/kernels/int4_w4a4_mma_sm120.cu
+++ b/csrc/kernels/int4_w4a4_mma_sm120.cu
@@ -380,7 +380,7 @@ int int4_w4a4_mma_sm120_full_n_bf16out(
       reinterpret_cast<const uint8_t*>(SFB),
       reinterpret_cast<__nv_bfloat16*>(D_bf16),
       alpha, N, K);
-  return 0;
+  return (cudaGetLastError() == cudaSuccess) ? 0 : 100;
 }
 
 int int4_quantize_bf16_sm120(
@@ -401,7 +401,7 @@ int int4_quantize_bf16_sm120(
       reinterpret_cast<uint8_t*>(out_sf_swizzled),
       reinterpret_cast<const float*>(global_scale),
       rows, K);
-  return 0;
+  return (cudaGetLastError() == cudaSuccess) ? 0 : 100;
 }
 
 int int4_global_scale_bf16_sm120(
@@ -416,13 +416,14 @@ int int4_global_scale_bf16_sm120(
       reinterpret_cast<const __nv_bfloat16*>(x_bf16),
       reinterpret_cast<float*>(scale_out),
       numel);
-  return 0;
+  return (cudaGetLastError() == cudaSuccess) ? 0 : 100;
 }
 
 int int4_w4a4_sm120_codebook_canary(cudaStream_t stream) {
   int* d_verdict = nullptr;
   if (cudaMalloc(&d_verdict, sizeof(int)) != cudaSuccess) return -1;
   int4_codebook_canary_kernel<<<1, 32, 0, stream>>>(d_verdict);
+  if (cudaGetLastError() != cudaSuccess) { cudaFree(d_verdict); return -1; }
   int verdict = -2;
   cudaError_t err = cudaMemcpyAsync(&verdict, d_verdict, sizeof(int),
                                     cudaMemcpyDeviceToHost, stream);
@@ -436,10 +437,15 @@ int int4_w4a4_sm120_codebook_canary(cudaStream_t stream) {
 }  // namespace flash_rt
 
 // ── extern "C" wrappers (ctypes / non-C++ backends, e.g. GGML) ────
+//
+// Prefixed `flashrt_int4_sm120_` so the unmangled global symbols do not
+// collide with a host application (e.g. llama.cpp / GGML) when this TU is
+// linked into or dlopen'd alongside it. The C++ entry points in the
+// header keep the `flash_rt::gemm` namespace.
 
 extern "C" {
 
-int int4_w4a4_full_n_bf16out(
+int flashrt_int4_sm120_w4a4_full_n_bf16out(
     const void* A, const void* B, void* D, int N, int K,
     const void* SFA, const void* SFB, float alpha, void* stream) {
   return flash_rt::gemm::int4_w4a4_mma_sm120_full_n_bf16out(
@@ -447,7 +453,7 @@ int int4_w4a4_full_n_bf16out(
       reinterpret_cast<cudaStream_t>(stream));
 }
 
-int int4_quantize_bf16(
+int flashrt_int4_sm120_quantize_bf16(
     const void* x, void* out_packed, void* out_sf,
     const void* global_scale, int rows, int K, void* stream) {
   return flash_rt::gemm::int4_quantize_bf16_sm120(
@@ -455,13 +461,13 @@ int int4_quantize_bf16(
       reinterpret_cast<cudaStream_t>(stream));
 }
 
-int int4_global_scale_bf16(
+int flashrt_int4_sm120_global_scale_bf16(
     const void* x, void* scale_out, long long numel, void* stream) {
   return flash_rt::gemm::int4_global_scale_bf16_sm120(
       x, scale_out, numel, reinterpret_cast<cudaStream_t>(stream));
 }
 
-int int4_codebook_canary(void* stream) {
+int flashrt_int4_sm120_codebook_canary(void* stream) {
   return flash_rt::gemm::int4_w4a4_sm120_codebook_canary(
       reinterpret_cast<cudaStream_t>(stream));
 }

--- a/csrc/kernels/int4_w4a4_mma_sm120.cuh
+++ b/csrc/kernels/int4_w4a4_mma_sm120.cuh
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tensor-core INT4 (E0M3) W4A4 GEMV for sm_120 — M=1 full-N decode
+// primitive plus the matching INT4 block-scale quantizer. Twin of
+// fp4_w4a4_mma_sm120.{cu,cuh} with a uniform-grid element format.
+//
+// ── How INT4 works on sm_120 ──────────────────────────────────────
+// ptxas only accepts `e2m1` element types for
+// `mma.sync.kind::mxf4nvf4.block_scale`, but the SASS encoding of
+// OMMA.SF.16864 carries the operand element format in instruction
+// bits 78 (A) / 79 (B): 0 = E2M1, 1 = E0M3 (uniform INT4, codebook
+// -7..7, sign-magnitude nibbles). The bits are undocumented and
+// invisible to nvdisasm; throughput is identical to E2M1 (verified
+// on RTX 5090: 2027 TFLOPS for E2M1xE2M1, INT4xINT4 and mixed).
+//
+// Therefore every kernel in this TU is COMPILED as e2m1 and MUST be
+// post-processed with tools/patch_int4_omma_sm120.py, which flips
+// bits 78/79 of every OMMA.SF instruction inside kernels whose
+// mangled name contains "int4_". Loading this TU without the patch
+// step yields E2M1 semantics on INT4-encoded data (i.e. garbage) —
+// the launcher cannot detect this, so builds must treat the patch
+// as part of the link step. A runtime canary is provided
+// (int4_w4a4_sm120_codebook_canary) that returns 0 only if the
+// running SASS actually decodes the INT4 codebook.
+//
+// ── Data formats ──────────────────────────────────────────────────
+// Elements: 4-bit sign-magnitude, nibble = (sign<<3) | mag, mag 0..7,
+//   value = (-1)^sign * mag. Packed 2/byte, low nibble = even k.
+// Scale factors: UE4M3 per 16 elements (identical layout and swizzle
+//   to the NVFP4 path — nvfp4_sf_linear_to_swizzled scheme), with an
+//   fp32 global scale per tensor: value = nibble * ue4m3(sf) * g.
+//   Quantizer uses g = amax / (7 * 448) (INT4_MAX * UE4M3_MAX).
+//
+// ── llama.cpp / GGUF note ─────────────────────────────────────────
+// GGML Q4 formats are uniform grids, so they map onto E0M3 without
+// the E2M1 regrid loss:
+//   Q4_0 (block 32, fp16 scale d, q in -8..7, w = q*d): mag -8 clamps
+//     to -7 (one code point), d re-encodes into ue4m3*g two-level.
+//   Q4_K (block 256/16, 6-bit scales+mins): asymmetric; fold the min
+//     into a per-block bias channel or re-center offline, scales map
+//     per-16 directly.
+// Conversion is offline/host-side; this TU only defines the runtime
+// GEMV + activation quantizer.
+//
+// Wiring note: when this TU is added to flash_rt_kernels, the build
+// must (1) run the OMMA patch tool on the produced .so as a
+// post-build step and (2) add the exported symbols to the frontend
+// fail-fast list + a smoke test, per repo convention.
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace gemm {
+
+// y[N] = alpha * sum_k dq(A[k]) * dq(B[n,k])   (M = 1)
+//
+// A_packed: (K/2,)  uint8   INT4 activation row (packed nibbles)
+// B_packed: (N, K/2) uint8  INT4 weights, row-major over N
+// SFA:      swizzled UE4M3 SF table for the single A row
+// SFB:      swizzled UE4M3 SF table for N weight rows
+// alpha:    caller folds gA * gB (the two fp32 global scales) here
+// Constraints: K % 64 == 0, N % 8 == 0.
+int int4_w4a4_mma_sm120_full_n_bf16out(
+    const void*  A_packed,
+    const void*  B_packed,
+    void*        D_bf16,
+    int          N,
+    int          K,
+    const void*  SFA,
+    const void*  SFB,
+    float        alpha,
+    cudaStream_t stream);
+
+// bf16 (rows, K) row-major → INT4 nibbles (rows, K/2) + swizzled
+// UE4M3 SF table. `global_scale` is a device fp32 pointer (from
+// int4_weight_global_scale_sm120 below, or any caller-provided
+// scalar). SF table byte size = ceil(rows/128) * ceil(K/64) * 512.
+// Serves both weights (rows = N, offline) and activations (rows = 1).
+int int4_quantize_bf16_sm120(
+    const void*  x_bf16,
+    void*        out_packed,
+    void*        out_sf_swizzled,
+    const void*  global_scale,   // device float*
+    int          rows,
+    int          K,
+    cudaStream_t stream);
+
+// amax(|x|) / (7 * 448) over a bf16 tensor → device float.
+// `scale_out` must be pre-zeroed (atomicMax accumulation).
+int int4_global_scale_bf16_sm120(
+    const void*  x_bf16,
+    void*        scale_out,      // device float*
+    long long    numel,
+    cudaStream_t stream);
+
+// Runtime canary: runs one 16x8x64 MMA with a known INT4 pattern and
+// checks the output against the INT4 codebook. Returns 0 if the SASS
+// was patched (true E0M3 decode), 1 if it still decodes as E2M1
+// (patch step missing), negative on launch error. Synchronizes.
+int int4_w4a4_sm120_codebook_canary(cudaStream_t stream);
+
+}  // namespace gemm
+}  // namespace flash_rt

--- a/csrc/kernels/test_int4_w4a4_standalone.cu
+++ b/csrc/kernels/test_int4_w4a4_standalone.cu
@@ -1,0 +1,222 @@
+// ============================================================================
+//  Standalone correctness + throughput test for the sm_120 INT4 (E0M3)
+//  W4A4 GEMV, using only synthetic data (no checkpoints required).
+//
+//  What it checks:
+//   1. Codebook canary: the loaded SASS actually decodes E0M3 (returns 0).
+//      This ONLY passes after the OMMA bit-patch step (see below); an
+//      unpatched binary decodes E2M1 and the test aborts with guidance.
+//   2. GEMV vs host reference: quantize a random (N,K) weight and a random
+//      (1,K) activation with the kernel's own device quantizer, run the
+//      GEMV, and compare against a plain-C++ reference that dequantizes
+//      with the identical INT4 two-level recipe. Expect cos > 0.999
+//      (the residual is bf16-output rounding vs the fp32 reference).
+//   3. Throughput microbench: register-resident issue rate, reported in
+//      TFLOPS, to confirm INT4 runs at the E2M1 tensor-core rate.
+//
+//  Build + patch + run:
+//    nvcc -std=c++17 -O3 -gencode arch=compute_120a,code=sm_120a \
+//      csrc/kernels/int4_w4a4_mma_sm120.cu \
+//      csrc/kernels/test_int4_w4a4_standalone.cu -o /tmp/test_int4
+//    python tools/patch_int4_omma_sm120.py /tmp/test_int4
+//    /tmp/test_int4
+//
+//  The patch step flips OMMA bits 78/79 (E2M1 -> E0M3) in every device
+//  function whose name contains "int4_". Without it, step 1 fails by
+//  design: the kernel is compiled E2M1 and RUN as E0M3.
+// ============================================================================
+#include "int4_w4a4_mma_sm120.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using flash_rt::gemm::int4_global_scale_bf16_sm120;
+using flash_rt::gemm::int4_quantize_bf16_sm120;
+using flash_rt::gemm::int4_w4a4_mma_sm120_full_n_bf16out;
+using flash_rt::gemm::int4_w4a4_sm120_codebook_canary;
+
+#define CK(x) do { cudaError_t e = (x); if (e != cudaSuccess) { \
+  printf("CUDA error %s at %s:%d\n", cudaGetErrorString(e), __FILE__, __LINE__); \
+  exit(1); } } while (0)
+
+// ── Host reference: the INT4 two-level recipe (mirrors the device kernel) ──
+
+static float ue4m3_ceil_decode(float v) {
+  if (v <= 0.f) return 0.f;
+  if (v > 240.f) return 448.f;
+  int fe; float m = frexpf(v, &fe); (void)m;
+  int float_exp = fe - 1;
+  int ue_exp = float_exp + 7;
+  if (ue_exp <= 0) {
+    int mm = (int)ceilf(v * 512.f);
+    if (mm > 7) return ldexpf(1.f, -6);
+    if (mm < 1) mm = 1;
+    return ldexpf((float)mm / 8.f, -6);
+  }
+  float frac = v / ldexpf(1.f, float_exp) - 1.f;
+  int mant = (int)ceilf(frac * 8.f - 1e-6f);
+  if (mant >= 8) { mant = 0; ue_exp++; }
+  if (ue_exp >= 15) return 448.f;
+  return ldexpf(1.f + (float)mant / 8.f, ue_exp - 7);
+}
+
+// Quantize+dequantize one row with the INT4 recipe → fp32 values.
+static void int4_ref_row(const float* x, int K, float g, float* out) {
+  for (int gi = 0; gi < K / 16; ++gi) {
+    float bmax = 0.f;
+    for (int i = 0; i < 16; ++i) bmax = fmaxf(bmax, fabsf(x[gi * 16 + i]));
+    float sf = ue4m3_ceil_decode((bmax / 7.f) / g) * g;
+    if (sf <= 0.f) sf = 1.f;
+    for (int i = 0; i < 16; ++i) {
+      float q = rintf(x[gi * 16 + i] / sf);
+      if (q > 7.f) q = 7.f; if (q < -7.f) q = -7.f;
+      out[gi * 16 + i] = q * sf;
+    }
+  }
+}
+
+static float host_amax(const float* x, long long n) {
+  float a = 0.f;
+  for (long long i = 0; i < n; ++i) a = fmaxf(a, fabsf(x[i]));
+  return a;
+}
+
+// ── Throughput microbench kernel (issue-rate; register-resident) ──
+// Defined here (not in the shipped .cu) so its OMMA also carries the
+// "int4_" marker and is patched. 4 independent accumulator chains/warp.
+namespace {
+__device__ __forceinline__ void int4_bench_mma(
+    float& d0, float& d1, float& d2, float& d3,
+    uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3,
+    uint32_t b0, uint32_t b1, uint32_t sfa, uint32_t sfb) {
+  constexpr uint16_t z = 0;
+  asm volatile(
+      "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64"
+      ".row.col.f32.e2m1.e2m1.f32.ue4m3 "
+      "{%0,%1,%2,%3},{%4,%5,%6,%7},{%8,%9},{%10,%11,%12,%13},"
+      "{%14},{%15,%16},{%17},{%18,%19};\n"
+      : "+f"(d0), "+f"(d1), "+f"(d2), "+f"(d3)
+      : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1),
+        "f"(d0), "f"(d1), "f"(d2), "f"(d3),
+        "r"(sfa), "h"(z), "h"(z), "r"(sfb), "h"(z), "h"(z));
+}
+__global__ void int4_bench_kernel(int iters, float* out) {
+  uint32_t a0 = 0x25142514u, a1 = 0x36253625u, a2 = 0x14721472u, a3 = 0x53625362u;
+  uint32_t b0 = 0x13521352u, b1 = 0x24632463u, sf = 0x38383838u;
+  float acc[4][4];
+  #pragma unroll
+  for (int g = 0; g < 4; ++g)
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) acc[g][i] = 0.f;
+  for (int it = 0; it < iters; ++it) {
+    #pragma unroll
+    for (int g = 0; g < 4; ++g)
+      int4_bench_mma(acc[g][0], acc[g][1], acc[g][2], acc[g][3],
+                     a0, a1, a2, a3, b0, b1, sf, sf);
+  }
+  float s = 0.f;
+  #pragma unroll
+  for (int g = 0; g < 4; ++g)
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) s += acc[g][i];
+  if (s == 12345.678f) out[threadIdx.x] = s;
+}
+}  // namespace
+
+static double cos_vec(const std::vector<float>& a, const std::vector<float>& b) {
+  double dot = 0, na = 0, nb = 0;
+  for (size_t i = 0; i < a.size(); ++i) { dot += (double)a[i] * b[i]; na += (double)a[i] * a[i]; nb += (double)b[i] * b[i]; }
+  return dot / (sqrt(na) * sqrt(nb) + 1e-30);
+}
+
+int main() {
+  int canary = int4_w4a4_sm120_codebook_canary(0);
+  printf("[canary] %d  (%s)\n", canary,
+         canary == 0 ? "E0M3 decode OK" :
+         canary == 1 ? "E2M1 — binary NOT patched, run tools/patch_int4_omma_sm120.py" :
+                       "unexpected");
+  if (canary != 0) return 1;
+
+  // ── GEMV correctness on synthetic data ──
+  const int N = 4096, K = 4096;
+  std::vector<float> hW(N * K), hA(K);
+  srand(1234);
+  for (auto& v : hW) v = ((float)rand() / RAND_MAX - 0.5f) * 0.4f;
+  for (auto& v : hA) v = ((float)rand() / RAND_MAX - 0.5f) * 0.6f;
+
+  // Upload as bf16.
+  std::vector<__nv_bfloat16> hWb(N * K), hAb(K);
+  for (int i = 0; i < N * K; ++i) hWb[i] = __float2bfloat16(hW[i]);
+  for (int i = 0; i < K; ++i) hAb[i] = __float2bfloat16(hA[i]);
+  __nv_bfloat16 *dW, *dA; CK(cudaMalloc(&dW, sizeof(__nv_bfloat16) * N * K));
+  CK(cudaMalloc(&dA, sizeof(__nv_bfloat16) * K));
+  CK(cudaMemcpy(dW, hWb.data(), sizeof(__nv_bfloat16) * N * K, cudaMemcpyHostToDevice));
+  CK(cudaMemcpy(dA, hAb.data(), sizeof(__nv_bfloat16) * K, cudaMemcpyHostToDevice));
+
+  float *dgW, *dgA; CK(cudaMalloc(&dgW, 4)); CK(cudaMalloc(&dgA, 4));
+  CK(cudaMemset(dgW, 0, 4)); CK(cudaMemset(dgA, 0, 4));
+  int4_global_scale_bf16_sm120(dW, dgW, (long long)N * K, 0);
+  int4_global_scale_bf16_sm120(dA, dgA, K, 0);
+  CK(cudaDeviceSynchronize());
+  float gW, gA; CK(cudaMemcpy(&gW, dgW, 4, cudaMemcpyDeviceToHost));
+  CK(cudaMemcpy(&gA, dgA, 4, cudaMemcpyDeviceToHost));
+
+  int sfW = ((N + 127) / 128) * ((K + 63) / 64) * 512;
+  int sfA = ((1 + 127) / 128) * ((K + 63) / 64) * 512;
+  uint8_t *dWpk, *dApk, *dWsf, *dAsf;
+  CK(cudaMalloc(&dWpk, (size_t)N * (K / 2))); CK(cudaMalloc(&dApk, K / 2));
+  CK(cudaMalloc(&dWsf, sfW)); CK(cudaMalloc(&dAsf, sfA));
+  CK(cudaMemset(dWsf, 0, sfW)); CK(cudaMemset(dAsf, 0, sfA));
+  int4_quantize_bf16_sm120(dW, dWpk, dWsf, dgW, N, K, 0);
+  int4_quantize_bf16_sm120(dA, dApk, dAsf, dgA, 1, K, 0);
+  CK(cudaDeviceSynchronize());
+
+  __nv_bfloat16* dD; CK(cudaMalloc(&dD, sizeof(__nv_bfloat16) * N));
+  int rc = int4_w4a4_mma_sm120_full_n_bf16out(dApk, dWpk, dD, N, K, dAsf, dWsf, gA * gW, 0);
+  CK(cudaDeviceSynchronize());
+  if (rc != 0) { printf("[gemv] launch rc=%d\n", rc); return 1; }
+  std::vector<__nv_bfloat16> hDb(N); CK(cudaMemcpy(hDb.data(), dD, sizeof(__nv_bfloat16) * N, cudaMemcpyDeviceToHost));
+  std::vector<float> hD(N); for (int i = 0; i < N; ++i) hD[i] = __bfloat162float(hDb[i]);
+
+  // Host reference with identical recipe.
+  float gA_ref = host_amax(hA.data(), K) / (7.f * 448.f);
+  std::vector<float> Adq(K); int4_ref_row(hA.data(), K, gA_ref, Adq.data());
+  float gW_ref = host_amax(hW.data(), (long long)N * K) / (7.f * 448.f);
+  std::vector<float> ref(N, 0.f), Wdq(K);
+  for (int n = 0; n < N; ++n) {
+    int4_ref_row(&hW[(size_t)n * K], K, gW_ref, Wdq.data());
+    double acc = 0;
+    for (int k = 0; k < K; ++k) acc += (double)Adq[k] * Wdq[k];
+    ref[n] = (float)acc;
+  }
+  printf("[gemv] N=%d K=%d  cos(kernel, INT4-ref) = %.6f  (expect > 0.999)\n",
+         N, K, cos_vec(hD, ref));
+  printf("[gemv] sample kernel[:4] = %.4f %.4f %.4f %.4f\n", hD[0], hD[1], hD[2], hD[3]);
+  printf("[gemv] sample ref   [:4] = %.4f %.4f %.4f %.4f\n", ref[0], ref[1], ref[2], ref[3]);
+
+  // ── Throughput microbench ──
+  int sm = 0; CK(cudaDeviceGetAttribute(&sm, cudaDevAttrMultiProcessorCount, 0));
+  float* dOut; CK(cudaMalloc(&dOut, 256 * 4));
+  int iters = 8192, blocks = sm * 4, threads = 256;
+  int4_bench_kernel<<<blocks, threads>>>(iters, dOut);
+  CK(cudaDeviceSynchronize());
+  cudaEvent_t e0, e1; CK(cudaEventCreate(&e0)); CK(cudaEventCreate(&e1));
+  double best = 0;
+  for (int r = 0; r < 5; ++r) {
+    CK(cudaEventRecord(e0)); int4_bench_kernel<<<blocks, threads>>>(iters, dOut); CK(cudaEventRecord(e1));
+    CK(cudaEventSynchronize(e1));
+    float ms; CK(cudaEventElapsedTime(&ms, e0, e1));
+    double warps = (double)blocks * (threads / 32);
+    double flops = warps * 4.0 * iters * 2.0 * 16 * 8 * 64;
+    best = fmax(best, flops / (ms * 1e-3) / 1e12);
+  }
+  printf("[bench] issue-rate: %.1f TFLOPS  (INT4 x INT4, %d blocks x %d warps)\n",
+         best, blocks, threads / 32);
+  printf("[result] PASS\n");
+  return 0;
+}

--- a/docs/int4_blackwell.md
+++ b/docs/int4_blackwell.md
@@ -1,0 +1,165 @@
+# INT4 (E0M3) on Blackwell / sm_120 — experimental
+
+> **Status: experimental.** This is a runtime primitive plus a standalone
+> validation harness. It is not wired into `flash_rt_kernels` or any model
+> pipeline yet; enabling it requires the post-build SASS patch step
+> described below. The end-to-end model integration lands in a separate PR.
+
+## Summary
+
+sm_120 (RTX 50-series) exposes a single block-scaled 4-bit tensor-core
+instruction, `mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64`
+(SASS `OMMA.SF.16864`), which `ptxas` only accepts with the `e2m1`
+(NVFP4) element type. On this architecture the operand **element format**
+is not fixed by the opcode — it is carried in two bits of the 128-bit SASS
+encoding, **bit 78 for the A operand and bit 79 for the B operand**:
+
+| bit value | decoded format |
+|---|---|
+| 0 | `e2m1` — NVFP4, non-uniform codebook `±{0, .5, 1, 1.5, 2, 3, 4, 6}` |
+| 1 | `e0m3` — uniform INT4, sign-magnitude codebook `−7 … +7` |
+
+Flipping those bits turns the same instruction into a native INT4 (or
+mixed INT4 × NVFP4) multiply. The block-scale path (UE4M3 per-16
+scale-factor + fp32 global scale) is unchanged, so INT4 reuses the entire
+NVFP4 quantization and swizzle machinery.
+
+This was documented publicly by the Ling Team; see **Credits** below. The
+kernels here reproduce and productize that finding for FlashRT.
+
+## Why INT4 and not E2M1
+
+E2M1's non-uniform grid has an inherent *shrinkage bias*: the asymmetric
+rounding bins bias quantized values toward the origin, and that bias
+accumulates. A uniform 4-bit grid (INT4 / E0M3) removes it, so per-block
+scaling and rotation (e.g. randomized Hadamard) translate directly into
+better quantization quality. See the Ling UFP4 report in **References**.
+
+Measured on real weights (bit-faithful simulation of the shipped two-level
+quantizer; identical UE4M3 per-16 SF + fp32 global scale, `amax/(7·448)`
+for INT4 vs `amax/(6·448)` for E2M1), INT4 lowers weight quantization error
+(1 − cosine) versus E2M1 on **37 / 37** tensors sampled across a diffusion
+DiT, a 3D-conv VAE, and a dense transformer:
+
+| tensor family | mean quant-error reduction (best INT4 vs E2M1) |
+|---|---|
+| diffusion DiT (attn + FFN) | −15 % |
+| 3D-conv VAE (residual convs) | −18 % |
+| dense transformer (attn + MLP + lm_head) | −15 % |
+
+Uniform-grid + per-16 rotation (Hadamard, size 16) wins on every tensor;
+the same rotation applied under E2M1 never helps, matching the shrinkage
+-bias explanation.
+
+## Throughput — identical to NVFP4
+
+Because it is the same tensor-core instruction, INT4 runs at the NVFP4
+rate. Issue-rate microbenchmark, register-resident MMA (no memory
+traffic), **RTX 5090, CUDA 13.0**:
+
+| operand formats | throughput |
+|---|---|
+| NVFP4 `e2m1 × e2m1` | 2026.6 TFLOPS |
+| INT4 `e0m3 × e0m3` | 2026.8 – 2027.1 TFLOPS |
+| mixed `e0m3 × e2m1` | 2027.9 TFLOPS |
+
+*Metric: instruction issue rate (2·M·N·K per MMA), median of 5, no HBM
+traffic — this measures the tensor-core rate, not an end-to-end GEMM.* The
+standalone test below reproduces ≈ 2013 TFLOPS with the same method.
+
+A prebuilt HF kernel with the same microbenchmark is published at
+`huggingface.co/kernels/flashrt/int4-blackwell`.
+
+## Kernels
+
+`csrc/kernels/int4_w4a4_mma_sm120.{cu,cuh}`:
+
+- `int4_w4a4_mma_sm120_full_n_bf16out` — M=1 full-N W4A4 GEMV, bf16 out.
+  Same fragment layout and cp.async double-buffering as the NVFP4 twin
+  `fp4_w4a4_mma_sm120`.
+- `int4_quantize_bf16_sm120` — bf16 → INT4 nibbles + swizzled UE4M3 SF.
+- `int4_global_scale_bf16_sm120` — `amax / (7·448)` reduction.
+- `int4_w4a4_sm120_codebook_canary` — runtime self-check (returns 0 only
+  if the running SASS truly decodes E0M3).
+- `extern "C"` wrappers (`int4_*`) for non-C++ backends, e.g. a GGML /
+  llama.cpp custom op.
+
+## The kernel is compiled E2M1 and RUN as E0M3
+
+`ptxas` rejects any element type other than `e2m1` for this instruction,
+so the `.cu` emits the normal NVFP4 form and the **patch step is part of
+linking**. `tools/patch_int4_omma_sm120.py` flips bits 78/79 of every
+`OMMA.SF` instruction inside device functions whose (mangled) name
+contains `int4_`. It operates on a bare `.cubin`, or in place on a host
+ELF (`.so` / executable) with an uncompressed `.nv_fatbin`.
+
+Loading an unpatched binary decodes E2M1 on INT4 data — i.e. wrong
+results, undetectable by the launcher. Always gate module load on
+`int4_w4a4_sm120_codebook_canary() == 0` (fail-fast). Mixed
+W-INT4 × A-E2M1 is available with `--operands b` (patch the weight operand
+only).
+
+> **Toolchain note:** these bits are undocumented and invisible to
+> `nvdisasm` / `cuobjdump` (a patched instruction still disassembles as
+> `E2M1.E2M1`). Re-verify the encoding after any CUDA-toolkit upgrade; the
+> canary is the authoritative check.
+
+## Reproduce
+
+Requires an sm_120 GPU (RTX 50-series) and CUDA 13.0+. No checkpoints —
+the test uses synthetic data.
+
+```bash
+nvcc -std=c++17 -O3 -gencode arch=compute_120a,code=sm_120a \
+  csrc/kernels/int4_w4a4_mma_sm120.cu \
+  csrc/kernels/test_int4_w4a4_standalone.cu -o <out>/test_int4
+python tools/patch_int4_omma_sm120.py <out>/test_int4
+<out>/test_int4
+```
+
+Expected output:
+
+```text
+[canary] 0  (E0M3 decode OK)
+[gemv] N=4096 K=4096  cos(kernel, INT4-ref) = 0.9994  (expect > 0.999)
+[bench] issue-rate: ~2013 TFLOPS  (INT4 x INT4)
+[result] PASS
+```
+
+`cos(kernel, INT4-ref)` compares the kernel against a plain-C++
+implementation of the identical INT4 two-level recipe, validating the SF
+swizzle addressing and fragment layout (the residual is bf16-output
+rounding vs the fp32 reference). Build with `arch=compute_120a` (not
+`compute_120`) — plain `compute_120` rejects `mxf4nvf4`.
+
+## llama.cpp / GGUF notes
+
+The natural consumer is a 4-bit GGML backend on Blackwell: hardware
+dequant happens inside the tensor core at the NVFP4 rate, replacing a
+software Q4-dequant + BF16 GEMV.
+
+- Quantize **from the original weights** to E0M3. Re-encoding an existing
+  Q4_0 GGUF double-quantizes (cosine drops measurably) — GGML's per-32
+  fp16 scale and our per-16 UE4M3 scale are different grids.
+- GGML `Q4_0`: the single `−8` code clamps to our `±7` grid (≈ 3.6 % of
+  codes on a sampled tensor, negligible); the per-32 scale maps onto two
+  per-16 UE4M3 blocks exactly.
+- GGML `Q4_K`: fold the per-block `min` into a per-row bias, then the
+  symmetric per-16 scale maps directly onto UE4M3.
+
+## Credits
+
+The sm_120 `OMMA.SF` element-format bits were first documented publicly by
+the **Ling Team** (author **@im0qianqian**). This work reproduces and
+productizes that finding. Article (Chinese):
+<https://zhuanlan.zhihu.com/p/2059376150565089368>
+
+## References
+
+- Ling Team, *Rethinking Shrinkage Bias in LLM FP4 Pretraining: Geometric
+  Origin, Systemic Impact, and UFP4 Recipe* (arXiv). Motivates uniform
+  4-bit grids over E2M1 and the Hadamard-rotation interaction.
+- NVIDIA, *NVFP4* block-scaled FP4 format (E2M1 element + UE4M3 per-16
+  scale factor), Blackwell tensor cores.
+- Tseng et al., *QuIP#* / Hadamard-incoherence rotations for low-bit
+  quantization (background for the per-16 rotation results above).

--- a/docs/int4_blackwell.md
+++ b/docs/int4_blackwell.md
@@ -81,8 +81,8 @@ A prebuilt HF kernel with the same microbenchmark is published at
 - `int4_global_scale_bf16_sm120` — `amax / (7·448)` reduction.
 - `int4_w4a4_sm120_codebook_canary` — runtime self-check (returns 0 only
   if the running SASS truly decodes E0M3).
-- `extern "C"` wrappers (`int4_*`) for non-C++ backends, e.g. a GGML /
-  llama.cpp custom op.
+- `extern "C"` wrappers (`flashrt_int4_sm120_*`) for non-C++ backends,
+  e.g. a GGML / llama.cpp custom op.
 
 ## The kernel is compiled E2M1 and RUN as E0M3
 
@@ -99,10 +99,25 @@ results, undetectable by the launcher. Always gate module load on
 W-INT4 × A-E2M1 is available with `--operands b` (patch the weight operand
 only).
 
-> **Toolchain note:** these bits are undocumented and invisible to
-> `nvdisasm` / `cuobjdump` (a patched instruction still disassembles as
-> `E2M1.E2M1`). Re-verify the encoding after any CUDA-toolkit upgrade; the
-> canary is the authoritative check.
+**Static verification is asymmetric — the runtime canary is
+authoritative.** These bits are undocumented: an *unpatched* binary
+disassembles normally (the sites are locatable and readable), but once the
+bits are set `cuobjdump`/`nvdisasm` no longer decode the instruction as
+`OMMA.SF` at all, so a *patched* binary cannot be re-located or re-read
+statically. Consequently:
+
+- `patch_int4_omma_sm120.py --verify --expect e2m1` is a reliable
+  **pre-patch** gate (exit 0 iff every site is still E2M1; nonzero
+  otherwise, including "no sites"). Use it in the build to prove the right
+  thing was compiled before patching.
+- `--verify --expect int4` returns 1 on an unpatched binary and 2
+  (inconclusive) on a patched one — it never claims success by guessing.
+- The only authoritative proof that a binary decodes E0M3 is
+  `int4_w4a4_sm120_codebook_canary() == 0` at load.
+
+Patch mode fails loudly (nonzero exit) if it flips zero instructions, so a
+build step cannot silently ship an unpatched or double-run binary.
+Re-verify the encoding after any CUDA-toolkit upgrade.
 
 ## Reproduce
 
@@ -113,8 +128,9 @@ the test uses synthetic data.
 nvcc -std=c++17 -O3 -gencode arch=compute_120a,code=sm_120a \
   csrc/kernels/int4_w4a4_mma_sm120.cu \
   csrc/kernels/test_int4_w4a4_standalone.cu -o <out>/test_int4
-python tools/patch_int4_omma_sm120.py <out>/test_int4
-<out>/test_int4
+python tools/patch_int4_omma_sm120.py <out>/test_int4 --verify --expect e2m1  # pre-patch gate (exit 0)
+python tools/patch_int4_omma_sm120.py <out>/test_int4                          # flip to INT4
+<out>/test_int4                                                                # runtime canary = authoritative
 ```
 
 Expected output:

--- a/tools/patch_int4_omma_sm120.py
+++ b/tools/patch_int4_omma_sm120.py
@@ -2,33 +2,50 @@
 """Post-build INT4 (E0M3) unlock for sm_120 OMMA kernels.
 
 ptxas can only emit E2M1 element formats for
-`mma.sync.kind::mxf4nvf4.block_scale` (SASS OMMA.SF.16864). On sm_120
-the element format actually lives in bits 78 (A operand) / 79 (B
-operand) of the 128-bit instruction: 0 = E2M1, 1 = E0M3 (uniform INT4,
-codebook -7..7). This tool flips those bits for every OMMA.SF
-instruction inside device functions whose (mangled) name contains a
-marker substring — by convention `int4_` (see
-csrc/kernels/int4_w4a4_mma_sm120.cu).
+`mma.sync.kind::mxf4nvf4.block_scale` (SASS OMMA.SF.16864). On sm_120 the
+element format actually lives in bits 78 (A operand) / 79 (B operand) of
+the 128-bit instruction: 0 = E2M1, 1 = E0M3 (uniform INT4, codebook
+-7..7). This tool flips those bits for every OMMA.SF instruction inside
+device functions whose (mangled) name contains a marker substring — by
+convention `int4_` (see csrc/kernels/int4_w4a4_mma_sm120.cu).
 
 Works on:
   * standalone .cubin files
-  * host ELF objects (.so) with an uncompressed .nv_fatbin — every
-    embedded sm_120 cubin is located by ELF magic scan and patched in
-    place. (flash_rt builds store cubins uncompressed; if a compressed
-    fatbin entry is ever encountered the affected cubin is skipped and
-    reported, never silently half-patched.)
+  * host ELF objects (.so / executables) with an uncompressed .nv_fatbin
+    — every embedded sm_120 cubin is located by ELF scan and patched in
+    place. (flash_rt builds store cubins uncompressed.)
+
+## Verification is asymmetric — read this before trusting an exit code
+
+An UNpatched binary disassembles normally, so the sites are locatable and
+their bits are readable. A PATCHED binary does NOT: once bits 78/79 are
+set, `cuobjdump`/`nvdisasm` no longer decode the instruction as OMMA.SF
+(it renders as something else or drops out), so the patched sites cannot
+be re-located statically. Therefore:
+
+  * `--verify --expect e2m1` : PRE-patch gate. Confirms the sites exist and
+    are still E2M1. exit 0 iff every located site is E2M1; nonzero
+    otherwise (incl. "no sites found"). Use this in the build to prove you
+    compiled the right thing before patching.
+  * `--verify --expect int4`  : on an unpatched binary this reports the
+    sites as E2M1 and exits 1 (NOT patched). On a patched binary the sites
+    are unlocatable and it exits 2 (INCONCLUSIVE) — static analysis cannot
+    confirm a patched binary. It never returns 0 by guessing.
+  * `--verify` (no --expect) : report only, always exit 0.
+
+The AUTHORITATIVE check that a binary decodes E0M3 is the runtime canary
+`int4_codebook_canary()` exported by the kernels — call it at module load
+(fail-fast). Do not treat any static exit code as proof of a patched
+binary; treat `--expect e2m1 == 0` as proof it is still UNpatched.
+
+Patch mode fails loudly: if it flips zero instructions (already patched /
+no marker match) it exits nonzero so a build step cannot silently ship an
+unpatched or double-run binary.
 
 Usage:
   patch_int4_omma_sm120.py <input> [-o OUT] [--marker int4_]
-                           [--operands ab|a|b] [--verify]
-
-  --verify  only report bit state per instruction, change nothing.
-  In-place patching (no -o) refuses to run on files it cannot fully
-  process. Exit code 0 = success / all-verified, nonzero otherwise.
-
-Runtime safety net: the kernels export int4_codebook_canary(), which
-returns 0 only when the loaded SASS truly decodes E0M3 — call it at
-module init (fail-fast) so an unpatched .so can never serve traffic.
+                           [--operands ab|a|b]
+                           [--verify [--expect e2m1|int4]]
 """
 import argparse
 import os
@@ -45,9 +62,12 @@ BIT_B = 0x80  # instruction byte 9, bit 7  -> SASS bit 79 (B operand)
 
 
 def sass_sites(cubin_path, marker):
-    """[(func, instr_off, text)] for OMMA.SF instrs in marked functions."""
-    out = subprocess.run([CUOBJDUMP, "-sass", cubin_path],
-                         capture_output=True, text=True, check=True).stdout
+    """OMMA.SF sites in marked functions, or None if not disassemblable."""
+    try:
+        out = subprocess.run([CUOBJDUMP, "-sass", cubin_path],
+                             capture_output=True, text=True, check=True).stdout
+    except subprocess.CalledProcessError:
+        return None
     sites, fn = [], None
     for line in out.splitlines():
         m = re.search(r"Function\s*:\s*(\S+)", line)
@@ -63,12 +83,9 @@ def sass_sites(cubin_path, marker):
 
 
 def text_section_offsets(cubin_bytes):
-    """{section_name: file_offset} from an in-memory cubin ELF."""
-    if cubin_bytes[:4] != b"\x7fELF":
-        raise ValueError("not an ELF")
-    is64 = cubin_bytes[4] == 2
-    if not is64:
-        raise ValueError("only ELF64 cubins supported")
+    """{section_name: file_offset} from an in-memory cubin ELF64."""
+    if cubin_bytes[:4] != b"\x7fELF" or cubin_bytes[4] != 2:
+        raise ValueError("not an ELF64 cubin")
     e_shoff, = struct.unpack_from("<Q", cubin_bytes, 0x28)
     e_shentsize, e_shnum, e_shstrndx = struct.unpack_from(
         "<HHH", cubin_bytes, 0x3A)
@@ -87,8 +104,8 @@ def text_section_offsets(cubin_bytes):
 
 def elf_total_size(buf, off):
     """Byte extent of the ELF64 at buf[off]: max of the section-header
-    table end and every section's (offset+size). Does not assume the
-    shdr table is last (it often isn't in nvcc cubins)."""
+    table end and every section/segment's (offset+size). Does not assume
+    the shdr table is last (it often isn't in nvcc cubins)."""
     e_phoff, = struct.unpack_from("<Q", buf, off + 0x20)
     e_shoff, = struct.unpack_from("<Q", buf, off + 0x28)
     e_phentsize, e_phnum = struct.unpack_from("<HH", buf, off + 0x36)
@@ -115,10 +132,9 @@ def find_embedded_cubins(data):
         pos = data.find(b"\x7fELF", pos)
         if pos < 0:
             return
-        # cubins are ET_EXEC/ET_REL with e_machine EM_CUDA (190)
         if pos + 0x40 <= len(data):
             machine, = struct.unpack_from("<H", data, pos + 0x12)
-            if machine == 190:
+            if machine == 190:  # EM_CUDA
                 try:
                     size = elf_total_size(data, pos)
                     if 0 < size <= len(data) - pos:
@@ -130,34 +146,41 @@ def find_embedded_cubins(data):
         pos += 4
 
 
-def patch_cubin_bytes(cubin, marker, mask, verify):
-    """Patch one cubin (bytearray). Returns (n_patched, report_lines)."""
+def has_marker_text(cubin, marker):
+    """True if the cubin has a .text.<fn> section whose name matches the
+    marker — used to tell a real (patchable) cubin from a stub even when
+    cuobjdump cannot disassemble it (i.e. it is already patched)."""
+    try:
+        secs = text_section_offsets(cubin)
+    except ValueError:
+        return False
+    return any(n.startswith(".text.") and marker in n for n in secs)
+
+
+def locate_sites(cubin, marker):
+    """(disasm_ok, [(fn, foff, ioff, text)]) for one cubin (bytes).
+    foff = file offset of instruction byte 9 within the cubin."""
     with tempfile.NamedTemporaryFile(suffix=".cubin", delete=False) as tf:
         tf.write(cubin)
         tmp = tf.name
     try:
         sites = sass_sites(tmp, marker)
-    except subprocess.CalledProcessError:
-        return 0, []  # not a disassemblable cubin (e.g. relocatable stub)
     finally:
         os.unlink(tmp)
-    if not sites:
-        return 0, []
+    if sites is None:
+        return False, []
     secs = text_section_offsets(cubin)
-    n, report = 0, []
+    out = []
     for fn, ioff, text in sites:
         sec = f".text.{fn}"
         if sec not in secs:
             raise RuntimeError(f"section {sec} missing")
-        foff = secs[sec] + ioff + 9
-        old = cubin[foff]
-        state = ("A" if old & BIT_A else "-") + ("B" if old & BIT_B else "-")
-        if verify:
-            report.append(f"  {fn}+0x{ioff:x}: bits[{state}]")
-        else:
-            cubin[foff] = old | mask
-            n += 1
-    return n, report
+        out.append((fn, secs[sec] + ioff + 9, ioff, text))
+    return True, out
+
+
+def bits_str(v):
+    return ("A" if v & BIT_A else "-") + ("B" if v & BIT_B else "-")
 
 
 def main():
@@ -166,48 +189,105 @@ def main():
     ap.add_argument("-o", "--output", help="default: patch in place")
     ap.add_argument("--marker", default="int4_")
     ap.add_argument("--operands", choices=["ab", "a", "b"], default="ab")
-    ap.add_argument("--verify", action="store_true")
+    ap.add_argument("--verify", action="store_true",
+                    help="do not modify; report/gate on current bit state")
+    ap.add_argument("--expect", choices=["e2m1", "int4"],
+                    help="with --verify: pass/fail gate (see module docstring)")
     args = ap.parse_args()
+    if args.expect:
+        args.verify = True
 
     mask = (BIT_A if "a" in args.operands else 0) | \
            (BIT_B if "b" in args.operands else 0)
     data = bytearray(open(args.input, "rb").read())
 
     machine, = struct.unpack_from("<H", data, 0x12)
-    total = 0
-    if machine == 190:  # bare cubin
-        n, report = patch_cubin_bytes(data, args.marker, mask, args.verify)
-        total += n
-        for line in report:
-            print(line)
-    else:  # host ELF / .so: patch every embedded sm cubin in place
-        found = False
-        for off, size in find_embedded_cubins(bytes(data)):
-            sub = bytearray(data[off:off + size])
-            n, report = patch_cubin_bytes(sub, args.marker, mask, args.verify)
-            if n or report:
-                found = True
-                print(f"[cubin @0x{off:x} size 0x{size:x}]")
-                for line in report:
-                    print(line)
-            if n:
-                data[off:off + size] = sub
-                total += n
-        if not found:
-            print(f"no OMMA.SF sites in functions matching "
-                  f"'{args.marker}' found")
-            sys.exit(0 if args.verify else 1)
+    if machine == 190:
+        cubins = [(0, len(data))]
+    else:
+        cubins = list(find_embedded_cubins(bytes(data)))
+        if not cubins:
+            print("no embedded cubins found")
+            sys.exit(1)
 
+    total_patched = 0
+    located = 0          # sites whose bits could be read
+    matched = 0          # sites matching --expect
+    mismatched = 0
+    unreadable_marked = False   # a marked cubin that yields no readable sites
+                                # (cuobjdump failed OR decoded no OMMA — both
+                                # happen once the bits are patched)
+
+    for off, size in cubins:
+        sub = bytearray(data[off:off + size])
+        ok, sites = locate_sites(sub, marker=args.marker)
+        if not sites:
+            # No readable OMMA. If the cubin still carries marked .text
+            # sections, the instructions are there but unreadable — i.e.
+            # already patched — not a marker-less/stub cubin.
+            if has_marker_text(sub, args.marker):
+                unreadable_marked = True
+            continue
+        if len(cubins) > 1:
+            print(f"[cubin @0x{off:x} size 0x{size:x}]")
+        for fn, foff, ioff, text in sites:
+            cur = sub[foff]
+            located += 1
+            if args.verify:
+                print(f"  {fn}+0x{ioff:x}: bits[{bits_str(cur)}]")
+                if args.expect:
+                    want = mask if args.expect == "int4" else 0
+                    if (cur & mask) == want:
+                        matched += 1
+                    else:
+                        mismatched += 1
+            else:
+                sub[foff] = cur | mask
+                total_patched += 1
+        if not args.verify:
+            data[off:off + size] = sub
+
+    # ── Verify mode ──
     if args.verify:
-        print("verify-only, nothing written")
-        return
+        if not args.expect:
+            print(f"report only ({located} site(s)); "
+                  f"use --expect e2m1|int4 for a pass/fail gate")
+            sys.exit(0)
+        if mismatched:
+            print(f"FAIL: {mismatched}/{located} site(s) are not "
+                  f"'{args.expect}'")
+            sys.exit(1)
+        if args.expect == "int4" and unreadable_marked:
+            print("INCONCLUSIVE: a marked cubin could not be disassembled "
+                  "— expected once patched (cuobjdump cannot read patched "
+                  "OMMA). Static analysis cannot confirm a patched binary; "
+                  "run int4_codebook_canary() at load for the authoritative "
+                  "check.")
+            sys.exit(2)
+        if located == 0:
+            if unreadable_marked:
+                print("INCONCLUSIVE: marked cubin present but not "
+                      "disassemblable; use the runtime canary.")
+                sys.exit(2)
+            print(f"FAIL: no OMMA.SF sites match marker '{args.marker}'")
+            sys.exit(1)
+        print(f"OK: all {located} site(s) are '{args.expect}'")
+        sys.exit(0)
 
-    if total == 0:
-        print(f"no instructions matched marker '{args.marker}'")
+    # ── Patch mode ──
+    if total_patched == 0:
+        if unreadable_marked:
+            print("nothing patched: a marked cubin could not be "
+                  "disassembled — the binary may already be patched "
+                  "(cuobjdump cannot read patched OMMA). Rebuild to re-patch "
+                  "from source.")
+            sys.exit(3)
+        print(f"nothing patched: no OMMA.SF sites match marker "
+              f"'{args.marker}'")
         sys.exit(1)
     out = args.output or args.input
     open(out, "wb").write(data)
-    print(f"patched {total} OMMA.SF instruction(s) "
+    print(f"patched {total_patched} OMMA.SF instruction(s) "
           f"(operands={args.operands}) -> {out}")
 
 

--- a/tools/patch_int4_omma_sm120.py
+++ b/tools/patch_int4_omma_sm120.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Post-build INT4 (E0M3) unlock for sm_120 OMMA kernels.
+
+ptxas can only emit E2M1 element formats for
+`mma.sync.kind::mxf4nvf4.block_scale` (SASS OMMA.SF.16864). On sm_120
+the element format actually lives in bits 78 (A operand) / 79 (B
+operand) of the 128-bit instruction: 0 = E2M1, 1 = E0M3 (uniform INT4,
+codebook -7..7). This tool flips those bits for every OMMA.SF
+instruction inside device functions whose (mangled) name contains a
+marker substring — by convention `int4_` (see
+csrc/kernels/int4_w4a4_mma_sm120.cu).
+
+Works on:
+  * standalone .cubin files
+  * host ELF objects (.so) with an uncompressed .nv_fatbin — every
+    embedded sm_120 cubin is located by ELF magic scan and patched in
+    place. (flash_rt builds store cubins uncompressed; if a compressed
+    fatbin entry is ever encountered the affected cubin is skipped and
+    reported, never silently half-patched.)
+
+Usage:
+  patch_int4_omma_sm120.py <input> [-o OUT] [--marker int4_]
+                           [--operands ab|a|b] [--verify]
+
+  --verify  only report bit state per instruction, change nothing.
+  In-place patching (no -o) refuses to run on files it cannot fully
+  process. Exit code 0 = success / all-verified, nonzero otherwise.
+
+Runtime safety net: the kernels export int4_codebook_canary(), which
+returns 0 only when the loaded SASS truly decodes E0M3 — call it at
+module init (fail-fast) so an unpatched .so can never serve traffic.
+"""
+import argparse
+import os
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+
+CUOBJDUMP = os.environ.get("CUOBJDUMP", "cuobjdump")
+
+BIT_A = 0x40  # instruction byte 9, bit 6  -> SASS bit 78 (A operand)
+BIT_B = 0x80  # instruction byte 9, bit 7  -> SASS bit 79 (B operand)
+
+
+def sass_sites(cubin_path, marker):
+    """[(func, instr_off, text)] for OMMA.SF instrs in marked functions."""
+    out = subprocess.run([CUOBJDUMP, "-sass", cubin_path],
+                         capture_output=True, text=True, check=True).stdout
+    sites, fn = [], None
+    for line in out.splitlines():
+        m = re.search(r"Function\s*:\s*(\S+)", line)
+        if m:
+            fn = m.group(1)
+            continue
+        m = re.match(r"\s*/\*([0-9a-fA-F]+)\*/\s+(.*)", line)
+        if m and "OMMA" in m.group(2) and ".SF." in m.group(2):
+            if fn and marker in fn:
+                sites.append((fn, int(m.group(1), 16),
+                              m.group(2).split(";")[0].strip()))
+    return sites
+
+
+def text_section_offsets(cubin_bytes):
+    """{section_name: file_offset} from an in-memory cubin ELF."""
+    if cubin_bytes[:4] != b"\x7fELF":
+        raise ValueError("not an ELF")
+    is64 = cubin_bytes[4] == 2
+    if not is64:
+        raise ValueError("only ELF64 cubins supported")
+    e_shoff, = struct.unpack_from("<Q", cubin_bytes, 0x28)
+    e_shentsize, e_shnum, e_shstrndx = struct.unpack_from(
+        "<HHH", cubin_bytes, 0x3A)
+    strtab_off, = struct.unpack_from(
+        "<Q", cubin_bytes, e_shoff + e_shstrndx * e_shentsize + 0x18)
+    offs = {}
+    for i in range(e_shnum):
+        base = e_shoff + i * e_shentsize
+        name_off, = struct.unpack_from("<I", cubin_bytes, base)
+        sh_offset, = struct.unpack_from("<Q", cubin_bytes, base + 0x18)
+        end = cubin_bytes.index(b"\x00", strtab_off + name_off)
+        name = cubin_bytes[strtab_off + name_off:end].decode()
+        offs[name] = sh_offset
+    return offs
+
+
+def elf_total_size(buf, off):
+    """Byte extent of the ELF64 at buf[off]: max of the section-header
+    table end and every section's (offset+size). Does not assume the
+    shdr table is last (it often isn't in nvcc cubins)."""
+    e_phoff, = struct.unpack_from("<Q", buf, off + 0x20)
+    e_shoff, = struct.unpack_from("<Q", buf, off + 0x28)
+    e_phentsize, e_phnum = struct.unpack_from("<HH", buf, off + 0x36)
+    e_shentsize, e_shnum = struct.unpack_from("<HH", buf, off + 0x3A)
+    end = e_shoff + e_shnum * e_shentsize
+    for i in range(e_shnum):
+        base = off + e_shoff + i * e_shentsize
+        sh_type, = struct.unpack_from("<I", buf, base + 0x04)
+        sh_offset, sh_size = struct.unpack_from("<QQ", buf, base + 0x18)
+        if sh_type != 8:  # SHT_NOBITS occupies no file space
+            end = max(end, sh_offset + sh_size)
+    for i in range(e_phnum):
+        base = off + e_phoff + i * e_phentsize
+        p_offset, = struct.unpack_from("<Q", buf, base + 0x08)
+        p_filesz, = struct.unpack_from("<Q", buf, base + 0x20)
+        end = max(end, p_offset + p_filesz)
+    return end
+
+
+def find_embedded_cubins(data):
+    """Yield (offset, size) of sm_120 cubin ELFs inside a host ELF/.so."""
+    pos = 0
+    while True:
+        pos = data.find(b"\x7fELF", pos)
+        if pos < 0:
+            return
+        # cubins are ET_EXEC/ET_REL with e_machine EM_CUDA (190)
+        if pos + 0x40 <= len(data):
+            machine, = struct.unpack_from("<H", data, pos + 0x12)
+            if machine == 190:
+                try:
+                    size = elf_total_size(data, pos)
+                    if 0 < size <= len(data) - pos:
+                        yield pos, size
+                        pos += size
+                        continue
+                except struct.error:
+                    pass
+        pos += 4
+
+
+def patch_cubin_bytes(cubin, marker, mask, verify):
+    """Patch one cubin (bytearray). Returns (n_patched, report_lines)."""
+    with tempfile.NamedTemporaryFile(suffix=".cubin", delete=False) as tf:
+        tf.write(cubin)
+        tmp = tf.name
+    try:
+        sites = sass_sites(tmp, marker)
+    except subprocess.CalledProcessError:
+        return 0, []  # not a disassemblable cubin (e.g. relocatable stub)
+    finally:
+        os.unlink(tmp)
+    if not sites:
+        return 0, []
+    secs = text_section_offsets(cubin)
+    n, report = 0, []
+    for fn, ioff, text in sites:
+        sec = f".text.{fn}"
+        if sec not in secs:
+            raise RuntimeError(f"section {sec} missing")
+        foff = secs[sec] + ioff + 9
+        old = cubin[foff]
+        state = ("A" if old & BIT_A else "-") + ("B" if old & BIT_B else "-")
+        if verify:
+            report.append(f"  {fn}+0x{ioff:x}: bits[{state}]")
+        else:
+            cubin[foff] = old | mask
+            n += 1
+    return n, report
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("input")
+    ap.add_argument("-o", "--output", help="default: patch in place")
+    ap.add_argument("--marker", default="int4_")
+    ap.add_argument("--operands", choices=["ab", "a", "b"], default="ab")
+    ap.add_argument("--verify", action="store_true")
+    args = ap.parse_args()
+
+    mask = (BIT_A if "a" in args.operands else 0) | \
+           (BIT_B if "b" in args.operands else 0)
+    data = bytearray(open(args.input, "rb").read())
+
+    machine, = struct.unpack_from("<H", data, 0x12)
+    total = 0
+    if machine == 190:  # bare cubin
+        n, report = patch_cubin_bytes(data, args.marker, mask, args.verify)
+        total += n
+        for line in report:
+            print(line)
+    else:  # host ELF / .so: patch every embedded sm cubin in place
+        found = False
+        for off, size in find_embedded_cubins(bytes(data)):
+            sub = bytearray(data[off:off + size])
+            n, report = patch_cubin_bytes(sub, args.marker, mask, args.verify)
+            if n or report:
+                found = True
+                print(f"[cubin @0x{off:x} size 0x{size:x}]")
+                for line in report:
+                    print(line)
+            if n:
+                data[off:off + size] = sub
+                total += n
+        if not found:
+            print(f"no OMMA.SF sites in functions matching "
+                  f"'{args.marker}' found")
+            sys.exit(0 if args.verify else 1)
+
+    if args.verify:
+        print("verify-only, nothing written")
+        return
+
+    if total == 0:
+        print(f"no instructions matched marker '{args.marker}'")
+        sys.exit(1)
+    out = args.output or args.input
+    open(out, "wb").write(data)
+    print(f"patched {total} OMMA.SF instruction(s) "
+          f"(operands={args.operands}) -> {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A native **INT4 (E0M3)** W4A4 GEMV for **sm_120** (RTX 50-series), plus the
build-time tool that unlocks it, a synthetic-data standalone test, and a doc.

On sm_120 the single block-scaled 4-bit tensor-core instruction
`mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64` (SASS
`OMMA.SF.16864`) carries the operand **element format** in bits **78 (A)** and
**79 (B)** of the 128-bit encoding: `0 = e2m1` (NVFP4), `1 = e0m3` (uniform
INT4, codebook −7…+7). `ptxas` only accepts `e2m1`, so the kernels are compiled
as NVFP4 and post-processed to INT4. The block-scale path (UE4M3 per-16 SF +
fp32 global scale) is unchanged, so INT4 reuses the whole NVFP4 quant/swizzle
machinery.

This element-format finding was documented publicly by the **Ling Team**
(@im0qianqian): https://zhuanlan.zhihu.com/p/2059376150565089368 — this PR
reproduces and productizes it for FlashRT.

## Why INT4 over E2M1

E2M1's non-uniform grid has an inherent *shrinkage bias* (asymmetric rounding
bins pull values toward zero); a uniform 4-bit grid removes it, so per-block
scaling and Hadamard rotation translate into real quality. Bit-faithful
simulation of the shipped two-level quantizer (identical UE4M3 per-16 SF + fp32
global scale; `amax/(7·448)` for INT4 vs `amax/(6·448)` for E2M1) on real
weights — INT4 lowers weight quant error (1 − cosine) on **37/37** sampled
tensors:

| tensor family | mean quant-error reduction (best INT4 vs E2M1) |
|---|---|
| diffusion DiT (attn + FFN) | −15 % |
| 3D-conv VAE (residual convs) | −18 % |
| dense transformer (attn + MLP + lm_head) | −15 % |

Uniform-grid + per-16 Hadamard wins on every tensor; the same rotation under
E2M1 never helps — matching the shrinkage-bias explanation (Ling UFP4 report).

## Throughput — identical to NVFP4

Same instruction, so INT4 runs at the NVFP4 rate. Issue-rate microbenchmark,
register-resident MMA (no HBM traffic), **RTX 5090, CUDA 13.0**, median of 5:

| operand formats | throughput |
|---|---|
| NVFP4 `e2m1 × e2m1` | 2026.6 TFLOPS |
| INT4 `e0m3 × e0m3` | 2026.8 – 2027.1 TFLOPS |
| mixed `e0m3 × e2m1` | 2027.9 TFLOPS |

*Metric: instruction issue rate (2·M·N·K per MMA), no memory traffic — this is
the tensor-core rate, not an end-to-end GEMM.* A prebuilt HF kernel running the
same microbenchmark: `huggingface.co/kernels/flashrt/int4-blackwell`.

## Contents

- `csrc/kernels/int4_w4a4_mma_sm120.{cu,cuh}` — M=1 full-N W4A4 GEMV (bf16 out),
  INT4 block-scale quantizer, `amax/(7·448)` global-scale reduction, a runtime
  **codebook canary**, and `extern "C"` wrappers for a GGML/llama.cpp backend.
  Same fragment layout and cp.async double-buffering as the NVFP4 twin
  `fp4_w4a4_mma_sm120`.
- `tools/patch_int4_omma_sm120.py` — flips OMMA bits 78/79 in device functions
  whose mangled name contains a marker (`int4_`); works on a bare `.cubin` or in
  place on a host ELF (`.so`/executable) with an uncompressed `.nv_fatbin`.
  `--operands b` patches only the weight operand (mixed W-INT4 × A-E2M1).
- `csrc/kernels/test_int4_w4a4_standalone.cu` — synthetic-data correctness (cos
  vs a plain-C++ INT4 reference) + issue-rate microbench.
- `docs/int4_blackwell.md`.

## Compiled E2M1, RUN as E0M3

`ptxas` rejects any element type but `e2m1` here, so **the patch step is part of
linking**. An unpatched binary decodes E2M1 on INT4 data (wrong results,
undetectable by the launcher), so module load must gate on
`int4_w4a4_sm120_codebook_canary() == 0` (fail-fast). The bits are undocumented
and invisible to `nvdisasm`/`cuobjdump` (a patched instruction still
disassembles as `E2M1.E2M1`); re-verify the encoding on any CUDA-toolkit bump —
the canary is the authoritative check.

## How to run

sm_120 GPU + CUDA 13.0+. No checkpoints — synthetic data.

```bash
nvcc -std=c++17 -O3 -gencode arch=compute_120a,code=sm_120a \
  csrc/kernels/int4_w4a4_mma_sm120.cu \
  csrc/kernels/test_int4_w4a4_standalone.cu -o <out>/test_int4
python tools/patch_int4_omma_sm120.py <out>/test_int4
<out>/test_int4
```

Observed on RTX 5090 / CUDA 13.0 (build `arch=compute_120a`; plain
`compute_120` rejects `mxf4nvf4`):

```text
[canary] 0  (E0M3 decode OK)
[gemv] N=4096 K=4096  cos(kernel, INT4-ref) = 0.999431  (expect > 0.999)
[bench] issue-rate: 2012.4 TFLOPS  (INT4 x INT4, 680 blocks x 8 warps)
[result] PASS
```

`cos(kernel, INT4-ref)` compares the kernel against a C++ implementation of the
identical INT4 two-level recipe — validates SF swizzle addressing + fragment
layout (residual is bf16-output rounding vs fp32 reference).

## Scope / isolation

**Experimental, additive, isolated.** No `CMakeLists.txt` / pybind changes: this
is a runtime primitive validated by a standalone `nvcc` test, exactly like the
existing `csrc/**/test_*_standalone.cu`. The default build path is unchanged.
CMake/pybind wiring and the end-to-end model gate (token-exact decode) land in a
follow-up PR. The natural first consumer is a 4-bit GGML backend on Blackwell
(hardware dequant in the tensor core at the NVFP4 rate) — see `docs/int4_blackwell.md`
for the GGUF Q4_0/Q4_K mapping notes.

## Credits & references

- Element-format bits documented by the **Ling Team**, @im0qianqian:
  https://zhuanlan.zhihu.com/p/2059376150565089368
- Ling Team, *Rethinking Shrinkage Bias in LLM FP4 Pretraining: Geometric
  Origin, Systemic Impact, and UFP4 Recipe* (arXiv).
