### PR TITLE
fix(csrc): clamp GEMV launch_bounds minBlocks to the 1536-thread cap

### DIFF
--- a/csrc/gemm/bf16_gemv_m1_sm120.cu
+++ b/csrc/gemm/bf16_gemv_m1_sm120.cu
@@ -8,7 +8,7 @@
 // warp; the partial sums are folded by a warp-shuffle reduction. A is read from
 // global (no smem staging): at BF16 the FP8 variant's smem stage would be 2x
 // the bytes (K=9728 -> 19.5 KB/block) and cap blocks/SM under
-// launch_bounds(.,8); A is tiny (<=19 KB) and stays hot in L2 across blocks, so
+// the launch_bounds; A is tiny (<=19 KB) and stays hot in L2 across blocks, so
 // reading it from global keeps smem=0 and occupancy maximal — the all-BF16
 // decode is HBM-bound on the weight read, which this saturates.
 
@@ -24,8 +24,17 @@ namespace gemv_m1 {
 
 namespace {
 
+// minBlocks=8 only fits blocks of <=192 threads: 8 x 256 exceeds the 1536
+// threads/SM cap on sm_87/89/110/120/121, so ptxas discards the whole hint.
+// Clamp it to what the arch can hold, keeping the honored W=4 hint intact.
+constexpr int kMaxThreadsPerSM = 1536;
+template <int W>
+constexpr int kMinBlocks = (kMaxThreadsPerSM / (W * 32)) < 8
+                               ? (kMaxThreadsPerSM / (W * 32))
+                               : 8;
+
 template <int WARPS_PER_BLOCK>
-__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, kMinBlocks<WARPS_PER_BLOCK>)
 void gemv_bf16_m1_kernel(
     const __nv_bfloat16* __restrict__ A,   // [K]
     const __nv_bfloat16* __restrict__ B,   // [N, K]

--- a/csrc/gemm/fp8_gemv_m1_sm120.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm120.cu
@@ -23,11 +23,20 @@ namespace gemv_m1 {
 
 namespace {
 
+// minBlocks=8 only fits blocks of <=192 threads: 8 x 256 exceeds the 1536
+// threads/SM cap on sm_87/89/110/120/121, so ptxas discards the whole hint.
+// Clamp it to what the arch can hold, keeping the honored W=4 hint intact.
+constexpr int kMaxThreadsPerSM = 1536;
+template <int W>
+constexpr int kMinBlocks = (kMaxThreadsPerSM / (W * 32)) < 8
+                               ? (kMaxThreadsPerSM / (W * 32))
+                               : 8;
+
 // One warp per output row n. A staged in smem as raw fp8 (K bytes). B row read
 // in uint4 (16 fp8) coalesced chunks, stride 32 across the warp. K assumed a
 // multiple of 16 (all Higgs/Qwen3 GEMM K: 2560/4096/9728).
 template <int WARPS_PER_BLOCK>
-__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, kMinBlocks<WARPS_PER_BLOCK>)
 void gemv_fp8_m1_kernel(
     const __nv_fp8_e4m3* __restrict__ A,   // [K]
     const __nv_fp8_e4m3* __restrict__ B,   // [N, K]
@@ -74,7 +83,7 @@ void gemv_fp8_m1_kernel(
 // dependency like the norm — so it folds into the epilogue for free, removing
 // the separate residual_add launch. Each output n is written by one warp lane.
 template <int WARPS_PER_BLOCK>
-__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, kMinBlocks<WARPS_PER_BLOCK>)
 void gemv_fp8_m1_resadd_kernel(
     const __nv_fp8_e4m3* __restrict__ A,
     const __nv_fp8_e4m3* __restrict__ B,
@@ -108,7 +117,7 @@ void gemv_fp8_m1_resadd_kernel(
 // per-call activation scale never needs a host round-trip. Identical dot product
 // to gemv_fp8_m1_kernel; only the epilogue scale source differs.
 template <int WARPS_PER_BLOCK>
-__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, kMinBlocks<WARPS_PER_BLOCK>)
 void gemv_fp8_m1_dscale_kernel(
     const __nv_fp8_e4m3* __restrict__ A,
     const __nv_fp8_e4m3* __restrict__ B,

--- a/csrc/gemm/fp8_gemv_m1_sm89.cu
+++ b/csrc/gemm/fp8_gemv_m1_sm89.cu
@@ -22,8 +22,17 @@ namespace gemv_m1_sm89 {
 
 namespace {
 
+// minBlocks=8 only fits blocks of <=192 threads: 8 x 256 exceeds the 1536
+// threads/SM cap on sm_87/89/110/120/121, so ptxas discards the whole hint.
+// Clamp it to what the arch can hold, keeping the honored W=4 hint intact.
+constexpr int kMaxThreadsPerSM = 1536;
+template <int W>
+constexpr int kMinBlocks = (kMaxThreadsPerSM / (W * 32)) < 8
+                               ? (kMaxThreadsPerSM / (W * 32))
+                               : 8;
+
 template <int WARPS_PER_BLOCK>
-__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, kMinBlocks<WARPS_PER_BLOCK>)
 void gemv_fp8_block128_m1_kernel(
     const __nv_fp8_e4m3* __restrict__ A,   // [K]
     const __nv_fp8_e4m3* __restrict__ B,   // [N, K]
@@ -91,7 +100,7 @@ int launch_block128_(const void* A, const void* B, void* D,
 // BF16-input variant: skips activation FP8 quantization.
 // A is BF16, B is FP8 with block-128 weight scale. No act_scale needed.
 template <int WARPS_PER_BLOCK>
-__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, 8)
+__global__ __launch_bounds__(WARPS_PER_BLOCK * 32, kMinBlocks<WARPS_PER_BLOCK>)
 void gemv_fp8_block128_m1_bf16in_kernel(
     const __nv_bfloat16* __restrict__ A,   // [K] BF16
     const __nv_fp8_e4m3* __restrict__ B,   // [N, K] FP8


### PR DESCRIPTION
## Summary

- Clamp the `minBlocks` hint on the six `csrc/gemm` M=1 GEMV kernels to
  `min(8, 1536/(W*32))`, so the hint is achievable for every instantiated
  `WARPS_PER_BLOCK` instead of being discarded wholesale by ptxas.
- Keep the honored `W=4` hint at 8, unchanged: it is live on
  `cosmos3_reasoner/pipeline_thor.py:271`, `_higgs_audio_v3_bf16.py:68`, and
  `_higgs_audio_v3_fp8.py:29-30`.
- Reject both alternatives: deleting the second argument changes honored `W=4`
  kernels (fp8 60r -> 38r), and `minBlocks=1` raises registers to 74-78r.
- Duplicate the six-line constant per translation unit rather than adding a
  shared header, per repository style.

## Root cause

All three files are `template <int WARPS_PER_BLOCK>` instantiated at W=4/8/16
but carried a fixed `minBlocks=8`. The cap on sm_87/89/110/120/121 is 1536
threads/SM, so `minBlocks=8` only fits blocks of <=192 threads: W=4
(128x8=1024) is honored, while W=8 (2048) and W=16 (4096) are out of range and
ptxas drops the entire hint with `.minnctapersm will be ignored`.

PR #161 fixed the same defect in the three `csrc/kernels` Qwen3-VL Jetson
GEMVs, so its claim of no invalid `launch_bounds` warnings holds only for the
files it touched. A `GPU_ARCH=110` Thor build still reported six, because
`CMakeLists.txt:653-657` compiles the two sm120 files into
`decode_gemv_m1_obj` for `GPU_ARCH` in {110,120,121,89}.

## Runtime boundaries

- No entry point, signature, launch geometry, or numerical path changes; only
  the compiler hint.
- `fp8_gemv_m1_sm89.cu` stays gated to `GPU_ARCH=89` (`CMakeLists.txt:1185`).
- Honored hints keep their register counts bit-for-bit, so live decode paths
  are unaffected.
- The only register movement is on `gemv_bf16_m1_w8` / `_w16`, which have no
  callers: they appear solely as `.cuh` declarations and the pybind bindings at
  `csrc/bindings.cpp:6552-6553`. All six `getattr` sites over GEMV names
  resolve to fixed literals -- w4 / fp8 w4-w8, or the separate `qwen3_vl_*`
  family -- and none constructs a bf16 w8/w16 name. Removing those unused
  entry points would also drop the new spill, but that deletes exported pybind
  symbols and is left for the owner.

## Validation

Hardware: Jetson Thor, CUDA 13.0.88. Each file compiled for its target
architectures -- 7 (file, arch) combinations.

- [x] Invalid-`launch_bounds` warnings 10 -> 0: `bf16_gemv_m1_sm120.cu` 2 -> 0
      on each of sm_110a/sm_120a/sm_89, `fp8_gemv_m1_sm120.cu` 4 -> 0 on each
      of the same three, `fp8_gemv_m1_sm89.cu` 4 -> 0 on sm_89.
- [x] Honored hints, registers unchanged: `gemv_bf16_m1_kernel<4>` 47r
      (sm_110a) / 47r (sm_120a) / 48r (sm_89); `gemv_fp8_m1_kernel<4>` and
      `gemv_fp8_m1_resadd_kernel<4>` 60r on all three;
      `gemv_fp8_block128_m1_kernel<4>` 60r (sm_89).
- [x] Previously-discarded instances: both fp8 files unchanged; bf16 W=8/W=16
      sm_110a 42r -> 40r, sm_120a 44r -> 40r with 12 bytes of new spill,
      sm_89 38r -> 38r.
- [x] Clamp arithmetic checked host-side by `static_assert` against the exact
      bytes in the tree: W=4 -> 8, W=8 -> 6, W=16 -> 3, every instantiation
      within the 1536-thread cap.
- [x] `git diff --check` clean; diff limited to the three `.cu` files; no line
      widened past its existing width.
- [x] No Python test covers these entry points (`ht_gemv_*` is absent from
      `tests/`); verification is compile-level only.