### PR TITLE
feat(minimax-remover): TeaCache, universal FP8 scale cache, parallel frame output

### DIFF
--- a/docs/minimax_remover_usage.md
+++ b/docs/minimax_remover_usage.md
@@ -12,7 +12,13 @@ kernelized inference on Blackwell SM120. Two precision paths ship under
 
 Both reuse the **generic** FlashRT kernels for the transformer denoise path
 (quantized GEMMs, fused norm/gate/residual/gelu ops, kernel attention via
-FA2 / SageAttention). The VAE encode/decode is additionally accelerated by
+FA2 / SageAttention). On top of the kernelised transformer, the FP8 path
+also supports **training-free TeaCache step caching** (opt-in with
+`--teacache-skip 3,5,7,9`): 4 of 12 interior denoise steps reuse the cached
+noise prediction instead of running the transformer — mirroring the
+Motus/Cosmos3/Wan2.2 TeaCache mechanism and cutting ~0.9 s with no
+measurable PSNR loss (the flow-matching velocity is highly cacheable).
+The VAE encode/decode is additionally accelerated by
 **model-specific fp16 fused CUDA kernels** in the standalone
 `flash_rt_minimax_remover` module (opt-in build, see [Build](#build)):
 `fp16_rms_norm_ncdhw` (single-pass RMSNorm, fp16-native),
@@ -288,7 +294,13 @@ new pipeline so the scale is re-calibrated.**
   at load time; activation quantised with a calibrated static scale);
 - per-block LayerNorm + adaLN modulation + gate-residual fused into Triton
   kernels (fp32 statistics);
-- `torch.nn.functional.scaled_dot_product_attention` -> FA2 / SageAttention.
+- `torch.nn.functional.scaled_dot_product_attention` -> FA2 / SageAttention;
+- **TeaCache step caching** (opt-in via `skip_steps=[...]` / quickstart
+  `--teacache-skip`): zeroth-order reuse of the cached noise prediction at
+  the listed denoise steps. On the first (calibration) call it is forwarded
+  to the diffusers reference loop; on steady-state calls it is forwarded to
+  the FP8 manual denoise (and baked into the captured CUDA Graph). Step 0
+  (calibration) and the last step are never skipped.
 
 ### NVFP4 — `MiniMaxRemoverPipeline` (small-region only)
 
@@ -336,8 +348,8 @@ python3 examples/minimax_remover_quickstart.py \
     --masks-dir  ./object_removal_data/<masks> \
     --output-dir ./out                          # FP8 + VAE opt (default)
 python3 examples/minimax_remover_quickstart.py ... --no-vae-opt   # FP8, no VAE kernels
-python3 examples/minimax_remover_quickstart.py ... --use-fp4      # NVFP4
-python3 examples/minimax_remover_quickstart.py ... --no-flashrt   # fp16 reference
+python3 examples/minimax_remover_quickstart.py ... --nvfp4-transformer  # NVFP4 transformer (small-region only)
+python3 examples/minimax_remover_quickstart.py ... --no-flashrt   # fp16 reference (disables ALL opts)
 ```
 
 Wall time is a single end-to-end segment (load -> encode -> denoise loop ->
@@ -359,11 +371,12 @@ All rows compare against the non-FlashRT `--no-flashrt` fp16 reference on the
 | tennis (70 frames, 432x240) | FlashRT FP8 + VAE opt + CL + FP8 conv3d + fused FFN epilogue + fused bias-gate residual | 7.57 s | 2.30x | 40.0 / 36.2 dB | 0.99981 |
 | tennis (70 frames, 432x240) | **… + fused adaLN+quant (shared-scale QKV) + fused RMSNorm+RoPE + fused norm2+quant (FP8-only stack, `--no-nvfp4-vae`)** | **7.18 s** | **2.41x** | **40.0 / 36.0 dB** | 0.99981 |
 | tennis (70 frames, 432x240) | **… + NVFP4 VAE (38 conv layers → W4A4, FP4 cache)** | **6.71 s** | **2.58x** | **34.7 / 30.6 dB** | 0.99981 |
-| tennis (70 frames, 432x240) | **… + NVFP4 fused norm+silu+quant + FP4 cache reuse (#1) + FP8 fused norm+silu+amax+quant (#2) + Q/K bias fused into rmsnorm+rope+quant (#3, current default)** | **6.56 s** | **2.64x** | **35.2 / 31.7 dB** | 0.99918 |
-| tennis (70 frames, 432x240) | FlashRT NVFP4 transformer (`--use-fp4`) | 9.52 s | 1.82x | 7.0 / 6.2 dB | 0.00000 (broken — transformer FP4 error accumulates over 12 denoise steps) |
+| tennis (70 frames, 432x240) | **… + NVFP4 fused norm+silu+quant + FP4 cache reuse (#1) + FP8 fused norm+silu+amax+quant (#2) + Q/K bias fused into rmsnorm+rope+quant (#3)** | **6.56 s** | **2.64x** | **35.2 / 31.7 dB** | 0.99918 |
+| tennis (70 frames, 432x240) | **… + TeaCache {3,5,7,9} step caching (opt-in, `--teacache-skip 3,5,7,9`)** | **5.66 s** | **3.06x** | **35.1 / 31.5 dB** | 0.99918 |
+| tennis (70 frames, 432x240) | FlashRT NVFP4 transformer (`--nvfp4-transformer`) | 9.52 s | 1.82x | 7.0 / 6.2 dB | 0.00000 (broken — transformer FP4 error accumulates over 12 denoise steps) |
 | bmx-trees (80 frames, 432x240) | fp16 reference (`--no-flashrt`) | 19.76 s | 1.0x | — | — |
 | bmx-trees (80 frames, 432x240) | FlashRT FP8 (default) | 13.24 s | **1.49x** | 35.1 / 32.0 dB | 0.99912 |
-| bmx-trees (80 frames, 432x240) | FlashRT NVFP4 transformer (`--use-fp4`) | 10.72 s | 1.84x | 7.3 / 7.0 dB | 0.00000 (broken — transformer FP4 error accumulates over 12 denoise steps) |
+| bmx-trees (80 frames, 432x240) | FlashRT NVFP4 transformer (`--nvfp4-transformer`) | 10.72 s | 1.84x | 7.3 / 7.0 dB | 0.00000 (broken — transformer FP4 error accumulates over 12 denoise steps) |
 
 > Tennis numbers are from a same-session serial A/B (`--no-flashrt
 > --no-vae-opt` vs default FlashRT FP8 stack) measured on RTX 5060 Ti,
@@ -376,10 +389,17 @@ All rows compare against the non-FlashRT `--no-flashrt` fp16 reference on the
 
 Takeaways:
 
-- **The current default** (all of the below + NVFP4 VAE + #1/#2/#3 fused
-  norm+quant/bias) is **2.64× faster** than the fp16 reference (17.34 →
-  6.56 s) with PSNR **35.2 dB** mean over 69 inpainted frames, peak VRAM
-  2.57 GB (vs 3.67 GB fp16 ref, –30%). Add `--no-nvfp4-vae` and set
+- **The opt-in TeaCache profile** (all of the below + NVFP4 VAE + #1/#2/#3
+  fused norm+quant/bias + **TeaCache {3,5,7,9} step caching**) is **3.06× faster**
+  than the fp16 reference (17.33 → 5.66 s) with PSNR **35.1 dB** mean over
+  69 inpainted frames, peak VRAM 2.57 GB (vs 3.67 GB fp16 ref, –30%). The
+  TeaCache layer (`--teacache-skip 3,5,7,9`) reuses the
+  cached noise prediction at 4 of 12 interior denoise steps — MiniMax-Remover's
+  flow-matching velocity is highly cacheable, so this contributes ~0.9 s
+  (6.56 → 5.66 s) with no measurable PSNR change (35.2 → 35.1 dB). Pass
+  Omit the flag to preserve the full denoise schedule, or use
+  `--teacache-skip 4,7` for a conservative 2-step schedule. Add
+  `--no-nvfp4-vae` and set
   `FLASHRT_NVFP4_FUSED_NORMQUANT=0 FLASHRT_FP8_FUSED_NORMQUANT=0` for the
   higher-precision FP8-only stack (~40 dB, ~7.2 s) when absolute fidelity
   matters more than speed. The fused FFN epilogue kernel
@@ -442,12 +462,12 @@ Takeaways:
   Combined steady-state 5.86 → 5.73 s; PSNR 35.16 dB mean / 31.73 worst
   (vs 35.11 at the pre-fusion baseline) — the fp32 bias add in #3 is
   slightly *more* precise than the fp16 bias-add it replaces.
-- **NVFP4 transformer (`--use-fp4`) is unusable on full-frame latents**: cosine collapses to
+- **NVFP4 transformer (`--nvfp4-transformer`) is unusable on full-frame latents**: cosine collapses to
   ~0.0 and PSNR to ~7 dB (median per-pixel deviation ~85/255). The FP4
   quantisation error accumulates over the 12-step denoise loop in the transformer
   and the output drifts to black. NVFP4 transformer is only appropriate for
   small cropped regions, where its per-block error stays bounded. The NVFP4
-  **VAE** path (above) is unaffected because the VAE is a single-pass
+  **VAE** path (default, always on) is unaffected because the VAE is a single-pass
   encoder/decoder with no iterative error accumulation.
 
 ### Transformer GEMM (NVFP4 vs fp16 matmul, single layer)
@@ -503,9 +523,11 @@ the steady state; the FP8 path calibrates on the first call then freezes.
 |------|---------|--------|
 | `--vae-opt` / `--no-vae-opt` | **enabled** | Install FlashRT fp16 fused VAE kernels (`fp16_rms_norm_ncdhw`, `fp16_rms_silu_ncdhw`, NDHWC variants, fused norm+silu+amax) + channels-last 3D pipeline + running-max amax sharing between norm and conv + FP8 implicit-GEMM conv3d + `WanUpsample` cast elimination. Requires the `flash_rt_minimax_remover` module. |
 | `--fp8-conv` / `--no-fp8-conv` | **enabled** | Use FP8 implicit-GEMM conv3d kernel for applicable 3×3×3 causal convs (requires `--vae-opt`). Trades ~1 dB PSNR for ~14% decode speedup over channels-last-only cuDNN. |
-| `--use-fp4` | off | Use NVFP4 (W4A4) transformer instead of FP8 (W8A8). Small-region only — broken on full-frame. |
+| `--nvfp4-transformer` | off | Switch the **transformer** to NVFP4 (W4A4) instead of the default FP8 (W8A8). Note: the default path already uses NVFP4 for the **VAE** (single-pass, error-free); this flag adds NVFP4 to the 12-step iterative transformer denoise, where FP4 error accumulates and breaks full-frame outputs (cosine ~0.0, drifts to black). Only calibrated for small cropped regions (bbox crop). |
 | `--no-nvfp4-vae` | off | Disable NVFP4 W4A4 VAE conv3d (default: enabled). Uses purpose-built NVFP4 MMA kernel for eligible VAE conv layers (Ci>=192) for ~16% VAE speedup. |
-| `--no-flashrt` | off | Run the reference diffusers fp16 path (no FlashRT). |
+| `--teacache-skip` | disabled | Opt-in training-free TeaCache step caching for the transformer denoise loop: comma-separated 0-indexed step indices to skip. Step 0 (FP8 calibration) and the last step are never skipped. For example, `3,5,7,9` skips 4 of 12 interior steps; `4,7` is a conservative 2-step schedule. Only applies to the FlashRT FP8 path. |
+| `--universal-scale` | disabled | Opt in to checkpoint-bound, cross-resolution FP8 activation-scale reuse. Cache entries are schema-validated and read/write failures fall back to calibration without interrupting inference. |
+| `--no-flashrt` | off | Master "pure reference" switch: run the vanilla diffusers fp16 path **and disable ALL FlashRT optimisations** (VAE fused kernels, FP8/NVFP4 conv, NVFP4 VAE, TeaCache). This is the ground-truth baseline for PSNR/timing A/B — no need to also pass `--no-vae-opt`. |
 
 ## Environment variables
 
@@ -545,9 +567,32 @@ output = pipeline(
     num_frames=len(frames),
     height=720, width=1280,
     num_inference_steps=12,
+    skip_steps=[3, 5, 7, 9],   # optional TeaCache: skip 4 interior steps (~0.9 s faster, PSNR-neutral)
 )
 video = output.frames
 ```
+
+`skip_steps` (optional list of int) enables training-free TeaCache step
+caching: the listed denoise steps reuse the cached noise prediction instead
+of running the transformer, mirroring the Motus/Cosmos3/Wan2.2 mechanism.
+Step 0 (FP8 calibration) and the last step are never skipped. The quickstart
+leaves TeaCache disabled by default; pass `[3, 5, 7, 9]` explicitly to use
+the measured four-step schedule.
+
+Cross-resolution activation-scale reuse is also opt-in. Bind the cache to
+the checkpoint weight bytes when enabling it:
+
+```python
+pipeline = MiniMaxRemoverPipelineFP8(
+    pipe,
+    use_universal_scale=True,
+    checkpoint_path="/path/to/model/transformer",
+)
+```
+
+The cache identity also includes the FP8 target, compute dtype, kernel schema,
+cache schema, model config, and FP8 layer layout. Invalid or inaccessible
+cache files are ignored and inference falls back to calibration.
 
 ### FP8 + NVFP4 VAE (recommended default — full-frame, fastest)
 

--- a/examples/minimax_remover_quickstart.py
+++ b/examples/minimax_remover_quickstart.py
@@ -11,7 +11,7 @@ This is a FlashRT optimization of the upstream project:
 
 It wraps a loaded diffusers MiniMax-Remover pipeline with
 ``flash_rt.models.minimax_remover.MiniMaxRemoverPipelineFP8`` (default) or
-``MiniMaxRemoverPipeline`` (NVFP4, --use-fp4). The FP8 path rewrites the
+``MiniMaxRemoverPipeline`` (NVFP4 transformer, --nvfp4-transformer). The FP8 path rewrites the
 transformer denoise path onto FP8 (W8A8) GEMMs with static calibration,
 fused norm/RoPE/gelu kernels and kernel attention; the NVFP4 path adds a
 graph-captured manual flow-matching loop. FP8 stays close to the fp16
@@ -59,9 +59,17 @@ Run
 ------------------------------------------------------------------
 Precision note
 ------------------------------------------------------------------
-NVFP4 (W4A4) is calibrated for the model's large GEMMs. The fused
-norm/RoPE kernels keep the precision-critical path fp32-stat. For
-large full-frame latents, 4-bit weight/activation quantisation can
+The default path uses FP8 (W8A8) for the transformer and NVFP4 (W4A4)
+for the VAE conv layers. The NVFP4 VAE is safe because the VAE is a
+single-pass encoder/decoder (no error accumulation).
+
+`--nvfp4-transformer` additionally switches the TRANSFORMER to NVFP4
+(W4A4). The 12-step iterative denoise accumulates FP4 error, so
+full-frame latents drift to black (cosine ~0.0). Only use it for small
+cropped regions (bbox crop) where per-block error stays bounded.
+
+The fused norm/RoPE kernels keep the precision-critical path fp32-stat.
+For large full-frame latents, 4-bit weight/activation quantisation can
 accumulate small per-block error; if you observe colour drift on a
 high-resolution full-frame job, prefer the bbox-cropped regime (crop
 to the mask region before inference) where the quantisation grid is
@@ -94,6 +102,13 @@ import torch.nn as nn
 import torch.nn.functional as F
 from PIL import Image
 
+# OpenCV's PNG/JPEG encoders are faster than PIL (notably ~20% on PNG) and
+# release the GIL, so prefer cv2 when available; fall back to PIL otherwise.
+# cv2's own import is ~0.19s, so only probe for its presence here and defer
+# the actual import to _save_one (startup-critical path stays untaxed).
+import importlib.util as _ilu
+_CV2_SPEC = _ilu.find_spec("cv2")
+
 # Make the flash_rt package importable when run directly from the repo root.
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -123,6 +138,7 @@ MASK_THRESHOLD = 127
 NUM_INFERENCE_STEPS = 12
 PIPE_ITERATIONS = 6
 RANDOM_SEED = 42
+TEACACHE_SKIP_DEFAULT = ""
 
 
 # =====================================================================
@@ -397,7 +413,8 @@ class MinimaxRemoverPipeline(DiffusionPipeline):
                  images: Optional[torch.Tensor] = None,
                  masks: Optional[torch.Tensor] = None,
                  latents: Optional[torch.Tensor] = None,
-                 output_type: Optional[str] = "np", iterations: int = 16):
+                 output_type: Optional[str] = "np", iterations: int = 16,
+                 skip_steps: Optional[List[int]] = None):
         device = self._execution_device
         batch_size = 1
         transformer_dtype = torch.float16
@@ -432,14 +449,28 @@ class MinimaxRemoverPipeline(DiffusionPipeline):
             masks_latents = (masks_latents - latents_mean) * latents_std
 
         self._num_timesteps = len(timesteps)
+        skip_set = set(skip_steps) if skip_steps else set()
+        skip_set.discard(0)
+        if len(timesteps) > 1:
+            skip_set.discard(len(timesteps) - 1)
+        cached_noise_pred = None
+        n_skipped = 0
         for i, t in enumerate(timesteps):
-            latent_model_input = latents.to(transformer_dtype)
-            latent_model_input = torch.cat(
-                [latent_model_input, masked_latents, masks_latents], dim=1)
-            timestep = t.expand(latents.shape[0])
-            noise_pred = self.transformer(
-                hidden_states=latent_model_input.half(), timestep=timestep)[0]
+            if i in skip_set and cached_noise_pred is not None:
+                noise_pred = cached_noise_pred
+                n_skipped += 1
+            else:
+                latent_model_input = latents.to(transformer_dtype)
+                latent_model_input = torch.cat(
+                    [latent_model_input, masked_latents, masks_latents], dim=1)
+                timestep = t.expand(latents.shape[0])
+                noise_pred = self.transformer(
+                    hidden_states=latent_model_input.half(), timestep=timestep)[0]
+                cached_noise_pred = noise_pred
             latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+        if n_skipped:
+            print(f"  [teacache] reused cached noise_pred at {n_skipped}/{len(timesteps)} "
+                  f"steps (training-free step caching)")
 
         latents = latents.half() / latents_std + latents_mean
         video = self.vae.decode(latents, return_dict=False)[0]
@@ -585,13 +616,14 @@ def parse_args() -> argparse.Namespace:
                    help="Denoise steps (default 12).")
     p.add_argument("--no-flashrt", action="store_true",
                    help="Run the reference diffusers path instead of FlashRT (for diffing).")
-    p.add_argument("--use-fp4", action="store_true",
-                   help="Use NVFP4 (W4A4) instead of the default FP8 (W8A8). "
-                        "NVFP4 is only calibrated for small cropped regions "
-                        "(bbox crop); full-frame inpainting will produce "
-                        "black/drift outputs. FP8 (default) is recommended "
-                        "for full-frame inpainting (end-to-end cosine >= 0.999, "
-                        "PSNR ~35-41 dB vs fp16).")
+    p.add_argument("--nvfp4-transformer", action="store_true",
+                   help="Switch the TRANSFORMER to NVFP4 (W4A4) instead of the "
+                        "default FP8 (W8A8). Note: the default path already uses "
+                        "NVFP4 for the VAE (single-pass, error-free); this flag "
+                        "adds NVFP4 to the 12-step iterative transformer denoise, "
+                        "where FP4 error accumulates and breaks full-frame "
+                        "outputs (cosine ~0.0, drifts to black). Only calibrated "
+                        "for small cropped regions (bbox crop). (default: off)")
     p.add_argument("--vae-opt", action=argparse.BooleanOptionalAction,
                    default=True,
                    help="Apply FlashRT VAE optimisations: fused fp16 RMS_norm "
@@ -609,6 +641,30 @@ def parse_args() -> argparse.Namespace:
                    help="Disable NVFP4 W4A4 VAE conv3d (default: enabled). "
                         "Uses purpose-built NVFP4 MMA kernel for eligible "
                         "decode conv layers (Ci>=192) for ~3-7%% VAE speedup.")
+    p.add_argument("--teacache-skip", type=str, default=TEACACHE_SKIP_DEFAULT,
+                   help="Training-free TeaCache step caching: comma-separated "
+                        "0-indexed denoise step indices to SKIP (reuse the "
+                        "cached noise prediction from the last computed step, "
+                        "matching the Motus/Cosmos3 TeaCache mechanism). Step 0 "
+                        "and the last step are never skipped. For example, "
+                        "'3,5,7,9' skips 4 of 12 interior steps. "
+                        "(default: disabled)")
+    p.add_argument("--universal-scale", action=argparse.BooleanOptionalAction,
+                   default=False,
+                   help="Persist FP8 activation scales to disk "
+                        "(~/.flash_rt/calibration/) after the first run and "
+                        "reuse them across ALL resolutions on subsequent runs "
+                        "(margin=--universal-margin). Eliminates the per-call "
+                        "FP8 calibration step + Triton JIT cold-start for a "
+                        "~23%% cold-call speedup. PSNR >= 36 dB vs fp16 across "
+                        "288x160..480x272. This approximate cross-resolution "
+                        "reuse path is opt-in. (default: disabled)")
+    p.add_argument("--universal-margin", type=float, default=1.3,
+                   help="FP8 act_scale margin for the universal-scale path "
+                        "(default 1.3). Cross-resolution amax varies <5%% in "
+                        "median but ~3%% of layers deviate >20%%; the enlarged "
+                        "margin safely covers this. Lower (1.1) = higher "
+                        "fidelity but saturation risk at unseen resolutions.")
     return p.parse_args()
 
 
@@ -663,14 +719,21 @@ def main() -> None:
 
     pipe = build_pipeline(model_dir)
 
-    if args.vae_opt:
+    # --no-flashrt is the master "pure reference" switch: it disables ALL
+    # FlashRT optimisations (VAE fused kernels, FP8/NVFP4 conv, step
+    # caching) so the run is a vanilla fp16 diffusers ground truth — the
+    # baseline for PSNR/timing A/B. Users need not also pass --no-vae-opt.
+    vae_opt = args.vae_opt and not args.no_flashrt
+    nvfp4_vae = (vae_opt and not args.nvfp4_transformer and not args.no_nvfp4_vae)
+
+    if vae_opt:
         from flash_rt.models.minimax_remover._vae_opt import install_vae_optimizations
         stats = install_vae_optimizations(pipe.vae,
                                            use_fp8_conv=args.fp8_conv)
         print(f"  VAE optimised: {stats}")
 
     # NVFP4 VAE conv3d (default ON for FlashRT FP8 path; --no-nvfp4-vae to disable)
-    if args.vae_opt and not args.no_flashrt and not args.use_fp4 and not args.no_nvfp4_vae:
+    if nvfp4_vae:
         from flash_rt.models.minimax_remover._vae_nvfp4 import install_vae_nvfp4
         nvfp4_stats = install_vae_nvfp4(pipe.vae)
         if nvfp4_stats.get('enabled'):
@@ -679,13 +742,17 @@ def main() -> None:
     if args.no_flashrt:
         runner = pipe
         tag = "reference (diffusers fp16)"
-    elif args.use_fp4:
+    elif args.nvfp4_transformer:
         from flash_rt.models.minimax_remover import MiniMaxRemoverPipeline
         runner = MiniMaxRemoverPipeline(pipe)
-        tag = "FlashRT NVFP4 W4A4 (small-region only)"
+        tag = "FlashRT NVFP4 W4A4 transformer (small-region only)"
     else:
         from flash_rt.models.minimax_remover import MiniMaxRemoverPipelineFP8
-        runner = MiniMaxRemoverPipelineFP8(pipe)
+        runner = MiniMaxRemoverPipelineFP8(
+            pipe,
+            use_universal_scale=args.universal_scale,
+            universal_margin=args.universal_margin,
+            checkpoint_path=model_dir / "transformer")
         tag = "FlashRT FP8 W8A8 (full-frame)"
 
     t, h, w, _ = frames_padded.shape
@@ -693,15 +760,27 @@ def main() -> None:
     images_tensor = images_tensor / 127.5 - 1.0
     masks_infer = torch.from_numpy(masks_padded.astype(np.float32))
 
+    skip_steps = None
+    # TeaCache only applies to the FlashRT FP8 path. The `--no-flashrt`
+    # reference is the fp16 ground truth (full N-step denoise) used for
+    # PSNR/timing A/B, so never skip steps there even if --teacache-skip
+    # is explicitly set. The `--nvfp4-transformer` NVFP4 wrapper
+    # does not accept skip_steps, so it is also excluded.
+    if args.teacache_skip.strip() and not args.no_flashrt and not args.nvfp4_transformer:
+        skip_steps = sorted({int(s) for s in args.teacache_skip.split(",") if s.strip()})
+
     print(f"  running inference [{tag}] (all frames at once)...")
     torch.cuda.reset_peak_memory_stats()
     torch.cuda.empty_cache()
     t0 = time.time()
-    out = runner(
+    call_kwargs = dict(
         images=images_tensor, masks=masks_infer, num_frames=t,
         height=h, width=w, num_inference_steps=args.num_inference_steps,
         generator=torch.Generator(device=DEVICE).manual_seed(RANDOM_SEED),
-        iterations=args.iterations).frames[0]
+        iterations=args.iterations)
+    if skip_steps is not None:
+        call_kwargs["skip_steps"] = skip_steps
+    out = runner(**call_kwargs).frames[0]
     torch.cuda.synchronize()
     elapsed = time.time() - t0
     print(f"  inference wall time: {elapsed:.2f}s")
@@ -710,19 +789,58 @@ def main() -> None:
     proc_len = out_u8.shape[0]
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    saved = inpainted = uncovered = 0
+    # Pre-build the per-frame output arrays, then fan out the (CPU-bound)
+    # PNG/JPEG encoding + disk writes across a thread pool. zlib/jpeg release
+    # the GIL while compressing, so this scales near-linearly with cores --
+    # the sequential loop below was a major fraction of end-to-end wall time.
+    tasks: List[Tuple[Path, np.ndarray, str]] = []
+    inpainted = uncovered = 0
     for local_i, path in enumerate(image_paths):
-        dst = output_dir / path.name
+        ext = path.suffix.lower()
         if local_i < proc_len and has_region[local_i]:
-            crop = out_u8[local_i, :orig_h, :orig_w, :]
-            Image.fromarray(crop, mode="RGB").save(dst)
+            tasks.append((output_dir / path.name,
+                          np.ascontiguousarray(out_u8[local_i, :orig_h, :orig_w, :]),
+                          ext))
             inpainted += 1
-        elif local_i >= proc_len and has_region[local_i]:
-            Image.fromarray(frames[local_i], mode="RGB").save(dst)
-            uncovered += 1
         else:
-            Image.fromarray(frames[local_i], mode="RGB").save(dst)
-        saved += 1
+            if local_i >= proc_len and has_region[local_i]:
+                uncovered += 1
+            tasks.append((output_dir / path.name,
+                          np.ascontiguousarray(frames[local_i]), ext))
+
+    def _save_one(task: Tuple[Path, np.ndarray, str]) -> None:
+        dst, arr, ext = task
+        if _CV2_SPEC is not None:
+            # Lazy import: cv2 is ~0.19s to import, paid once on first save
+            # rather than at process startup. Python caches it, so the cost
+            # is only incurred by the first thread; the import lock keeps
+            # concurrent threads safe.
+            import cv2
+            # cv2 expects BGR; our arrays are RGB.
+            bgr = np.ascontiguousarray(arr[:, :, ::-1])
+            if ext == ".png":
+                saved_ok = cv2.imwrite(
+                    str(dst), bgr, [cv2.IMWRITE_PNG_COMPRESSION, 3]
+                )
+            else:
+                saved_ok = cv2.imwrite(
+                    str(dst), bgr, [cv2.IMWRITE_JPEG_QUALITY, 95]
+                )
+            if not saved_ok:
+                raise OSError(f"failed to write output frame: {dst}")
+        elif ext == ".png":
+            Image.fromarray(arr).save(dst, compress_level=3)
+        else:
+            Image.fromarray(arr).save(dst, quality=95)
+
+    max_workers = max(1, min(8, (os.cpu_count() or 4), len(tasks)))
+    if len(tasks) <= 1 or max_workers <= 1:
+        for task in tasks:
+            _save_one(task)
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            list(ex.map(_save_one, tasks))
+    saved = len(tasks)
 
     peak_alloc = torch.cuda.max_memory_allocated() / 1024 ** 3
     peak_reserved = torch.cuda.max_memory_reserved() / 1024 ** 3

--- a/flash_rt/models/minimax_remover/_attention.py
+++ b/flash_rt/models/minimax_remover/_attention.py
@@ -27,12 +27,28 @@ FP8 (``_kern_block``) block paths. No MiniMax-Remover imports -- tensors
 only.
 """
 
+import logging
 import math
 import os
 
 import torch
 
 from ._kernels import rms_norm_fp32stat, rope_apply_bshd, freqs_to_cos_sin
+
+logger = logging.getLogger(__name__)
+
+
+def _is_sm89_query_scale_shape_error(error):
+    """Return whether SageAttention rejected its known query-scale shape."""
+    message = str(error)
+    return "query_scale" in message and "must have shape" in message
+
+
+# Sequence lengths where SageAttention's fused int8-quant sm89 kernel
+# crashed (query_scale shape mismatch). Once blacklisted, those shapes
+# use the standard fp16 path (rmsnorm+rope → sage high-level API, which
+# handles any seq len). Populated at runtime via try/except fallback.
+_sage_blacklist: set = set()
 
 # Optional MiniMax-Remover fused kernels — used when both are available.
 _fvk = None
@@ -224,10 +240,13 @@ class FlashRTFA2Processor:
                     and (Dd & 7) == 0)
         # ── Fully-fused path: RMSNorm + RoPE + int8 quant → sm89 attn ──
         # Eliminates the fp16 intermediate between norm+rope and QK quantize.
+        # Skipped for seq lengths where SageAttention's sm89 kernel is known
+        # to crash (query_scale shape mismatch at certain S values).
         _fuse_quant = (_fuse_qk and _has_fused_rmsnorm_rope_quant
                        and mode in ("sage_fp8", "sage2")
                        and _get_sm89() is not None
-                       and _get_per_channel_fp8() is not None)
+                       and _get_per_channel_fp8() is not None
+                       and S not in _sage_blacklist)
 
         # Q/K GEMM: when the Q/K bias will be fused into the downstream
         # rmsnorm+rope+quant kernel (pre-norm add), fetch Q/K WITHOUT bias
@@ -315,17 +334,39 @@ class FlashRTFA2Processor:
             out = torch.empty(B, S, H, Dd, device=q.device, dtype=q.dtype)
 
             sm89 = _get_sm89()
-            sm89.qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf(
-                q_int8, k_int8, v_fp8, out, q_scale, k_scale, v_scale,
-                0, 0, 2, scale, 0)
-
-            hidden_states = out.view(B, S, H * Dd)
-            to_out0 = attn.to_out[0]
-            if no_out_bias and hasattr(to_out0, "gemm_no_bias"):
-                hidden_states = to_out0.gemm_no_bias(hidden_states)
+            try:
+                sm89.qk_int8_sv_f8_accum_f16_fuse_v_scale_attn_inst_buf(
+                    q_int8, k_int8, v_fp8, out, q_scale, k_scale, v_scale,
+                    0, 0, 2, scale, 0)
+            except RuntimeError as e:
+                if not _is_sm89_query_scale_shape_error(e):
+                    raise
+                # SageAttention sm89 tiling limitation at this seq len.
+                # Blacklist S and fall back to the standard rmsnorm+rope
+                # path, which routes through sage's high-level API (handles
+                # any seq len correctly).
+                _sage_blacklist.add(S)
+                logger.warning(
+                    "SageAttention fused-quant crashed at S=%d (%s); "
+                    "falling back to standard path for this seq len "
+                    "(~5%% slower, same precision)", S, e)
+                # Redo Q/K WITH bias (the nobias GEMM skipped it).
+                if _qk_nobias:
+                    if _use_fp8:
+                        q = attn.to_q.gemm_from_fp8_ext(fp8_hidden, fp8_scale)
+                        k = attn.to_k.gemm_from_fp8_ext(fp8_hidden, fp8_scale)
+                    else:
+                        q = attn.to_q(hidden_states)
+                        k = attn.to_k(hidden_states)
+                # Fall through to _fuse_qk standard path below.
             else:
-                hidden_states = to_out0(hidden_states)
-            return hidden_states
+                hidden_states = out.view(B, S, H * Dd)
+                to_out0 = attn.to_out[0]
+                if no_out_bias and hasattr(to_out0, "gemm_no_bias"):
+                    hidden_states = to_out0.gemm_no_bias(hidden_states)
+                else:
+                    hidden_states = to_out0(hidden_states)
+                return hidden_states
 
         if _fuse_qk:
             if not q.is_contiguous():

--- a/flash_rt/models/minimax_remover/_fp8_manual_denoise.py
+++ b/flash_rt/models/minimax_remover/_fp8_manual_denoise.py
@@ -60,8 +60,7 @@ import os
 
 import torch
 
-from ._kernels import (ada_layernorm_fp16_io, euler_step_inplace, mask_mul,
-                       latent_normalize, latent_denormalize)
+from ._kernels import ada_layernorm_fp16_io
 
 logger = logging.getLogger(__name__)
 
@@ -165,22 +164,45 @@ class FP8ManualDenoise:
     # The graph-capturable N-step loop.                                   #
     # ------------------------------------------------------------------ #
     def _denoise_loop_body(self, lat_buf, masked_buf, masks_buf, concat_buf,
-                           tproj_all, mod_out, dt_all, rotary_emb, num_steps):
+                           tproj_all, mod_out, dt_all, rotary_emb, num_steps,
+                           skip_steps=None):
+        """Zeroth-order TeaCache: at skip steps reuse the cached noise_pred
+        (the velocity from the last COMPUTED step) and only run the cheap
+        euler step, mirroring the Motus/Cosmos3 TeaCache mechanism."""
         C = lat_buf.shape[1]
         tr = self.transformer
         eps = self.eps
+        skip_set = set(skip_steps) if skip_steps else set()
+        skip_set.discard(0)
+        if num_steps > 1:
+            skip_set.discard(num_steps - 1)
+        cached_noise_pred = None
         for step in range(num_steps):
-            concat_buf[:, :C].copy_(lat_buf)
-            concat_buf[:, C:2 * C].copy_(masked_buf)
-            concat_buf[:, 2 * C:3 * C].copy_(masks_buf)
-            noise_pred = transformer_forward_fp8(
-                tr, concat_buf, tproj_all[step], mod_out[step],
-                rotary_emb, eps)
-            euler_step_inplace(lat_buf, noise_pred, dt_all[step])
+            if step in skip_set and cached_noise_pred is not None:
+                noise_pred = cached_noise_pred
+            else:
+                concat_buf[:, :C].copy_(lat_buf)
+                concat_buf[:, C:2 * C].copy_(masked_buf)
+                concat_buf[:, 2 * C:3 * C].copy_(masks_buf)
+                noise_pred = transformer_forward_fp8(
+                    tr, concat_buf, tproj_all[step], mod_out[step],
+                    rotary_emb, eps)
+                cached_noise_pred = noise_pred
+            # Euler flow-matching step: latents += dt * noise_pred.
+            # PyTorch in-place add_ replaces the Triton ``euler_step_inplace``
+            # kernel to avoid Triton JIT cold-start (~0.3s on the first call).
+            # The fp16 accumulation difference is negligible (verified
+            # opt-vs-Triton PSNR >= 46 dB over 8 denoise steps).
+            lat_buf.add_(noise_pred, alpha=dt_all[step])
 
     def _capture_graph(self, latents, masked_latents, masks_latents,
-                       tproj_all, mod_out, dt_all, rotary_emb, num_steps):
-        """Capture the full N-step denoise loop as one CUDA Graph."""
+                       tproj_all, mod_out, dt_all, rotary_emb, num_steps,
+                       skip_steps=None):
+        """Capture the full N-step denoise loop as one CUDA Graph.
+
+        The TeaCache skip schedule is baked into the captured graph (the
+        Python branch is resolved at capture time), matching how Motus
+        bakes its skip set before graph capture."""
         device = latents.device
         C = latents.shape[1]
         B, _, T, H, W = latents.shape
@@ -194,7 +216,8 @@ class FP8ManualDenoise:
         def denoise():
             self._denoise_loop_body(
                 lat_buf, masked_buf, masks_buf, concat_buf,
-                tproj_all, mod_out, dt_all, rotary_emb, num_steps)
+                tproj_all, mod_out, dt_all, rotary_emb, num_steps,
+                skip_steps=skip_steps)
 
         # Warmup on a side stream to compile all kernels / init cuBLASLt
         # workspaces before capture. The FP8 scales are already frozen, so
@@ -216,8 +239,9 @@ class FP8ManualDenoise:
             denoise()
 
         logger.info("MiniMax-Remover FP8: CUDA Graph captured for shape %s "
-                    "(%d steps, warmup=%d)", tuple(latents.shape),
-                    num_steps, n_warmup)
+                    "(%d steps, warmup=%d, skip=%s)", tuple(latents.shape),
+                    num_steps, n_warmup,
+                    sorted(skip_steps) if skip_steps else None)
         return (graph, lat_buf, masked_buf, masks_buf,
                 tproj_all, mod_out, dt_all, rotary_emb)
 
@@ -225,12 +249,19 @@ class FP8ManualDenoise:
     # Public entry: run the denoise, capture-or-replay per shape.         #
     # ------------------------------------------------------------------ #
     def denoise(self, latents, masked_latents, masks_latents, num_steps,
-                use_graph=True):
+                use_graph=True, skip_steps=None):
         """Run the N-step denoise; capture+replay a graph when use_graph.
+
+        ``skip_steps`` (optional list of int) enables zeroth-order
+        TeaCache: the listed steps reuse the cached noise prediction
+        instead of running the transformer forward. Step 0 and the last
+        step are never skipped. When ``use_graph`` the skip schedule is
+        baked into the captured graph (per-shape, per-schedule cache).
 
         Returns the final latents tensor (same shape/dtype as ``latents``).
         """
-        shape_key = tuple(latents.shape) + (num_steps,)
+        skip_key = tuple(sorted(skip_steps)) if skip_steps else ()
+        shape_key = tuple(latents.shape) + (num_steps,) + skip_key
         entry = self._graphs.get(shape_key) if use_graph else None
 
         if entry is None:
@@ -239,7 +270,8 @@ class FP8ManualDenoise:
             if use_graph:
                 entry = self._capture_graph(
                     latents, masked_latents, masks_latents,
-                    tproj_all, mod_out, dt_all, rotary_emb, num_steps)
+                    tproj_all, mod_out, dt_all, rotary_emb, num_steps,
+                    skip_steps=skip_steps)
                 self._graphs[shape_key] = entry
             else:
                 # Eager manual path (no graph) -- still avoids condition_embedder
@@ -251,7 +283,8 @@ class FP8ManualDenoise:
                 lat_buf = latents.clone()
                 self._denoise_loop_body(
                     lat_buf, masked_latents, masks_latents, concat_buf,
-                    tproj_all, mod_out, dt_all, rotary_emb, num_steps)
+                    tproj_all, mod_out, dt_all, rotary_emb, num_steps,
+                    skip_steps=skip_steps)
                 return lat_buf
 
         (graph, lat_buf, masked_buf, masks_buf,

--- a/flash_rt/models/minimax_remover/_fp8_pipeline.py
+++ b/flash_rt/models/minimax_remover/_fp8_pipeline.py
@@ -5,21 +5,93 @@ produces black/drift outputs on full-frame large latents, FP8 stays close
 to the fp16 reference: end-to-end cosine >= 0.999 and PSNR ~35-41 dB vs
 fp16 on full-frame clips.
 
-Uses static calibration: the first inference call runs in dynamic-FP8
-calibration mode (accumulating activation amax on GPU), then freezes to a
-static act_scale for all subsequent calls (zero CPU sync overhead in the
-steady state).
+Universal-scale fast path (opt-in, ``use_universal_scale=True``):
+    The FP8 activation scales (``act_amax_max`` per Linear) are calibrated
+    ONCE at a representative resolution, persisted to disk
+    (``~/.flash_rt/calibration/``), and reused across ALL resolutions with
+    an enlarged margin (``universal_margin=1.3``) that absorbs
+    cross-resolution activation variance. This lets the very first call
+    skip the dynamic-FP8 calibration step entirely (saves ~0.15s) and,
+    combined with PyTorch-native elementwise ops (no Triton JIT cold-start),
+    yields a ~23% cold-call speedup for one-shot / arbitrary-resolution use.
+    Measured PSNR >= 36 dB vs fp16 reference across 288×160 … 480×272.
+
+Per-resolution calibration path (default, ``use_universal_scale=False``):
+    The first ``__call__`` runs in dynamic-FP8 calibration mode
+    (accumulating activation amax on GPU), then freezes to a static
+    act_scale for all subsequent calls.
 """
 
+import hashlib
+import inspect
+import json
 import logging
+import math
 import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
 
 import torch
 
 logger = logging.getLogger(__name__)
 
 from flash_rt.models.minimax_remover._utils import load_fp8_kernels
-from flash_rt.models.minimax_remover._kernels import mask_mul
+
+_SCALE_CACHE_SCHEMA_VERSION = 2
+_FP8_KERNEL_CACHE_SCHEMA = "minimax-remover-fp8-w8a8-v1"
+_WEIGHT_FILE_SUFFIXES = frozenset(
+    {".safetensors", ".bin", ".pt", ".pth", ".ckpt"}
+)
+
+
+def _call_accepts_keyword(call, keyword):
+    """Return whether ``call`` explicitly accepts a keyword or ``**kwargs``."""
+    try:
+        parameters = inspect.signature(call).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == keyword
+        or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+
+
+def _checkpoint_weights_digest(checkpoint_path):
+    """Return a SHA-256 digest over checkpoint weight file names and bytes."""
+    root = Path(checkpoint_path).expanduser()
+    if root.is_file():
+        files = [root]
+        base = root.parent
+    elif root.is_dir():
+        files = sorted(
+            path
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix.lower() in _WEIGHT_FILE_SUFFIXES
+        )
+        base = root
+    else:
+        raise OSError(f"checkpoint path does not exist: {root}")
+    if not files:
+        raise ValueError(f"no checkpoint weight files found under {root}")
+
+    digest = hashlib.sha256()
+    for path in files:
+        relative = path.relative_to(base).as_posix().encode("utf-8")
+        digest.update(len(relative).to_bytes(4, "little"))
+        digest.update(relative)
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_checkpoint_digest(checkpoint_digest):
+    value = str(checkpoint_digest).lower()
+    if len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+        raise ValueError("checkpoint_digest must be a 64-character SHA-256 hex digest")
+    return value
 
 
 def _import_runtime_fp8():
@@ -58,11 +130,35 @@ class MiniMaxRemoverPipelineFP8:
         num_inference_steps: denoise steps (12)
         fp8_target: "all" or "ffn_only"
         use_bf16: run transformer in bf16 (default False, keeps fp16)
-        calib_margin: act_scale margin multiplier (1.1)
+        calib_margin: act_scale margin multiplier for per-resolution
+            calibration mode (1.1). Ignored when ``use_universal_scale``
+            is True and a cached scale exists.
+        use_universal_scale: if True, load/persist FP8
+            ``act_amax_max`` from disk so the first call skips the
+            dynamic-FP8 calibration step entirely. The scale is
+            calibrated once at a representative resolution and reused
+            across all resolutions with an enlarged margin
+            (``universal_margin``). Disabled by default so the original
+            per-resolution calibration behavior is unchanged.
+        universal_margin: act_scale margin for the universal-scale path
+            (default 1.3). Cross-resolution activation amax varies by
+            <5% in median, but ~3% of layers deviate >20%; the enlarged
+            margin safely covers this. Ignored when
+            ``use_universal_scale`` is False.
+        checkpoint_path: checkpoint file or directory used to bind an
+            opt-in scale cache to the exact weight bytes. If omitted, a
+            local ``transformer.config._name_or_path`` is used when available.
+        checkpoint_digest: precomputed SHA-256 weight digest. This avoids
+            hashing a large checkpoint at construction and takes precedence
+            over ``checkpoint_path``.
+        scale_cache_dir: optional cache directory override.
     """
 
     def __init__(self, pipe, num_inference_steps=12, fp8_target="all",
-                 use_bf16=False, calib_margin=1.1):
+                 use_bf16=False, calib_margin=1.1,
+                 use_universal_scale=False, universal_margin=1.3,
+                 checkpoint_path=None, checkpoint_digest=None,
+                 scale_cache_dir=None):
         self.fvk = load_fp8_kernels()
         (install_flashrt_fp8, set_calibration, freeze_calibration,
          install_fused_blocks, install_fa2_attention) = _import_runtime_fp8()
@@ -71,17 +167,66 @@ class MiniMaxRemoverPipelineFP8:
         self.transformer = pipe.transformer
         self.num_inference_steps = num_inference_steps
         self.calib_margin = calib_margin
+        self.use_universal_scale = use_universal_scale
+        self.universal_margin = universal_margin
+        self._compute_dtype_name = "bfloat16" if use_bf16 else "float16"
+        self._scale_cache_dir = (
+            Path(scale_cache_dir).expanduser()
+            if scale_cache_dir is not None
+            else None
+        )
+        self._checkpoint_digest = None
         self._calibrated = False
+        self._scale_dirty = False  # need to dump scales after calibration
 
         self._set_calibration = lambda on: set_calibration(self.transformer, on)
         self._freeze_calibration = lambda: freeze_calibration(
             self.transformer, margin=self.calib_margin)
 
         fp8_target_env = os.environ.get("FLASHRT_FP8_TARGET", fp8_target)
+        self.fp8_target = fp8_target_env
         n_lin = install_flashrt_fp8(self.transformer,
                                     verbose=True, target=fp8_target_env)
         logger.info("MiniMax-Remover FP8: target=%r, %d Linears -> FP8 W8A8 GEMM",
                     fp8_target_env, n_lin)
+
+        if self.use_universal_scale:
+            try:
+                if checkpoint_digest is not None:
+                    self._checkpoint_digest = _validate_checkpoint_digest(
+                        checkpoint_digest
+                    )
+                else:
+                    if checkpoint_path is None:
+                        checkpoint_path = getattr(
+                            self.transformer.config, "_name_or_path", None
+                        )
+                    if checkpoint_path is None:
+                        raise ValueError(
+                            "checkpoint_path or checkpoint_digest is required"
+                        )
+                    self._checkpoint_digest = _checkpoint_weights_digest(
+                        checkpoint_path
+                    )
+            except (OSError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "MiniMax-Remover FP8: universal-scale cache disabled "
+                    "because checkpoint identity could not be established: %s",
+                    exc,
+                )
+                self.use_universal_scale = False
+
+        # Try loading universal scales from disk (skip calibration on first call).
+        if self.use_universal_scale:
+            if self._load_universal_scales():
+                self._calibrated = True
+                logger.info("MiniMax-Remover FP8: universal scale loaded "
+                            "(margin=%.2f) — calibration skipped",
+                            self.universal_margin)
+            else:
+                self._scale_dirty = True
+                logger.info("MiniMax-Remover FP8: no universal-scale cache; "
+                            "will calibrate on first call then persist")
 
         if use_bf16:
             self.transformer.to(torch.bfloat16)
@@ -96,6 +241,10 @@ class MiniMaxRemoverPipelineFP8:
                     n_attn)
 
         self._orig_pipe_call = self.pipe.__call__
+        self._pipe_accepts_skip_steps = _call_accepts_keyword(
+            self._orig_pipe_call, "skip_steps"
+        )
+        self._warned_skip_steps_unsupported = False
         from flash_rt.models.minimax_remover._fp8_manual_denoise import (
             FP8ManualDenoise,
         )
@@ -110,6 +259,227 @@ class MiniMaxRemoverPipelineFP8:
         self._dtype = torch.bfloat16 if use_bf16 else torch.float16
         self._vae_dtype = next(self.pipe.vae.parameters()).dtype
 
+    # ------------------------------------------------------------------ #
+    # Universal-scale disk cache (cross-resolution FP8 calibration).      #
+    # ------------------------------------------------------------------ #
+    _FP8_MAX = 448.0
+
+    def _scale_layers(self):
+        from flash_rt.models.minimax_remover._fp8_linear import FlashRTFp8Linear
+
+        return [
+            (name, module)
+            for name, module in self.transformer.named_modules()
+            if isinstance(module, FlashRTFp8Linear)
+        ]
+
+    @staticmethod
+    def _config_payload(config):
+        if hasattr(config, "to_dict"):
+            return config.to_dict()
+        if isinstance(config, Mapping):
+            return dict(config)
+        if hasattr(config, "__dict__"):
+            return {
+                key: value
+                for key, value in vars(config).items()
+                if not key.startswith("_")
+            }
+        return repr(config)
+
+    def _model_fingerprint(self):
+        """Hash checkpoint, precision contract, config, and FP8 layer layout."""
+        identity = {
+            "schema_version": _SCALE_CACHE_SCHEMA_VERSION,
+            "kernel_schema": _FP8_KERNEL_CACHE_SCHEMA,
+            "checkpoint_digest": self._checkpoint_digest,
+            "fp8_target": self.fp8_target,
+            "compute_dtype": self._compute_dtype_name,
+            "config": self._config_payload(self.transformer.config),
+            "layers": [
+                {
+                    "name": name,
+                    "in_features": module.in_features,
+                    "out_features": module.out_features,
+                }
+                for name, module in self._scale_layers()
+            ],
+        }
+        encoded = json.dumps(
+            identity, sort_keys=True, separators=(",", ":"), default=repr
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()[:24]
+
+    def _scale_cache_path(self):
+        fp = self._model_fingerprint()
+        if self._scale_cache_dir is not None:
+            d = self._scale_cache_dir
+        elif os.environ.get("FLASHRT_MINIMAX_SCALE_CACHE_DIR"):
+            d = Path(
+                os.environ["FLASHRT_MINIMAX_SCALE_CACHE_DIR"]
+            ).expanduser()
+        else:
+            d = Path.home() / ".flash_rt" / "calibration"
+        return d / f"minimax_remover_fp8_{fp}.json"
+
+    def _validated_cache_amax(self, data, layers):
+        if not isinstance(data, dict):
+            raise ValueError("top-level JSON value must be an object")
+
+        expected = {
+            "schema_version": _SCALE_CACHE_SCHEMA_VERSION,
+            "kernel_schema": _FP8_KERNEL_CACHE_SCHEMA,
+            "fingerprint": self._model_fingerprint(),
+            "checkpoint_digest": self._checkpoint_digest,
+            "fp8_target": self.fp8_target,
+            "compute_dtype": self._compute_dtype_name,
+            "n_layers": len(layers),
+        }
+        for key, value in expected.items():
+            if data.get(key) != value:
+                raise ValueError(f"{key} mismatch")
+
+        cached_layers = data.get("layers")
+        if not isinstance(cached_layers, list) or len(cached_layers) != len(layers):
+            raise ValueError("layer list mismatch")
+
+        amax_values = []
+        for cached, (name, module) in zip(cached_layers, layers):
+            if not isinstance(cached, dict):
+                raise ValueError(f"layer entry for {name} must be an object")
+            if (
+                cached.get("name") != name
+                or cached.get("in_features") != module.in_features
+                or cached.get("out_features") != module.out_features
+            ):
+                raise ValueError(f"layer metadata mismatch for {name}")
+            value = cached.get("amax_max")
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"invalid amax for {name}")
+            value = float(value)
+            if not math.isfinite(value) or value <= 0:
+                raise ValueError(f"non-finite or non-positive amax for {name}")
+            amax_values.append(value)
+        return amax_values
+
+    def _load_universal_scales(self):
+        """Load persisted ``act_amax_max`` and inject frozen act_scales.
+
+        Returns True if scales were loaded and injected, False if no cache
+        exists (caller should calibrate then call ``_dump_universal_scales``).
+        """
+        try:
+            cache = self._scale_cache_path()
+            if not cache.is_file():
+                return False
+            data = json.loads(cache.read_text(encoding="utf-8"))
+            layers = self._scale_layers()
+            amax_values = self._validated_cache_amax(data, layers)
+            scales = [
+                torch.tensor(
+                    [max(amax * self.universal_margin / self._FP8_MAX, 1e-12)],
+                    dtype=torch.float32,
+                    device=module.weight_fp8.device,
+                )
+                for amax, (_, module) in zip(amax_values, layers)
+            ]
+        except (
+            json.JSONDecodeError,
+            OSError,
+            OverflowError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            logger.warning(
+                "MiniMax-Remover FP8: universal-scale cache ignored: %s", exc
+            )
+            return False
+
+        with torch.no_grad():
+            for scale, (_, module) in zip(scales, layers):
+                module.act_scale.data = scale
+                module.calibrating = False
+        return True
+
+    def _dump_universal_scales(self):
+        """Persist ``act_amax_max`` from all FP8 Linears to disk.
+
+        Called once after the first calibration call. The raw amax is
+        margin-neutral — the universal margin is applied at load time.
+        """
+        temp_path = None
+        try:
+            layers = self._scale_layers()
+            layer_data = []
+            for name, module in layers:
+                amax = float(module.act_amax_max.item())
+                if not math.isfinite(amax) or amax <= 0:
+                    raise ValueError(
+                        f"cannot persist invalid calibrated amax for {name}"
+                    )
+                layer_data.append(
+                    {
+                        "name": name,
+                        "in_features": module.in_features,
+                        "out_features": module.out_features,
+                        "amax_max": amax,
+                    }
+                )
+            cache = self._scale_cache_path()
+            payload = {
+                "schema_version": _SCALE_CACHE_SCHEMA_VERSION,
+                "kernel_schema": _FP8_KERNEL_CACHE_SCHEMA,
+                "fingerprint": self._model_fingerprint(),
+                "checkpoint_digest": self._checkpoint_digest,
+                "fp8_target": self.fp8_target,
+                "compute_dtype": self._compute_dtype_name,
+                "n_layers": len(layer_data),
+                "layers": layer_data,
+            }
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=cache.parent,
+                prefix=f".{cache.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                temp_path = Path(handle.name)
+                json.dump(payload, handle, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, cache)
+        except (OSError, OverflowError, RuntimeError, TypeError, ValueError) as exc:
+            logger.warning(
+                "MiniMax-Remover FP8: could not persist universal-scale "
+                "cache; inference will continue with calibrated scales: %s",
+                exc,
+            )
+            if temp_path is not None:
+                try:
+                    temp_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            return False
+
+        logger.info("MiniMax-Remover FP8: universal scale persisted (%d "
+                    "layers -> %s)", len(layer_data), cache)
+        return True
+
+    def _warn_unsupported_skip_steps(self):
+        if self._warned_skip_steps_unsupported:
+            return
+        self._warned_skip_steps_unsupported = True
+        logger.warning(
+            "MiniMax-Remover FP8: wrapped pipeline does not accept "
+            "skip_steps; the calibration/reference call will run all "
+            "denoise steps. TeaCache remains available on subsequent "
+            "FlashRT manual denoise calls."
+        )
+
     @torch.no_grad()
     def __call__(self, *args, **kwargs):
         """Run the wrapped pipe, calibrating FP8 scales on the first call.
@@ -121,6 +491,14 @@ class MiniMaxRemoverPipelineFP8:
         benefits from the fused path instead of only multi-call ones.
         The cost is a single CPU sync (~1 ms) after step 1.
 
+        ``skip_steps`` (optional list of int) enables training-free
+        TeaCache step caching: the listed denoise steps reuse the cached
+        noise prediction instead of running the transformer, mirroring
+        the Motus/Cosmos3 TeaCache mechanism. On the first call it is
+        forwarded only when the wrapped pipeline declares support for the
+        keyword; otherwise calibration runs all steps. On steady-state calls
+        it is forwarded to the FP8 manual denoise loop.
+
         When ``FLASHRT_FP8_GRAPH=1`` and scales are frozen (call 2+), the
         denoise loop runs via the manual graph-capturable path
         (``_manual_call`` -> ``FP8ManualDenoise``). The first call always
@@ -128,7 +506,13 @@ class MiniMaxRemoverPipelineFP8:
         the second call and replayed thereafter.
         """
         use_graph = os.environ.get("FLASHRT_FP8_GRAPH", "0") == "1"
+        skip_steps = kwargs.pop("skip_steps", None)
+        fwd_kwargs = dict(kwargs)
+        if skip_steps is not None and self._pipe_accepts_skip_steps:
+            fwd_kwargs["skip_steps"] = skip_steps
         if not self._calibrated:
+            if skip_steps is not None and not self._pipe_accepts_skip_steps:
+                self._warn_unsupported_skip_steps()
             logger.info("MiniMax-Remover FP8: calibration mode "
                         "(first call, dynamic FP8 + amax accumulation; "
                         "freezes after step 1)")
@@ -150,27 +534,35 @@ class MiniMaxRemoverPipelineFP8:
             handle = self.transformer.register_forward_hook(
                 _freeze_after_step1)
             try:
-                result = self._orig_pipe_call(*args, **kwargs)
+                result = self._orig_pipe_call(*args, **fwd_kwargs)
             finally:
                 handle.remove()
+            # Persist universal scales for future cold-start speedup.
+            if self._scale_dirty:
+                self._dump_universal_scales()
+                self._scale_dirty = False
         elif use_graph:
             # Frozen scales + graph requested: manual graph-capturable path.
-            result = self._manual_call(*args, use_graph=True, **kwargs)
+            result = self._manual_call(*args, use_graph=True,
+                                       skip_steps=skip_steps, **kwargs)
         elif os.environ.get("FLASHRT_FP8_EAGER_MANUAL", "1") == "1":
             # Steady-state: eager manual denoise (avoids the per-step
             # torch.cat of [latents, masked, masks] and the scheduler.step
             # CPU sync of the diffusers path). masked/masks latents are
             # constant across steps; _denoise_loop_body copies only the
             # changing latents slice into a persistent concat buffer.
-            result = self._manual_call(*args, use_graph=False, **kwargs)
+            result = self._manual_call(*args, use_graph=False,
+                                       skip_steps=skip_steps, **kwargs)
         else:
-            result = self._orig_pipe_call(*args, **kwargs)
+            if skip_steps is not None and not self._pipe_accepts_skip_steps:
+                self._warn_unsupported_skip_steps()
+            result = self._orig_pipe_call(*args, **fwd_kwargs)
         return result
 
     @torch.no_grad()
     def _manual_call(self, images, masks, num_frames, height, width,
                      num_inference_steps=12, generator=None, iterations=16,
-                     output_type="np", use_graph=False):
+                     output_type="np", use_graph=False, skip_steps=None):
         """Manual encode + graph-denoise + decode (mirrors the diffusers
         ``MinimaxRemoverPipeline.__call__`` but replaces the denoise loop
         with the CUDA-graph-capturable ``FP8ManualDenoise``). Requires
@@ -196,7 +588,7 @@ class MiniMaxRemoverPipelineFP8:
         from einops import rearrange
         images_t = rearrange(images, "f h w c -> c f h w")
         images_t = pipe.resize(images_t[None, ...], height, width).to(device).to(self._vae_dtype)
-        masked_images = mask_mul(images_t, masks_t)
+        masked_images = images_t * (1.0 - masks_t)
 
         latents_mean = (torch.tensor(pipe.vae.config.latents_mean)
                         .view(1, pipe.vae.config.z_dim, 1, 1, 1)
@@ -214,7 +606,7 @@ class MiniMaxRemoverPipelineFP8:
 
         result_latents = self._graph_denoise.denoise(
             latents, masked_latents, masks_latents, num_inference_steps,
-            use_graph=use_graph)
+            use_graph=use_graph, skip_steps=skip_steps)
 
         result_latents = (result_latents.to(self._vae_dtype) / latents_std
                           + latents_mean)

--- a/tests/test_minimax_remover_smoke.py
+++ b/tests/test_minimax_remover_smoke.py
@@ -384,7 +384,11 @@ def test_fp8_pipeline_call_does_not_patch_pipe_class(monkeypatch):
     pipe2 = _CallablePipe("pipe2")
     original_call = _CallablePipe.__call__
 
-    wrapped = _fp8_pipeline.MiniMaxRemoverPipelineFP8(pipe1)
+    # use_universal_scale=False keeps this class-isolation test off the
+    # cross-resolution scale-cache path, which needs a realistic dict-like
+    # transformer.config and would write to ~/.flash_rt/calibration/.
+    wrapped = _fp8_pipeline.MiniMaxRemoverPipelineFP8(
+        pipe1, use_universal_scale=False)
 
     assert _CallablePipe.__call__ is original_call
     assert pipe2("unwrapped") == ("pipe2", ("unwrapped",), {})
@@ -406,6 +410,403 @@ def test_fp8_pipeline_call_does_not_patch_pipe_class(monkeypatch):
     assert wrapped("again") == ("pipe1", ("again",), {})
     assert set_calibration_calls == [True]
     assert freeze_calls == [1.1]
+
+
+# ── 5. TeaCache step-caching plumbing (skip_steps) ──
+
+def test_fp8_pipeline_call_forwards_skip_steps_to_pipe(monkeypatch):
+    """skip_steps reaches the wrapped pipe's __call__ on the calibration call.
+
+    The single-call quickstart runs the first (calibration) call through the
+    diffusers reference ``__call__``, so the TeaCache schedule must be
+    forwarded there for it to take effect without a warm-up pass.
+    """
+    import torch
+
+    from flash_rt.models.minimax_remover import _fp8_pipeline
+
+    # Exercise the delegation path (orig pipe __call__) rather than the
+    # eager-manual denoise default, so the stub does not need a real
+    # transformer/scheduler.
+    monkeypatch.setenv("FLASHRT_FP8_EAGER_MANUAL", "0")
+    monkeypatch.setattr(_fp8_pipeline, "load_fp8_kernels", lambda: object())
+
+    def _fake_runtime():
+        def install_flashrt_fp8(_t, verbose=True, target="all"):
+            return 0
+
+        def set_calibration(_t, on):
+            return None
+
+        def freeze_calibration(_t, margin=1.1):
+            return 3
+
+        def install_fused_blocks(_t):
+            return 0
+
+        def install_fa2_attention(_t):
+            return 0
+
+        return (install_flashrt_fp8, set_calibration, freeze_calibration,
+                install_fused_blocks, install_fa2_attention)
+
+    monkeypatch.setattr(_fp8_pipeline, "_import_runtime_fp8", _fake_runtime)
+
+    class _Param:
+        dtype = torch.float16
+
+    class _Transformer:
+        def __init__(self):
+            self.config = types.SimpleNamespace(eps=1e-6)
+            self._hooks = []
+
+        def to(self, _d):
+            return self
+
+        def parameters(self):
+            return iter([_Param()])
+
+        def register_forward_hook(self, fn):
+            self._hooks.append(fn)
+
+            class _Handle:
+                def remove(_self):
+                    pass
+
+            return _Handle()
+
+        def _fire_hooks(self):
+            for fn in list(self._hooks):
+                fn(self, None, None)
+
+    class _Vae:
+        def parameters(self):
+            return iter([_Param()])
+
+    received = []
+
+    class _Pipe:
+        def __init__(self):
+            self.transformer = _Transformer()
+            self.vae = _Vae()
+
+        def __call__(self, *args, **kwargs):
+            received.append(dict(kwargs))
+            # Fire the one-shot calibration freeze hook on the first call.
+            self.transformer._fire_hooks()
+            return ("ok", args, kwargs)
+
+    # use_universal_scale=False avoids the disk-backed scale cache so this
+    # skip_steps-forwarding test stays hermetic (no ~/.flash_rt writes).
+    wrapped = _fp8_pipeline.MiniMaxRemoverPipelineFP8(
+        _Pipe(), use_universal_scale=False)
+    out = wrapped(num_frames=5, skip_steps=[3, 5, 7, 9])
+
+    assert out[0] == "ok"
+    assert received, "wrapped pipe __call__ was never invoked"
+    assert received[0].get("skip_steps") == [3, 5, 7, 9], (
+        "skip_steps must be forwarded to the reference __call__ on the "
+        "calibration (first) call")
+
+
+def test_fp8_pipeline_does_not_forward_unsupported_skip_steps(caplog):
+    """A standard pipeline without ``skip_steps`` still calibrates safely."""
+    import logging
+
+    from flash_rt.models.minimax_remover import _fp8_pipeline
+
+    class _Handle:
+        def remove(self):
+            pass
+
+    class _Transformer:
+        def register_forward_hook(self, hook):
+            self.hook = hook
+            return _Handle()
+
+    class _Pipe:
+        def __call__(self, *, num_frames):
+            return num_frames
+
+    pipe = _Pipe()
+    wrapped = object.__new__(_fp8_pipeline.MiniMaxRemoverPipelineFP8)
+    wrapped._calibrated = False
+    wrapped._scale_dirty = False
+    wrapped._pipe_accepts_skip_steps = False
+    wrapped._warned_skip_steps_unsupported = False
+    wrapped._set_calibration = lambda _on: None
+    wrapped._freeze_calibration = lambda: 0
+    wrapped.transformer = _Transformer()
+    wrapped._orig_pipe_call = pipe.__call__
+    wrapped.calib_margin = 1.1
+
+    with caplog.at_level(logging.WARNING):
+        assert wrapped(num_frames=5, skip_steps=[3, 5]) == 5
+
+    assert "does not accept skip_steps" in caplog.text
+
+
+def test_fp8_manual_denoise_supports_skip_steps():
+    """The FP8 manual denoise carries skip_steps through every entry point."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "flash_rt/models/minimax_remover/_fp8_manual_denoise.py").read_text()
+
+    # Zeroth-order TeaCache reuse logic (skip step reuses cached noise_pred).
+    assert "cached_noise_pred" in src
+    assert "if step in skip_set and cached_noise_pred is not None:" in src
+    # The public denoise() / _denoise_loop_body() / _capture_graph() all
+    # carry the parameter.
+    assert src.count("skip_steps=None") >= 3
+    # The captured-graph cache key is per skip-schedule, because the skip
+    # set is baked into the graph at capture time (like Motus).
+    assert "skip_key" in src
+    assert "skip_steps=skip_steps" in src
+
+
+def test_fp8_pipeline_threads_skip_steps_to_manual_call():
+    """_manual_call carries skip_steps and forwards it to FP8ManualDenoise."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "flash_rt/models/minimax_remover/_fp8_pipeline.py").read_text()
+
+    # __call__ pops skip_steps out of the public kwargs...
+    assert 'skip_steps = kwargs.pop("skip_steps", None)' in src
+    # ...forwards it when the wrapped pipeline explicitly supports it...
+    assert "self._pipe_accepts_skip_steps" in src
+    assert 'fwd_kwargs["skip_steps"] = skip_steps' in src
+    # ...and threads it into _manual_call on the steady-state branches.
+    assert "skip_steps=skip_steps, **kwargs" in src
+    # _manual_call signature carries the parameter...
+    assert "skip_steps=None):" in src
+    # ...and forwards it to the FP8ManualDenoise.denoise().
+    assert "use_graph=use_graph, skip_steps=skip_steps" in src
+
+
+def test_quickstart_approximate_paths_are_opt_in():
+    """The quickstart preserves the original denoise and scale behavior."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "examples/minimax_remover_quickstart.py").read_text()
+
+    # Both approximate optimizations require explicit CLI flags.
+    assert 'TEACACHE_SKIP_DEFAULT = ""' in src
+    assert "default=TEACACHE_SKIP_DEFAULT" in src
+    universal_flag = src.index('p.add_argument("--universal-scale"')
+    assert "default=False" in src[universal_flag:universal_flag + 500]
+    # The reference __call__ carries the parameter...
+    assert "skip_steps: Optional[List[int]] = None" in src
+    # ...with zeroth-order reuse in the denoise loop.
+    assert "cached_noise_pred" in src
+    assert "if i in skip_set and cached_noise_pred is not None:" in src
+    # --no-flashrt is the master "pure reference" switch: it disables ALL
+    # FlashRT optimisations (no need to also pass --no-vae-opt).
+    assert "vae_opt = args.vae_opt and not args.no_flashrt" in src
+    # TeaCache is never applied on the reference path (ground truth = full
+    # N-step denoise for PSNR/timing A/B) nor on the NVFP4 transformer
+    # path (its wrapper does not accept skip_steps).
+    assert ("if args.teacache_skip.strip() and not args.no_flashrt "
+            "and not args.nvfp4_transformer:") in src
+
+
+def test_quickstart_checks_cv2_write_result():
+    """A failed OpenCV write must not be reported as a saved frame."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "examples/minimax_remover_quickstart.py").read_text()
+
+    assert "saved_ok = cv2.imwrite(" in src
+    assert "if not saved_ok:" in src
+    assert 'raise OSError(f"failed to write output frame: {dst}")' in src
+
+
+def test_sm89_attention_fallback_matches_only_known_error():
+    """Unrelated runtime errors must not be swallowed by the fallback."""
+    from flash_rt.models.minimax_remover._attention import (
+        _is_sm89_query_scale_shape_error,
+    )
+
+    assert _is_sm89_query_scale_shape_error(
+        RuntimeError("query_scale must have shape (1, 32)")
+    )
+    assert not _is_sm89_query_scale_shape_error(
+        RuntimeError("output must have shape (1, 32)")
+    )
+    assert not _is_sm89_query_scale_shape_error(
+        RuntimeError("query_scale is on the wrong device")
+    )
+
+
+def _make_scale_cache_wrapper(tmp_path, checkpoint_digest="a" * 64):
+    import torch
+
+    from flash_rt.models.minimax_remover import _fp8_pipeline
+
+    class _Layer:
+        in_features = 8
+        out_features = 16
+
+        def __init__(self):
+            self.weight_fp8 = torch.zeros(1)
+            self.act_amax_max = torch.tensor([224.0])
+            self.act_scale = torch.tensor([99.0])
+            self.calibrating = True
+
+    layer = _Layer()
+    wrapped = object.__new__(_fp8_pipeline.MiniMaxRemoverPipelineFP8)
+    wrapped.transformer = types.SimpleNamespace(config={"layers": 1})
+    wrapped.fp8_target = "all"
+    wrapped._compute_dtype_name = "float16"
+    wrapped._checkpoint_digest = checkpoint_digest
+    wrapped._scale_cache_dir = tmp_path
+    wrapped.universal_margin = 1.3
+    wrapped._scale_layers = lambda: [("block.proj", layer)]
+    return wrapped, layer
+
+
+def test_universal_scale_cache_is_checkpoint_bound(tmp_path):
+    """Changing checkpoint bytes changes both the digest and cache key."""
+    from flash_rt.models.minimax_remover import _fp8_pipeline
+
+    checkpoint = tmp_path / "model.safetensors"
+    checkpoint.write_bytes(b"first weights")
+    first = _fp8_pipeline._checkpoint_weights_digest(checkpoint)
+    checkpoint.write_bytes(b"second weights")
+    second = _fp8_pipeline._checkpoint_weights_digest(checkpoint)
+
+    assert first != second
+    first_wrapper, _ = _make_scale_cache_wrapper(tmp_path / "cache", first)
+    second_wrapper, _ = _make_scale_cache_wrapper(tmp_path / "cache", second)
+    assert first_wrapper._model_fingerprint() != second_wrapper._model_fingerprint()
+    assert first_wrapper._scale_cache_path() != second_wrapper._scale_cache_path()
+
+
+def test_universal_scale_cache_round_trip_and_validation(tmp_path):
+    """Only a complete, finite, schema-matching cache may mutate scales."""
+    import json
+
+    wrapped, layer = _make_scale_cache_wrapper(tmp_path)
+    assert wrapped._dump_universal_scales()
+    cache = wrapped._scale_cache_path()
+    payload = json.loads(cache.read_text())
+    assert payload["schema_version"] == 2
+    assert payload["checkpoint_digest"] == "a" * 64
+    assert payload["fp8_target"] == "all"
+    assert payload["compute_dtype"] == "float16"
+
+    layer.act_scale.fill_(99.0)
+    assert wrapped._load_universal_scales()
+    assert layer.act_scale.item() == pytest.approx(224.0 * 1.3 / 448.0)
+    assert not layer.calibrating
+
+    for invalid in (
+        [],
+        {**payload, "schema_version": 1},
+        {
+            **payload,
+            "layers": [{**payload["layers"][0], "amax_max": float("nan")}],
+        },
+    ):
+        cache.write_text(json.dumps(invalid))
+        layer.act_scale.fill_(77.0)
+        assert not wrapped._load_universal_scales()
+        assert layer.act_scale.item() == 77.0
+
+
+def test_universal_scale_cache_write_failure_is_nonfatal(
+        tmp_path, monkeypatch, caplog):
+    """Read-only or failed cache storage must not interrupt inference."""
+    import logging
+
+    from flash_rt.models.minimax_remover import _fp8_pipeline
+
+    wrapped, _ = _make_scale_cache_wrapper(tmp_path)
+
+    def _fail_replace(_source, _destination):
+        raise OSError("read-only cache")
+
+    monkeypatch.setattr(_fp8_pipeline.os, "replace", _fail_replace)
+    with caplog.at_level(logging.WARNING):
+        assert not wrapped._dump_universal_scales()
+    assert "inference will continue" in caplog.text
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_universal_scale_cache_read_failure_is_nonfatal(caplog):
+    """An inaccessible cache falls back without touching existing scales."""
+    import logging
+
+    wrapped, layer = _make_scale_cache_wrapper(None)
+
+    class _UnreadableCache:
+        @staticmethod
+        def is_file():
+            return True
+
+        @staticmethod
+        def read_text(**_kwargs):
+            raise OSError("cache is not readable")
+
+    wrapped._scale_cache_path = lambda: _UnreadableCache()
+    with caplog.at_level(logging.WARNING):
+        assert not wrapped._load_universal_scales()
+    assert layer.act_scale.item() == 99.0
+    assert "cache ignored" in caplog.text
+
+
+def test_fp8_pipeline_universal_scale_default_is_off():
+    """Constructing the wrapper must retain per-resolution calibration."""
+    import inspect
+
+    from flash_rt.models.minimax_remover import _fp8_pipeline
+
+    parameter = inspect.signature(
+        _fp8_pipeline.MiniMaxRemoverPipelineFP8
+    ).parameters["use_universal_scale"]
+    assert parameter.default is False
+
+
+# ── 6. --nvfp4-transformer naming (replaces the confusing --use-fp4) ──
+
+def test_quickstart_nvfp4_transformer_flag_naming():
+    """The transformer-NVFP4 flag is named --nvfp4-transformer, not --use-fp4.
+
+    The old ``--use-fp4`` name was misleading because the default path
+    *already* uses NVFP4 for the VAE. The renamed flag makes explicit that
+    it switches the **transformer** (the 12-step iterative denoise, where
+    FP4 error accumulates) — distinct from the always-on NVFP4 VAE.
+    """
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "examples/minimax_remover_quickstart.py").read_text()
+
+    # New flag is present...
+    assert '"--nvfp4-transformer"' in src
+    assert "args.nvfp4_transformer" in src
+    # ...and the old confusing name is gone from the quickstart.
+    assert '"--use-fp4"' not in src
+    assert "args.use_fp4" not in src
+    # The NVFP4 VAE install is gated on the new attribute.
+    assert "not args.nvfp4_transformer and not args.no_nvfp4_vae" in src
+
+
+def test_quickstart_nvfp4_transformer_excludes_nvfp4_vae():
+    """--nvfp4-transformer disables the NVFP4 VAE (the two NVFP4 paths are
+    mutually exclusive: VAE NVFP4 is validated only on the FP8 transformer
+    path, and the NVFP4 transformer path is a standalone small-region
+    experiment)."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    src = (root / "examples/minimax_remover_quickstart.py").read_text()
+
+    # nvfp4_vae is False when nvfp4_transformer is set.
+    assert "nvfp4_vae = (vae_opt and not args.nvfp4_transformer" in src
 
 
 # ── 4. Gated build: required symbols present and callable ──


### PR DESCRIPTION
## Summary

This PR adds scoped MiniMax-Remover runtime enhancements while preserving the existing default denoise and calibration behavior. The branch is rebased onto the latest `flashrt-project/main` and contains one effective commit across six MiniMax-specific files.

## Highlights

- **Opt-in TeaCache step caching**: pass `--teacache-skip 3,5,7,9` (or `skip_steps=[3, 5, 7, 9]`) to reuse selected denoise predictions. The default remains the full denoise schedule.
- **Opt-in universal FP8 scale cache**: pass `--universal-scale` to reuse activation scales across resolutions. The default remains per-resolution calibration.
- **Checkpoint-bound cache identity**: cache keys include a SHA-256 digest of checkpoint weight bytes, FP8 target, compute dtype, kernel/cache schema, model config, and FP8 layer layout.
- **Strict, fail-open cache handling**: cache schema, metadata, layer layout, and finite positive values are validated before any scale is injected. Writes are atomic; read/write failures warn and fall back to calibration without interrupting inference.
- **Safe TeaCache wrapper contract**: `skip_steps` is forwarded during calibration only when the wrapped pipeline declares support for it. Standard diffusers pipelines no longer fail with an unexpected keyword.
- **SageAttention fallback hardening**: only the known `query_scale` shape error triggers the SM89 fallback; unrelated runtime errors propagate.
- **Parallel frame output**: OpenCV writes run through the parallel output path, and a false `cv2.imwrite()` result now raises an explicit error.
- **Clearer precision naming**: `--nvfp4-transformer` replaces the ambiguous `--use-fp4` flag.

The measured TeaCache profile remains documented as an optional performance profile: 5.66 s / 3.06x versus the fp16 reference on the recorded RTX 5060 Ti workload. It is not enabled by default.

## Files changed

| File | Change |
| --- | --- |
| `flash_rt/models/minimax_remover/_fp8_pipeline.py` | TeaCache capability detection and hardened checkpoint-bound scale cache |
| `flash_rt/models/minimax_remover/_attention.py` | Narrow SM89 SageAttention fallback |
| `flash_rt/models/minimax_remover/_fp8_manual_denoise.py` | TeaCache plumbing and PyTorch elementwise path |
| `examples/minimax_remover_quickstart.py` | Opt-in defaults, checkpoint identity, parallel output checks, and CLI naming |
| `tests/test_minimax_remover_smoke.py` | Runtime-contract, cache validation, failure-mode, and default-behavior coverage |
| `docs/minimax_remover_usage.md` | Updated opt-in semantics and cache identity documentation |

## Validation

- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_minimax_remover_smoke.py`: **31 passed, 4 skipped**
- Related generic/import/build-inventory tests: **67 passed, 13 skipped**
- One additional install-smoke artifact check failed in the isolated source worktree because no locally built `flash_rt_kernels` shared library was present; no build files or kernel sources change in this PR.
- `python -m compileall`: passed
- Package and MiniMax module imports without optional runtime dependencies: passed
- `git diff --check`: passed
- Private-path scan: no findings

## Checklist

- [x] Based on latest upstream `main`
- [x] Single clean PR commit
- [x] Approximate performance paths are opt-in
- [x] Cache is checkpoint-bound, schema-validated, atomic, and fail-open
- [x] Public wrapper compatibility is covered
- [x] No CMake, C++ kernel, binding, or other-model changes
