### PR TITLE
Extend model runtime v1 with generic stage capabilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,9 +194,22 @@ same mechanism-not-policy rule. Design:
 [`docs/runtime_contract.md`](docs/runtime_contract.md). The essentials
 reviewers hold every PR to:
 
+- Optional model-runtime capabilities append only to the main struct tail and
+  require an independent size probe. Never grow the embedded verbs table.
+- Extension IDs and tables are core-owned. Provider/model/backend names,
+  private registries, post-finish table attachment, and parallel identity/hash
+  implementations are rejected.
+- One runtime publishes one selected execution authority: legacy stages,
+  generic stages, or step-only. A new capability must include authority,
+  malformed-table, owner-lifetime, fingerprint and baseline-prefix tests.
+- Metadata-only exports are zero-resource identity/lifetime anchors. They must
+  not fake an exec context or imply snapshot/restore support.
+
 - `runtime/` headers are the ONLY frozen surface and are additive-only after
-  v1: append fields (bump ABI version + struct_size), append enum values,
-  never reorder or remove. Nothing under `cpp/` is ABI.
+  v1: append fields/enums, never reorder or remove. Export revisions follow
+  their documented version policy; model-runtime v1 tails use independent
+  size probes without changing the required prefix. Nothing under `cpp/` is
+  ABI.
 - The contract is data first, verbs as sugar: ports (with update class) and
   the stage DAG are the standard face; `step` is convenience, never the
   center. Do not add scenario fields, model names, or scheduling concepts to

--- a/docs/model_runtime_api.md
+++ b/docs/model_runtime_api.md
@@ -13,6 +13,7 @@ layer norms: [`runtime_contract.md`](runtime_contract.md).
 | layout | `FLAT 0` · `HWC 1` · `NHWC 2` · `CHW 3` · `NCHW 4` |
 | direction | `IN 0` · `OUT 1` |
 | update | `SWAP 0` · `STAGED 1` · `SETUP 2` |
+| generic executor | `GRAPH 0` · `OPAQUE 1` |
 
 `STATE` is reserved for real proprioception; internal embedding/residual
 windows are `TENSOR`. A `STAGED` declaration is a promise the port accepts hot
@@ -60,6 +61,7 @@ frt_model_runtime_v1 {
   stages / n_stages                  subgraph DAG
   self + verbs                       producer verbs (below)
   owner / retain / release           lifetime (see below)
+  query_extension                    optional, size-probed capability tail
 }
 ```
 
@@ -69,6 +71,14 @@ the latest `sizeof(frt_model_runtime_v1)`. Any future additive tail has its own
 required-size probe before it is read. The embedded `frt_model_runtime_verbs`
 table is not tail-extensible: growing it would move `owner/retain/release` and
 break this prefix.
+
+Before reading `query_extension`, require
+`struct_size >= FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE`. A
+baseline-prefix producer is valid and simply has no extension tail. Every
+tail-capable core builder installs a callable query function, even when it
+returns `-3` (unsupported) for every ID. Query failures clear the output
+pointer; version zero is invalid (`-1`). Extension tables are runtime-owned and
+stable while the caller holds a model-runtime reference.
 
 **Verbs** (`frt_model_runtime_verbs`; every entry is always callable — absent
 producer verbs are filled with unsupported stubs returning `-3`):
@@ -81,11 +91,50 @@ producer verbs are filled with unsupported stubs returning `-3`):
 | `step(self)` | HOT (sugar) | fire all stages in declared order; scheduling hosts fire stages themselves |
 | `last_error(self)` | — | message for the most recent failure |
 
-Status codes follow the pi05 C face: `0` ok, `-1` invalid, `-2` not found,
+Status codes follow the common runtime convention: `0` ok, `-1` invalid, `-2` not found,
 `-3` unsupported, `-4` shape mismatch, `-5` insufficient storage, `-6` backend.
 
 **Hot contract** (SWAP writes and both hot verbs): never recapture, never
 allocate, never rebind graph pointers — only buffer contents change.
+
+## Execution authority and generic selected plans
+
+One runtime instance has exactly one execution authority:
+
+| legacy stages | generic plan | real `step` | result |
+|---:|---:|---:|---|
+| nonempty | absent | optional | legacy GRAPH plan |
+| empty | nonempty | optional | generic selected plan |
+| empty | absent | present | step-only black box |
+| nonempty | present | any | invalid |
+| empty | empty/absent | absent | invalid |
+
+`step` is whole-model sugar for a declared plan, not a second DAG. A host uses
+either `step()` or manual selected-plan scheduling for a tick.
+
+`FRT_EXT_GENERIC_STAGE_PLAN_V1` is the only extension currently assigned. Its
+table contains a frozen-stride descriptor array:
+
+```c
+frt_generic_stage_desc_v1 {
+  name;
+  executor_kind;   /* GRAPH or OPAQUE */
+  executor_ref;    /* graph index or provider-private uint32 */
+  n_after / after; /* strictly increasing earlier stage indices */
+}
+```
+
+GRAPH references index `exp->graphs`. OPAQUE references are passed unchanged
+to `run_opaque(stage_self, executor_ref)`; core does not interpret them or keep
+a provider registry. M0 OPAQUE execution is synchronous and blocking. It does
+not promise async submission, cancellation, graph capture, no host allocation,
+or model-level snapshot/restore. A mixed GRAPH/OPAQUE consumer must honor every
+dependency conservatively before starting downstream work.
+
+Generic names are unique valid UTF-8, contain no ASCII control bytes, and are
+at most `FRT_GENERIC_STAGE_NAME_MAX_BYTES` bytes. A generic plan must contain
+at least one OPAQUE stage; pure GRAPH plans use the legacy stage array. OPAQUE
+plans require one builder-registered runner and a real `last_error` verb.
 
 All three construction paths enforce the STAGED promise: any STAGED `IN`
 requires a non-null `set_input`, and any STAGED `OUT` requires a non-null
@@ -118,6 +167,35 @@ frt_model_runtime_v1* m = frt_runtime_builder_finish_model(
     b, &verbs, verbs_self, owner, retain_owner, release_owner);
 ```
 
+For a generic selected plan, use the same builder and identity:
+
+```c
+frt_runtime_builder_add_generic_stage(
+    b, "prefill", FRT_GENERIC_STAGE_OPAQUE, 10, NULL, 0);
+uint32_t after[] = {0};
+frt_runtime_builder_add_generic_stage(
+    b, "decode", FRT_GENERIC_STAGE_OPAQUE, 11, after, 1);
+frt_runtime_builder_set_generic_stage_runner(b, provider, run_opaque);
+```
+
+The builder appends one canonical record per selected stage:
+
+```text
+gstage-v1:<i>:<name_len>:<name_bytes>:<kind>:<executor_ref>:<n_after>:<after...>\n
+```
+
+`name_len` is the UTF-8 byte length, so delimiters inside names cannot collide.
+The builder remains the only fingerprint implementation. With no generic plan,
+legacy identity bytes and fingerprints are unchanged.
+
+Providers with no FlashRT resources use
+`frt_model_runtime_builder_create_metadata()`. It produces a non-null export
+whose `ctx` is null and whose stream/graph/buffer/region counts are all zero.
+That export is only the common identity, fingerprint and lifetime anchor. The
+restricted builder accepts identity/manifest, unbound STAGED or SETUP ports,
+and all-OPAQUE generic or step-only authority; it rejects resources, SWAP,
+GRAPH/mixed plans, standalone export finish, and legacy wrapping.
+
 Identity covers each port's schema **and its bound window** (buffer index
 into the declared buffers array, offset, bytes) plus the stage DAG; only
 `cadence_hint_hz` stays out. A port-schema or window change therefore changes
@@ -138,6 +216,10 @@ frt_model_runtime_v1* m = frt_model_runtime_wrap(
     &verbs, verbs_self, wrapper_owner, wrapper_release);
 ```
 
+This path is intentionally narrow: it requires a real non-null exec context
+and a nonempty legacy graph plan. It cannot turn a metadata anchor or a
+zero-stage export into a new authority under an inherited fingerprint.
+
 **Verb override** — inherit an existing model-runtime declaration and replace
 only verbs. This is the standard hand-off when a setup producer owns capture,
 ports, stage DAG and fingerprint, while a native C++ runtime owns hot-path
@@ -152,6 +234,26 @@ frt_model_runtime_v1* m = frt_model_runtime_override_verbs(
 The override retains `producer_model`, so inherited port/stage pointers remain
 valid even if the original producer reference is released first. Deployment
 identity is unchanged.
+
+Step-only runtimes cannot be overridden because `step` is their sole identity-
+bound authority. An all-OPAQUE generic runtime may be overridden: query is
+forwarded to the retained base, the original `stage_self`/runner remain in
+force, and OPAQUE errors continue to use the base `last_error`. M0 rejects a
+mixed-plan override rather than publishing an ambiguous error/owner surface.
+
+Python exposes the same two producer modes:
+
+```python
+from flash_rt.runtime.export import (
+    GenericStageSpec, build_metadata_model_runtime,
+)
+
+runtime = build_metadata_model_runtime(
+    identity={"provider_build": digest},
+    generic_stages=[GenericStageSpec("infer", "opaque", 7)],
+    run_opaque=lambda executor_ref: provider.run(executor_ref),
+)
+```
 
 `finish_model`, `wrap`, and `override_verbs` apply the same STAGED verb check
 before taking ownership. A producer must not publish a STAGED declaration and

--- a/docs/model_runtime_api.md
+++ b/docs/model_runtime_api.md
@@ -240,6 +240,9 @@ bound authority. An all-OPAQUE generic runtime may be overridden: query is
 forwarded to the retained base, the original `stage_self`/runner remain in
 force, and OPAQUE errors continue to use the base `last_error`. M0 rejects a
 mixed-plan override rather than publishing an ambiguous error/owner surface.
+Before retaining either owner, the override validates an external generic
+table's runner, error authority, names, executor references and dependency DAG.
+Malformed or dual-authority tables fail closed and are never republished.
 
 Python exposes the same two producer modes:
 

--- a/docs/pr_review_checklist.md
+++ b/docs/pr_review_checklist.md
@@ -125,6 +125,19 @@ Keep responsibilities in their owner layer.
 | `serving/` | scenario hosts, sessions, protocols, request policy | kernel implementation, default core imports, common execution policy |
 | `training/` | training and finetuning paths | inference hot-path dependencies unless explicitly shared and tested |
 
+For a model-runtime capability change, require all of the following:
+
+- the released prefix, verbs size/offsets, enum values and ABI version remain
+  exact; each additive tail/table has its own required-size probe;
+- an independently compiled baseline-prefix producer and a tail-aware consumer
+  prove no out-of-bounds tail read;
+- extension IDs and canonical identity records are assigned in core, contain no
+  provider/model/backend names, and are emitted only by the common builder;
+- authority XOR, malformed/unknown table, owner retention, override forwarding,
+  metadata restrictions and fingerprint change/no-change matrices are tested;
+- OPAQUE execution does not silently acquire graph hot-path, async, cancellation
+  or model-state guarantees that its table does not declare.
+
 Blockers:
 
 - A frontend imports a serving host or server-only dependency.

--- a/docs/runtime_contract.md
+++ b/docs/runtime_contract.md
@@ -7,8 +7,9 @@ as one POD struct — `frt_runtime_export_v1` — and adopted by the consumer.
 The exec contract (`docs/exec_contract.md`) fixes *how to replay*. The runtime
 export fixes *what a deployed model IS*: which streams, graphs, buffers, and
 restorable state regions exist, and the identity that stored state is bound to.
-Both layers are mechanism only. Plans are deliberately **not** exported — DAG
-orchestration is the consumer's job.
+Both layers are mechanism only. The base export does not publish scheduling
+policy. The model-runtime face may publish one selected stage DAG as execution
+mechanism; orchestration policy remains the consumer's job.
 
 ## Structure
 
@@ -172,6 +173,18 @@ their own version policy:
   future additive tails are individually size-probed while
   `FRT_MODEL_RUNTIME_ABI_VERSION` remains `1`. The embedded verbs table is
   frozen and cannot grow because fields follow it.
+
+The first model-runtime tail is `query_extension`. It is read only after the
+`FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE` probe. CORE assigns extension IDs;
+providers cannot add private IDs to the public namespace, attach tables after
+finish, or compute a parallel identity. The current generic stage-plan table
+describes one selected GRAPH/OPAQUE DAG and remains owned by the runtime.
+
+A provider with no FlashRT graph resources may use the core metadata-only
+model builder. Its non-null zero-resource export is an identity/lifetime anchor,
+not an execution context and not a model-state snapshot promise. OPAQUE and
+step-only runtimes remain fail-closed for model-level state until a separately
+reviewed state capability exists.
 
 An incompatible major type/symbol requires a separately reviewed ABI. An
 additive tail does not justify duplicating the full model-runtime interface.

--- a/flash_rt/runtime/export.py
+++ b/flash_rt/runtime/export.py
@@ -83,6 +83,10 @@ UPDATE = {
     "swap": int(_c.PORT_SWAP), "staged": int(_c.PORT_STAGED),
     "setup": int(_c.PORT_SETUP),
 }
+GENERIC_EXECUTOR = {
+    "graph": int(_c.GENERIC_STAGE_GRAPH),
+    "opaque": int(_c.GENERIC_STAGE_OPAQUE),
+}
 
 
 def _enum(table: Mapping[str, int], value: int | str) -> int:
@@ -167,6 +171,20 @@ class StageSpec:
 
 
 @dataclass
+class GenericStageSpec:
+    """One stage in a backend-neutral selected plan.
+
+    ``executor_ref`` indexes export graphs for ``graph`` and remains an opaque,
+    provider-owned integer for ``opaque``.
+    """
+
+    name: str
+    executor_kind: int | str
+    executor_ref: int
+    after: Sequence[int] = ()
+
+
+@dataclass
 class RuntimeExport:
     """A finished export. ``ptr`` is the ``frt_runtime_export_v1*`` to hand to a
     native consumer. The export holds one reference; this object anchors every
@@ -208,6 +226,9 @@ class ModelRuntime:
     def stages(self) -> list:
         return list(_c.model_stages(self.ptr))
 
+    def generic_stages(self) -> list:
+        return list(_c.model_generic_stages(self.ptr))
+
     def release(self) -> None:
         """Drop the producer's reference (native retains keep it alive)."""
         if self.ptr:
@@ -248,7 +269,8 @@ def build_export(
     """
     b, anchor, manifest_json = _assemble(
         ctx, streams=streams, graphs=graphs, buffers=buffers, regions=regions,
-        ports=(), stages=(), identity=identity, manifest_extra=manifest_extra,
+        ports=(), stages=(), generic_stages=(), identity=identity,
+        manifest_extra=manifest_extra,
         owner=owner)
     ptr = b.finish(anchor)
     return RuntimeExport(
@@ -269,6 +291,7 @@ def build_model_runtime(
     regions: Sequence[RegionSpec] = (),
     ports: Sequence[PortSpec] = (),
     stages: Sequence[StageSpec] = (),
+    generic_stages: Sequence[GenericStageSpec] = (),
     identity: Mapping[str, str],
     manifest_extra: Mapping[str, Any] | None = None,
     owner: Any = None,
@@ -276,6 +299,7 @@ def build_model_runtime(
     get_output=None,
     prepare=None,
     step=None,
+    run_opaque=None,
 ) -> ModelRuntime:
     """Assemble an ``frt_model_runtime_v1``: an export plus the dynamic-IO
     contract (ports, stage DAG, optional verb callables) under one identity —
@@ -303,12 +327,19 @@ def build_model_runtime(
         raise ValueError("STAGED input ports require set_input")
     if staged_outputs and get_output is None:
         raise ValueError("STAGED output ports require get_output")
+    if stages and generic_stages:
+        raise ValueError("legacy and generic stage plans are mutually exclusive")
+    if generic_stages and run_opaque is None:
+        raise ValueError("generic stage plans require run_opaque")
 
     b, anchor, manifest_json = _assemble(
         ctx, streams=streams, graphs=graphs, buffers=buffers, regions=regions,
-        ports=ports, stages=stages, identity=identity,
+        ports=ports, stages=stages, generic_stages=generic_stages,
+        identity=identity,
         manifest_extra=manifest_extra, owner=owner)
-    anchor._objs.append((set_input, get_output, prepare, step))
+    if generic_stages:
+        b.set_generic_stage_runner(run_opaque)
+    anchor._objs.append((set_input, get_output, prepare, step, run_opaque))
     ptr = b.finish_model(anchor, set_input=set_input, get_output=get_output,
                          prepare=prepare, step=step)
     export_ptr = int(_c.model_export_ptr(ptr))
@@ -322,7 +353,81 @@ def build_model_runtime(
     )
 
 
+def build_metadata_model_runtime(
+    *,
+    ports: Sequence[PortSpec] = (),
+    generic_stages: Sequence[GenericStageSpec] = (),
+    identity: Mapping[str, str],
+    manifest_extra: Mapping[str, Any] | None = None,
+    owner: Any = None,
+    set_input=None,
+    get_output=None,
+    step=None,
+    run_opaque=None,
+) -> ModelRuntime:
+    """Build a provider-owned runtime with no FlashRT graph resources.
+
+    The resulting non-null export is only an identity and lifetime anchor. The
+    C builder rejects SWAP windows, GRAPH stages and every resource declaration.
+    """
+    staged_inputs = any(
+        _enum(UPDATE, p.update) == UPDATE["staged"] and
+        _enum(DIRECTION, p.direction) == DIRECTION["in"] for p in ports)
+    staged_outputs = any(
+        _enum(UPDATE, p.update) == UPDATE["staged"] and
+        _enum(DIRECTION, p.direction) == DIRECTION["out"] for p in ports)
+    if staged_inputs and set_input is None:
+        raise ValueError("STAGED input ports require set_input")
+    if staged_outputs and get_output is None:
+        raise ValueError("STAGED output ports require get_output")
+    if generic_stages and run_opaque is None:
+        raise ValueError("generic stage plans require run_opaque")
+
+    b = _c.Builder.metadata()
+    for p in ports:
+        b.add_port(p.name, _enum(MODALITY, p.modality), _enum(DTYPE, p.dtype),
+                   _enum(LAYOUT, p.layout), _enum(DIRECTION, p.direction),
+                   _enum(UPDATE, p.update), int(bool(p.required)),
+                   list(p.shape), p.cadence_hz, 0, 0, 0)
+    for st in generic_stages:
+        b.add_generic_stage(st.name,
+                            _enum(GENERIC_EXECUTOR, st.executor_kind),
+                            st.executor_ref, list(st.after))
+    for k, v in identity.items():
+        b.add_identity(str(k), str(v))
+    manifest = {
+        "ports": [{"name": p.name, "modality": _enum(MODALITY, p.modality),
+                   "dtype": _enum(DTYPE, p.dtype),
+                   "layout": _enum(LAYOUT, p.layout),
+                   "direction": _enum(DIRECTION, p.direction),
+                   "update": _enum(UPDATE, p.update),
+                   "required": bool(p.required), "shape": list(p.shape),
+                   "cadence_hz": p.cadence_hz} for p in ports],
+        "generic_stages": [
+            {"name": st.name,
+             "executor_kind": _enum(GENERIC_EXECUTOR, st.executor_kind),
+             "executor_ref": st.executor_ref, "after": list(st.after)}
+            for st in generic_stages],
+    }
+    if manifest_extra:
+        manifest.update(dict(manifest_extra))
+    manifest_json = json.dumps(manifest, sort_keys=True)
+    b.set_manifest(manifest_json)
+    if generic_stages:
+        b.set_generic_stage_runner(run_opaque)
+    anchor = _Anchor([owner, set_input, get_output, step, run_opaque])
+    ptr = b.finish_model(anchor, set_input=set_input, get_output=get_output,
+                         step=step)
+    export_ptr = int(_c.model_export_ptr(ptr))
+    return ModelRuntime(
+        ptr=ptr, export_ptr=export_ptr,
+        fingerprint=int(_c.export_fingerprint(export_ptr)),
+        identity=_c.export_identity(export_ptr), manifest=manifest_json,
+        _anchor=anchor)
+
+
 def _assemble(ctx, *, streams, graphs, buffers, regions, ports, stages,
+              generic_stages,
               identity, manifest_extra, owner):
     if not streams:
         raise ValueError("at least one stream is required")
@@ -356,6 +461,10 @@ def _assemble(ctx, *, streams, graphs, buffers, regions, ports, stages,
         if st.graph not in graph_index:
             raise ValueError(f"stage references unknown graph {st.graph!r}")
         b.add_stage(graph_index[st.graph], list(st.after))
+    for st in generic_stages:
+        b.add_generic_stage(st.name,
+                            _enum(GENERIC_EXECUTOR, st.executor_kind),
+                            st.executor_ref, list(st.after))
     for k, v in identity.items():
         b.add_identity(str(k), str(v))
 
@@ -380,6 +489,12 @@ def _assemble(ctx, *, streams, graphs, buffers, regions, ports, stages,
     if stages:
         manifest["stages"] = [
             {"graph": st.graph, "after": list(st.after)} for st in stages]
+    if generic_stages:
+        manifest["generic_stages"] = [
+            {"name": st.name,
+             "executor_kind": _enum(GENERIC_EXECUTOR, st.executor_kind),
+             "executor_ref": st.executor_ref, "after": list(st.after)}
+            for st in generic_stages]
     if manifest_extra:
         manifest.update(dict(manifest_extra))
     manifest_json = json.dumps(manifest, sort_keys=True)
@@ -396,9 +511,10 @@ def _assemble(ctx, *, streams, graphs, buffers, regions, ports, stages,
 __all__ = [
     "RuntimeExport", "ModelRuntime",
     "StreamSpec", "GraphSpec", "BufferSpec", "RegionSpec", "PortSpec",
-    "StageSpec",
-    "build_export", "build_model_runtime",
+    "StageSpec", "GenericStageSpec",
+    "build_export", "build_model_runtime", "build_metadata_model_runtime",
     "ROLE_INPUT", "ROLE_OUTPUT", "ROLE_STATE", "ROLE_SCRATCH",
     "REGION_SNAPSHOT", "REGION_RESTORE", "REGION_DEFAULT",
     "MODALITY", "DTYPE", "LAYOUT", "DIRECTION", "UPDATE",
+    "GENERIC_EXECUTOR",
 ]

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -30,11 +30,30 @@ target_include_directories(flashrt_runtime
          ${CMAKE_CURRENT_SOURCE_DIR}/../exec/include)
 
 if(BUILD_TESTING)
-  add_executable(test_model_runtime
-    tests/test_model_runtime.cpp
+  add_library(model_runtime_v1_abi_baseline_producer SHARED
     tests/model_runtime_v1_abi_baseline_producer.cpp)
-  target_link_libraries(test_model_runtime PRIVATE flashrt_runtime)
+  target_include_directories(model_runtime_v1_abi_baseline_producer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../exec/include)
+  add_library(model_runtime_v1_abi_baseline_consumer SHARED
+    tests/model_runtime_v1_abi_baseline_consumer.cpp)
+  target_include_directories(model_runtime_v1_abi_baseline_consumer PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../exec/include)
+
+  add_executable(test_model_runtime tests/test_model_runtime.cpp)
+  target_link_libraries(test_model_runtime PRIVATE flashrt_runtime
+    model_runtime_v1_abi_baseline_producer)
   add_test(NAME model_runtime COMMAND test_model_runtime)
+
+  add_executable(test_model_runtime_abi_compat
+    tests/test_model_runtime_abi_compat.cpp)
+  target_link_libraries(test_model_runtime_abi_compat PRIVATE
+    flashrt_runtime ${CMAKE_DL_LIBS})
+  add_test(NAME model_runtime_abi_compat
+    COMMAND test_model_runtime_abi_compat
+      $<TARGET_FILE:model_runtime_v1_abi_baseline_producer>
+      $<TARGET_FILE:model_runtime_v1_abi_baseline_consumer>)
 endif()
 
 # --- pybind setup/dev module (optional) ---

--- a/runtime/bindings/runtime_pybind.cpp
+++ b/runtime/bindings/runtime_pybind.cpp
@@ -213,6 +213,8 @@ PYBIND11_MODULE(_flashrt_runtime, m) {
 
     m.attr("MODEL_ABI_VERSION") = FRT_MODEL_RUNTIME_ABI_VERSION;
     m.attr("MODEL_V1_BASE_SIZE") = FRT_MODEL_RUNTIME_V1_BASE_SIZE;
+    m.attr("MODEL_V1_QUERY_EXTENSION_SIZE") =
+        FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE;
     m.attr("MOD_TENSOR") = (unsigned)FRT_RT_MOD_TENSOR;
     m.attr("MOD_IMAGE") = (unsigned)FRT_RT_MOD_IMAGE;
     m.attr("MOD_TEXT") = (unsigned)FRT_RT_MOD_TEXT;

--- a/runtime/bindings/runtime_pybind.cpp
+++ b/runtime/bindings/runtime_pybind.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -36,10 +37,18 @@ void release_py_owner(void* owner) {
 /* Model-runtime verbs implemented by Python callables. Trampolines acquire
  * the GIL (a native consumer calls these fn pointers from its own threads)
  * and translate exceptions into negative status + last_error. */
+struct PyVerbs;
+
+struct PyOpaqueRunner {
+    py::object callback;
+    PyVerbs* error_sink = nullptr;
+};
+
 struct PyVerbs {
     py::object set_input, get_output, prepare, step;
     std::string last_error;
     py::object owner;   /* the producer object the export anchors */
+    std::unique_ptr<PyOpaqueRunner> opaque_runner;
 };
 
 void release_py_verbs(void* p) {
@@ -119,6 +128,17 @@ int verb_step(void* self) {
     }
 }
 
+int verb_run_opaque(void* self, uint32_t executor_ref) {
+    auto* runner = static_cast<PyOpaqueRunner*>(self);
+    py::gil_scoped_acquire gil;
+    try {
+        return py::cast<int>(runner->callback(executor_ref));
+    } catch (const std::exception& e) {
+        if (runner->error_sink) runner->error_sink->last_error = e.what();
+        return -1;
+    }
+}
+
 const char* verb_last_error(void* self) {
     return static_cast<PyVerbs*>(self)->last_error.c_str();
 }
@@ -129,10 +149,16 @@ void check(int rc, const char* what) {
 
 struct PyRtBuilder {
     frt_runtime_builder b;
+    std::unique_ptr<PyOpaqueRunner> opaque_runner;
 
     explicit PyRtBuilder(std::uintptr_t ctx_raw) {
         b = frt_runtime_builder_create(reinterpret_cast<frt_ctx>(ctx_raw));
         if (!b) throw std::runtime_error("frt_runtime_builder_create failed (null ctx?)");
+    }
+    PyRtBuilder() {
+        b = frt_model_runtime_builder_create_metadata();
+        if (!b) throw std::runtime_error(
+            "frt_model_runtime_builder_create_metadata failed");
     }
     ~PyRtBuilder() {
         /* A never-finished builder leaks its holder by design tradeoff: the
@@ -164,6 +190,7 @@ struct PyRtBuilder {
         pv->prepare = std::move(prepare);
         pv->step = std::move(step);
         pv->owner = std::move(owner);
+        if (opaque_runner) opaque_runner->error_sink = pv;
 
         frt_model_runtime_verbs verbs{};
         verbs.struct_size = sizeof(verbs);
@@ -176,11 +203,29 @@ struct PyRtBuilder {
 
         frt_model_runtime_v1* mr = frt_runtime_builder_finish_model(
             b, &verbs, pv, pv, /*retain_owner=*/nullptr, &release_py_verbs);
-        if (!mr) { release_py_verbs(pv); throw std::runtime_error("finish_model failed"); }
+        if (!mr) {
+            if (opaque_runner) opaque_runner->error_sink = nullptr;
+            release_py_verbs(pv);
+            throw std::runtime_error("finish_model failed");
+        }
+        pv->opaque_runner = std::move(opaque_runner);
         b = nullptr;
         return reinterpret_cast<std::uintptr_t>(mr);
     }
 };
+
+const frt_generic_stage_plan_ext_v1* generic_plan(frt_model_runtime_v1* model) {
+    if (model->struct_size < FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE ||
+        !model->query_extension) return nullptr;
+    const void* extension = nullptr;
+    if (model->query_extension(model, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                               &extension) != 0) return nullptr;
+    auto* plan = static_cast<const frt_generic_stage_plan_ext_v1*>(extension);
+    if (!plan || plan->abi_version < FRT_GENERIC_STAGE_PLAN_ABI_VERSION ||
+        plan->struct_size < FRT_GENERIC_STAGE_PLAN_EXT_V1_SIZE)
+        throw std::runtime_error("invalid generic stage-plan extension");
+    return plan;
+}
 
 frt_runtime_export_v1* as_export(std::uintptr_t p) {
     auto* e = reinterpret_cast<frt_runtime_export_v1*>(p);
@@ -239,9 +284,19 @@ PYBIND11_MODULE(_flashrt_runtime, m) {
     m.attr("PORT_SWAP") = (unsigned)FRT_RT_PORT_SWAP;
     m.attr("PORT_STAGED") = (unsigned)FRT_RT_PORT_STAGED;
     m.attr("PORT_SETUP") = (unsigned)FRT_RT_PORT_SETUP;
+    m.attr("GENERIC_STAGE_GRAPH") = (unsigned)FRT_GENERIC_STAGE_GRAPH;
+    m.attr("GENERIC_STAGE_OPAQUE") = (unsigned)FRT_GENERIC_STAGE_OPAQUE;
+    m.attr("GENERIC_STAGE_NAME_MAX_BYTES") =
+        (unsigned)FRT_GENERIC_STAGE_NAME_MAX_BYTES;
+    m.attr("GENERIC_STAGE_DESC_V1_SIZE") =
+        (unsigned)sizeof(frt_generic_stage_desc_v1);
+    m.attr("GENERIC_STAGE_PLAN_EXT_V1_SIZE") =
+        (unsigned)FRT_GENERIC_STAGE_PLAN_EXT_V1_SIZE;
+    m.attr("EXT_GENERIC_STAGE_PLAN_V1") = FRT_EXT_GENERIC_STAGE_PLAN_V1;
 
     py::class_<PyRtBuilder>(m, "Builder")
         .def(py::init<std::uintptr_t>(), py::arg("ctx_raw"))
+        .def_static("metadata", []() { return std::make_unique<PyRtBuilder>(); })
         .def("add_stream", [](PyRtBuilder& s, const std::string& name, int stream_id,
                               int priority, std::uintptr_t native_handle) {
             s.need();
@@ -313,6 +368,30 @@ PYBIND11_MODULE(_flashrt_runtime, m) {
                                                 (uint32_t)after.size()),
                   "add_stage");
         }, py::arg("graph"), py::arg("after") = std::vector<unsigned>{})
+        .def("add_generic_stage", [](PyRtBuilder& s, const std::string& name,
+                                     unsigned executor_kind,
+                                     unsigned executor_ref,
+                                     const std::vector<unsigned>& after) {
+            s.need();
+            check(frt_runtime_builder_add_generic_stage(
+                      s.b, name.c_str(), executor_kind, executor_ref,
+                      after.data(), (uint32_t)after.size()),
+                  "add_generic_stage");
+        }, py::arg("name"), py::arg("executor_kind"),
+           py::arg("executor_ref"),
+           py::arg("after") = std::vector<unsigned>{})
+        .def("set_generic_stage_runner", [](PyRtBuilder& s,
+                                             py::object callback) {
+            s.need();
+            if (callback.is_none())
+                throw std::invalid_argument("opaque runner must be callable");
+            auto runner = std::make_unique<PyOpaqueRunner>();
+            runner->callback = std::move(callback);
+            check(frt_runtime_builder_set_generic_stage_runner(
+                      s.b, runner.get(), verb_run_opaque),
+                  "set_generic_stage_runner");
+            s.opaque_runner = std::move(runner);
+        }, py::arg("callback"))
         .def("finish", &PyRtBuilder::finish, py::arg("owner"),
              "Consume the builder; returns the export pointer (uintptr). The export "
              "holds one reference; hand the pointer to a native consumer, which must "
@@ -387,6 +466,28 @@ PYBIND11_MODULE(_flashrt_runtime, m) {
             out.append(e);
         }
         return out;
+    });
+    m.def("model_generic_stages", [](std::uintptr_t p) {
+        auto* plan = generic_plan(as_model(p));
+        py::list out;
+        if (!plan) return out;
+        for (std::uint64_t i = 0; i < plan->n_stages; ++i) {
+            const frt_generic_stage_desc_v1& d = plan->stages[i];
+            py::dict e;
+            e["name"] = std::string(d.name);
+            e["executor_kind"] = d.executor_kind;
+            e["executor_ref"] = d.executor_ref;
+            e["after"] = std::vector<unsigned>(d.after, d.after + d.n_after);
+            out.append(e);
+        }
+        return out;
+    });
+    m.def("model_run_opaque", [](std::uintptr_t p, unsigned executor_ref) {
+        auto* plan = generic_plan(as_model(p));
+        if (!plan || !plan->run_opaque)
+            throw std::runtime_error("model has no OPAQUE executor");
+        py::gil_scoped_release nogil;
+        return plan->run_opaque(plan->stage_self, executor_ref);
     });
     m.def("model_retain", [](std::uintptr_t p) { auto* mr = as_model(p); mr->retain(mr->owner); });
     m.def("model_release", [](std::uintptr_t p) {

--- a/runtime/include/flashrt/model_runtime.h
+++ b/runtime/include/flashrt/model_runtime.h
@@ -202,6 +202,17 @@ typedef struct frt_model_runtime_verbs {
 /* ------------------------------------------------------------------ */
 /* The model runtime object.                                           */
 /* ------------------------------------------------------------------ */
+struct frt_model_runtime_v1;
+
+/* Optional capabilities are discovered through an additive tail instead of
+ * growing the ABI-frozen verbs table. Consumers must probe the runtime's
+ * struct_size before reading this function pointer. */
+typedef int (*frt_model_runtime_query_extension_fn)(
+    const struct frt_model_runtime_v1* runtime,
+    uint64_t extension_id,
+    uint32_t min_version,
+    const void** out_extension);
+
 typedef struct frt_model_runtime_v1 {
     uint32_t abi_version;      /* = FRT_MODEL_RUNTIME_ABI_VERSION          */
     uint32_t struct_size;      /* = sizeof(frt_model_runtime_v1)           */
@@ -222,6 +233,9 @@ typedef struct frt_model_runtime_v1 {
     void* owner;
     void (*retain)(void* owner);
     void (*release)(void* owner);
+
+    /* Additive v1 tail. Baseline-prefix producers end before this field. */
+    frt_model_runtime_query_extension_fn query_extension;
 } frt_model_runtime_v1;
 
 /* Minimum byte prefix every v1 consumer may require. Keep this anchored to
@@ -231,6 +245,10 @@ typedef struct frt_model_runtime_v1 {
 #define FRT_MODEL_RUNTIME_V1_BASE_SIZE \
     ((uint32_t)(offsetof(frt_model_runtime_v1, release) + \
                 sizeof(((frt_model_runtime_v1*)0)->release)))
+
+#define FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE \
+    ((uint32_t)(offsetof(frt_model_runtime_v1, query_extension) + \
+                sizeof(((frt_model_runtime_v1*)0)->query_extension)))
 
 /* Factory symbol convention for NATIVE model runtimes: a model-runtime .so
  * exports exactly this symbol. Returns a retained object (caller releases). */

--- a/runtime/include/flashrt/model_runtime.h
+++ b/runtime/include/flashrt/model_runtime.h
@@ -105,6 +105,15 @@ enum frt_rt_port_update {
     FRT_RT_PORT_SETUP  = 2
 };
 
+enum frt_generic_stage_executor_kind_v1 {
+    FRT_GENERIC_STAGE_GRAPH  = 0,
+    FRT_GENERIC_STAGE_OPAQUE = 1
+};
+
+#define FRT_GENERIC_STAGE_NAME_MAX_BYTES 255u
+#define FRT_GENERIC_STAGE_PLAN_ABI_VERSION 1u
+#define FRT_EXT_GENERIC_STAGE_PLAN_V1 UINT64_C(0x0000000000000001)
+
 /* ------------------------------------------------------------------ */
 /* Payload types (STAGED lane).                                        */
 /* ------------------------------------------------------------------ */
@@ -158,6 +167,29 @@ typedef struct frt_runtime_stage_desc {
     uint32_t n_after;
     const uint32_t* after;     /* stage indices                            */
 } frt_runtime_stage_desc;
+
+/* Generic selected-plan descriptors. Unlike extension tables, array elements
+ * have frozen size/stride and must not receive additive tail fields. */
+typedef struct frt_generic_stage_desc_v1 {
+    const char* name;
+    uint32_t executor_kind;
+    uint32_t executor_ref;
+    uint32_t n_after;
+    const uint32_t* after;
+} frt_generic_stage_desc_v1;
+
+typedef struct frt_generic_stage_plan_ext_v1 {
+    uint32_t abi_version;
+    uint32_t struct_size;
+    const frt_generic_stage_desc_v1* stages;
+    uint64_t n_stages;
+    void* stage_self;
+    int (*run_opaque)(void* stage_self, uint32_t executor_ref);
+} frt_generic_stage_plan_ext_v1;
+
+#define FRT_GENERIC_STAGE_PLAN_EXT_V1_SIZE \
+    ((uint32_t)(offsetof(frt_generic_stage_plan_ext_v1, run_opaque) + \
+                sizeof(((frt_generic_stage_plan_ext_v1*)0)->run_opaque)))
 
 /* ------------------------------------------------------------------ */
 /* Verbs — implemented by the producer, called by the host.            */
@@ -275,6 +307,19 @@ int frt_runtime_builder_add_port(frt_runtime_builder, const char* name,
                                  uint64_t bytes);
 int frt_runtime_builder_add_stage(frt_runtime_builder, uint32_t graph,
                                   const uint32_t* after, uint32_t n_after);
+int frt_runtime_builder_add_generic_stage(
+    frt_runtime_builder, const char* name, uint32_t executor_kind,
+    uint32_t executor_ref, const uint32_t* after, uint32_t n_after);
+int frt_runtime_builder_set_generic_stage_runner(
+    frt_runtime_builder, void* stage_self,
+    int (*run_opaque)(void* stage_self, uint32_t executor_ref));
+
+/* Create a model-only builder for a provider that owns no FlashRT execution
+ * resources. Its export remains the identity/lifetime anchor, with null ctx
+ * and zero resource arrays. The builder is deliberately restricted to
+ * identity/manifest, unbound STAGED or SETUP ports, and all-OPAQUE generic or
+ * step-only authority. */
+frt_runtime_builder frt_model_runtime_builder_create_metadata(void);
 
 /* Like frt_runtime_builder_finish, but returns the model runtime whose
  * `exp` is the internally-built export (one object, one refcount). `verbs`

--- a/runtime/src/internal.h
+++ b/runtime/src/internal.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <deque>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -20,6 +21,13 @@ namespace frt_rt {
  * count drops to zero. std::deque: element addresses are stable under
  * push_back, so descriptors can point at .c_str() / .data() safely. */
 struct Holder {
+#if defined(__GNUC__) || defined(__clang__)
+    Holder() __attribute__((visibility("hidden"))) = default;
+    ~Holder() __attribute__((visibility("hidden"))) = default;
+#else
+    Holder() = default;
+    ~Holder() = default;
+#endif
     std::atomic<int> refs{1};
     void* user_owner = nullptr;
     void (*user_release)(void*) = nullptr;
@@ -40,6 +48,14 @@ struct Holder {
     std::deque<std::vector<uint32_t>> after_arrays;
     std::vector<frt_runtime_port_desc>  ports;
     std::vector<frt_runtime_stage_desc> stages;
+    std::unique_ptr<frt_generic_stage_desc_v1[]> generic_stages;
+    size_t n_generic_stages = 0;
+    size_t generic_stage_capacity = 0;
+    frt_generic_stage_plan_ext_v1 generic_stage_plan{};
+    bool generic_plan_present = false;
+    bool generic_runner_registered = false;
+    void* generic_stage_self = nullptr;
+    int (*run_opaque)(void*, uint32_t) = nullptr;
 
     frt_runtime_export_v1 exp{};
     frt_model_runtime_v1  model{};
@@ -56,6 +72,7 @@ struct frt_runtime_builder_s {
     frt_ctx ctx = nullptr;
     frt_rt::Holder* h = nullptr;  /* built up in place; adopted by finish */
     std::string identity_pairs;
+    bool metadata_only = false;
 };
 
 namespace frt_rt {

--- a/runtime/src/model_runtime.cpp
+++ b/runtime/src/model_runtime.cpp
@@ -41,6 +41,58 @@ bool valid_staged_verbs(const frt_runtime_port_desc* ports, uint64_t n_ports,
            (!needs_get_output || verbs->get_output);
 }
 
+bool valid_utf8_stage_name(const char* name) {
+    if (!name) return false;
+    const auto* p = reinterpret_cast<const unsigned char*>(name);
+    const size_t n = std::strlen(name);
+    if (n == 0 || n > FRT_GENERIC_STAGE_NAME_MAX_BYTES) return false;
+    for (size_t i = 0; i < n;) {
+        const unsigned char c = p[i];
+        if (c < 0x20 || c == 0x7f) return false;
+        if (c < 0x80) { ++i; continue; }
+        size_t more = 0;
+        uint32_t cp = 0;
+        if ((c & 0xe0) == 0xc0) { more = 1; cp = c & 0x1f; }
+        else if ((c & 0xf0) == 0xe0) { more = 2; cp = c & 0x0f; }
+        else if ((c & 0xf8) == 0xf0) { more = 3; cp = c & 0x07; }
+        else return false;
+        if (i + more >= n) return false;
+        for (size_t j = 1; j <= more; ++j) {
+            if ((p[i + j] & 0xc0) != 0x80) return false;
+            cp = (cp << 6) | (p[i + j] & 0x3f);
+        }
+        if ((more == 1 && cp < 0x80) || (more == 2 && cp < 0x800) ||
+            (more == 3 && cp < 0x10000) || cp > 0x10ffff ||
+            (cp >= 0xd800 && cp <= 0xdfff)) return false;
+        i += more + 1;
+    }
+    return true;
+}
+
+bool has_real_step(const frt_model_runtime_verbs* verbs) {
+    return has_complete_verbs(verbs) && verbs->step;
+}
+
+bool has_real_last_error(const frt_model_runtime_verbs* verbs) {
+    return has_complete_verbs(verbs) && verbs->last_error;
+}
+
+bool valid_authority(const Holder* h, const frt_model_runtime_verbs* verbs) {
+    if (!h->stages.empty() && h->generic_plan_present) return false;
+    if (h->generic_plan_present) {
+        if (h->n_generic_stages == 0) return false;
+        bool has_opaque = false;
+        for (size_t i = 0; i < h->n_generic_stages; ++i)
+            has_opaque |= h->generic_stages[i].executor_kind ==
+                          FRT_GENERIC_STAGE_OPAQUE;
+        if (!has_opaque) return false;
+        if (!h->generic_runner_registered || !h->run_opaque ||
+            !has_real_last_error(verbs)) return false;
+        return true;
+    }
+    return !h->stages.empty() || has_real_step(verbs);
+}
+
 /* Default stubs for verbs a producer does not provide: report unsupported
  * (-3) instead of leaving null function pointers for consumers to crash on. */
 int stub_set_input(void*, uint32_t, const void*, uint64_t, int) { return -3; }
@@ -58,6 +110,19 @@ int query_no_extensions(const frt_model_runtime_v1* runtime, uint64_t,
     if (out_extension) *out_extension = nullptr;
     if (!runtime || !out_extension || min_version == 0) return -1;
     return -3;
+}
+
+int query_holder_extensions(const frt_model_runtime_v1* runtime,
+                            uint64_t extension_id, uint32_t min_version,
+                            const void** out_extension) {
+    if (out_extension) *out_extension = nullptr;
+    if (!runtime || !out_extension || min_version == 0) return -1;
+    if (extension_id != FRT_EXT_GENERIC_STAGE_PLAN_V1 || min_version > 1)
+        return -3;
+    auto* h = static_cast<const Holder*>(runtime->owner);
+    if (!h || !h->generic_plan_present) return -3;
+    *out_extension = &h->generic_stage_plan;
+    return 0;
 }
 
 void copy_verbs(frt_model_runtime_v1* m, const frt_model_runtime_verbs* verbs,
@@ -91,6 +156,8 @@ extern "C" int frt_runtime_builder_add_port(frt_runtime_builder b,
                                             frt_buffer buffer, uint64_t offset,
                                             uint64_t bytes) {
     if (!b || !valid_port_args(name, direction, update, shape, rank)) return -1;
+    if (b->metadata_only &&
+        (update == FRT_RT_PORT_SWAP || buffer || offset || bytes)) return -1;
     Holder* h = b->h;
     h->shape_arrays.emplace_back(shape, shape + rank);
     frt_runtime_port_desc d{};
@@ -115,7 +182,8 @@ extern "C" int frt_runtime_builder_add_stage(frt_runtime_builder b,
                                              uint32_t graph,
                                              const uint32_t* after,
                                              uint32_t n_after) {
-    if (!b || (n_after && !after)) return -1;
+    if (!b || b->metadata_only || b->h->generic_plan_present ||
+        (n_after && !after)) return -1;
     Holder* h = b->h;
     if (graph >= h->graphs.size()) return -1;
     for (uint32_t i = 0; i < n_after; ++i)
@@ -129,6 +197,58 @@ extern "C" int frt_runtime_builder_add_stage(frt_runtime_builder b,
     return 0;
 }
 
+extern "C" int frt_runtime_builder_add_generic_stage(
+        frt_runtime_builder b, const char* name, uint32_t executor_kind,
+        uint32_t executor_ref, const uint32_t* after, uint32_t n_after) {
+    if (!b || !b->h->stages.empty() || !valid_utf8_stage_name(name) ||
+        executor_kind > FRT_GENERIC_STAGE_OPAQUE || (n_after && !after))
+        return -1;
+    Holder* h = b->h;
+    if (b->metadata_only && executor_kind != FRT_GENERIC_STAGE_OPAQUE)
+        return -1;
+    if (executor_kind == FRT_GENERIC_STAGE_GRAPH &&
+        executor_ref >= h->graphs.size()) return -1;
+    for (size_t i = 0; i < h->n_generic_stages; ++i)
+        if (std::strcmp(h->generic_stages[i].name, name) == 0) return -1;
+    uint32_t previous = 0;
+    for (uint32_t i = 0; i < n_after; ++i) {
+        if (after[i] >= h->n_generic_stages ||
+            (i && after[i] <= previous)) return -1;
+        previous = after[i];
+    }
+    h->after_arrays.emplace_back(after, after + n_after);
+    frt_generic_stage_desc_v1 d{};
+    d.name = stored(h, name);
+    d.executor_kind = executor_kind;
+    d.executor_ref = executor_ref;
+    d.n_after = n_after;
+    d.after = h->after_arrays.back().data();
+    if (h->n_generic_stages == h->generic_stage_capacity) {
+        const size_t next_capacity = h->generic_stage_capacity
+            ? h->generic_stage_capacity * 2 : 4;
+        auto next = std::make_unique<frt_generic_stage_desc_v1[]>(
+            next_capacity);
+        for (size_t i = 0; i < h->n_generic_stages; ++i)
+            next[i] = h->generic_stages[i];
+        h->generic_stages = std::move(next);
+        h->generic_stage_capacity = next_capacity;
+    }
+    h->generic_stages[h->n_generic_stages++] = d;
+    h->generic_plan_present = true;
+    return 0;
+}
+
+extern "C" int frt_runtime_builder_set_generic_stage_runner(
+        frt_runtime_builder b, void* stage_self,
+        int (*run_opaque)(void*, uint32_t)) {
+    if (!b || !run_opaque || b->h->generic_runner_registered) return -1;
+    b->h->generic_plan_present = true;
+    b->h->generic_runner_registered = true;
+    b->h->generic_stage_self = stage_self;
+    b->h->run_opaque = run_opaque;
+    return 0;
+}
+
 extern "C" frt_model_runtime_v1* frt_runtime_builder_finish_model(
         frt_runtime_builder b,
         const frt_model_runtime_verbs* verbs, void* verbs_self,
@@ -138,7 +258,19 @@ extern "C" frt_model_runtime_v1* frt_runtime_builder_finish_model(
     Holder* h = b->h;
     if (!valid_staged_verbs(h->ports.data(), h->ports.size(), verbs))
         return nullptr;
+    if (!valid_authority(h, verbs)) return nullptr;
     frt_rt::finish_export_into(h, b, owner, retain_owner, release_owner);
+
+    if (h->generic_plan_present) {
+        h->generic_stage_plan.abi_version =
+            FRT_GENERIC_STAGE_PLAN_ABI_VERSION;
+        h->generic_stage_plan.struct_size =
+            (uint32_t)sizeof(frt_generic_stage_plan_ext_v1);
+        h->generic_stage_plan.stages = h->generic_stages.get();
+        h->generic_stage_plan.n_stages = h->n_generic_stages;
+        h->generic_stage_plan.stage_self = h->generic_stage_self;
+        h->generic_stage_plan.run_opaque = h->run_opaque;
+    }
 
     frt_model_runtime_v1& m = h->model;
     m.abi_version = FRT_MODEL_RUNTIME_ABI_VERSION;
@@ -147,6 +279,7 @@ extern "C" frt_model_runtime_v1* frt_runtime_builder_finish_model(
     m.ports = h->ports.data();   m.n_ports = h->ports.size();
     m.stages = h->stages.data(); m.n_stages = h->stages.size();
     copy_verbs(&m, verbs, verbs_self);
+    m.query_extension = query_holder_extensions;
     m.owner = h;
     m.retain = frt_rt::frt_rt_holder_retain;
     m.release = frt_rt::frt_rt_holder_release;
@@ -194,9 +327,9 @@ extern "C" frt_model_runtime_v1* frt_model_runtime_wrap(
         const frt_runtime_stage_desc* stages, uint64_t n_stages,
         const frt_model_runtime_verbs* verbs, void* verbs_self,
         void* wrapper_owner, void (*wrapper_release_fn)(void*)) {
-    if (!exp || exp->abi_version != FRT_RUNTIME_ABI_VERSION ||
+    if (!exp || !exp->ctx || exp->abi_version != FRT_RUNTIME_ABI_VERSION ||
         exp->struct_size < sizeof(frt_runtime_export_v1) ||
-        !exp->retain || !exp->release) return nullptr;
+        !exp->retain || !exp->release || n_stages == 0) return nullptr;
     if ((n_ports && !ports) || (n_stages && !stages)) return nullptr;
     for (uint64_t i = 0; i < n_ports; ++i)
         if (!valid_port_args(ports[i].name, ports[i].direction,
@@ -253,8 +386,50 @@ struct VerbOverride {
     const frt_model_runtime_v1* base = nullptr;
     void* owner = nullptr;
     void (*release_owner)(void*) = nullptr;
+    frt_model_runtime_verbs target_verbs{};
+    void* target_self = nullptr;
+    bool forward_base_error = false;
     frt_model_runtime_v1 model{};
 };
+
+int override_set_input(void* self, uint32_t port, const void* data,
+                       uint64_t bytes, int stream) {
+    auto* o = static_cast<VerbOverride*>(self);
+    return o->target_verbs.set_input(o->target_self, port, data, bytes, stream);
+}
+int override_get_output(void* self, uint32_t port, void* out,
+                        uint64_t capacity, uint64_t* written, int stream) {
+    auto* o = static_cast<VerbOverride*>(self);
+    return o->target_verbs.get_output(o->target_self, port, out, capacity,
+                                      written, stream);
+}
+int override_prepare(void* self, uint32_t graph, frt_shape_key key) {
+    auto* o = static_cast<VerbOverride*>(self);
+    return o->target_verbs.prepare(o->target_self, graph, key);
+}
+int override_step(void* self) {
+    auto* o = static_cast<VerbOverride*>(self);
+    return o->target_verbs.step(o->target_self);
+}
+const char* override_last_error(void* self) {
+    auto* o = static_cast<VerbOverride*>(self);
+    if (o->forward_base_error)
+        return o->base->verbs.last_error(o->base->self);
+    return o->target_verbs.last_error(o->target_self);
+}
+
+int override_query_extensions(const frt_model_runtime_v1* runtime,
+                              uint64_t extension_id, uint32_t min_version,
+                              const void** out_extension) {
+    if (out_extension) *out_extension = nullptr;
+    if (!runtime || !out_extension || min_version == 0) return -1;
+    auto* o = static_cast<const VerbOverride*>(runtime->owner);
+    if (!o || !o->base ||
+        o->base->struct_size < FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE ||
+        !o->base->query_extension) return -3;
+    return o->base->query_extension(o->base, extension_id, min_version,
+                                    out_extension);
+}
 
 extern "C" void override_retain(void* owner) {
     static_cast<VerbOverride*>(owner)->refs.fetch_add(1,
@@ -278,6 +453,23 @@ bool valid_model_runtime(const frt_model_runtime_v1* m) {
     return true;
 }
 
+int get_generic_plan(const frt_model_runtime_v1* model,
+                     const frt_generic_stage_plan_ext_v1** out) {
+    *out = nullptr;
+    if (model->struct_size < FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE ||
+        !model->query_extension) return -3;
+    const void* extension = nullptr;
+    const int rc = model->query_extension(
+        model, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1, &extension);
+    if (rc != 0) return rc;
+    auto* plan = static_cast<const frt_generic_stage_plan_ext_v1*>(extension);
+    if (!plan || plan->abi_version < FRT_GENERIC_STAGE_PLAN_ABI_VERSION ||
+        plan->struct_size < FRT_GENERIC_STAGE_PLAN_EXT_V1_SIZE ||
+        !plan->stages || plan->n_stages == 0) return -1;
+    *out = plan;
+    return 0;
+}
+
 }  // namespace
 
 extern "C" frt_model_runtime_v1* frt_model_runtime_override_verbs(
@@ -287,6 +479,15 @@ extern "C" frt_model_runtime_v1* frt_model_runtime_override_verbs(
         void (*release_owner)(void*)) {
     if (!valid_model_runtime(in)) return nullptr;
     if (!valid_staged_verbs(in->ports, in->n_ports, verbs)) return nullptr;
+    const frt_generic_stage_plan_ext_v1* generic_plan = nullptr;
+    const int generic_rc = get_generic_plan(in, &generic_plan);
+    if (generic_rc != 0 && generic_rc != -3) return nullptr;
+    if (!in->n_stages && !generic_plan) return nullptr;  /* step-only */
+    if (generic_plan) {
+        for (uint64_t i = 0; i < generic_plan->n_stages; ++i)
+            if (generic_plan->stages[i].executor_kind !=
+                FRT_GENERIC_STAGE_OPAQUE) return nullptr;
+    }
 
     auto* o = new VerbOverride();
     o->base = in;
@@ -303,8 +504,18 @@ extern "C" frt_model_runtime_v1* frt_model_runtime_override_verbs(
     m.ports = in->ports;     m.n_ports = in->n_ports;
     m.stages = in->stages;   m.n_stages = in->n_stages;
     copy_verbs(&m, verbs, verbs_self);
+    o->target_verbs = m.verbs;
+    o->target_self = verbs_self;
+    o->forward_base_error = generic_plan != nullptr;
+    m.verbs.set_input = override_set_input;
+    m.verbs.get_output = override_get_output;
+    m.verbs.prepare = override_prepare;
+    m.verbs.step = override_step;
+    m.verbs.last_error = override_last_error;
+    m.self = o;
     m.owner = o;
     m.retain = override_retain;
     m.release = override_release;
+    m.query_extension = override_query_extensions;
     return &o->model;
 }

--- a/runtime/src/model_runtime.cpp
+++ b/runtime/src/model_runtime.cpp
@@ -241,7 +241,8 @@ extern "C" int frt_runtime_builder_add_generic_stage(
 extern "C" int frt_runtime_builder_set_generic_stage_runner(
         frt_runtime_builder b, void* stage_self,
         int (*run_opaque)(void*, uint32_t)) {
-    if (!b || !run_opaque || b->h->generic_runner_registered) return -1;
+    if (!b || !run_opaque || !b->h->stages.empty() ||
+        b->h->generic_runner_registered) return -1;
     b->h->generic_plan_present = true;
     b->h->generic_runner_registered = true;
     b->h->generic_stage_self = stage_self;
@@ -465,7 +466,31 @@ int get_generic_plan(const frt_model_runtime_v1* model,
     auto* plan = static_cast<const frt_generic_stage_plan_ext_v1*>(extension);
     if (!plan || plan->abi_version < FRT_GENERIC_STAGE_PLAN_ABI_VERSION ||
         plan->struct_size < FRT_GENERIC_STAGE_PLAN_EXT_V1_SIZE ||
-        !plan->stages || plan->n_stages == 0) return -1;
+        !plan->stages || plan->n_stages == 0 || !plan->run_opaque ||
+        !has_real_last_error(&model->verbs)) return -1;
+    if (!model->exp || model->exp->abi_version != FRT_RUNTIME_ABI_VERSION ||
+        model->exp->struct_size < sizeof(frt_runtime_export_v1)) return -1;
+
+    bool has_opaque = false;
+    for (uint64_t i = 0; i < plan->n_stages; ++i) {
+        const frt_generic_stage_desc_v1& stage = plan->stages[i];
+        if (!valid_utf8_stage_name(stage.name) ||
+            stage.executor_kind > FRT_GENERIC_STAGE_OPAQUE ||
+            (stage.n_after && !stage.after)) return -1;
+        if (stage.executor_kind == FRT_GENERIC_STAGE_GRAPH &&
+            stage.executor_ref >= model->exp->n_graphs) return -1;
+        has_opaque |= stage.executor_kind == FRT_GENERIC_STAGE_OPAQUE;
+        for (uint64_t previous = 0; previous < i; ++previous)
+            if (std::strcmp(plan->stages[previous].name, stage.name) == 0)
+                return -1;
+        uint32_t previous = 0;
+        for (uint32_t d = 0; d < stage.n_after; ++d) {
+            if (stage.after[d] >= i ||
+                (d && stage.after[d] <= previous)) return -1;
+            previous = stage.after[d];
+        }
+    }
+    if (!has_opaque) return -1;
     *out = plan;
     return 0;
 }
@@ -482,6 +507,7 @@ extern "C" frt_model_runtime_v1* frt_model_runtime_override_verbs(
     const frt_generic_stage_plan_ext_v1* generic_plan = nullptr;
     const int generic_rc = get_generic_plan(in, &generic_plan);
     if (generic_rc != 0 && generic_rc != -3) return nullptr;
+    if (in->n_stages && generic_plan) return nullptr;
     if (!in->n_stages && !generic_plan) return nullptr;  /* step-only */
     if (generic_plan) {
         for (uint64_t i = 0; i < generic_plan->n_stages; ++i)

--- a/runtime/src/model_runtime.cpp
+++ b/runtime/src/model_runtime.cpp
@@ -53,6 +53,13 @@ const char* stub_last_error(void*) {
     return "verb not provided by this producer";
 }
 
+int query_no_extensions(const frt_model_runtime_v1* runtime, uint64_t,
+                        uint32_t min_version, const void** out_extension) {
+    if (out_extension) *out_extension = nullptr;
+    if (!runtime || !out_extension || min_version == 0) return -1;
+    return -3;
+}
+
 void copy_verbs(frt_model_runtime_v1* m, const frt_model_runtime_verbs* verbs,
                 void* verbs_self) {
     m->verbs.struct_size = (uint32_t)sizeof(frt_model_runtime_verbs);
@@ -69,6 +76,7 @@ void copy_verbs(frt_model_runtime_v1* m, const frt_model_runtime_verbs* verbs,
     if (!m->verbs.step) m->verbs.step = stub_step;
     if (!m->verbs.last_error) m->verbs.last_error = stub_last_error;
     m->self = verbs_self;
+    m->query_extension = query_no_extensions;
 }
 
 }  // namespace

--- a/runtime/src/runtime_export.cpp
+++ b/runtime/src/runtime_export.cpp
@@ -8,6 +8,7 @@
 #include "internal.h"
 
 #include <cstdio>
+#include <cstring>
 
 namespace frt_rt {
 
@@ -91,6 +92,22 @@ void finish_export_into(Holder* h, frt_runtime_builder_s* b,
         }
         id += '\n';
     }
+    for (size_t i = 0; i < h->n_generic_stages; ++i) {
+        const auto& s = h->generic_stages[i];
+        const size_t name_len = std::strlen(s.name);
+        std::snprintf(line, sizeof(line), "gstage-v1:%zu:%zu:", i, name_len);
+        id += line;
+        id.append(s.name, name_len);
+        std::snprintf(line, sizeof(line), ":%u:%u:%u:", s.executor_kind,
+                      s.executor_ref, s.n_after);
+        id += line;
+        for (uint32_t d = 0; d < s.n_after; ++d) {
+            std::snprintf(line, sizeof(line), "%s%u", d ? "," : "",
+                          s.after[d]);
+            id += line;
+        }
+        id += '\n';
+    }
     h->identity = std::move(id);
 
     h->user_owner = owner;
@@ -126,10 +143,17 @@ extern "C" frt_runtime_builder frt_runtime_builder_create(frt_ctx ctx) {
     return b;
 }
 
+extern "C" frt_runtime_builder frt_model_runtime_builder_create_metadata() {
+    auto* b = new frt_runtime_builder_s();
+    b->h = new Holder();
+    b->metadata_only = true;
+    return b;
+}
+
 extern "C" int frt_runtime_builder_add_stream(frt_runtime_builder b,
                                               const char* name, int stream_id,
                                               int priority, void* native_handle) {
-    if (!b || !name || stream_id < 0) return -1;
+    if (!b || b->metadata_only || !name || stream_id < 0) return -1;
     frt_runtime_stream_desc d{};
     d.name = stored(b->h, name);
     d.stream_id = stream_id;
@@ -144,7 +168,7 @@ extern "C" int frt_runtime_builder_add_graph(frt_runtime_builder b,
                                              frt_shape_key default_key,
                                              const frt_shape_key* keys,
                                              uint64_t n_keys, int stream_id) {
-    if (!b || !name || !g || (n_keys && !keys)) return -1;
+    if (!b || b->metadata_only || !name || !g || (n_keys && !keys)) return -1;
     b->h->key_arrays.emplace_back(keys, keys + n_keys);
     frt_runtime_graph_desc d{};
     d.name = stored(b->h, name);
@@ -160,7 +184,7 @@ extern "C" int frt_runtime_builder_add_graph(frt_runtime_builder b,
 extern "C" int frt_runtime_builder_add_buffer(frt_runtime_builder b,
                                               const char* name, frt_buffer buf,
                                               uint64_t bytes, uint32_t role) {
-    if (!b || !name || !buf) return -1;
+    if (!b || b->metadata_only || !name || !buf) return -1;
     frt_runtime_buffer_desc d{};
     d.name = stored(b->h, name);
     d.handle = buf;
@@ -174,7 +198,7 @@ extern "C" int frt_runtime_builder_add_region(frt_runtime_builder b,
                                               const char* name, frt_buffer buf,
                                               uint64_t offset, uint64_t bytes,
                                               uint32_t flags) {
-    if (!b || !name || !buf || !bytes) return -1;
+    if (!b || b->metadata_only || !name || !buf || !bytes) return -1;
     frt_runtime_region_desc d{};
     d.name = stored(b->h, name);
     d.buffer = buf;
@@ -220,9 +244,15 @@ extern "C" frt_runtime_export_v1* frt_runtime_builder_finish(
         frt_runtime_builder b, void* owner,
         void (*retain_owner)(void*), void (*release_owner)(void*)) {
     if (!b) return nullptr;
+    if (b->metadata_only) {
+        delete b->h;
+        delete b;
+        return nullptr;
+    }
     /* Ports/stages declare a MODEL runtime; a plain export cannot carry
      * them — use frt_runtime_builder_finish_model instead. */
-    if (!b->h->ports.empty() || !b->h->stages.empty()) return nullptr;
+    if (!b->h->ports.empty() || !b->h->stages.empty() ||
+        b->h->generic_plan_present) return nullptr;
     Holder* h = b->h;
     frt_rt::finish_export_into(h, b, owner, retain_owner, release_owner);
     delete b;  /* h lives on inside the export */

--- a/runtime/tests/model_runtime_v1_abi_baseline_consumer.cpp
+++ b/runtime/tests/model_runtime_v1_abi_baseline_consumer.cpp
@@ -1,0 +1,19 @@
+#include "abi/model_runtime_v1_abi_baseline.h"
+
+extern "C" int flashrt_model_runtime_v1_prefix_consume(const void* object) {
+    auto* model = static_cast<const frt_model_runtime_v1*>(object);
+    if (!model || model->abi_version != FRT_MODEL_RUNTIME_ABI_VERSION ||
+        model->struct_size < sizeof(frt_model_runtime_v1) || !model->exp ||
+        !model->retain || !model->release) return -1;
+    model->retain(model->owner);
+    model->release(model->owner);
+    return 0;
+}
+
+extern "C" int flashrt_model_runtime_v1_exact_size_consume(
+        const void* object) {
+    auto* model = static_cast<const frt_model_runtime_v1*>(object);
+    if (!model || model->abi_version != FRT_MODEL_RUNTIME_ABI_VERSION ||
+        model->struct_size != sizeof(frt_model_runtime_v1)) return -1;
+    return 0;
+}

--- a/runtime/tests/model_runtime_v1_abi_baseline_producer.cpp
+++ b/runtime/tests/model_runtime_v1_abi_baseline_producer.cpp
@@ -26,6 +26,9 @@ void* create_baseline(const frt_runtime_export_v1* exp, void* owner,
     model->abi_version = FRT_MODEL_RUNTIME_ABI_VERSION;
     model->struct_size = (uint32_t)sizeof(*model);
     model->exp = exp;
+    static const frt_runtime_stage_desc stage = {0, 0, nullptr};
+    model->stages = &stage;
+    model->n_stages = 1;
     model->verbs.struct_size = (uint32_t)sizeof(model->verbs);
     model->verbs.set_input = unsupported_set_input;
     model->verbs.get_output = unsupported_get_output;
@@ -43,3 +46,14 @@ void destroy_baseline(void* model) {
 }
 
 }  // namespace flashrt::model_runtime_v1_abi
+
+extern "C" void* flashrt_model_runtime_v1_abi_baseline_create(
+        const frt_runtime_export_v1* exp, void* owner,
+        void (*retain_owner)(void*), void (*release_owner)(void*)) {
+    return flashrt::model_runtime_v1_abi::create_baseline(
+        exp, owner, retain_owner, release_owner);
+}
+
+extern "C" void flashrt_model_runtime_v1_abi_baseline_destroy(void* model) {
+    flashrt::model_runtime_v1_abi::destroy_baseline(model);
+}

--- a/runtime/tests/test_model_runtime.cpp
+++ b/runtime/tests/test_model_runtime.cpp
@@ -38,6 +38,12 @@ namespace abi_baseline = flashrt::model_runtime_v1_abi::baseline;
 
 static_assert(FRT_MODEL_RUNTIME_ABI_VERSION == 1u,
               "v1 model-runtime ABI version changed");
+static_assert(FRT_GENERIC_STAGE_GRAPH == 0 &&
+                  FRT_GENERIC_STAGE_OPAQUE == 1,
+              "generic executor values are ABI-frozen");
+static_assert(FRT_GENERIC_STAGE_PLAN_EXT_V1_SIZE ==
+                  sizeof(frt_generic_stage_plan_ext_v1),
+              "generic plan v1 currently has no optional tail");
 ASSERT_BASELINE_VALUE(FRT_RT_MOD_TENSOR);
 ASSERT_BASELINE_VALUE(FRT_RT_MOD_IMAGE);
 ASSERT_BASELINE_VALUE(FRT_RT_MOD_TEXT);
@@ -161,6 +167,17 @@ static int v_prepare(void* s, uint32_t, frt_shape_key) {
 }
 static int v_step(void* s) { ((VerbLog*)s)->step++; return 0; }
 static const char* v_last_error(void*) { return ""; }
+static const char* v_base_error(void*) { return "base opaque error"; }
+static const char* v_override_error(void*) { return "override IO error"; }
+
+struct OpaqueLog { int calls = 0; uint32_t last_ref = 0; };
+static int run_opaque(void* self, uint32_t executor_ref) {
+    auto* log = static_cast<OpaqueLog*>(self);
+    log->calls++;
+    log->last_ref = executor_ref;
+    return 0;
+}
+static int run_opaque_noop(void*, uint32_t) { return 0; }
 
 struct Owner { int retains = 0, releases = 0; };
 static void owner_retain(void* p)  { ((Owner*)p)->retains++; }
@@ -247,12 +264,358 @@ int main() {
                   FRT_RT_LAYOUT_FLAT, FRT_RT_PORT_IN, FRT_RT_PORT_SETUP, 0,
                   shape, 1, 0, nullptr, 0, 0) == 0,
               "add non-staged port");
+        frt_model_runtime_verbs step_verbs{};
+        step_verbs.struct_size = sizeof(step_verbs);
+        step_verbs.step = v_step;
+        VerbLog setup_log;
         frt_model_runtime_v1* sm = frt_runtime_builder_finish_model(
-            sb, nullptr, nullptr, nullptr, nullptr, nullptr);
-        CHECK(sm && sm->verbs.step(sm->self) == -3 &&
+            sb, &step_verbs, &setup_log, nullptr, nullptr, nullptr);
+        CHECK(sm && sm->verbs.step(sm->self) == 0 &&
+                  sm->verbs.set_input(sm->self, 0, nullptr, 0, -1) == -3 &&
                   sm->verbs.last_error(sm->self)[0] != '\0',
-              "missing non-staged verbs retain unsupported stubs");
+              "non-authority verbs may retain unsupported stubs");
         sm->release(sm->owner);
+    }
+
+    /* --- generic selected-plan validation and discovery --- */
+    {
+        frt_model_runtime_verbs generic_verbs{};
+        generic_verbs.struct_size = sizeof(generic_verbs);
+        generic_verbs.step = v_step;
+        generic_verbs.last_error = v_base_error;
+        OpaqueLog opaque_log;
+
+        frt_runtime_builder gb = make_builder();
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "", FRT_GENERIC_STAGE_OPAQUE, 1, nullptr, 0) < 0,
+              "generic stage rejects an empty name");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "bad\nname", FRT_GENERIC_STAGE_OPAQUE, 1,
+                  nullptr, 0) < 0,
+              "generic stage rejects ASCII controls");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "\xc0\x80", FRT_GENERIC_STAGE_OPAQUE, 1,
+                  nullptr, 0) < 0,
+              "generic stage rejects invalid UTF-8");
+        std::string too_long(FRT_GENERIC_STAGE_NAME_MAX_BYTES + 1, 'x');
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, too_long.c_str(), FRT_GENERIC_STAGE_OPAQUE, 1,
+                  nullptr, 0) < 0,
+              "generic stage enforces the frozen name byte limit");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "bad-kind", 2, 1, nullptr, 0) < 0,
+              "generic stage rejects unknown executor kinds");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "bad-graph", FRT_GENERIC_STAGE_GRAPH, 99,
+                  nullptr, 0) < 0,
+              "generic graph stage rejects an unknown graph");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "context:main", FRT_GENERIC_STAGE_OPAQUE, 17,
+                  nullptr, 0) == 0,
+              "generic stage accepts delimiter-safe names");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "context:main", FRT_GENERIC_STAGE_OPAQUE, 18,
+                  nullptr, 0) < 0,
+              "generic stage names are unique");
+        const uint32_t duplicate_deps[2] = {0, 0};
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "bad-deps", FRT_GENERIC_STAGE_OPAQUE, 19,
+                  duplicate_deps, 2) < 0,
+              "generic dependencies must be strictly increasing");
+        const uint32_t future_dep[1] = {1};
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "future", FRT_GENERIC_STAGE_OPAQUE, 19,
+                  future_dep, 1) < 0,
+              "generic dependencies only reference earlier stages");
+        const uint32_t after_context[1] = {0};
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  gb, "action", FRT_GENERIC_STAGE_OPAQUE, 42,
+                  after_context, 1) == 0,
+              "generic stage records an ordered dependency");
+        CHECK(frt_runtime_builder_set_generic_stage_runner(
+                  gb, &opaque_log, run_opaque) == 0 &&
+              frt_runtime_builder_set_generic_stage_runner(
+                  gb, &opaque_log, run_opaque) < 0,
+              "generic runner is registered exactly once");
+        frt_model_runtime_v1* gm = frt_runtime_builder_finish_model(
+            gb, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(gm && gm->n_stages == 0,
+              "generic plan is the sole schedulable authority");
+
+        const void* extension = reinterpret_cast<const void*>(0x1);
+        CHECK(gm->query_extension(gm, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                                  &extension) == 0 && extension,
+              "generic extension query succeeds at version one");
+        auto* plan = static_cast<const frt_generic_stage_plan_ext_v1*>(extension);
+        CHECK(plan->abi_version == 1 &&
+                  plan->struct_size == sizeof(*plan) && plan->n_stages == 2 &&
+                  std::strcmp(plan->stages[0].name, "context:main") == 0 &&
+                  plan->stages[1].executor_ref == 42 &&
+                  plan->stages[1].n_after == 1 &&
+                  plan->stages[1].after[0] == 0,
+              "generic extension table and descriptors remain stable");
+        CHECK(plan->run_opaque(plan->stage_self,
+                               plan->stages[1].executor_ref) == 0 &&
+                  opaque_log.calls == 1 && opaque_log.last_ref == 42,
+              "opaque execution uses executor_ref rather than stage index");
+        const void* stable_extension = nullptr;
+        CHECK(gm->query_extension(gm, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                                  &stable_extension) == 0 &&
+                  stable_extension == extension,
+              "query returns a lifetime-stable extension table");
+        extension = reinterpret_cast<const void*>(0x1);
+        CHECK(gm->query_extension(gm, FRT_EXT_GENERIC_STAGE_PLAN_V1, 2,
+                                  &extension) == -3 && !extension,
+              "query rejects an unsupported extension version");
+        extension = reinterpret_cast<const void*>(0x1);
+        CHECK(gm->query_extension(gm, UINT64_C(0xffff), 1,
+                                  &extension) == -3 && !extension,
+              "query rejects unknown extension IDs and clears output");
+        extension = reinterpret_cast<const void*>(0x1);
+        CHECK(gm->query_extension(nullptr, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                                  &extension) == -1 && !extension &&
+                  gm->query_extension(gm, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                                      nullptr) == -1,
+              "query rejects null runtime/output arguments without mutation");
+        std::string generic_id = gm->exp->identity;
+        CHECK(generic_id.find(
+                  "gstage-v1:0:12:context:main:1:17:0:\n") !=
+                  std::string::npos &&
+              generic_id.find("gstage-v1:1:6:action:1:42:1:0\n") !=
+                  std::string::npos,
+              "generic stages use length-delimited canonical identity records");
+        VerbLog override_log;
+        frt_model_runtime_verbs replacement_verbs = generic_verbs;
+        replacement_verbs.last_error = v_override_error;
+        frt_model_runtime_v1* generic_override =
+            frt_model_runtime_override_verbs(
+                gm, &replacement_verbs, &override_log, nullptr, nullptr,
+                nullptr);
+        const void* forwarded_extension = nullptr;
+        CHECK(generic_override &&
+                  generic_override->query_extension(
+                      generic_override, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                      &forwarded_extension) == 0 &&
+                  forwarded_extension == stable_extension,
+              "all-OPAQUE override forwards the base extension table");
+        auto* forwarded_plan =
+            static_cast<const frt_generic_stage_plan_ext_v1*>(
+                forwarded_extension);
+        CHECK(forwarded_plan->run_opaque(forwarded_plan->stage_self, 73) == 0 &&
+                  opaque_log.calls == 2 && opaque_log.last_ref == 73,
+              "override preserves the base stage_self and runner");
+        CHECK(std::strcmp(generic_override->verbs.last_error(
+                              generic_override->self),
+                          "base opaque error") == 0,
+              "generic override preserves the base authoritative error source");
+        gm->release(gm->owner);
+        CHECK(generic_override->query_extension(
+                  generic_override, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                  &forwarded_extension) == 0,
+              "override retains extension storage after base release");
+        generic_override->release(generic_override->owner);
+
+        frt_runtime_builder empty = make_builder();
+        CHECK(frt_runtime_builder_set_generic_stage_runner(
+                  empty, nullptr, run_opaque_noop) == 0 &&
+              frt_runtime_builder_finish_model(
+                  empty, &generic_verbs, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr,
+              "an explicitly present empty generic plan is rejected");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  empty, "infer", FRT_GENERIC_STAGE_OPAQUE, 7,
+                  nullptr, 0) == 0,
+              "empty-plan validation failure leaves the builder retryable");
+        frt_model_runtime_v1* repaired = frt_runtime_builder_finish_model(
+            empty, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(repaired != nullptr, "repaired generic plan finishes");
+        repaired->release(repaired->owner);
+
+        frt_runtime_builder utf8 = make_builder();
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  utf8, "\xe9\x98\xb6\xe6\xae\xb5",
+                  FRT_GENERIC_STAGE_OPAQUE, 5, nullptr, 0) == 0 &&
+              frt_runtime_builder_set_generic_stage_runner(
+                  utf8, nullptr, run_opaque_noop) == 0,
+              "generic stage accepts valid UTF-8 names");
+        repaired = frt_runtime_builder_finish_model(
+            utf8, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(repaired && std::string(repaired->exp->identity).find(
+                  "gstage-v1:0:6:") != std::string::npos,
+              "canonical name length counts UTF-8 bytes");
+        repaired->release(repaired->owner);
+
+        frt_runtime_builder missing_runner = make_builder();
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  missing_runner, "infer", FRT_GENERIC_STAGE_OPAQUE, 8,
+                  nullptr, 0) == 0 &&
+              frt_runtime_builder_finish_model(
+                  missing_runner, &generic_verbs, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr,
+              "OPAQUE plan without a registered runner is rejected");
+        CHECK(frt_runtime_builder_set_generic_stage_runner(
+                  missing_runner, nullptr, run_opaque_noop) == 0,
+              "missing-runner rejection leaves builder retryable");
+        frt_model_runtime_verbs no_error = generic_verbs;
+        no_error.last_error = nullptr;
+        CHECK(frt_runtime_builder_finish_model(
+                  missing_runner, &no_error, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr,
+              "OPAQUE plan requires a real authoritative last_error verb");
+        repaired = frt_runtime_builder_finish_model(
+            missing_runner, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(repaired != nullptr,
+              "runner/error validation failures do not consume builder");
+        repaired->release(repaired->owner);
+
+        frt_runtime_builder pure_graph = make_builder();
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  pure_graph, "graph", FRT_GENERIC_STAGE_GRAPH, 0,
+                  nullptr, 0) == 0 &&
+              frt_runtime_builder_set_generic_stage_runner(
+                  pure_graph, nullptr, run_opaque_noop) == 0 &&
+              frt_runtime_builder_finish_model(
+                  pure_graph, &generic_verbs, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr,
+              "pure GRAPH generic plan is rejected in favor of legacy stages");
+        const uint32_t after_graph[1] = {0};
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  pure_graph, "opaque", FRT_GENERIC_STAGE_OPAQUE, 9,
+                  after_graph, 1) == 0,
+              "a mixed generic plan can repair the pure-GRAPH rejection");
+        repaired = frt_runtime_builder_finish_model(
+            pure_graph, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(repaired != nullptr, "mixed GRAPH/OPAQUE generic plan finishes");
+        CHECK(frt_model_runtime_override_verbs(
+                  repaired, &generic_verbs, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr,
+              "mixed generic plan rejects verb override in M0");
+        repaired->release(repaired->owner);
+
+        frt_runtime_builder legacy = make_builder();
+        CHECK(frt_runtime_builder_add_stage(legacy, 0, nullptr, 0) == 0 &&
+              frt_runtime_builder_add_generic_stage(
+                  legacy, "opaque", FRT_GENERIC_STAGE_OPAQUE, 1,
+                  nullptr, 0) < 0,
+              "legacy authority rejects a second generic authority");
+        repaired = frt_runtime_builder_finish_model(
+            legacy, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(repaired != nullptr, "rejected second authority does not mutate builder");
+        repaired->release(repaired->owner);
+
+        frt_runtime_builder no_authority = make_builder();
+        CHECK(frt_runtime_builder_finish_model(
+                  no_authority, nullptr, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr,
+              "runtime without a plan or real step is rejected");
+        repaired = frt_runtime_builder_finish_model(
+            no_authority, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
+        CHECK(repaired != nullptr, "step-only runtime is an explicit authority");
+        CHECK(frt_model_runtime_override_verbs(
+                  repaired, &generic_verbs, nullptr, nullptr, nullptr,
+                  nullptr) == nullptr,
+              "step-only runtime rejects identity-preserving verb override");
+        repaired->release(repaired->owner);
+    }
+
+    /* --- metadata-only provider: identity anchor without exec resources --- */
+    {
+        CHECK(frt_runtime_builder_create(nullptr) == nullptr,
+              "ordinary runtime builder continues to reject null ctx");
+        frt_runtime_builder metadata =
+            frt_model_runtime_builder_create_metadata();
+        frt_shape_key key = 0;
+        CHECK(metadata &&
+                  frt_runtime_builder_add_stream(
+                      metadata, "main", 0, 0, nullptr) < 0 &&
+                  frt_runtime_builder_add_graph(
+                      metadata, "graph", FAKE_G0, 0, &key, 1, 0) < 0 &&
+                  frt_runtime_builder_add_buffer(
+                      metadata, "buffer", FAKE_B0, 16, FRT_RT_ROLE_INPUT) < 0 &&
+                  frt_runtime_builder_add_region(
+                      metadata, "region", FAKE_B0, 0, 16,
+                      FRT_RT_REGION_SNAPSHOT) < 0 &&
+                  frt_runtime_builder_add_stage(
+                      metadata, 0, nullptr, 0) < 0,
+              "metadata builder rejects every FlashRT resource declaration");
+        const int64_t scalar[1] = {1};
+        CHECK(frt_runtime_builder_add_port(
+                  metadata, "swap", FRT_RT_MOD_TENSOR, FRT_RT_DTYPE_F32,
+                  FRT_RT_LAYOUT_FLAT, FRT_RT_PORT_IN, FRT_RT_PORT_SWAP, 0,
+                  scalar, 1, 0, FAKE_B0, 0, 4) < 0,
+              "metadata builder rejects SWAP windows");
+        CHECK(frt_runtime_builder_add_generic_stage(
+                  metadata, "graph", FRT_GENERIC_STAGE_GRAPH, 0,
+                  nullptr, 0) < 0,
+              "metadata builder rejects GRAPH and mixed plans");
+        CHECK(frt_runtime_builder_add_port(
+                  metadata, "input", FRT_RT_MOD_TENSOR, FRT_RT_DTYPE_F32,
+                  FRT_RT_LAYOUT_FLAT, FRT_RT_PORT_IN, FRT_RT_PORT_STAGED, 1,
+                  scalar, 1, 0, nullptr, 0, 0) == 0 &&
+                  frt_runtime_builder_add_identity(
+                      metadata, "provider", "fixture") == 0 &&
+                  frt_runtime_builder_set_manifest(
+                      metadata, "{\"provider\":\"fixture\"}") == 0 &&
+                  frt_runtime_builder_add_generic_stage(
+                      metadata, "infer", FRT_GENERIC_STAGE_OPAQUE, 101,
+                      nullptr, 0) == 0,
+              "metadata builder accepts identity, discovery, staged IO and OPAQUE plan");
+        OpaqueLog metadata_log;
+        CHECK(frt_runtime_builder_set_generic_stage_runner(
+                  metadata, &metadata_log, run_opaque) == 0,
+              "metadata builder records its blocking OPAQUE runner");
+        frt_model_runtime_verbs metadata_verbs{};
+        metadata_verbs.struct_size = sizeof(metadata_verbs);
+        metadata_verbs.set_input = v_set_input;
+        metadata_verbs.last_error = v_last_error;
+        VerbLog metadata_verb_log;
+        Owner metadata_owner;
+        frt_model_runtime_v1* mm = frt_runtime_builder_finish_model(
+            metadata, &metadata_verbs, &metadata_verb_log, &metadata_owner,
+            owner_retain, owner_release);
+        CHECK(mm && mm->exp && !mm->exp->ctx &&
+                  mm->exp->n_streams == 0 && mm->exp->n_graphs == 0 &&
+                  mm->exp->n_buffers == 0 &&
+                  mm->exp->n_capsule_regions == 0 &&
+                  mm->exp->identity && mm->exp->fingerprint != 0,
+              "metadata runtime publishes one valid zero-resource export anchor");
+        const void* metadata_extension = nullptr;
+        CHECK(mm->query_extension(mm, FRT_EXT_GENERIC_STAGE_PLAN_V1, 1,
+                                  &metadata_extension) == 0 &&
+                  static_cast<const frt_generic_stage_plan_ext_v1*>(
+                      metadata_extension)->n_stages == 1,
+              "metadata runtime publishes its all-OPAQUE selected plan");
+        frt_runtime_stage_desc fake_stage{};
+        const int retains_before_wrap = metadata_owner.retains;
+        CHECK(frt_model_runtime_wrap(
+                  mm->exp, nullptr, 0, &fake_stage, 1, nullptr, nullptr,
+                  nullptr, nullptr) == nullptr &&
+                  metadata_owner.retains == retains_before_wrap,
+              "legacy wrapper rejects a null-ctx metadata anchor without retaining it");
+        mm->release(mm->owner);
+        CHECK(metadata_owner.retains == 1 && metadata_owner.releases == 1,
+              "metadata runtime retains and releases its sole owner exactly once");
+
+        frt_runtime_builder metadata_step =
+            frt_model_runtime_builder_create_metadata();
+        frt_runtime_builder_add_identity(metadata_step, "provider", "step");
+        frt_model_runtime_verbs step_only_verbs{};
+        step_only_verbs.struct_size = sizeof(step_only_verbs);
+        step_only_verbs.step = v_step;
+        VerbLog metadata_step_log;
+        mm = frt_runtime_builder_finish_model(
+            metadata_step, &step_only_verbs, &metadata_step_log,
+            nullptr, nullptr, nullptr);
+        CHECK(mm && !mm->exp->ctx && mm->verbs.step(mm->self) == 0 &&
+                  metadata_step_log.step == 1,
+              "metadata runtime supports explicit step-only authority");
+        mm->release(mm->owner);
+
+        frt_runtime_builder metadata_export =
+            frt_model_runtime_builder_create_metadata();
+        CHECK(frt_runtime_builder_finish(
+                  metadata_export, nullptr, nullptr, nullptr) == nullptr,
+              "metadata-only builder cannot publish a standalone export");
     }
 
     /* --- independently compiled ABI baseline -> current prefix consumer --- */
@@ -349,6 +712,8 @@ int main() {
     CHECK(m->exp->fingerprint ==
               frt_runtime_fingerprint(id.data(), id.size()),
           "fingerprint == hash(identity)");
+    CHECK(m->exp->fingerprint == UINT64_C(0xd1393a80cdef15b3),
+          "legacy identity and fingerprint remain exact across CORE-B");
 
     /* port schema change => different fingerprint */
     {

--- a/runtime/tests/test_model_runtime.cpp
+++ b/runtime/tests/test_model_runtime.cpp
@@ -111,6 +111,12 @@ ASSERT_BASELINE_OFFSET(frt_model_runtime_verbs, last_error);
 static_assert(FRT_MODEL_RUNTIME_V1_BASE_SIZE ==
                   sizeof(abi_baseline::frt_model_runtime_v1),
               "v1 required prefix changed");
+static_assert(FRT_MODEL_RUNTIME_V1_BASE_SIZE ==
+                  offsetof(frt_model_runtime_v1, query_extension),
+              "query_extension must immediately follow the v1 prefix");
+static_assert(FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE ==
+                  sizeof(frt_model_runtime_v1),
+              "query_extension must be the only current v1 tail field");
 static_assert(alignof(frt_model_runtime_v1) ==
                   alignof(abi_baseline::frt_model_runtime_v1),
               "frt_model_runtime_v1 prefix alignment changed");
@@ -265,6 +271,9 @@ int main() {
             static_cast<frt_model_runtime_v1*>(baseline_object);
         CHECK(current_view->struct_size == FRT_MODEL_RUNTIME_V1_BASE_SIZE,
               "ABI baseline publishes exactly the v1 required prefix");
+        CHECK(current_view->struct_size <
+                  FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE,
+              "tail-aware consumer detects extension absence before reading tail");
 
         current_view->struct_size = FRT_MODEL_RUNTIME_V1_BASE_SIZE - 1;
         CHECK(frt_model_runtime_override_verbs(
@@ -306,6 +315,18 @@ int main() {
     CHECK(m != nullptr, "finish_model");
     CHECK(m->abi_version == FRT_MODEL_RUNTIME_ABI_VERSION &&
           m->struct_size == sizeof(frt_model_runtime_v1), "model ABI stamp");
+    const void* absent_extension = reinterpret_cast<const void*>(0x1);
+    CHECK(m->struct_size >= FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE &&
+              m->query_extension &&
+              m->query_extension(m, UINT64_C(0xffff), 1,
+                                 &absent_extension) == -3 &&
+              absent_extension == nullptr,
+          "tail-capable runtime publishes an unsupported query stub");
+    absent_extension = reinterpret_cast<const void*>(0x1);
+    CHECK(m->query_extension(m, UINT64_C(0xffff), 0,
+                             &absent_extension) == -1 &&
+              absent_extension == nullptr,
+          "query rejects version zero and clears output");
     CHECK(m->exp && m->exp->abi_version == FRT_RUNTIME_ABI_VERSION,
           "embedded export is stamped");
     CHECK(m->n_ports == 2 && m->n_stages == 2, "port/stage counts");

--- a/runtime/tests/test_model_runtime.cpp
+++ b/runtime/tests/test_model_runtime.cpp
@@ -183,6 +183,19 @@ struct Owner { int retains = 0, releases = 0; };
 static void owner_retain(void* p)  { ((Owner*)p)->retains++; }
 static void owner_release(void* p) { ((Owner*)p)->releases++; }
 
+static const frt_generic_stage_plan_ext_v1* EXTERNAL_GENERIC_PLAN = nullptr;
+static int query_external_generic_plan(const frt_model_runtime_v1* runtime,
+                                       uint64_t extension_id,
+                                       uint32_t min_version,
+                                       const void** out_extension) {
+    if (out_extension) *out_extension = nullptr;
+    if (!runtime || !out_extension || min_version == 0) return -1;
+    if (extension_id != FRT_EXT_GENERIC_STAGE_PLAN_V1 || min_version > 1 ||
+        !EXTERNAL_GENERIC_PLAN) return -3;
+    *out_extension = EXTERNAL_GENERIC_PLAN;
+    return 0;
+}
+
 static frt_runtime_builder make_builder() {
     frt_runtime_builder b = frt_runtime_builder_create(FAKE_CTX);
     frt_runtime_builder_add_stream(b, "main", 0, 0, nullptr);
@@ -494,14 +507,121 @@ int main() {
 
         frt_runtime_builder legacy = make_builder();
         CHECK(frt_runtime_builder_add_stage(legacy, 0, nullptr, 0) == 0 &&
+              frt_runtime_builder_set_generic_stage_runner(
+                  legacy, nullptr, run_opaque_noop) < 0 &&
               frt_runtime_builder_add_generic_stage(
                   legacy, "opaque", FRT_GENERIC_STAGE_OPAQUE, 1,
                   nullptr, 0) < 0,
-              "legacy authority rejects a second generic authority");
+              "legacy authority rejects generic runner and stage setters");
         repaired = frt_runtime_builder_finish_model(
             legacy, &generic_verbs, nullptr, nullptr, nullptr, nullptr);
-        CHECK(repaired != nullptr, "rejected second authority does not mutate builder");
+        CHECK(repaired != nullptr,
+              "rejected generic setters leave the legacy builder finishable");
         repaired->release(repaired->owner);
+
+        frt_shape_key external_key = 0;
+        frt_runtime_graph_desc external_graph{
+            "graph", FAKE_G0, 0, &external_key, 1, 0};
+        Owner external_owner;
+        frt_runtime_export_v1 external_export{};
+        external_export.abi_version = FRT_RUNTIME_ABI_VERSION;
+        external_export.struct_size = sizeof(external_export);
+        external_export.ctx = FAKE_CTX;
+        external_export.graphs = &external_graph;
+        external_export.n_graphs = 1;
+        external_export.owner = &external_owner;
+        external_export.retain = owner_retain;
+        external_export.release = owner_release;
+
+        const uint32_t external_dep[1] = {0};
+        frt_generic_stage_desc_v1 external_stages[2] = {
+            {"context", FRT_GENERIC_STAGE_OPAQUE, 10, 0, nullptr},
+            {"action", FRT_GENERIC_STAGE_OPAQUE, 11, 1, external_dep},
+        };
+        frt_generic_stage_plan_ext_v1 external_plan{
+            FRT_GENERIC_STAGE_PLAN_ABI_VERSION,
+            sizeof(frt_generic_stage_plan_ext_v1),
+            external_stages,
+            2,
+            nullptr,
+            run_opaque_noop,
+        };
+        frt_model_runtime_v1 external_model{};
+        external_model.abi_version = FRT_MODEL_RUNTIME_ABI_VERSION;
+        external_model.struct_size = sizeof(external_model);
+        external_model.exp = &external_export;
+        external_model.verbs = generic_verbs;
+        external_model.owner = &external_owner;
+        external_model.retain = owner_retain;
+        external_model.release = owner_release;
+        external_model.query_extension = query_external_generic_plan;
+        EXTERNAL_GENERIC_PLAN = &external_plan;
+
+        auto reject_external = [&](const char* message) {
+            Owner replacement_owner;
+            frt_model_runtime_v1* rejected = frt_model_runtime_override_verbs(
+                &external_model, &generic_verbs, nullptr,
+                &replacement_owner, owner_retain, owner_release);
+            CHECK(!rejected && external_owner.retains == 0 &&
+                      replacement_owner.retains == 0,
+                  message);
+        };
+
+        external_plan.run_opaque = nullptr;
+        reject_external("external generic plan rejects a null runner before retain");
+        external_plan.run_opaque = run_opaque_noop;
+
+        external_model.verbs.last_error = nullptr;
+        reject_external("external generic plan requires base error authority");
+        external_model.verbs.last_error = v_base_error;
+
+        external_stages[0].executor_kind = 2;
+        reject_external("external generic plan rejects unknown executor kinds");
+        external_stages[0].executor_kind = FRT_GENERIC_STAGE_OPAQUE;
+
+        external_stages[0].executor_kind = FRT_GENERIC_STAGE_GRAPH;
+        external_stages[0].executor_ref = 1;
+        reject_external("external generic plan rejects unknown graph references");
+        external_stages[0].executor_kind = FRT_GENERIC_STAGE_OPAQUE;
+        external_stages[0].executor_ref = 10;
+
+        external_stages[1].after = nullptr;
+        reject_external("external generic plan rejects a missing dependency array");
+        external_stages[1].after = external_dep;
+        const uint32_t invalid_external_dep[1] = {1};
+        external_stages[1].after = invalid_external_dep;
+        reject_external("external generic dependencies only reference earlier stages");
+        const uint32_t duplicate_external_deps[2] = {0, 0};
+        external_stages[1].after = duplicate_external_deps;
+        external_stages[1].n_after = 2;
+        reject_external("external generic dependencies are strictly increasing");
+        external_stages[1].after = external_dep;
+        external_stages[1].n_after = 1;
+
+        external_stages[1].name = "context";
+        reject_external("external generic stage names are unique");
+        external_stages[1].name = "action";
+
+        frt_runtime_stage_desc external_legacy_stage{0, 0, nullptr};
+        external_model.stages = &external_legacy_stage;
+        external_model.n_stages = 1;
+        reject_external(
+            "external runtime rejects simultaneous legacy and generic authority");
+        external_model.stages = nullptr;
+        external_model.n_stages = 0;
+
+        Owner replacement_owner;
+        frt_model_runtime_v1* accepted_external =
+            frt_model_runtime_override_verbs(
+                &external_model, &generic_verbs, nullptr,
+                &replacement_owner, owner_retain, owner_release);
+        CHECK(accepted_external && external_owner.retains == 1 &&
+                  replacement_owner.retains == 1,
+              "validated external generic plan is retained and published");
+        accepted_external->release(accepted_external->owner);
+        CHECK(external_owner.releases == 1 && replacement_owner.releases == 1,
+              "validated external generic override releases both owners");
+        EXTERNAL_GENERIC_PLAN = nullptr;
 
         frt_runtime_builder no_authority = make_builder();
         CHECK(frt_runtime_builder_finish_model(

--- a/runtime/tests/test_model_runtime_abi_compat.cpp
+++ b/runtime/tests/test_model_runtime_abi_compat.cpp
@@ -1,0 +1,96 @@
+#include "flashrt/model_runtime.h"
+
+#include <dlfcn.h>
+
+#include <cstdio>
+
+namespace {
+
+using BaselineCreate = void* (*)(const frt_runtime_export_v1*, void*,
+                                  void (*)(void*), void (*)(void*));
+using BaselineDestroy = void (*)(void*);
+using Consume = int (*)(const void*);
+
+int failures = 0;
+#define CHECK(condition, message) do {                                      \
+    if (!(condition)) { std::printf("FAIL: %s\n", message); failures = 1; } \
+} while (0)
+
+void retain_noop(void*) {}
+void release_noop(void*) {}
+int step_noop(void*) { return 0; }
+const char* no_error(void*) { return ""; }
+
+void* open_local(const char* path) {
+    void* handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    if (!handle) std::printf("dlopen failed: %s\n", dlerror());
+    return handle;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 3) return 2;
+    void* producer_dso = open_local(argv[1]);
+    void* consumer_dso = open_local(argv[2]);
+    CHECK(producer_dso && consumer_dso, "fixtures load with RTLD_LOCAL");
+    if (!producer_dso || !consumer_dso) return 1;
+
+    auto create = reinterpret_cast<BaselineCreate>(
+        dlsym(producer_dso, "flashrt_model_runtime_v1_abi_baseline_create"));
+    auto destroy = reinterpret_cast<BaselineDestroy>(
+        dlsym(producer_dso, "flashrt_model_runtime_v1_abi_baseline_destroy"));
+    auto prefix_consume = reinterpret_cast<Consume>(
+        dlsym(consumer_dso, "flashrt_model_runtime_v1_prefix_consume"));
+    auto exact_consume = reinterpret_cast<Consume>(
+        dlsym(consumer_dso,
+              "flashrt_model_runtime_v1_exact_size_consume"));
+    CHECK(create && destroy && prefix_consume && exact_consume,
+          "fixture symbols resolve through their own handles");
+
+    frt_runtime_export_v1 fake_export{};
+    fake_export.abi_version = FRT_RUNTIME_ABI_VERSION;
+    fake_export.struct_size = sizeof(fake_export);
+    void* baseline = create(&fake_export, nullptr, retain_noop, release_noop);
+    auto* baseline_view = static_cast<frt_model_runtime_v1*>(baseline);
+    CHECK(baseline_view &&
+              baseline_view->struct_size == FRT_MODEL_RUNTIME_V1_BASE_SIZE,
+          "baseline producer publishes exactly the required prefix");
+    CHECK(prefix_consume(baseline) == 0 && exact_consume(baseline) == 0,
+          "baseline producer is accepted by baseline consumers");
+    CHECK(baseline_view->struct_size <
+              FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE,
+          "tail-aware consumer treats baseline extension as absent");
+
+    frt_runtime_builder builder =
+        frt_runtime_builder_create(reinterpret_cast<frt_ctx>(0x10));
+    frt_runtime_builder_add_stream(builder, "main", 0, 0, nullptr);
+    const frt_shape_key key = 0;
+    frt_runtime_builder_add_graph(
+        builder, "infer", reinterpret_cast<frt_graph>(0x20), 0, &key, 1, 0);
+    frt_runtime_builder_add_stage(builder, 0, nullptr, 0);
+    frt_runtime_builder_add_identity(builder, "fixture", "tail");
+    frt_model_runtime_verbs verbs{};
+    verbs.struct_size = sizeof(verbs);
+    verbs.step = step_noop;
+    verbs.last_error = no_error;
+    frt_model_runtime_v1* tail = frt_runtime_builder_finish_model(
+        builder, &verbs, nullptr, nullptr, nullptr, nullptr);
+    CHECK(tail && tail->struct_size >=
+                      FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE,
+          "tail producer publishes the additive query field");
+    CHECK(prefix_consume(tail) == 0,
+          "prefix-compliant consumer ignores the additive tail");
+    CHECK(exact_consume(tail) == -1,
+          "archived exact-size consumer safely rejects and requires rebuild");
+    const void* extension = reinterpret_cast<const void*>(0x1);
+    CHECK(tail->query_extension(tail, UINT64_C(0xffff), 1, &extension) == -3 &&
+              extension == nullptr,
+          "tail-aware consumer calls the stable unsupported query stub");
+
+    tail->release(tail->owner);
+    destroy(baseline);
+    dlclose(consumer_dso);
+    dlclose(producer_dso);
+    return failures;
+}

--- a/runtime/tests/test_model_runtime_py.py
+++ b/runtime/tests/test_model_runtime_py.py
@@ -24,8 +24,9 @@ import _flashrt_runtime as rt
 
 import flash_rt.runtime.export as export_mod
 from flash_rt.runtime.export import (
-    BufferSpec, GraphSpec, PortSpec, RegionSpec, StageSpec, StreamSpec,
-    build_model_runtime, DTYPE, LAYOUT, MODALITY, UPDATE,
+    BufferSpec, GenericStageSpec, GraphSpec, PortSpec, RegionSpec, StageSpec,
+    StreamSpec, build_metadata_model_runtime, build_model_runtime,
+    DTYPE, LAYOUT, MODALITY, UPDATE,
 )
 from flash_rt.subgraphs.stage_plan import (
     StagePlan,
@@ -77,6 +78,27 @@ class ModelV1(ctypes.Structure):
                 ("owner", ctypes.c_void_p),
                 ("retain", ctypes.CFUNCTYPE(None, ctypes.c_void_p)),
                 ("release", ctypes.CFUNCTYPE(None, ctypes.c_void_p))]
+
+
+class ModelV1Tail(ctypes.Structure):
+    _fields_ = ModelV1._fields_ + [("query_extension", ctypes.c_void_p)]
+
+
+class GenericStageDesc(ctypes.Structure):
+    _fields_ = [("name", ctypes.c_char_p),
+                ("executor_kind", ctypes.c_uint32),
+                ("executor_ref", ctypes.c_uint32),
+                ("n_after", ctypes.c_uint32),
+                ("after", ctypes.POINTER(ctypes.c_uint32))]
+
+
+class GenericStagePlan(ctypes.Structure):
+    _fields_ = [("abi_version", ctypes.c_uint32),
+                ("struct_size", ctypes.c_uint32),
+                ("stages", ctypes.POINTER(GenericStageDesc)),
+                ("n_stages", ctypes.c_uint64),
+                ("stage_self", ctypes.c_void_p),
+                ("run_opaque", ctypes.c_void_p)]
 
 
 def make_setup():
@@ -243,6 +265,7 @@ def check_low_level_staged_builder_guard(setup):
         final_owner,
         set_input=lambda port, payload, stream: 0,
         get_output=lambda port, stream: b"",
+        step=lambda: 0,
     )
     del final_owner
     gc.collect()
@@ -388,6 +411,74 @@ def check_vjp_guided_port_lowering(setup):
         mr.release()
 
 
+def check_generic_and_metadata(setup):
+    ctx, sid, _, _, g = setup
+    opaque_refs = []
+    def make_generic(executor_ref=91):
+        return build_model_runtime(
+            ctx,
+            streams=[StreamSpec("main", sid)],
+            graphs=[GraphSpec("graph", g)],
+            generic_stages=[
+                GenericStageSpec("graph", "graph", 0),
+                GenericStageSpec("opaque:decode", "opaque", executor_ref,
+                                 after=(0,)),
+            ],
+            identity={"provider": "python-fixture"},
+            step=lambda: 0,
+            run_opaque=lambda ref: opaque_refs.append(ref) or 0,
+        )
+
+    generic = make_generic()
+    try:
+        check("Python generic plan is the sole stage authority",
+              generic.stages() == [] and generic.generic_stages() == [
+                  {"name": "graph", "executor_kind": rt.GENERIC_STAGE_GRAPH,
+                   "executor_ref": 0, "after": []},
+                  {"name": "opaque:decode",
+                   "executor_kind": rt.GENERIC_STAGE_OPAQUE,
+                   "executor_ref": 91, "after": [0]},
+              ])
+        check("Python generic identity is canonical",
+              "gstage-v1:1:13:opaque:decode:1:91:1:0\n" in generic.identity)
+        check("Python OPAQUE trampoline receives executor_ref",
+              rt.model_run_opaque(generic.ptr, 91) == 0 and opaque_refs == [91])
+        same = make_generic()
+        changed = make_generic(92)
+        try:
+            check("generic fingerprint is deterministic and ref-sensitive",
+                  same.fingerprint == generic.fingerprint and
+                  changed.fingerprint != generic.fingerprint)
+        finally:
+            same.release()
+            changed.release()
+    finally:
+        generic.release()
+
+    metadata_refs = []
+    metadata = build_metadata_model_runtime(
+        ports=[PortSpec("input", "tensor", "f32", "flat", "in", "staged",
+                        shape=(1,), required=True)],
+        generic_stages=[GenericStageSpec("infer", "opaque", 7)],
+        identity={"provider": "metadata-fixture"},
+        set_input=lambda port, payload, stream: 0,
+        run_opaque=lambda ref: metadata_refs.append(ref) or 0,
+    )
+    try:
+        check("Python metadata runtime has a zero-resource export anchor",
+              rt.export_counts(metadata.export_ptr) == {
+                  "streams": 0, "graphs": 0, "buffers": 0,
+                  "capsule_regions": 0})
+        check("Python metadata runtime publishes all-OPAQUE plan",
+              metadata.generic_stages() == [
+                  {"name": "infer", "executor_kind": rt.GENERIC_STAGE_OPAQUE,
+                   "executor_ref": 7, "after": []}])
+        check("Python metadata OPAQUE callback runs",
+              rt.model_run_opaque(metadata.ptr, 7) == 0 and metadata_refs == [7])
+    finally:
+        metadata.release()
+
+
 def main():
     CHECKS.clear()
     setup = make_setup()
@@ -396,6 +487,13 @@ def main():
     print("== struct layout (ctypes mirror vs specs) ==")
     check("ctypes v1 prefix matches exported required size",
           ctypes.sizeof(ModelV1) == int(rt.MODEL_V1_BASE_SIZE))
+    check("ctypes v1 tail matches exported query size",
+          ctypes.sizeof(ModelV1Tail) ==
+          int(rt.MODEL_V1_QUERY_EXTENSION_SIZE))
+    check("ctypes generic descriptor/table match C ABI sizes",
+          ctypes.sizeof(GenericStageDesc) == int(rt.GENERIC_STAGE_DESC_V1_SIZE)
+          and ctypes.sizeof(GenericStagePlan) ==
+          int(rt.GENERIC_STAGE_PLAN_EXT_V1_SIZE))
     check_staged_callback_guards()
     check_low_level_staged_builder_guard(setup)
     calls = {"set_input": [], "step": 0}
@@ -453,6 +551,7 @@ def main():
     print("== stage plan registry ==")
     check_stage_plan_registry()
     check_vjp_guided_port_lowering(setup)
+    check_generic_and_metadata(setup)
 
     print("== verbs through the C function pointers ==")
     rc = rt.model_set_input(mr.ptr, 1, b"\xAA\xBB", -1)


### PR DESCRIPTION
## Summary

Extend `frt_model_runtime_v1` without introducing a parallel ABI:

- append a size-probed `query_extension` tail while keeping ABI version 1 and the released required prefix unchanged;
- add the core-owned `GENERIC_STAGE_PLAN_V1` table for one selected GRAPH/OPAQUE DAG;
- enforce a single execution authority: legacy stages, generic stages, or step-only;
- add a restricted metadata-only model builder for providers with no FlashRT execution resources;
- expose the same builder path to Python without duplicating validation, identity, or fingerprint logic.

This is common runtime mechanism. It contains no provider, model, backend, scheduler, or state-policy implementation. Provider adoption and Nexus execution remain separate follow-up changes.

## Contract boundaries

- `frt_model_runtime_verbs` layout is unchanged.
- `FRT_MODEL_RUNTIME_ABI_VERSION` remains `1`.
- Consumers require only `FRT_MODEL_RUNTIME_V1_BASE_SIZE` and probe `FRT_MODEL_RUNTIME_V1_QUERY_EXTENSION_SIZE` before reading the tail.
- Generic descriptors are runtime-owned and immutable for the runtime lifetime.
- OPAQUE M0 execution is synchronous and blocking; no async, cancellation, capture-safe, no-allocation, or snapshot guarantee is added.
- Generic stages are registered through the existing builder and enter the canonical identity as length-delimited records.
- Legacy runtimes with no generic plan retain byte-exact identity and fingerprint behavior.
- Metadata-only exports are zero-resource identity/lifetime anchors, not fake exec contexts or model-state promises.

## Validation

- [x] Released prefix, verbs layout, enum values, and ABI version remain exact
- [x] Independent baseline producer/prefix consumer DSOs pass through `RTLD_LOCAL`
- [x] Tail producer is accepted by a prefix-compliant consumer
- [x] Archived exact-size consumer safely rejects the larger tail object
- [x] Query ID/version/null/unsupported and stable-table matrix passes
- [x] Generic descriptor, dependency, UTF-8, runner, and authority negative matrix passes
- [x] Legacy-to-generic setter rejection is symmetric and leaves the builder retryable
- [x] Malformed external generic tables fail before either owner is retained
- [x] Metadata resource/SWAP/GRAPH/wrap/step-only restrictions pass
- [x] Override retains and forwards all-OPAQUE table, runner, self, and error authority
- [x] Legacy canonical identity and golden fingerprint remain exact
- [x] Python generic and metadata producer parity passes
- [x] Release runtime tests: 2/2
- [x] Python runtime contract checks: 45/45
- [x] ASAN + UBSAN runtime tests: 2/2
- [x] Native frontend semantic/CUDA-off tests: 17/17
- [x] C and C++ public-header probes pass with warnings as errors
- [x] Runtime DSO removes no symbols; added symbols are exactly the three documented builder APIs
- [x] `csrc/`, `exec/`, and `cpp/` have no changes
- [x] `git diff --check` passes
