### PR TITLE
Add Qwen3.6-35B-A3B text inference

### DIFF
--- a/docs/nexn2_usage.md
+++ b/docs/nexn2_usage.md
@@ -99,7 +99,10 @@ Nexn2TorchFrontendRtx(
 
 Methods: `set_prompt(text)`, `infer() -> (1, S, vocab)`, `generate(max_new_tokens) -> list[int]`, `tokenizer`, `latency_records` (list[float], per `infer()`).
 
-Env knobs: `FLASHRT_NEXN2_PREFILL_CHUNK` (chunked-prefill block size, default 8192; 0 disables), `FLASHRT_NEXN2_GRAPH_CACHE_MAX` (decode CUDA-graph LRU cap, default 256).
+Env knobs: `FLASHRT_QWEN35MOE_PREFILL_CHUNK` (chunked-prefill block size,
+default 8192; 0 disables) and `FLASHRT_QWEN35MOE_GRAPH_CACHE_MAX` (decode
+CUDA-graph LRU cap, default 256). The older `FLASHRT_NEXN2_PREFILL_CHUNK` and
+`FLASHRT_NEXN2_GRAPH_CACHE_MAX` names remain compatible aliases.
 
 ## 5. Performance
 
@@ -185,8 +188,8 @@ logits that seed decode are stable:
   activations no longer bound it; the residual limit on a 32 GB card is the
   bf16 KV cache (~5.4 GB at 256k over the 10 full-attn layers) alongside the
   ~22 GB of weights. `generate()` auto-chunks; tune the block via
-  `FLASHRT_NEXN2_PREFILL_CHUNK` (default 8192; lower trades a little throughput
-  for headroom). The raw `infer()` path returns all-position logits and is a
-  separate single-pass validation tool, capped at ~4k by the `(S, 248320)`
-  logit tensor — use `generate()` for long context.
+  `FLASHRT_QWEN35MOE_PREFILL_CHUNK` (default 8192; lower trades a little
+  throughput for headroom). The raw `infer()` path returns all-position logits
+  and is a separate single-pass validation tool, capped at ~4k by the
+  `(S, 248320)` logit tensor — use `generate()` for long context.
 * Text LLM only — not wired into the `load_model` / VLA `predict()` API.

--- a/docs/qwen36_moe_usage.md
+++ b/docs/qwen36_moe_usage.md
@@ -1,0 +1,162 @@
+# Qwen3.6-35B-A3B text inference
+
+FlashRT runs the language backbone from the official
+`Qwen/Qwen3.6-35B-A3B` BF16 checkpoint on an RTX 5090. The checkpoint uses the
+same `qwen3_5_moe` text architecture as Nex-N2-mini, so both models share the
+same weight loader, prefill, attention, MoE, recurrent-state, and CUDA Graph
+decode implementation.
+
+This entry is text-only. It does not load the vision tower and it validates but
+does not execute the checkpoint's MTP head. Image/video input and speculative
+decode are not part of this interface.
+
+## Requirements
+
+| | |
+|---|---|
+| Checkpoint | `Qwen/Qwen3.6-35B-A3B` BF16 safetensors |
+| Hardware | RTX 5090 / SM120 |
+| GPU memory | 32 GB |
+| Framework | PyTorch |
+| Runtime quantization | NVFP4 |
+| Build flag | `-DFLASHRT_ENABLE_QWEN35MOE=ON` |
+
+Configure and build the gated `qwen3_5_moe` kernels:
+
+```bash
+cmake -S . -B build -DFLASHRT_ENABLE_QWEN35MOE=ON
+cmake --build build -j
+pip install -e ".[torch]"
+```
+
+## Usage
+
+```python
+from flash_rt.frontends.torch.qwen36_moe_rtx import (
+    Qwen36MoeTextFrontendRtx,
+)
+
+frontend = Qwen36MoeTextFrontendRtx(
+    "/models/Qwen3.6-35B-A3B",
+    device="cuda:0",
+    max_seq=4096,
+    kernelized=True,
+    quant_scope="experts",
+)
+frontend.set_prompt("Explain why deterministic reductions matter.")
+token_ids = frontend.generate(max_new_tokens=64)
+print(frontend.tokenizer.decode(token_ids))
+```
+
+`set_prompt()` accepts already-rendered text. For chat requests, render the
+checkpoint's own template first:
+
+```python
+messages = [{"role": "user", "content": "Write a CUDA reduction checklist."}]
+prompt = frontend.tokenizer.apply_chat_template(
+    messages,
+    tokenize=False,
+    add_generation_prompt=True,
+)
+frontend.set_prompt(prompt)
+```
+
+The direct frontend is intentional. `flash_rt.load_model()` wraps VLA models
+with a `predict(images, ...)` API and therefore redirects
+`config="qwen36_moe"` to the class above.
+
+## Checkpoint contract
+
+Before allocating GPU memory, the frontend checks:
+
+- the exact 40-layer `qwen3_5_moe` text geometry;
+- the 30 linear-attention / 10 full-attention schedule;
+- all 693 text-backbone tensors consumed by the shared pipeline;
+- all 19 official MTP tensors;
+- every safetensors shard referenced by the index.
+
+Extra vision tensors are allowed and ignored by this text-only entry. The
+validation can be run without loading model weights:
+
+```bash
+PYTHONPATH=. python - <<'PY'
+from flash_rt.frontends.torch.qwen36_moe_rtx import (
+    validate_qwen36_moe_checkpoint,
+)
+print(validate_qwen36_moe_checkpoint("/models/Qwen3.6-35B-A3B"))
+PY
+```
+
+## Runtime controls
+
+The shared architecture uses:
+
+- `FLASHRT_QWEN35MOE_PREFILL_CHUNK` — chunked-prefill block size, default
+  `8192`; `0` disables chunking.
+- `FLASHRT_QWEN35MOE_GRAPH_CACHE_MAX` — decode CUDA Graph LRU capacity,
+  default `256`.
+
+The older `FLASHRT_NEXN2_PREFILL_CHUNK` and
+`FLASHRT_NEXN2_GRAPH_CACHE_MAX` names remain compatible aliases.
+
+## Validation
+
+The repository smoke test is checkpoint-independent:
+
+```bash
+PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+  pytest -q -p no:cacheprovider tests/test_qwen36_moe_smoke.py
+```
+
+Set `FLASHRT_QWEN36_MOE_CKPT_DIR` to include the official checkpoint contract
+test. Performance and precision numbers must be measured on Qwen3.6 weights;
+Nex-N2-mini measurements are not interchangeable even though the compute
+pipeline is shared.
+
+The optional real-model test loads the checkpoint, checks finite logits, and
+compares cold and warm CUDA Graph generation with an official Transformers
+BF16 greedy-token fixture:
+
+```bash
+FLASHRT_QWEN36_MOE_CKPT_DIR=/models/Qwen3.6-35B-A3B \
+PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+pytest -q -p no:cacheprovider tests/test_qwen36_moe_gpu.py
+```
+
+First-light data on an RTX 5090, PyTorch 2.9.1, CUDA 12.8 runtime, and the
+official BF16 checkpoint:
+
+| Measurement | Result |
+|---|---:|
+| Runtime weight load | 47.96 s |
+| Resident allocated memory after load | 21.44 GiB |
+| Peak allocated memory during load | 22.94 GiB |
+| First 21-token prefill, including warmup | 230.95 ms |
+| Subsequent 20–45-token prefill | 28.99–35.12 ms |
+| 64-token prompt, 32-token eager decode | 48.14 tok/s |
+| 64-token prompt, 32-token warm CUDA Graph decode | 195.49 tok/s |
+
+The eager, first-capture, and warm-graph runs produced the same 32 token IDs.
+These numbers are a first-light correctness run, not a context-length sweep.
+
+Four chat prompts from 12 to 45 tokens were also compared with the official
+Transformers BF16 implementation:
+
+| Precision check | Result |
+|---|---:|
+| Last-token logit cosine, minimum | 0.95635 |
+| Last-token logit cosine, mean | 0.96455 |
+| First-token argmax matches | 4 / 4 |
+| Greedy generation matches | 64 / 64 tokens |
+
+The logit cosine is lower than the Nex-N2-mini measurement, but the tested
+greedy sequences were token-exact for 16 generated tokens on all four prompts.
+
+## Limitations
+
+- Text only; the vision tower is not loaded.
+- Greedy decode only on the kernelized path.
+- The MTP tensors are validated but not loaded, so speculative decode is not
+  enabled.
+- Only the BF16 source checkpoint with runtime NVFP4 conversion is supported.
+- SM120 only.

--- a/docs/qwen36_moe_usage.md
+++ b/docs/qwen36_moe_usage.md
@@ -19,12 +19,14 @@ decode are not part of this interface.
 | GPU memory | 32 GB |
 | Framework | PyTorch |
 | Runtime quantization | NVFP4 |
-| Build flag | `-DFLASHRT_ENABLE_QWEN35MOE=ON` |
+| Build flags | `-DGPU_ARCH=120 -DFLASHRT_ENABLE_QWEN35MOE=ON` |
 
 Configure and build the gated `qwen3_5_moe` kernels:
 
 ```bash
-cmake -S . -B build -DFLASHRT_ENABLE_QWEN35MOE=ON
+cmake -S . -B build \
+  -DGPU_ARCH=120 \
+  -DFLASHRT_ENABLE_QWEN35MOE=ON
 cmake --build build -j
 pip install -e ".[torch]"
 ```
@@ -40,7 +42,6 @@ frontend = Qwen36MoeTextFrontendRtx(
     "/models/Qwen3.6-35B-A3B",
     device="cuda:0",
     max_seq=4096,
-    kernelized=True,
     quant_scope="experts",
 )
 frontend.set_prompt("Explain why deterministic reductions matter.")
@@ -65,14 +66,22 @@ The direct frontend is intentional. `flash_rt.load_model()` wraps VLA models
 with a `predict(images, ...)` API and therefore redirects
 `config="qwen36_moe"` to the class above.
 
+The frontend defaults to `kernelized=True`. Setting `kernelized=False` is
+rejected because it would select the parent Transformers reference path, which
+loads the complete multimodal BF16 model rather than this text-only NVFP4
+runtime.
+
 ## Checkpoint contract
 
 Before allocating GPU memory, the frontend checks:
 
-- the exact 40-layer `qwen3_5_moe` text geometry;
+- the exact 40-layer `qwen3_5_moe` text geometry, including MoE widths,
+  convolution width, gated attention, normalization epsilon, and RoPE
+  parameters;
 - the 30 linear-attention / 10 full-attention schedule;
-- all 693 text-backbone tensors consumed by the shared pipeline;
-- all 19 official MTP tensors;
+- the exact shapes of all 693 text-backbone tensors consumed by the shared
+  pipeline;
+- the exact shapes of all 19 official MTP tensors;
 - every safetensors shard referenced by the index.
 
 Extra vision tensors are allowed and ignored by this text-only entry. The
@@ -113,9 +122,10 @@ test. Performance and precision numbers must be measured on Qwen3.6 weights;
 Nex-N2-mini measurements are not interchangeable even though the compute
 pipeline is shared.
 
-The optional real-model test loads the checkpoint, checks finite logits, and
-compares cold and warm CUDA Graph generation with an official Transformers
-BF16 greedy-token fixture:
+The optional GPU suite checks the shared weighted-sum reducer against the
+former Torch reduction, repeats it eagerly and through CUDA Graph replay, then
+loads the checkpoint, checks finite logits, and compares cold and warm CUDA
+Graph generation with an official Transformers BF16 greedy-token fixture:
 
 ```bash
 FLASHRT_QWEN36_MOE_CKPT_DIR=/models/Qwen3.6-35B-A3B \
@@ -155,7 +165,8 @@ greedy sequences were token-exact for 16 generated tokens on all four prompts.
 ## Limitations
 
 - Text only; the vision tower is not loaded.
-- Greedy decode only on the kernelized path.
+- The kernelized runtime NVFP4 path is required.
+- Greedy decode only.
 - The MTP tensors are validated but not loaded, so speculative decode is not
   enabled.
 - Only the BF16 source checkpoint with runtime NVFP4 conversion is supported.

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -456,11 +456,12 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 "Supported: pi0, pi05, llm, mllm")
     elif config not in ("pi05", "groot", "groot_n17", "pi0", "pi0fast",
                       "motus", "wan22_ti2v_5b", "cosmos3_video",
-                      "cosmos3_edge", "nexn2"):
+                      "cosmos3_edge", "nexn2", "qwen36_moe"):
         raise ValueError(
             f"Unknown config: {config}. "
             f"Supported: pi05, groot, groot_n17, pi0, pi0fast, motus, "
-            f"wan22_ti2v_5b, cosmos3_video, cosmos3_edge, nexn2")
+            f"wan22_ti2v_5b, cosmos3_video, cosmos3_edge, nexn2, "
+            f"qwen36_moe")
     if framework not in ("torch", "jax", "jetson_pi"):
         raise ValueError(
             f"Unknown framework: {framework}. Supported: torch, jax, jetson_pi")
@@ -538,6 +539,13 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             "    from flash_rt.frontends.torch.nexn2_rtx import "
             "Nexn2TorchFrontendRtx\n"
             "See docs/nexn2_usage.md.")
+    if config == "qwen36_moe":
+        raise NotImplementedError(
+            "config='qwen36_moe' is a text LLM and is not served through "
+            "load_model's VLA wrapper. Construct it directly:\n"
+            "    from flash_rt.frontends.torch.qwen36_moe_rtx import "
+            "Qwen36MoeTextFrontendRtx\n"
+            "See docs/qwen36_moe_usage.md.")
 
     from flash_rt.hardware import detect_arch, resolve_pipeline_class
     arch = detect_arch() if hardware == "auto" else hardware

--- a/flash_rt/frontends/torch/_nexn2_rtx_decode.py
+++ b/flash_rt/frontends/torch/_nexn2_rtx_decode.py
@@ -34,6 +34,13 @@ from flash_rt.frontends.torch._nexn2_rtx_forward import (
 from flash_rt.frontends.torch._nexn2_rtx_nvfp4_weights import _sf_swz_bytes
 from flash_rt.hardware.rtx.attn_backend_nexn2 import RtxFlashAttnBackendNexn2
 
+
+def _qwen35moe_env(name: str, default: str) -> str:
+    generic = f"FLASHRT_QWEN35MOE_{name}"
+    legacy = f"FLASHRT_NEXN2_{name}"
+    return os.environ.get(generic, os.environ.get(legacy, default))
+
+
 # Prompt length at/above which the batched prefill wins over the per-token loop
 # (batched has a fixed forward overhead; below this the loop's lower latency
 # wins). See Nexn2DecodeState.batched_prefill.
@@ -222,7 +229,7 @@ class Nexn2DecodeState:
         # used pos once over the cap; 0/negative disables the bound (legacy).
         self._graphs = collections.OrderedDict()
         self.graph_cache_max = int(
-            os.environ.get('FLASHRT_NEXN2_GRAPH_CACHE_MAX', '256'))
+            _qwen35moe_env("GRAPH_CACHE_MAX", "256"))
         self._snap_lin = [torch.empty_like(t) for t in self.lin_state]
         self._snap_conv = [torch.empty_like(t) for t in self.lin_conv_state]
         # Pre-allocated KV snapshot rows (one [.,1,.] slice each) reused every
@@ -265,7 +272,7 @@ class Nexn2DecodeState:
         # the ~16k single-pass ceiling on a 32 GB card. A multiple of the WY
         # chunk (64). 0 disables (always single-pass).
         self.prefill_chunk = int(
-            os.environ.get('FLASHRT_NEXN2_PREFILL_CHUNK', '8192'))
+            _qwen35moe_env("PREFILL_CHUNK", "8192"))
 
     def reset(self):
         for s in self.lin_state:
@@ -465,7 +472,18 @@ def _moe_layer_decode(h, ld, state, fvk, device):
         inter.data_ptr(), dn_p.data_ptr(), dn_s.data_ptr(), dn_a.data_ptr(),
         idx.data_ptr(), d_dn.data_ptr(), TOPK, n_dn, INTER,
         INTER, dn_p[0].numel(), dn_s[0].numel(), s)
-    out = (tw_row.float() @ d_dn.float()).unsqueeze(0)   # (1, n_dn) weighted sum
+    # Fixed-order weighted sum. The generic torch matmul may choose a
+    # reduction whose accumulation order changes between launches, which can
+    # flip a later greedy decision when two logits are nearly tied.
+    if 'decode_topk_rows' not in ld:
+        ld['decode_topk_rows'] = torch.arange(
+            TOPK, dtype=torch.int32, device=device)
+    out = torch.empty(n_dn, dtype=torch.float32, device=device)
+    fvk.moe_weighted_sum_sm120_bf16(
+        d_dn.data_ptr(), ld['decode_topk_rows'].data_ptr(),
+        tw_row.data_ptr(), out.data_ptr(),
+        1, TOPK, n_dn, n_dn, s)
+    out = out.unsqueeze(0)
 
     if fused_rs:                                      # already projected above
         sg, su = sg_f, su_f

--- a/flash_rt/frontends/torch/_nexn2_rtx_nvfp4_weights.py
+++ b/flash_rt/frontends/torch/_nexn2_rtx_nvfp4_weights.py
@@ -57,7 +57,8 @@ def _open_shards(ckpt_dir: str):
     idx_path = os.path.join(ckpt_dir, 'model.safetensors.index.json')
     if not os.path.isfile(idx_path):
         raise RuntimeError(
-            f'Nex-N2 ckpt missing model.safetensors.index.json: {ckpt_dir!r}')
+            'qwen3_5_moe checkpoint missing '
+            f'model.safetensors.index.json: {ckpt_dir!r}')
     wmap = json.load(open(idx_path))['weight_map']
     handles_d = {}
     for shard in set(wmap.values()):

--- a/flash_rt/frontends/torch/nexn2_rtx.py
+++ b/flash_rt/frontends/torch/nexn2_rtx.py
@@ -34,22 +34,25 @@ _REQUIRED_FVK = (
 )
 
 
-def _require_kernels(fvk) -> None:
+def _require_kernels(
+        fvk, *, model_label: str = "Nex-N2",
+        usage_doc: str = "docs/nexn2_usage.md") -> None:
     """Raise a clear RuntimeError if the gated qwen3_5_moe kernels or the FA2
     module are missing (build was not configured with
     -DFLASHRT_ENABLE_QWEN35MOE=ON, or flash_rt_fa2 is absent)."""
     missing = [s for s in _REQUIRED_FVK if not hasattr(fvk, s)]
     if missing:
         raise RuntimeError(
-            "Nex-N2 kernelized path needs the qwen3_5_moe SM120 kernels, which "
+            f"{model_label} kernelized path needs the qwen3_5_moe SM120 "
+            "kernels, which "
             "are absent from flash_rt_kernels (missing: "
             f"{', '.join(missing)}). Rebuild on an SM120 toolchain with "
-            "-DFLASHRT_ENABLE_QWEN35MOE=ON. See docs/nexn2_usage.md.")
+            f"-DFLASHRT_ENABLE_QWEN35MOE=ON. See {usage_doc}.")
     try:
         from flash_rt import flash_rt_fa2 as _fa2
     except Exception as e:                                  # pragma: no cover
         raise RuntimeError(
-            "Nex-N2 full attention needs the vendored FA2 module "
+            f"{model_label} full attention needs the vendored FA2 module "
             "(flash_rt_fa2), which failed to import. Build with FA2 enabled "
             "(ENABLE_FA2, auto-on for SM120).") from e
     fa2_missing = [s for s in ('fwd_bf16', 'fwd_bf16_causal')
@@ -63,6 +66,9 @@ def _require_kernels(fvk) -> None:
 
 class Nexn2TorchFrontendRtx:
     """Nex-N2-mini inference frontend (PyTorch + RTX SM120)."""
+
+    _MODEL_LABEL = "Nex-N2"
+    _USAGE_DOC = "docs/nexn2_usage.md"
 
     def __init__(self, checkpoint_path: str, *,
                  device: str = 'cuda:0',
@@ -148,7 +154,12 @@ class Nexn2TorchFrontendRtx:
             extract_weights_nexn2_nvfp4,
         )
 
-        _require_kernels(fvk)            # fail fast before loading the 35B ckpt
+        # Fail before loading the 35B checkpoint.
+        _require_kernels(
+            fvk,
+            model_label=self._MODEL_LABEL,
+            usage_doc=self._USAGE_DOC,
+        )
 
         self._tokenizer = AutoTokenizer.from_pretrained(self.checkpoint_path)
         self._fvk = fvk

--- a/flash_rt/frontends/torch/qwen36_moe_rtx.py
+++ b/flash_rt/frontends/torch/qwen36_moe_rtx.py
@@ -1,0 +1,255 @@
+"""Qwen3.6-35B-A3B text inference on RTX SM120.
+
+The language backbone is the same ``qwen3_5_moe`` architecture used by
+Nex-N2-mini, so this frontend reuses that implementation.  The official
+Qwen3.6 checkpoint also contains a vision tower and an MTP head; this entry
+validates those weights but intentionally exposes only text prefill and greedy
+decode.  Vision and speculative decoding are separate integration surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from flash_rt.frontends.torch.nexn2_rtx import Nexn2TorchFrontendRtx
+
+
+_EXPECTED_LAYER_TYPES = tuple(
+    "full_attention" if (i + 1) % 4 == 0 else "linear_attention"
+    for i in range(40)
+)
+
+_EXPECTED_TEXT_CONFIG = {
+    "model_type": "qwen3_5_moe_text",
+    "num_hidden_layers": 40,
+    "hidden_size": 2048,
+    "vocab_size": 248320,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 2,
+    "head_dim": 256,
+    "num_experts": 256,
+    "num_experts_per_tok": 8,
+    "linear_num_key_heads": 16,
+    "linear_num_value_heads": 32,
+    "linear_key_head_dim": 128,
+    "linear_value_head_dim": 128,
+    "full_attention_interval": 4,
+    "mtp_num_hidden_layers": 1,
+}
+
+_MTP_KEYS = {
+    "mtp.fc.weight",
+    "mtp.norm.weight",
+    "mtp.pre_fc_norm_embedding.weight",
+    "mtp.pre_fc_norm_hidden.weight",
+    "mtp.layers.0.input_layernorm.weight",
+    "mtp.layers.0.post_attention_layernorm.weight",
+    "mtp.layers.0.self_attn.q_proj.weight",
+    "mtp.layers.0.self_attn.k_proj.weight",
+    "mtp.layers.0.self_attn.v_proj.weight",
+    "mtp.layers.0.self_attn.o_proj.weight",
+    "mtp.layers.0.self_attn.q_norm.weight",
+    "mtp.layers.0.self_attn.k_norm.weight",
+    "mtp.layers.0.mlp.gate.weight",
+    "mtp.layers.0.mlp.experts.gate_up_proj",
+    "mtp.layers.0.mlp.experts.down_proj",
+    "mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+    "mtp.layers.0.mlp.shared_expert.up_proj.weight",
+    "mtp.layers.0.mlp.shared_expert.down_proj.weight",
+    "mtp.layers.0.mlp.shared_expert_gate.weight",
+}
+
+
+def _required_text_keys(layer_types: tuple[str, ...]) -> set[str]:
+    keys = {
+        "lm_head.weight",
+        "model.language_model.embed_tokens.weight",
+        "model.language_model.norm.weight",
+    }
+    mlp_suffixes = (
+        "mlp.gate.weight",
+        "mlp.experts.gate_up_proj",
+        "mlp.experts.down_proj",
+        "mlp.shared_expert.gate_proj.weight",
+        "mlp.shared_expert.up_proj.weight",
+        "mlp.shared_expert.down_proj.weight",
+        "mlp.shared_expert_gate.weight",
+    )
+    linear_suffixes = (
+        "linear_attn.in_proj_qkv.weight",
+        "linear_attn.in_proj_z.weight",
+        "linear_attn.in_proj_a.weight",
+        "linear_attn.in_proj_b.weight",
+        "linear_attn.conv1d.weight",
+        "linear_attn.A_log",
+        "linear_attn.dt_bias",
+        "linear_attn.norm.weight",
+        "linear_attn.out_proj.weight",
+    )
+    full_suffixes = (
+        "self_attn.q_proj.weight",
+        "self_attn.k_proj.weight",
+        "self_attn.v_proj.weight",
+        "self_attn.o_proj.weight",
+        "self_attn.q_norm.weight",
+        "self_attn.k_norm.weight",
+    )
+    for i, layer_type in enumerate(layer_types):
+        prefix = f"model.language_model.layers.{i}."
+        keys.add(prefix + "input_layernorm.weight")
+        keys.add(prefix + "post_attention_layernorm.weight")
+        keys.update(prefix + suffix for suffix in mlp_suffixes)
+        suffixes = (
+            full_suffixes
+            if layer_type == "full_attention"
+            else linear_suffixes
+        )
+        keys.update(prefix + suffix for suffix in suffixes)
+    return keys
+
+
+def validate_qwen36_moe_checkpoint(checkpoint_path: str) -> dict[str, Any]:
+    """Validate the official BF16 checkpoint before allocating GPU weights."""
+    checkpoint_path = os.path.abspath(os.fspath(checkpoint_path))
+    config_path = os.path.join(checkpoint_path, "config.json")
+    index_path = os.path.join(
+        checkpoint_path, "model.safetensors.index.json")
+
+    for path in (config_path, index_path):
+        if not os.path.isfile(path):
+            raise FileNotFoundError(
+                f"Qwen3.6-35B-A3B checkpoint is missing {path!r}")
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+    if config.get("model_type") != "qwen3_5_moe":
+        raise ValueError(
+            "Qwen3.6-35B-A3B text frontend requires "
+            "model_type='qwen3_5_moe'; "
+            f"got {config.get('model_type')!r} in {config_path}")
+
+    text_config = config.get("text_config")
+    if not isinstance(text_config, dict):
+        raise ValueError(f"missing text_config object in {config_path}")
+
+    mismatches = []
+    for name, expected in _EXPECTED_TEXT_CONFIG.items():
+        actual = text_config.get(name)
+        if actual != expected:
+            mismatches.append(f"{name}={actual!r} (expected {expected!r})")
+    layer_types = tuple(text_config.get("layer_types") or ())
+    if layer_types != _EXPECTED_LAYER_TYPES:
+        mismatches.append(
+            "layer_types does not match the 30-linear/10-full attention "
+            "qwen3_5_moe schedule")
+    if mismatches:
+        raise ValueError(
+            "checkpoint is not compatible with the Qwen3.6-35B-A3B "
+            "SM120 text pipeline: " + "; ".join(mismatches))
+
+    with open(index_path, "r", encoding="utf-8") as f:
+        index = json.load(f)
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict):
+        raise ValueError(f"missing weight_map object in {index_path}")
+
+    required_text = _required_text_keys(layer_types)
+    missing_text = sorted(required_text.difference(weight_map))
+    if missing_text:
+        preview = ", ".join(missing_text[:8])
+        if len(missing_text) > 8:
+            preview += f", ... ({len(missing_text)} missing)"
+        raise ValueError(
+            "Qwen3.6-35B-A3B checkpoint is missing text backbone tensors: "
+            + preview)
+
+    missing_mtp = sorted(_MTP_KEYS.difference(weight_map))
+    if missing_mtp:
+        preview = ", ".join(missing_mtp[:8])
+        if len(missing_mtp) > 8:
+            preview += f", ... ({len(missing_mtp)} missing)"
+        raise ValueError(
+            "Qwen3.6-35B-A3B checkpoint is missing its MTP tensor group: "
+            + preview)
+
+    shards = sorted(set(weight_map.values()))
+    bad_shards = []
+    for shard in shards:
+        path = os.path.join(checkpoint_path, shard)
+        if not os.path.isfile(path) or os.path.getsize(path) == 0:
+            bad_shards.append(shard)
+    if bad_shards:
+        preview = ", ".join(bad_shards[:8])
+        if len(bad_shards) > 8:
+            preview += f", ... ({len(bad_shards)} missing or empty)"
+        raise FileNotFoundError(
+            "Qwen3.6-35B-A3B checkpoint has missing or empty shards: "
+            + preview)
+
+    return {
+        "checkpoint_path": checkpoint_path,
+        "text_tensor_count": len(required_text),
+        "mtp_tensor_count": len(_MTP_KEYS),
+        "vision_tensor_count": sum(
+            ".visual." in name for name in weight_map),
+        "tensor_count": len(weight_map),
+        "shard_count": len(shards),
+    }
+
+
+class Qwen36MoeTextFrontendRtx(Nexn2TorchFrontendRtx):
+    """Qwen3.6-35B-A3B text-only frontend for RTX SM120."""
+
+    _MODEL_LABEL = "Qwen3.6-35B-A3B text"
+    _USAGE_DOC = "docs/qwen36_moe_usage.md"
+
+    def __init__(self, checkpoint_path: str, *,
+                 device: str = "cuda:0",
+                 max_seq: int = 2048,
+                 quant: str = "nvfp4",
+                 kernelized: bool = False,
+                 quant_scope: str = "experts") -> None:
+        if quant != "nvfp4":
+            raise NotImplementedError(
+                f"quant={quant!r} is not implemented; only 'nvfp4' is "
+                "supported")
+        contract = validate_qwen36_moe_checkpoint(checkpoint_path)
+        super().__init__(
+            checkpoint_path,
+            device=device,
+            max_seq=max_seq,
+            quant=quant,
+            kernelized=kernelized,
+            quant_scope=quant_scope,
+        )
+        self._checkpoint_contract = contract
+
+    def generate(self, max_new_tokens: int, *, do_sample: bool = False):
+        """Generate tokens with the shared qwen3_5_moe CUDA Graph path."""
+        if not self._kernelized:
+            return super().generate(
+                max_new_tokens=max_new_tokens, do_sample=do_sample)
+        if self._prompt_ids is None:
+            raise ValueError("call set_prompt(...) before generate()")
+        if do_sample:
+            raise NotImplementedError(
+                "the Qwen3.6-35B-A3B kernelized path supports greedy "
+                "decoding only")
+
+        from flash_rt.frontends.torch._nexn2_rtx_decode import (
+            Nexn2DecodeState,
+            generate_greedy_graph,
+        )
+
+        if self._decode_state is None:
+            self._decode_state = Nexn2DecodeState(
+                self._weights, self._user_max_seq, self.device)
+        return generate_greedy_graph(
+            self._decode_state,
+            self._prompt_ids,
+            max_new_tokens,
+            self._fvk,
+            self.device,
+        )

--- a/flash_rt/frontends/torch/qwen36_moe_rtx.py
+++ b/flash_rt/frontends/torch/qwen36_moe_rtx.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import ExitStack
 from typing import Any
 
 from flash_rt.frontends.torch.nexn2_rtx import Nexn2TorchFrontendRtx
@@ -29,85 +30,133 @@ _EXPECTED_TEXT_CONFIG = {
     "num_attention_heads": 16,
     "num_key_value_heads": 2,
     "head_dim": 256,
+    "attention_bias": False,
+    "attn_output_gate": True,
+    "hidden_act": "silu",
     "num_experts": 256,
     "num_experts_per_tok": 8,
+    "moe_intermediate_size": 512,
+    "shared_expert_intermediate_size": 512,
     "linear_num_key_heads": 16,
     "linear_num_value_heads": 32,
     "linear_key_head_dim": 128,
     "linear_value_head_dim": 128,
+    "linear_conv_kernel_dim": 4,
+    "mamba_ssm_dtype": "float32",
     "full_attention_interval": 4,
+    "partial_rotary_factor": 0.25,
+    "rms_norm_eps": 1e-6,
     "mtp_num_hidden_layers": 1,
+    "mtp_use_dedicated_embeddings": False,
+    "tie_word_embeddings": False,
 }
 
-_MTP_KEYS = {
-    "mtp.fc.weight",
-    "mtp.norm.weight",
-    "mtp.pre_fc_norm_embedding.weight",
-    "mtp.pre_fc_norm_hidden.weight",
-    "mtp.layers.0.input_layernorm.weight",
-    "mtp.layers.0.post_attention_layernorm.weight",
-    "mtp.layers.0.self_attn.q_proj.weight",
-    "mtp.layers.0.self_attn.k_proj.weight",
-    "mtp.layers.0.self_attn.v_proj.weight",
-    "mtp.layers.0.self_attn.o_proj.weight",
-    "mtp.layers.0.self_attn.q_norm.weight",
-    "mtp.layers.0.self_attn.k_norm.weight",
-    "mtp.layers.0.mlp.gate.weight",
-    "mtp.layers.0.mlp.experts.gate_up_proj",
-    "mtp.layers.0.mlp.experts.down_proj",
-    "mtp.layers.0.mlp.shared_expert.gate_proj.weight",
-    "mtp.layers.0.mlp.shared_expert.up_proj.weight",
-    "mtp.layers.0.mlp.shared_expert.down_proj.weight",
-    "mtp.layers.0.mlp.shared_expert_gate.weight",
+_EXPECTED_ROPE_PARAMETERS = {
+    "rope_type": "default",
+    "rope_theta": 10000000,
+    "partial_rotary_factor": 0.25,
+    "mrope_interleaved": True,
+    "mrope_section": [11, 11, 10],
 }
+
+
+def _expected_mlp_shapes(prefix: str) -> dict[str, tuple[int, ...]]:
+    return {
+        prefix + "mlp.gate.weight": (256, 2048),
+        prefix + "mlp.experts.gate_up_proj": (256, 1024, 2048),
+        prefix + "mlp.experts.down_proj": (256, 2048, 512),
+        prefix + "mlp.shared_expert.gate_proj.weight": (512, 2048),
+        prefix + "mlp.shared_expert.up_proj.weight": (512, 2048),
+        prefix + "mlp.shared_expert.down_proj.weight": (2048, 512),
+        prefix + "mlp.shared_expert_gate.weight": (1, 2048),
+    }
+
+
+def _expected_attention_shapes(
+        prefix: str, layer_type: str) -> dict[str, tuple[int, ...]]:
+    if layer_type == "full_attention":
+        return {
+            prefix + "self_attn.q_proj.weight": (8192, 2048),
+            prefix + "self_attn.k_proj.weight": (512, 2048),
+            prefix + "self_attn.v_proj.weight": (512, 2048),
+            prefix + "self_attn.o_proj.weight": (2048, 4096),
+            prefix + "self_attn.q_norm.weight": (256,),
+            prefix + "self_attn.k_norm.weight": (256,),
+        }
+    return {
+        prefix + "linear_attn.in_proj_qkv.weight": (8192, 2048),
+        prefix + "linear_attn.in_proj_z.weight": (4096, 2048),
+        prefix + "linear_attn.in_proj_a.weight": (32, 2048),
+        prefix + "linear_attn.in_proj_b.weight": (32, 2048),
+        prefix + "linear_attn.conv1d.weight": (8192, 1, 4),
+        prefix + "linear_attn.A_log": (32,),
+        prefix + "linear_attn.dt_bias": (32,),
+        prefix + "linear_attn.norm.weight": (128,),
+        prefix + "linear_attn.out_proj.weight": (2048, 4096),
+    }
+
+
+def _expected_text_shapes(
+        layer_types: tuple[str, ...]) -> dict[str, tuple[int, ...]]:
+    shapes = {
+        "lm_head.weight": (248320, 2048),
+        "model.language_model.embed_tokens.weight": (248320, 2048),
+        "model.language_model.norm.weight": (2048,),
+    }
+    for i, layer_type in enumerate(layer_types):
+        prefix = f"model.language_model.layers.{i}."
+        shapes[prefix + "input_layernorm.weight"] = (2048,)
+        shapes[prefix + "post_attention_layernorm.weight"] = (2048,)
+        shapes.update(_expected_mlp_shapes(prefix))
+        shapes.update(_expected_attention_shapes(prefix, layer_type))
+    return shapes
+
+
+def _expected_mtp_shapes() -> dict[str, tuple[int, ...]]:
+    prefix = "mtp.layers.0."
+    shapes = {
+        "mtp.fc.weight": (2048, 4096),
+        "mtp.norm.weight": (2048,),
+        "mtp.pre_fc_norm_embedding.weight": (2048,),
+        "mtp.pre_fc_norm_hidden.weight": (2048,),
+        prefix + "input_layernorm.weight": (2048,),
+        prefix + "post_attention_layernorm.weight": (2048,),
+    }
+    shapes.update(_expected_attention_shapes(prefix, "full_attention"))
+    shapes.update(_expected_mlp_shapes(prefix))
+    return shapes
+
+
+_MTP_KEYS = set(_expected_mtp_shapes())
 
 
 def _required_text_keys(layer_types: tuple[str, ...]) -> set[str]:
-    keys = {
-        "lm_head.weight",
-        "model.language_model.embed_tokens.weight",
-        "model.language_model.norm.weight",
-    }
-    mlp_suffixes = (
-        "mlp.gate.weight",
-        "mlp.experts.gate_up_proj",
-        "mlp.experts.down_proj",
-        "mlp.shared_expert.gate_proj.weight",
-        "mlp.shared_expert.up_proj.weight",
-        "mlp.shared_expert.down_proj.weight",
-        "mlp.shared_expert_gate.weight",
-    )
-    linear_suffixes = (
-        "linear_attn.in_proj_qkv.weight",
-        "linear_attn.in_proj_z.weight",
-        "linear_attn.in_proj_a.weight",
-        "linear_attn.in_proj_b.weight",
-        "linear_attn.conv1d.weight",
-        "linear_attn.A_log",
-        "linear_attn.dt_bias",
-        "linear_attn.norm.weight",
-        "linear_attn.out_proj.weight",
-    )
-    full_suffixes = (
-        "self_attn.q_proj.weight",
-        "self_attn.k_proj.weight",
-        "self_attn.v_proj.weight",
-        "self_attn.o_proj.weight",
-        "self_attn.q_norm.weight",
-        "self_attn.k_norm.weight",
-    )
-    for i, layer_type in enumerate(layer_types):
-        prefix = f"model.language_model.layers.{i}."
-        keys.add(prefix + "input_layernorm.weight")
-        keys.add(prefix + "post_attention_layernorm.weight")
-        keys.update(prefix + suffix for suffix in mlp_suffixes)
-        suffixes = (
-            full_suffixes
-            if layer_type == "full_attention"
-            else linear_suffixes
-        )
-        keys.update(prefix + suffix for suffix in suffixes)
-    return keys
+    return set(_expected_text_shapes(layer_types))
+
+
+def _read_tensor_shapes(
+        checkpoint_path: str,
+        weight_map: dict[str, str],
+        tensor_names: set[str],
+) -> dict[str, tuple[int, ...]]:
+    from safetensors import safe_open
+
+    shapes = {}
+    with ExitStack() as stack:
+        readers = {
+            shard: stack.enter_context(
+                safe_open(
+                    os.path.join(checkpoint_path, shard),
+                    framework="pt",
+                    device="cpu",
+                )
+            )
+            for shard in set(weight_map[name] for name in tensor_names)
+        }
+        for name in tensor_names:
+            shapes[name] = tuple(
+                readers[weight_map[name]].get_slice(name).get_shape())
+    return shapes
 
 
 def validate_qwen36_moe_checkpoint(checkpoint_path: str) -> dict[str, Any]:
@@ -139,6 +188,17 @@ def validate_qwen36_moe_checkpoint(checkpoint_path: str) -> dict[str, Any]:
         actual = text_config.get(name)
         if actual != expected:
             mismatches.append(f"{name}={actual!r} (expected {expected!r})")
+    rope_parameters = text_config.get("rope_parameters")
+    if not isinstance(rope_parameters, dict):
+        mismatches.append(
+            "rope_parameters is missing or is not an object")
+    else:
+        for name, expected in _EXPECTED_ROPE_PARAMETERS.items():
+            actual = rope_parameters.get(name)
+            if actual != expected:
+                mismatches.append(
+                    f"rope_parameters.{name}={actual!r} "
+                    f"(expected {expected!r})")
     layer_types = tuple(text_config.get("layer_types") or ())
     if layer_types != _EXPECTED_LAYER_TYPES:
         mismatches.append(
@@ -188,6 +248,23 @@ def validate_qwen36_moe_checkpoint(checkpoint_path: str) -> dict[str, Any]:
             "Qwen3.6-35B-A3B checkpoint has missing or empty shards: "
             + preview)
 
+    expected_shapes = _expected_text_shapes(layer_types)
+    expected_shapes.update(_expected_mtp_shapes())
+    actual_shapes = _read_tensor_shapes(
+        checkpoint_path, weight_map, set(expected_shapes))
+    shape_mismatches = [
+        f"{name}={actual_shapes[name]!r} (expected {expected!r})"
+        for name, expected in sorted(expected_shapes.items())
+        if actual_shapes[name] != expected
+    ]
+    if shape_mismatches:
+        preview = "; ".join(shape_mismatches[:8])
+        if len(shape_mismatches) > 8:
+            preview += f"; ... ({len(shape_mismatches)} mismatched)"
+        raise ValueError(
+            "Qwen3.6-35B-A3B checkpoint tensor shape mismatches: "
+            + preview)
+
     return {
         "checkpoint_path": checkpoint_path,
         "text_tensor_count": len(required_text),
@@ -209,12 +286,16 @@ class Qwen36MoeTextFrontendRtx(Nexn2TorchFrontendRtx):
                  device: str = "cuda:0",
                  max_seq: int = 2048,
                  quant: str = "nvfp4",
-                 kernelized: bool = False,
+                 kernelized: bool = True,
                  quant_scope: str = "experts") -> None:
         if quant != "nvfp4":
             raise NotImplementedError(
                 f"quant={quant!r} is not implemented; only 'nvfp4' is "
                 "supported")
+        if not kernelized:
+            raise NotImplementedError(
+                "Qwen3.6-35B-A3B text only supports kernelized=True with "
+                "runtime NVFP4 conversion")
         contract = validate_qwen36_moe_checkpoint(checkpoint_path)
         super().__init__(
             checkpoint_path,
@@ -228,9 +309,6 @@ class Qwen36MoeTextFrontendRtx(Nexn2TorchFrontendRtx):
 
     def generate(self, max_new_tokens: int, *, do_sample: bool = False):
         """Generate tokens with the shared qwen3_5_moe CUDA Graph path."""
-        if not self._kernelized:
-            return super().generate(
-                max_new_tokens=max_new_tokens, do_sample=do_sample)
         if self._prompt_ids is None:
             raise ValueError("call set_prompt(...) before generate()")
         if do_sample:

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -156,10 +156,13 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     # (-DFLASHRT_ENABLE_QWEN35MOE=ON). Registered here for discoverability /
     # resolve_pipeline_class, but the frontend exposes an LLM surface
     # (infer()->logits, generate_greedy) rather than the VLA predict(images)
-    # API, so it is used via direct instantiation of Nexn2TorchFrontendRtx
-    # (see docs/nexn2_usage.md) rather than load_model's VLAModel wrapper.
+    # API, so these are used via direct frontend construction rather than
+    # load_model's VLAModel wrapper.
     ("nexn2", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.nexn2_rtx", "Nexn2TorchFrontendRtx"),
+    ("qwen36_moe", "torch", "rtx_sm120"):
+        ("flash_rt.frontends.torch.qwen36_moe_rtx",
+         "Qwen36MoeTextFrontendRtx"),
 
     # ── Pi0-FAST ── (SM120 runtime fork inside pipeline, no AttentionBackend protocol.)
     ("pi0fast", "torch", "thor"):

--- a/tests/test_qwen36_moe_gpu.py
+++ b/tests/test_qwen36_moe_gpu.py
@@ -1,0 +1,69 @@
+"""Optional first-light test for Qwen3.6-35B-A3B on SM120.
+
+Run with:
+
+    FLASHRT_QWEN36_MOE_CKPT_DIR=/models/Qwen3.6-35B-A3B \
+    PYTHONPATH=. pytest -q tests/test_qwen36_moe_gpu.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+CKPT = os.environ.get("FLASHRT_QWEN36_MOE_CKPT_DIR")
+
+pytestmark = pytest.mark.skipif(
+    not CKPT,
+    reason="set FLASHRT_QWEN36_MOE_CKPT_DIR for the real-model test",
+)
+
+
+def test_qwen36_moe_first_light_matches_hf_golden():
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    if torch.cuda.get_device_capability() != (12, 0):
+        pytest.skip("the kernelized qwen3_5_moe path requires SM120")
+
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        Qwen36MoeTextFrontendRtx,
+    )
+
+    frontend = Qwen36MoeTextFrontendRtx(
+        CKPT,
+        device="cuda:0",
+        max_seq=128,
+        kernelized=True,
+        quant_scope="experts",
+    )
+    messages = [{
+        "role": "user",
+        "content": "Write a Python function that merges two sorted lists.",
+    }]
+    prompt = frontend.tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    frontend.set_prompt(prompt)
+
+    with torch.no_grad():
+        logits = frontend.infer()
+    assert logits.shape == (1, 20, 248320)
+    assert torch.isfinite(logits).all()
+
+    # Official Transformers BF16 greedy output for the prompt above.
+    golden = [
+        8160, 579, 264, 7047, 1817, 25, 271, 16,
+        13, 220, 2972, 15771, 2598, 279, 2570, 5952,
+    ]
+    with torch.no_grad():
+        generations = [
+            frontend.generate(max_new_tokens=len(golden))
+            for _ in range(8)
+        ]
+    assert generations == [golden] * len(generations)

--- a/tests/test_qwen36_moe_gpu.py
+++ b/tests/test_qwen36_moe_gpu.py
@@ -8,6 +8,7 @@ Run with:
 
 from __future__ import annotations
 
+import importlib
 import os
 
 import pytest
@@ -15,19 +16,93 @@ import pytest
 
 CKPT = os.environ.get("FLASHRT_QWEN36_MOE_CKPT_DIR")
 
-pytestmark = pytest.mark.skipif(
-    not CKPT,
-    reason="set FLASHRT_QWEN36_MOE_CKPT_DIR for the real-model test",
-)
 
-
-def test_qwen36_moe_first_light_matches_hf_golden():
+def _require_sm120():
     import torch
 
     if not torch.cuda.is_available():
         pytest.skip("CUDA is unavailable")
     if torch.cuda.get_device_capability() != (12, 0):
         pytest.skip("the kernelized qwen3_5_moe path requires SM120")
+    try:
+        kernels = importlib.import_module("flash_rt.flash_rt_kernels")
+    except ImportError as exc:
+        pytest.skip(f"FlashRT CUDA extension is unavailable: {exc}")
+    if not hasattr(kernels, "moe_weighted_sum_sm120_bf16"):
+        pytest.skip("FlashRT was built without qwen3_5_moe kernels")
+    return torch, kernels
+
+
+def _weighted_sum(kernels, d_dn, rows, weights, out):
+    import torch
+
+    status = kernels.moe_weighted_sum_sm120_bf16(
+        d_dn.data_ptr(),
+        rows.data_ptr(),
+        weights.data_ptr(),
+        out.data_ptr(),
+        1,
+        weights.numel(),
+        d_dn.shape[1],
+        d_dn.shape[1],
+        torch.cuda.current_stream().cuda_stream,
+    )
+    assert status == 0
+
+
+def test_qwen35moe_weighted_sum_is_graph_deterministic():
+    torch, kernels = _require_sm120()
+
+    generator = torch.Generator(device="cuda").manual_seed(7)
+    d_dn = torch.randn(
+        8, 2048, dtype=torch.bfloat16, device="cuda",
+        generator=generator)
+    rows = torch.arange(8, dtype=torch.int32, device="cuda")
+    weights = torch.softmax(
+        torch.randn(8, dtype=torch.float32, device="cuda",
+                    generator=generator),
+        dim=0,
+    ).contiguous()
+    reference = weights @ d_dn.float()
+    out = torch.empty(2048, dtype=torch.float32, device="cuda")
+
+    _weighted_sum(kernels, d_dn, rows, weights, out)
+    torch.cuda.synchronize()
+    assert torch.isfinite(out).all()
+    assert (out - reference).abs().max().item() <= 5e-7
+
+    eager_results = []
+    for _ in range(20):
+        _weighted_sum(kernels, d_dn, rows, weights, out)
+        eager_results.append(out.clone())
+    torch.cuda.synchronize()
+    assert all(torch.equal(eager_results[0], result)
+               for result in eager_results[1:])
+
+    graph_out = torch.empty_like(out)
+    _weighted_sum(kernels, d_dn, rows, weights, graph_out)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _weighted_sum(kernels, d_dn, rows, weights, graph_out)
+
+    graph_results = []
+    for _ in range(20):
+        graph.replay()
+        graph_results.append(graph_out.clone())
+    torch.cuda.synchronize()
+    assert torch.isfinite(graph_results[0]).all()
+    assert all(torch.equal(graph_results[0], result)
+               for result in graph_results[1:])
+    assert torch.equal(graph_results[0], eager_results[0])
+
+
+@pytest.mark.skipif(
+    not CKPT,
+    reason="set FLASHRT_QWEN36_MOE_CKPT_DIR for the real-model test",
+)
+def test_qwen36_moe_first_light_matches_hf_golden():
+    torch, _ = _require_sm120()
 
     from flash_rt.frontends.torch.qwen36_moe_rtx import (
         Qwen36MoeTextFrontendRtx,

--- a/tests/test_qwen36_moe_smoke.py
+++ b/tests/test_qwen36_moe_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 
@@ -23,14 +24,32 @@ def _config():
             "num_attention_heads": 16,
             "num_key_value_heads": 2,
             "head_dim": 256,
+            "attention_bias": False,
+            "attn_output_gate": True,
+            "hidden_act": "silu",
             "num_experts": 256,
             "num_experts_per_tok": 8,
+            "moe_intermediate_size": 512,
+            "shared_expert_intermediate_size": 512,
             "linear_num_key_heads": 16,
             "linear_num_value_heads": 32,
             "linear_key_head_dim": 128,
             "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "mamba_ssm_dtype": "float32",
             "full_attention_interval": 4,
+            "partial_rotary_factor": 0.25,
+            "rms_norm_eps": 1e-6,
             "mtp_num_hidden_layers": 1,
+            "mtp_use_dedicated_embeddings": False,
+            "tie_word_embeddings": False,
+            "rope_parameters": {
+                "rope_type": "default",
+                "rope_theta": 10000000,
+                "partial_rotary_factor": 0.25,
+                "mrope_interleaved": True,
+                "mrope_section": [11, 11, 10],
+            },
             "layer_types": layer_types,
         },
     }
@@ -56,6 +75,22 @@ def _checkpoint(tmp_path):
     return tmp_path
 
 
+def _mock_checkpoint_shapes(monkeypatch, overrides=None):
+    from flash_rt.frontends.torch import qwen36_moe_rtx
+
+    shapes = qwen36_moe_rtx._expected_text_shapes(
+        qwen36_moe_rtx._EXPECTED_LAYER_TYPES)
+    shapes.update(qwen36_moe_rtx._expected_mtp_shapes())
+    shapes.update(overrides or {})
+    monkeypatch.setattr(
+        qwen36_moe_rtx,
+        "_read_tensor_shapes",
+        lambda checkpoint_path, weight_map, tensor_names: {
+            name: shapes[name] for name in tensor_names
+        },
+    )
+
+
 def test_frontend_is_a_thin_qwen_entry():
     from flash_rt.frontends.torch.nexn2_rtx import Nexn2TorchFrontendRtx
     from flash_rt.frontends.torch.qwen36_moe_rtx import (
@@ -65,6 +100,8 @@ def test_frontend_is_a_thin_qwen_entry():
     assert issubclass(Qwen36MoeTextFrontendRtx, Nexn2TorchFrontendRtx)
     assert Qwen36MoeTextFrontendRtx._MODEL_LABEL == (
         "Qwen3.6-35B-A3B text")
+    assert inspect.signature(
+        Qwen36MoeTextFrontendRtx).parameters["kernelized"].default is True
 
 
 def test_registry_resolves_qwen36_moe():
@@ -97,11 +134,21 @@ def test_constructor_rejects_quant_before_checkpoint_access():
         Qwen36MoeTextFrontendRtx("/nonexistent", quant="fp8")
 
 
-def test_checkpoint_contract_accepts_complete_layout(tmp_path):
+def test_constructor_rejects_reference_path_before_checkpoint_access():
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        Qwen36MoeTextFrontendRtx,
+    )
+
+    with pytest.raises(NotImplementedError, match="kernelized=True"):
+        Qwen36MoeTextFrontendRtx("/nonexistent", kernelized=False)
+
+
+def test_checkpoint_contract_accepts_complete_layout(tmp_path, monkeypatch):
     from flash_rt.frontends.torch.qwen36_moe_rtx import (
         validate_qwen36_moe_checkpoint,
     )
 
+    _mock_checkpoint_shapes(monkeypatch)
     result = validate_qwen36_moe_checkpoint(str(_checkpoint(tmp_path)))
     assert result["text_tensor_count"] == 693
     assert result["mtp_tensor_count"] == 19
@@ -109,7 +156,28 @@ def test_checkpoint_contract_accepts_complete_layout(tmp_path):
     assert result["shard_count"] == 1
 
 
-def test_checkpoint_contract_rejects_wrong_geometry(tmp_path):
+@pytest.mark.parametrize(
+    ("path", "invalid", "message"),
+    [
+        (("moe_intermediate_size",), 1024, "moe_intermediate_size=1024"),
+        (
+            ("shared_expert_intermediate_size",),
+            1024,
+            "shared_expert_intermediate_size=1024",
+        ),
+        (("linear_conv_kernel_dim",), 3, "linear_conv_kernel_dim=3"),
+        (("partial_rotary_factor",), 0.5, "partial_rotary_factor=0.5"),
+        (("rms_norm_eps",), 1e-5, "rms_norm_eps=1e-05"),
+        (("attn_output_gate",), False, "attn_output_gate=False"),
+        (
+            ("rope_parameters", "rope_theta"),
+            10000,
+            "rope_parameters.rope_theta=10000",
+        ),
+    ],
+)
+def test_checkpoint_contract_rejects_wrong_geometry(
+        tmp_path, path, invalid, message):
     from flash_rt.frontends.torch.qwen36_moe_rtx import (
         validate_qwen36_moe_checkpoint,
     )
@@ -117,10 +185,13 @@ def test_checkpoint_contract_rejects_wrong_geometry(tmp_path):
     checkpoint = _checkpoint(tmp_path)
     config_path = checkpoint / "config.json"
     config = json.loads(config_path.read_text(encoding="utf-8"))
-    config["text_config"]["num_experts"] = 128
+    target = config["text_config"]
+    for name in path[:-1]:
+        target = target[name]
+    target[path[-1]] = invalid
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
-    with pytest.raises(ValueError, match="num_experts=128"):
+    with pytest.raises(ValueError, match=message):
         validate_qwen36_moe_checkpoint(str(checkpoint))
 
 
@@ -164,6 +235,19 @@ def test_checkpoint_contract_rejects_missing_shard(tmp_path):
 
     with pytest.raises(FileNotFoundError, match="missing or empty shards"):
         validate_qwen36_moe_checkpoint(str(checkpoint))
+
+
+def test_checkpoint_contract_rejects_wrong_tensor_shape(
+        tmp_path, monkeypatch):
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        validate_qwen36_moe_checkpoint,
+    )
+
+    name = "model.language_model.layers.0.linear_attn.conv1d.weight"
+    _mock_checkpoint_shapes(monkeypatch, {name: (8192, 1, 3)})
+
+    with pytest.raises(ValueError, match=r"conv1d\.weight=.*8192, 1, 3"):
+        validate_qwen36_moe_checkpoint(str(_checkpoint(tmp_path)))
 
 
 def test_generic_env_names_precede_legacy_aliases(monkeypatch):

--- a/tests/test_qwen36_moe_smoke.py
+++ b/tests/test_qwen36_moe_smoke.py
@@ -1,0 +1,235 @@
+"""Smoke tests for the Qwen3.6-35B-A3B text frontend."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+
+def _config():
+    layer_types = [
+        "full_attention" if (i + 1) % 4 == 0 else "linear_attention"
+        for i in range(40)
+    ]
+    return {
+        "model_type": "qwen3_5_moe",
+        "text_config": {
+            "model_type": "qwen3_5_moe_text",
+            "num_hidden_layers": 40,
+            "hidden_size": 2048,
+            "vocab_size": 248320,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 2,
+            "head_dim": 256,
+            "num_experts": 256,
+            "num_experts_per_tok": 8,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 32,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "full_attention_interval": 4,
+            "mtp_num_hidden_layers": 1,
+            "layer_types": layer_types,
+        },
+    }
+
+
+def _checkpoint(tmp_path):
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        _MTP_KEYS,
+        _required_text_keys,
+    )
+
+    config = _config()
+    layer_types = tuple(config["text_config"]["layer_types"])
+    keys = _required_text_keys(layer_types) | _MTP_KEYS
+    shard = "model-00001-of-00001.safetensors"
+    (tmp_path / shard).write_bytes(b"checkpoint")
+    (tmp_path / "config.json").write_text(
+        json.dumps(config), encoding="utf-8")
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {key: shard for key in keys}}),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_frontend_is_a_thin_qwen_entry():
+    from flash_rt.frontends.torch.nexn2_rtx import Nexn2TorchFrontendRtx
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        Qwen36MoeTextFrontendRtx,
+    )
+
+    assert issubclass(Qwen36MoeTextFrontendRtx, Nexn2TorchFrontendRtx)
+    assert Qwen36MoeTextFrontendRtx._MODEL_LABEL == (
+        "Qwen3.6-35B-A3B text")
+
+
+def test_registry_resolves_qwen36_moe():
+    from flash_rt.hardware import _PIPELINE_MAP, resolve_pipeline_class
+
+    assert _PIPELINE_MAP[("qwen36_moe", "torch", "rtx_sm120")] == (
+        "flash_rt.frontends.torch.qwen36_moe_rtx",
+        "Qwen36MoeTextFrontendRtx",
+    )
+    cls = resolve_pipeline_class("qwen36_moe", "torch", "rtx_sm120")
+    assert cls.__name__ == "Qwen36MoeTextFrontendRtx"
+
+
+def test_load_model_redirects_to_text_frontend():
+    import flash_rt
+
+    with pytest.raises(NotImplementedError) as exc:
+        flash_rt.load_model("/nonexistent", config="qwen36_moe")
+    message = str(exc.value)
+    assert "Qwen36MoeTextFrontendRtx" in message
+    assert "text LLM" in message
+
+
+def test_constructor_rejects_quant_before_checkpoint_access():
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        Qwen36MoeTextFrontendRtx,
+    )
+
+    with pytest.raises(NotImplementedError, match="only 'nvfp4'"):
+        Qwen36MoeTextFrontendRtx("/nonexistent", quant="fp8")
+
+
+def test_checkpoint_contract_accepts_complete_layout(tmp_path):
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        validate_qwen36_moe_checkpoint,
+    )
+
+    result = validate_qwen36_moe_checkpoint(str(_checkpoint(tmp_path)))
+    assert result["text_tensor_count"] == 693
+    assert result["mtp_tensor_count"] == 19
+    assert result["tensor_count"] == 712
+    assert result["shard_count"] == 1
+
+
+def test_checkpoint_contract_rejects_wrong_geometry(tmp_path):
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        validate_qwen36_moe_checkpoint,
+    )
+
+    checkpoint = _checkpoint(tmp_path)
+    config_path = checkpoint / "config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["text_config"]["num_experts"] = 128
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="num_experts=128"):
+        validate_qwen36_moe_checkpoint(str(checkpoint))
+
+
+def test_checkpoint_contract_rejects_missing_text_tensor(tmp_path):
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        validate_qwen36_moe_checkpoint,
+    )
+
+    checkpoint = _checkpoint(tmp_path)
+    index_path = checkpoint / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    del index["weight_map"]["lm_head.weight"]
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="lm_head.weight"):
+        validate_qwen36_moe_checkpoint(str(checkpoint))
+
+
+def test_checkpoint_contract_rejects_partial_mtp(tmp_path):
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        validate_qwen36_moe_checkpoint,
+    )
+
+    checkpoint = _checkpoint(tmp_path)
+    index_path = checkpoint / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    del index["weight_map"]["mtp.fc.weight"]
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="MTP tensor group"):
+        validate_qwen36_moe_checkpoint(str(checkpoint))
+
+
+def test_checkpoint_contract_rejects_missing_shard(tmp_path):
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        validate_qwen36_moe_checkpoint,
+    )
+
+    checkpoint = _checkpoint(tmp_path)
+    (checkpoint / "model-00001-of-00001.safetensors").unlink()
+
+    with pytest.raises(FileNotFoundError, match="missing or empty shards"):
+        validate_qwen36_moe_checkpoint(str(checkpoint))
+
+
+def test_generic_env_names_precede_legacy_aliases(monkeypatch):
+    from flash_rt.frontends.torch._nexn2_rtx_decode import _qwen35moe_env
+
+    monkeypatch.setenv("FLASHRT_NEXN2_PREFILL_CHUNK", "4096")
+    assert _qwen35moe_env("PREFILL_CHUNK", "8192") == "4096"
+    monkeypatch.setenv("FLASHRT_QWEN35MOE_PREFILL_CHUNK", "2048")
+    assert _qwen35moe_env("PREFILL_CHUNK", "8192") == "2048"
+
+
+def test_kernelized_generate_uses_shared_graph_path(monkeypatch):
+    from flash_rt.frontends.torch import _nexn2_rtx_decode as decode
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        Qwen36MoeTextFrontendRtx,
+    )
+
+    calls = {}
+
+    class FakeState:
+        def __init__(self, weights, max_seq, device):
+            calls["state"] = (weights, max_seq, device)
+
+    def fake_generate(state, prompt_ids, count, fvk, device):
+        calls["generate"] = (state, prompt_ids, count, fvk, device)
+        return [7] * count
+
+    monkeypatch.setattr(decode, "Nexn2DecodeState", FakeState)
+    monkeypatch.setattr(decode, "generate_greedy_graph", fake_generate)
+
+    frontend = Qwen36MoeTextFrontendRtx.__new__(
+        Qwen36MoeTextFrontendRtx)
+    frontend._kernelized = True
+    frontend._prompt_ids = object()
+    frontend._decode_state = None
+    frontend._weights = object()
+    frontend._user_max_seq = 128
+    frontend.device = "cuda:0"
+    frontend._fvk = object()
+
+    assert frontend.generate(3) == [7, 7, 7]
+    assert calls["state"] == (
+        frontend._weights, frontend._user_max_seq, frontend.device)
+    assert calls["generate"][1:] == (
+        frontend._prompt_ids, 3, frontend._fvk, frontend.device)
+    with pytest.raises(NotImplementedError, match="greedy"):
+        frontend.generate(1, do_sample=True)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("FLASHRT_QWEN36_MOE_CKPT_DIR"),
+    reason="set FLASHRT_QWEN36_MOE_CKPT_DIR for checkpoint validation",
+)
+def test_real_checkpoint_contract():
+    from flash_rt.frontends.torch.qwen36_moe_rtx import (
+        validate_qwen36_moe_checkpoint,
+    )
+
+    result = validate_qwen36_moe_checkpoint(
+        os.environ["FLASHRT_QWEN36_MOE_CKPT_DIR"])
+    assert result == {
+        "checkpoint_path": os.path.abspath(
+            os.environ["FLASHRT_QWEN36_MOE_CKPT_DIR"]),
+        "text_tensor_count": 693,
+        "mtp_tensor_count": 19,
+        "vision_tensor_count": 333,
+        "tensor_count": 1045,
+        "shard_count": 26,
+    }


### PR DESCRIPTION
## Summary

- add a text-only SM120 frontend for the official `Qwen/Qwen3.6-35B-A3B` checkpoint
- reuse the existing `qwen3_5_moe` Nex-N2 weight loader, prefill, attention, MoE, recurrent-state, and CUDA Graph decode implementation
- validate the exact compute geometry, nested RoPE parameters, all 693 text tensor shapes, all 19 MTP tensor shapes, and every indexed checkpoint shard before GPU allocation
- default to the kernelized runtime NVFP4 path and reject the multimodal BF16 reference path
- register an explicit `qwen36_moe` route and provide a clear redirect from the VLA-oriented `load_model` API
- use architecture-generic runtime controls while preserving the existing Nex-N2 environment variable aliases
- replace the decode-time generic top-8 expert reduction with the existing fixed-order MoE weighted-sum kernel

## Motivation

Qwen3.6-35B-A3B and Nex-N2-mini share the same `qwen3_5_moe` text architecture, but they are distinct checkpoint contracts. A dedicated thin frontend lets Qwen3.6 reuse the proven compute path without duplicating model math or accepting incompatible checkpoints silently.

The fixed-order expert reduction prevents rare greedy-token divergence when two later logits are nearly tied.

## Scope

This integration is intentionally limited to:

- text inference
- RTX Blackwell SM120
- runtime NVFP4 conversion from the official BF16 checkpoint
- greedy decode

Vision tensors are ignored by the text frontend. MTP tensors are validated but are not executed. `kernelized=False` is rejected because the inherited reference route would load the complete multimodal BF16 model.

## Validation

Hardware: RTX 5090 (SM120), CUDA 12.8 runtime, PyTorch 2.9.1.

Build:

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
  -DGPU_ARCH=120 -DFLASHRT_ENABLE_QWEN35MOE=ON
cmake --build build --target flash_rt_kernels flash_rt_fa2 -j
```

Focused regression suite:

```text
97 passed, 14 skipped
```

The suite covers the new frontend, negative geometry and tensor-shape contracts, Nex-N2 regression surface, model routing, build inventory, kernel bindings, and FA2 build modes.

Real-checkpoint GPU suite:

```text
2 passed
```

The GPU suite loads all 26 checkpoint shards, checks finite logits, requires eight consecutive generated sequences to match the official Transformers BF16 16-token greedy fixture exactly, and exercises the fixed-order reducer eagerly and through CUDA Graph replay.

Reducer regression:

```text
maximum absolute difference from Torch reduction: 1.1920929e-07
20/20 eager executions bit-exact
20/20 CUDA Graph replays bit-exact and finite
graph and eager outputs bit-exact
```

Checkpoint contract:

```text
693 text tensors with exact shapes
19 MTP tensors with exact shapes
333 vision tensors ignored by the text frontend
1045 indexed tensors across 26 shards
```

Same-shape RTX 5090 measurement (`P=64`, `N=64`, warm CUDA Graph):

```text
prefill: 40.42 ms
decode median: 257.95 tok/s
decode range across 8 runs: 256.90-258.22 tok/s
8/8 repeated sequences identical
```

The corresponding Nex-N2 decode measurement is 258.05 tok/s, placing the shared path within normal run-to-run variance.

Precision against the official Transformers BF16 implementation over four prompts:

```text
last-token logit cosine: 0.95635 minimum, 0.96455 mean
first-token argmax: 4/4
16-token greedy generation: 64/64 token IDs
```

Additional checks:

- `git diff --check`
- Python byte-compilation for all changed Python modules
- clean `import flash_rt`
- repeated privacy scan of the complete PR diff
