### PR TITLE
feat(qwen3-vl): Jetson Orin (SM87) decode quantization and Thor (SM110) BF16 frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1156,13 +1156,15 @@ if(FLASHRT_BUILD_QWEN3_VL)
   # GEMM/GEMV + fused act/norm-quant + QK norm-rope kernels for the official
   # FP8 Qwen3-VL path. SM87 (Jetson Orin): BF16 ViT helper module only; the
   # language path reuses the generic flash_rt_kernels BF16 Qwen3 helpers.
+  # SM110 (Jetson Thor): BF16 ViT tower (SDPA attention, no FP8 block-128
+  # path) plus the M=1 decode GEMVs and the batched QK norm-rope prefill.
   # All build into a separate module so neither bloats flash_rt_kernels.so.
   if(NOT (GPU_ARCH STREQUAL "120" OR GPU_ARCH STREQUAL "89" OR
-          GPU_ARCH STREQUAL "87"))
+          GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "110"))
     message(FATAL_ERROR
       "FLASHRT_BUILD_QWEN3_VL requires GPU_ARCH=120 (RTX 5090 / sm_120) or "
-      "GPU_ARCH=89 (Ada / sm_89) or GPU_ARCH=87 (Jetson Orin / sm_87); "
-      "got '${GPU_ARCH}'.")
+      "GPU_ARCH=89 (Ada / sm_89) or GPU_ARCH=87 (Jetson Orin / sm_87) or "
+      "GPU_ARCH=110 (Jetson Thor / sm_110); got '${GPU_ARCH}'.")
   endif()
 
   set(QWEN3_VL_SOURCES
@@ -1185,9 +1187,27 @@ if(FLASHRT_BUILD_QWEN3_VL)
       csrc/kernels/qwen3_qkv_post_proc.cu
       csrc/kernels/bf16_matmul_bf16.cu)
   elseif(GPU_ARCH STREQUAL "87")
+    # Weight-only quantized decode GEMVs ship alongside the bf16 one; the
+    # int8/int4 pair is the Ampere-friendly tier (hardware I2F dequant),
+    # while e4m3/e2m1 need the FP8 conversion sm_87 lacks.
     list(APPEND QWEN3_VL_SOURCES
       csrc/kernels/bf16_matmul_bf16.cu
-      csrc/kernels/qwen3_vl_bf16_gemv_m1.cu)
+      csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
+      csrc/kernels/qwen3_vl_int8_gemv_m1.cu
+      csrc/kernels/qwen3_vl_int4_gemv_m1.cu
+      csrc/kernels/qwen3_vl_w8_gemv_m1.cu
+      csrc/kernels/qwen3_vl_w4_gemv_m1.cu
+      csrc/kernels/qwen3_int8_kv.cu)
+  elseif(GPU_ARCH STREQUAL "110")
+    # Thor: BF16 ViT tower (SDPA attention — no FP8 block-128 ViT path here),
+    # the e4m3/e2m1 decode GEMVs (Thor has hardware FP8 conversion, unlike
+    # Orin), plus the batched QK norm-rope kernel the BF16 prefill uses.
+    list(APPEND QWEN3_VL_SOURCES
+      csrc/kernels/bf16_matmul_bf16.cu
+      csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
+      csrc/kernels/qwen3_vl_w8_gemv_m1.cu
+      csrc/kernels/qwen3_vl_w4_gemv_m1.cu
+      csrc/kernels/qwen3_qkv_post_proc.cu)
   endif()
 
   pybind11_add_module(flash_rt_qwen3_vl_kernels ${QWEN3_VL_SOURCES})
@@ -1195,13 +1215,27 @@ if(FLASHRT_BUILD_QWEN3_VL)
     target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
       ENABLE_QWEN3_VL_FP8_ACT=1)
   endif()
-  if(GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "89")
+  if(GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "89" OR
+     GPU_ARCH STREQUAL "110")
     target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
       ENABLE_QWEN3_VL_BF16_CUBLASLT=1)
   endif()
-  if(GPU_ARCH STREQUAL "87")
+  if(GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "110")
     target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
       ENABLE_QWEN3_VL_BF16_GEMV_M1=1)
+  endif()
+  # INT8/INT4 decode GEMVs + INT8 KV cache: Orin only. Thor has hardware FP8
+  # conversion so it uses the e4m3/e2m1 tiers, and its attention backend has no
+  # INT8 KV path, so building these there would export unused bindings.
+  if(GPU_ARCH STREQUAL "87")
+    target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
+      ENABLE_QWEN3_VL_INT_DECODE=1)
+  endif()
+  # Arches that compile qwen3_qkv_post_proc.cu. Kept separate from
+  # ENABLE_SM89_BLOCK_FP8_GEMM so Thor binds these without the FP8 path.
+  if(GPU_ARCH STREQUAL "89" OR GPU_ARCH STREQUAL "110")
+    target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
+      ENABLE_QWEN3_VL_QKV_POSTPROC=1)
   endif()
   if(GPU_ARCH STREQUAL "89")
     target_compile_definitions(flash_rt_qwen3_vl_kernels PRIVATE
@@ -1226,7 +1260,8 @@ if(FLASHRT_BUILD_QWEN3_VL)
       ${GPU_GENCODE}
     >)
   target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cudart)
-  if(GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "89")
+  if(GPU_ARCH STREQUAL "87" OR GPU_ARCH STREQUAL "89" OR
+     GPU_ARCH STREQUAL "110")
     # bf16_matmul_bf16 (ViT/language bf16 linears) uses cuBLASLt.
     target_link_libraries(flash_rt_qwen3_vl_kernels PRIVATE CUDA::cublasLt)
   endif()

--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ RTX 5090, NVFP4 language stack + FP8 ViT, image + text:
 | Full resolution | 1581 | **~100 ms** | **~150 tok/s** | [Qwen3-VL RTX 5090](docs/qwen3_vl_nvfp4.md#1-headline-performance) |
 | 0.5 MP cap | 473 | **~32 ms** | **~150 tok/s** | [Qwen3-VL resolution sweep](docs/qwen3_vl_nvfp4.md#ttft-vs-resolution-the-dominant-knob) |
 
+#### Qwen3-VL-2B on Jetson
+
+Official BF16 checkpoint, full-resolution image + text (1581 prompt tokens,
+6256 vision patches), with opt-in weight-only decode quantization:
+
+| Hardware | Decode tier | Prefill | Decode | Source |
+|---|---|---:|---:|---|
+| Jetson AGX Thor | BF16 | **230 ms** (eager) | **66.4 tok/s** | [Qwen3-VL Jetson Thor](docs/qwen3_vl_thor.md#jetson-thor-validation) |
+| Jetson AGX Thor | `w8` (FP8 e4m3) | 230 ms (eager) | **106.6 tok/s** | [Measured tiers](docs/qwen3_vl_thor.md#measured-tiers) |
+| Jetson AGX Thor | `w4` (NVFP4 e2m1) | 230 ms (eager) | **158.1 tok/s** | [Measured tiers](docs/qwen3_vl_thor.md#measured-tiers) |
+| Jetson AGX Orin | BF16 | 927 ms (graph) | 36.8 tok/s | [Qwen3-VL Jetson Orin](docs/qwen3_vl_rtx_bf16.md#jetson-orin-validation) |
+
+Thor prefill is eager by measurement, not omission: a prefill CUDA Graph
+prototype bought 0.3% there (GPU-bound), so it was not shipped; see
+[Where prefill time goes](docs/qwen3_vl_thor.md#where-prefill-time-goes).
+
 #### Higgs Audio v3
 
 | Hardware | Mode | Latency | TTFA | Throughput | Source |
@@ -1045,7 +1061,7 @@ examples/
 - **Wan2.2 TI2V-5B** (`config="wan22_ti2v_5b"`) — [Wan2.2 usage](docs/wan22_usage.md)
 - **Cosmos3-Nano text-to-video** (`config="cosmos3_video"`) — RTX 5090 BF16/FP8 denoise and complete benchmark workflow; [usage and performance](docs/cosmos3_video_usage.md)
 - **Cosmos3-Edge AV inverse dynamics and Reasoner** (`config="cosmos3_edge"`) — Jetson AGX Thor official baseline, 6.60x no-cache AV denoise, and NVFP4 multimodal chat decode; [complete usage and performance](docs/cosmos3_edge_thor.md)
-- **Qwen3-VL-8B** — RTX 5090 NVFP4/FP8 multimodal path and RTX 4090 official-FP8 path; [RTX 5090 usage](docs/qwen3_vl_nvfp4.md), [RTX 4090 usage](docs/qwen3_vl_fp8_sm89.md)
+- **Qwen3-VL-8B** — RTX 5090 NVFP4/FP8 multimodal path, RTX 4090 official-FP8 path, and Jetson BF16 paths for Thor and Orin; [RTX 5090 usage](docs/qwen3_vl_nvfp4.md), [RTX 4090 usage](docs/qwen3_vl_fp8_sm89.md), [Jetson Thor usage](docs/qwen3_vl_thor.md), [Jetson Orin usage](docs/qwen3_vl_rtx_bf16.md)
 - **MiniMax-Remover** — FP8 transformer + NVFP4 VAE video inpainting; [usage and performance](docs/minimax_remover_usage.md)
 - **MelBandRoformer** — kernelized FP8 audio source separation; [usage and performance](docs/melband_roformer_usage.md)
 - **OmniVoice TTS** — BF16/FP4 acceleration and HTTP serving; [serving quickstart](serving/omnivoice_agent/README.md)
@@ -1065,13 +1081,13 @@ artifacts and dispatch map are.
 
 | Hardware | SM | Status | Validated paths / notes |
 |---|---:|---|---|
-| Jetson AGX Thor | SM110 | Production target | Pi0, Pi0.5, GROOT N1.6, Pi0-FAST, Qwen3.6 Thor path, Lingbot, and Cosmos3-Edge AV/Reasoner; CUTLASS FMHA / Thor attention paths; Pi0.5 FP8 and NVFP4 validation live in [examples/thor](examples/thor/README.md#thor-vla-performance). |
+| Jetson AGX Thor | SM110 | Production target | Pi0, Pi0.5, GROOT N1.6, Pi0-FAST, Qwen3.6 Thor path, Lingbot, Cosmos3-Edge AV/Reasoner, and Qwen3-VL BF16 with opt-in W8/W4 decode ([docs](docs/qwen3_vl_thor.md)); CUTLASS FMHA / Thor attention paths; Pi0.5 FP8 and NVFP4 validation live in [examples/thor](examples/thor/README.md#thor-vla-performance). |
 | RTX 5090 | SM120 | Production target | Pi0/Pi0.5/GROOT/Pi0-FAST RTX paths, Qwen3.6, Qwen3-8B, Qwen3-VL, Higgs Audio v3 FP8, Motus, Wan2.2, Cosmos3-Nano, and HF Kernel Hub package validation; see [RTX 5090 latency](examples/blackwell/README.md#vla-latency-rtx-5090). |
 | RTX 4090 | SM89 | Validated / supported target | RTX VLA build path and deployment recipe; Higgs BF16 path compiles/configures. See [deployment_rtx4090.md](docs/deployment_rtx4090.md). |
 | RTX 5060 Ti | SM120 | Community validated | Pi0.5 FP8 and LIBERO Spatial submission; see [Community benchmarks](#community-benchmarks). |
 | RTX 4060 Ti | SM89 | Validated build/run target | Included in current tested hardware list; run local benchmarks before making model-specific latency claims. |
 | NVIDIA L40 | SM89 | Community validated | Pi0.5 FP8 submission; see [Community benchmarks](#community-benchmarks). |
-| Jetson AGX Orin | SM87 | Community port | Pi0.5 INT8/BF16 paths, Orin tile dispatch, frame-cache inference; see [deployment_orin.md](docs/deployment_orin.md). |
+| Jetson AGX Orin | SM87 | Community port | Pi0.5 INT8/BF16 paths, Orin tile dispatch, frame-cache inference, and Qwen3-VL BF16 with opt-in INT8/INT4 decode ([docs](docs/qwen3_vl_rtx_bf16.md)); see [deployment_orin.md](docs/deployment_orin.md). |
 | A100 / A10 / RTX 3090 / RTX 3080 / A5000 / A6000 and other SM80/86/89 GPUs | SM80/86/89 | Build target | CMake and FA2 gates cover Ampere/Ada shapes. Treat unlisted cards as expected to build until a benchmark or regression row is submitted. |
 
 Feature notes:

--- a/csrc/kernels/qwen3_int8_kv.cu
+++ b/csrc/kernels/qwen3_int8_kv.cu
@@ -1,0 +1,220 @@
+#include "qwen3_int8_kv.cuh"
+
+#include <math_constants.h>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int HD = 128;          // head_dim
+constexpr int NKV = 8;           // kv heads
+constexpr int GQA = 2;           // q heads per kv head (16/8)
+constexpr int CHUNK = 128;       // kv positions per flash-decoding chunk
+
+// ── row quantize: one warp per 128-elem row ──
+__global__ void kv_rows_quant_int8_kernel(
+    const __nv_bfloat16* __restrict__ src, int8_t* __restrict__ dst,
+    __nv_bfloat16* __restrict__ scales, int n_rows) {
+    const int row = blockIdx.x * (blockDim.x >> 5) + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (row >= n_rows) return;
+    const __nv_bfloat16* s = src + (size_t)row * HD;
+    float v[4];
+    float amax = 0.0f;
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) {
+        v[k] = __bfloat162float(s[lane * 4 + k]);
+        amax = fmaxf(amax, fabsf(v[k]));
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, off));
+    }
+    const float scale = fmaxf(amax / 127.0f, 1e-8f);
+    const float inv = 1.0f / scale;
+    int8_t* d = dst + (size_t)row * HD;
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) {
+        d[lane * 4 + k] = static_cast<int8_t>(lrintf(v[k] * inv));
+    }
+    if (lane == 0) scales[row] = __float2bfloat16(scale);
+}
+
+// ── flash-decoding partial: grid (NKV, n_chunks), 128 threads ──
+// Phase A: 4 warps compute chunk scores (both GQA q-heads) into smem.
+// Phase B: chunk softmax + P·V accumulation, thread per output dim.
+__global__ __launch_bounds__(128) void attn_decode_int8kv_partial_kernel(
+    const __nv_bfloat16* __restrict__ q,
+    const int8_t* __restrict__ k8, const int8_t* __restrict__ v8,
+    const __nv_bfloat16* __restrict__ ks, const __nv_bfloat16* __restrict__ vs,
+    float* __restrict__ part_o, float* __restrict__ part_m,
+    float* __restrict__ part_l, int kv_len, float softmax_scale) {
+    const int h = blockIdx.x;               // kv head
+    const int c = blockIdx.y;               // chunk
+    const int tid = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int j0 = c * CHUNK;
+    const int jn = min(kv_len - j0, CHUNK); // valid positions in this chunk
+
+    __shared__ float s0[CHUNK], s1[CHUNK];
+    __shared__ float red0[CHUNK], red1[CHUNK];   // reduce scratch / p values
+    __shared__ float m01[2], l01[2];
+
+    // q rows for the two q-heads of this kv head; 4 dims per lane.
+    const __nv_bfloat16* q0 = q + (size_t)(h * GQA) * HD;
+    const __nv_bfloat16* q1 = q0 + HD;
+    float q0r[4], q1r[4];
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) {
+        q0r[k] = __bfloat162float(q0[lane * 4 + k]);
+        q1r[k] = __bfloat162float(q1[lane * 4 + k]);
+    }
+
+    // Phase A: scores. Warp w handles positions j = w + 4*t.
+    for (int t = warp; t < CHUNK; t += 4) {
+        if (t < jn) {
+            const int j = j0 + t;
+            const int8_t* kr = k8 + ((size_t)j * NKV + h) * HD;
+            const int kv4 = *reinterpret_cast<const int*>(kr + lane * 4);
+            const int8_t* kb = reinterpret_cast<const int8_t*>(&kv4);
+            float d0 = 0.0f, d1 = 0.0f;
+            #pragma unroll
+            for (int k = 0; k < 4; ++k) {
+                const float kf = static_cast<float>(kb[k]);
+                d0 = fmaf(q0r[k], kf, d0);
+                d1 = fmaf(q1r[k], kf, d1);
+            }
+            #pragma unroll
+            for (int off = 16; off > 0; off >>= 1) {
+                d0 += __shfl_xor_sync(0xffffffff, d0, off);
+                d1 += __shfl_xor_sync(0xffffffff, d1, off);
+            }
+            if (lane == 0) {
+                const float kscale =
+                    __bfloat162float(ks[(size_t)j * NKV + h]) * softmax_scale;
+                s0[t] = d0 * kscale;
+                s1[t] = d1 * kscale;
+            }
+        } else if (lane == 0) {
+            s0[t] = -CUDART_INF_F;
+            s1[t] = -CUDART_INF_F;
+        }
+    }
+    __syncthreads();
+
+    // Chunk softmax stats (block reduce over CHUNK slots).
+    red0[tid] = s0[tid];
+    red1[tid] = s1[tid];
+    __syncthreads();
+    for (int off = 64; off > 0; off >>= 1) {
+        if (tid < off) {
+            red0[tid] = fmaxf(red0[tid], red0[tid + off]);
+            red1[tid] = fmaxf(red1[tid], red1[tid + off]);
+        }
+        __syncthreads();
+    }
+    const float m0 = red0[0], m1 = red1[0];
+    __syncthreads();
+    // p = exp(s - m) * v_scale (fold V row scale into p once per row).
+    {
+        const int t = tid;
+        float p0 = 0.0f, p1 = 0.0f;
+        if (t < jn) {
+            const float vscale = __bfloat162float(vs[(size_t)(j0 + t) * NKV + h]);
+            p0 = __expf(s0[t] - m0);
+            p1 = __expf(s1[t] - m1);
+            s0[t] = p0 * vscale;
+            s1[t] = p1 * vscale;
+        } else {
+            s0[t] = 0.0f;
+            s1[t] = 0.0f;
+        }
+        red0[t] = p0;
+        red1[t] = p1;
+    }
+    __syncthreads();
+    for (int off = 64; off > 0; off >>= 1) {
+        if (tid < off) {
+            red0[tid] += red0[tid + off];
+            red1[tid] += red1[tid + off];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) { l01[0] = red0[0]; m01[0] = m0; }
+    if (tid == 1) { l01[1] = red1[0]; m01[1] = m1; }
+
+    // Phase B: acc_d = sum_j p'_j * v8[j][d]; thread per dim.
+    float acc0 = 0.0f, acc1 = 0.0f;
+    for (int t = 0; t < jn; ++t) {
+        const int8_t* vr = v8 + ((size_t)(j0 + t) * NKV + h) * HD;
+        const float vf = static_cast<float>(vr[tid]);
+        acc0 = fmaf(s0[t], vf, acc0);
+        acc1 = fmaf(s1[t], vf, acc1);
+    }
+    __syncthreads();
+    const int qh0 = h * GQA, qh1 = qh0 + 1;
+    float* po = part_o + ((size_t)c * (NKV * GQA)) * HD;
+    po[(size_t)qh0 * HD + tid] = acc0;
+    po[(size_t)qh1 * HD + tid] = acc1;
+    if (tid == 0) {
+        part_m[c * (NKV * GQA) + qh0] = m01[0];
+        part_l[c * (NKV * GQA) + qh0] = l01[0];
+    }
+    if (tid == 1) {
+        part_m[c * (NKV * GQA) + qh1] = m01[1];
+        part_l[c * (NKV * GQA) + qh1] = l01[1];
+    }
+}
+
+// ── combine: grid (16 q-heads), 128 threads (one per dim) ──
+__global__ __launch_bounds__(128) void attn_decode_int8kv_combine_kernel(
+    const float* __restrict__ part_o, const float* __restrict__ part_m,
+    const float* __restrict__ part_l, __nv_bfloat16* __restrict__ out,
+    int n_chunks) {
+    const int qh = blockIdx.x;
+    const int d = threadIdx.x;
+    constexpr int NQ = NKV * GQA;
+    float M = -CUDART_INF_F;
+    for (int c = 0; c < n_chunks; ++c) {
+        M = fmaxf(M, part_m[c * NQ + qh]);
+    }
+    float o = 0.0f, l = 0.0f;
+    for (int c = 0; c < n_chunks; ++c) {
+        const float w = __expf(part_m[c * NQ + qh] - M);
+        o = fmaf(w, part_o[((size_t)c * NQ + qh) * HD + d], o);
+        l = fmaf(w, part_l[c * NQ + qh], l);
+    }
+    out[(size_t)qh * HD + d] = __float2bfloat16(o / l);
+}
+
+}  // namespace
+
+void qwen3_kv_rows_quant_int8(
+    const __nv_bfloat16* src, int8_t* dst, __nv_bfloat16* scales,
+    int n_rows, cudaStream_t stream) {
+    constexpr int kThreads = 256;                      // 8 rows per block
+    const int rows_per_block = kThreads / 32;
+    dim3 grid((n_rows + rows_per_block - 1) / rows_per_block);
+    kv_rows_quant_int8_kernel<<<grid, kThreads, 0, stream>>>(
+        src, dst, scales, n_rows);
+}
+
+void qwen3_attn_decode_int8kv_partial(
+    const __nv_bfloat16* q, const int8_t* k8, const int8_t* v8,
+    const __nv_bfloat16* ks, const __nv_bfloat16* vs,
+    float* part_o, float* part_m, float* part_l,
+    int kv_len, int n_chunks, float softmax_scale, cudaStream_t stream) {
+    dim3 grid(NKV, n_chunks);
+    attn_decode_int8kv_partial_kernel<<<grid, 128, 0, stream>>>(
+        q, k8, v8, ks, vs, part_o, part_m, part_l, kv_len, softmax_scale);
+}
+
+void qwen3_attn_decode_int8kv_combine(
+    const float* part_o, const float* part_m, const float* part_l,
+    __nv_bfloat16* out, int n_chunks, cudaStream_t stream) {
+    attn_decode_int8kv_combine_kernel<<<dim3(NKV * GQA), 128, 0, stream>>>(
+        part_o, part_m, part_l, out, n_chunks);
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_int8_kv.cuh
+++ b/csrc/kernels/qwen3_int8_kv.cuh
@@ -1,0 +1,39 @@
+#pragma once
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt::kernels {
+
+// ── INT8 KV cache for Qwen3-VL q=1 decode attention (Orin/Ampere) ──
+// KV rows are quantized per-(position, kv-head): one bf16 scale per 128-elem
+// row (scale = amax/127). Decode attention reads int8 K/V + scales (half the
+// HBM bytes of bf16 KV) with a flash-decoding split over KV chunks.
+
+// Quantize n_rows contiguous 128-elem bf16 rows to int8 + per-row bf16 scale.
+// Layout-agnostic: used for the post-prefill bulk pass (n_rows = L*S*NKV, the
+// whole contiguous cache prefix per K/V) and the per-step row pass (n_rows =
+// NKV at one (layer, pos)).
+void qwen3_kv_rows_quant_int8(
+    const __nv_bfloat16* src, int8_t* dst, __nv_bfloat16* scales,
+    int n_rows, cudaStream_t stream);
+
+// Flash-decoding partial pass: q=1, GQA (16 Q / 8 KV heads, head_dim 128).
+//   q        : [16,128] bf16 (Q_buf row)
+//   k8/v8    : [kv_len, 8, 128] int8 (layer base)
+//   ks/vs    : [kv_len, 8] bf16 row scales
+//   part_o   : [n_chunks, 16, 128] fp32
+//   part_m/l : [n_chunks, 16] fp32
+// grid (8 kv-heads, n_chunks); one block = 2 q-heads x 128 dims.
+void qwen3_attn_decode_int8kv_partial(
+    const __nv_bfloat16* q, const int8_t* k8, const int8_t* v8,
+    const __nv_bfloat16* ks, const __nv_bfloat16* vs,
+    float* part_o, float* part_m, float* part_l,
+    int kv_len, int n_chunks, float softmax_scale, cudaStream_t stream);
+
+// Combine pass: merge chunk partials into O (bf16 [16,128]).
+void qwen3_attn_decode_int8kv_combine(
+    const float* part_o, const float* part_m, const float* part_l,
+    __nv_bfloat16* out, int n_chunks, cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
@@ -11,7 +11,7 @@ constexpr int kWarpsPerBlock = 8;
 constexpr int kThreads = kWarpsPerBlock * 32;
 
 template<int K_FIXED>
-__global__ __launch_bounds__(kThreads, 8) void qwen3_vl_bf16_gemv_m1_kernel(
+__global__ __launch_bounds__(kThreads) void qwen3_vl_bf16_gemv_m1_kernel(
     const __nv_bfloat16* __restrict__ x,
     const __nv_bfloat16* __restrict__ W,
     __nv_bfloat16* __restrict__ out,

--- a/csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_bf16_gemv_m1.cu
@@ -11,34 +11,29 @@ constexpr int kWarpsPerBlock = 8;
 constexpr int kThreads = kWarpsPerBlock * 32;
 
 template<int K_FIXED>
-__global__ void qwen3_vl_bf16_gemv_m1_kernel(
+__global__ __launch_bounds__(kThreads, 8) void qwen3_vl_bf16_gemv_m1_kernel(
     const __nv_bfloat16* __restrict__ x,
     const __nv_bfloat16* __restrict__ W,
     __nv_bfloat16* __restrict__ out,
     int N) {
-    __shared__ __nv_bfloat16 x_sh[K_FIXED];
-
-    const int4* x_i4 = reinterpret_cast<const int4*>(x);
-    int4* x_sh_i4 = reinterpret_cast<int4*>(x_sh);
-    constexpr int K_INT4 = K_FIXED / 8;
-    #pragma unroll 1
-    for (int j = threadIdx.x; j < K_INT4; j += kThreads) {
-        x_sh_i4[j] = x_i4[j];
-    }
-    __syncthreads();
-
+    // No shared-memory staging of x: x is tiny (K bf16 = 4-12 KB) and stays
+    // hot in L2 across the many weight-row blocks, so reading it from global
+    // keeps smem=0 and occupancy maximal — the decode is HBM-bound on the
+    // weight read, which this saturates (mirrors bf16_gemv_m1_sm120).
     const int warp_id = threadIdx.x / 32;
     const int lane = threadIdx.x & 31;
     const int n = blockIdx.x * kWarpsPerBlock + warp_id;
     if (n >= N) return;
 
+    const int4* x_i4 = reinterpret_cast<const int4*>(x);
     const int4* w_row_i4 = reinterpret_cast<const int4*>(W + n * K_FIXED);
+    constexpr int K_INT4 = K_FIXED / 8;
 
     float acc = 0.0f;
     #pragma unroll 1
     for (int i4 = lane; i4 < K_INT4; i4 += 32) {
         int4 wv = w_row_i4[i4];
-        int4 xv = x_sh_i4[i4];
+        int4 xv = x_i4[i4];
         #pragma unroll
         for (int k = 0; k < 4; ++k) {
             __nv_bfloat162 wb = *reinterpret_cast<__nv_bfloat162*>(

--- a/csrc/kernels/qwen3_vl_int4_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_int4_gemv_m1.cu
@@ -1,0 +1,105 @@
+#include "qwen3_vl_int4_gemv_m1.cuh"
+
+#include <stdexcept>
+#include <string>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kWarpsPerBlock = 8;
+constexpr int kThreads = kWarpsPerBlock * 32;
+constexpr int kUnroll = 4;                           // independent weight loads in flight
+                                                     // (must divide NG/32; NG/32 = 4 (K=2048) / 12 (K=6144))
+
+__device__ __forceinline__ float dot_block(const uint8_t* wb, int4 xa, int4 xb) {
+    float p = 0.0f;
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) {
+        float2 f0 = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162*>(
+            &(reinterpret_cast<int*>(&xa)[k])));
+        int b0 = static_cast<int>(wb[k]);
+        int lo0 = (static_cast<int>(static_cast<int8_t>(b0 << 4))) >> 4;
+        int hi0 = (static_cast<int>(static_cast<int8_t>(b0))) >> 4;
+        p = fmaf(static_cast<float>(lo0), f0.x, p);
+        p = fmaf(static_cast<float>(hi0), f0.y, p);
+        float2 f1 = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162*>(
+            &(reinterpret_cast<int*>(&xb)[k])));
+        int b1 = static_cast<int>(wb[k + 4]);
+        int lo1 = (static_cast<int>(static_cast<int8_t>(b1 << 4))) >> 4;
+        int hi1 = (static_cast<int>(static_cast<int8_t>(b1))) >> 4;
+        p = fmaf(static_cast<float>(lo1), f1.x, p);
+        p = fmaf(static_cast<float>(hi1), f1.y, p);
+    }
+    return p;
+}
+
+// One warp per output row. The int4 GEMV is latency-bound on Orin LPDDR5 (ncu:
+// ~88% occupancy, both mem/compute pipes moderate). To hide weight-load latency
+// we keep max warps (1 row/warp) and instead lift instruction-level parallelism:
+// each lane issues kUnroll INDEPENDENT uint2 weight loads (+ their activation)
+// up front, then does the kUnroll dot-products — so several LPDDR reads are in
+// flight at once. Nibble unpack: shift+sign-extend+I2F; per-16 bf16 scale; fp32
+// accumulation. NG is a multiple of 32*kUnroll for K in {2048,6144} (no tail).
+template<int K_FIXED>
+__global__ __launch_bounds__(kThreads, 8) void qwen3_vl_int4_gemv_m1_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const uint8_t* __restrict__ Wp,
+    const __nv_bfloat16* __restrict__ Ws,
+    __nv_bfloat16* __restrict__ out,
+    int N) {
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int n = blockIdx.x * kWarpsPerBlock + warp;
+    if (n >= N) return;
+
+    constexpr int NG = K_FIXED >> 4;                 // per-16 blocks
+    const uint2* wrow = reinterpret_cast<const uint2*>(
+        Wp + (size_t)n * (K_FIXED / 2));
+    const __nv_bfloat16* srow = Ws + (size_t)n * NG;
+    const int4* x_i4 = reinterpret_cast<const int4*>(x);
+
+    float acc = 0.0f;
+    for (int g0 = lane; g0 < NG; g0 += 32 * kUnroll) {
+        uint2 wp[kUnroll];
+        #pragma unroll
+        for (int u = 0; u < kUnroll; ++u) {
+            wp[u] = wrow[g0 + u * 32];            // independent HBM loads in flight
+        }
+        #pragma unroll
+        for (int u = 0; u < kUnroll; ++u) {
+            const int g = g0 + u * 32;
+            const uint8_t* wb = reinterpret_cast<const uint8_t*>(&wp[u]);
+            float part = dot_block(wb, x_i4[g * 2], x_i4[g * 2 + 1]);
+            acc = fmaf(part, __bfloat162float(srow[g]), acc);
+        }
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_xor_sync(0xffffffff, acc, off);
+    }
+    if (lane == 0) {
+        out[n] = __float2bfloat16(acc);
+    }
+}
+
+}  // namespace
+
+void qwen3_vl_int4_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream) {
+    dim3 grid((N + kWarpsPerBlock - 1) / kWarpsPerBlock);
+    if (K == 2048) {
+        qwen3_vl_int4_gemv_m1_kernel<2048>
+            <<<grid, kThreads, 0, stream>>>(x, Wp, Ws, out, N);
+    } else if (K == 6144) {
+        qwen3_vl_int4_gemv_m1_kernel<6144>
+            <<<grid, kThreads, 0, stream>>>(x, Wp, Ws, out, N);
+    } else {
+        throw std::runtime_error(
+            "qwen3_vl_int4_gemv_m1 supports only K=2048 or K=6144, got K=" +
+            std::to_string(K));
+    }
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_int4_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_int4_gemv_m1.cu
@@ -42,7 +42,7 @@ __device__ __forceinline__ float dot_block(const uint8_t* wb, int4 xa, int4 xb) 
 // flight at once. Nibble unpack: shift+sign-extend+I2F; per-16 bf16 scale; fp32
 // accumulation. NG is a multiple of 32*kUnroll for K in {2048,6144} (no tail).
 template<int K_FIXED>
-__global__ __launch_bounds__(kThreads, 8) void qwen3_vl_int4_gemv_m1_kernel(
+__global__ __launch_bounds__(kThreads) void qwen3_vl_int4_gemv_m1_kernel(
     const __nv_bfloat16* __restrict__ x,
     const uint8_t* __restrict__ Wp,
     const __nv_bfloat16* __restrict__ Ws,

--- a/csrc/kernels/qwen3_vl_int4_gemv_m1.cuh
+++ b/csrc/kernels/qwen3_vl_int4_gemv_m1.cuh
@@ -1,0 +1,23 @@
+#pragma once
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt::kernels {
+
+// M=1 decode GEMV with INT4 symmetric weights and BF16 activation (W4A16).
+//   x   : [K]         bf16 activation
+//   Wp  : [N, K/2]    two int4 per byte (low nibble = even elem, high = odd);
+//                     each nibble is 2's-complement in [-7, 7]
+//   Ws  : [N, K/16]   bf16 per-16-element block scales (scale = amax/7)
+//   out : [N]         bf16
+// Half the weight bytes of int8 (0.5 B/elem + 0.125 B scale). Nibble unpack is
+// a cheap shift + sign-extend + hardware int->float I2F — Ampere-friendly
+// (contrast the e2m1 `qwen3_vl_w4_gemv_m1`, whose LUT/fp8 path is ALU-bound on
+// sm_87). For the weight-bandwidth-bound M=1 decode this ~halves weight HBM
+// traffic vs int8. Precision is coarser (15 levels) — validate per task.
+void qwen3_vl_int4_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_int8_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_int8_gemv_m1.cu
@@ -1,0 +1,110 @@
+#include "qwen3_vl_int8_gemv_m1.cuh"
+
+#include <stdexcept>
+#include <string>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kWarpsPerBlock = 8;
+constexpr int kThreads = kWarpsPerBlock * 32;
+constexpr int kRows = 1;                             // output rows per warp
+
+// One warp computes kRows output rows, templated on R so the activation can be
+// loaded once per K-block and reused across rows (register blocking) if a wider
+// tile ever wins. kRows=1 measured best on Orin's 16 SMs, so today each warp
+// owns one row.
+// Weights dequant via hardware int8->float I2F (no HW FP8 on Ampere sm_87);
+// per-16 bf16 block scale applied once per (row, block); fp32 accumulation.
+// Measured non-wins (do not re-add): smem-staging x (occupancy loss on 16 SMs);
+// half2/__hfma2 accumulation (int8 per-16 partial can overflow half on outlier
+// activations — fp32 is the safe choice).
+// The minBlocks hint mainly acts as a register clamp here: 8 x 256 threads
+// exceeds the 1536 threads/SM these arches allow.
+template<int K_FIXED, int R>
+__global__ __launch_bounds__(kThreads, 8) void qwen3_vl_int8_gemv_m1_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const uint8_t* __restrict__ Wp,
+    const __nv_bfloat16* __restrict__ Ws,
+    __nv_bfloat16* __restrict__ out,
+    int N) {
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int n0 = (blockIdx.x * kWarpsPerBlock + warp) * R;
+    if (n0 >= N) return;
+
+    constexpr int NG = K_FIXED >> 4;                 // K / 16 blocks
+    const int4* x_i4 = reinterpret_cast<const int4*>(x);
+
+    float acc[R];
+    #pragma unroll
+    for (int r = 0; r < R; ++r) acc[r] = 0.0f;
+
+    for (int g = lane; g < NG; g += 32) {
+        // Activation: 16 bf16 -> 16 float, loaded once, reused for all R rows.
+        int4 xv0 = x_i4[g * 2];
+        int4 xv1 = x_i4[g * 2 + 1];
+        float xf[16];
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            __nv_bfloat162 xb0 = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&xv0)[k]));
+            float2 f0 = __bfloat1622float2(xb0);
+            xf[2 * k] = f0.x; xf[2 * k + 1] = f0.y;
+            __nv_bfloat162 xb1 = *reinterpret_cast<__nv_bfloat162*>(
+                &(reinterpret_cast<int*>(&xv1)[k]));
+            float2 f1 = __bfloat1622float2(xb1);
+            xf[8 + 2 * k] = f1.x; xf[8 + 2 * k + 1] = f1.y;
+        }
+        #pragma unroll
+        for (int r = 0; r < R; ++r) {
+            const int nn = n0 + r;
+            if (nn >= N) break;
+            const uint4* wrow = reinterpret_cast<const uint4*>(
+                Wp + (size_t)nn * K_FIXED);
+            uint4 wp = wrow[g];                       // 16 int8 (16 B)
+            const int8_t* w1 = reinterpret_cast<const int8_t*>(&wp);
+            float part = 0.0f;
+            #pragma unroll
+            for (int j = 0; j < 16; ++j) {
+                part = fmaf(static_cast<float>(w1[j]), xf[j], part);
+            }
+            acc[r] = fmaf(part, __bfloat162float(Ws[(size_t)nn * NG + g]),
+                          acc[r]);
+        }
+    }
+    #pragma unroll
+    for (int r = 0; r < R; ++r) {
+        float a = acc[r];
+        #pragma unroll
+        for (int off = 16; off > 0; off >>= 1) {
+            a += __shfl_xor_sync(0xffffffff, a, off);
+        }
+        if (lane == 0 && (n0 + r) < N) {
+            out[n0 + r] = __float2bfloat16(a);
+        }
+    }
+}
+
+}  // namespace
+
+void qwen3_vl_int8_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream) {
+    const int rows_per_block = kWarpsPerBlock * kRows;
+    dim3 grid((N + rows_per_block - 1) / rows_per_block);
+    if (K == 2048) {
+        qwen3_vl_int8_gemv_m1_kernel<2048, kRows>
+            <<<grid, kThreads, 0, stream>>>(x, Wp, Ws, out, N);
+    } else if (K == 6144) {
+        qwen3_vl_int8_gemv_m1_kernel<6144, kRows>
+            <<<grid, kThreads, 0, stream>>>(x, Wp, Ws, out, N);
+    } else {
+        throw std::runtime_error(
+            "qwen3_vl_int8_gemv_m1 supports only K=2048 or K=6144, got K=" +
+            std::to_string(K));
+    }
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_int8_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_int8_gemv_m1.cu
@@ -20,10 +20,8 @@ constexpr int kRows = 1;                             // output rows per warp
 // Measured non-wins (do not re-add): smem-staging x (occupancy loss on 16 SMs);
 // half2/__hfma2 accumulation (int8 per-16 partial can overflow half on outlier
 // activations — fp32 is the safe choice).
-// The minBlocks hint mainly acts as a register clamp here: 8 x 256 threads
-// exceeds the 1536 threads/SM these arches allow.
 template<int K_FIXED, int R>
-__global__ __launch_bounds__(kThreads, 8) void qwen3_vl_int8_gemv_m1_kernel(
+__global__ __launch_bounds__(kThreads) void qwen3_vl_int8_gemv_m1_kernel(
     const __nv_bfloat16* __restrict__ x,
     const uint8_t* __restrict__ Wp,
     const __nv_bfloat16* __restrict__ Ws,

--- a/csrc/kernels/qwen3_vl_int8_gemv_m1.cuh
+++ b/csrc/kernels/qwen3_vl_int8_gemv_m1.cuh
@@ -1,0 +1,22 @@
+#pragma once
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt::kernels {
+
+// M=1 decode GEMV with INT8 symmetric weights and BF16 activation (W8A16).
+//   x   : [K]        bf16 activation
+//   Wp  : [N, K]     int8 (stored as uint8 bytes; 1 byte/weight)
+//   Ws  : [N, K/16]  bf16 per-16-element block scales (scale = amax/127)
+//   out : [N]        bf16
+// Same byte traffic as the e4m3 W8 kernel (1.125 B/elem vs bf16 2.0), but the
+// dequant is int8->float via a hardware I2F instruction. On Ampere (sm_87,
+// Jetson Orin) there is NO hardware FP8 conversion, so the e4m3 kernel's
+// fp8->half2 expand is a software bit-sequence that makes it ALU-bound; the
+// int8 dequant keeps this GEMV bandwidth-bound on pre-sm89 GPUs.
+void qwen3_vl_int8_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_w4_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_w4_gemv_m1.cu
@@ -1,0 +1,107 @@
+#include "qwen3_vl_w4_gemv_m1.cuh"
+
+#include <cuda_fp8.h>
+#include <stdexcept>
+#include <string>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kWarpsPerBlock = 8;
+constexpr int kThreads = kWarpsPerBlock * 32;
+
+// Dequant 4 e2m1 nibbles (packed in the low 16 bits of `w`, one nibble per
+// 4-bit field) to 4 e4m3 bytes (packed in the returned uint32), branchless via
+// a __byte_perm 8-entry magnitude LUT + sign OR. Processing 4 nibbles per
+// __byte_perm (which produces 4 bytes) — vs 1 byte/2 nibbles — halves the
+// dequant ALU so the GEMV approaches the memory-bandwidth bound.
+__device__ __forceinline__ unsigned dequant4(unsigned w) {
+    unsigned mag = __byte_perm(0x3C383000u, 0x4C484440u, w & 0x7777u);
+    unsigned sgn = ((w & 0x8u) << 4) | ((w & 0x80u) << 8)
+                 | ((w & 0x800u) << 12) | ((w & 0x8000u) << 16);
+    return mag | sgn;
+}
+
+// One warp per output row n. The activation x is shared across all rows, so
+// the block cooperatively stages x (bf16 -> half) into dynamic shared memory
+// ONCE (eliminating per-warp re-conversion + L2 re-reads). The dot product
+// uses __hfma2 half2 SIMD (weight half2 from fp8x2->half2, x half2 from smem);
+// per group the 8 pairs accumulate into a half2, then reduce to float and
+// apply the per-block scale in fp32. This drops the compute floor so the GEMV
+// reaches the memory-bandwidth bound.
+__global__ __launch_bounds__(kThreads) void qwen3_vl_w4_gemv_m1_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const uint8_t* __restrict__ Wp,
+    const __nv_bfloat16* __restrict__ Ws,
+    __nv_bfloat16* __restrict__ out,
+    int N, int K) {
+    extern __shared__ __half2 xsh[];                // K/2 half2 (= K halfs)
+    const int nh2 = K >> 1;
+    const __nv_bfloat162* x2g =
+        reinterpret_cast<const __nv_bfloat162*>(x);
+    for (int i = threadIdx.x; i < nh2; i += kThreads) {
+        xsh[i] = __float22half2_rn(__bfloat1622float2(x2g[i]));
+    }
+    __syncthreads();
+
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int n = blockIdx.x * kWarpsPerBlock + warp;
+    if (n >= N) return;
+
+    const int NG = K >> 4;                          // K / 16 blocks
+    const uint8_t* wrow = Wp + (size_t)n * (K >> 1);
+    const __nv_bfloat16* srow = Ws + (size_t)n * NG;
+
+    float acc = 0.0f;
+    for (int g = lane; g < NG; g += 32) {
+        uint2 wp = *reinterpret_cast<const uint2*>(wrow + (size_t)g * 8);
+        unsigned e[4] = {dequant4(wp.x), dequant4(wp.x >> 16),
+                         dequant4(wp.y), dequant4(wp.y >> 16)};
+        const __half2* xg = xsh + g * 8;            // 8 half2 pairs / group
+        __half2 acc2 = __floats2half2_rn(0.0f, 0.0f);
+        #pragma unroll
+        for (int p = 0; p < 8; ++p) {
+            __nv_fp8x2_e4m3 f8;
+            f8.__x = (unsigned short)((p & 1) ? (e[p >> 1] >> 16)
+                                              : (e[p >> 1] & 0xFFFFu));
+            acc2 = __hfma2(static_cast<__half2>(f8), xg[p], acc2);
+        }
+        float part = __low2float(acc2) + __high2float(acc2);
+        acc = fmaf(part, __bfloat162float(srow[g]), acc);
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_xor_sync(0xffffffff, acc, off);
+    }
+    if (lane == 0) {
+        out[n] = __float2bfloat16(acc);
+    }
+}
+
+}  // namespace
+
+void qwen3_vl_w4_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream) {
+    if (K <= 0 || (K % 16) != 0) {
+        throw std::runtime_error(
+            "qwen3_vl_w4_gemv_m1 requires K to be a positive multiple of 16 "
+            "(one uint2 weight load and one block scale per 16 elements), "
+            "got K=" + std::to_string(K));
+    }
+    dim3 grid((N + kWarpsPerBlock - 1) / kWarpsPerBlock);
+    size_t smem = (size_t)K * sizeof(__half);
+    // The activation is staged in dynamic shared memory; past the 48 KB
+    // default the launch would fail with an opaque error at the next sync.
+    if (smem > 48u * 1024u) {
+        throw std::runtime_error(
+            "qwen3_vl_w4_gemv_m1 stages K halves in dynamic shared memory and "
+            "so supports K <= 24576 (48 KB); got K=" + std::to_string(K));
+    }
+    qwen3_vl_w4_gemv_m1_kernel<<<grid, kThreads, smem, stream>>>(
+        x, Wp, Ws, out, N, K);
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_w4_gemv_m1.cuh
+++ b/csrc/kernels/qwen3_vl_w4_gemv_m1.cuh
@@ -1,0 +1,19 @@
+#pragma once
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt::kernels {
+
+// M=1 decode GEMV with NVFP4 (e2m1) weights and BF16 activation (W4A16).
+//   x   : [K]        bf16 activation
+//   Wp  : [N, K/2]   uint8, packed e2m1 (low nibble = even col, high = odd)
+//   Ws  : [N, K/16]  bf16 per-16-element block scales
+//   out : [N]        bf16
+// Weight bytes/elem = 0.5 (packed) + 0.125 (bf16 scale/16) = 0.625 vs bf16 2.0
+// -> ~3.2x less HBM traffic, the decode-throughput lever on bandwidth-bound Thor.
+void qwen3_vl_w4_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_w8_gemv_m1.cu
+++ b/csrc/kernels/qwen3_vl_w8_gemv_m1.cu
@@ -1,0 +1,77 @@
+#include "qwen3_vl_w8_gemv_m1.cuh"
+
+#include <cuda_fp8.h>
+#include <stdexcept>
+#include <string>
+
+namespace flash_rt::kernels {
+
+namespace {
+
+constexpr int kWarpsPerBlock = 8;
+constexpr int kThreads = kWarpsPerBlock * 32;
+
+// One warp per output row n. Each lane strides over the row's 16-element
+// blocks (16 e4m3 bytes = one uint4), converts each e4m3->float (hardware),
+// dots with the BF16 activation (x is tiny, hot in L2), applies the per-block
+// scale once per group. fp32 accumulation: e4m3 dequant values reach ~448, so
+// half2 accumulation would overflow the half range — W8 uses fp32. Already
+// bandwidth-bound (~219 GB/s of Thor's ~229 achievable), so no smem/SIMD win.
+__global__ __launch_bounds__(kThreads) void qwen3_vl_w8_gemv_m1_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const uint8_t* __restrict__ Wp,
+    const __nv_bfloat16* __restrict__ Ws,
+    __nv_bfloat16* __restrict__ out,
+    int N, int K) {
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int n = blockIdx.x * kWarpsPerBlock + warp;
+    if (n >= N) return;
+
+    const int NG = K >> 4;                          // K / 16 blocks
+    const uint8_t* wrow = Wp + (size_t)n * K;
+    const __nv_bfloat16* srow = Ws + (size_t)n * NG;
+
+    float acc = 0.0f;
+    for (int g = lane; g < NG; g += 32) {
+        uint4 wp = *reinterpret_cast<const uint4*>(wrow + (size_t)g * 16);
+        const __nv_fp8x2_e4m3* w2 =
+            reinterpret_cast<const __nv_fp8x2_e4m3*>(&wp);       // 8 pairs
+        const __nv_bfloat162* x2 =
+            reinterpret_cast<const __nv_bfloat162*>(x + (size_t)g * 16);
+        float part = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            float2 wf = __half22float2(static_cast<__half2>(w2[j]));
+            float2 xf = __bfloat1622float2(x2[j]);
+            part = fmaf(wf.x, xf.x, part);
+            part = fmaf(wf.y, xf.y, part);
+        }
+        acc = fmaf(part, __bfloat162float(srow[g]), acc);
+    }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        acc += __shfl_xor_sync(0xffffffff, acc, off);
+    }
+    if (lane == 0) {
+        out[n] = __float2bfloat16(acc);
+    }
+}
+
+}  // namespace
+
+void qwen3_vl_w8_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream) {
+    if (K <= 0 || (K % 16) != 0) {
+        throw std::runtime_error(
+            "qwen3_vl_w8_gemv_m1 requires K to be a positive multiple of 16 "
+            "(one uint4 weight load and one block scale per 16 elements), "
+            "got K=" + std::to_string(K));
+    }
+    dim3 grid((N + kWarpsPerBlock - 1) / kWarpsPerBlock);
+    qwen3_vl_w8_gemv_m1_kernel<<<grid, kThreads, 0, stream>>>(
+        x, Wp, Ws, out, N, K);
+}
+
+}  // namespace flash_rt::kernels

--- a/csrc/kernels/qwen3_vl_w8_gemv_m1.cuh
+++ b/csrc/kernels/qwen3_vl_w8_gemv_m1.cuh
@@ -1,0 +1,20 @@
+#pragma once
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace flash_rt::kernels {
+
+// M=1 decode GEMV with FP8 e4m3 weights and BF16 activation (W8A16).
+//   x   : [K]        bf16 activation
+//   Wp  : [N, K]     e4m3 (1 byte/weight)
+//   Ws  : [N, K/16]  bf16 per-16-element block scales
+//   out : [N]        bf16
+// Weight bytes/elem = 1.0 (e4m3) + 0.125 (bf16 scale/16) = 1.125 vs bf16 2.0
+// -> ~1.8x less HBM traffic. e4m3->float is a single hardware conversion, so
+// (unlike the FP4 path) this kernel stays bandwidth-bound on Thor's LPDDR5x.
+void qwen3_vl_w8_gemv_m1(
+    const __nv_bfloat16* x, const uint8_t* Wp, const __nv_bfloat16* Ws,
+    __nv_bfloat16* out, int N, int K, cudaStream_t stream);
+
+}  // namespace flash_rt::kernels

--- a/csrc/qwen3_vl_bindings.cpp
+++ b/csrc/qwen3_vl_bindings.cpp
@@ -37,12 +37,26 @@
 
 #ifdef ENABLE_QWEN3_VL_BF16_GEMV_M1
 #include "kernels/qwen3_vl_bf16_gemv_m1.cuh"
+#include "kernels/qwen3_vl_w8_gemv_m1.cuh"
+#include "kernels/qwen3_vl_w4_gemv_m1.cuh"
+#endif
+
+// INT8/INT4 decode GEMVs + INT8 KV cache: Orin only (see CMakeLists.txt).
+#ifdef ENABLE_QWEN3_VL_INT_DECODE
+#include "kernels/qwen3_vl_int8_gemv_m1.cuh"
+#include "kernels/qwen3_vl_int4_gemv_m1.cuh"
+#include "kernels/qwen3_int8_kv.cuh"
 #endif
 
 #ifdef ENABLE_SM89_BLOCK_FP8_GEMM
 #include "gemm/fp8_block128_gemm_mma_sm89.cuh"
 #include "gemm/fp8_gemv_m1_sm89.cuh"
 #include "quantize/fp8_per_token_block_quant.cuh"
+#endif
+
+// Fused QK norm-rope-kvwrite. Compiled on every arch that builds
+// qwen3_qkv_post_proc.cu: SM89 for the FP8 path, SM110 (Thor) for BF16 prefill.
+#ifdef ENABLE_QWEN3_VL_QKV_POSTPROC
 #include "kernels/qwen3_qkv_post_proc.cuh"
 #endif
 
@@ -97,7 +111,7 @@ static T* as_ptr(uintptr_t p) {
     return reinterpret_cast<T*>(p);
 }
 
-#ifdef ENABLE_SM89_BLOCK_FP8_GEMM
+#if defined(ENABLE_SM89_BLOCK_FP8_GEMM) || defined(ENABLE_QWEN3_VL_QKV_POSTPROC)
 static void* to_ptr(uintptr_t addr) { return reinterpret_cast<void*>(addr); }
 #endif
 
@@ -373,6 +387,53 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
 #undef BIND_GEGLU_TILE
 #endif
 
+#define BIND_BLOCK128_GEMV_M1(NAME)                                           \
+    m.def("ht_" #NAME,                                                       \
+        [](uintptr_t A, uintptr_t B, uintptr_t D,                            \
+           int M, int N, int K, uintptr_t act_scale, uintptr_t w_scale,       \
+           float alpha, uintptr_t stream) {                                  \
+            return flash_rt::gemm::gemv_m1_sm89::NAME(                            \
+                to_ptr(A), to_ptr(B), to_ptr(D),                             \
+                M, N, K, reinterpret_cast<const float*>(act_scale),          \
+                reinterpret_cast<const float*>(w_scale), alpha,              \
+                to_stream(stream));                                          \
+        },                                                                   \
+        py::arg("A"), py::arg("B"), py::arg("D"),                          \
+        py::arg("M"), py::arg("N"), py::arg("K"),                          \
+        py::arg("act_scale"), py::arg("w_scale"), py::arg("alpha"),        \
+        py::arg("stream") = 0)
+
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w4);
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w8);
+    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w16);
+
+    // BF16-input GEMV: A is BF16, B is FP8 with block-128 weight scale.
+    // Eliminates standalone FP8 activation quantization before O-proj.
+#define BIND_BLOCK128_GEMV_M1_BF16IN(NAME)                                     \
+    m.def("ht_" #NAME,                                                         \
+        [](uintptr_t A, uintptr_t B, uintptr_t D,                              \
+           int M, int N, int K, uintptr_t w_scale, uintptr_t stream) {         \
+            return flash_rt::gemm::gemv_m1_sm89::NAME(                          \
+                to_ptr(A), to_ptr(B), to_ptr(D),                               \
+                M, N, K, reinterpret_cast<const float*>(w_scale),              \
+                to_stream(stream));                                            \
+        },                                                                     \
+        py::arg("A"), py::arg("B"), py::arg("D"),                              \
+        py::arg("M"), py::arg("N"), py::arg("K"),                              \
+        py::arg("w_scale"), py::arg("stream") = 0)
+
+    BIND_BLOCK128_GEMV_M1_BF16IN(gemv_fp8_block128_m1_bf16in_w8);
+    BIND_BLOCK128_GEMV_M1_BF16IN(gemv_fp8_block128_m1_bf16in_w16);
+
+#undef BIND_BLOCK128_GEMV_M1_BF16IN
+
+#endif  // ENABLE_SM89_BLOCK_FP8_GEMM
+
+// ── Fused QK norm-rope-kvwrite ──
+// Shared by the SM89 FP8 path and the SM110 (Thor) BF16 prefill, which builds
+// qwen3_qkv_post_proc.cu without the SM89 block-FP8 GEMM. The batched variant
+// is the one the Thor prefill uses.
+#ifdef ENABLE_QWEN3_VL_QKV_POSTPROC
     m.def("qwen3_qk_norm_rope_kvwrite_bf16",
         [](uintptr_t q_pre, uintptr_t k_pre, uintptr_t v_pre,
            uintptr_t q_norm_w, uintptr_t k_norm_w,
@@ -430,51 +491,10 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         py::arg("q_dst_row_elems"), py::arg("kv_dst_row_elems"),
         py::arg("n_q_heads"), py::arg("n_kv_heads"),
         py::arg("eps") = 1e-6f, py::arg("stream") = 0);
-
-#define BIND_BLOCK128_GEMV_M1(NAME)                                           \
-    m.def("ht_" #NAME,                                                       \
-        [](uintptr_t A, uintptr_t B, uintptr_t D,                            \
-           int M, int N, int K, uintptr_t act_scale, uintptr_t w_scale,       \
-           float alpha, uintptr_t stream) {                                  \
-            return flash_rt::gemm::gemv_m1_sm89::NAME(                            \
-                to_ptr(A), to_ptr(B), to_ptr(D),                             \
-                M, N, K, reinterpret_cast<const float*>(act_scale),          \
-                reinterpret_cast<const float*>(w_scale), alpha,              \
-                to_stream(stream));                                          \
-        },                                                                   \
-        py::arg("A"), py::arg("B"), py::arg("D"),                          \
-        py::arg("M"), py::arg("N"), py::arg("K"),                          \
-        py::arg("act_scale"), py::arg("w_scale"), py::arg("alpha"),        \
-        py::arg("stream") = 0)
-
-    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w4);
-    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w8);
-    BIND_BLOCK128_GEMV_M1(gemv_fp8_block128_m1_w16);
-
-    // BF16-input GEMV: A is BF16, B is FP8 with block-128 weight scale.
-    // Eliminates standalone FP8 activation quantization before O-proj.
-#define BIND_BLOCK128_GEMV_M1_BF16IN(NAME)                                     \
-    m.def("ht_" #NAME,                                                         \
-        [](uintptr_t A, uintptr_t B, uintptr_t D,                              \
-           int M, int N, int K, uintptr_t w_scale, uintptr_t stream) {         \
-            return flash_rt::gemm::gemv_m1_sm89::NAME(                          \
-                to_ptr(A), to_ptr(B), to_ptr(D),                               \
-                M, N, K, reinterpret_cast<const float*>(w_scale),              \
-                to_stream(stream));                                            \
-        },                                                                     \
-        py::arg("A"), py::arg("B"), py::arg("D"),                              \
-        py::arg("M"), py::arg("N"), py::arg("K"),                              \
-        py::arg("w_scale"), py::arg("stream") = 0)
-
-    BIND_BLOCK128_GEMV_M1_BF16IN(gemv_fp8_block128_m1_bf16in_w8);
-    BIND_BLOCK128_GEMV_M1_BF16IN(gemv_fp8_block128_m1_bf16in_w16);
-
-#undef BIND_BLOCK128_GEMV_M1_BF16IN
-
-#endif  // ENABLE_SM89_BLOCK_FP8_GEMM
+#endif  // ENABLE_QWEN3_VL_QKV_POSTPROC
 
 #ifdef ENABLE_QWEN3_VL_BF16_CUBLASLT
-    // BF16 cuBLASLt matmul for Qwen3-VL BF16 linears on SM87/SM89. SM120
+    // BF16 cuBLASLt matmul for Qwen3-VL BF16 linears on SM87/SM89/SM110. SM120
     // uses w16a16_gemm_sm120_bf16 from flash_rt_kernels instead.
     m.def("bf16_matmul_cublaslt_bf16",
         [](uintptr_t x, uintptr_t W, uintptr_t out,
@@ -500,6 +520,133 @@ PYBIND11_MODULE(flash_rt_qwen3_vl_kernels, m) {
         },
         py::arg("x"), py::arg("W"), py::arg("out"),
         py::arg("N"), py::arg("K"), py::arg("stream") = 0);
-#endif
-#endif
+
+    // ── Weight-only quantized M=1 decode GEMVs ──
+    // Decode at M=1 is bound by the weight HBM read, so shrinking the weights
+    // buys throughput directly. All of these take packed weights + bf16 per-16
+    // block scales and dequantize in-kernel to bf16, so no FP8/FP4 tensor core
+    // is required. Prefill keeps using the bf16 weights.
+
+    // FP8 e4m3 (scale = amax/448): 1.125 B/elem vs bf16 2.0. Relies on the
+    // hardware e4m3 conversion, so it only stays bandwidth-bound on sm_89+.
+    m.def("qwen3_vl_w8_gemv_m1",
+        [](uintptr_t x, uintptr_t Wp, uintptr_t Ws, uintptr_t out,
+           int N, int K, uintptr_t stream) {
+            flash_rt::kernels::qwen3_vl_w8_gemv_m1(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const uint8_t*>(Wp),
+                reinterpret_cast<const __nv_bfloat16*>(Ws),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("Wp"), py::arg("Ws"), py::arg("out"),
+        py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+
+    // NVFP4 e2m1 (scale = amax/6), two nibbles per byte: 0.625 B/elem, ~3.2x
+    // less weight traffic than bf16. Dequant is a __byte_perm LUT into e4m3, so
+    // like the W8 sibling it wants sm_89+.
+    m.def("qwen3_vl_w4_gemv_m1",
+        [](uintptr_t x, uintptr_t Wp, uintptr_t Ws, uintptr_t out,
+           int N, int K, uintptr_t stream) {
+            flash_rt::kernels::qwen3_vl_w4_gemv_m1(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const uint8_t*>(Wp),
+                reinterpret_cast<const __nv_bfloat16*>(Ws),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("Wp"), py::arg("Ws"), py::arg("out"),
+        py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+#endif  // ENABLE_QWEN3_VL_BF16_GEMV_M1
+#endif  // ENABLE_QWEN3_VL_BF16_CUBLASLT
+
+#ifdef ENABLE_QWEN3_VL_INT_DECODE
+    // INT8 symmetric (scale = amax/127): 1.125 B/elem vs bf16 2.0. Dequant is
+    // a hardware I2F, which is why this — not the e4m3 sibling — is the W8
+    // choice on Ampere (sm_87), where FP8 conversion is emulated in software.
+    m.def("qwen3_vl_int8_gemv_m1",
+        [](uintptr_t x, uintptr_t Wp, uintptr_t Ws, uintptr_t out,
+           int N, int K, uintptr_t stream) {
+            flash_rt::kernels::qwen3_vl_int8_gemv_m1(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const uint8_t*>(Wp),
+                reinterpret_cast<const __nv_bfloat16*>(Ws),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("Wp"), py::arg("Ws"), py::arg("out"),
+        py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+
+    // INT4 symmetric (scale = amax/7), two nibbles per byte: 0.625 B/elem.
+    // Unpack is shift + sign-extend + I2F, also Ampere-friendly. Coarser than
+    // INT8 (15 levels) — validate per model.
+    m.def("qwen3_vl_int4_gemv_m1",
+        [](uintptr_t x, uintptr_t Wp, uintptr_t Ws, uintptr_t out,
+           int N, int K, uintptr_t stream) {
+            flash_rt::kernels::qwen3_vl_int4_gemv_m1(
+                reinterpret_cast<const __nv_bfloat16*>(x),
+                reinterpret_cast<const uint8_t*>(Wp),
+                reinterpret_cast<const __nv_bfloat16*>(Ws),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                N, K, to_stream(stream));
+        },
+        py::arg("x"), py::arg("Wp"), py::arg("Ws"), py::arg("out"),
+        py::arg("N"), py::arg("K"), py::arg("stream") = 0);
+
+    // ── INT8 KV cache: row quantize + q=1 flash-decoding attention ──
+    // KV rows are mirrored into int8 with one bf16 scale per (position,
+    // kv-head) 128-element row, halving the KV bytes each decode step reads.
+    // Prefill still runs FA2 against the bf16 cache.
+
+    // Quantize n_rows contiguous 128-element bf16 rows. Layout-agnostic, so it
+    // serves both the per-step pass (n_rows = kv_heads at one layer/position)
+    // and the post-prefill bulk pass over the whole cache prefix.
+    m.def("qwen3_kv_rows_quant_int8",
+        [](uintptr_t src, uintptr_t dst, uintptr_t scales, int n_rows,
+           uintptr_t stream) {
+            flash_rt::kernels::qwen3_kv_rows_quant_int8(
+                reinterpret_cast<const __nv_bfloat16*>(src),
+                reinterpret_cast<int8_t*>(dst),
+                reinterpret_cast<__nv_bfloat16*>(scales),
+                n_rows, to_stream(stream));
+        },
+        py::arg("src"), py::arg("dst"), py::arg("scales"),
+        py::arg("n_rows"), py::arg("stream") = 0);
+
+    // Partial pass: one block per (kv-head, 128-position chunk). Specialized
+    // for GQA 16Q/8KV with head_dim 128.
+    m.def("qwen3_attn_decode_int8kv_partial",
+        [](uintptr_t q, uintptr_t k8, uintptr_t v8, uintptr_t ks,
+           uintptr_t vs, uintptr_t part_o, uintptr_t part_m, uintptr_t part_l,
+           int kv_len, int n_chunks, float softmax_scale, uintptr_t stream) {
+            flash_rt::kernels::qwen3_attn_decode_int8kv_partial(
+                reinterpret_cast<const __nv_bfloat16*>(q),
+                reinterpret_cast<const int8_t*>(k8),
+                reinterpret_cast<const int8_t*>(v8),
+                reinterpret_cast<const __nv_bfloat16*>(ks),
+                reinterpret_cast<const __nv_bfloat16*>(vs),
+                reinterpret_cast<float*>(part_o),
+                reinterpret_cast<float*>(part_m),
+                reinterpret_cast<float*>(part_l),
+                kv_len, n_chunks, softmax_scale, to_stream(stream));
+        },
+        py::arg("q"), py::arg("k8"), py::arg("v8"), py::arg("ks"),
+        py::arg("vs"), py::arg("part_o"), py::arg("part_m"), py::arg("part_l"),
+        py::arg("kv_len"), py::arg("n_chunks"), py::arg("softmax_scale"),
+        py::arg("stream") = 0);
+
+    // Combine pass: rescale and merge the chunk partials into bf16 O.
+    m.def("qwen3_attn_decode_int8kv_combine",
+        [](uintptr_t part_o, uintptr_t part_m, uintptr_t part_l,
+           uintptr_t out, int n_chunks, uintptr_t stream) {
+            flash_rt::kernels::qwen3_attn_decode_int8kv_combine(
+                reinterpret_cast<const float*>(part_o),
+                reinterpret_cast<const float*>(part_m),
+                reinterpret_cast<const float*>(part_l),
+                reinterpret_cast<__nv_bfloat16*>(out),
+                n_chunks, to_stream(stream));
+        },
+        py::arg("part_o"), py::arg("part_m"), py::arg("part_l"),
+        py::arg("out"), py::arg("n_chunks"), py::arg("stream") = 0);
+#endif  // ENABLE_QWEN3_VL_INT_DECODE
 }

--- a/docs/qwen3_vl_rtx_bf16.md
+++ b/docs/qwen3_vl_rtx_bf16.md
@@ -86,7 +86,7 @@ decode graphs per `(cache_pos, rope_pos)` bucket.
 
 ```bash
 python examples/orin/qwen3_vl_quickstart.py \
-  --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+  --checkpoint /path/to/Qwen3-VL-2B-Instruct \
   --image FlashRT.png \
   --prompt "Describe this image in one sentence." \
   --max-new-tokens 32
@@ -109,7 +109,7 @@ FP8/NVFP4 reports:
 
 ```bash
 python examples/orin/qwen3_vl_quickstart.py \
-  --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+  --checkpoint /path/to/Qwen3-VL-2B-Instruct \
   --image FlashRT.png \
   --prompt "Describe this image in one sentence." \
   --max-new-tokens 4 \
@@ -129,7 +129,7 @@ Environment:
 - L4T: R36.4.7
 - CUDA Toolkit: 12.6.68
 - PyTorch: 2.8.0 + CUDA 12.6
-- Checkpoint: `/root/models/Qwen3-VL-2B-Instruct`
+- Checkpoint: `/path/to/Qwen3-VL-2B-Instruct`
 - Workload: `FlashRT.png`, prompt `Describe this image in one sentence.`
 
 Local checks:
@@ -306,7 +306,7 @@ after graph capture and warmup:
 nsys profile --trace=cuda \
   --capture-range=cudaProfilerApi --capture-range-end=stop \
   --cuda-graph-trace=node \
-  -o /root/qwen3_vl_bf16_prefill_replay \
+  -o /path/to/qwen3_vl_bf16_prefill_replay \
   python ...
 ```
 

--- a/docs/qwen3_vl_rtx_bf16.md
+++ b/docs/qwen3_vl_rtx_bf16.md
@@ -94,6 +94,16 @@ python examples/orin/qwen3_vl_quickstart.py \
 
 Use `--no-graph` to run the eager correctness path without CUDA Graph replay.
 
+Both decode-quantization flags default to `bf16`, so the command above is the
+plain BF16 path. Add `--weight-mode int8 --kv-mode int8` for the recommended
+Orin decode configuration; see [Decode weight quantization](#decode-weight-quantization-weight_mode)
+below for the full menu and why the FP8/FP4 tiers are the wrong choice here.
+
+The frontend is registered for `('qwen3_vl', 'torch', 'rtx_sm87')`, so
+`flash_rt.hardware.resolve_pipeline_class` finds it. `load_model()` still
+raises a redirect, because Qwen3-VL exposes a chat surface
+(`generate(messages) -> str`) rather than the VLA `predict()` surface.
+
 For the full-resolution comparison workload used by the existing Qwen3-VL
 FP8/NVFP4 reports:
 
@@ -167,6 +177,91 @@ The two optimization effects were measured separately:
 The fixed-K M=1 GEMV helper provides the larger decode win. The cuBLASLt
 autotune mainly affects M>1 prefill replay; it has little effect on decode
 throughput once the M=1 GEMV helper is enabled.
+
+### Decode weight quantization (`weight_mode`)
+
+Decode runs at M=1, so every step reads the whole weight set once and is bound
+by weight bandwidth rather than math. Shrinking the weights converts almost
+directly into tokens/s. `weight_mode` picks a weight-only tier; the GEMV
+dequantizes to BF16 in-kernel, so no FP8/FP4 tensor core is involved. Prefill
+always keeps using the BF16 weights.
+
+| `weight_mode` | format | weight bytes/element | notes |
+|---|---|---:|---|
+| `bf16` (default) | BF16 | 2.0 | unchanged baseline |
+| `int8` | INT8 symmetric, scale = amax/127 | 1.125 | recommended on Orin |
+| `int4` | INT4 symmetric, scale = amax/7 | 0.625 | chat-grade precision |
+| `w8` | FP8 e4m3, scale = amax/448 | 1.125 | **not recommended on Orin** |
+| `w4` | NVFP4 e2m1, scale = amax/6 | 0.625 | **not recommended on Orin** |
+
+Scales are per 16 elements, stored BF16.
+
+**Why the integer tiers and not the float ones.** Orin is Ampere (sm_87), which
+has no hardware FP8 conversion instruction. The e4m3/e2m1 dequant therefore
+compiles to a software bit sequence and the GEMV flips from bandwidth-bound to
+ALU-bound, so `w8` and `w4` measure *slower than BF16* here despite moving fewer
+bytes. `int8`/`int4` dequantize with a hardware integer-to-float conversion and
+keep the bandwidth win. The `w8`/`w4` tiers remain available because they are
+the right choice on sm_89+, where that conversion exists.
+
+`int8` and `int4` use K-templated kernels built for the Qwen3-VL-2B dimensions
+(K in {2048, 6144}). The constructor rejects other dimensions up front rather
+than failing partway through the first decode step; use `w8`/`w4` or `bf16` for
+8B.
+
+### INT8 KV cache (`kv_mode`)
+
+`kv_mode='int8'` keeps INT8 mirrors of the KV cache with one BF16 scale per
+(position, KV-head) row and runs q=1 decode attention over those mirrors with a
+two-pass flash-decoding kernel, halving the KV bytes each decode step reads.
+That matters more as the prompt grows, since attention reads the whole KV cache
+every token. Prefill still runs FA2 against the BF16 cache.
+
+The decode kernel is specialized for the 2B attention geometry (GQA 16Q/8KV,
+head_dim 128) and is rejected at construction otherwise.
+
+### Measured tiers
+
+Measured during development on Jetson AGX Orin with a Qwen3-VL-2B-architecture
+checkpoint at prompt = 1581 tokens (6256 vision patches). Absolute throughput
+depends on device, prompt length and clocks, so treat the ratios as the
+portable result and re-measure locally:
+
+```bash
+python examples/orin/qwen3_vl_quickstart.py --checkpoint <ckpt> \
+  --image FlashRT.png --prompt "Describe this image in one sentence." \
+  --max-new-tokens 64 --benchmark 20 --weight-mode int8 --kv-mode int8
+```
+
+| `weight_mode` | vs BF16 decode | logit cosine vs BF16 |
+|---|---:|---:|
+| `bf16` | 1.00× | — |
+| `int8` | ~1.7× | 0.99985 (effectively lossless) |
+| `int4` | ~2.3× | 0.989 (chat-grade) |
+| `w8` | ~0.8× (regression) | 0.99932 |
+| `w4` | ~0.65× (regression) | not measured |
+
+`kv_mode='int8'` is orthogonal to the weight tier. Its speedup grows with prompt
+length, since attention reads the whole KV cache every token, and it does not
+change prefill. Its effect on output quality has not been characterised yet —
+validate it against the BF16 KV path for your workload before relying on it.
+
+Two results are worth recording because they look like obvious wins and are
+not: staging the activation in shared memory *cost* throughput (Orin has 16 SMs,
+so the occupancy loss outweighed the saved L2 re-reads, and the activation was
+already L2-hot), and the FP8/FP4 tiers regress for the hardware reason above.
+
+### In-graph argmax decode
+
+`generate(use_graph=True)` captures the argmax and the token feedback into each
+decode graph, so a replay yields the next token with no host round-trip. EOS is
+checked from a pinned async copy one step behind, so decoding can overshoot EOS
+by at most one token; the returned text is trimmed at the first EOS either way,
+so callers see no difference.
+
+The argmax runs on the BF16 logits directly. FP32 is a superset of BF16, so the
+ordering — and therefore the argmax — is identical to an FP32 argmax. This is
+exact, not an approximation.
 
 ### Resolution knob
 
@@ -245,8 +340,12 @@ quantized path.
   pressure is high.
 - Single-image prompts are supported. Multi-image and video are not part of
   this BF16 bring-up.
-- The frontend is instantiated directly; server integration and `load_model()`
-  registration are not included.
-- The path is BF16-only. It is a correctness and portability baseline for
-  official checkpoints, not a replacement for the optimized FP8/NVFP4 paths.
+- The frontend can be instantiated directly or resolved through
+  `resolve_pipeline_class`; `load_model()` deliberately redirects, since this is
+  a chat VLM rather than a VLA. Server integration is not included.
+- Weights and prefill are BF16. Decode weight quantization and the INT8 KV
+  cache are opt-in and off by default; the `int8`/`int4` tiers additionally
+  require the Qwen3-VL-2B dimensions. This path is a correctness and
+  portability baseline for official checkpoints, not a replacement for the
+  optimized FP8/NVFP4 paths on sm_89+.
 - Decode graphs are captured per cache position and RoPE position.

--- a/docs/qwen3_vl_thor.md
+++ b/docs/qwen3_vl_thor.md
@@ -92,14 +92,16 @@ roughly 2·S kernel launches per layer.
 **Vision.** The BF16 `Qwen3VlVisionRtx` tower is reused with its FP8 path
 explicitly disabled. Autodetecting on compute capability is not sufficient here:
 Thor reports sm_110, which satisfies the `>= 89` FP8 test, but its Qwen3-VL
-module deliberately omits the FP8 block-128 ViT kernels. Patch attention falls
-back to non-causal SDPA because `flash_rt_fa2` is absent; patch attention is
-bidirectional, so that is equivalent rather than an approximation. On the SDPA
-path the tower prefers the **cuDNN backend**, probed once at kernel init (never
-inside a capture): at the ViT shape (head_dim 64, non-causal, 6256 patches) it
-measures 1.6 ms per block vs 3.8 ms for torch's default flash backend — 2.3×,
-worth ~52 ms of full-resolution prefill across the 24 blocks. When the probe
-fails the code falls back to the default SDPA dispatcher.
+module deliberately omits the FP8 block-128 ViT kernels. The Thor frontend
+therefore explicitly selects non-causal SDPA for patch attention; existing RTX
+frontends retain the required FA2 backend and still fail fast if
+`flash_rt_fa2` is missing. Patch attention is bidirectional, so SDPA is
+equivalent rather than an approximation. On Thor the tower prefers the
+**cuDNN backend**, probed once at kernel init (never inside a capture): at the
+ViT shape (head_dim 64, non-causal, 6256 patches) it measures 1.6 ms per block
+vs 3.8 ms for torch's default flash backend — 2.3×, worth ~52 ms of
+full-resolution prefill across the 24 blocks. When the probe fails the code
+falls back to the default SDPA dispatcher.
 
 **Linears.** M=1 decode uses the dedicated warp-per-row BF16 GEMV, which beats
 cuBLASLt's weak M=1 tactics. Larger M (prefill) goes through the Thor cuBLASLt
@@ -109,7 +111,7 @@ BF16 matmul.
 
 ```bash
 python examples/thor/qwen3_vl_quickstart.py \
-  --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+  --checkpoint /path/to/Qwen3-VL-2B-Instruct \
   --image FlashRT.png \
   --prompt "Describe this image in one sentence." \
   --max-new-tokens 32

--- a/docs/qwen3_vl_thor.md
+++ b/docs/qwen3_vl_thor.md
@@ -1,0 +1,365 @@
+# Qwen3-VL official BF16 on Jetson Thor (SM110)
+
+This path brings up Qwen3-VL on Jetson AGX Thor using the official BF16
+checkpoint weights. It is the SM110 counterpart to the
+[Orin BF16 path](./qwen3_vl_rtx_bf16.md) and to the optimized
+[SM89 FP8](./qwen3_vl_fp8_sm89.md) and [SM120 NVFP4](./qwen3_vl_nvfp4.md)
+Qwen3-VL paths: the model stays in BF16, while the runtime uses FlashRT's
+fixed-shape CUDA Graph decode replay and a small set of Thor-friendly BF16
+kernels, with opt-in weight-only decode quantization on top.
+
+All language dimensions are read from `config.json`, so the 2B/4B/8B variants
+load unchanged. `Qwen3-VL-2B-Instruct` is the primary bring-up target.
+
+## Supported configuration
+
+| | |
+|---|---|
+| Config name | `qwen3_vl` |
+| Framework | `torch` |
+| Hardware | `thor` (SM110, compute capability 11.0) |
+| Frontend | `flash_rt.frontends.torch.qwen3_vl_thor.Qwen3VlTorchFrontendThor` |
+| Attention | `flash_rt.hardware.thor.attn_backend_qwen3.ThorAttnBackendQwen3` |
+| Precision | BF16 weights; opt-in W8A16 / W4A16 decode |
+| Inputs | text-only, or a single image plus text |
+
+## Checkpoint
+
+Use an official BF16 checkpoint, for example:
+
+```text
+Qwen3-VL-2B-Instruct
+Qwen3-VL-8B-Instruct
+```
+
+Only **2B is validated** on Thor. Larger variants load through the same
+config-driven path, but they are untested here, and their decode projections
+fall outside the fixed-K M=1 GEMV (K in {2048, 6144}) onto the cuBLASLt path, so
+decode throughput will differ materially.
+
+No offline quantization step is required. When `weight_mode` is not `bf16`, the
+decode weights are quantized once at load time from the resident BF16 tensors.
+
+## Build
+
+Thor needs `GPU_ARCH=110` and the gated Qwen3-VL kernel module:
+
+```bash
+git clone --depth 1 --branch v4.4.2 \
+    https://github.com/NVIDIA/cutlass.git third_party/cutlass
+pip install -e ".[torch]"
+cmake -B build -S . -DGPU_ARCH=110 -DFLASHRT_BUILD_QWEN3_VL=ON
+cmake --build build -j$(nproc) \
+  --target flash_rt_kernels flash_rt_qwen3_vl_kernels
+```
+
+Note there is **no `flash_rt_fa2` target here.** The vendored FA2 is not built
+for sm_110 (see the `ENABLE_FA2` gate in `CMakeLists.txt`), which is the main
+reason Thor has its own frontend and attention backend.
+
+For SM110 the Qwen3-VL module compiles the BF16 ViT helpers, the cuBLASLt BF16
+matmul, the `bf16`/`w8`/`w4` M=1 decode GEMVs, and the batched QK norm-rope
+kernel used by prefill. It does **not** compile the FP8 block-128 path, so the
+ViT tower runs BF16.
+
+Two Orin-only pieces are deliberately absent here: the `int8`/`int4` decode
+GEMVs and the INT8 KV cache (`csrc/kernels/qwen3_int8_kv.cu`,
+`ENABLE_QWEN3_VL_INT_DECODE`). Thor has hardware FP8 conversion, so `w8`/`w4`
+are the right weight tiers, and `ThorAttnBackendQwen3` has no INT8 KV path —
+building those would export unused bindings. There is no `kv_mode` knob on Thor.
+
+## Runtime architecture
+
+**Attention.** `ThorAttnBackendQwen3` keeps exactly the buffer surface the RTX
+backend exposes (`Q_buf` / `K_cache` / `V_cache` / `O_buf`, `get_slot_ptrs`,
+`kv_layer_stride_bytes` / `kv_row_stride_bytes`, `reset_cache`, `run`), so the
+frontend's KV-write pointer math is arch-independent. The kernel underneath is a
+GQA `scaled_dot_product_attention`: numerically faithful (BF16 math, FP32
+softmax) and the correctness baseline for this bring-up. Swapping in the Thor
+CUTLASS causal FMHA later requires no frontend change.
+
+Native-GQA SDPA support is probed once at construction, not on the first
+attention call — the probe itself launches an SDPA, which must not happen inside
+a CUDA Graph capture. When unsupported, `run` expands K/V instead.
+
+**RoPE and KV writes.** Prefill drives the batched
+`qwen3_qk_norm_rope_kvwrite_batched_bf16` in a single launch per layer, which is
+bit-identical to the per-row `qwen3_q_norm_rope_qstage_bf16` /
+`qwen3_k_norm_rope_kvwrite_bf16` kernels decode uses. Prefill and decode math
+therefore agree without re-implementing RoPE in torch, and prefill avoids
+roughly 2·S kernel launches per layer.
+
+**Vision.** The BF16 `Qwen3VlVisionRtx` tower is reused with its FP8 path
+explicitly disabled. Autodetecting on compute capability is not sufficient here:
+Thor reports sm_110, which satisfies the `>= 89` FP8 test, but its Qwen3-VL
+module deliberately omits the FP8 block-128 ViT kernels. Patch attention falls
+back to non-causal SDPA because `flash_rt_fa2` is absent; patch attention is
+bidirectional, so that is equivalent rather than an approximation. On the SDPA
+path the tower prefers the **cuDNN backend**, probed once at kernel init (never
+inside a capture): at the ViT shape (head_dim 64, non-causal, 6256 patches) it
+measures 1.6 ms per block vs 3.8 ms for torch's default flash backend — 2.3×,
+worth ~52 ms of full-resolution prefill across the 24 blocks. When the probe
+fails the code falls back to the default SDPA dispatcher.
+
+**Linears.** M=1 decode uses the dedicated warp-per-row BF16 GEMV, which beats
+cuBLASLt's weak M=1 tactics. Larger M (prefill) goes through the Thor cuBLASLt
+BF16 matmul.
+
+## Quickstart
+
+```bash
+python examples/thor/qwen3_vl_quickstart.py \
+  --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+  --image FlashRT.png \
+  --prompt "Describe this image in one sentence." \
+  --max-new-tokens 32
+```
+
+Omit `--image` for a text-only prompt. Use `--no-graph` for the eager decode
+correctness reference. `--benchmark N` times eager prefill and warm graph decode
+separately.
+
+Constructor arguments:
+
+| Argument | Default | Meaning |
+|---|---|---|
+| `checkpoint_path` | — | BF16 checkpoint directory |
+| `device` | `'cuda:0'` | target device |
+| `max_seq` | `4096` | KV cache capacity, in prompt + generated tokens |
+| `max_pixels` | `None` | cap on visual tokens, forwarded to the processor's smart-resize |
+| `weight_mode` | `'bf16'` | decode weight tier (see below) |
+| `wq_overrides` | `None` | per-projection tier overrides (see below) |
+
+`max_seq` sizes the KV cache and must cover prompt plus generated tokens; a
+full-resolution image prompt already costs ~1.6 K tokens, so the `4096` default
+leaves modest headroom. `set_prompt_text()` takes a pre-templated string instead
+of a `messages` list, for text-only harnesses that build their own prompt.
+
+Decode graphs are cached per `(cache_pos, rope_pos)` and the cache is capped at
+`max_seq` entries — one per reachable position, so a graph is never evicted while
+still reachable. Thor therefore has no graph-cache environment variables; the
+`FLASHRT_QWEN3_VL_*_GRAPH_CACHE_MAX` knobs belong to the other Qwen3-VL
+frontends (Orin/SM89/SM120) and are not read here.
+
+The frontend is registered for `('qwen3_vl', 'torch', 'thor')`, so
+`flash_rt.hardware.resolve_pipeline_class` finds it. `load_model()` raises a
+redirect, because Qwen3-VL exposes a chat surface (`generate(messages) -> str`)
+rather than the VLA `predict()` surface.
+
+## Decode weight quantization (`weight_mode`)
+
+Decode runs at M=1 and is bound by weight bandwidth, so shrinking the weights
+converts almost directly into tokens/s. The GEMV dequantizes to BF16 in-kernel.
+Prefill always keeps using the BF16 weights.
+
+| `weight_mode` | format | weight bytes/element | decode vs BF16 | logit cosine vs BF16 |
+|---|---|---:|---:|---:|
+| `bf16` (default) | BF16 | 2.0 | 1.00× | — |
+| `w8` | FP8 e4m3, scale = amax/448 | 1.125 | 1.61× | 0.99923 (effectively lossless) |
+| `w4` | NVFP4 e2m1, scale = amax/6 | 0.625 | 2.38× | 0.986 (chat-grade) |
+
+Scales are per 16 elements, stored BF16. The measured columns come from the
+workload in [Jetson Thor validation](#jetson-thor-validation) below; treat the
+ratios as the portable result and re-measure on your own prompt lengths.
+
+Unlike Orin, Thor *does* have hardware FP8 conversion, so the e4m3/e2m1 tiers
+are the right choice here and stay bandwidth-bound. (The Orin doc explains why
+the integer tiers win on Ampere instead.)
+
+`wq_overrides` sets the tier per projection for sensitivity work, keyed
+`'{proj}'` or `'L{layer}.{proj}'` over
+`qkv_proj` / `o_proj` / `gate_up` / `mlp_down` / `lm_head`:
+
+```python
+fe = Qwen3VlTorchFrontendThor(ckpt, weight_mode='w4',
+                              wq_overrides={'lm_head': 'w8',
+                                            'L0.gate_up': 'bf16'})
+```
+
+Unknown keys are rejected rather than ignored, because a silently dropped
+override reads as "this projection does not matter" in a sweep.
+`set_wq_overrides()` requantizes in place and drops the captured decode graphs,
+which bake in the quant-buffer pointers.
+
+Measured on the validation workload below, `w8` matched the BF16 greedy top-1
+on 31 of 32 teacher-forced steps and `w4` on 30 of 32; every divergence was a
+near-tie wording change ("an orange lightning bolt symbol" vs "a stylized
+orange lightning bolt icon") and the captions stayed accurate. Still, a single
+early divergence can reword a whole continuation, so the low-bit tiers are a
+quality/throughput trade rather than a free win. `w4` at full strength wants an
+outlier-channel (AWQ-style) fold to hold precision; that fold is not part of
+this path, so validate `w4` output against `bf16` on your own workload before
+relying on it.
+
+## Jetson Thor validation
+
+Environment:
+
+- Device: Jetson AGX Thor, SM110 (compute capability 11.0)
+- L4T: R38.2.0 (Ubuntu 24.04)
+- CUDA Toolkit: 13.0.88, driver 580.00
+- PyTorch: 2.9.0 + CUDA 13.0
+- Checkpoint: `Qwen/Qwen3-VL-2B-Instruct`, official BF16 weights
+- Workload: `FlashRT.png`, prompt `Describe this image in one sentence.`
+  → 6256 vision patches, 1581 prompt tokens
+
+Build and symbol checks passed as described in [Local checks](#local-checks);
+`tests/test_qwen3_vl_thor.py` reports 40 passed, 3 skipped on device.
+
+**Correctness.** Text-only and single-image greedy prompts both produce coherent
+answers. The eager decode path (`--no-graph`) and CUDA-Graph replay returned
+character-identical text on the same prompt, which is the intended property:
+graph replay changes launch overhead, not math.
+
+Full-resolution BF16 result, `generate(max_new_tokens=64)` (greedy hits EOS
+after ~33 generated tokens on this prompt; cold includes ViT graph capture and
+cuDNN/cuBLASLt plan building in a fresh process):
+
+```text
+vision patches: 6256
+prompt tokens: 1581
+generate latency: 2097.0 ms cold / 736.3 ms warm
+prefill P50 (eager): 230 ms (run-to-run range 218-233 ms)
+decode throughput (warm graph): 65.5 tok/s
+```
+
+### Where prefill time goes
+
+Profiled at the workload above, prefill splits roughly 60% ViT tower / 40%
+language stack, and the single largest kernel is the ViT's bidirectional patch
+attention over all 6256 patches (24 blocks; O(P²) work). Two results from
+chasing that number are worth recording:
+
+- **A prefill CUDA Graph is deliberately not shipped.** A working prototype
+  (language stack captured, staged inputs, LRU-bucketed on `(S, span)`,
+  bit-identical logits) measured **0.3%** at full resolution and 1.6% on a
+  text-only prompt. Prefill is GPU-bound on Thor: the host enqueues the whole
+  prefill in ~11 ms against ~280 ms of GPU work, so the enqueue cost a graph
+  removes was already fully hidden. The decode graphs stay — decode's per-step
+  GPU work is small enough that launch overhead matters there.
+- **The ViT patch-attention backend switch is what moved prefill.** Routing the
+  SDPA fallback through the probed cuDNN backend (see
+  [Runtime architecture](#runtime-architecture)) took full-resolution prefill
+  P50 from a repeatable ~282 ms to ~230 ms (−18%, run-to-run range 218–233 ms)
+  with the generated text unchanged — consistent with the per-block kernel
+  delta (2.1 ms × 24 blocks ≈ 51 ms). The CUTLASS SM100 FMHA
+  (`libfmha_fp16_strided.so`) was also measured here and **lost** to cuDNN at
+  this shape (6.2 ms vs 1.6 ms per block) — its tiles are sized for head_dim
+  128, and the ViT runs head_dim 64.
+
+### Measured tiers
+
+Single process, retiering in place via `set_wq_overrides()` so all three rows
+share one weight load; decode throughput is the best of 5 × 64-token warm graph
+replays at prompt = 1581 tokens. Logit fidelity is teacher-forced against the
+BF16 run over 32 decode steps, so it isolates weight-quantization error from
+divergence in the sampled sequence:
+
+```bash
+python examples/thor/qwen3_vl_quickstart.py --checkpoint <ckpt> \
+  --image FlashRT.png --prompt "Describe this image in one sentence." \
+  --max-new-tokens 64 --benchmark 10 --weight-mode w4
+```
+
+| `weight_mode` | decode | vs BF16 | logit cosine (mean / min) | greedy top-1 agreement |
+|---|---:|---:|---:|---:|
+| `bf16` | 66.4 tok/s | 1.00× | — | — |
+| `w8` | 106.6 tok/s | 1.61× | 0.99923 / 0.99837 | 31/32 |
+| `w4` | 158.1 tok/s | 2.38× | 0.98617 / 0.96577 | 30/32 |
+
+The tiers scale close to the bytes they move (2.0 → 1.125 → 0.625 bytes per
+weight predicts 1.78× and 3.2×), which confirms decode is bandwidth-bound here
+and that Thor's hardware FP8 conversion keeps it that way. The shortfall is the
+per-step fixed cost that does not shrink with the weights: attention over a
+1581-token KV cache, the norm/RoPE kernels, and graph replay overhead.
+
+### Resolution knob
+
+Capping visual resolution reduces both vision patches and LLM prefill tokens.
+Measured at `weight_mode='bf16'`; warm generate is `generate(max_new_tokens=64)`
+(greedy hits EOS after ~30–35 tokens depending on resolution), while the decode
+column forces all 64 graph-replay steps:
+
+| `max_pixels` | vision patches | prompt tokens | warm generate | prefill P50 (eager) | decode |
+|---|---:|---:|---:|---:|---:|
+| none | 6256 | 1581 | 736.3 ms | 230 ms | 65.5 tok/s |
+| 1.00 M | 3888 | 989 | 622.3 ms | 127.5 ms | 66.5 tok/s |
+| 0.50 M | 1824 | 473 | 570.8 ms | 62.3 ms | 68.1 tok/s |
+| 0.25 M | 972 | 260 | 518.9 ms | 42.0 ms | 69.1 tok/s |
+
+Every setting produced an accurate caption on this image, though the wording
+varied between resolutions; `max_pixels` discards visual detail and should be
+validated per task, not assumed free. The knob is a prefill lever: prefill
+drops ~5.5× from full resolution to 0.25 M while decode moves only ~5%, since
+decode cost is dominated by weight traffic rather than by KV length at these
+sequence lengths.
+
+**cuBLASLt autotune.** `FLASHRT_BF16_CUBLASLT_AUTOTUNE_ALGOS` (default `8`,
+set `1` to effectively disable) measured under 2% on prefill P50 and no
+measurable decode effect. Thor's default cuBLASLt heuristics are already close
+for these prefill shapes, so this knob matters much less here than the M=1 GEMV
+and `weight_mode` choices.
+
+**Versus Orin.** On the identical workload and prompt length, the
+[Orin BF16 path](./qwen3_vl_rtx_bf16.md) records 36.8 tok/s BF16 decode and
+927.5 ms prefill P50. Thor is ~1.8× on decode and ~4× on prefill at BF16
+(230 ms eager vs 927.5 ms graph replay — modes differ, but Thor measured that
+a prefill graph is worth 0.3% here, so the comparison stands), and reaches
+158 tok/s with `w4`. The clearest remaining prefill target is the ViT tower
+itself — its O(P²) patch attention and FP8-less GEMMs — not the launch path.
+
+## Validation status
+
+| Item | Status |
+|---|---|
+| Text-only prompt, greedy | supported |
+| Single-image prompt, greedy | supported |
+| Eager prefill | supported |
+| Graph-replay decode | supported (bit-identical to eager) |
+| BF16 weights | supported |
+| W8A16 / W4A16 decode | opt-in |
+| Multi-image, video | **not supported** — raises |
+| FP8 ViT tower | **not supported** on Thor |
+| Prefill CUDA Graph capture | **deliberately omitted** — prototyped, measured 0.3% (prefill is GPU-bound) |
+| INT8 KV cache (`kv_mode`) | **not available** on Thor — Orin-only kernels |
+| Speculative decoding | **not supported** |
+| Mid-sequence causal prefill block | **not supported** — raises |
+| Server integration / `load_model()` | not included |
+
+The last item deserves a note: a causal prefill block ending mid-sequence needs
+a bottom-right-aligned mask, which SDPA's `is_causal` does not provide.
+Constructing one would allocate on the attention hot path, so the backend raises
+instead of silently attending to the wrong positions.
+
+## Local checks
+
+No GPU or checkpoint required:
+
+```bash
+python -m py_compile \
+  flash_rt/frontends/torch/qwen3_vl_thor.py \
+  flash_rt/hardware/thor/attn_backend_qwen3.py \
+  examples/thor/qwen3_vl_quickstart.py
+PYTHONPATH=. python -m pytest tests/test_qwen3_vl_thor.py -q
+```
+
+On the device, confirm the expected symbols resolved and that FA2 is absent:
+
+```bash
+PYTHONPATH=. python - <<'PY'
+from flash_rt import flash_rt_kernels as fvk
+from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+for n in ('bf16_matmul_cublaslt_bf16', 'qwen3_vl_bf16_gemv_m1',
+          'qwen3_qk_norm_rope_kvwrite_batched_bf16',
+          'qwen3_vl_w8_gemv_m1', 'qwen3_vl_w4_gemv_m1'):
+    assert hasattr(vlk, n), n
+for n in ('embedding_lookup_bf16', 'qwen3_q_norm_rope_qstage_bf16',
+          'qwen3_k_norm_rope_kvwrite_bf16'):
+    assert hasattr(fvk, n), n
+try:
+    from flash_rt import flash_rt_fa2
+    raise SystemExit('unexpected: flash_rt_fa2 built on sm_110')
+except ImportError:
+    print('ok: fa2 absent as expected')
+PY
+```

--- a/docs/qwen3_vl_thor.md
+++ b/docs/qwen3_vl_thor.md
@@ -132,13 +132,17 @@ Constructor arguments:
 
 `max_seq` sizes the KV cache and must cover prompt plus generated tokens; a
 full-resolution image prompt already costs ~1.6 K tokens, so the `4096` default
-leaves modest headroom. `set_prompt_text()` takes a pre-templated string instead
-of a `messages` list, for text-only harnesses that build their own prompt.
+leaves modest headroom. `set_prompt_text()` takes a plain string (plus optional
+`system=`) instead of a `messages` list; it wraps the string in a user message
+and applies the chat template, for text-only harnesses.
 
 Decode graphs are cached per `(cache_pos, rope_pos)` and the cache is capped at
-`max_seq` entries — one per reachable position, so a graph is never evicted while
-still reachable. Thor therefore has no graph-cache environment variables; the
-`FLASHRT_QWEN3_VL_*_GRAPH_CACHE_MAX` knobs belong to the other Qwen3-VL
+`max_seq` entries, so a graph is never evicted within a single generation.
+Prompts with different image geometries key different `(cache_pos, rope_pos)`
+pairs and may evict older entries across a session. Each cached graph holds a
+private CUDA memory pool, so very long generations trade GPU memory for
+capture-free decode. Thor therefore has no graph-cache environment variables;
+the `FLASHRT_QWEN3_VL_*_GRAPH_CACHE_MAX` knobs belong to the other Qwen3-VL
 frontends (Orin/SM89/SM120) and are not read here.
 
 The frontend is registered for `('qwen3_vl', 'torch', 'thor')`, so
@@ -177,7 +181,9 @@ fe = Qwen3VlTorchFrontendThor(ckpt, weight_mode='w4',
 ```
 
 Unknown keys are rejected rather than ignored, because a silently dropped
-override reads as "this projection does not matter" in a sweep.
+override reads as "this projection does not matter" in a sweep. Overrides
+apply independently of the global mode: `weight_mode='bf16'` with a single
+non-bf16 override quantizes just that projection.
 `set_wq_overrides()` requantizes in place and drops the captured decode graphs,
 which bake in the quant-buffer pointers.
 
@@ -204,7 +210,7 @@ Environment:
   → 6256 vision patches, 1581 prompt tokens
 
 Build and symbol checks passed as described in [Local checks](#local-checks);
-`tests/test_qwen3_vl_thor.py` reports 40 passed, 3 skipped on device.
+`tests/test_qwen3_vl_thor.py` reports 42 passed on device.
 
 **Correctness.** Text-only and single-image greedy prompts both produce coherent
 answers. The eager decode path (`--no-graph`) and CUDA-Graph replay returned
@@ -212,8 +218,8 @@ character-identical text on the same prompt, which is the intended property:
 graph replay changes launch overhead, not math.
 
 Full-resolution BF16 result, `generate(max_new_tokens=64)` (greedy hits EOS
-after ~33 generated tokens on this prompt; cold includes ViT graph capture and
-cuDNN/cuBLASLt plan building in a fresh process):
+after ~33 generated tokens on this prompt; cold includes decode-graph capture
+and cuDNN/cuBLASLt plan building in a fresh process):
 
 ```text
 vision patches: 6256

--- a/examples/orin/qwen3_vl_quickstart.py
+++ b/examples/orin/qwen3_vl_quickstart.py
@@ -3,7 +3,7 @@
 
 Example:
   python examples/orin/qwen3_vl_quickstart.py \
-    --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+    --checkpoint /path/to/Qwen3-VL-2B-Instruct \
     --image FlashRT.png \
     --prompt "Describe this image in one sentence." \
     --max-new-tokens 32
@@ -17,7 +17,7 @@ import time
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
-    p.add_argument('--checkpoint', default='/root/models/Qwen3-VL-2B-Instruct')
+    p.add_argument('--checkpoint', required=True)
     p.add_argument('--image', required=True)
     p.add_argument('--prompt', default='Describe this image in one sentence.')
     p.add_argument('--max-new-tokens', type=int, default=32)

--- a/examples/orin/qwen3_vl_quickstart.py
+++ b/examples/orin/qwen3_vl_quickstart.py
@@ -26,6 +26,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument('--device', default='cuda:0')
     p.add_argument('--precision', default='bf16',
                    help='runtime precision path; currently implemented: bf16')
+    p.add_argument('--weight-mode', default='bf16',
+                   choices=('bf16', 'int8', 'int4', 'w8', 'w4'),
+                   help=('decode weight-only quantization tier; int8/int4 are '
+                         'the Ampere-friendly ones and need the 2B dimensions'))
+    p.add_argument('--kv-mode', default='bf16', choices=('bf16', 'int8'),
+                   help='KV cache precision for q=1 decode attention')
     p.add_argument('--reps', type=int, default=1,
                    help=('repeat generation in one process; useful for '
                          'graph warm replay timing'))
@@ -62,7 +68,8 @@ def main() -> None:
 
     model = Qwen3VlTorchFrontendRtxBF16(
         args.checkpoint, device=args.device, max_seq=args.max_seq,
-        max_pixels=args.max_pixels)
+        max_pixels=args.max_pixels, weight_mode=args.weight_mode,
+        kv_mode=args.kv_mode)
     text = ''
     lat_ms = []
     for _ in range(max(1, args.reps)):

--- a/examples/thor/README.md
+++ b/examples/thor/README.md
@@ -54,6 +54,43 @@ python examples/thor/eval_libero.py \
 See [Thor VLA performance](#thor-vla-performance) below for the
 latency/accuracy table across 1/2/3 views.
 
+## Qwen3-VL (multimodal chat)
+
+`qwen3_vl_quickstart.py` runs the official BF16 Qwen3-VL checkpoint as a chat
+VLM (text-only, or a single image plus text). It needs the gated Qwen3-VL
+kernel module in addition to `flash_rt_kernels`:
+
+```bash
+cmake -B build -S . -DGPU_ARCH=110 -DFLASHRT_BUILD_QWEN3_VL=ON
+cmake --build build -j$(nproc) \
+    --target flash_rt_kernels flash_rt_qwen3_vl_kernels
+```
+
+```bash
+python examples/thor/qwen3_vl_quickstart.py \
+    --checkpoint /path/to/Qwen3-VL-2B-Instruct \
+    --image FlashRT.png \
+    --prompt "Describe this image in one sentence." \
+    --max-new-tokens 32
+```
+
+Omit `--image` for a text-only prompt, `--no-graph` for the eager decode
+reference, and `--benchmark N` to time prefill and warm graph decode
+separately. `--weight-mode` picks the weight-only decode tier; measured on a
+full-resolution image prompt (1581 tokens, 6256 vision patches):
+
+| `--weight-mode` | decode | vs BF16 |
+|---|---:|---:|
+| `bf16` | 66.4 tok/s | 1.00× |
+| `w8` | 106.6 tok/s | 1.61× |
+| `w4` | 158.1 tok/s | 2.38× |
+
+Prefill is eager on Thor (a prefill graph measured 0.3% — it is GPU-bound) and
+measured ~230 ms P50 at full resolution with the cuDNN ViT patch attention.
+Quality measurements, the `max_pixels` resolution knob, and the per-projection
+`wq_overrides` sweep surface are in
+[`docs/qwen3_vl_thor.md`](../../docs/qwen3_vl_thor.md).
+
 ## Thor VLA performance
 
 ### Precision (Pi0.5, 2-view LIBERO)

--- a/examples/thor/qwen3_vl_quickstart.py
+++ b/examples/thor/qwen3_vl_quickstart.py
@@ -3,7 +3,7 @@
 
 Example:
   python examples/thor/qwen3_vl_quickstart.py \
-    --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+    --checkpoint /path/to/Qwen3-VL-2B-Instruct \
     --image FlashRT.png \
     --prompt "Describe this image in one sentence." \
     --max-new-tokens 32
@@ -21,7 +21,7 @@ import time
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
-    p.add_argument('--checkpoint', default='/root/models/Qwen3-VL-2B-Instruct')
+    p.add_argument('--checkpoint', required=True)
     p.add_argument('--image', default=None,
                    help='omit for a text-only prompt')
     p.add_argument('--prompt', default='Describe this image in one sentence.')

--- a/examples/thor/qwen3_vl_quickstart.py
+++ b/examples/thor/qwen3_vl_quickstart.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Qwen3-VL quickstart for Jetson Thor (SM110).
+
+Example:
+  python examples/thor/qwen3_vl_quickstart.py \
+    --checkpoint /root/models/Qwen3-VL-2B-Instruct \
+    --image FlashRT.png \
+    --prompt "Describe this image in one sentence." \
+    --max-new-tokens 32
+
+Build first (see docs/qwen3_vl_thor.md):
+  cmake -B build -S . -DGPU_ARCH=110 -DFLASHRT_BUILD_QWEN3_VL=ON
+  cmake --build build -j --target flash_rt_kernels flash_rt_qwen3_vl_kernels
+"""
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument('--checkpoint', default='/root/models/Qwen3-VL-2B-Instruct')
+    p.add_argument('--image', default=None,
+                   help='omit for a text-only prompt')
+    p.add_argument('--prompt', default='Describe this image in one sentence.')
+    p.add_argument('--max-new-tokens', type=int, default=32)
+    p.add_argument('--max-seq', type=int, default=4096)
+    p.add_argument('--max-pixels', type=int, default=None)
+    p.add_argument('--device', default='cuda:0')
+    p.add_argument('--weight-mode', default='bf16',
+                   choices=('bf16', 'w8', 'w4'),
+                   help=('decode weight-only quantization tier; w4 gives the '
+                         'largest decode speedup on Thor'))
+    p.add_argument('--reps', type=int, default=1,
+                   help=('repeat generation in one process; useful for warm '
+                         'graph replay timing'))
+    p.add_argument('--benchmark', type=int, default=0,
+                   help='if >0, separately time prefill and warm graph decode')
+    p.add_argument('--no-graph', action='store_true',
+                   help='force the eager decode path (correctness reference)')
+    return p.parse_args()
+
+
+def main() -> None:
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_thor import (
+        Qwen3VlTorchFrontendThor,
+    )
+
+    args = parse_args()
+
+    content: list = []
+    if args.image:
+        from PIL import Image
+        with Image.open(args.image) as im:
+            content.append({'type': 'image', 'image': im.convert('RGB')})
+    content.append({'type': 'text', 'text': args.prompt})
+    messages = [{'role': 'user', 'content': content}]
+
+    model = Qwen3VlTorchFrontendThor(
+        args.checkpoint, device=args.device, max_seq=args.max_seq,
+        max_pixels=args.max_pixels, weight_mode=args.weight_mode)
+
+    text = ''
+    lat_ms = []
+    for _ in range(max(1, args.reps)):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        text = model.generate(
+            messages, max_new_tokens=args.max_new_tokens,
+            use_graph=not args.no_graph)
+        torch.cuda.synchronize()
+        lat_ms.append((time.perf_counter() - t0) * 1000.0)
+    print(text)
+    print('\nlatency_ms: ' + ', '.join(f'{v:.1f}' for v in lat_ms))
+    if len(lat_ms) > 1:
+        print(f'warm_latency_ms: {lat_ms[-1]:.1f}')
+
+    if args.benchmark > 0:
+        if args.no_graph:
+            raise ValueError('--benchmark requires CUDA Graph replay')
+        model.set_prompt(messages)
+        p = model._prompt
+        assert p is not None
+
+        # Prefill is eager on Thor; time it directly.
+        torch.cuda.synchronize()
+        ttft = []
+        for _ in range(args.benchmark):
+            t0 = time.perf_counter()
+            model.prefill()
+            torch.cuda.synchronize()
+            ttft.append((time.perf_counter() - t0) * 1000.0)
+        prefill_p50 = statistics.median(ttft)
+
+        n_dec = max(1, args.max_new_tokens)
+        model.warmup_decode_graphs(n_dec)
+        torch.cuda.synchronize()
+        base_slot = int(p['S'])
+        base_rope = int(p['mrope_max']) + 1
+        t0 = time.perf_counter()
+        for j in range(n_dec):
+            model.decode_step_graph(
+                0, cache_pos=base_slot + j, rope_pos=base_rope + j)
+        torch.cuda.synchronize()
+        dt = time.perf_counter() - t0
+
+        print('\n--- benchmark ---')
+        print(f'prompt tokens (incl. vision) : {int(p["S"])}')
+        print(f'weight_mode                  : {args.weight_mode}')
+        print(f'prefill P50 (eager)          : {prefill_p50:.1f} ms')
+        print(f'decode throughput (warm graph): {n_dec / dt:.1f} tok/s '
+              f'({n_dec} tok in {dt * 1000.0:.1f} ms)')
+
+
+if __name__ == '__main__':
+    main()

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -447,7 +447,12 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             "import Qwen3VlFp8Sm89Frontend\n"
             "    from flash_rt.frontends.torch.qwen3_vl_rtx import "
             "Qwen3VlTorchFrontendRtx\n"
-            "See docs/qwen3_vl_fp8_sm89.md and docs/qwen3_vl_nvfp4.md.")
+            "    from flash_rt.frontends.torch.qwen3_vl_thor import "
+            "Qwen3VlTorchFrontendThor\n"
+            "    from flash_rt.frontends.torch.qwen3_vl_rtx_bf16 import "
+            "Qwen3VlTorchFrontendRtxBF16\n"
+            "See docs/qwen3_vl_fp8_sm89.md, docs/qwen3_vl_nvfp4.md, "
+            "docs/qwen3_vl_thor.md and docs/qwen3_vl_rtx_bf16.md.")
 
     if framework == "jetson_pi":
         if config not in ("pi0", "pi05", "llm", "mllm"):

--- a/flash_rt/frontends/torch/_qwen3_vl_bf16_weights.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_bf16_weights.py
@@ -59,10 +59,15 @@ def _to_bf16(t: torch.Tensor, device: str) -> torch.Tensor:
 
 
 def _load_bf16_linear(handles: WeightHandles, out: dict, short: str,
-                      base: str, handles_d, wmap, device: str) -> None:
-    out[short + '_w'] = _anchor(
-        handles, _to_bf16(_get_tensor(handles_d, wmap, base + '.weight'),
-                          device))
+                      base: str, handles_d, wmap, device: str,
+                      keep_tensor: bool = False) -> None:
+    t = _to_bf16(_get_tensor(handles_d, wmap, base + '.weight'), device)
+    out[short + '_w'] = _anchor(handles, t)
+    if keep_tensor:
+        # Exposed under '_t' for weight-only decode quantization, which needs
+        # to read the weights back. _anchor already keeps the tensor alive, so
+        # this costs no extra memory.
+        out[short + '_t'] = t
 
 
 def extract_weights_qwen3_vl_bf16(ckpt_dir: str,
@@ -108,7 +113,9 @@ def extract_weights_qwen3_vl_bf16(ckpt_dir: str,
         raise RuntimeError(
             'Qwen3-VL BF16 ckpt has neither lm_head.weight nor '
             'tie_word_embeddings=true')
-    handles.ptrs['lm_head_w'] = _anchor(handles, _to_bf16(lm_head_cpu, device))
+    lm_head = _to_bf16(lm_head_cpu, device)
+    handles.ptrs['lm_head_w'] = _anchor(handles, lm_head)
+    handles.ptrs['lm_head_t'] = lm_head
 
     per_layer: list[dict] = [None] * num_layers   # type: ignore[list-item]
     for L in range(num_layers):
@@ -130,9 +137,10 @@ def extract_weights_qwen3_vl_bf16(ckpt_dir: str,
                      device)
         qkv = torch.cat([q, k, v], dim=0).contiguous()
         ld['qkv_proj_w'] = _anchor(handles, qkv)
+        ld['qkv_proj_t'] = qkv
         ld['qkv_proj_N'] = int(qkv.shape[0])
         _load_bf16_linear(handles, ld, 'o_proj', sa + 'o_proj',
-                          handles_d, wmap, device)
+                          handles_d, wmap, device, keep_tensor=True)
         ld['q_norm_w'] = _anchor(handles, _to_bf16(
             _get_tensor(handles_d, wmap, sa + 'q_norm.weight'), device))
         ld['k_norm_w'] = _anchor(handles, _to_bf16(
@@ -145,9 +153,10 @@ def extract_weights_qwen3_vl_bf16(ckpt_dir: str,
                       device)
         gate_up = torch.cat([gate, up], dim=0).contiguous()
         ld['gate_up_w'] = _anchor(handles, gate_up)
+        ld['gate_up_t'] = gate_up
         ld['gate_up_N'] = int(gate_up.shape[0])
         _load_bf16_linear(handles, ld, 'mlp_down', mp + 'down_proj',
-                          handles_d, wmap, device)
+                          handles_d, wmap, device, keep_tensor=True)
         per_layer[L] = ld
 
     handles.ptrs.update({

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -19,6 +19,7 @@ Sibling of the language path in ``qwen3_rtx`` / ``qwen3_vl_rtx``.
 """
 from __future__ import annotations
 
+import contextlib
 import math
 from typing import Any
 
@@ -36,7 +37,7 @@ class Qwen3VlVisionRtx:
     """
 
     def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
-                 config: dict | None = None) -> None:
+                 config: dict | None = None, fp8: bool | None = None) -> None:
         import torch
 
         from safetensors import safe_open
@@ -45,6 +46,7 @@ class Qwen3VlVisionRtx:
         self._fvk = None
         self._fa2 = None
         self._vlk = None
+        self._vit_sdpa_ctx = None  # set by _kernels() on the SDPA fallback
         # patch-count -> (graph, static_inputs, captured_outputs)
         self._graphs: dict = {}
         self._graph_stream = None
@@ -65,6 +67,11 @@ class Qwen3VlVisionRtx:
             torch.device(device))[0] * 10 + torch.cuda.get_device_capability(
                 torch.device(device))[1]
         self._use_fp8_gemm = self._device_sm >= 89
+        if fp8 is not None:
+            # Explicit override. Thor (sm_110) passes the sm>=89 test but its
+            # Qwen3-VL module omits the FP8 block-128 ViT kernels, so it has to
+            # ask for the BF16 tower.
+            self._use_fp8_gemm = bool(fp8)
 
         import json
         import os
@@ -180,13 +187,41 @@ class Qwen3VlVisionRtx:
 
     def _kernels(self):
         if self._fvk is None:
-            from flash_rt import flash_rt_fa2 as fa2
+            try:
+                from flash_rt import flash_rt_fa2 as fa2
+            except ImportError:
+                # Not built on Thor (sm_110); _attn falls back to SDPA.
+                fa2 = None
             from flash_rt import flash_rt_kernels as fvk
             from flash_rt import flash_rt_qwen3_vl_kernels as vlk
             self._fvk, self._fa2, self._vlk = fvk, fa2, vlk
             import torch
             self._num_sms = torch.cuda.get_device_properties(
                 torch.device(self.device)).multi_processor_count
+            # Capability check on the module and symbol only. Do NOT also gate
+            # on head_dim: FA2 does instantiate the ViT's head_dim 64 (see
+            # FA2_HDIMS), and excluding it would silently reroute the working
+            # SM89/SM120 ViT attention to SDPA.
+            self._vit_use_fa2 = fa2 is not None and hasattr(fa2, 'fwd_bf16')
+            # On the SDPA fallback (Thor sm_110), prefer the cuDNN backend:
+            # at the ViT shape (head_dim 64, non-causal) it measures ~2.3x
+            # faster than torch's flash backend there. Probe once here, not on
+            # the first forward — the probe launches an SDPA, which must not
+            # happen inside a CUDA Graph capture.
+            self._vit_sdpa_ctx = None
+            if not self._vit_use_fa2:
+                try:
+                    from torch.nn.attention import SDPBackend, sdpa_kernel
+                    probe = torch.zeros(
+                        1, self.num_heads, 8, self.head_dim,
+                        device=self.device, dtype=torch.bfloat16)
+                    with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                        torch.nn.functional.scaled_dot_product_attention(
+                            probe, probe, probe)
+                    self._vit_sdpa_ctx = (
+                        lambda: sdpa_kernel(SDPBackend.CUDNN_ATTENTION))
+                except Exception:
+                    self._vit_sdpa_ctx = None
         return self._fvk, self._fa2, self._vlk
 
     # ── primitives ──
@@ -394,17 +429,32 @@ class Qwen3VlVisionRtx:
             qv = q.view(1, S, nh, hd)
             kv = k.view(1, S, nh, hd)
             vv = v.view(1, S, nh, hd)
-            fa2.fwd_bf16(
-                Q=qv.data_ptr(), K=kv.data_ptr(), V=vv.data_ptr(),
-                O=o.data_ptr(), softmax_lse=lse.data_ptr(),
-                softmax_lse_accum=0, o_accum=0, batch=1,
-                seqlen_q=S, seqlen_k=S,
-                num_heads_q=nh, num_heads_kv=nh, head_dim=hd,
-                q_strides=(qv.stride(0), qv.stride(1), qv.stride(2)),
-                k_strides=(kv.stride(0), kv.stride(1), kv.stride(2)),
-                v_strides=(vv.stride(0), vv.stride(1), vv.stride(2)),
-                o_strides=(o.stride(0), o.stride(1), o.stride(2)),
-                softmax_scale=scale, num_sms=self._num_sms, stream=stream)
+            if self._vit_use_fa2:
+                fa2.fwd_bf16(
+                    Q=qv.data_ptr(), K=kv.data_ptr(), V=vv.data_ptr(),
+                    O=o.data_ptr(), softmax_lse=lse.data_ptr(),
+                    softmax_lse_accum=0, o_accum=0, batch=1,
+                    seqlen_q=S, seqlen_k=S,
+                    num_heads_q=nh, num_heads_kv=nh, head_dim=hd,
+                    q_strides=(qv.stride(0), qv.stride(1), qv.stride(2)),
+                    k_strides=(kv.stride(0), kv.stride(1), kv.stride(2)),
+                    v_strides=(vv.stride(0), vv.stride(1), vv.stride(2)),
+                    o_strides=(o.stride(0), o.stride(1), o.stride(2)),
+                    softmax_scale=scale, num_sms=self._num_sms, stream=stream)
+            else:
+                # flash_rt_fa2 is not built (Thor sm_110). Patch attention is
+                # bidirectional, so plain non-causal SDPA is equivalent. The
+                # probed cuDNN backend is ~2.3x the flash backend at this
+                # shape; fall back to the default dispatcher when the probe
+                # failed.
+                ctx = (self._vit_sdpa_ctx() if self._vit_sdpa_ctx is not None
+                       else contextlib.nullcontext())
+                with ctx:
+                    oh = torch.nn.functional.scaled_dot_product_attention(
+                        qv.transpose(1, 2), kv.transpose(1, 2),
+                        vv.transpose(1, 2),
+                        attn_mask=None, is_causal=False, scale=scale)
+                o.copy_(oh.transpose(1, 2))
             # proj input is the attention output (not a norm/gelu), so its
             # quant cannot be fused upstream; the proj bias rides the residual.
             if blk['proj'][0] is not None:

--- a/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
+++ b/flash_rt/frontends/torch/_qwen3_vl_vision_rtx.py
@@ -31,13 +31,14 @@ class Qwen3VlVisionRtx:
     early-layer paths can stay BF16 via explicit config overrides.
 
     Public surface:
-      __init__(checkpoint_path, *, device='cuda:0')
+      __init__(checkpoint_path, *, device='cuda:0', attention_backend='fa2')
       forward(pixel_values, pos_embeds, rope_cos, rope_sin)
         -> (image_embeds, deepstack_features)
     """
 
     def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
-                 config: dict | None = None, fp8: bool | None = None) -> None:
+                 config: dict | None = None, fp8: bool | None = None,
+                 attention_backend: str = 'fa2') -> None:
         import torch
 
         from safetensors import safe_open
@@ -46,11 +47,16 @@ class Qwen3VlVisionRtx:
         self._fvk = None
         self._fa2 = None
         self._vlk = None
-        self._vit_sdpa_ctx = None  # set by _kernels() on the SDPA fallback
+        self._vit_sdpa_ctx = None  # set by _kernels() for explicit SDPA
         # patch-count -> (graph, static_inputs, captured_outputs)
         self._graphs: dict = {}
         self._graph_stream = None
         self._use_fp8_gemm = False
+        if attention_backend not in ('fa2', 'sdpa'):
+            raise ValueError(
+                f'attention_backend must be "fa2" or "sdpa", got '
+                f'{attention_backend!r}')
+        self._attention_backend = attention_backend
 
         cfg = config if config is not None else _read_vision_config(
             checkpoint_path)
@@ -187,10 +193,9 @@ class Qwen3VlVisionRtx:
 
     def _kernels(self):
         if self._fvk is None:
-            try:
+            if self._attention_backend == 'fa2':
                 from flash_rt import flash_rt_fa2 as fa2
-            except ImportError:
-                # Not built on Thor (sm_110); _attn falls back to SDPA.
+            else:
                 fa2 = None
             from flash_rt import flash_rt_kernels as fvk
             from flash_rt import flash_rt_qwen3_vl_kernels as vlk
@@ -202,8 +207,11 @@ class Qwen3VlVisionRtx:
             # on head_dim: FA2 does instantiate the ViT's head_dim 64 (see
             # FA2_HDIMS), and excluding it would silently reroute the working
             # SM89/SM120 ViT attention to SDPA.
-            self._vit_use_fa2 = fa2 is not None and hasattr(fa2, 'fwd_bf16')
-            # On the SDPA fallback (Thor sm_110), prefer the cuDNN backend:
+            self._vit_use_fa2 = self._attention_backend == 'fa2'
+            if self._vit_use_fa2 and not hasattr(fa2, 'fwd_bf16'):
+                raise RuntimeError(
+                    'attention_backend="fa2" requires flash_rt_fa2.fwd_bf16')
+            # On Thor's explicit SDPA path, prefer the cuDNN backend:
             # at the ViT shape (head_dim 64, non-causal) it measures ~2.3x
             # faster than torch's flash backend there. Probe once here, not on
             # the first forward — the probe launches an SDPA, which must not

--- a/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
@@ -859,9 +859,18 @@ class Qwen3VlTorchFrontendRtxBF16:
     def warmup_decode_graphs(self, n_tokens: int) -> None:
         if self._prompt is None:
             raise RuntimeError('call set_prompt() before warmup_decode_graphs()')
+        n_tokens = int(n_tokens)
+        if n_tokens < 1:
+            raise ValueError(f'n_tokens must be >= 1, got {n_tokens}')
         base_slot = int(self._prompt['S'])
         base_rope = int(self._prompt['mrope_max']) + 1
-        for i in range(int(n_tokens)):
+        required_slots = base_slot + n_tokens
+        if required_slots > self.max_seq:
+            raise ValueError(
+                f'prompt ({base_slot} tokens) + {n_tokens} decode warmup '
+                f'steps needs {required_slots} KV slots, but max_seq='
+                f'{self.max_seq}')
+        for i in range(n_tokens):
             self._ensure_decode_graph(base_slot + i, base_rope + i)
 
     # ── device-argmax decode ──
@@ -917,9 +926,17 @@ class Qwen3VlTorchFrontendRtxBF16:
         if self._prompt is None:
             raise RuntimeError(
                 'call set_prompt() before warmup_decode_da_graphs()')
+        n_tokens = int(n_tokens)
+        if n_tokens < 1:
+            raise ValueError(f'n_tokens must be >= 1, got {n_tokens}')
         base_slot = int(self._prompt['S'])
         base_rope = int(self._prompt['mrope_max']) + 1
-        for i in range(int(n_tokens) - 1):
+        required_slots = base_slot + n_tokens - 1
+        if required_slots > self.max_seq:
+            raise ValueError(
+                f'prompt ({base_slot} tokens) + n_tokens={n_tokens} needs '
+                f'{required_slots} KV slots, but max_seq={self.max_seq}')
+        for i in range(n_tokens - 1):
             self._ensure_decode_graph_da(base_slot + i, base_rope + i, i + 1)
 
     def generate(self, messages: list, *, max_new_tokens: int = 64,
@@ -933,6 +950,10 @@ class Qwen3VlTorchFrontendRtxBF16:
         """
         import torch
 
+        max_new_tokens = int(max_new_tokens)
+        if max_new_tokens < 1:
+            raise ValueError(
+                f'max_new_tokens must be >= 1, got {max_new_tokens}')
         if use_graph:
             if max_new_tokens - 1 > self.max_decode_graphs:
                 raise ValueError(
@@ -940,17 +961,18 @@ class Qwen3VlTorchFrontendRtxBF16:
                     f'cache cap ({self.max_decode_graphs}); raise '
                     'FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX or lower '
                     'max_new_tokens')
-            if max_new_tokens > self.max_seq:
-                raise ValueError(
-                    f'max_new_tokens={max_new_tokens} exceeds max_seq='
-                    f'{self.max_seq} (the generated-token ring size)')
-
         self.set_prompt(messages)
-        logits = self.prefill_graph() if use_graph else self.prefill()
         p = self._prompt
         assert p is not None
         base_slot = int(p['S'])
         base_rope = int(p['mrope_max']) + 1
+        required_slots = base_slot + max_new_tokens - 1
+        if required_slots > self.max_seq:
+            raise ValueError(
+                f'prompt ({base_slot} tokens) + max_new_tokens='
+                f'{max_new_tokens} needs {required_slots} KV slots, but '
+                f'max_seq={self.max_seq}')
+        logits = self.prefill_graph() if use_graph else self.prefill()
 
         if not use_graph:
             tok = int(logits[0].float().argmax())

--- a/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
+++ b/flash_rt/frontends/torch/qwen3_vl_rtx_bf16.py
@@ -42,6 +42,17 @@ _QWEN3_VL_RTX_BF16_CORE_FNS = (
     'qwen3_k_norm_rope_kvwrite_prefill_bf16',
 )
 
+# Decode weight-only quantization tiers, in weight bytes/element:
+#   bf16 2.0 | int8, w8 1.125 | int4, w4 0.625
+# int8/int4 dequantize via a hardware I2F and are the tiers that pay off on
+# Ampere; w8/w4 (e4m3/e2m1) need the FP8 conversion sm_87 lacks, so there they
+# turn ALU-bound. Prefill always uses the bf16 weights.
+_WEIGHT_MODES = ('bf16', 'int8', 'int4', 'w8', 'w4')
+
+# The int8/int4 GEMVs are compiled per-K, for the Qwen3-VL-2B shapes only.
+_K_TEMPLATED_MODES = ('int8', 'int4')
+_TEMPLATED_K = (2048, 6144)
+
 
 def _require_qwen3_vl_rtx_bf16_kernels():
     try:
@@ -75,12 +86,39 @@ class Qwen3VlTorchFrontendRtxBF16:
     This is the BF16 precision variant for the RTX-family backend. The first
     validated target is Jetson Orin SM87, where the FP8/NVFP4 Qwen3-VL paths
     are not available.
+
+    Two optional knobs trade decode precision for bandwidth. Both default to
+    ``'bf16'``, and both affect only the M=1 decode path — prefill always runs
+    the BF16 weights and BF16 KV:
+
+    ``weight_mode``
+        ``'bf16'`` | ``'int8'`` | ``'int4'`` | ``'w8'`` | ``'w4'`` — weight-only
+        quantization of the language linears and lm_head. On Ampere use
+        ``int8``/``int4``: they dequantize via a hardware I2F, whereas the
+        e4m3/e2m1 tiers (``w8``/``w4``) need an FP8 conversion sm_87 lacks and
+        become ALU-bound. ``int8``/``int4`` require the Qwen3-VL-2B dimensions.
+
+    ``kv_mode``
+        ``'bf16'`` | ``'int8'`` — KV cache precision for decode attention.
     """
 
     def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
                  max_seq: int = 2048, max_pixels: int | None = None,
                  max_prefill_graphs: int | None = None,
-                 max_decode_graphs: int | None = None) -> None:
+                 max_decode_graphs: int | None = None,
+                 weight_mode: str = 'bf16',
+                 kv_mode: str = 'bf16') -> None:
+        if weight_mode not in _WEIGHT_MODES:
+            raise ValueError(
+                f'weight_mode must be one of {_WEIGHT_MODES}, '
+                f'got {weight_mode!r}')
+        if kv_mode not in ('bf16', 'int8'):
+            raise ValueError(
+                f"kv_mode must be 'bf16' or 'int8', got {kv_mode!r}")
+        self._wq_mode = weight_mode
+        self._use_wq = weight_mode != 'bf16'
+        self._kv_mode = kv_mode
+
         import torch
         from transformers import AutoProcessor
 
@@ -110,6 +148,10 @@ class Qwen3VlTorchFrontendRtxBF16:
         self.max_decode_graphs = int(max_decode_graphs)
         self._decode_graphs: collections.OrderedDict[tuple[int, int], Any] = (
             collections.OrderedDict())
+        # Decode graphs that also capture the argmax and the token feedback, so
+        # a replay needs no host round-trip. Keyed the same way as above.
+        self._decode_da_graphs: collections.OrderedDict[
+            tuple[int, int], Any] = collections.OrderedDict()
         self._prefill_graphs: collections.OrderedDict[
             tuple[int, int, int, int], Any] = collections.OrderedDict()
         self._pg_buffers: collections.OrderedDict[
@@ -177,6 +219,17 @@ class Qwen3VlTorchFrontendRtxBF16:
                 'longest_edge': int(max_pixels),
             }
 
+        if self._wq_mode in _K_TEMPLATED_MODES:
+            bad = [k for k in (self._cfg['hidden_size'],
+                               self._cfg['intermediate'])
+                   if k not in _TEMPLATED_K]
+            if bad:
+                raise RuntimeError(
+                    f'weight_mode={self._wq_mode!r} uses a K-templated decode '
+                    f'GEMV built only for K in {_TEMPLATED_K} (the Qwen3-VL-2B '
+                    f'shapes); this checkpoint needs K={sorted(set(bad))}. Use '
+                    "weight_mode='w8'/'w4' or 'bf16' instead.")
+
         self._weights = extract_weights_qwen3_vl_bf16(
             self.checkpoint_path, device=self.device)
         assert_extraction_invariants_qwen3_vl_bf16(self._weights)
@@ -188,9 +241,12 @@ class Qwen3VlTorchFrontendRtxBF16:
             num_q_heads=self._cfg['num_q_heads'],
             num_kv_heads=self._cfg['num_kv_heads'],
             head_dim=self._cfg['head_dim'],
-            device=self.device)
+            device=self.device,
+            use_int8_kv=(self._kv_mode == 'int8'))
         self._alloc_buffers()
         self._build_mrope_caches()
+        if self._use_wq:
+            self._load_wq_weights()
 
     _PG_KEYS = ('input_ids', 'pixel_values', 'pos_embeds',
                 'vcos', 'vsin', 'mcos', 'msin')
@@ -235,6 +291,10 @@ class Qwen3VlTorchFrontendRtxBF16:
         self._norm_buf = torch.empty(S, H, device=d, dtype=bf16)
         self._logits = torch.empty(1, cfg['vocab_size'], device=d, dtype=bf16)
         self._static_token_id = torch.zeros(1, 1, device=d, dtype=torch.long)
+        # Generated-token ring for the device-argmax decode graphs: each graph
+        # bakes in a write to one slot, so the host only reads slots back for
+        # the EOS check instead of syncing every token.
+        self._out_ids_buf = torch.zeros(S, device=d, dtype=torch.long)
         self._graph_stream = torch.cuda.Stream(device=d)
 
     def _build_mrope_caches(self) -> None:
@@ -277,7 +337,8 @@ class Qwen3VlTorchFrontendRtxBF16:
 
     def clear_graphs(self) -> None:
         """Drop captured Qwen3-VL BF16 prefill/decode CUDA Graphs."""
-        for attr in ('_prefill_graphs', '_decode_graphs', '_pg_buffers'):
+        for attr in ('_prefill_graphs', '_decode_graphs', '_decode_da_graphs',
+                     '_pg_buffers'):
             cache = getattr(self, attr, None)
             if cache:
                 cache.clear()
@@ -296,6 +357,11 @@ class Qwen3VlTorchFrontendRtxBF16:
                 'max_graphs': self.max_decode_graphs,
                 'graph_count': len(self._decode_graphs),
                 'graph_keys': list(self._decode_graphs.keys()),
+            },
+            'decode_device_argmax': {
+                'max_graphs': self.max_decode_graphs,
+                'graph_count': len(self._decode_da_graphs),
+                'graph_keys': list(self._decode_da_graphs.keys()),
             },
         }
 
@@ -367,6 +433,89 @@ class Qwen3VlTorchFrontendRtxBF16:
             'mrope_max': int(pos_ids.max()),
         }
         self._prompt['pg_key'] = self._stage_prefill_inputs(n_patch, S, sg['span'])
+
+    def _quant_wq(self, w):
+        """bf16 [N, K] -> (packed uint8, bf16 per-16 block scales [N, K/16]).
+
+        Weight-only: the GEMV dequantizes to bf16 in-kernel, so no FP8/FP4
+        tensor core is involved and this is safe on Ampere.
+        """
+        import torch
+
+        N, K = w.shape
+        g = w.float().view(N, K // 16, 16)
+        if self._wq_mode == 'int8':
+            scale = (g.abs().amax(2, keepdim=True) / 127.0).clamp(min=1e-8)
+            q = (g / scale).round().clamp_(-127, 127).to(torch.int8).view(N, K)
+            packed = q.view(torch.uint8).contiguous()
+        elif self._wq_mode == 'int4':
+            scale = (g.abs().amax(2, keepdim=True) / 7.0).clamp(min=1e-8)
+            q = (g / scale).round().clamp_(-7, 7).to(torch.int32).view(N, K)
+            lo = q[:, 0::2] & 0xF
+            hi = q[:, 1::2] & 0xF
+            packed = (lo | (hi << 4)).to(torch.uint8).contiguous()
+        elif self._wq_mode == 'w8':
+            scale = (g.abs().amax(2, keepdim=True) / 448.0).clamp(min=1e-8)
+            q = (g / scale).to(torch.float8_e4m3fn).view(N, K)
+            packed = q.view(torch.uint8).contiguous()
+        else:   # 'w4' — e2m1: nearest of 8 magnitudes plus sign, 2 per byte
+            mags = torch.tensor(
+                [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], device=w.device)
+            scale = (g.abs().amax(2, keepdim=True) / 6.0).clamp(min=1e-8)
+            s = g / scale
+            idx = (s.abs().unsqueeze(-1)
+                   - mags.view(1, 1, 1, 8)).abs().argmin(dim=-1)
+            code = (idx | (s < 0).to(torch.int64).mul(8)).view(N, K)
+            packed = (code[:, 0::2]
+                      | (code[:, 1::2] << 4)).to(torch.uint8).contiguous()
+        scales = scale.view(N, K // 16).to(torch.bfloat16).contiguous()
+        return packed, scales
+
+    def _load_wq_weights(self) -> None:
+        """Quantize the language linears and lm_head for the decode GEMV.
+
+        Quantizes from the resident device tensors the weight loader kept under
+        its '_t' keys, so sharded checkpoints work without re-implementing the
+        loader's shard handling. The bf16 weights stay resident for prefill.
+        """
+        self._wq_gemv = {
+            'int8': 'qwen3_vl_int8_gemv_m1',
+            'int4': 'qwen3_vl_int4_gemv_m1',
+            'w8': 'qwen3_vl_w8_gemv_m1',
+            'w4': 'qwen3_vl_w4_gemv_m1',
+        }[self._wq_mode]
+        if not hasattr(self._vlk, self._wq_gemv):
+            raise RuntimeError(
+                f'weight_mode={self._wq_mode!r} requires {self._wq_gemv} in '
+                'flash_rt_qwen3_vl_kernels (rebuild with -DGPU_ARCH=87 '
+                '-DFLASHRT_BUILD_QWEN3_VL=ON)')
+        self._wq_gemv = getattr(self._vlk, self._wq_gemv)
+        # Anchors keep the packed buffers alive: captured graphs bake in their
+        # pointers.
+        self._wq_anchors: list = []
+        layers = self._weights.ptrs['layers']
+
+        def store(lw, key):
+            p, s = self._quant_wq(lw[key + '_t'])
+            self._wq_anchors += [p, s]
+            lw[key + '_wq'] = (int(p.data_ptr()), int(s.data_ptr()))
+
+        for L in range(self._cfg['num_hidden_layers']):
+            for key in ('qkv_proj', 'o_proj', 'gate_up', 'mlp_down'):
+                store(layers[L], key)
+
+        p, s = self._quant_wq(self._weights.ptrs['lm_head_t'])
+        self._wq_anchors += [p, s]
+        self._lmhead_wq = (int(p.data_ptr()), int(s.data_ptr()))
+
+    def _decode_gemv(self, lw, key, x, out, N: int, K: int, stream) -> None:
+        """M=1 decode projection: quantized GEMV when enabled, else bf16."""
+        wq = lw.get(key + '_wq') if self._use_wq else None
+        if wq is not None:
+            self._wq_gemv(x.data_ptr(), wq[0], wq[1], out.data_ptr(),
+                          N, K, stream)
+        else:
+            self._bf16_gemm(x, int(lw[key + '_w']), out, 1, N, K, stream)
 
     def _bf16_gemm(self, x, weight_ptr: int, out, M: int, N: int, K: int,
                    stream: int) -> None:
@@ -476,9 +625,8 @@ class Qwen3VlTorchFrontendRtxBF16:
             h2.data_ptr(), int(lw['input_norm_w']), xn.data_ptr(),
             1, H, eps, stream)
         qkv = self._qkv_out[:1]
-        self._bf16_gemm(
-            xn, int(lw['qkv_proj_w']), qkv, 1, int(lw['qkv_proj_N']), H,
-            stream)
+        self._decode_gemv(
+            lw, 'qkv_proj', xn, qkv, int(lw['qkv_proj_N']), H, stream)
         kv_layer_stride = self._attn.kv_layer_stride_bytes
         kv_row_stride = self._attn.kv_row_stride_bytes
         kv_slot_off = L * kv_layer_stride + cur_pos * kv_row_stride
@@ -492,32 +640,30 @@ class Qwen3VlTorchFrontendRtxBF16:
             self._attn.K_cache.data_ptr() + kv_slot_off,
             self._attn.V_cache.data_ptr() + kv_slot_off,
             NKV, eps, stream)
+        # Mirror the rows just written; no-op when kv_mode='bf16'.
+        self._attn.quantize_kv_rows(L, cur_pos, stream)
         self._attn.run(
             'full', layer_idx=L, q_seq=1, kv_seq=cur_pos + 1,
             stream=stream, causal=True)
         attn_2d = self._attn.O_buf[:, :1].reshape(1, H).contiguous()
         attn_out = self._tmp_hidden[:1]
-        self._bf16_gemm(
-            attn_2d, int(lw['o_proj_w']), attn_out, 1, H, H, stream)
+        self._decode_gemv(lw, 'o_proj', attn_2d, attn_out, H, H, stream)
 
         xn2 = self._norm_buf[:1]
         fvk.residual_add_rms_norm(
             h.data_ptr(), attn_out.view(1, 1, H).data_ptr(),
             int(lw['post_attn_norm_w']), xn2.data_ptr(), 1, H, eps, stream)
         gate_up = self._gate_up[:1]
-        self._bf16_gemm(
-            xn2, int(lw['gate_up_w']), gate_up, 1, int(lw['gate_up_N']), H,
-            stream)
-        gate = self._gate_tmp[:1]
-        up = self._up_tmp[:1]
-        gate.copy_(gate_up[:, :I])
-        up.copy_(gate_up[:, I:])
+        self._decode_gemv(
+            lw, 'gate_up', xn2, gate_up, int(lw['gate_up_N']), H, stream)
+        # gate_up is one contiguous [1, 2I] row, so hand silu_mul the two
+        # halves by pointer offset rather than copying them out.
+        gu = gate_up.view(-1)
         fvk.silu_mul_qwen36_bf16(
-            gate.data_ptr(), up.data_ptr(), self._mlp_act[:1].data_ptr(),
-            I, stream)
+            gu[:I].data_ptr(), gu[I:].data_ptr(),
+            self._mlp_act[:1].data_ptr(), I, stream)
         down = self._tmp_hidden[:1]
-        self._bf16_gemm(
-            self._mlp_act[:1], int(lw['mlp_down_w']), down, 1, H, I, stream)
+        self._decode_gemv(lw, 'mlp_down', self._mlp_act[:1], down, H, I, stream)
         h_out = (self._h_a if (L % 2 == 0) else self._h_b)[:, :1]
         torch.add(h, down.view(1, 1, H), out=h_out)
         return h_out
@@ -556,6 +702,10 @@ class Qwen3VlTorchFrontendRtxBF16:
                     cur[0, a:b].data_ptr(),
                     deepstack[L].to(torch.bfloat16).data_ptr(),
                     (b - a) * H, stream)
+
+        # Mirror the freshly written KV prefix into the int8 cache in one bulk
+        # pass; captured into the prefill graph, no-op when kv_mode='bf16'.
+        self._attn.quantize_kv_prefix(S, stream)
 
         x = cur.view(S, H)[S - 1:S].contiguous()
         xn = self._norm_buf[:1]
@@ -649,9 +799,16 @@ class Qwen3VlTorchFrontendRtxBF16:
             cur.view(1, H).contiguous().data_ptr(),
             int(self._weights.ptrs['final_norm_w']),
             xn.data_ptr(), 1, H, cfg['rms_norm_eps'], stream)
-        self._bf16_gemm(
-            xn, int(self._weights.ptrs['lm_head_w']), self._logits,
-            1, cfg['vocab_size'], H, stream)
+        # lm_head is the largest single decode GEMV, so it follows weight_mode
+        # too. Prefill keeps using the bf16 weights.
+        if self._use_wq:
+            self._wq_gemv(
+                xn.data_ptr(), self._lmhead_wq[0], self._lmhead_wq[1],
+                self._logits.data_ptr(), cfg['vocab_size'], H, stream)
+        else:
+            self._bf16_gemm(
+                xn, int(self._weights.ptrs['lm_head_w']), self._logits,
+                1, cfg['vocab_size'], H, stream)
         return self._logits
 
     def decode_step(self, token_id: int, *, cache_pos: int, rope_pos: int):
@@ -707,28 +864,143 @@ class Qwen3VlTorchFrontendRtxBF16:
         for i in range(int(n_tokens)):
             self._ensure_decode_graph(base_slot + i, base_rope + i)
 
+    # ── device-argmax decode ──
+    # These graphs capture the argmax and the token feedback as well as the
+    # forward, so replaying one produces the next token without the host
+    # reading logits back, running argmax and refilling the input.
+
+    def _decode_body_da(self, *, cache_pos: int, rope_pos: int, out_idx: int):
+        import torch
+
+        logits = self._decode_token_tensor(
+            self._static_token_id, cache_pos=cache_pos, rope_pos=rope_pos)
+        # argmax straight on the bf16 logits: fp32 is a superset of bf16, so
+        # the ordering — hence the argmax — is identical, and skipping the cast
+        # avoids materializing an fp32 copy of the vocab row inside the graph.
+        tok = torch.argmax(logits, dim=-1)
+        self._static_token_id.copy_(tok.view(1, 1))
+        self._out_ids_buf[out_idx].copy_(tok[0])
+        return logits
+
+    def _ensure_decode_graph_da(self, cache_pos: int, rope_pos: int,
+                                out_idx: int):
+        import torch
+
+        # out_idx is part of the key: the captured body bakes in a write to
+        # that exact ring slot. Two prompts of different lengths can otherwise
+        # reach the same (cache_pos, rope_pos) at different ring positions,
+        # since base_slot and base_rope shift together.
+        key = (int(cache_pos), int(rope_pos), int(out_idx))
+        graph = self._graph_cache_get(self._decode_da_graphs, key)
+        if graph is not None:
+            return graph
+        gs = self._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs), torch.inference_mode():
+            for _ in range(2):
+                self._decode_body_da(
+                    cache_pos=cache_pos, rope_pos=rope_pos, out_idx=out_idx)
+        gs.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=gs), torch.inference_mode():
+            self._decode_body_da(
+                cache_pos=cache_pos, rope_pos=rope_pos, out_idx=out_idx)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._decode_da_graphs[key] = graph
+        self._decode_da_graphs.move_to_end(key)
+        self._trim_lru_graph_cache(
+            self._decode_da_graphs, self.max_decode_graphs)
+        return graph
+
+    def warmup_decode_da_graphs(self, n_tokens: int) -> None:
+        if self._prompt is None:
+            raise RuntimeError(
+                'call set_prompt() before warmup_decode_da_graphs()')
+        base_slot = int(self._prompt['S'])
+        base_rope = int(self._prompt['mrope_max']) + 1
+        for i in range(int(n_tokens) - 1):
+            self._ensure_decode_graph_da(base_slot + i, base_rope + i, i + 1)
+
     def generate(self, messages: list, *, max_new_tokens: int = 64,
                  use_graph: bool = True) -> str:
-        """Greedy single-image generation."""
+        """Greedy single-image generation.
+
+        With ``use_graph`` the decode loop runs entirely on the device: each
+        graph replay produces the next token and feeds it back. EOS is checked
+        from an async copy one step behind, so the host never blocks between
+        tokens, at the cost of at most one replay past EOS.
+        """
+        import torch
+
+        if use_graph:
+            if max_new_tokens - 1 > self.max_decode_graphs:
+                raise ValueError(
+                    f'max_new_tokens={max_new_tokens} exceeds the decode graph '
+                    f'cache cap ({self.max_decode_graphs}); raise '
+                    'FLASHRT_QWEN3_VL_DECODE_GRAPH_CACHE_MAX or lower '
+                    'max_new_tokens')
+            if max_new_tokens > self.max_seq:
+                raise ValueError(
+                    f'max_new_tokens={max_new_tokens} exceeds max_seq='
+                    f'{self.max_seq} (the generated-token ring size)')
+
         self.set_prompt(messages)
         logits = self.prefill_graph() if use_graph else self.prefill()
         p = self._prompt
         assert p is not None
         base_slot = int(p['S'])
         base_rope = int(p['mrope_max']) + 1
-        tok = int(logits[0].float().argmax())
-        out_ids = [tok]
-        for i in range(max_new_tokens - 1):
-            if tok in self._eos_token_ids:
-                break
-            if use_graph:
-                logits = self.decode_step_with_graph(
-                    tok, cache_pos=base_slot + i, rope_pos=base_rope + i)
-            else:
+
+        if not use_graph:
+            tok = int(logits[0].float().argmax())
+            out_ids = [tok]
+            for i in range(max_new_tokens - 1):
+                if tok in self._eos_token_ids:
+                    break
                 logits = self.decode_step(
                     tok, cache_pos=base_slot + i, rope_pos=base_rope + i)
-            tok = int(logits[0].float().argmax())
-            out_ids.append(tok)
+                tok = int(logits[0].float().argmax())
+                out_ids.append(tok)
+        else:
+            # Seed from the prefill logits before capturing: capture runs
+            # warmup bodies whose argmax overwrites _static_token_id and
+            # _logits, so this has to be read (and cloned) first.
+            tok0 = torch.argmax(self._logits.float(), dim=-1).clone()
+            first = int(tok0)
+            if first in self._eos_token_ids:
+                # Nothing to decode. The loop below never inspects slot 0 (it
+                # only checks tokens a graph wrote), so without this an EOS
+                # straight out of prefill would replay every captured graph.
+                return ''
+            # Capture every graph up front for the same reason — capturing
+            # inside the replay loop would corrupt the token chain.
+            for i in range(max_new_tokens - 1):
+                self._ensure_decode_graph_da(
+                    base_slot + i, base_rope + i, i + 1)
+            self._static_token_id.copy_(tok0.view(1, 1))
+            self._out_ids_buf[0].copy_(tok0[0])
+            # Pinned double buffer: after each replay start an async copy of
+            # the new token and test the previous one while the GPU works.
+            tok_host = [torch.zeros(1, dtype=torch.long, pin_memory=True)
+                        for _ in range(2)]
+            events = [torch.cuda.Event(), torch.cuda.Event()]
+            n_done = 1
+            prev = -1
+            for i in range(max_new_tokens - 1):
+                self._decode_da_graphs[
+                    (base_slot + i, base_rope + i, i + 1)].replay()
+                n_done += 1
+                cur = i & 1
+                tok_host[cur].copy_(self._out_ids_buf[i + 1],
+                                    non_blocking=True)
+                events[cur].record()
+                if prev >= 0:
+                    events[prev].synchronize()
+                    if int(tok_host[prev][0]) in self._eos_token_ids:
+                        break
+                prev = cur
+            out_ids = [int(t) for t in self._out_ids_buf[:n_done].tolist()]
 
         eos = [t for t in out_ids if t in self._eos_token_ids]
         if eos:

--- a/flash_rt/frontends/torch/qwen3_vl_thor.py
+++ b/flash_rt/frontends/torch/qwen3_vl_thor.py
@@ -1,0 +1,857 @@
+"""FlashRT — Qwen3-VL BF16 frontend for Jetson Thor (SM110).
+
+Correctness-first BF16 bring-up of Qwen3-VL on Thor, establishing numerical
+parity with the HF BF16 reference. All language dims are read from
+``config.json``, so the 2B/4B/8B variants load unchanged.
+
+Why a dedicated Thor module rather than the SM87 ``Qwen3VlTorchFrontendRtxBF16``:
+  * Thor does not build the vendored FA2 (``flash_rt_fa2``); attention runs
+    through :class:`ThorAttnBackendQwen3` (SDPA today; the Thor CUTLASS causal
+    FMHA can be swapped in later behind the same buffer surface).
+  * Prefill drives the batched `qwen3_qk_norm_rope_kvwrite_batched_bf16` in one
+    launch per layer, which is bit-identical to the per-row
+    `qwen3_q_norm_rope_qstage_bf16` / `qwen3_k_norm_rope_kvwrite_bf16` kernels
+    that decode uses. So prefill and decode math agree without re-implementing
+    RoPE in torch, and prefill avoids ~2·S launches per layer.
+  * bf16 linears use the Thor ``flash_rt_qwen3_vl_kernels`` cuBLASLt matmul.
+
+v1 scope: text-only and single-image chat prompts, greedy generation, eager
+prefill, graph-replay decode. Multi-image, video, an FP8 ViT tower and
+speculative decoding are not supported yet.
+
+See docs/qwen3_vl_thor.md.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+
+# flash_rt_kernels (fvk) language ops required on Thor. embedding_lookup_bf16
+# and bf16_matmul_bf16 are model-neutral and built for every arch.
+_THOR_CORE_FNS = (
+    'rms_norm',
+    'residual_add',
+    'residual_add_rms_norm',
+    'silu_mul_qwen36_bf16',
+    'qwen3_q_norm_rope_qstage_bf16',
+    'qwen3_k_norm_rope_kvwrite_bf16',
+    'embedding_lookup_bf16',
+    'bf16_matmul_bf16',
+)
+# flash_rt_qwen3_vl_kernels (vlk) ops required on Thor.
+_THOR_VL_FNS = (
+    'bf16_matmul_cublaslt_bf16',
+    'qwen3_qk_norm_rope_kvwrite_batched_bf16',
+)
+
+
+def _require_thor_kernels():
+    try:
+        from flash_rt import flash_rt_kernels as fvk
+        from flash_rt import flash_rt_qwen3_vl_kernels as vlk
+    except ImportError as e:
+        raise RuntimeError(
+            'Qwen3VlTorchFrontendThor requires flash_rt_kernels and '
+            'flash_rt_qwen3_vl_kernels. Build with '
+            '-DGPU_ARCH=110 -DFLASHRT_BUILD_QWEN3_VL=ON '
+            '(targets flash_rt_kernels flash_rt_qwen3_vl_kernels).') from e
+    missing_core = [n for n in _THOR_CORE_FNS if not hasattr(fvk, n)]
+    missing_vl = [n for n in _THOR_VL_FNS if not hasattr(vlk, n)]
+    if missing_core or missing_vl:
+        pieces = []
+        if missing_core:
+            pieces.append('flash_rt_kernels: ' + ', '.join(missing_core))
+        if missing_vl:
+            pieces.append('flash_rt_qwen3_vl_kernels: ' + ', '.join(missing_vl))
+        raise RuntimeError(
+            'Thor Qwen3-VL kernels are incomplete: ' + '; '.join(pieces))
+    return fvk, vlk
+
+
+# Valid decode weight-quant modes and the projections an override may target.
+_WQ_MODES = ('bf16', 'w8', 'w4')
+_WQ_PROJ_KEYS = ('qkv_proj', 'o_proj', 'gate_up', 'mlp_down', 'lm_head')
+
+
+def _validate_wq_overrides(overrides: dict | None) -> dict:
+    """Validate a per-projection quant-mode override map and return a copy.
+
+    Keys are ``'{proj}'`` or ``'L{layer}.{proj}'``; values are in
+    ``_WQ_MODES``. Unknown keys are rejected rather than ignored — a silently
+    dropped override reads as "this projection doesn't matter" in a
+    sensitivity sweep.
+    """
+    ov = dict(overrides or {})
+    bad = {k: v for k, v in ov.items() if v not in _WQ_MODES}
+    if bad:
+        raise ValueError(f'wq_overrides values must be one of {_WQ_MODES}: '
+                         f'{bad}')
+    for key in ov:
+        if key.startswith('L') and '.' in key:
+            prefix, base = key.split('.', 1)
+            if not prefix[1:].isdigit():
+                raise ValueError(
+                    f'wq_overrides key {key!r}: layer prefix must be '
+                    f"'L<integer>.' (e.g. 'L12.gate_up')")
+        else:
+            base = key
+        if base not in _WQ_PROJ_KEYS:
+            raise ValueError(
+                f'wq_overrides key {key!r} must be one of {_WQ_PROJ_KEYS} '
+                f"(optionally 'L<layer>.' prefixed)")
+    return ov
+
+
+class Qwen3VlTorchFrontendThor:
+    """Batch-1 Qwen3-VL image+text inference (Thor SM110, BF16)."""
+
+    def __init__(self, checkpoint_path: str, *, device: str = 'cuda:0',
+                 max_seq: int = 4096, max_pixels: int | None = None,
+                 weight_mode: str = 'bf16',
+                 wq_overrides: dict[str, str] | None = None) -> None:
+        if weight_mode not in _WQ_MODES:
+            raise ValueError(f"weight_mode must be one of {_WQ_MODES}, got "
+                             f"{weight_mode!r}")
+        self._wq_overrides = _validate_wq_overrides(wq_overrides)
+        self._wq_mode = weight_mode          # 'bf16' | 'w8' | 'w4'
+        self._use_wq = weight_mode in ('w8', 'w4')
+
+        import torch
+        from transformers import AutoProcessor, AutoTokenizer
+
+        from flash_rt.frontends.torch._qwen3_vl_bf16_weights import (
+            assert_extraction_invariants_qwen3_vl_bf16,
+            extract_weights_qwen3_vl_bf16,
+        )
+        from flash_rt.hardware.thor.attn_backend_qwen3 import (
+            ThorAttnBackendQwen3,
+        )
+
+        self.checkpoint_path = str(checkpoint_path)
+        self.device = device
+        self.max_seq = int(max_seq)
+        self.max_pixels = max_pixels
+        self._prompt: dict[str, Any] | None = None
+
+        dev = torch.device(device)
+        if dev.type != 'cuda' or not torch.cuda.is_available():
+            raise RuntimeError('Qwen3VlTorchFrontendThor requires CUDA')
+        cap = torch.cuda.get_device_capability(dev)
+        if cap != (11, 0):
+            raise RuntimeError(
+                'Qwen3VlTorchFrontendThor targets Jetson Thor (SM110 / '
+                f'cc 11.0); got sm_{cap[0]}{cap[1]} on {device}. Use the '
+                'RTX/SM89 Qwen3-VL frontends on those arches.')
+
+        self._fvk, self._vlk = _require_thor_kernels()
+
+        with open(os.path.join(self.checkpoint_path, 'config.json')) as f:
+            cfg = json.load(f)
+        self._cfg_raw = cfg
+        text_cfg = cfg['text_config']
+        self._cfg = {
+            'rms_norm_eps': float(text_cfg.get('rms_norm_eps', 1e-6)),
+            'head_dim': int(text_cfg.get('head_dim') or
+                            text_cfg['hidden_size'] //
+                            text_cfg['num_attention_heads']),
+            'hidden_size': int(text_cfg['hidden_size']),
+            'vocab_size': int(text_cfg['vocab_size']),
+            'num_hidden_layers': int(text_cfg['num_hidden_layers']),
+            'num_q_heads': int(text_cfg['num_attention_heads']),
+            'num_kv_heads': int(text_cfg['num_key_value_heads']),
+            'intermediate': int(text_cfg['intermediate_size']),
+            'rope_theta': float(text_cfg.get('rope_theta')
+                                or cfg.get('rope_theta') or 1_000_000.0),
+        }
+        self._head_dim = self._cfg['head_dim']
+        if self._head_dim != 128:
+            raise RuntimeError(
+                f'Thor Qwen3 kernels require head_dim=128, got {self._head_dim}')
+        self._image_token_id = int(cfg['image_token_id'])
+        self._video_token_id = int(cfg['video_token_id'])
+        self._vision_start_token_id = int(cfg['vision_start_token_id'])
+        vc = cfg['vision_config']
+        self._vision_cfg = vc
+        self._merge = int(vc['spatial_merge_size'])
+        self._vis_head_dim = int(vc['hidden_size']) // int(vc['num_heads'])
+        self._num_grid_per_side = int(vc['num_position_embeddings'] ** 0.5)
+        self._deepstack_layers = len(vc['deepstack_visual_indexes'])
+        rope_scaling = text_cfg.get('rope_scaling') or cfg.get('rope_scaling')
+        if not rope_scaling or 'mrope_section' not in rope_scaling:
+            raise RuntimeError(
+                'Qwen3-VL config missing rope_scaling.mrope_section')
+        self._mrope_section = tuple(rope_scaling['mrope_section'])
+        eos = cfg.get('eos_token_id', text_cfg.get('eos_token_id'))
+        if eos is None:
+            self._eos_token_ids: set[int] = set()
+        else:
+            self._eos_token_ids = set(eos if isinstance(eos, list) else [eos])
+
+        self._weights = extract_weights_qwen3_vl_bf16(
+            self.checkpoint_path, device=self.device)
+        assert_extraction_invariants_qwen3_vl_bf16(self._weights)
+
+        self._attn = ThorAttnBackendQwen3(
+            max_seq=self.max_seq, max_q_seq=self.max_seq,
+            dtype=torch.bfloat16,
+            num_layers=self._cfg['num_hidden_layers'],
+            num_q_heads=self._cfg['num_q_heads'],
+            num_kv_heads=self._cfg['num_kv_heads'],
+            head_dim=self._cfg['head_dim'], device=self.device)
+
+        self.processor = AutoProcessor.from_pretrained(self.checkpoint_path)
+        self._tokenizer = AutoTokenizer.from_pretrained(self.checkpoint_path)
+        self._processor_kwargs: dict[str, Any] = {'device': self.device}
+        if max_pixels is not None:
+            size = getattr(getattr(self.processor, 'image_processor', None),
+                           'size', {}) or {}
+            self._processor_kwargs['size'] = {
+                'shortest_edge': int(size.get('shortest_edge', 65536)),
+                'longest_edge': int(max_pixels),
+            }
+
+        self._vision = None  # lazily constructed on the first image prompt
+        self._alloc_buffers()
+        self._build_mrope_caches()
+        if self._use_wq:
+            self._load_wq_weights()
+
+    # ── setup ──
+
+    def _alloc_buffers(self) -> None:
+        import torch
+
+        cfg = self._cfg
+        d = torch.device(self.device)
+        bf16 = torch.bfloat16
+        S = self.max_seq
+        H = cfg['hidden_size']
+        I = cfg['intermediate']
+        NQ = cfg['num_q_heads']
+        NKV = cfg['num_kv_heads']
+        HD = cfg['head_dim']
+        self._qkv_N = (NQ + 2 * NKV) * HD
+        self._h_a = torch.empty(1, S, H, device=d, dtype=bf16)
+        self._h_b = torch.empty(1, S, H, device=d, dtype=bf16)
+        self._qkv_out = torch.empty(S, self._qkv_N, device=d, dtype=bf16)
+        self._gate_up = torch.empty(S, 2 * I, device=d, dtype=bf16)
+        self._gate_tmp = torch.empty(S, I, device=d, dtype=bf16)
+        self._up_tmp = torch.empty(S, I, device=d, dtype=bf16)
+        self._mlp_act = torch.empty(S, I, device=d, dtype=bf16)
+        self._tmp_hidden = torch.empty(S, H, device=d, dtype=bf16)
+        self._norm_buf = torch.empty(S, H, device=d, dtype=bf16)
+        self._norm_buf2 = torch.empty(S, H, device=d, dtype=bf16)
+        self._attn_out = torch.empty(S, H, device=d, dtype=bf16)
+        self._logits = torch.empty(1, cfg['vocab_size'], device=d, dtype=bf16)
+        # CUDA-graph decode state (all Thor decode primitives are capturable).
+        self._static_token_id = torch.zeros(1, 1, device=d, dtype=torch.long)
+        self._graph_stream = torch.cuda.Stream(device=d)
+        import collections
+        self._decode_graphs: "collections.OrderedDict[tuple[int, int], Any]" = (
+            collections.OrderedDict())
+        self._graph_warmed = False
+        # One graph per decode position; capping below max_seq would thrash
+        # (evict + recapture every token) on long generations.
+        self._max_decode_graphs = self.max_seq
+
+    def _build_mrope_caches(self) -> None:
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+        self._mrope_cos_cache, self._mrope_sin_cache = geo.build_mrope_cache(
+            max_pos=self.max_seq + self._num_grid_per_side,
+            head_dim=self._head_dim, rope_theta=self._cfg['rope_theta'],
+            device=self.device)
+        self._vision_rope_cos_cache, self._vision_rope_sin_cache = (
+            geo.build_vision_rope_cache(
+                max_hw=self.max_seq * self._merge,
+                head_dim=self._vis_head_dim, device=self.device))
+
+    # ── weight-quantized (W8A16 / W4A16) decode weights ──
+
+    def _quant_wq(self, w, mode: str | None = None):
+        """bf16 [N,K] -> (packed uint8, bf16 per-16 block scales [N,K/16]) for
+        the given weight-quant mode (defaults to the frontend's global mode).
+        'w8' = e4m3 (1 byte/w, scale=amax/448); 'w4' = e2m1 (0.5 byte/w,
+        scale=amax/6, nearest-magnitude rounding)."""
+        import torch
+        mode = mode or self._wq_mode
+        N, K = w.shape
+        g = w.float().view(N, K // 16, 16)
+        if mode == 'w8':
+            scale = (g.abs().amax(2, keepdim=True) / 448.0).clamp(min=1e-8)
+            q = (g / scale).to(torch.float8_e4m3fn).view(N, K)
+            packed = q.view(torch.uint8).contiguous()
+        else:  # 'w4' — e2m1, nearest of 8 magnitudes + sign, 2 per byte
+            mags = torch.tensor(
+                [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], device=w.device)
+            scale = (g.abs().amax(2, keepdim=True) / 6.0).clamp(min=1e-8)
+            s = g / scale
+            idx = (s.abs().unsqueeze(-1)
+                   - mags.view(1, 1, 1, 8)).abs().argmin(dim=-1)
+            code = idx | (s < 0).to(torch.int64).mul(8)
+            code = code.view(N, K)
+            lo = code[:, 0::2]
+            hi = code[:, 1::2]
+            packed = (lo | (hi << 4)).to(torch.uint8).contiguous()
+        scales = scale.view(N, K // 16).to(torch.bfloat16).contiguous()
+        return packed, scales
+
+    def _wq_mode_for(self, key: str, layer: int | None = None) -> str:
+        """Per-projection quant mode: exact 'L{i}.{key}' override, then
+        '{key}', then the global mode. 'bf16' = keep unquantized."""
+        ov = self._wq_overrides
+        if layer is not None:
+            m = ov.get(f'L{layer}.{key}')
+            if m is not None:
+                return m
+        return ov.get(key, self._wq_mode)
+
+
+    def _load_wq_weights(self) -> None:
+        """Quantize the language linears (+ tied lm_head) to the decode weight
+        format (W8A16 / W4A16, per-projection overridable) for the
+        bandwidth-bound M=1 decode GEMV. Quantizes from the resident device
+        tensors the loader kept, so sharded checkpoints need no special
+        handling; the bf16 weights stay resident for prefill."""
+        for fn in ('qwen3_vl_w8_gemv_m1', 'qwen3_vl_w4_gemv_m1'):
+            if not hasattr(self._vlk, fn):
+                raise RuntimeError(
+                    f'weight_mode={self._wq_mode!r} requires {fn} in '
+                    'flash_rt_qwen3_vl_kernels (rebuild with -DGPU_ARCH=110 '
+                    '-DFLASHRT_BUILD_QWEN3_VL=ON)')
+        gemv = {'w8': self._vlk.qwen3_vl_w8_gemv_m1,
+                'w4': self._vlk.qwen3_vl_w4_gemv_m1}
+        # Captured graphs bake in quant-buffer pointers; requantizing would
+        # leave them reading freed memory, and the new buffers need a fresh
+        # 3-iteration warmup.
+        self._decode_graphs.clear()
+        self._graph_warmed = False
+        self._wq_anchors: list = []
+        layers = self._weights.ptrs['layers']
+
+        def store(lw, key, L):
+            mode = self._wq_mode_for(key, L)
+            if mode == 'bf16':
+                lw.pop(key + '_wq', None)
+                return
+            p, s = self._quant_wq(lw[key + '_t'], mode)
+            self._wq_anchors += [p, s]
+            lw[key + '_wq'] = (int(p.data_ptr()), int(s.data_ptr()),
+                               gemv[mode])
+
+        for L in range(self._cfg['num_hidden_layers']):
+            for key in ('qkv_proj', 'o_proj', 'gate_up', 'mlp_down'):
+                store(layers[L], key, L)
+
+        mode = self._wq_mode_for('lm_head')
+        if mode == 'bf16':
+            self._lmhead_wq = None
+        else:
+            p, s = self._quant_wq(self._weights.ptrs['lm_head_t'], mode)
+            self._wq_anchors += [p, s]
+            self._lmhead_wq = (int(p.data_ptr()), int(s.data_ptr()),
+                               gemv[mode])
+
+    def _proj(self, lw, key, x, out, S, N, K, stream) -> None:
+        """Projection GEMM. M=1 decode uses the W8/W4 GEMV when enabled;
+        prefill (S>1) and bf16 mode use the bf16 GEMM path."""
+        wq = lw.get(key + '_wq') if self._use_wq else None
+        if S == 1 and wq is not None:
+            wq[2](x.data_ptr(), wq[0], wq[1], out.data_ptr(), N, K, stream)
+        else:
+            self._bf16_gemm(x, int(lw[key + '_w']), out, S, N, K, stream)
+
+    def _lm_head(self, xn, out, stream, *, decode: bool) -> None:
+        V = self._cfg['vocab_size']
+        H = self._cfg['hidden_size']
+        if decode and self._use_wq and self._lmhead_wq is not None:
+            wq = self._lmhead_wq
+            wq[2](xn.data_ptr(), wq[0], wq[1], out.data_ptr(), V, H, stream)
+        else:
+            self._bf16_gemm(xn, int(self._weights.ptrs['lm_head_w']),
+                            out, 1, V, H, stream)
+
+    def _ensure_native_vision(self):
+        """Lazily build the native Thor bf16 ViT (``Qwen3VlVisionRtx`` forced
+        to its bf16 path — all its bf16 kernels are present on Thor, the
+        FP8-block128 ones are not). Drops the HF ``AutoModelForImageTextToText``
+        dependency for the image path. Same forward surface the HF path feeds:
+        (image_embeds [n_merged, out_hidden], [deepstack features])."""
+        if self._vision is None:
+            from flash_rt.frontends.torch._qwen3_vl_vision_rtx import (
+                Qwen3VlVisionRtx,
+            )
+            self._vision = Qwen3VlVisionRtx(
+                self.checkpoint_path, device=self.device,
+                config=self._vision_cfg, fp8=False)
+        return self._vision
+
+
+
+    def reset_state(self) -> None:
+        self._attn.reset_cache()
+
+    # ── prompt ──
+
+    def set_prompt(self, messages: list) -> None:
+        """Preprocess a text-only or single-image Qwen3-VL chat prompt."""
+        import torch
+        from flash_rt.frontends.torch import _qwen3_vl_geometry as geo
+
+        inputs = self.processor.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=True,
+            return_dict=True, return_tensors='pt',
+            processor_kwargs=self._processor_kwargs).to(self.device)
+        input_ids = inputs['input_ids'][0]
+        S = int(input_ids.shape[0])
+        if S > self.max_seq:
+            raise ValueError(
+                f'prompt length {S} exceeds max_seq {self.max_seq}')
+
+        image_grid = inputs.get('image_grid_thw')
+        video_grid = inputs.get('video_grid_thw')
+        if video_grid is not None and len(video_grid):
+            raise ValueError('Qwen3VlTorchFrontendThor v1 supports images, '
+                             'not video')
+        pix_img = inputs.get('pixel_values')
+        has_image = pix_img is not None
+
+        span = None
+        pixel_values = None
+        vcos = vsin = pos_embeds = None
+        if has_image:
+            pix_img = pix_img.to(torch.bfloat16)
+            segs = geo.vision_segments(
+                input_ids.cpu(), image_grid, None,
+                image_token_id=self._image_token_id,
+                video_token_id=self._video_token_id,
+                spatial_merge_size=self._merge)
+            if len(segs) != 1:
+                raise ValueError(
+                    'Qwen3VlTorchFrontendThor v1 supports exactly one image; '
+                    f'got {len(segs)} vision segments')
+            sg = segs[0]
+            span = sg['span']
+            import torch as _torch
+            n_patch = int(sg['patches'])
+            pixel_values = pix_img[:n_patch].contiguous()
+            seg_grid = _torch.tensor([sg['grid']], dtype=_torch.long)
+            vcos, vsin = geo.vision_rope_cos_sin_cached(
+                seg_grid, self._vision_rope_cos_cache,
+                self._vision_rope_sin_cache,
+                spatial_merge_size=self._merge)
+            pos_embeds = geo.vision_pos_embeds(
+                seg_grid, self._ensure_native_vision().pos_embed,
+                num_grid_per_side=self._num_grid_per_side,
+                spatial_merge_size=self._merge, device=self.device)
+
+        pos_ids = geo.mrope_position_ids(
+            input_ids.cpu(),
+            image_grid.cpu() if (has_image and image_grid is not None)
+            else None,
+            None,
+            image_token_id=self._image_token_id,
+            video_token_id=self._video_token_id,
+            vision_start_token_id=self._vision_start_token_id,
+            spatial_merge_size=self._merge)
+        mcos, msin = geo.mrope_cos_sin_cached(
+            pos_ids, self._mrope_cos_cache, self._mrope_sin_cache,
+            mrope_section=self._mrope_section)
+
+        self._prompt = {
+            'input_ids': input_ids.contiguous(),
+            'has_image': has_image,
+            'pixel_values': pixel_values,
+            'vcos': vcos, 'vsin': vsin, 'pos_embeds': pos_embeds,
+            'span': span,
+            'mcos': mcos, 'msin': msin,
+            'S': S,
+            'mrope_max': int(pos_ids.max()),
+        }
+
+    def set_prompt_text(self, text: str, *, system: str | None = None) -> None:
+        """Convenience: text-only chat prompt (Phase-1 language validation)."""
+        messages = []
+        if system is not None:
+            messages.append({'role': 'system', 'content': system})
+        messages.append({'role': 'user', 'content': text})
+        self.set_prompt(messages)
+
+    # ── linear helper ──
+
+    def _bf16_gemm(self, x, weight_ptr: int, out, M: int, N: int, K: int,
+                   stream: int) -> None:
+        # M=1 decode: the dedicated warp-per-row GEMV is bandwidth-bound and
+        # beats cuBLASLt's poor M=1 tactics (covers K in {2048, 6144}, which is
+        # every 2B decode GEMM including lm_head). Larger M (prefill) and other
+        # K go through cuBLASLt; the deterministic warp GEMM is the last resort.
+        if (M == 1 and K in (2048, 6144)
+                and hasattr(self._vlk, 'qwen3_vl_bf16_gemv_m1')):
+            self._vlk.qwen3_vl_bf16_gemv_m1(
+                x.data_ptr(), int(weight_ptr), out.data_ptr(), N, K, stream)
+        elif hasattr(self._vlk, 'bf16_matmul_cublaslt_bf16'):
+            self._vlk.bf16_matmul_cublaslt_bf16(
+                x.data_ptr(), int(weight_ptr), out.data_ptr(), M, N, K, stream)
+        else:
+            self._fvk.bf16_matmul_bf16(
+                x.data_ptr(), int(weight_ptr), out.data_ptr(), M, N, K, stream)
+
+    # ── one decoder layer (prefill loops rows; decode is S=1) ──
+
+    def _layer_forward(self, L: int, h, cos_S, sin_S, start_pos: int, S: int):
+        import torch
+
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        I = cfg['intermediate']
+        NQ = cfg['num_q_heads']
+        NKV = cfg['num_kv_heads']
+        HD = cfg['head_dim']
+        Nq = NQ * HD
+        Nk = NKV * HD
+        eps = cfg['rms_norm_eps']
+        stream = torch.cuda.current_stream().cuda_stream
+        lw = self._weights.ptrs['layers'][L]
+
+        # 1) input RMSNorm
+        h2 = h.view(S, H)
+        xn = self._norm_buf[:S]
+        fvk.rms_norm(h2.data_ptr(), int(lw['input_norm_w']), xn.data_ptr(),
+                     S, H, eps, stream)
+
+        # 2) fused QKV projection
+        qkv = self._qkv_out[:S]
+        self._proj(lw, 'qkv_proj', xn, qkv, S, int(lw['qkv_proj_N']), H, stream)
+
+        # 3) fused q/k RMSNorm + MRoPE + KV-cache write for ALL S rows in ONE
+        #    launch. Bit-identical to the per-row decode kernels (verified), but
+        #    replaces the ~2·S per-layer Python→kernel launches that dominated
+        #    prefill/TTFT. cos_S/sin_S are (S,64) contiguous so the kernel's
+        #    token*64 row indexing matches; start_pos=0 for prefill.
+        q_row_stride = int(qkv.stride(0))
+        Q_buf = self._attn.Q_buf
+        q_dst_row = int(Q_buf.stride(1))
+        kv_layer_stride = self._attn.kv_layer_stride_bytes
+        kv_row_stride = self._attn.kv_row_stride_bytes
+        qkv_elem = qkv.element_size()
+        kv_dst_row_elems = kv_row_stride // qkv_elem
+        qkv_base = qkv.data_ptr()
+        k_base = self._attn.K_cache.data_ptr() + L * kv_layer_stride
+        v_base = self._attn.V_cache.data_ptr() + L * kv_layer_stride
+        self._vlk.qwen3_qk_norm_rope_kvwrite_batched_bf16(
+            qkv_base, qkv_base + Nq * qkv_elem,
+            qkv_base + (Nq + Nk) * qkv_elem,
+            int(lw['q_norm_w']), int(lw['k_norm_w']),
+            cos_S.data_ptr(), sin_S.data_ptr(),
+            Q_buf.data_ptr(),
+            k_base + start_pos * kv_row_stride,
+            v_base + start_pos * kv_row_stride,
+            S, q_row_stride, q_row_stride, q_row_stride,
+            q_dst_row, kv_dst_row_elems,
+            NQ, NKV, eps, stream)
+
+        # 4) attention over [start_pos : start_pos+S]
+        self._attn.run('full', layer_idx=L, q_seq=S,
+                       kv_seq=start_pos + S, stream=stream, causal=True)
+        attn_2d = self._attn.O_buf[:, :S].reshape(S, H)
+        attn_out = self._attn_out[:S]
+        self._proj(lw, 'o_proj', attn_2d.contiguous(), attn_out, S, H, H,
+                   stream)
+
+        # 5) residual + post-attn RMSNorm
+        xn2 = self._norm_buf[:S]
+        fvk.residual_add_rms_norm(
+            h.data_ptr(), attn_out.view(1, S, H).data_ptr(),
+            int(lw['post_attn_norm_w']), xn2.data_ptr(), S, H, eps, stream)
+
+        # 6) gate/up + silu·mul + down
+        gate_up = self._gate_up[:S]
+        self._proj(lw, 'gate_up', xn2, gate_up, S, int(lw['gate_up_N']), H,
+                   stream)
+        gate = self._gate_tmp[:S]
+        up = self._up_tmp[:S]
+        gate.copy_(gate_up[:, :I])
+        up.copy_(gate_up[:, I:])
+        fvk.silu_mul_qwen36_bf16(
+            gate.data_ptr(), up.data_ptr(), self._mlp_act[:S].data_ptr(),
+            S * I, stream)
+        down = self._tmp_hidden[:S]
+        self._proj(lw, 'mlp_down', self._mlp_act[:S], down, S, H, I, stream)
+
+        # 7) residual (into ping-pong; layer 0 reads _h_a so it must write
+        #    _h_b — flip parity so h_out never aliases h).
+        h_out = (self._h_b if (L % 2 == 0) else self._h_a)[:, :S]
+        torch.add(h.view(1, S, H), down.view(1, S, H), out=h_out)
+        return h_out
+
+    def _decode_layer(self, L, h, xn, cos, sin, cache_pos, next_norm_w):
+        """Aggressively-fused S=1 decode layer. ``h`` is the residual (updated
+        in place by residual_add_rms_norm); ``xn`` is this layer's pre-normed
+        input (consumed early by the QKV GEMV, then reused as the output
+        buffer for the NEXT layer's input norm). Fuses: (a) no gate/up copies —
+        silu_mul reads the fused gate_up buffer via strided pointers (S=1 slices
+        are contiguous); (b) the MLP residual-add folds into ``next_norm_w`` so
+        there is no separate residual add + input rms_norm per layer (the last
+        layer passes final_norm_w, folding the final norm too). Returns ``xn``
+        holding rms_norm(updated residual, next_norm_w)."""
+        import torch
+
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        I = cfg['intermediate']
+        NQ = cfg['num_q_heads']
+        NKV = cfg['num_kv_heads']
+        HD = cfg['head_dim']
+        Nq = NQ * HD
+        Nk = NKV * HD
+        eps = cfg['rms_norm_eps']
+        stream = torch.cuda.current_stream().cuda_stream
+        lw = self._weights.ptrs['layers'][L]
+
+        qkv = self._qkv_out[:1]
+        self._proj(lw, 'qkv_proj', xn, qkv, 1, int(lw['qkv_proj_N']), H, stream)
+
+        qe = qkv.element_size()
+        qkv_ptr = qkv.data_ptr()
+        Q_buf = self._attn.Q_buf
+        kv_ls = self._attn.kv_layer_stride_bytes
+        kv_rs = self._attn.kv_row_stride_bytes
+        slot = cache_pos * kv_rs
+        fvk.qwen3_q_norm_rope_qstage_bf16(
+            qkv_ptr, int(lw['q_norm_w']), cos.data_ptr(), sin.data_ptr(),
+            Q_buf.data_ptr(), NQ, eps, stream)
+        fvk.qwen3_k_norm_rope_kvwrite_bf16(
+            qkv_ptr + Nq * qe, qkv_ptr + (Nq + Nk) * qe, int(lw['k_norm_w']),
+            cos.data_ptr(), sin.data_ptr(),
+            self._attn.K_cache.data_ptr() + L * kv_ls + slot,
+            self._attn.V_cache.data_ptr() + L * kv_ls + slot,
+            NKV, eps, stream)
+
+        self._attn.run('full', layer_idx=L, q_seq=1, kv_seq=cache_pos + 1,
+                       stream=stream, causal=True)
+        attn_out = self._attn_out[:1]
+        self._proj(lw, 'o_proj',
+                   self._attn.O_buf[:, :1].reshape(1, H).contiguous(),
+                   attn_out, 1, H, H, stream)
+
+        xn2 = self._norm_buf2[:1]
+        fvk.residual_add_rms_norm(
+            h.data_ptr(), attn_out.view(1, 1, H).data_ptr(),
+            int(lw['post_attn_norm_w']), xn2.data_ptr(), 1, H, eps, stream)
+
+        gate_up = self._gate_up[:1]
+        self._proj(lw, 'gate_up', xn2, gate_up, 1, int(lw['gate_up_N']), H,
+                   stream)
+        gp = gate_up.data_ptr()
+        es = gate_up.element_size()
+        fvk.silu_mul_qwen36_bf16(
+            gp, gp + I * es, self._mlp_act[:1].data_ptr(), I, stream)
+        down = self._tmp_hidden[:1]
+        self._proj(lw, 'mlp_down', self._mlp_act[:1], down, 1, H, I, stream)
+
+        # MLP residual-add fused with the next layer's input RMSNorm.
+        fvk.residual_add_rms_norm(
+            h.data_ptr(), down.view(1, 1, H).data_ptr(), int(next_norm_w),
+            xn.data_ptr(), 1, H, eps, stream)
+        return xn
+
+    # ── prefill ──
+
+    def prefill(self):
+        """Eager multimodal prefill; returns (1, vocab) bf16 next-token logits."""
+        import torch
+
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before prefill()')
+        p = self._prompt
+        self.reset_state()
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        S = p['S']
+        stream = torch.cuda.current_stream().cuda_stream
+
+        h = self._h_a[:, :S]
+        fvk.embedding_lookup_bf16(
+            p['input_ids'].view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']), h.data_ptr(), S, H, stream)
+
+        deepstack = None
+        if p['has_image']:
+            import torch as _torch
+            a, b = p['span']
+            with _torch.no_grad():
+                emb, deepstack = self._ensure_native_vision().forward(
+                    p['pixel_values'], p['pos_embeds'],
+                    p['vcos'], p['vsin'])
+            h[0, a:b].copy_(emb.to(torch.bfloat16))
+
+        cur = h
+        # Batched QK norm-rope kernel (_layer_forward) hardcodes a 64-elem
+        # cos/sin row stride; enforce that coupling once (silent-wrong guard).
+        assert p['mcos'].is_contiguous() and p['mcos'].shape[-1] == 64, (
+            'batched prefill requires (S,64) row-contiguous mcos/msin')
+        for L in range(cfg['num_hidden_layers']):
+            cur = self._layer_forward(L, cur, p['mcos'], p['msin'], 0, S)
+            if deepstack is not None and L < self._deepstack_layers:
+                a, b = p['span']
+                fvk.residual_add(
+                    cur[0, a:b].data_ptr(),
+                    deepstack[L].to(torch.bfloat16).data_ptr(),
+                    (b - a) * H, stream)
+
+        x = cur.view(S, H)[S - 1:S].contiguous()
+        xn = self._norm_buf[:1]
+        fvk.rms_norm(x.data_ptr(), int(self._weights.ptrs['final_norm_w']),
+                     xn.data_ptr(), 1, H, cfg['rms_norm_eps'], stream)
+        self._lm_head(xn, self._logits, stream, decode=False)
+        torch.cuda.synchronize()
+        return self._logits
+
+    # ── decode ──
+
+    def decode_step(self, token_id: int, *, cache_pos: int, rope_pos: int):
+        import torch
+
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        eps = cfg['rms_norm_eps']
+        n = cfg['num_hidden_layers']
+        stream = torch.cuda.current_stream().cuda_stream
+        tok = torch.tensor([[int(token_id)]], dtype=torch.long,
+                           device=self.device)
+        h = self._h_a[:, :1]
+        fvk.embedding_lookup_bf16(
+            tok.view(-1).data_ptr(), int(self._weights.ptrs['embed_w']),
+            h.data_ptr(), 1, H, stream)
+        cos = self._mrope_cos_cache[rope_pos:rope_pos + 1]
+        sin = self._mrope_sin_cache[rope_pos:rope_pos + 1]
+        layers = self._weights.ptrs['layers']
+        final_w = int(self._weights.ptrs['final_norm_w'])
+        xn = self._norm_buf[:1]
+        fvk.rms_norm(h.view(1, H).data_ptr(), int(layers[0]['input_norm_w']),
+                     xn.data_ptr(), 1, H, eps, stream)
+        for L in range(n):
+            nw = int(layers[L + 1]['input_norm_w']) if L + 1 < n else final_w
+            xn = self._decode_layer(L, h, xn, cos, sin, cache_pos, nw)
+        self._lm_head(xn, self._logits, stream, decode=True)
+        torch.cuda.synchronize()
+        return self._logits
+
+    # ── graph-captured decode ──
+
+    def _decode_body(self, cache_pos: int, rope_pos: int) -> None:
+        """Capture-safe decode body: reads self._static_token_id, writes
+        self._logits. No per-call tensor allocation, no synchronize. Uses the
+        fully-fused decode chain (one input norm before the loop; each layer's
+        MLP residual-add folds into the next layer's input norm / final norm)."""
+        import torch
+
+        cfg = self._cfg
+        fvk = self._fvk
+        H = cfg['hidden_size']
+        eps = cfg['rms_norm_eps']
+        n = cfg['num_hidden_layers']
+        stream = torch.cuda.current_stream().cuda_stream
+        h = self._h_a[:, :1]
+        fvk.embedding_lookup_bf16(
+            self._static_token_id.view(-1).data_ptr(),
+            int(self._weights.ptrs['embed_w']), h.data_ptr(), 1, H, stream)
+        cos = self._mrope_cos_cache[rope_pos:rope_pos + 1]
+        sin = self._mrope_sin_cache[rope_pos:rope_pos + 1]
+        layers = self._weights.ptrs['layers']
+        final_w = int(self._weights.ptrs['final_norm_w'])
+        xn = self._norm_buf[:1]
+        fvk.rms_norm(h.view(1, H).data_ptr(), int(layers[0]['input_norm_w']),
+                     xn.data_ptr(), 1, H, eps, stream)
+        for L in range(n):
+            nw = int(layers[L + 1]['input_norm_w']) if L + 1 < n else final_w
+            xn = self._decode_layer(L, h, xn, cos, sin, cache_pos, nw)
+        self._lm_head(xn, self._logits, stream, decode=True)
+
+    def _ensure_decode_graph(self, cache_pos: int, rope_pos: int):
+        import torch
+
+        key = (int(cache_pos), int(rope_pos))
+        g = self._decode_graphs.get(key)
+        if g is not None:
+            self._decode_graphs.move_to_end(key)
+            return g
+        gs = self._graph_stream
+        gs.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(gs):
+            for _ in range(3 if not self._graph_warmed else 1):
+                self._decode_body(cache_pos, rope_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        self._graph_warmed = True
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g, stream=gs):
+            self._decode_body(cache_pos, rope_pos)
+        gs.synchronize()
+        torch.cuda.current_stream().wait_stream(gs)
+        while len(self._decode_graphs) >= self._max_decode_graphs:
+            self._decode_graphs.popitem(last=False)
+        self._decode_graphs[key] = g
+        return g
+
+    def decode_step_graph(self, token_id: int, *, cache_pos: int,
+                          rope_pos: int):
+        """Decode one token via a captured CUDA Graph replay."""
+        self._static_token_id.fill_(int(token_id))
+        self._ensure_decode_graph(cache_pos, rope_pos).replay()
+        return self._logits
+
+    def warmup_decode_graphs(self, n_tokens: int) -> None:
+        if self._prompt is None:
+            raise RuntimeError('call set_prompt() before warmup_decode_graphs')
+        base_slot = int(self._prompt['S'])
+        base_rope = int(self._prompt['mrope_max']) + 1
+        for i in range(int(n_tokens)):
+            self._ensure_decode_graph(base_slot + i, base_rope + i)
+
+    def set_wq_overrides(self, overrides: dict | None) -> None:
+        """Set per-projection quant-mode overrides and requantize the decode
+        weights in place (validated). No-op re-quant if ``weight_mode='bf16'``
+        (nothing is W-quantized)."""
+        self._wq_overrides = _validate_wq_overrides(overrides)
+        if self._use_wq:
+            self._load_wq_weights()
+
+    def _finish_greedy(self, out_ids: list, max_new_tokens: int) -> str:
+        """Shared greedy tail: clip to the token budget, then cut at the
+        first EOS within it, then decode."""
+        out_ids = out_ids[:max_new_tokens]
+        eos = next((i for i, t in enumerate(out_ids)
+                    if t in self._eos_token_ids), None)
+        if eos is not None:
+            out_ids = out_ids[:eos]
+        return self._tokenizer.decode(out_ids, skip_special_tokens=True)
+
+    def generate(self, messages: list, *, max_new_tokens: int = 64,
+                 use_graph: bool = True) -> str:
+        """Greedy generation. Decode runs via captured CUDA-Graph replay by
+        default (graph output is bit-identical to eager); ``use_graph=False``
+        forces the eager per-step path (correctness reference)."""
+        self.set_prompt(messages)
+        logits = self.prefill()
+        p = self._prompt
+        assert p is not None
+        base_slot = int(p['S'])
+        base_rope = int(p['mrope_max']) + 1
+        step = self.decode_step_graph if use_graph else self.decode_step
+        tok = int(logits[0].argmax())
+        out_ids = [tok]
+        for i in range(max_new_tokens - 1):
+            if tok in self._eos_token_ids:
+                break
+            logits = step(
+                tok, cache_pos=base_slot + i, rope_pos=base_rope + i)
+            tok = int(logits[0].argmax())
+            out_ids.append(tok)
+        return self._finish_greedy(out_ids, max_new_tokens)

--- a/flash_rt/frontends/torch/qwen3_vl_thor.py
+++ b/flash_rt/frontends/torch/qwen3_vl_thor.py
@@ -395,7 +395,8 @@ class Qwen3VlTorchFrontendThor:
             )
             self._vision = Qwen3VlVisionRtx(
                 self.checkpoint_path, device=self.device,
-                config=self._vision_cfg, fp8=False)
+                config=self._vision_cfg, fp8=False,
+                attention_backend='sdpa')
         return self._vision
 
     def reset_state(self) -> None:

--- a/flash_rt/frontends/torch/qwen3_vl_thor.py
+++ b/flash_rt/frontends/torch/qwen3_vl_thor.py
@@ -23,13 +23,16 @@ See docs/qwen3_vl_thor.md.
 """
 from __future__ import annotations
 
+import collections
 import json
 import os
 from typing import Any
 
 
 # flash_rt_kernels (fvk) language ops required on Thor. embedding_lookup_bf16
-# and bf16_matmul_bf16 are model-neutral and built for every arch.
+# and bf16_matmul_bf16 are model-neutral and built for every arch;
+# bf16_matmul_bf16 is uncalled here (GEMMs go through the vlk cuBLASLt/GEMV
+# path) and is required purely as a build-inventory health check.
 _THOR_CORE_FNS = (
     'rms_norm',
     'residual_add',
@@ -101,7 +104,16 @@ def _validate_wq_overrides(overrides: dict | None) -> dict:
             raise ValueError(
                 f'wq_overrides key {key!r} must be one of {_WQ_PROJ_KEYS} '
                 f"(optionally 'L<layer>.' prefixed)")
+        if base == 'lm_head' and base != key:
+            raise ValueError(
+                f"wq_overrides key {key!r}: lm_head is not per-layer; "
+                "use 'lm_head'")
     return ov
+
+
+def _wq_active(mode: str, overrides: dict) -> bool:
+    """True when the global mode or any override requests quantization."""
+    return mode != 'bf16' or any(v != 'bf16' for v in overrides.values())
 
 
 class Qwen3VlTorchFrontendThor:
@@ -116,10 +128,10 @@ class Qwen3VlTorchFrontendThor:
                              f"{weight_mode!r}")
         self._wq_overrides = _validate_wq_overrides(wq_overrides)
         self._wq_mode = weight_mode          # 'bf16' | 'w8' | 'w4'
-        self._use_wq = weight_mode in ('w8', 'w4')
+        self._use_wq = _wq_active(weight_mode, self._wq_overrides)
 
         import torch
-        from transformers import AutoProcessor, AutoTokenizer
+        from transformers import AutoProcessor
 
         from flash_rt.frontends.torch._qwen3_vl_bf16_weights import (
             assert_extraction_invariants_qwen3_vl_bf16,
@@ -202,7 +214,7 @@ class Qwen3VlTorchFrontendThor:
             head_dim=self._cfg['head_dim'], device=self.device)
 
         self.processor = AutoProcessor.from_pretrained(self.checkpoint_path)
-        self._tokenizer = AutoTokenizer.from_pretrained(self.checkpoint_path)
+        self._tokenizer = self.processor.tokenizer
         self._processor_kwargs: dict[str, Any] = {'device': self.device}
         if max_pixels is not None:
             size = getattr(getattr(self.processor, 'image_processor', None),
@@ -248,7 +260,6 @@ class Qwen3VlTorchFrontendThor:
         # CUDA-graph decode state (all Thor decode primitives are capturable).
         self._static_token_id = torch.zeros(1, 1, device=d, dtype=torch.long)
         self._graph_stream = torch.cuda.Stream(device=d)
-        import collections
         self._decode_graphs: "collections.OrderedDict[tuple[int, int], Any]" = (
             collections.OrderedDict())
         self._graph_warmed = False
@@ -308,7 +319,6 @@ class Qwen3VlTorchFrontendThor:
                 return m
         return ov.get(key, self._wq_mode)
 
-
     def _load_wq_weights(self) -> None:
         """Quantize the language linears (+ tied lm_head) to the decode weight
         format (W8A16 / W4A16, per-projection overridable) for the
@@ -318,7 +328,7 @@ class Qwen3VlTorchFrontendThor:
         for fn in ('qwen3_vl_w8_gemv_m1', 'qwen3_vl_w4_gemv_m1'):
             if not hasattr(self._vlk, fn):
                 raise RuntimeError(
-                    f'weight_mode={self._wq_mode!r} requires {fn} in '
+                    f'W8/W4 decode requires {fn} in '
                     'flash_rt_qwen3_vl_kernels (rebuild with -DGPU_ARCH=110 '
                     '-DFLASHRT_BUILD_QWEN3_VL=ON)')
         gemv = {'w8': self._vlk.qwen3_vl_w8_gemv_m1,
@@ -387,8 +397,6 @@ class Qwen3VlTorchFrontendThor:
                 self.checkpoint_path, device=self.device,
                 config=self._vision_cfg, fp8=False)
         return self._vision
-
-
 
     def reset_state(self) -> None:
         self._attn.reset_cache()
@@ -486,16 +494,13 @@ class Qwen3VlTorchFrontendThor:
         # M=1 decode: the dedicated warp-per-row GEMV is bandwidth-bound and
         # beats cuBLASLt's poor M=1 tactics (covers K in {2048, 6144}, which is
         # every 2B decode GEMM including lm_head). Larger M (prefill) and other
-        # K go through cuBLASLt; the deterministic warp GEMM is the last resort.
+        # K go through cuBLASLt.
         if (M == 1 and K in (2048, 6144)
                 and hasattr(self._vlk, 'qwen3_vl_bf16_gemv_m1')):
             self._vlk.qwen3_vl_bf16_gemv_m1(
                 x.data_ptr(), int(weight_ptr), out.data_ptr(), N, K, stream)
-        elif hasattr(self._vlk, 'bf16_matmul_cublaslt_bf16'):
-            self._vlk.bf16_matmul_cublaslt_bf16(
-                x.data_ptr(), int(weight_ptr), out.data_ptr(), M, N, K, stream)
         else:
-            self._fvk.bf16_matmul_bf16(
+            self._vlk.bf16_matmul_cublaslt_bf16(
                 x.data_ptr(), int(weight_ptr), out.data_ptr(), M, N, K, stream)
 
     # ── one decoder layer (prefill loops rows; decode is S=1) ──
@@ -682,9 +687,8 @@ class Qwen3VlTorchFrontendThor:
 
         deepstack = None
         if p['has_image']:
-            import torch as _torch
             a, b = p['span']
-            with _torch.no_grad():
+            with torch.no_grad():
                 emb, deepstack = self._ensure_native_vision().forward(
                     p['pixel_values'], p['pos_embeds'],
                     p['vcos'], p['vsin'])
@@ -693,7 +697,8 @@ class Qwen3VlTorchFrontendThor:
         cur = h
         # Batched QK norm-rope kernel (_layer_forward) hardcodes a 64-elem
         # cos/sin row stride; enforce that coupling once (silent-wrong guard).
-        assert p['mcos'].is_contiguous() and p['mcos'].shape[-1] == 64, (
+        assert all(t.is_contiguous() and t.shape[-1] == 64
+                   for t in (p['mcos'], p['msin'])), (
             'batched prefill requires (S,64) row-contiguous mcos/msin')
         for L in range(cfg['num_hidden_layers']):
             cur = self._layer_forward(L, cur, p['mcos'], p['msin'], 0, S)
@@ -715,31 +720,12 @@ class Qwen3VlTorchFrontendThor:
     # ── decode ──
 
     def decode_step(self, token_id: int, *, cache_pos: int, rope_pos: int):
+        """Eager single-token decode (correctness reference for graph replay).
+        Same body as the captured path, run directly with a sync."""
         import torch
 
-        cfg = self._cfg
-        fvk = self._fvk
-        H = cfg['hidden_size']
-        eps = cfg['rms_norm_eps']
-        n = cfg['num_hidden_layers']
-        stream = torch.cuda.current_stream().cuda_stream
-        tok = torch.tensor([[int(token_id)]], dtype=torch.long,
-                           device=self.device)
-        h = self._h_a[:, :1]
-        fvk.embedding_lookup_bf16(
-            tok.view(-1).data_ptr(), int(self._weights.ptrs['embed_w']),
-            h.data_ptr(), 1, H, stream)
-        cos = self._mrope_cos_cache[rope_pos:rope_pos + 1]
-        sin = self._mrope_sin_cache[rope_pos:rope_pos + 1]
-        layers = self._weights.ptrs['layers']
-        final_w = int(self._weights.ptrs['final_norm_w'])
-        xn = self._norm_buf[:1]
-        fvk.rms_norm(h.view(1, H).data_ptr(), int(layers[0]['input_norm_w']),
-                     xn.data_ptr(), 1, H, eps, stream)
-        for L in range(n):
-            nw = int(layers[L + 1]['input_norm_w']) if L + 1 < n else final_w
-            xn = self._decode_layer(L, h, xn, cos, sin, cache_pos, nw)
-        self._lm_head(xn, self._logits, stream, decode=True)
+        self._static_token_id.fill_(int(token_id))
+        self._decode_body(cache_pos, rope_pos)
         torch.cuda.synchronize()
         return self._logits
 
@@ -812,21 +798,24 @@ class Qwen3VlTorchFrontendThor:
             raise RuntimeError('call set_prompt() before warmup_decode_graphs')
         base_slot = int(self._prompt['S'])
         base_rope = int(self._prompt['mrope_max']) + 1
+        if base_slot + int(n_tokens) > self.max_seq:
+            raise ValueError(
+                f'warmup of {n_tokens} positions from slot {base_slot} '
+                f'exceeds max_seq={self.max_seq}')
         for i in range(int(n_tokens)):
             self._ensure_decode_graph(base_slot + i, base_rope + i)
 
     def set_wq_overrides(self, overrides: dict | None) -> None:
         """Set per-projection quant-mode overrides and requantize the decode
-        weights in place (validated). No-op re-quant if ``weight_mode='bf16'``
-        (nothing is W-quantized)."""
+        weights in place (validated)."""
+        was = self._use_wq
         self._wq_overrides = _validate_wq_overrides(overrides)
-        if self._use_wq:
+        self._use_wq = _wq_active(self._wq_mode, self._wq_overrides)
+        if was or self._use_wq:
             self._load_wq_weights()
 
-    def _finish_greedy(self, out_ids: list, max_new_tokens: int) -> str:
-        """Shared greedy tail: clip to the token budget, then cut at the
-        first EOS within it, then decode."""
-        out_ids = out_ids[:max_new_tokens]
+    def _finish_greedy(self, out_ids: list) -> str:
+        """Greedy tail: cut at the first EOS, then decode."""
         eos = next((i for i, t in enumerate(out_ids)
                     if t in self._eos_token_ids), None)
         if eos is not None:
@@ -838,12 +827,21 @@ class Qwen3VlTorchFrontendThor:
         """Greedy generation. Decode runs via captured CUDA-Graph replay by
         default (graph output is bit-identical to eager); ``use_graph=False``
         forces the eager per-step path (correctness reference)."""
+        if max_new_tokens < 1:
+            raise ValueError(
+                f'max_new_tokens must be >= 1, got {max_new_tokens}')
         self.set_prompt(messages)
-        logits = self.prefill()
         p = self._prompt
         assert p is not None
         base_slot = int(p['S'])
         base_rope = int(p['mrope_max']) + 1
+        if base_slot + max_new_tokens - 1 > self.max_seq:
+            raise ValueError(
+                f'prompt ({base_slot} tokens) + max_new_tokens='
+                f'{max_new_tokens} needs '
+                f'{base_slot + max_new_tokens - 1} KV slots, but '
+                f'max_seq={self.max_seq}')
+        logits = self.prefill()
         step = self.decode_step_graph if use_graph else self.decode_step
         tok = int(logits[0].argmax())
         out_ids = [tok]
@@ -854,4 +852,4 @@ class Qwen3VlTorchFrontendThor:
                 tok, cache_pos=base_slot + i, rope_pos=base_rope + i)
             tok = int(logits[0].argmax())
             out_ids.append(tok)
-        return self._finish_greedy(out_ids, max_new_tokens)
+        return self._finish_greedy(out_ids)

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -145,6 +145,19 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     ("qwen3_vl", "torch", "rtx_sm89"):
         ("flash_rt.frontends.torch.qwen3_vl_fp8_sm89_multimodal",
          "Qwen3VlFp8Sm89Frontend"),
+    # Jetson Thor (SM110): BF16 frontend. The vendored FA2 is not built on
+    # sm_110, so attention runs through the Thor SDPA backend; dims come from
+    # config.json. See docs/qwen3_vl_thor.md.
+    ("qwen3_vl", "torch", "thor"):
+        ("flash_rt.frontends.torch.qwen3_vl_thor",
+         "Qwen3VlTorchFrontendThor"),
+    # Jetson Orin (SM87, Ampere): no FP8/FP4 tensor cores, so neither the FP8
+    # nor the NVFP4 Qwen3-VL path applies. BF16 language stack over the FA2
+    # (sm_80 codegen) attention backend, with opt-in INT8/INT4 decode weight
+    # quantization. See docs/qwen3_vl_rtx_bf16.md.
+    ("qwen3_vl", "torch", "rtx_sm87"):
+        ("flash_rt.frontends.torch.qwen3_vl_rtx_bf16",
+         "Qwen3VlTorchFrontendRtxBF16"),
 
     # Cosmos3-Edge official Thor baseline.
     ("cosmos3_edge", "torch", "thor"):
@@ -173,6 +186,16 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
 }
 
 
+# (config, framework, "rtx_sm87") keys supported on Jetson Orin. Ampere has no
+# FP8/FP4 tensor cores, so each model needs an arch-specific INT8/BF16
+# frontend; an explicit allowlist keeps an unrelated FP8 frontend from
+# resolving here and crashing later at the first kernel launch.
+_SM87_ALLOWED = {
+    ("pi05", "torch", "rtx_sm87"),
+    ("qwen3_vl", "torch", "rtx_sm87"),
+}
+
+
 def resolve_pipeline_class(config: str, framework: str, arch: str):
     """Resolve (config, framework, arch) to a pipeline class object.
 
@@ -180,11 +203,12 @@ def resolve_pipeline_class(config: str, framework: str, arch: str):
     does not pull in torch/jax/rtx code until a load happens.
     """
     key = (config, framework, arch)
-    if arch == "rtx_sm87" and key != ("pi05", "torch", "rtx_sm87"):
+    if arch == "rtx_sm87" and key not in _SM87_ALLOWED:
+        supported = sorted({c for (c, f, _) in _SM87_ALLOWED if f == framework})
         raise RuntimeError(
-            "FlashRT: Jetson Orin SM87 currently supports only "
-            "config='pi05' with framework='torch'. "
-            f"config={config!r} framework={framework!r} is not supported yet."
+            "FlashRT: Jetson Orin SM87 supports the following configs with "
+            f"framework={framework!r}: {supported}. "
+            f"config={config!r} is not supported yet."
         )
     if key not in _PIPELINE_MAP:
         supported = sorted(

--- a/flash_rt/hardware/rtx/attn_backend_qwen3.py
+++ b/flash_rt/hardware/rtx/attn_backend_qwen3.py
@@ -51,7 +51,8 @@ class RtxFlashAttnBackendQwen3:
                  num_q_heads: int | None = None,
                  num_kv_heads: int | None = None,
                  head_dim: int | None = None,
-                 device: str = "cuda"):
+                 device: str = "cuda",
+                 use_int8_kv: bool = False):
         import os
 
         import torch
@@ -117,6 +118,47 @@ class RtxFlashAttnBackendQwen3:
             n_splits, 1, self.NUM_Q_HEADS, self._max_q_seq, self.HEAD_DIM,
             dtype=torch.float32, device=d,
         )
+
+        # ── INT8 KV cache (opt-in) ──
+        # int8 mirrors of K/V with one bf16 scale per (position, kv-head) row.
+        # q=1 decode reads these instead of the bf16 cache, halving the KV
+        # bytes per step; prefill still runs FA2 against the bf16 cache.
+        # Everything is allocated here so the decode path stays graph-safe.
+        self._use_int8_kv = bool(use_int8_kv)
+        if self._use_int8_kv:
+            from flash_rt import flash_rt_qwen3_vl_kernels as _vlk
+            for fn in ('qwen3_kv_rows_quant_int8',
+                       'qwen3_attn_decode_int8kv_partial',
+                       'qwen3_attn_decode_int8kv_combine'):
+                if not hasattr(_vlk, fn):
+                    raise RuntimeError(
+                        f'use_int8_kv=True requires {fn} in '
+                        'flash_rt_qwen3_vl_kernels (rebuild with '
+                        '-DFLASHRT_BUILD_QWEN3_VL=ON)')
+            self._vlk = _vlk
+            if (self.NUM_Q_HEADS, self.NUM_KV_HEADS, self.HEAD_DIM) != (
+                    16, 8, 128):
+                raise RuntimeError(
+                    'the int8-KV decode kernel is specialized for GQA 16Q/8KV '
+                    f'head_dim=128; got {self.NUM_Q_HEADS}Q/'
+                    f'{self.NUM_KV_HEADS}KV head_dim={self.HEAD_DIM}')
+            self.K8 = torch.empty(
+                self.NUM_FULL_LAYERS, self._max_seq,
+                self.NUM_KV_HEADS, self.HEAD_DIM,
+                dtype=torch.int8, device=d)
+            self.V8 = torch.empty_like(self.K8)
+            self.KS = torch.empty(
+                self.NUM_FULL_LAYERS, self._max_seq, self.NUM_KV_HEADS,
+                dtype=bf16, device=d)
+            self.VS = torch.empty_like(self.KS)
+            n_chunks_max = (self._max_seq + 127) // 128
+            self._i8_part_o = torch.empty(
+                n_chunks_max, self.NUM_Q_HEADS, self.HEAD_DIM,
+                dtype=torch.float32, device=d)
+            self._i8_part_m = torch.empty(
+                n_chunks_max, self.NUM_Q_HEADS,
+                dtype=torch.float32, device=d)
+            self._i8_part_l = torch.empty_like(self._i8_part_m)
 
         # FA2 module. Fail loud if missing — Qwen3 path requires the
         # vendored fp16/bf16 FA2 build.
@@ -252,6 +294,37 @@ class RtxFlashAttnBackendQwen3:
         self.K_cache.zero_()
         self.V_cache.zero_()
 
+    # ── INT8 KV maintenance (no-ops unless use_int8_kv) ──
+
+    def quantize_kv_rows(self, layer_idx: int, pos: int,
+                         stream: int = 0) -> None:
+        """Mirror the K/V rows a decode step just wrote at (layer, pos) into
+        int8. Graph-safe: fixed pointers, one tiny launch each."""
+        if not self._use_int8_kv:
+            return
+        nkv = self.NUM_KV_HEADS
+        self._vlk.qwen3_kv_rows_quant_int8(
+            self.K_cache[layer_idx, pos].data_ptr(),
+            self.K8[layer_idx, pos].data_ptr(),
+            self.KS[layer_idx, pos].data_ptr(), nkv, stream)
+        self._vlk.qwen3_kv_rows_quant_int8(
+            self.V_cache[layer_idx, pos].data_ptr(),
+            self.V8[layer_idx, pos].data_ptr(),
+            self.VS[layer_idx, pos].data_ptr(), nkv, stream)
+
+    def quantize_kv_prefix(self, kv_len: int, stream: int = 0) -> None:
+        """Bulk-mirror KV[0:kv_len] for every layer after prefill."""
+        if not self._use_int8_kv:
+            return
+        n_rows = int(kv_len) * self.NUM_KV_HEADS
+        for L in range(self.NUM_FULL_LAYERS):
+            self._vlk.qwen3_kv_rows_quant_int8(
+                self.K_cache[L, 0].data_ptr(), self.K8[L, 0].data_ptr(),
+                self.KS[L, 0].data_ptr(), n_rows, stream)
+            self._vlk.qwen3_kv_rows_quant_int8(
+                self.V_cache[L, 0].data_ptr(), self.V8[L, 0].data_ptr(),
+                self.VS[L, 0].data_ptr(), n_rows, stream)
+
     # ── Attention call ──
 
     def run(self, site: str, layer_idx: int, q_seq: int,
@@ -297,6 +370,28 @@ class RtxFlashAttnBackendQwen3:
         # binding (template Is_causal=true). Both paths handle GQA
         # natively via FA2's h_h_k_ratio — no repeat_interleave / SDPA
         # detour.
+        if self._use_int8_kv and q_seq == 1:
+            # Flash-decoding over the int8 KV mirrors: half the KV HBM bytes
+            # of the bf16 FA2 path. Partials + combine buffers were
+            # pre-allocated in __init__, so this is graph-safe.
+            n_chunks = (kv_seq + 127) // 128
+            self._vlk.qwen3_attn_decode_int8kv_partial(
+                self.Q_buf[0, 0].data_ptr(),
+                self.K8[layer_idx].data_ptr(),
+                self.V8[layer_idx].data_ptr(),
+                self.KS[layer_idx].data_ptr(),
+                self.VS[layer_idx].data_ptr(),
+                self._i8_part_o.data_ptr(),
+                self._i8_part_m.data_ptr(),
+                self._i8_part_l.data_ptr(),
+                kv_seq, n_chunks, float(softmax_scale), stream)
+            self._vlk.qwen3_attn_decode_int8kv_combine(
+                self._i8_part_o.data_ptr(),
+                self._i8_part_m.data_ptr(),
+                self._i8_part_l.data_ptr(),
+                self.O_buf[0, 0].data_ptr(), n_chunks, stream)
+            return o.data_ptr()
+
         if self._use_fvk_fa2 and q_seq == 1:
             self._fa2_fwd(
                 Q=q.data_ptr(), K=k.data_ptr(), V=v.data_ptr(),

--- a/flash_rt/hardware/thor/attn_backend_qwen3.py
+++ b/flash_rt/hardware/thor/attn_backend_qwen3.py
@@ -107,11 +107,12 @@ class ThorAttnBackendQwen3:
 
     @property
     def kv_layer_stride_bytes(self) -> int:
-        return self._max_seq * self.NUM_KV_HEADS * self.HEAD_DIM * 2
+        return self._max_seq * self.kv_row_stride_bytes
 
     @property
     def kv_row_stride_bytes(self) -> int:
-        return self.NUM_KV_HEADS * self.HEAD_DIM * 2
+        return (self.NUM_KV_HEADS * self.HEAD_DIM
+                * self.K_cache.element_size())
 
     # ── AttentionBackend protocol ──
 

--- a/flash_rt/hardware/thor/attn_backend_qwen3.py
+++ b/flash_rt/hardware/thor/attn_backend_qwen3.py
@@ -1,0 +1,228 @@
+"""FlashRT — Thor (SM110) Qwen3 dense full-attention backend.
+
+Thor analogue of ``flash_rt.hardware.rtx.attn_backend_qwen3``. It keeps exactly
+the buffer surface the Qwen3-VL frontends rely on (``Q_buf`` / ``K_cache`` /
+``V_cache`` / ``O_buf`` + ``get_slot_ptrs`` + ``kv_layer_stride_bytes`` /
+``kv_row_stride_bytes`` + ``reset_cache`` + ``run``), so the frontend's KV-write
+pointer math and attention call stay arch-independent.
+
+The one thing that differs from the RTX backend is the attention kernel: the
+vendored FA2 is not built on sm_110, so ``run`` uses a GQA
+``scaled_dot_product_attention``. SDPA is numerically faithful here (BF16 math,
+fp32 softmax) and is the correctness baseline for the Thor bring-up. A later
+phase can swap in the Thor CUTLASS causal FMHA without changing this surface.
+
+Cache layout (identical to the RTX backend)::
+
+    Q  : (1, max_q_seq, NUM_Q_HEADS,  HEAD_DIM) bf16
+    KV : (NUM_LAYERS,   max_seq,      NUM_KV_HEADS, HEAD_DIM) bf16
+
+Decode (q_seq=1): the frontend writes the new token's K/V into
+``K_cache[L, cur_pos]`` / ``V_cache[L, cur_pos]`` and Q into ``Q_buf[:, :1]``,
+then calls ``run("full", L, q_seq=1, kv_seq=cur_pos + 1)``.
+
+Prefill (q_seq=S): the frontend writes K/V[L, :S] and Q[:, :S], then calls
+``run("full", L, q_seq=S, kv_seq=S, causal=True)``.
+"""
+from __future__ import annotations
+
+
+class ThorAttnBackendQwen3:
+    """Qwen3 dense GQA full-attention backend for Jetson Thor (SM110).
+
+    BF16 attention math via SDPA. Mirrors the RTX backend's buffer surface and
+    per-model dim kwargs (num_layers / num_q_heads / num_kv_heads / head_dim)
+    so the 2B (28/16/8/128) and larger variants share one backend.
+    """
+
+    SITES = ("full",)
+    NUM_FULL_LAYERS = 28
+    NUM_Q_HEADS = 16
+    NUM_KV_HEADS = 8                # GQA 2:1 for the 2B variant
+    HEAD_DIM = 128
+
+    def __init__(self, max_seq: int, max_q_seq: int = 1, dtype=None,
+                 *, num_layers: int | None = None,
+                 num_q_heads: int | None = None,
+                 num_kv_heads: int | None = None,
+                 head_dim: int | None = None,
+                 device: str = "cuda") -> None:
+        import torch
+
+        self._torch = torch
+        bf16 = dtype if dtype is not None else torch.bfloat16
+        d = torch.device(device)
+
+        self.NUM_FULL_LAYERS = (
+            int(num_layers) if num_layers is not None
+            else type(self).NUM_FULL_LAYERS)
+        self.NUM_Q_HEADS = (
+            int(num_q_heads) if num_q_heads is not None
+            else type(self).NUM_Q_HEADS)
+        self.NUM_KV_HEADS = (
+            int(num_kv_heads) if num_kv_heads is not None
+            else type(self).NUM_KV_HEADS)
+        self.HEAD_DIM = (
+            int(head_dim) if head_dim is not None
+            else type(self).HEAD_DIM)
+        if self.NUM_Q_HEADS % self.NUM_KV_HEADS != 0:
+            raise ValueError(
+                f"num_q_heads ({self.NUM_Q_HEADS}) must be a multiple of "
+                f"num_kv_heads ({self.NUM_KV_HEADS})")
+
+        self._max_seq = int(max_seq)
+        self._max_q_seq = int(max_q_seq)
+        self._dtype = bf16
+
+        # Per-layer KV cache: (NUM_FULL_LAYERS, max_seq, NUM_KV_HEADS, HEAD_DIM).
+        self.K_cache = torch.empty(
+            self.NUM_FULL_LAYERS, self._max_seq,
+            self.NUM_KV_HEADS, self.HEAD_DIM, dtype=bf16, device=d,
+        )
+        self.V_cache = torch.empty_like(self.K_cache)
+
+        # Q / O scratch.
+        self.Q_buf = torch.empty(
+            1, self._max_q_seq, self.NUM_Q_HEADS, self.HEAD_DIM,
+            dtype=bf16, device=d,
+        )
+        self.O_buf = torch.empty_like(self.Q_buf)
+
+        # Probe native-GQA SDPA support here rather than on the first run():
+        # the probe itself launches an SDPA, which must not happen inside a
+        # CUDA Graph capture. When unsupported, run() expands K/V instead.
+        self._sdpa_gqa = True
+        if self.NUM_Q_HEADS > self.NUM_KV_HEADS:
+            probe = torch.empty(
+                1, self.NUM_Q_HEADS, 1, self.HEAD_DIM, dtype=bf16, device=d)
+            probe_kv = torch.empty(
+                1, self.NUM_KV_HEADS, 1, self.HEAD_DIM, dtype=bf16, device=d)
+            try:
+                torch.nn.functional.scaled_dot_product_attention(
+                    probe, probe_kv, probe_kv, enable_gqa=True)
+            except TypeError:
+                self._sdpa_gqa = False
+
+    # ── Layer cache pointer math ──
+
+    @property
+    def kv_layer_stride_bytes(self) -> int:
+        return self._max_seq * self.NUM_KV_HEADS * self.HEAD_DIM * 2
+
+    @property
+    def kv_row_stride_bytes(self) -> int:
+        return self.NUM_KV_HEADS * self.HEAD_DIM * 2
+
+    # ── AttentionBackend protocol ──
+
+    def sites(self) -> tuple[str, ...]:
+        return self.SITES
+
+    def _check_site(self, site: str) -> None:
+        if site != "full":
+            raise KeyError(
+                f"qwen3 thor backend only knows site='full', got {site!r}")
+
+    def head_dim(self, site: str) -> int:
+        self._check_site(site)
+        return self.HEAD_DIM
+
+    def num_q_heads(self, site: str) -> int:
+        self._check_site(site)
+        return self.NUM_Q_HEADS
+
+    def num_kv_heads(self, site: str) -> int:
+        self._check_site(site)
+        return self.NUM_KV_HEADS
+
+    def get_slot_ptrs(self, site: str, layer_idx: int) -> dict:
+        self._check_site(site)
+        layer_off_bytes = layer_idx * self.kv_layer_stride_bytes
+        return {
+            "Q": self.Q_buf.data_ptr(),
+            "K": self.K_cache.data_ptr() + layer_off_bytes,
+            "V": self.V_cache.data_ptr() + layer_off_bytes,
+            "kv_layer_stride_bytes": self.kv_layer_stride_bytes,
+            "kv_row_stride_bytes": self.kv_row_stride_bytes,
+        }
+
+    def reset_cache(self) -> None:
+        self.K_cache.zero_()
+        self.V_cache.zero_()
+
+    # ── Attention call ──
+
+    def run(self, site: str, layer_idx: int, q_seq: int,
+            *, kv_seq: int, stream: int = 0,
+            softmax_scale: float | None = None,
+            causal: bool = True) -> int:
+        """GQA SDPA over Q[:q_seq] vs K/V[layer_idx, :kv_seq].
+
+        Writes into ``O_buf[:, :q_seq]`` and returns its pointer. ``causal`` is
+        honoured for q_seq>1 prefill; q_seq==1 decode is causal-invariant.
+        """
+        self._check_site(site)
+        if not (1 <= q_seq <= self._max_q_seq):
+            raise ValueError(
+                f"q_seq={q_seq} out of range [1, {self._max_q_seq}]")
+        if not (1 <= kv_seq <= self._max_seq):
+            raise ValueError(
+                f"kv_seq={kv_seq} out of range [1, {self._max_seq}]")
+        if causal and q_seq > 1 and kv_seq != q_seq:
+            # A q-block that ends mid-sequence needs a bottom-right-aligned
+            # mask, but SDPA's is_causal is top-left-aligned. Building the mask
+            # here would allocate on the hot path, so refuse instead of
+            # silently attending to the wrong positions.
+            raise NotImplementedError(
+                "Thor Qwen3 attention supports causal prefill only with "
+                f"kv_seq == q_seq; got q_seq={q_seq} kv_seq={kv_seq}")
+
+        tt = self._torch
+        if softmax_scale is None:
+            softmax_scale = 1.0 / (self.HEAD_DIM ** 0.5)
+
+        # (1, q_seq, Hq, hd) -> (1, Hq, q_seq, hd)
+        q = self.Q_buf[:, :q_seq].transpose(1, 2)
+        # (1, kv_seq, Hkv, hd) -> (1, Hkv, kv_seq, hd)
+        k = self.K_cache[layer_idx:layer_idx + 1, :kv_seq].transpose(1, 2)
+        v = self.V_cache[layer_idx:layer_idx + 1, :kv_seq].transpose(1, 2)
+        ratio = self.NUM_Q_HEADS // self.NUM_KV_HEADS
+        is_causal = bool(causal and q_seq > 1)
+        sdpa = tt.nn.functional.scaled_dot_product_attention
+
+        if ratio > 1 and self._sdpa_gqa:
+            out_h = sdpa(q.contiguous(), k, v, attn_mask=None,
+                         is_causal=is_causal, scale=softmax_scale,
+                         enable_gqa=True)
+        else:
+            if ratio > 1:
+                # Expansion allocates; on this path it lands in the graph's
+                # private pool during capture.
+                k = k.repeat_interleave(ratio, dim=1)
+                v = v.repeat_interleave(ratio, dim=1)
+            out_h = sdpa(q.contiguous(), k.contiguous(), v.contiguous(),
+                         attn_mask=None, is_causal=is_causal,
+                         scale=softmax_scale)
+        # (1, Hq, q_seq, hd) -> (1, q_seq, Hq, hd)
+        self.O_buf[:, :q_seq].copy_(out_h.transpose(1, 2))
+        return self.O_buf.data_ptr()
+
+
+def make_qwen3_thor_attention_spec(*, num_layers: int, num_q_heads: int,
+                                   num_kv_heads: int, head_dim: int,
+                                   max_seq: int, max_q_seq: int = 1) -> dict:
+    """Static metadata describing the Thor Qwen3 full-attn site."""
+    return {
+        "sites": [
+            {
+                "name": "full",
+                "layer_count": int(num_layers),
+                "num_q_heads": int(num_q_heads),
+                "num_kv_heads": int(num_kv_heads),
+                "head_dim": int(head_dim),
+                "max_q_seq": int(max_q_seq),
+                "max_kv_seq": int(max_seq),
+                "kernel": "sdpa_bf16",
+            },
+        ],
+    }

--- a/tests/test_qwen3_attn_backend_int8kv.py
+++ b/tests/test_qwen3_attn_backend_int8kv.py
@@ -1,0 +1,182 @@
+"""Tests for the Qwen3 attention backend's opt-in INT8 KV cache.
+
+Covers the fail-fast contract (missing kernels, unsupported attention
+geometry) and proves the feature is inert when left off, which is what keeps
+the existing BF16 decode path byte-identical.
+
+CPU-runnable: needs torch but no GPU (device='cpu', num_sms mocked).
+
+Run:
+    PYTHONPATH=. python -m pytest tests/test_qwen3_attn_backend_int8kv.py -v
+"""
+from __future__ import annotations
+
+import importlib
+import unittest.mock as mock
+
+import pytest
+
+torch = pytest.importorskip('torch')
+
+
+BACKEND_MOD = 'flash_rt.hardware.rtx.attn_backend_qwen3'
+INT8KV_FNS = ('qwen3_kv_rows_quant_int8',
+              'qwen3_attn_decode_int8kv_partial',
+              'qwen3_attn_decode_int8kv_combine')
+# The geometry the int8-KV decode kernel is specialized for (Qwen3-VL-2B).
+DIMS_2B = dict(num_layers=2, num_q_heads=16, num_kv_heads=8, head_dim=128)
+# Qwen3-VL-8B: 32Q/8KV — outside the kernel's specialization.
+DIMS_8B = dict(num_layers=2, num_q_heads=32, num_kv_heads=8, head_dim=128)
+
+
+class _Fa2:
+    """Minimal stand-in for a fully built flash_rt_fa2."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+        self.fwd_bf16 = self._rec('fwd_bf16')
+        self.fwd_bf16_causal = self._rec('fwd_bf16_causal')
+
+    def _rec(self, name):
+        def _fn(**kw):
+            self.calls.append(name)
+        return _fn
+
+
+class _Vlk:
+    """Stand-in for flash_rt_qwen3_vl_kernels recording kernel calls."""
+
+    def __init__(self, *, drop: str | None = None):
+        self.calls: list[tuple[str, tuple]] = []
+        for fn in INT8KV_FNS:
+            if fn == drop:
+                continue
+            setattr(self, fn, self._rec(fn))
+
+    def _rec(self, name):
+        def _fn(*a, **kw):
+            self.calls.append((name, a))
+        return _fn
+
+
+def _make_backend(*, fa2=None, vlk=None, dims=None, **kwargs):
+    mod = importlib.import_module(BACKEND_MOD)
+    props = mock.Mock()
+    props.multi_processor_count = 8
+    modules = {'flash_rt.flash_rt_fa2': fa2 or _Fa2()}
+    if vlk is not None:
+        modules['flash_rt.flash_rt_qwen3_vl_kernels'] = vlk
+    with mock.patch.dict('sys.modules', modules), \
+            mock.patch.object(torch.cuda, 'get_device_properties',
+                              return_value=props):
+        return mod.RtxFlashAttnBackendQwen3(
+            max_seq=256, max_q_seq=1, device='cpu',
+            **(dims or DIMS_2B), **kwargs)
+
+
+# ── old path: the feature is inert when off ──
+
+def test_disabled_by_default_allocates_no_int8_mirrors():
+    backend = _make_backend()
+    assert backend._use_int8_kv is False
+    for attr in ('K8', 'V8', 'KS', 'VS'):
+        assert not hasattr(backend, attr), f'unexpected {attr} allocation'
+
+
+def test_quantize_helpers_are_no_ops_when_disabled():
+    """Frontends call these unconditionally, so they must be safe when off."""
+    backend = _make_backend()
+    backend.quantize_kv_rows(0, 0)
+    backend.quantize_kv_prefix(8)
+
+
+def test_decode_still_uses_fa2_when_disabled():
+    fa2 = _Fa2()
+    backend = _make_backend(fa2=fa2)
+    backend.run('full', layer_idx=0, q_seq=1, kv_seq=8)
+    assert fa2.calls == ['fwd_bf16']
+
+
+# ── new path ──
+
+def test_enabling_allocates_mirrors_scales_and_partials():
+    backend = _make_backend(vlk=_Vlk(), use_int8_kv=True)
+    assert backend.K8.dtype is torch.int8 and backend.V8.dtype is torch.int8
+    assert backend.K8.shape == backend.K_cache.shape
+    # One scale per (layer, position, kv-head).
+    assert backend.KS.shape == backend.K_cache.shape[:3]
+    assert backend.KS.dtype is torch.bfloat16
+    n_chunks_max = (256 + 127) // 128
+    assert backend._i8_part_o.shape == (n_chunks_max, 16, 128)
+    assert backend._i8_part_m.shape == (n_chunks_max, 16)
+
+
+def test_decode_routes_to_int8_kernels_instead_of_fa2():
+    fa2, vlk = _Fa2(), _Vlk()
+    backend = _make_backend(fa2=fa2, vlk=vlk, use_int8_kv=True)
+    backend.run('full', layer_idx=0, q_seq=1, kv_seq=200)
+
+    assert fa2.calls == [], 'FA2 must not run when int8 KV is active at q=1'
+    assert [name for name, _ in vlk.calls] == [
+        'qwen3_attn_decode_int8kv_partial',
+        'qwen3_attn_decode_int8kv_combine',
+    ]
+    # kv_len=200 spans two 128-position chunks.
+    partial_args = vlk.calls[0][1]
+    assert partial_args[8] == 200 and partial_args[9] == 2
+
+
+def test_prefill_still_uses_fa2_when_int8_kv_enabled():
+    """Only decode reads the int8 mirrors; prefill stays on the bf16 cache."""
+    fa2, vlk = _Fa2(), _Vlk()
+    mod = importlib.import_module(BACKEND_MOD)
+    props = mock.Mock()
+    props.multi_processor_count = 8
+    with mock.patch.dict('sys.modules', {
+            'flash_rt.flash_rt_fa2': fa2,
+            'flash_rt.flash_rt_qwen3_vl_kernels': vlk}), \
+            mock.patch.object(torch.cuda, 'get_device_properties',
+                              return_value=props):
+        backend = mod.RtxFlashAttnBackendQwen3(
+            max_seq=256, max_q_seq=8, device='cpu', use_int8_kv=True,
+            **DIMS_2B)
+    backend.run('full', layer_idx=0, q_seq=8, kv_seq=8, causal=True)
+    assert fa2.calls == ['fwd_bf16_causal']
+    assert vlk.calls == []
+
+
+def test_quantize_kv_rows_mirrors_both_k_and_v():
+    vlk = _Vlk()
+    backend = _make_backend(vlk=vlk, use_int8_kv=True)
+    backend.quantize_kv_rows(1, 5)
+    assert [name for name, _ in vlk.calls] == [
+        'qwen3_kv_rows_quant_int8'] * 2
+    # n_rows == kv_heads for a single position.
+    assert all(args[3] == 8 for _, args in vlk.calls)
+
+
+def test_quantize_kv_prefix_covers_every_layer():
+    vlk = _Vlk()
+    backend = _make_backend(vlk=vlk, use_int8_kv=True)
+    backend.quantize_kv_prefix(16)
+    # Two layers x (K, V).
+    assert len(vlk.calls) == 4
+    assert all(args[3] == 16 * 8 for _, args in vlk.calls)
+
+
+# ── fail-fast ──
+
+@pytest.mark.parametrize('missing', INT8KV_FNS)
+def test_missing_kernel_symbol_raises_naming_it(missing):
+    with pytest.raises(RuntimeError) as ei:
+        _make_backend(vlk=_Vlk(drop=missing), use_int8_kv=True)
+    assert missing in str(ei.value)
+
+
+def test_unsupported_attention_geometry_raises():
+    """8B's 32Q/8KV is outside the kernel's specialization — fail at
+    construction rather than at the first decode launch."""
+    with pytest.raises(RuntimeError) as ei:
+        _make_backend(vlk=_Vlk(), dims=DIMS_8B, use_int8_kv=True)
+    msg = str(ei.value)
+    assert '16Q/8KV' in msg and '32Q' in msg

--- a/tests/test_qwen3_vl_graph_cache.py
+++ b/tests/test_qwen3_vl_graph_cache.py
@@ -376,6 +376,9 @@ def test_qwen3_vl_rtx_bf16_graph_caches_are_lru_bounded(monkeypatch):
     monkeypatch.setattr(
         Qwen3VlTorchFrontendRtxBF16, "_decode_token_tensor",
         lambda self, token, *, cache_pos, rope_pos: None)
+    monkeypatch.setattr(
+        Qwen3VlTorchFrontendRtxBF16, "_decode_body_da",
+        lambda self, *, cache_pos, rope_pos, out_idx: None)
 
     fe = Qwen3VlTorchFrontendRtxBF16.__new__(
         Qwen3VlTorchFrontendRtxBF16)
@@ -384,6 +387,7 @@ def test_qwen3_vl_rtx_bf16_graph_caches_are_lru_bounded(monkeypatch):
     fe._prefill_graphs = collections.OrderedDict()
     fe._pg_buffers = collections.OrderedDict()
     fe._decode_graphs = collections.OrderedDict()
+    fe._decode_da_graphs = collections.OrderedDict()
     fe._graph_stream = _FakeStream()
     fe._static_token_id = object()
 
@@ -405,16 +409,82 @@ def test_qwen3_vl_rtx_bf16_graph_caches_are_lru_bounded(monkeypatch):
 
     assert len(fe._decode_graphs) == fe.max_decode_graphs
     assert list(fe._decode_graphs) == [(3, 103), (4, 104)]
+
+    for i in range(5):
+        fe._ensure_decode_graph_da(cache_pos=i, rope_pos=100 + i,
+                                   out_idx=i + 1)
+
+    assert len(fe._decode_da_graphs) == fe.max_decode_graphs
+    assert list(fe._decode_da_graphs) == [(3, 103, 4), (4, 104, 5)]
+
     stats = fe.graph_cache_stats()
     assert stats["prefill"]["graph_count"] == 2
     assert stats["prefill"]["buffer_count"] == 2
     assert stats["decode"]["graph_count"] == 2
+    assert stats["decode_device_argmax"]["graph_count"] == 2
 
     fe.clear_graphs()
 
     assert fe._prefill_graphs == collections.OrderedDict()
     assert fe._pg_buffers == collections.OrderedDict()
     assert fe._decode_graphs == collections.OrderedDict()
+    assert fe._decode_da_graphs == collections.OrderedDict()
+
+
+def test_qwen3_vl_rtx_bf16_device_argmax_key_includes_ring_slot(monkeypatch):
+    """base_slot and base_rope shift together with prompt length, so two
+    prompts of different lengths hit the same (cache_pos, rope_pos) at
+    different ring slots. The captured body bakes in a write to one slot, so
+    the slot must be part of the cache key or the second prompt replays the
+    first's graph and writes the wrong slot."""
+    import torch
+
+    from flash_rt.frontends.torch.qwen3_vl_rtx_bf16 import (
+        Qwen3VlTorchFrontendRtxBF16,
+    )
+
+    class _FakeStream:
+        cuda_stream = 0
+
+        def wait_stream(self, _other):
+            pass
+
+        def synchronize(self):
+            pass
+
+    monkeypatch.setattr(torch.cuda, "current_stream",
+                        lambda: _FakeStream(), raising=False)
+    monkeypatch.setattr(torch.cuda, "stream",
+                        lambda _stream: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "graph",
+                        lambda _graph, stream=None: contextlib.nullcontext(),
+                        raising=False)
+    monkeypatch.setattr(torch.cuda, "CUDAGraph", lambda: object(),
+                        raising=False)
+    monkeypatch.setattr(torch, "inference_mode",
+                        lambda: contextlib.nullcontext())
+    monkeypatch.setattr(
+        Qwen3VlTorchFrontendRtxBF16, "_decode_body_da",
+        lambda self, *, cache_pos, rope_pos, out_idx: None)
+
+    fe = Qwen3VlTorchFrontendRtxBF16.__new__(Qwen3VlTorchFrontendRtxBF16)
+    fe.max_decode_graphs = 8
+    fe._decode_da_graphs = collections.OrderedDict()
+    fe._graph_stream = _FakeStream()
+
+    # Prompt A: S=100, so i=0 -> (100, 100) writing ring slot 1.
+    a = fe._ensure_decode_graph_da(cache_pos=100, rope_pos=100, out_idx=1)
+    # Prompt B: S=99, so i=1 -> (100, 100) too, but writing ring slot 2.
+    b = fe._ensure_decode_graph_da(cache_pos=100, rope_pos=100, out_idx=2)
+
+    assert a is not b, 'graph reused for a different ring slot'
+    assert len(fe._decode_da_graphs) == 2
+    assert all(len(k) == 3 for k in fe._decode_da_graphs), \
+        'device-argmax cache key must include the ring slot'
+    # The same (position, slot) triple still hits the cache.
+    assert fe._ensure_decode_graph_da(
+        cache_pos=100, rope_pos=100, out_idx=1) is a
 
 
 def test_qwen3_vl_rtx_bf16_prefill_graph_restages_after_clear(monkeypatch):

--- a/tests/test_qwen3_vl_rtx_bf16.py
+++ b/tests/test_qwen3_vl_rtx_bf16.py
@@ -163,6 +163,67 @@ def test_decode_quant_knobs_default_to_bf16():
     assert sig.parameters['kv_mode'].default == 'bf16'
 
 
+def _decode_capacity_stub(*, prompt_len=5, max_seq=8):
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    frontend = object.__new__(m.Qwen3VlTorchFrontendRtxBF16)
+    frontend._prompt = {'S': prompt_len, 'mrope_max': prompt_len - 1}
+    frontend.max_seq = max_seq
+    frontend.max_decode_graphs = max_seq
+    return frontend
+
+
+def test_warmup_decode_graphs_checks_prompt_plus_decode_capacity():
+    frontend = _decode_capacity_stub()
+    positions = []
+    frontend._ensure_decode_graph = (
+        lambda cache_pos, rope_pos: positions.append((cache_pos, rope_pos)))
+
+    frontend.warmup_decode_graphs(3)
+    assert positions == [(5, 5), (6, 6), (7, 7)]
+    with pytest.raises(ValueError, match='KV slots'):
+        frontend.warmup_decode_graphs(4)
+    with pytest.raises(ValueError, match='n_tokens must be >= 1'):
+        frontend.warmup_decode_graphs(0)
+
+
+def test_warmup_decode_da_graphs_checks_generation_capacity():
+    frontend = _decode_capacity_stub()
+    positions = []
+    frontend._ensure_decode_graph_da = (
+        lambda cache_pos, rope_pos, out_idx: positions.append(
+            (cache_pos, rope_pos, out_idx)))
+
+    frontend.warmup_decode_da_graphs(4)
+    assert positions == [(5, 5, 1), (6, 6, 2), (7, 7, 3)]
+    with pytest.raises(ValueError, match='KV slots'):
+        frontend.warmup_decode_da_graphs(5)
+    with pytest.raises(ValueError, match='n_tokens must be >= 1'):
+        frontend.warmup_decode_da_graphs(0)
+
+
+@pytest.mark.parametrize('use_graph', [False, True])
+def test_generate_rejects_prompt_plus_generation_overflow(use_graph):
+    frontend = _decode_capacity_stub(prompt_len=7, max_seq=8)
+    frontend.set_prompt = lambda messages: None
+    with pytest.raises(ValueError, match='prompt .* max_new_tokens'):
+        frontend.generate([], max_new_tokens=3, use_graph=use_graph)
+
+
+@pytest.mark.parametrize('max_new_tokens', [0, -1])
+def test_generate_rejects_non_positive_token_count(max_new_tokens):
+    frontend = _decode_capacity_stub()
+    frontend.set_prompt = lambda messages: (_ for _ in ()).throw(
+        AssertionError('set_prompt must not run for an invalid token count'))
+    with pytest.raises(ValueError, match='max_new_tokens must be >= 1'):
+        frontend.generate([], max_new_tokens=max_new_tokens)
+
+
+def test_orin_quickstart_requires_checkpoint_argument():
+    src = (pathlib.Path(__file__).parents[1]
+           / 'examples/orin/qwen3_vl_quickstart.py').read_text()
+    assert "add_argument('--checkpoint', required=True)" in src
+
+
 # ── decode weight quantization ──
 
 @pytest.mark.parametrize('mode', ['bogus', 'fp8', 'int2', ''])

--- a/tests/test_qwen3_vl_rtx_bf16.py
+++ b/tests/test_qwen3_vl_rtx_bf16.py
@@ -11,6 +11,8 @@ Run:
 from __future__ import annotations
 
 import importlib
+import pathlib
+import types
 
 import pytest
 
@@ -147,5 +149,91 @@ def test_constructor_signature_has_required_kwargs():
     m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
     sig = inspect.signature(m.Qwen3VlTorchFrontendRtxBF16.__init__)
     params = set(sig.parameters.keys()) - {'self'}
-    for required in ('checkpoint_path', 'device', 'max_seq'):
+    for required in ('checkpoint_path', 'device', 'max_seq',
+                     'weight_mode', 'kv_mode'):
         assert required in params, f'missing parameter: {required}'
+
+
+def test_decode_quant_knobs_default_to_bf16():
+    """Defaults must leave the shipped BF16 decode path untouched."""
+    import inspect
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    sig = inspect.signature(m.Qwen3VlTorchFrontendRtxBF16.__init__)
+    assert sig.parameters['weight_mode'].default == 'bf16'
+    assert sig.parameters['kv_mode'].default == 'bf16'
+
+
+# ── decode weight quantization ──
+
+@pytest.mark.parametrize('mode', ['bogus', 'fp8', 'int2', ''])
+def test_invalid_weight_mode_rejected(mode):
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    with pytest.raises(ValueError) as ei:
+        m.Qwen3VlTorchFrontendRtxBF16('/nonexistent', weight_mode=mode)
+    assert 'weight_mode' in str(ei.value)
+
+
+@pytest.mark.parametrize('mode', ['bogus', 'fp8', ''])
+def test_invalid_kv_mode_rejected(mode):
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    with pytest.raises(ValueError) as ei:
+        m.Qwen3VlTorchFrontendRtxBF16('/nonexistent', kv_mode=mode)
+    assert 'kv_mode' in str(ei.value)
+
+
+def test_weight_mode_list_matches_example_choices():
+    """The quickstart's --weight-mode choices must track the frontend."""
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    src = (pathlib.Path(__file__).parents[1]
+           / 'examples/orin/qwen3_vl_quickstart.py').read_text()
+    for mode in m._WEIGHT_MODES:
+        assert f"'{mode}'" in src, f'{mode} missing from the Orin quickstart'
+
+
+def _quant_wq(mode, w):
+    """Drive the frontend's quantizer without constructing the class."""
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_rtx_bf16')
+    stub = types.SimpleNamespace(_wq_mode=mode)
+    return m.Qwen3VlTorchFrontendRtxBF16._quant_wq(stub, w)
+
+
+@pytest.mark.parametrize('mode,levels', [('int8', 127.0), ('int4', 7.0)])
+def test_quant_wq_int_round_trip(mode, levels):
+    """Packed weights must dequantize back to within one quantization step."""
+    torch = pytest.importorskip('torch')
+    torch.manual_seed(0)
+    N, K = 8, 64
+    w = torch.randn(N, K, dtype=torch.bfloat16)
+
+    packed, scales = _quant_wq(mode, w)
+    assert scales.shape == (N, K // 16) and scales.dtype is torch.bfloat16
+
+    if mode == 'int8':
+        assert packed.shape == (N, K)
+        q = packed.view(torch.int8).float()
+    else:
+        assert packed.shape == (N, K // 2)      # two nibbles per byte
+        lo = (packed & 0xF).to(torch.int8)
+        hi = (packed >> 4).to(torch.int8)
+        # Sign-extend 4-bit two's complement.
+        lo = torch.where(lo > 7, lo - 16, lo)
+        hi = torch.where(hi > 7, hi - 16, hi)
+        q = torch.stack([lo, hi], dim=-1).reshape(N, K).float()
+
+    deq = (q.view(N, K // 16, 16)
+           * scales.float().unsqueeze(-1)).reshape(N, K)
+    ref = w.float()
+    # Per-block step is amax/levels; allow one step of rounding error.
+    step = ref.view(N, K // 16, 16).abs().amax(2, keepdim=True) / levels
+    tol = step.expand(N, K // 16, 16).reshape(N, K)
+    assert torch.all((deq - ref).abs() <= tol + 1e-6)
+
+
+def test_quant_wq_int4_stays_in_representable_range():
+    """int4 codes must occupy the 4-bit two's-complement range [-7, 7]."""
+    torch = pytest.importorskip('torch')
+    torch.manual_seed(0)
+    packed, _ = _quant_wq('int4', torch.randn(4, 32, dtype=torch.bfloat16) * 10)
+    for nib in ((packed & 0xF).to(torch.int8), (packed >> 4).to(torch.int8)):
+        signed = torch.where(nib > 7, nib - 16, nib)
+        assert int(signed.min()) >= -7 and int(signed.max()) <= 7

--- a/tests/test_qwen3_vl_thor.py
+++ b/tests/test_qwen3_vl_thor.py
@@ -1,0 +1,440 @@
+"""Smoke tests for the Qwen3-VL Thor (SM110) BF16 frontend and its backend.
+
+CI-friendly: no checkpoint, no GPU. Covers import wiring, the fail-fast kernel
+check, required-kernel-list hygiene, the wq-override validator, and the
+_PIPELINE_MAP routing for both Jetson targets.
+
+Run:
+    PYTHONPATH=. python -m pytest tests/test_qwen3_vl_thor.py -v
+"""
+from __future__ import annotations
+
+import importlib
+import unittest.mock as mock
+
+import pytest
+
+
+FRONTEND_MOD = 'flash_rt.frontends.torch.qwen3_vl_thor'
+BACKEND_MOD = 'flash_rt.hardware.thor.attn_backend_qwen3'
+
+
+# ── wiring ──
+
+def test_thor_frontend_imports():
+    m = importlib.import_module(FRONTEND_MOD)
+    assert hasattr(m, 'Qwen3VlTorchFrontendThor')
+    assert hasattr(m, '_require_thor_kernels')
+
+
+def test_thor_attn_backend_imports():
+    m = importlib.import_module(BACKEND_MOD)
+    assert hasattr(m, 'ThorAttnBackendQwen3')
+    assert hasattr(m, 'make_qwen3_thor_attention_spec')
+
+
+def test_thor_attention_spec_reports_sdpa():
+    m = importlib.import_module(BACKEND_MOD)
+    spec = m.make_qwen3_thor_attention_spec(
+        num_layers=28, num_q_heads=16, num_kv_heads=8, head_dim=128,
+        max_seq=4096)
+    site = spec['sites'][0]
+    assert site['name'] == 'full' and site['kernel'] == 'sdpa_bf16'
+    assert site['layer_count'] == 28 and site['max_kv_seq'] == 4096
+
+
+# ── required-kernel lists ──
+
+def test_kernel_lists_are_non_empty_unique_and_bf16_only():
+    m = importlib.import_module(FRONTEND_MOD)
+    for names in (m._THOR_CORE_FNS, m._THOR_VL_FNS):
+        assert len(names) > 0
+        assert len(set(names)) == len(names)
+    joined = set(m._THOR_CORE_FNS) | set(m._THOR_VL_FNS)
+    assert not any('fp8' in n or 'nvfp4' in n for n in joined)
+
+
+def test_neutral_kernels_are_expected_from_flash_rt_kernels():
+    """embedding_lookup_bf16 / bf16_matmul_bf16 are model-neutral and built for
+    every arch, so they must be required from fvk, not the Qwen3-VL module."""
+    m = importlib.import_module(FRONTEND_MOD)
+    for name in ('embedding_lookup_bf16', 'bf16_matmul_bf16'):
+        assert name in m._THOR_CORE_FNS
+        assert name not in m._THOR_VL_FNS
+
+
+def test_thor_requires_the_batched_qkv_prefill_kernel():
+    """Thor prefill drives qwen3_qk_norm_rope_kvwrite_batched_bf16, which only
+    exists when the module is built with ENABLE_QWEN3_VL_QKV_POSTPROC."""
+    m = importlib.import_module(FRONTEND_MOD)
+    assert 'qwen3_qk_norm_rope_kvwrite_batched_bf16' in m._THOR_VL_FNS
+
+
+# ── fail-fast on a missing kernel symbol ──
+
+def _fake_modules(m, *, drop=None):
+    fvk = type('Fvk', (), {})
+    vlk = type('Vlk', (), {})
+    for fn in m._THOR_CORE_FNS:
+        if fn != drop:
+            setattr(fvk, fn, lambda *a, **k: None)
+    for fn in m._THOR_VL_FNS:
+        if fn != drop:
+            setattr(vlk, fn, lambda *a, **k: None)
+    return {'flash_rt.flash_rt_kernels': fvk,
+            'flash_rt.flash_rt_qwen3_vl_kernels': vlk}
+
+
+def test_require_thor_kernels_passes_when_complete():
+    m = importlib.import_module(FRONTEND_MOD)
+    with mock.patch.dict('sys.modules', _fake_modules(m)):
+        fvk, vlk = m._require_thor_kernels()
+    assert fvk is not None and vlk is not None
+
+
+@pytest.mark.parametrize('which', ['core', 'vl'])
+def test_require_thor_kernels_raises_naming_the_missing_symbol(which):
+    m = importlib.import_module(FRONTEND_MOD)
+    target = (m._THOR_CORE_FNS if which == 'core' else m._THOR_VL_FNS)[0]
+    with mock.patch.dict('sys.modules', _fake_modules(m, drop=target)):
+        with pytest.raises(RuntimeError) as ei:
+            m._require_thor_kernels()
+    assert target in str(ei.value)
+
+
+# ── constructor surface ──
+
+def test_constructor_signature():
+    import inspect
+    m = importlib.import_module(FRONTEND_MOD)
+    sig = inspect.signature(m.Qwen3VlTorchFrontendThor.__init__)
+    params = set(sig.parameters) - {'self'}
+    for required in ('checkpoint_path', 'device', 'max_seq', 'weight_mode',
+                     'wq_overrides'):
+        assert required in params, f'missing parameter: {required}'
+    # Deferred features must not be part of the v1 surface.
+    for absent in ('awq', 'awq_alpha', 'vit_backend', 'vit_mode'):
+        assert absent not in params, f'unexpected parameter: {absent}'
+
+
+def test_weight_mode_defaults_to_bf16():
+    import inspect
+    m = importlib.import_module(FRONTEND_MOD)
+    sig = inspect.signature(m.Qwen3VlTorchFrontendThor.__init__)
+    assert sig.parameters['weight_mode'].default == 'bf16'
+
+
+@pytest.mark.parametrize('mode', ['int8', 'fp8', 'bogus', ''])
+def test_invalid_weight_mode_rejected(mode):
+    m = importlib.import_module(FRONTEND_MOD)
+    with pytest.raises(ValueError) as ei:
+        m.Qwen3VlTorchFrontendThor('/nonexistent', weight_mode=mode)
+    assert 'weight_mode' in str(ei.value)
+
+
+# ── wq override validator ──
+
+@pytest.mark.parametrize('ov', [
+    None,
+    {},
+    {'gate_up': 'w8'},
+    {'lm_head': 'bf16'},
+    {'L12.gate_up': 'w4', 'mlp_down': 'w8'},
+])
+def test_valid_wq_overrides_accepted(ov):
+    m = importlib.import_module(FRONTEND_MOD)
+    assert m._validate_wq_overrides(ov) == dict(ov or {})
+
+
+@pytest.mark.parametrize('ov', [
+    {'gate_up': 'int8'},          # not a Thor mode
+    {'gate_up': 'fp8'},
+    {'nonsense': 'w4'},           # unknown projection
+    {'Lx.gate_up': 'w4'},         # malformed layer prefix
+    {'L1.nonsense': 'w4'},
+])
+def test_invalid_wq_overrides_rejected(ov):
+    m = importlib.import_module(FRONTEND_MOD)
+    with pytest.raises(ValueError):
+        m._validate_wq_overrides(ov)
+
+
+def test_wq_overrides_returns_a_copy():
+    """The frontend must not alias the caller's dict."""
+    m = importlib.import_module(FRONTEND_MOD)
+    src = {'gate_up': 'w8'}
+    out = m._validate_wq_overrides(src)
+    out['mlp_down'] = 'w4'
+    assert src == {'gate_up': 'w8'}
+
+
+# ── routing ──
+
+@pytest.mark.parametrize('arch,expected_cls', [
+    ('thor', 'Qwen3VlTorchFrontendThor'),
+    ('rtx_sm87', 'Qwen3VlTorchFrontendRtxBF16'),
+])
+def test_qwen3_vl_jetson_routing_resolves(arch, expected_cls):
+    hw = importlib.import_module('flash_rt.hardware')
+    key = ('qwen3_vl', 'torch', arch)
+    assert key in hw._PIPELINE_MAP
+    module_path, cls_name = hw._PIPELINE_MAP[key]
+    assert cls_name == expected_cls
+    mod = importlib.import_module(module_path)
+    assert hasattr(mod, cls_name)
+
+
+def test_sm87_allowlist_still_rejects_unlisted_configs():
+    """Adding qwen3_vl must not open SM87 up to every config."""
+    hw = importlib.import_module('flash_rt.hardware')
+    assert ('pi05', 'torch', 'rtx_sm87') in hw._SM87_ALLOWED
+    assert ('qwen3_vl', 'torch', 'rtx_sm87') in hw._SM87_ALLOWED
+    with pytest.raises(RuntimeError) as ei:
+        hw.resolve_pipeline_class('pi0', 'torch', 'rtx_sm87')
+    assert 'qwen3_vl' in str(ei.value) and 'pi05' in str(ei.value)
+
+
+def test_load_model_redirect_mentions_the_jetson_frontends():
+    """config='qwen3_vl' is a chat VLM; the redirect should name every
+    frontend, including the two Jetson ones."""
+    api = importlib.import_module('flash_rt.api')
+    with pytest.raises(NotImplementedError) as ei:
+        api.load_model('/nonexistent', config='qwen3_vl')
+    msg = str(ei.value)
+    assert 'qwen3_vl_thor' in msg and 'qwen3_vl_rtx_bf16' in msg
+
+
+# ── attention backend behaviour (CPU: needs torch, no GPU) ──
+
+torch = pytest.importorskip('torch')
+
+DIMS = dict(num_layers=2, num_q_heads=4, num_kv_heads=2, head_dim=8)
+
+
+def _backend(max_q_seq=1, **kw):
+    m = importlib.import_module(BACKEND_MOD)
+    return m.ThorAttnBackendQwen3(
+        max_seq=16, max_q_seq=max_q_seq, device='cpu', **DIMS, **kw)
+
+
+def _gqa_reference(q, k, v, *, n_q, n_kv, causal):
+    """Explicit GQA attention over (heads, seq, dim) float32 tensors."""
+    ratio = n_q // n_kv
+    out = torch.empty_like(q)
+    for h in range(n_q):
+        scores = q[h] @ k[h // ratio].transpose(0, 1)
+        scores = scores / (q.shape[-1] ** 0.5)
+        if causal:
+            sq, sk = scores.shape
+            mask = torch.ones(sq, sk, dtype=torch.bool).tril(diagonal=sk - sq)
+            scores = scores.masked_fill(~mask, float('-inf'))
+        out[h] = scores.softmax(dim=-1) @ v[h // ratio]
+    return out
+
+
+def test_backend_buffer_surface_matches_the_frontend_contract():
+    b = _backend(max_q_seq=4)
+    assert b.K_cache.shape == (2, 16, 2, 8) == b.V_cache.shape
+    assert b.Q_buf.shape == (1, 4, 4, 8) == b.O_buf.shape
+    assert b.sites() == ('full',)
+    assert (b.head_dim('full'), b.num_q_heads('full'),
+            b.num_kv_heads('full')) == (8, 4, 2)
+    # Strides the frontend uses for its KV-write pointer math (bf16 = 2 bytes).
+    assert b.kv_row_stride_bytes == 2 * 8 * 2
+    assert b.kv_layer_stride_bytes == 16 * 2 * 8 * 2
+    ptrs = b.get_slot_ptrs('full', 1)
+    assert ptrs['K'] == b.K_cache.data_ptr() + b.kv_layer_stride_bytes
+    assert ptrs['V'] == b.V_cache.data_ptr() + b.kv_layer_stride_bytes
+
+
+def test_decode_output_matches_a_gqa_reference():
+    torch.manual_seed(0)
+    b = _backend()
+    kv_seq = 6
+    b.K_cache.normal_()
+    b.V_cache.normal_()
+    b.Q_buf.normal_()
+
+    out_ptr = b.run('full', layer_idx=1, q_seq=1, kv_seq=kv_seq)
+    assert out_ptr == b.O_buf.data_ptr()
+
+    q = b.Q_buf[0, :1].transpose(0, 1).float()                 # (Hq, 1, hd)
+    k = b.K_cache[1, :kv_seq].transpose(0, 1).float()          # (Hkv, kv, hd)
+    v = b.V_cache[1, :kv_seq].transpose(0, 1).float()
+    ref = _gqa_reference(q, k, v, n_q=4, n_kv=2, causal=False)
+    got = b.O_buf[0, :1].transpose(0, 1).float()
+    torch.testing.assert_close(got, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_causal_prefill_masks_future_positions():
+    torch.manual_seed(0)
+    b = _backend(max_q_seq=5)
+    S = 5
+    b.K_cache.normal_()
+    b.V_cache.normal_()
+    b.Q_buf.normal_()
+    b.run('full', layer_idx=0, q_seq=S, kv_seq=S, causal=True)
+    first = b.O_buf[0, 0].clone()
+
+    # Row 0 may only attend to position 0, so perturbing later KV must not
+    # change it. A non-causal kernel would fail this.
+    b.K_cache[0, 1:S].normal_()
+    b.V_cache[0, 1:S].normal_()
+    b.run('full', layer_idx=0, q_seq=S, kv_seq=S, causal=True)
+    torch.testing.assert_close(b.O_buf[0, 0], first, rtol=0, atol=0)
+
+    q = b.Q_buf[0, :S].transpose(0, 1).float()
+    k = b.K_cache[0, :S].transpose(0, 1).float()
+    v = b.V_cache[0, :S].transpose(0, 1).float()
+    ref = _gqa_reference(q, k, v, n_q=4, n_kv=2, causal=True)
+    got = b.O_buf[0, :S].transpose(0, 1).float()
+    torch.testing.assert_close(got, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_gqa_expand_path_agrees_with_native_gqa():
+    """The fallback for torch builds without enable_gqa must match."""
+    torch.manual_seed(0)
+    b = _backend()
+    b.K_cache.normal_()
+    b.V_cache.normal_()
+    b.Q_buf.normal_()
+    b.run('full', layer_idx=0, q_seq=1, kv_seq=6)
+    native = b.O_buf.clone()
+
+    b._sdpa_gqa = False          # force the repeat_interleave path
+    b.O_buf.zero_()
+    b.run('full', layer_idx=0, q_seq=1, kv_seq=6)
+    torch.testing.assert_close(b.O_buf, native, rtol=1e-3, atol=1e-3)
+
+
+def test_mid_sequence_causal_block_raises():
+    """SDPA's is_causal is top-left aligned, so a q-block ending mid-sequence
+    would attend to the wrong positions. It must raise, not guess."""
+    b = _backend(max_q_seq=4)
+    with pytest.raises(NotImplementedError) as ei:
+        b.run('full', layer_idx=0, q_seq=2, kv_seq=6, causal=True)
+    assert 'kv_seq' in str(ei.value)
+    # The equivalent non-causal call is fine (and q=1 is causal-invariant).
+    b.run('full', layer_idx=0, q_seq=1, kv_seq=6, causal=True)
+
+
+def test_out_of_range_and_unknown_site_rejected():
+    b = _backend()
+    with pytest.raises(KeyError):
+        b.run('window', layer_idx=0, q_seq=1, kv_seq=1)
+    with pytest.raises(ValueError):
+        b.run('full', layer_idx=0, q_seq=1, kv_seq=999)
+    with pytest.raises(ValueError):
+        b.run('full', layer_idx=0, q_seq=99, kv_seq=1)
+    with pytest.raises(KeyError):
+        b.head_dim('window')
+
+
+def test_uneven_gqa_ratio_rejected():
+    m = importlib.import_module(BACKEND_MOD)
+    with pytest.raises(ValueError) as ei:
+        m.ThorAttnBackendQwen3(max_seq=8, device='cpu', num_layers=1,
+                               num_q_heads=6, num_kv_heads=4, head_dim=8)
+    assert 'multiple' in str(ei.value)
+
+
+# ── ViT patch-attention SDPA backend probe (CPU, fake kernel modules) ──
+#
+# On the SDPA fallback (Thor: no flash_rt_fa2), the ViT probes the cuDNN
+# SDPA backend once at lazy kernel init — never on the first forward, which
+# may run inside a CUDA Graph capture — and must degrade to the default
+# dispatcher when the probe fails. FA2 arches must not run the probe at all.
+
+VISION_MOD = 'flash_rt.frontends.torch._qwen3_vl_vision_rtx'
+
+
+def _vision_stub(monkeypatch, *, with_fa2: bool):
+    """Bare Qwen3VlVisionRtx whose lazy _kernels() sees fake kernel modules."""
+    import sys
+    import types
+
+    import flash_rt
+
+    vmod = importlib.import_module(VISION_MOD)
+    monkeypatch.setattr(flash_rt, 'flash_rt_kernels',
+                        types.SimpleNamespace(), raising=False)
+    monkeypatch.setattr(flash_rt, 'flash_rt_qwen3_vl_kernels',
+                        types.SimpleNamespace(), raising=False)
+    if with_fa2:
+        monkeypatch.setattr(
+            flash_rt, 'flash_rt_fa2',
+            types.SimpleNamespace(fwd_bf16=lambda **kw: None), raising=False)
+    else:
+        monkeypatch.delattr(flash_rt, 'flash_rt_fa2', raising=False)
+        # A None sys.modules entry makes the import raise ImportError.
+        monkeypatch.setitem(sys.modules, 'flash_rt.flash_rt_fa2', None)
+    monkeypatch.setattr(
+        torch.cuda, 'get_device_properties',
+        lambda _dev: types.SimpleNamespace(multi_processor_count=1),
+        raising=False)
+    v = vmod.Qwen3VlVisionRtx.__new__(vmod.Qwen3VlVisionRtx)
+    v.device = 'cpu'
+    v._fvk = v._fa2 = v._vlk = None
+    v._vit_sdpa_ctx = None
+    v.num_heads = 16
+    v.head_dim = 64
+    return v
+
+
+def _record_sdpa_kernel(monkeypatch):
+    import contextlib
+
+    import torch.nn.attention as tna
+
+    picked = []
+
+    def fake_sdpa_kernel(backend):
+        picked.append(backend)
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(tna, 'sdpa_kernel', fake_sdpa_kernel)
+    return picked
+
+
+def test_vit_cudnn_probe_skipped_when_fa2_present(monkeypatch):
+    v = _vision_stub(monkeypatch, with_fa2=True)
+
+    def _boom(*a, **k):
+        raise AssertionError('probe must not run when FA2 owns ViT attention')
+
+    monkeypatch.setattr(
+        torch.nn.functional, 'scaled_dot_product_attention', _boom)
+    v._kernels()
+    assert v._vit_use_fa2 is True
+    assert v._vit_sdpa_ctx is None
+
+
+def test_vit_cudnn_probe_sets_ctx_on_the_sdpa_fallback(monkeypatch):
+    import torch.nn.attention as tna
+
+    v = _vision_stub(monkeypatch, with_fa2=False)
+    picked = _record_sdpa_kernel(monkeypatch)
+    monkeypatch.setattr(
+        torch.nn.functional, 'scaled_dot_product_attention',
+        lambda *a, **k: torch.empty(0))
+    v._kernels()
+    assert v._vit_use_fa2 is False
+    assert picked == [tna.SDPBackend.CUDNN_ATTENTION]
+    assert v._vit_sdpa_ctx is not None
+    with v._vit_sdpa_ctx():
+        pass
+    assert picked == [tna.SDPBackend.CUDNN_ATTENTION] * 2
+
+
+def test_vit_cudnn_probe_failure_degrades_to_default_dispatcher(monkeypatch):
+    import torch.nn.attention as tna
+
+    v = _vision_stub(monkeypatch, with_fa2=False)
+
+    def _no_backend(_b):
+        raise RuntimeError('cuDNN attention unavailable')
+
+    monkeypatch.setattr(tna, 'sdpa_kernel', _no_backend)
+    v._kernels()  # must not raise
+    assert v._vit_use_fa2 is False
+    assert v._vit_sdpa_ctx is None

--- a/tests/test_qwen3_vl_thor.py
+++ b/tests/test_qwen3_vl_thor.py
@@ -152,6 +152,7 @@ def test_valid_wq_overrides_accepted(ov):
     {'nonsense': 'w4'},           # unknown projection
     {'Lx.gate_up': 'w4'},         # malformed layer prefix
     {'L1.nonsense': 'w4'},
+    {'L3.lm_head': 'w8'},         # lm_head is not per-layer
 ])
 def test_invalid_wq_overrides_rejected(ov):
     m = importlib.import_module(FRONTEND_MOD)
@@ -166,6 +167,17 @@ def test_wq_overrides_returns_a_copy():
     out = m._validate_wq_overrides(src)
     out['mlp_down'] = 'w4'
     assert src == {'gate_up': 'w8'}
+
+
+def test_wq_active_covers_global_mode_and_overrides():
+    """A non-bf16 override must activate quantization even when the global
+    weight_mode is bf16 (otherwise the override is silently dropped)."""
+    m = importlib.import_module(FRONTEND_MOD)
+    assert m._wq_active('w8', {})
+    assert m._wq_active('w4', {})
+    assert not m._wq_active('bf16', {})
+    assert m._wq_active('bf16', {'gate_up': 'w8'})
+    assert not m._wq_active('bf16', {'gate_up': 'bf16'})
 
 
 # ── routing ──

--- a/tests/test_qwen3_vl_thor.py
+++ b/tests/test_qwen3_vl_thor.py
@@ -360,7 +360,8 @@ def test_uneven_gqa_ratio_rejected():
 VISION_MOD = 'flash_rt.frontends.torch._qwen3_vl_vision_rtx'
 
 
-def _vision_stub(monkeypatch, *, with_fa2: bool):
+def _vision_stub(monkeypatch, *, with_fa2: bool,
+                 attention_backend: str | None = None):
     """Bare Qwen3VlVisionRtx whose lazy _kernels() sees fake kernel modules."""
     import sys
     import types
@@ -388,9 +389,30 @@ def _vision_stub(monkeypatch, *, with_fa2: bool):
     v.device = 'cpu'
     v._fvk = v._fa2 = v._vlk = None
     v._vit_sdpa_ctx = None
+    v._attention_backend = attention_backend or ('fa2' if with_fa2 else 'sdpa')
     v.num_heads = 16
     v.head_dim = 64
     return v
+
+
+def test_vit_default_fa2_backend_fails_fast_when_module_missing(monkeypatch):
+    v = _vision_stub(
+        monkeypatch, with_fa2=False, attention_backend='fa2')
+    with pytest.raises(ImportError):
+        v._kernels()
+
+
+def test_thor_explicitly_selects_sdpa_and_requires_checkpoint():
+    import inspect
+    import pathlib
+
+    m = importlib.import_module('flash_rt.frontends.torch.qwen3_vl_thor')
+    source = inspect.getsource(m.Qwen3VlTorchFrontendThor._ensure_native_vision)
+    assert "attention_backend='sdpa'" in source
+
+    quickstart = (pathlib.Path(__file__).parents[1]
+                  / 'examples/thor/qwen3_vl_quickstart.py').read_text()
+    assert "add_argument('--checkpoint', required=True)" in quickstart
 
 
 def _record_sdpa_kernel(monkeypatch):


### PR DESCRIPTION
## Summary

- Adds a Qwen3-VL decode-quantization path for Jetson Orin (SM87) with W8A16/W4A16 GEMV kernels and per-projection `wq_overrides`.
- Adds a batch-1 Qwen3-VL BF16 frontend for Jetson Thor (SM110) with CUDA-Graph decode replay and per-`(cache_pos, rope_pos)` graph caching.
- Activates quantization when a non-BF16 override is selected, rejects per-layer `lm_head` overrides, and deduplicates eager decode through `_decode_body`.
- Validates `prompt_len + max_new_tokens - 1 <= max_seq` before generation and applies matching capacity checks to decode graph warmup APIs.
- Keeps existing SM89/SM120 vision behavior fail-fast on missing FA2; only Thor explicitly selects the SDPA attention backend.
- Removes invalid eight-block occupancy hints from the SM87/SM110 GEMV kernels.
- Makes quickstart checkpoints required and removes private paths from public examples and documentation.

## Runtime boundaries

- `FLASHRT_BUILD_QWEN3_VL=OFF` still excludes the model-specific module by default.
- SM87 and SM110 kernels remain in the separate `flash_rt_qwen3_vl_kernels` module.
- SM87 retains the Orin INT8/INT4 decode surface.
- SM110 retains the Thor BF16/W8/W4 surface without Orin INT8 KV bindings.
- Existing RTX vision frontends continue to require `flash_rt_fa2`; missing FA2 no longer silently changes their numerical and performance path.

## Test plan

- [x] Related Python tests: `149 passed, 2 skipped`
- [x] Python `compileall`
- [x] `git diff --check`
- [x] SM87 configure, compile, and link of `flash_rt_qwen3_vl_kernels`
- [x] SM110 configure, compile, and link of `flash_rt_qwen3_vl_kernels`
- [x] No invalid `launch_bounds` ptxas warnings in either build
- [x] Architecture-specific symbol surfaces remain isolated
- [x] On-device eager decode and CUDA-Graph replay validation from the original PR
