### PR TITLE
Harden model runtime v1 ABI contracts

### DIFF
--- a/docs/cpp_runtime_design.md
+++ b/docs/cpp_runtime_design.md
@@ -147,7 +147,10 @@ be in flight.
 
 ## Freeze and evolution
 
-`runtime/include/flashrt/*.h` is additive-only after v1: append fields (bump
-ABI version + struct_size), append enum values, never reorder or remove.
+`runtime/include/flashrt/*.h` is additive-only after v1: append fields, append
+enum values, never reorder or remove. `frt_runtime_export_v1` follows its
+version + `struct_size` contract; `frt_model_runtime_v1` consumers require
+only `FRT_MODEL_RUNTIME_V1_BASE_SIZE` and probe future tails separately while
+the model-runtime ABI version remains 1. The embedded verbs table is frozen.
 Everything under `cpp/` may be refactored freely as long as the produced
 struct — and the identity it fingerprints — is preserved.

--- a/docs/model_runtime_api.md
+++ b/docs/model_runtime_api.md
@@ -90,7 +90,9 @@ no owner/export/base object; `finish_model` additionally leaves its builder
 unconsumed so the producer can supply corrected verbs and retry.
 `build_model_runtime()` performs the equivalent check against the actual
 Python callbacks before `_assemble()`. The pybind trampolines are therefore
-never allowed to conceal a missing Python implementation.
+never allowed to conceal a missing Python implementation:
+`Builder.finish_model()` maps each `None` callback to a null verb before core
+validation.
 
 **Lifetime**: the consumer retains/releases only the model runtime; the owner
 holds one export reference internally. `retain`/`release` are thread-safe;

--- a/docs/model_runtime_api.md
+++ b/docs/model_runtime_api.md
@@ -58,6 +58,13 @@ frt_model_runtime_v1 {
 }
 ```
 
+`FRT_MODEL_RUNTIME_V1_BASE_SIZE` is the only required size for the published v1
+prefix above. Consumers reject `struct_size < BASE_SIZE`; they must not require
+the latest `sizeof(frt_model_runtime_v1)`. Any future additive tail has its own
+required-size probe before it is read. The embedded `frt_model_runtime_verbs`
+table is not tail-extensible: growing it would move `owner/retain/release` and
+break this prefix.
+
 **Verbs** (`frt_model_runtime_verbs`; every entry is always callable — absent
 producer verbs are filled with unsupported stubs returning `-3`):
 
@@ -74,6 +81,16 @@ Status codes follow the pi05 C face: `0` ok, `-1` invalid, `-2` not found,
 
 **Hot contract** (SWAP writes and both hot verbs): never recapture, never
 allocate, never rebind graph pointers — only buffer contents change.
+
+All three construction paths enforce the STAGED promise: any STAGED `IN`
+requires a non-null `set_input`, and any STAGED `OUT` requires a non-null
+`get_output`. Missing verbs remain legal for SWAP/SETUP-only declarations and
+are filled with the callable `-3` stubs. A contract-validation failure retains
+no owner/export/base object; `finish_model` additionally leaves its builder
+unconsumed so the producer can supply corrected verbs and retry.
+`build_model_runtime()` performs the equivalent check against the actual
+Python callbacks before `_assemble()`. The pybind trampolines are therefore
+never allowed to conceal a missing Python implementation.
 
 **Lifetime**: the consumer retains/releases only the model runtime; the owner
 holds one export reference internally. `retain`/`release` are thread-safe;
@@ -128,6 +145,10 @@ frt_model_runtime_v1* m = frt_model_runtime_override_verbs(
 The override retains `producer_model`, so inherited port/stage pointers remain
 valid even if the original producer reference is released first. Deployment
 identity is unchanged.
+
+`finish_model`, `wrap`, and `override_verbs` apply the same STAGED verb check
+before taking ownership. A producer must not publish a STAGED declaration and
+rely on the final unsupported stub as its implementation.
 
 **Native factory (symbol convention)** — a model-runtime `.so` exports
 `FRT_MODEL_RUNTIME_OPEN_V1_SYMBOL`:
@@ -258,7 +279,7 @@ size_t frt_graph_variant_count(frt_graph);
 ## Validation
 
 ```
-./runtime/build/test_model_runtime                     # ABI, identity, lifetime, stubs
+./runtime/build/test_model_runtime                     # prefix ABI, STAGED guards, identity, lifetime
 ctest --test-dir cpp/build                             # modalities, staging pool, pi05 faces
 PYTHONPATH=.:./exec/build:./runtime/build \
   python runtime/tests/test_model_runtime_py.py        # Python producer through C fn pointers

--- a/docs/pr_review_checklist.md
+++ b/docs/pr_review_checklist.md
@@ -135,8 +135,10 @@ Blockers:
 - `exec/` gains a field or verb whose meaning is specific to one model family,
   protocol, session policy, scheduler policy, or KV-cache policy.
 - `runtime/` gains a model-named field, a scenario verb, or a non-additive
-  struct change; or a port is declared `STAGED` while its `set_input` refuses
-  hot updates (advertise-and-refuse).
+  struct change; a consumer requires the latest full
+  `sizeof(frt_model_runtime_v1)` instead of `FRT_MODEL_RUNTIME_V1_BASE_SIZE`;
+  or a port is declared `STAGED` without a working input `set_input` / output
+  `get_output` hot verb (advertise-and-refuse).
 - A hot-path verb (`set_input`/`get_output`, SWAP writes, tick) allocates,
   recaptures, or rebinds graph pointers.
 

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -114,12 +114,22 @@ DAG is for).
 Full structure map: [`cpp_runtime_design.md`](cpp_runtime_design.md).
 Field-by-field interface reference: [`model_runtime_api.md`](model_runtime_api.md).
 
-Two construction paths: the export builder assembles export + ports + stages
-under ONE identity (`frt_runtime_builder_finish_model` — a port-schema change
-changes the fingerprint), or `frt_model_runtime_wrap` wraps an existing
-export with ports/verbs (the native-adapter path; identity inherited).
-Consumers retain/release only the model runtime; it holds the export
-reference internally.
+Three construction paths share the contract: the export builder assembles
+export + ports + stages under ONE identity
+(`frt_runtime_builder_finish_model` — a port-schema change changes the
+fingerprint); `frt_model_runtime_wrap` wraps an existing export with
+ports/verbs (identity inherited); and `frt_model_runtime_override_verbs`
+retains an existing declaration while replacing only its verbs. Consumers
+retain/release only the model runtime; it holds the export/base reference
+internally.
+
+Construction is fail-closed on the STAGED promise: a STAGED input requires
+`set_input`, and a STAGED output requires `get_output`, on integrated build,
+adapter wrap, and verb override alike. Validation happens before owner/export/
+base retain; failed `finish_model` also leaves the builder available for a
+corrected retry. SWAP/SETUP-only declarations may still use unsupported stubs.
+The common Python producer checks the actual callback objects before
+`_assemble()`; non-null pybind trampolines do not count as implementations.
 
 ## C++ model runtime layer
 
@@ -151,9 +161,19 @@ Nexus and serving hosts do not change.
 
 ## Extending the ABI
 
-Additive only after v1: append struct fields (bump `FRT_RUNTIME_ABI_VERSION` +
-`struct_size`), append enum values, never reorder or remove. Consumers gate on
-`abi_version`/`struct_size` before reading anything else.
+Additive only after v1; never reorder or remove. The two public structs use
+their own version policy:
+
+- `frt_runtime_export_v1`: append fields with the export contract's
+  `FRT_RUNTIME_ABI_VERSION` + `struct_size` policy.
+- `frt_model_runtime_v1`: the existing prefix ends at `release` and is measured
+  by `FRT_MODEL_RUNTIME_V1_BASE_SIZE`. Consumers require only that prefix;
+  future additive tails are individually size-probed while
+  `FRT_MODEL_RUNTIME_ABI_VERSION` remains `1`. The embedded verbs table is
+  frozen and cannot grow because fields follow it.
+
+An incompatible major type/symbol requires a separately reviewed ABI. An
+additive tail does not justify duplicating the full model-runtime interface.
 
 ## Validation
 
@@ -165,8 +185,9 @@ PYTHONPATH=.:./exec/build:./runtime/build python runtime/tests/test_runtime_expo
 The export test covers: ctypes-mirror layout check of every field, fingerprint
 determinism / identity sensitivity / region-order sensitivity / manifest
 insensitivity, retain-release lifetime against the Python anchor, and replay
-through exported handles. The model-runtime test covers: port/stage
-declaration and validation, port schema in the identity fingerprint, verb
-dispatch, and lifetime on both construction paths. The consumer side is
+through exported handles. The model-runtime test covers: an independently
+compiled v1 ABI baseline, STAGED rejection/retry and no-retain failures,
+port/stage declaration, port schema in the identity fingerprint, verb
+dispatch, and lifetime on all three construction paths. The consumer side is
 validated in the FlashRT-Nexus repo (adopt + snapshot/restore through the
 capsule core).

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -129,7 +129,8 @@ adapter wrap, and verb override alike. Validation happens before owner/export/
 base retain; failed `finish_model` also leaves the builder available for a
 corrected retry. SWAP/SETUP-only declarations may still use unsupported stubs.
 The common Python producer checks the actual callback objects before
-`_assemble()`; non-null pybind trampolines do not count as implementations.
+`_assemble()`; the low-level pybind builder maps `None` to null verbs, so a
+trampoline does not count as an implementation unless its callback exists.
 
 ## C++ model runtime layer
 

--- a/flash_rt/runtime/export.py
+++ b/flash_rt/runtime/export.py
@@ -281,7 +281,7 @@ def build_model_runtime(
     contract (ports, stage DAG, optional verb callables) under one identity —
     a port-schema change changes the fingerprint.
 
-    Verb callables (all optional; absent verbs report unsupported):
+    Verb callables are optional unless required by a STAGED declaration:
       ``set_input(port, payload: bytes, stream) -> int``,
       ``get_output(port, stream) -> bytes``,
       ``prepare(graph, key) -> int``, ``step() -> int``.
@@ -289,6 +289,21 @@ def build_model_runtime(
     them from any thread. SWAP ports need no callable — hosts write the
     declared buffer window directly.
     """
+    staged_inputs = any(
+        _enum(UPDATE, port.update) == UPDATE["staged"] and
+        _enum(DIRECTION, port.direction) == DIRECTION["in"]
+        for port in ports
+    )
+    staged_outputs = any(
+        _enum(UPDATE, port.update) == UPDATE["staged"] and
+        _enum(DIRECTION, port.direction) == DIRECTION["out"]
+        for port in ports
+    )
+    if staged_inputs and set_input is None:
+        raise ValueError("STAGED input ports require set_input")
+    if staged_outputs and get_output is None:
+        raise ValueError("STAGED output ports require get_output")
+
     b, anchor, manifest_json = _assemble(
         ctx, streams=streams, graphs=graphs, buffers=buffers, regions=regions,
         ports=ports, stages=stages, identity=identity,

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -30,7 +30,9 @@ target_include_directories(flashrt_runtime
          ${CMAKE_CURRENT_SOURCE_DIR}/../exec/include)
 
 if(BUILD_TESTING)
-  add_executable(test_model_runtime tests/test_model_runtime.cpp)
+  add_executable(test_model_runtime
+    tests/test_model_runtime.cpp
+    tests/model_runtime_v1_abi_baseline_producer.cpp)
   target_link_libraries(test_model_runtime PRIVATE flashrt_runtime)
   add_test(NAME model_runtime COMMAND test_model_runtime)
 endif()

--- a/runtime/bindings/runtime_pybind.cpp
+++ b/runtime/bindings/runtime_pybind.cpp
@@ -167,10 +167,11 @@ struct PyRtBuilder {
 
         frt_model_runtime_verbs verbs{};
         verbs.struct_size = sizeof(verbs);
-        verbs.set_input = &verb_set_input;
-        verbs.get_output = &verb_get_output;
-        verbs.prepare = &verb_prepare;
-        verbs.step = &verb_step;
+        verbs.set_input = pv->set_input.is_none() ? nullptr : &verb_set_input;
+        verbs.get_output =
+            pv->get_output.is_none() ? nullptr : &verb_get_output;
+        verbs.prepare = pv->prepare.is_none() ? nullptr : &verb_prepare;
+        verbs.step = pv->step.is_none() ? nullptr : &verb_step;
         verbs.last_error = &verb_last_error;
 
         frt_model_runtime_v1* mr = frt_runtime_builder_finish_model(

--- a/runtime/bindings/runtime_pybind.cpp
+++ b/runtime/bindings/runtime_pybind.cpp
@@ -175,8 +175,8 @@ struct PyRtBuilder {
 
         frt_model_runtime_v1* mr = frt_runtime_builder_finish_model(
             b, &verbs, pv, pv, /*retain_owner=*/nullptr, &release_py_verbs);
-        b = nullptr;
         if (!mr) { release_py_verbs(pv); throw std::runtime_error("finish_model failed"); }
+        b = nullptr;
         return reinterpret_cast<std::uintptr_t>(mr);
     }
 };
@@ -192,7 +192,7 @@ frt_runtime_export_v1* as_export(std::uintptr_t p) {
 frt_model_runtime_v1* as_model(std::uintptr_t p) {
     auto* m = reinterpret_cast<frt_model_runtime_v1*>(p);
     if (!m || m->abi_version != FRT_MODEL_RUNTIME_ABI_VERSION ||
-        m->struct_size != sizeof(frt_model_runtime_v1))
+        m->struct_size < FRT_MODEL_RUNTIME_V1_BASE_SIZE)
         throw std::runtime_error("not a valid frt_model_runtime_v1 pointer");
     return m;
 }
@@ -211,6 +211,7 @@ PYBIND11_MODULE(_flashrt_runtime, m) {
     m.attr("REGION_RESTORE") = (unsigned)FRT_RT_REGION_RESTORE;
 
     m.attr("MODEL_ABI_VERSION") = FRT_MODEL_RUNTIME_ABI_VERSION;
+    m.attr("MODEL_V1_BASE_SIZE") = FRT_MODEL_RUNTIME_V1_BASE_SIZE;
     m.attr("MOD_TENSOR") = (unsigned)FRT_RT_MOD_TENSOR;
     m.attr("MOD_IMAGE") = (unsigned)FRT_RT_MOD_IMAGE;
     m.attr("MOD_TEXT") = (unsigned)FRT_RT_MOD_TEXT;

--- a/runtime/include/flashrt/model_runtime.h
+++ b/runtime/include/flashrt/model_runtime.h
@@ -194,6 +194,11 @@ typedef struct frt_model_runtime_verbs {
     const char* (*last_error)(void* self);
 } frt_model_runtime_verbs;
 
+/* ABI-frozen in v1. Do not append fields here: this table is embedded in the
+ * middle of frt_model_runtime_v1, so growing it would move owner/retain/release
+ * and break the v1 prefix. New optional entry points belong in an additive
+ * tail on frt_model_runtime_v1 itself. */
+
 /* ------------------------------------------------------------------ */
 /* The model runtime object.                                           */
 /* ------------------------------------------------------------------ */
@@ -218,6 +223,14 @@ typedef struct frt_model_runtime_v1 {
     void (*retain)(void* owner);
     void (*release)(void* owner);
 } frt_model_runtime_v1;
+
+/* Minimum byte prefix every v1 consumer may require. Keep this anchored to
+ * the last v1 field instead of sizeof(frt_model_runtime_v1): future additive
+ * tail fields must remain optional for baseline-prefix producers and invisible
+ * to prefix-only consumers. Read a tail only after probing its required size. */
+#define FRT_MODEL_RUNTIME_V1_BASE_SIZE \
+    ((uint32_t)(offsetof(frt_model_runtime_v1, release) + \
+                sizeof(((frt_model_runtime_v1*)0)->release)))
 
 /* Factory symbol convention for NATIVE model runtimes: a model-runtime .so
  * exports exactly this symbol. Returns a retained object (caller releases). */
@@ -247,8 +260,10 @@ int frt_runtime_builder_add_stage(frt_runtime_builder, uint32_t graph,
 
 /* Like frt_runtime_builder_finish, but returns the model runtime whose
  * `exp` is the internally-built export (one object, one refcount). `verbs`
- * is copied; entries may be null (the runtime then reports them
- * unsupported). Consumes the builder. */
+ * is copied; entries may be null except that every STAGED input requires a
+ * real set_input and every STAGED output requires a real get_output. A
+ * contract-validation failure returns null without consuming the builder or
+ * retaining owner; success consumes the builder. */
 frt_model_runtime_v1* frt_runtime_builder_finish_model(
     frt_runtime_builder,
     const frt_model_runtime_verbs* verbs, void* verbs_self,
@@ -262,7 +277,8 @@ frt_model_runtime_v1* frt_runtime_builder_finish_model(
 /* producer builds both. Descriptor arrays are copied. The wrapper     */
 /* takes one export reference and calls `wrapper_release(wrapper_owner)`*/
 /* exactly once when its refcount hits zero (use it to destroy the     */
-/* producer instance behind `verbs_self`).                             */
+/* producer instance behind `verbs_self`). STAGED declarations require */
+/* matching input/output verbs, as on construction path 1.             */
 /* ------------------------------------------------------------------ */
 frt_model_runtime_v1* frt_model_runtime_wrap(
     const frt_runtime_export_v1* exp,
@@ -278,7 +294,8 @@ frt_model_runtime_v1* frt_model_runtime_wrap(
 /* a native runtime owns hot-path transforms. The override retains `in` */
 /* so all inherited descriptor pointers stay valid; consumers release   */
 /* only the returned object. `retain_owner`/`release_owner` manage the  */
-/* native verb object, called once at construction/destruction.         */
+/* native verb object, called once at construction/destruction. The new */
+/* verbs must satisfy every inherited STAGED input/output declaration.   */
 /* ------------------------------------------------------------------ */
 frt_model_runtime_v1* frt_model_runtime_override_verbs(
     const frt_model_runtime_v1* in,

--- a/runtime/src/model_runtime.cpp
+++ b/runtime/src/model_runtime.cpp
@@ -21,6 +21,26 @@ bool valid_port_args(const char* name, uint32_t direction, uint32_t update,
     return true;
 }
 
+bool has_complete_verbs(const frt_model_runtime_verbs* verbs) {
+    return verbs &&
+           verbs->struct_size >= (uint32_t)sizeof(frt_model_runtime_verbs);
+}
+
+bool valid_staged_verbs(const frt_runtime_port_desc* ports, uint64_t n_ports,
+                        const frt_model_runtime_verbs* verbs) {
+    bool needs_set_input = false;
+    bool needs_get_output = false;
+    for (uint64_t i = 0; i < n_ports; ++i) {
+        if (ports[i].update != FRT_RT_PORT_STAGED) continue;
+        if (ports[i].direction == FRT_RT_PORT_IN) needs_set_input = true;
+        if (ports[i].direction == FRT_RT_PORT_OUT) needs_get_output = true;
+    }
+    if (!needs_set_input && !needs_get_output) return true;
+    if (!has_complete_verbs(verbs)) return false;
+    return (!needs_set_input || verbs->set_input) &&
+           (!needs_get_output || verbs->get_output);
+}
+
 /* Default stubs for verbs a producer does not provide: report unsupported
  * (-3) instead of leaving null function pointers for consumers to crash on. */
 int stub_set_input(void*, uint32_t, const void*, uint64_t, int) { return -3; }
@@ -108,6 +128,8 @@ extern "C" frt_model_runtime_v1* frt_runtime_builder_finish_model(
         void (*release_owner)(void*)) {
     if (!b) return nullptr;
     Holder* h = b->h;
+    if (!valid_staged_verbs(h->ports.data(), h->ports.size(), verbs))
+        return nullptr;
     frt_rt::finish_export_into(h, b, owner, retain_owner, release_owner);
 
     frt_model_runtime_v1& m = h->model;
@@ -172,6 +194,7 @@ extern "C" frt_model_runtime_v1* frt_model_runtime_wrap(
         if (!valid_port_args(ports[i].name, ports[i].direction,
                              ports[i].update, ports[i].shape, ports[i].rank))
             return nullptr;
+    if (!valid_staged_verbs(ports, n_ports, verbs)) return nullptr;
     for (uint64_t i = 0; i < n_stages; ++i) {
         if (stages[i].graph >= exp->n_graphs) return nullptr;
         if (stages[i].n_after && !stages[i].after) return nullptr;
@@ -241,7 +264,7 @@ extern "C" void override_release(void* owner) {
 
 bool valid_model_runtime(const frt_model_runtime_v1* m) {
     if (!m || m->abi_version != FRT_MODEL_RUNTIME_ABI_VERSION ||
-        m->struct_size < sizeof(frt_model_runtime_v1)) return false;
+        m->struct_size < FRT_MODEL_RUNTIME_V1_BASE_SIZE) return false;
     if (!m->exp || !m->retain || !m->release) return false;
     if ((m->n_ports && !m->ports) || (m->n_stages && !m->stages)) return false;
     return true;
@@ -255,6 +278,7 @@ extern "C" frt_model_runtime_v1* frt_model_runtime_override_verbs(
         void* owner, void (*retain_owner)(void*),
         void (*release_owner)(void*)) {
     if (!valid_model_runtime(in)) return nullptr;
+    if (!valid_staged_verbs(in->ports, in->n_ports, verbs)) return nullptr;
 
     auto* o = new VerbOverride();
     o->base = in;

--- a/runtime/tests/abi/README.md
+++ b/runtime/tests/abi/README.md
@@ -1,0 +1,18 @@
+# Model-runtime ABI baselines
+
+This directory stores immutable declarations used to verify binary
+compatibility. A baseline is a snapshot of a published ABI, not a second API
+and not a version alias.
+
+Rules:
+
+- Preserve the published type names, field order, enum values, and data model.
+- Compile baseline producers in isolated translation units that do not include
+  the candidate model-runtime header.
+- Include a baseline in a namespace only for compile-time layout comparison.
+- Do not update a v1 baseline when additive tail fields are introduced; compare
+  those fields through their own required-size probes.
+- Do not install these headers or expose baseline-producer helpers from runtime DSOs.
+
+`model_runtime_v1_abi_baseline.h` captures the v1 required prefix through
+`release`, plus the v1 payload, descriptor, verbs, and enum layouts.

--- a/runtime/tests/abi/model_runtime_v1_abi_baseline.h
+++ b/runtime/tests/abi/model_runtime_v1_abi_baseline.h
@@ -1,0 +1,129 @@
+/* Model-runtime v1 ABI baseline.
+ *
+ * This is a self-contained snapshot of the data ABI published before any
+ * additive frt_model_runtime_v1 tail. Keep the original ABI type and enum
+ * names: the baseline producer is compiled in an isolated translation unit,
+ * while layout checks include this file inside a C++ namespace.
+ *
+ * Do not replace these declarations with includes from model_runtime.h.
+ */
+#ifndef FLASHRT_MODEL_RUNTIME_V1_ABI_BASELINE_H
+#define FLASHRT_MODEL_RUNTIME_V1_ABI_BASELINE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "flashrt/runtime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FRT_MODEL_RUNTIME_ABI_VERSION 1u
+
+enum frt_rt_modality {
+    FRT_RT_MOD_TENSOR = 0,
+    FRT_RT_MOD_IMAGE  = 1,
+    FRT_RT_MOD_TEXT   = 2,
+    FRT_RT_MOD_STATE  = 3,
+    FRT_RT_MOD_ACTION = 4,
+    FRT_RT_MOD_AUDIO  = 5,
+    FRT_RT_MOD_DEPTH  = 6,
+    FRT_RT_MOD_FORCE  = 7
+};
+
+enum frt_rt_dtype {
+    FRT_RT_DTYPE_U8   = 0,
+    FRT_RT_DTYPE_F32  = 1,
+    FRT_RT_DTYPE_F16  = 2,
+    FRT_RT_DTYPE_BF16 = 3,
+    FRT_RT_DTYPE_I32  = 4,
+    FRT_RT_DTYPE_I64  = 5
+};
+
+enum frt_rt_layout {
+    FRT_RT_LAYOUT_FLAT = 0,
+    FRT_RT_LAYOUT_HWC  = 1,
+    FRT_RT_LAYOUT_NHWC = 2,
+    FRT_RT_LAYOUT_CHW  = 3,
+    FRT_RT_LAYOUT_NCHW = 4
+};
+
+enum frt_rt_pixel_format {
+    FRT_RT_PIXEL_RGB8  = 0,
+    FRT_RT_PIXEL_BGR8  = 1,
+    FRT_RT_PIXEL_RGBA8 = 2,
+    FRT_RT_PIXEL_BGRA8 = 3,
+    FRT_RT_PIXEL_GRAY8 = 4
+};
+
+enum frt_rt_port_direction { FRT_RT_PORT_IN = 0, FRT_RT_PORT_OUT = 1 };
+
+enum frt_rt_port_update {
+    FRT_RT_PORT_SWAP   = 0,
+    FRT_RT_PORT_STAGED = 1,
+    FRT_RT_PORT_SETUP  = 2
+};
+
+typedef struct frt_image_view {
+    uint32_t struct_size;
+    uint32_t pixel_format;
+    const void* data;
+    uint64_t bytes;
+    int32_t width, height, stride_bytes;
+    uint32_t reserved;
+    uint64_t timestamp_ns;
+} frt_image_view;
+
+typedef struct frt_runtime_port_desc {
+    const char* name;
+    uint32_t modality;
+    uint32_t dtype;
+    uint32_t layout;
+    uint32_t direction;
+    uint32_t update;
+    uint32_t required;
+    const int64_t* shape;
+    uint32_t rank;
+    uint32_t cadence_hint_hz;
+    frt_buffer buffer;
+    uint64_t offset;
+    uint64_t bytes;
+} frt_runtime_port_desc;
+
+typedef struct frt_runtime_stage_desc {
+    uint32_t graph;
+    uint32_t n_after;
+    const uint32_t* after;
+} frt_runtime_stage_desc;
+
+typedef struct frt_model_runtime_verbs {
+    uint32_t struct_size;
+    uint32_t reserved;
+    int (*set_input)(void*, uint32_t, const void*, uint64_t, int);
+    int (*get_output)(void*, uint32_t, void*, uint64_t, uint64_t*, int);
+    int (*prepare)(void*, uint32_t, frt_shape_key);
+    int (*step)(void*);
+    const char* (*last_error)(void*);
+} frt_model_runtime_verbs;
+
+typedef struct frt_model_runtime_v1 {
+    uint32_t abi_version;
+    uint32_t struct_size;
+    const frt_runtime_export_v1* exp;
+    const frt_runtime_port_desc* ports;
+    uint64_t n_ports;
+    const frt_runtime_stage_desc* stages;
+    uint64_t n_stages;
+    void* self;
+    frt_model_runtime_verbs verbs;
+    void* owner;
+    void (*retain)(void* owner);
+    void (*release)(void* owner);
+} frt_model_runtime_v1;
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* FLASHRT_MODEL_RUNTIME_V1_ABI_BASELINE_H */

--- a/runtime/tests/abi/model_runtime_v1_abi_baseline_producer.h
+++ b/runtime/tests/abi/model_runtime_v1_abi_baseline_producer.h
@@ -1,0 +1,15 @@
+#ifndef FLASHRT_MODEL_RUNTIME_V1_ABI_BASELINE_PRODUCER_H
+#define FLASHRT_MODEL_RUNTIME_V1_ABI_BASELINE_PRODUCER_H
+
+#include "flashrt/runtime.h"
+
+namespace flashrt::model_runtime_v1_abi {
+
+void* create_baseline(const frt_runtime_export_v1* exp, void* owner,
+                      void (*retain_owner)(void*),
+                      void (*release_owner)(void*));
+void destroy_baseline(void* model);
+
+}  // namespace flashrt::model_runtime_v1_abi
+
+#endif  // FLASHRT_MODEL_RUNTIME_V1_ABI_BASELINE_PRODUCER_H

--- a/runtime/tests/model_runtime_v1_abi_baseline_producer.cpp
+++ b/runtime/tests/model_runtime_v1_abi_baseline_producer.cpp
@@ -1,0 +1,45 @@
+#include "abi/model_runtime_v1_abi_baseline.h"
+#include "abi/model_runtime_v1_abi_baseline_producer.h"
+
+namespace {
+
+int unsupported_set_input(void*, uint32_t, const void*, uint64_t, int) {
+    return -3;
+}
+int unsupported_get_output(void*, uint32_t, void*, uint64_t, uint64_t*, int) {
+    return -3;
+}
+int unsupported_prepare(void*, uint32_t, frt_shape_key) { return -3; }
+int unsupported_step(void*) { return -3; }
+const char* unsupported_last_error(void*) {
+    return "verb not provided by the ABI baseline producer";
+}
+
+}  // namespace
+
+namespace flashrt::model_runtime_v1_abi {
+
+void* create_baseline(const frt_runtime_export_v1* exp, void* owner,
+                      void (*retain_owner)(void*),
+                      void (*release_owner)(void*)) {
+    auto* model = new frt_model_runtime_v1{};
+    model->abi_version = FRT_MODEL_RUNTIME_ABI_VERSION;
+    model->struct_size = (uint32_t)sizeof(*model);
+    model->exp = exp;
+    model->verbs.struct_size = (uint32_t)sizeof(model->verbs);
+    model->verbs.set_input = unsupported_set_input;
+    model->verbs.get_output = unsupported_get_output;
+    model->verbs.prepare = unsupported_prepare;
+    model->verbs.step = unsupported_step;
+    model->verbs.last_error = unsupported_last_error;
+    model->owner = owner;
+    model->retain = retain_owner;
+    model->release = release_owner;
+    return model;
+}
+
+void destroy_baseline(void* model) {
+    delete static_cast<frt_model_runtime_v1*>(model);
+}
+
+}  // namespace flashrt::model_runtime_v1_abi

--- a/runtime/tests/test_model_runtime.cpp
+++ b/runtime/tests/test_model_runtime.cpp
@@ -215,6 +215,13 @@ int main() {
         /* The builder survives both refusals; valid verbs consume it. */
         frt_model_runtime_verbs staged_verbs{};
         staged_verbs.struct_size = sizeof(staged_verbs);
+        staged_verbs.get_output = v_get_output;
+        CHECK(frt_runtime_builder_finish_model(
+                  b, &staged_verbs, nullptr, &rejected_owner, owner_retain,
+                  owner_release) == nullptr &&
+                  rejected_owner.retains == 0 && rejected_owner.releases == 0,
+              "finish_model rejects missing STAGED input and remains retryable");
+        staged_verbs.get_output = nullptr;
         staged_verbs.set_input = v_set_input;
         CHECK(frt_runtime_builder_finish_model(
                   b, &staged_verbs, nullptr, &rejected_owner, owner_retain,
@@ -386,7 +393,7 @@ int main() {
             eb, &eo, owner_retain, owner_release);
         CHECK(exp != nullptr, "plain export for the wrap path");
 
-        frt_runtime_port_desc ports[1] = {};
+        frt_runtime_port_desc ports[2] = {};
         ports[0].name = "images";
         ports[0].modality = FRT_RT_MOD_IMAGE;
         ports[0].dtype = FRT_RT_DTYPE_BF16;
@@ -396,22 +403,39 @@ int main() {
         ports[0].required = 1;
         ports[0].shape = IMG_SHAPE;
         ports[0].rank = 4;
+        ports[1].name = "actions";
+        ports[1].modality = FRT_RT_MOD_ACTION;
+        ports[1].dtype = FRT_RT_DTYPE_BF16;
+        ports[1].layout = FRT_RT_LAYOUT_FLAT;
+        ports[1].direction = FRT_RT_PORT_OUT;
+        ports[1].update = FRT_RT_PORT_STAGED;
+        ports[1].shape = ACT_SHAPE;
+        ports[1].rank = 2;
         frt_runtime_stage_desc stages[1] = {};
         stages[0].graph = 0;
 
         frt_runtime_stage_desc bad = {};
         bad.graph = 9;
-        CHECK(frt_model_runtime_wrap(exp, ports, 1, &bad, 1, &verbs, &vlog,
+        CHECK(frt_model_runtime_wrap(exp, ports, 2, &bad, 1, &verbs, &vlog,
                                      nullptr, nullptr) == nullptr,
               "wrap rejects a stage over a missing graph");
-        CHECK(frt_model_runtime_wrap(exp, ports, 1, stages, 1, nullptr,
-                                     nullptr, &wrapper_freed,
+        frt_model_runtime_verbs output_only = verbs;
+        output_only.set_input = nullptr;
+        CHECK(frt_model_runtime_wrap(exp, ports, 2, stages, 1, &output_only,
+                                     &vlog, &wrapper_freed,
                                      [](void* p) { *(int*)p += 1; }) == nullptr &&
                   eo.retains == 1 && wrapper_freed == 0,
               "wrap rejects missing STAGED input without retaining owners");
+        frt_model_runtime_verbs input_only = verbs;
+        input_only.get_output = nullptr;
+        CHECK(frt_model_runtime_wrap(exp, ports, 2, stages, 1, &input_only,
+                                     nullptr, &wrapper_freed,
+                                     [](void* p) { *(int*)p += 1; }) == nullptr &&
+                  eo.retains == 1 && wrapper_freed == 0,
+              "wrap rejects missing STAGED output without retaining owners");
 
         frt_model_runtime_v1* wm = frt_model_runtime_wrap(
-            exp, ports, 1, stages, 1, &verbs, &vlog, &wrapper_freed,
+            exp, ports, 2, stages, 1, &verbs, &vlog, &wrapper_freed,
             [](void* p) { *(int*)p += 1; });
         CHECK(wm != nullptr, "frt_model_runtime_wrap");
         CHECK(wm->exp == exp, "wrap keeps the export pointer");
@@ -448,6 +472,14 @@ int main() {
         native_verbs.last_error = v_last_error;
 
         frt_model_runtime_verbs incomplete_verbs = native_verbs;
+        incomplete_verbs.set_input = nullptr;
+        CHECK(frt_model_runtime_override_verbs(
+                  base, &incomplete_verbs, &native_vlog, &native_owner,
+                  owner_retain, owner_release) == nullptr &&
+                  native_owner.retains == 0 && base_owner.retains == 1,
+              "override rejects missing STAGED input without retaining owners");
+
+        incomplete_verbs = native_verbs;
         incomplete_verbs.get_output = nullptr;
         CHECK(frt_model_runtime_override_verbs(
                   base, &incomplete_verbs, &native_vlog, &native_owner,

--- a/runtime/tests/test_model_runtime.cpp
+++ b/runtime/tests/test_model_runtime.cpp
@@ -7,10 +7,129 @@
  * model-level tests (cpp/tests) and the consumer-side suites.
  */
 #include "flashrt/model_runtime.h"
+#include "abi/model_runtime_v1_abi_baseline_producer.h"
 
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <string>
+
+/* The baseline keeps the released ABI names intact. A namespace lets this
+ * translation unit compare it with the current header without renaming either
+ * side; the producer fixture includes the same baseline globally. */
+namespace flashrt::model_runtime_v1_abi::baseline {
+#include "abi/model_runtime_v1_abi_baseline.h"
+}  // namespace flashrt::model_runtime_v1_abi::baseline
+
+namespace abi_baseline = flashrt::model_runtime_v1_abi::baseline;
+
+#define ASSERT_BASELINE_OFFSET(type, field) \
+    static_assert(offsetof(type, field) == \
+                      offsetof(abi_baseline::type, field), \
+                  #type "." #field " offset changed")
+#define ASSERT_BASELINE_LAYOUT(type) \
+    static_assert(sizeof(type) == sizeof(abi_baseline::type) && \
+                      alignof(type) == alignof(abi_baseline::type), \
+                  #type " layout changed")
+#define ASSERT_BASELINE_VALUE(value) \
+    static_assert(static_cast<int>(value) == \
+                      static_cast<int>(abi_baseline::value), \
+                  #value " value changed")
+
+static_assert(FRT_MODEL_RUNTIME_ABI_VERSION == 1u,
+              "v1 model-runtime ABI version changed");
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_TENSOR);
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_IMAGE);
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_TEXT);
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_STATE);
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_ACTION);
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_AUDIO);
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_DEPTH);
+ASSERT_BASELINE_VALUE(FRT_RT_MOD_FORCE);
+ASSERT_BASELINE_VALUE(FRT_RT_DTYPE_U8);
+ASSERT_BASELINE_VALUE(FRT_RT_DTYPE_F32);
+ASSERT_BASELINE_VALUE(FRT_RT_DTYPE_F16);
+ASSERT_BASELINE_VALUE(FRT_RT_DTYPE_BF16);
+ASSERT_BASELINE_VALUE(FRT_RT_DTYPE_I32);
+ASSERT_BASELINE_VALUE(FRT_RT_DTYPE_I64);
+ASSERT_BASELINE_VALUE(FRT_RT_LAYOUT_FLAT);
+ASSERT_BASELINE_VALUE(FRT_RT_LAYOUT_HWC);
+ASSERT_BASELINE_VALUE(FRT_RT_LAYOUT_NHWC);
+ASSERT_BASELINE_VALUE(FRT_RT_LAYOUT_CHW);
+ASSERT_BASELINE_VALUE(FRT_RT_LAYOUT_NCHW);
+ASSERT_BASELINE_VALUE(FRT_RT_PIXEL_RGB8);
+ASSERT_BASELINE_VALUE(FRT_RT_PIXEL_BGR8);
+ASSERT_BASELINE_VALUE(FRT_RT_PIXEL_RGBA8);
+ASSERT_BASELINE_VALUE(FRT_RT_PIXEL_BGRA8);
+ASSERT_BASELINE_VALUE(FRT_RT_PIXEL_GRAY8);
+ASSERT_BASELINE_VALUE(FRT_RT_PORT_IN);
+ASSERT_BASELINE_VALUE(FRT_RT_PORT_OUT);
+ASSERT_BASELINE_VALUE(FRT_RT_PORT_SWAP);
+ASSERT_BASELINE_VALUE(FRT_RT_PORT_STAGED);
+ASSERT_BASELINE_VALUE(FRT_RT_PORT_SETUP);
+
+ASSERT_BASELINE_LAYOUT(frt_image_view);
+ASSERT_BASELINE_OFFSET(frt_image_view, struct_size);
+ASSERT_BASELINE_OFFSET(frt_image_view, pixel_format);
+ASSERT_BASELINE_OFFSET(frt_image_view, data);
+ASSERT_BASELINE_OFFSET(frt_image_view, bytes);
+ASSERT_BASELINE_OFFSET(frt_image_view, width);
+ASSERT_BASELINE_OFFSET(frt_image_view, height);
+ASSERT_BASELINE_OFFSET(frt_image_view, stride_bytes);
+ASSERT_BASELINE_OFFSET(frt_image_view, reserved);
+ASSERT_BASELINE_OFFSET(frt_image_view, timestamp_ns);
+
+ASSERT_BASELINE_LAYOUT(frt_runtime_port_desc);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, name);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, modality);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, dtype);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, layout);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, direction);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, update);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, required);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, shape);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, rank);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, cadence_hint_hz);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, buffer);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, offset);
+ASSERT_BASELINE_OFFSET(frt_runtime_port_desc, bytes);
+
+ASSERT_BASELINE_LAYOUT(frt_runtime_stage_desc);
+ASSERT_BASELINE_OFFSET(frt_runtime_stage_desc, graph);
+ASSERT_BASELINE_OFFSET(frt_runtime_stage_desc, n_after);
+ASSERT_BASELINE_OFFSET(frt_runtime_stage_desc, after);
+
+ASSERT_BASELINE_LAYOUT(frt_model_runtime_verbs);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, struct_size);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, reserved);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, set_input);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, get_output);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, prepare);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, step);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, last_error);
+
+static_assert(FRT_MODEL_RUNTIME_V1_BASE_SIZE ==
+                  sizeof(abi_baseline::frt_model_runtime_v1),
+              "v1 required prefix changed");
+static_assert(alignof(frt_model_runtime_v1) ==
+                  alignof(abi_baseline::frt_model_runtime_v1),
+              "frt_model_runtime_v1 prefix alignment changed");
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, abi_version);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, struct_size);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, exp);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, ports);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, n_ports);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, stages);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, n_stages);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, self);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, verbs);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, owner);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, retain);
+ASSERT_BASELINE_OFFSET(frt_model_runtime_v1, release);
+
+#undef ASSERT_BASELINE_OFFSET
+#undef ASSERT_BASELINE_LAYOUT
+#undef ASSERT_BASELINE_VALUE
 
 static int g_fail = 0;
 #define CHECK(cond, msg) do { \
@@ -87,18 +206,79 @@ int main() {
         add_ports_and_stages(b);
         CHECK(frt_runtime_builder_finish(b, nullptr, nullptr, nullptr) == nullptr,
               "plain finish refuses a builder that declared ports/stages");
-        /* the builder survives that refusal — finish_model consumes it */
+        Owner rejected_owner;
+        CHECK(frt_runtime_builder_finish_model(
+                  b, nullptr, nullptr, &rejected_owner, owner_retain,
+                  owner_release) == nullptr &&
+                  rejected_owner.retains == 0 && rejected_owner.releases == 0,
+              "finish_model rejects STAGED ports without retaining owner");
+        /* The builder survives both refusals; valid verbs consume it. */
+        frt_model_runtime_verbs staged_verbs{};
+        staged_verbs.struct_size = sizeof(staged_verbs);
+        staged_verbs.set_input = v_set_input;
+        CHECK(frt_runtime_builder_finish_model(
+                  b, &staged_verbs, nullptr, &rejected_owner, owner_retain,
+                  owner_release) == nullptr &&
+                  rejected_owner.retains == 0 && rejected_owner.releases == 0,
+              "finish_model rejects missing STAGED output and remains retryable");
+        staged_verbs.get_output = v_get_output;
         frt_model_runtime_v1* m = frt_runtime_builder_finish_model(
-            b, nullptr, nullptr, nullptr, nullptr, nullptr);
-        CHECK(m != nullptr, "finish_model after refused finish");
-        /* absent producer verbs become unsupported stubs, never null */
-        CHECK(m->verbs.set_input && m->verbs.step && m->verbs.last_error,
-              "null verbs are stubbed");
-        CHECK(m->verbs.set_input(m->self, 0, nullptr, 0, -1) == -3 &&
-                  m->verbs.step(m->self) == -3 &&
-                  m->verbs.last_error(m->self)[0] != '\0',
-              "stubs report unsupported (-3) with an explanation");
+            b, &staged_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(m != nullptr, "finish_model succeeds after validation retry");
         m->release(m->owner);
+
+        frt_runtime_builder sb = make_builder();
+        const int64_t shape[1] = {16};
+        CHECK(frt_runtime_builder_add_port(
+                  sb, "setup", FRT_RT_MOD_TENSOR, FRT_RT_DTYPE_F32,
+                  FRT_RT_LAYOUT_FLAT, FRT_RT_PORT_IN, FRT_RT_PORT_SETUP, 0,
+                  shape, 1, 0, nullptr, 0, 0) == 0,
+              "add non-staged port");
+        frt_model_runtime_v1* sm = frt_runtime_builder_finish_model(
+            sb, nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(sm && sm->verbs.step(sm->self) == -3 &&
+                  sm->verbs.last_error(sm->self)[0] != '\0',
+              "missing non-staged verbs retain unsupported stubs");
+        sm->release(sm->owner);
+    }
+
+    /* --- independently compiled ABI baseline -> current prefix consumer --- */
+    {
+        Owner export_owner;
+        frt_runtime_builder eb = make_builder();
+        frt_runtime_export_v1* exp = frt_runtime_builder_finish(
+            eb, &export_owner, owner_retain, owner_release);
+        CHECK(exp != nullptr, "export backing the v1 ABI baseline producer");
+
+        Owner baseline_owner;
+        void* baseline_object =
+            flashrt::model_runtime_v1_abi::create_baseline(
+                exp, &baseline_owner, owner_retain, owner_release);
+        auto* current_view =
+            static_cast<frt_model_runtime_v1*>(baseline_object);
+        CHECK(current_view->struct_size == FRT_MODEL_RUNTIME_V1_BASE_SIZE,
+              "ABI baseline publishes exactly the v1 required prefix");
+
+        current_view->struct_size = FRT_MODEL_RUNTIME_V1_BASE_SIZE - 1;
+        CHECK(frt_model_runtime_override_verbs(
+                  current_view, nullptr, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr && baseline_owner.retains == 0,
+              "consumer rejects a short v1 prefix without retaining it");
+        current_view->struct_size = FRT_MODEL_RUNTIME_V1_BASE_SIZE;
+        frt_model_runtime_v1* adopted = frt_model_runtime_override_verbs(
+            current_view, nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(adopted != nullptr &&
+                  adopted->struct_size == sizeof(frt_model_runtime_v1),
+              "current consumer accepts the independently compiled ABI baseline");
+        CHECK(baseline_owner.retains == 1 && baseline_owner.releases == 0,
+              "current wrapper retains the baseline producer once");
+        adopted->release(adopted->owner);
+        CHECK(baseline_owner.releases == 1,
+              "current wrapper releases the baseline producer once");
+        flashrt::model_runtime_v1_abi::destroy_baseline(baseline_object);
+        exp->release(exp->owner);
+        CHECK(export_owner.releases == 1,
+              "ABI baseline backing export releases once");
     }
 
     /* --- integrated build: struct, identity, fingerprint, verbs --- */
@@ -224,6 +404,11 @@ int main() {
         CHECK(frt_model_runtime_wrap(exp, ports, 1, &bad, 1, &verbs, &vlog,
                                      nullptr, nullptr) == nullptr,
               "wrap rejects a stage over a missing graph");
+        CHECK(frt_model_runtime_wrap(exp, ports, 1, stages, 1, nullptr,
+                                     nullptr, &wrapper_freed,
+                                     [](void* p) { *(int*)p += 1; }) == nullptr &&
+                  eo.retains == 1 && wrapper_freed == 0,
+              "wrap rejects missing STAGED input without retaining owners");
 
         frt_model_runtime_v1* wm = frt_model_runtime_wrap(
             exp, ports, 1, stages, 1, &verbs, &vlog, &wrapper_freed,
@@ -261,6 +446,14 @@ int main() {
         native_verbs.prepare = v_prepare;
         native_verbs.step = v_step;
         native_verbs.last_error = v_last_error;
+
+        frt_model_runtime_verbs incomplete_verbs = native_verbs;
+        incomplete_verbs.get_output = nullptr;
+        CHECK(frt_model_runtime_override_verbs(
+                  base, &incomplete_verbs, &native_vlog, &native_owner,
+                  owner_retain, owner_release) == nullptr &&
+                  native_owner.retains == 0 && base_owner.retains == 1,
+              "override rejects missing STAGED output without retaining owners");
 
         frt_model_runtime_v1* over = frt_model_runtime_override_verbs(
             base, &native_verbs, &native_vlog, &native_owner, owner_retain,

--- a/runtime/tests/test_model_runtime_py.py
+++ b/runtime/tests/test_model_runtime_py.py
@@ -195,6 +195,72 @@ def check_staged_callback_guards():
     check("Python STAGED rejection happens before _assemble", assemble_calls == 0)
 
 
+def check_low_level_staged_builder_guard(setup):
+    ctx, _, _, _, _ = setup
+    builder = rt.Builder(ctx.raw())
+    builder.add_identity("model", "low-level-staged-guard")
+    builder.add_port("input", rt.MOD_TENSOR, rt.DTYPE_F32,
+                     rt.LAYOUT_FLAT, rt.PORT_IN, rt.PORT_STAGED,
+                     shape=[1])
+    builder.add_port("output", rt.MOD_TENSOR, rt.DTYPE_F32,
+                     rt.LAYOUT_FLAT, rt.PORT_OUT, rt.PORT_STAGED,
+                     shape=[1])
+
+    class Owner:
+        pass
+
+    missing_input_owner = Owner()
+    missing_input_ref = weakref.ref(missing_input_owner)
+    try:
+        builder.finish_model(
+            missing_input_owner,
+            get_output=lambda port, stream: b"",
+        )
+    except RuntimeError as exc:
+        missing_input_rejected = str(exc) == "finish_model failed"
+    else:
+        missing_input_rejected = False
+    del missing_input_owner
+    gc.collect()
+
+    missing_output_owner = Owner()
+    missing_output_ref = weakref.ref(missing_output_owner)
+    try:
+        builder.finish_model(
+            missing_output_owner,
+            set_input=lambda port, payload, stream: 0,
+        )
+    except RuntimeError as exc:
+        missing_output_rejected = str(exc) == "finish_model failed"
+    else:
+        missing_output_rejected = False
+    del missing_output_owner
+    gc.collect()
+
+    final_owner = Owner()
+    final_owner_ref = weakref.ref(final_owner)
+    ptr = builder.finish_model(
+        final_owner,
+        set_input=lambda port, payload, stream: 0,
+        get_output=lambda port, stream: b"",
+    )
+    del final_owner
+    gc.collect()
+
+    check("low-level builder rejects missing STAGED input",
+          missing_input_rejected)
+    check("low-level builder rejects missing STAGED output",
+          missing_output_rejected)
+    check("low-level failures release owners",
+          missing_input_ref() is None and missing_output_ref() is None)
+    check("low-level builder remains retryable after STAGED rejection",
+          ptr != 0 and final_owner_ref() is not None)
+    rt.model_release(ptr)
+    gc.collect()
+    check("low-level successful retry releases its owner",
+          final_owner_ref() is None)
+
+
 def check_stage_plan_registry():
     register_stage_plan(
         "unit_chain",
@@ -331,6 +397,7 @@ def main():
     check("ctypes v1 prefix matches exported required size",
           ctypes.sizeof(ModelV1) == int(rt.MODEL_V1_BASE_SIZE))
     check_staged_callback_guards()
+    check_low_level_staged_builder_guard(setup)
     calls = {"set_input": [], "step": 0}
 
     def py_set_input(port, payload, stream):

--- a/runtime/tests/test_model_runtime_py.py
+++ b/runtime/tests/test_model_runtime_py.py
@@ -95,7 +95,11 @@ def make_setup():
 
 def build(setup, img_h=224, verbs=None):
     ctx, sid, src, dst, g = setup
-    verbs = verbs or {}
+    if verbs is None:
+        verbs = {
+            "set_input": lambda port, payload, stream: 0,
+            "get_output": lambda port, stream: b"",
+        }
     return build_model_runtime(
         ctx,
         streams=[StreamSpec("main", sid)],
@@ -142,7 +146,53 @@ def build_split(setup):
         stages=plan.to_stage_specs(export_mod),
         identity={"model": "trivial", "quant": "none"},
         manifest_extra={"stage_plan": plan.manifest()},
+        set_input=lambda port, payload, stream: 0,
+        get_output=lambda port, stream: b"",
     )
+
+
+def check_staged_callback_guards():
+    original_assemble = export_mod._assemble
+    assemble_calls = 0
+
+    def forbidden_assemble(*args, **kwargs):
+        nonlocal assemble_calls
+        assemble_calls += 1
+        raise AssertionError("_assemble must not run after STAGED validation failure")
+
+    export_mod._assemble = forbidden_assemble
+    try:
+        try:
+            build_model_runtime(
+                None, streams=(), graphs=(),
+                ports=[PortSpec("input", "tensor", "f32", "flat",
+                                "in", "staged", shape=(1,))],
+                identity={"model": "invalid-staged-input"},
+            )
+        except ValueError as exc:
+            input_rejected = str(exc) == "STAGED input ports require set_input"
+        else:
+            input_rejected = False
+
+        try:
+            build_model_runtime(
+                None, streams=(), graphs=(),
+                ports=[PortSpec("output", "tensor", "f32", "flat",
+                                "out", "staged", shape=(1,))],
+                identity={"model": "invalid-staged-output"},
+            )
+        except ValueError as exc:
+            output_rejected = str(exc) == "STAGED output ports require get_output"
+        else:
+            output_rejected = False
+    finally:
+        export_mod._assemble = original_assemble
+
+    check("Python producer rejects STAGED input without set_input",
+          input_rejected)
+    check("Python producer rejects STAGED output without get_output",
+          output_rejected)
+    check("Python STAGED rejection happens before _assemble", assemble_calls == 0)
 
 
 def check_stage_plan_registry():
@@ -278,6 +328,9 @@ def main():
     ctx, sid, src, dst, g = setup
 
     print("== struct layout (ctypes mirror vs specs) ==")
+    check("ctypes v1 prefix matches exported required size",
+          ctypes.sizeof(ModelV1) == int(rt.MODEL_V1_BASE_SIZE))
+    check_staged_callback_guards()
     calls = {"set_input": [], "step": 0}
 
     def py_set_input(port, payload, stream):
@@ -297,7 +350,7 @@ def main():
                                  get_output=py_get_output, step=py_step))
     m = ModelV1.from_address(mr.ptr)
     check("abi stamp", m.abi_version == int(rt.MODEL_ABI_VERSION)
-          and m.struct_size == ctypes.sizeof(ModelV1))
+          and m.struct_size >= int(rt.MODEL_V1_BASE_SIZE))
     check("embedded export pointer", m.exp == mr.export_ptr)
     check("port count", m.n_ports == 3 and m.n_stages == 1)
     p0 = m.ports[0]


### PR DESCRIPTION
## Summary

This is CORE-A of the model-runtime v1 evolution work. It hardens the existing v1 contract without adding capability extensions, provider-specific behavior, or a parallel runtime ABI.

- define `FRT_MODEL_RUNTIME_V1_BASE_SIZE` and switch core/pybind consumers to required-prefix probing
- freeze the embedded verbs table and document additive tail rules
- fail closed when STAGED input/output ports lack real `set_input`/`get_output` implementations across `finish_model`, `wrap`, and `override_verbs`
- preserve clean failure semantics: no owner/base/export retain and a retryable builder
- validate actual Python callbacks before `_assemble()` and map low-level pybind `None` callbacks to null C verbs, so trampolines cannot conceal missing implementations
- cover missing STAGED input/output independently across `finish_model`, `wrap`, and `override_verbs`, including low-level Python builder rejection, ownership cleanup, and retry
- add an immutable v1 ABI baseline under `runtime/tests/abi/`; its producer is compiled in isolation with the published ABI names, while the current consumer verifies layout, required-prefix adoption, lifecycle, and short-prefix rejection

## Why

The existing pybind layer always installs non-null C++ trampolines, even when a Python callback is absent. Core pointer validation alone could therefore publish a runtime that advertised STAGED I/O but only returned unsupported at execution time. In addition, consumers probing the latest `sizeof(frt_model_runtime_v1)` would reject valid baseline-prefix producers after an additive v1 tail extension.

This change makes the existing v1 interface mechanically fail closed and establishes the prefix rule needed before later capability-extension work.

## Impact and boundaries

- No new exported runtime symbols.
- No `query_extension` or `GENERIC_STAGE_PLAN` implementation; those remain CORE-B work.
- No provider/model-specific ABI behavior.
- PR #152 should rebase onto this change, remove its duplicate common STAGED guard, delete its declaration-only public escape, and convert its private `create_over` consumer to `FRT_MODEL_RUNTIME_V1_BASE_SIZE` with model-level tests.

## Validation

- runtime Release CTest: passed
- Python model-runtime contract: 36/36 passed
- ASAN + UBSAN runtime CTest: passed
- dynamic symbol set compared with `main`: unchanged
- `git diff --check`: passed
- capability/provider privacy scan: clean
