### PR TITLE
GROOT N1.7 update: Thor NVFP4 + FA4 performance tier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1337,10 +1337,8 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/softmax.cu
   csrc/kernels/attention_cublas.cu
   csrc/kernels/attention_mha.cu
-  csrc/kernels/attention_mha_masked.cu
   csrc/kernels/attention_mha_causal.cu
   csrc/kernels/rope_qwen3.cu
-  csrc/kernels/vec_fp16_backbone.cu
   csrc/kernels/decoder_fused.cu
   csrc/kernels/dit_bf16.cu
   csrc/kernels/attention_dit_bf16.cu
@@ -1369,6 +1367,22 @@ pybind11_add_module(flash_rt_kernels
 set_target_properties(flash_rt_kernels PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/flash_rt)
+
+# ── Thor-class VLA helper kernels (SM100/SM110 only) ──
+# The masked-softmax MHA variants and the 16-byte-load norm/rope/quantize
+# rewrites exist for the GROOT N1.7 Thor path; their element math targets
+# SM100-class memory behaviour and no SM8x frontend calls them. Their
+# bindings in csrc/bindings.cpp are guarded by FLASHRT_HAVE_THOR_VLA_KERNELS
+# so source and binding drop together on other architectures.
+if(ENABLE_SM100_CUTLASS)
+  target_sources(flash_rt_kernels PRIVATE
+    csrc/kernels/attention_mha_masked.cu
+    csrc/kernels/vec_fp16_backbone.cu)
+  target_compile_definitions(flash_rt_kernels PRIVATE FLASHRT_HAVE_THOR_VLA_KERNELS=1)
+  message(STATUS "Thor VLA helper kernels: ENABLED (sm_${GPU_ARCH})")
+else()
+  message(STATUS "Thor VLA helper kernels: DISABLED (SM100-class only)")
+endif()
 
 if(FLASHRT_ENABLE_COSMOS3_EDGE)
   target_sources(flash_rt_kernels PRIVATE csrc/kernels/cosmos3_edge_misc.cu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1337,6 +1337,7 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/softmax.cu
   csrc/kernels/attention_cublas.cu
   csrc/kernels/attention_mha.cu
+  csrc/kernels/attention_mha_masked.cu
   csrc/kernels/attention_mha_causal.cu
   csrc/kernels/rope_qwen3.cu
   csrc/kernels/vec_fp16_backbone.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1714,6 +1714,9 @@ if(ENABLE_SM100_CUTLASS)
     csrc/fused_fp4/silu_mul_mul_fp4_sfa_v2.cu
     csrc/fused_fp4/silu_mul_two_fp4_to_fp4.cu
     csrc/gemm/fp4/cutlass_fp4_gemm_fp4out.cu
+    csrc/gemm/fp4/cutlass_fp4_gemm_bias_bf16_sm100.cu
+    csrc/quantize/quantize_fp4_sfa_bf16.cu
+    csrc/fused_fp4/dit_norm_fp4_sfa.cu
   )
   if(FLASHRT_ENABLE_COSMOS3_EDGE)
     target_sources(fp4_kernels_obj PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1339,6 +1339,7 @@ pybind11_add_module(flash_rt_kernels
   csrc/kernels/attention_mha.cu
   csrc/kernels/attention_mha_causal.cu
   csrc/kernels/rope_qwen3.cu
+  csrc/kernels/vec_fp16_backbone.cu
   csrc/kernels/decoder_fused.cu
   csrc/kernels/dit_bf16.cu
   csrc/kernels/attention_dit_bf16.cu

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Baseline comparisons and source methodology live in [Benchmark Comparison](docs/
 
 | Hardware | Mode | Latency | Throughput | Source |
 |---|---|---:|---:|---|
-| Jetson AGX Thor | NVFP4 + FA4, 2-view | **31 ms** | **32 Hz** | [N1.7 Thor NVFP4](USAGE.md#groot-n17-thor) |
+| Jetson AGX Thor | NVFP4 + FA4, 2-view | **30 ms** | **33 Hz** | [N1.7 Thor NVFP4](USAGE.md#groot-n17-thor) |
 | Jetson AGX Thor | FP8, 2-view | **50 ms** | **20 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
 | RTX 5090 | DiT path | **22 ms** | **45 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
 
@@ -1062,7 +1062,7 @@ examples/
 - **Pi0.5** (`config="pi05"`) — [quickstart](#quick-start), [API reference](USAGE.md#api-reference), [NVFP4 notes](USAGE.md#nvfp4-pi05-only), [Thor example](examples/thor/README.md), [RTX 5090 example](examples/blackwell/README.md)
 - **Pi0** (`config="pi0"`) — [API snippets](#api-snippets), [usage guide](USAGE.md#api-reference)
 - **GROOT N1.6** (`config="groot"`) — [API snippets](#api-snippets), [GROOT embodiment slots](#groot-n16-embodiment-slots)
-- **GROOT N1.7** (`config="groot_n17"`) — 31 ms on Jetson AGX Thor (NVFP4 + FA4 tier; 50 ms FP8), 22 ms on RTX 5090; [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
+- **GROOT N1.7** (`config="groot_n17"`) — 30 ms on Jetson AGX Thor (NVFP4 + FA4 tier; 50 ms FP8), 22 ms on RTX 5090; [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
 - **Pi0-FAST** (`config="pi0fast"`) — [usage guide](USAGE.md#pi0-fast), [performance modes](#pi0-fast-performance-modes)
 - **LingBot-VLA** — [LingBot usage](docs/lingbot_usage.md), [Thor latency](docs/lingbot_usage.md#5-accuracy--latency-thor-sm_110-cuda-graph-replay)
 - **Motus Stage3 RTX beta** (`config="motus"`) — [Motus usage](docs/motus_usage_beta.md), [legacy async chunk runner](docs/rtc_lite_design.md)

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ Baseline comparisons and source methodology live in [Benchmark Comparison](docs/
 
 | Hardware | Mode | Latency | Throughput | Source |
 |---|---|---:|---:|---|
-| Jetson AGX Thor | NVFP4 + FA4, 2-view | **30 ms** | **33 Hz** | [N1.7 Thor NVFP4](USAGE.md#groot-n17-thor) |
-| Jetson AGX Thor | FP8, 2-view | **50 ms** | **20 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
+| Jetson AGX Thor | NVFP4 + FA4, LIBERO 1-view | **23.7 ms** | **42 Hz** | [N1.7 Thor NVFP4](USAGE.md#groot-n17-thor) |
+| Jetson AGX Thor | FP8, LIBERO 1-view | **36.8 ms** | **27 Hz** | [Benchmark comparison](docs/benchmark_comparison.md#groot-n17-on-jetson-agx-thor) |
+| Jetson AGX Thor | NVFP4 + FA4, 2-view | **29.9 ms** | **33 Hz** | [N1.7 Thor NVFP4](USAGE.md#groot-n17-thor) |
+| Jetson AGX Thor | FP8, 2-view | **50.2 ms** | **20 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
 | RTX 5090 | DiT path | **22 ms** | **45 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
 
 #### Pi0-FAST
@@ -1062,7 +1064,7 @@ examples/
 - **Pi0.5** (`config="pi05"`) — [quickstart](#quick-start), [API reference](USAGE.md#api-reference), [NVFP4 notes](USAGE.md#nvfp4-pi05-only), [Thor example](examples/thor/README.md), [RTX 5090 example](examples/blackwell/README.md)
 - **Pi0** (`config="pi0"`) — [API snippets](#api-snippets), [usage guide](USAGE.md#api-reference)
 - **GROOT N1.6** (`config="groot"`) — [API snippets](#api-snippets), [GROOT embodiment slots](#groot-n16-embodiment-slots)
-- **GROOT N1.7** (`config="groot_n17"`) — 30 ms on Jetson AGX Thor (NVFP4 + FA4 tier; 50 ms FP8), 22 ms on RTX 5090; [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
+- **GROOT N1.7** (`config="groot_n17"`) — 23.7 ms on Jetson AGX Thor (NVFP4 + FA4 tier, LIBERO 1-view; 36.8 ms FP8), 22 ms on RTX 5090; [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
 - **Pi0-FAST** (`config="pi0fast"`) — [usage guide](USAGE.md#pi0-fast), [performance modes](#pi0-fast-performance-modes)
 - **LingBot-VLA** — [LingBot usage](docs/lingbot_usage.md), [Thor latency](docs/lingbot_usage.md#5-accuracy--latency-thor-sm_110-cuda-graph-replay)
 - **Motus Stage3 RTX beta** (`config="motus"`) — [Motus usage](docs/motus_usage_beta.md), [legacy async chunk runner](docs/rtc_lite_design.md)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Baseline comparisons and source methodology live in [Benchmark Comparison](docs/
 | Jetson AGX Thor | FP8, LIBERO 1-view | **36.8 ms** | **27 Hz** | [Benchmark comparison](docs/benchmark_comparison.md#groot-n17-on-jetson-agx-thor) |
 | Jetson AGX Thor | NVFP4 + FA4, 2-view | **29.9 ms** | **33 Hz** | [N1.7 Thor NVFP4](USAGE.md#groot-n17-thor) |
 | Jetson AGX Thor | FP8, 2-view | **50.2 ms** | **20 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
-| RTX 5090 | DiT path | **22 ms** | **45 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
+| RTX 5090 | FP8, 2-view base, full graph | **16.6 ms** | **60 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
 
 #### Pi0-FAST
 
@@ -1064,7 +1064,7 @@ examples/
 - **Pi0.5** (`config="pi05"`) — [quickstart](#quick-start), [API reference](USAGE.md#api-reference), [NVFP4 notes](USAGE.md#nvfp4-pi05-only), [Thor example](examples/thor/README.md), [RTX 5090 example](examples/blackwell/README.md)
 - **Pi0** (`config="pi0"`) — [API snippets](#api-snippets), [usage guide](USAGE.md#api-reference)
 - **GROOT N1.6** (`config="groot"`) — [API snippets](#api-snippets), [GROOT embodiment slots](#groot-n16-embodiment-slots)
-- **GROOT N1.7** (`config="groot_n17"`) — 23.7 ms on Jetson AGX Thor (NVFP4 + FA4 tier, LIBERO 1-view; 36.8 ms FP8), 22 ms on RTX 5090; [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
+- **GROOT N1.7** (`config="groot_n17"`) — 23.7 ms on Jetson AGX Thor (NVFP4 + FA4 tier, LIBERO 1-view; 36.8 ms FP8), 16.6 ms on RTX 5090 (2-view base, full graph); [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
 - **Pi0-FAST** (`config="pi0fast"`) — [usage guide](USAGE.md#pi0-fast), [performance modes](#pi0-fast-performance-modes)
 - **LingBot-VLA** — [LingBot usage](docs/lingbot_usage.md), [Thor latency](docs/lingbot_usage.md#5-accuracy--latency-thor-sm_110-cuda-graph-replay)
 - **Motus Stage3 RTX beta** (`config="motus"`) — [Motus usage](docs/motus_usage_beta.md), [legacy async chunk runner](docs/rtc_lite_design.md)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Baseline comparisons and source methodology live in [Benchmark Comparison](docs/
 
 | Hardware | Mode | Latency | Throughput | Source |
 |---|---|---:|---:|---|
-| Jetson AGX Thor | DiT path | **49 ms** | **20 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
+| Jetson AGX Thor | NVFP4 + FA4, 2-view | **31 ms** | **32 Hz** | [N1.7 Thor NVFP4](USAGE.md#groot-n17-thor) |
+| Jetson AGX Thor | FP8, 2-view | **50 ms** | **20 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
 | RTX 5090 | DiT path | **22 ms** | **45 Hz** | [GROOT N1.7 API](#groot-n17-rtx) |
 
 #### Pi0-FAST
@@ -609,7 +610,8 @@ data regardless of cache.
 Optional NVFP4 (Blackwell block-scaled FP4) quantization on the Pi0.5 encoder
 FFN stack. Implemented for **Pi0.5 torch and JAX on Thor** — passing
 `use_fp4=True` with any other config (pi0 / groot / pi0fast) emits a warning
-and uses the FP8 route.
+and uses the FP8 route. (`config="groot_n17"` on Thor has its own NVFP4
+tier behind the same flag — see [GROOT N1.7 Thor](USAGE.md#groot-n17-thor).)
 
 ```python
 model = flash_rt.load_model(
@@ -1060,7 +1062,7 @@ examples/
 - **Pi0.5** (`config="pi05"`) — [quickstart](#quick-start), [API reference](USAGE.md#api-reference), [NVFP4 notes](USAGE.md#nvfp4-pi05-only), [Thor example](examples/thor/README.md), [RTX 5090 example](examples/blackwell/README.md)
 - **Pi0** (`config="pi0"`) — [API snippets](#api-snippets), [usage guide](USAGE.md#api-reference)
 - **GROOT N1.6** (`config="groot"`) — [API snippets](#api-snippets), [GROOT embodiment slots](#groot-n16-embodiment-slots)
-- **GROOT N1.7** (`config="groot_n17"`) — 49 ms on Jetson AGX Thor, 22 ms on RTX 5090; [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
+- **GROOT N1.7** (`config="groot_n17"`) — 31 ms on Jetson AGX Thor (NVFP4 + FA4 tier; 50 ms FP8), 22 ms on RTX 5090; [usage guide](USAGE.md#groot-n17-rtx), [API snippet](#groot-n17-rtx)
 - **Pi0-FAST** (`config="pi0fast"`) — [usage guide](USAGE.md#pi0-fast), [performance modes](#pi0-fast-performance-modes)
 - **LingBot-VLA** — [LingBot usage](docs/lingbot_usage.md), [Thor latency](docs/lingbot_usage.md#5-accuracy--latency-thor-sm_110-cuda-graph-replay)
 - **Motus Stage3 RTX beta** (`config="motus"`) — [Motus usage](docs/motus_usage_beta.md), [legacy async chunk runner](docs/rtc_lite_design.md)

--- a/USAGE.md
+++ b/USAGE.md
@@ -515,6 +515,48 @@ fe = flash_rt.load_model(
 # equivalently: GrootN17TorchFrontendThorFP16(checkpoint, num_views=2, embodiment_tag=...)
 ```
 
+**NVFP4 tier (opt-in, fastest verified Thor config).** `use_fp4=True`
+keeps the FP8 backbone and moves the action-head side to block-scaled
+NVFP4 with fused epilogues, plus a vectorized small-kernel tier and
+masked-softmax attention across the whole pipeline:
+
+* every DiT GEMM (fused self-attn QKV, cross-attn Q, attention output,
+  both FFN projections) runs as an NVFP4 GEMM with per-16-element
+  dynamic activation scales — no calibration pass — with bias,
+  bias+residual and bias+tanh-GELU+FP4-output fused into the epilogues;
+* the per-frame cross-KV projections are NVFP4 as well;
+* the AdaLN / pre-FFN norms emit FP4 directly, the self-attention reads
+  the fused QKV GEMM output in place, and the backbone's small
+  per-layer kernels (norms, RoPE, FP8 quantizes, GQA expand) run
+  16-byte-load vectorized variants;
+* the masked-softmax attention variants drop the per-layer -inf logits
+  pre-fill, which also makes graph replays exactly deterministic.
+
+```python
+fe = flash_rt.load_model(
+    "/path/to/GR00T-N1.7-3B",
+    framework="torch", config="groot_n17", hardware="thor",
+    use_fp4=True,
+    num_views=2, embodiment_tag="oxe_droid_relative_eef_relative_joint",
+)
+# equivalently: GrootN17TorchFrontendThorFP4(checkpoint, num_views=2, embodiment_tag=...)
+```
+
+Reference (Jetson AGX Thor, wall-clock per-frame image→action e2e,
+same-session A/B/A against the FP8 default): **≈ 36 ms** (vision
+backbone graph ≈ 19.5 ms + action graph ≈ 16.3 ms) vs ≈ 50 ms FP8 —
+**1.37×** — with action cosine ≈ 0.9999 vs the FP8 tier on the
+reference fixture and graph-replay determinism exactly 1.0. (Absolute
+Thor latencies drift ~1 ms at day scale; the same-session speedup is
+the stable metric.)
+
+Precision ladder: on an 8-sample reference set the all-FP4 default
+holds worst-sample action cosine ≈ 0.998 vs the FP8 tier (the other
+samples sit at ≈ 0.9999). The first DiT layers are the sensitive ones;
+`GrootN17TorchFrontendThorFP4(..., dit_fp8_layers=(0, 1, 2, 3))` keeps
+them on the calibrated FP8 path and lifts the worst sample to ≈ 0.9998
+for roughly +2 ms per frame.
+
 ### GROOT N1.7 RTX
 
 GROOT N1.7 is registered for the RTX SM120 / SM89 torch path:

--- a/USAGE.md
+++ b/USAGE.md
@@ -660,13 +660,18 @@ The gripper DOF is a near-constant scalar whose cosine is intrinsically noisy
 (the bf16 reference itself scores ≈ 0.94); the combined action cosine clears
 the ≥ 0.999 bar on both paths.
 
-RTX 5090 latency (warm, P50):
+RTX 5090 latency (warm, P50), with the backbone run eagerly — that is,
+`infer()` without `aux=`:
 
 | Stage | FP8 (default) | full-FP16 (opt-in) |
 |---|---:|---:|
 | Backbone (ViT+LLM+VL self-attn, per observation) | 12.8 ms | 15.3 ms |
 | Infer (DiT 4-step loop, CUDA graph) | 10.7 ms | 10.9 ms |
 | E2E (backbone + infer) | 24.0 ms | 26.6 ms |
+
+Passing `aux=` to `infer()` on the RTX FP8 path captures and replays the
+backbone graph as well, covering the whole backbone-to-action path and
+bringing E2E to **16.61 ms** on RTX 5090 (2-view base checkpoint).
 
 FP8 saves ≈ 2.7 ms E2E (1.11×), concentrated in the backbone GEMMs (1.19×);
 the DiT is never quantized, so infer is effectively the same on both paths.

--- a/USAGE.md
+++ b/USAGE.md
@@ -546,14 +546,24 @@ fe = flash_rt.load_model(
 # equivalently: GrootN17TorchFrontendThorFP4(checkpoint, num_views=2, embodiment_tag=...)
 ```
 
-Reference (Jetson AGX Thor, wall-clock per-frame image→action e2e,
-same-session A/B/A against the FP8 default): **≈ 31 ms** (vision
-backbone graph ≈ 14.8 ms + action graph ≈ 16.0 ms) vs ≈ 50 ms FP8 —
-**1.64×** — with action cosine ≈ 0.9999 vs the FP8 tier on the
-reference fixture and graph-replay determinism exactly 1.0. Without
-the FA4 runtime deps the tier still runs (fmha/cublas fallback) at
-≈ 36 ms. (Absolute Thor latencies drift ~1 ms at day scale; the
-same-session speedup is the stable metric.)
+Reference (Jetson AGX Thor, JetPack 7.2, MAXN; wall-clock per-frame
+image→action e2e over a real 2-view fixture, `T=40`, 4 denoising steps,
+batch 1; medians over 20 iterations after warmup, run as one
+same-session A/B/A against the FP8 default): **29.9 ms** (vision
+backbone graph 14.2 ms + action graph 15.6 ms) vs **51.6 / 50.2 ms**
+FP8 — **1.70×**, 33 Hz — with action cosine 0.99994 vs the FP8 tier on
+that fixture and graph-replay determinism exactly 1.0. Without the FA4
+runtime deps the tier still runs (fmha/cublas fallback) at ≈ 35 ms.
+(Absolute Thor latencies drift ~1 ms at day scale; the same-session
+speedup is the stable metric.)
+
+Reproduce with:
+
+```bash
+python benchmarks/groot_n17_thor_latency.py \
+    --ckpt <n17-checkpoint-dir> --aux <aux-fixture.pt> \
+    --tier fp4 --views 2 --warmup 5 --iters 20
+```
 
 Precision ladder: on an 8-sample reference set the all-FP4 default
 holds worst-sample action cosine ≈ 0.998 vs the FP8 tier (the other

--- a/USAGE.md
+++ b/USAGE.md
@@ -547,28 +547,35 @@ fe = flash_rt.load_model(
 ```
 
 Reference (Jetson AGX Thor, JetPack 7.2, MAXN; wall-clock per-frame
-image→action e2e over a real 2-view fixture, `T=40`, 4 denoising steps,
-batch 1; medians over 20 iterations after warmup, run as one
-same-session A/B/A against the FP8 default): **29.9 ms** (vision
-backbone graph 14.2 ms + action graph 15.6 ms) vs **51.6 / 50.2 ms**
-FP8 — **1.70×**, 33 Hz — with action cosine 0.99994 vs the FP8 tier on
-that fixture and graph-replay determinism exactly 1.0. Without the FA4
-runtime deps the tier still runs (fmha/cublas fallback) at ≈ 35 ms.
-(Absolute Thor latencies drift ~1 ms at day scale; the same-session
-speedup is the stable metric.)
+image→action e2e, 4 denoising steps, batch 1, medians over 20
+iterations after 5 warmup iterations, run as one same-session A/B/A
+against the FP8 default):
+
+| Checkpoint / cameras | FP8 | NVFP4 + FA4 | Speedup |
+|---|---:|---:|---:|
+| LIBERO fine-tune (`libero_10`), 1 camera | 36.8 ms (27 Hz) | **23.7 ms (42 Hz)** | 1.56× |
+| Base `GR00T-N1.7-3B`, 2 cameras, `T=40` | 50.2 ms (20 Hz) | **29.9 ms (33 Hz)** | 1.70× |
+
+Action cosine against the FP8 tier is 1.000000 on the LIBERO fixture
+and 0.99994 on the 2-view base-checkpoint fixture; graph replays are
+bit-identical on both tiers. Without the FA4 runtime deps the tier
+still runs (fmha/cuBLAS fallback), roughly 5 ms slower on the 2-view
+shape. (Absolute Thor latencies drift ~1 ms at day scale; the
+same-session speedup is the stable metric.)
 
 Reproduce with:
 
 ```bash
 python benchmarks/groot_n17_thor_latency.py \
     --ckpt <n17-checkpoint-dir> --aux <aux-fixture.pt> \
-    --tier fp4 --views 2 --warmup 5 --iters 20
+    --tier fp4 --views 1 --embodiment libero_sim --warmup 5 --iters 20
 ```
 
-Across an 8-sample reference set the tier holds action cosine ≥ 0.9993
-against the FP8 tier on 7 of 8 samples, with a worst sample of 0.9976.
-For accuracy-critical deployments, validate on the target task rather
-than on cosine alone, or run the FP8 tier.
+Across an 8-sample set captured from the base checkpoint the tier holds
+action cosine ≥ 0.9993 against the FP8 tier on 7 of 8 samples, with a
+worst sample of 0.9976; on the LIBERO fine-tune it matches the FP8 tier
+to 1.000000. For accuracy-critical deployments, validate on the target
+task rather than on cosine alone, or run the FP8 tier.
 
 ### GROOT N1.7 RTX
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -565,12 +565,10 @@ python benchmarks/groot_n17_thor_latency.py \
     --tier fp4 --views 2 --warmup 5 --iters 20
 ```
 
-Precision ladder: on an 8-sample reference set the all-FP4 default
-holds worst-sample action cosine ≈ 0.998 vs the FP8 tier (the other
-samples sit at ≈ 0.9999). The first DiT layers are the sensitive ones;
-`GrootN17TorchFrontendThorFP4(..., dit_fp8_layers=(0, 1, 2, 3))` keeps
-them on the calibrated FP8 path and lifts the worst sample to ≈ 0.9998
-for roughly +2 ms per frame.
+Across an 8-sample reference set the tier holds action cosine ≥ 0.9993
+against the FP8 tier on 7 of 8 samples, with a worst sample of 0.9976.
+For accuracy-critical deployments, validate on the target task rather
+than on cosine alone, or run the FP8 tier.
 
 ### GROOT N1.7 RTX
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -530,7 +530,11 @@ masked-softmax attention across the whole pipeline:
   per-layer kernels (norms, RoPE, FP8 quantizes, GQA expand) run
   16-byte-load vectorized variants;
 * the masked-softmax attention variants drop the per-layer -inf logits
-  pre-fill, which also makes graph replays exactly deterministic.
+  pre-fill, which also makes graph replays exactly deterministic;
+* the three backbone attention sites (ViT, LLM causal-GQA,
+  VL-self-attn) run the vendored FlashAttention-4 (CuTe-DSL) forward
+  when its runtime deps are installed (the `thor-fa4` pip extra),
+  falling back to the fmha/cublas chain otherwise.
 
 ```python
 fe = flash_rt.load_model(
@@ -543,12 +547,13 @@ fe = flash_rt.load_model(
 ```
 
 Reference (Jetson AGX Thor, wall-clock per-frame image→action e2e,
-same-session A/B/A against the FP8 default): **≈ 36 ms** (vision
-backbone graph ≈ 19.5 ms + action graph ≈ 16.3 ms) vs ≈ 50 ms FP8 —
-**1.37×** — with action cosine ≈ 0.9999 vs the FP8 tier on the
-reference fixture and graph-replay determinism exactly 1.0. (Absolute
-Thor latencies drift ~1 ms at day scale; the same-session speedup is
-the stable metric.)
+same-session A/B/A against the FP8 default): **≈ 31 ms** (vision
+backbone graph ≈ 14.8 ms + action graph ≈ 16.0 ms) vs ≈ 50 ms FP8 —
+**1.64×** — with action cosine ≈ 0.9999 vs the FP8 tier on the
+reference fixture and graph-replay determinism exactly 1.0. Without
+the FA4 runtime deps the tier still runs (fmha/cublas fallback) at
+≈ 36 ms. (Absolute Thor latencies drift ~1 ms at day scale; the
+same-session speedup is the stable metric.)
 
 Precision ladder: on an 8-sample reference set the all-FP4 default
 holds worst-sample action cosine ≈ 0.998 vs the FP8 tier (the other

--- a/benchmarks/groot_n17_thor_latency.py
+++ b/benchmarks/groot_n17_thor_latency.py
@@ -1,0 +1,122 @@
+"""GROOT N1.7 Thor end-to-end latency benchmark.
+
+Measures the full per-frame image->action path (vision backbone graph
+replay + action graph replay) with wall-clock timing, reporting the
+median over ``--iters`` iterations after ``--warmup`` warmup frames,
+plus the per-component split and an FP8-tier action-cosine check when
+both tiers are run.
+
+Requires an N1.7 checkpoint snapshot and an aux fixture captured from
+the official preprocessing path (see ``tests/_helpers/groot_n17``).
+
+Usage:
+    python benchmarks/groot_n17_thor_latency.py \
+        --ckpt <path-to-GR00T-N1.7-snapshot> \
+        --aux <path-to-aux-fixture.pt> \
+        --tier fp4 --views 2 \
+        --embodiment oxe_droid_relative_eef_relative_joint
+"""
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import torch
+
+
+def _cos(a, b):
+    a = torch.as_tensor(a).float().flatten().double().cpu()
+    b = torch.as_tensor(b).float().flatten().double().cpu()
+    return float(a @ b / (a.norm() * b.norm()))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True,
+                    help="N1.7 checkpoint snapshot directory")
+    ap.add_argument("--aux", required=True,
+                    help="aux fixture .pt (single dict or list of dicts)")
+    ap.add_argument("--tier", choices=["fp8", "fp4"], default="fp4")
+    ap.add_argument("--views", type=int, default=2)
+    ap.add_argument("--embodiment",
+                    default="oxe_droid_relative_eef_relative_joint")
+    ap.add_argument("--warmup", type=int, default=5)
+    ap.add_argument("--iters", type=int, default=20)
+    ap.add_argument("--calib-aux", default=None,
+                    help="optional aux-list .pt for multi-sample calibration")
+    ap.add_argument("--ref-out", default=None,
+                    help="save the first inference output to this .pt")
+    ap.add_argument("--ref-in", default=None,
+                    help="compare the first inference output against this .pt")
+    ap.add_argument("--dit-fp8-layers", default=None,
+                    help="comma-separated DiT layers kept on the FP8 path "
+                         "(fp4 tier precision ladder)")
+    args = ap.parse_args()
+
+    if args.tier == "fp4":
+        from flash_rt.frontends.torch.groot_n17_thor_fp4 import (
+            GrootN17TorchFrontendThorFP4 as Frontend)
+        kw = {}
+        if args.dit_fp8_layers:
+            kw["dit_fp8_layers"] = tuple(
+                int(x) for x in args.dit_fp8_layers.split(","))
+    else:
+        from flash_rt.frontends.torch.groot_n17_thor_fp8 import (
+            GrootN17TorchFrontendThorFP8 as Frontend)
+        kw = {}
+
+    aux = torch.load(args.aux, weights_only=False, map_location="cpu")
+    if isinstance(aux, list):
+        aux = aux[0]
+
+    fe = Frontend(args.ckpt, num_views=args.views,
+                  embodiment_tag=args.embodiment, **kw)
+    if args.calib_aux:
+        fe.calibrate(torch.load(args.calib_aux, weights_only=False,
+                                map_location="cpu"))
+    fe.set_prompt(aux=aux, prompt="benchmark")
+
+    state_normed = torch.zeros(1, 1, 132, dtype=torch.float32)
+    noise = aux["initial_noise"].to("cuda").bfloat16().contiguous()
+
+    def e2e_once():
+        fe._backbone_features = fe.run_backbone_graph(aux)
+        return fe.infer(state_normed, initial_noise=noise.clone())
+
+    out0 = e2e_once()
+    if args.ref_out:
+        torch.save(out0.detach().float().cpu(), args.ref_out)
+    if args.ref_in:
+        ref = torch.load(args.ref_in, weights_only=False, map_location="cpu")
+        print(f"action cosine vs reference: {_cos(out0, ref):.6f}")
+
+    for _ in range(args.warmup):
+        e2e_once()
+    torch.cuda.synchronize()
+
+    e2e, bb, act = [], [], []
+    for _ in range(args.iters):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fe._backbone_features = fe.run_backbone_graph(aux)
+        torch.cuda.synchronize()
+        t1 = time.perf_counter()
+        fe.infer(state_normed, initial_noise=noise.clone())
+        torch.cuda.synchronize()
+        t2 = time.perf_counter()
+        bb.append((t1 - t0) * 1e3)
+        act.append((t2 - t1) * 1e3)
+        e2e.append((t2 - t0) * 1e3)
+
+    det = e2e_once()
+    m = statistics.median
+    print(f"[groot_n17-thor-{args.tier}] backbone={m(bb):.2f} ms  "
+          f"action={m(act):.2f} ms  e2e={m(e2e):.2f} ms  "
+          f"({1000.0 / m(e2e):.1f} Hz)  "
+          f"[median of {args.iters} after {args.warmup} warmup]  "
+          f"replay-determinism={_cos(out0, det):.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/groot_n17_thor_latency.py
+++ b/benchmarks/groot_n17_thor_latency.py
@@ -49,6 +49,9 @@ def main() -> None:
                     help="save the first inference output to this .pt")
     ap.add_argument("--ref-in", default=None,
                     help="compare the first inference output against this .pt")
+    ap.add_argument("--min-cosine", type=float, default=None,
+                    help="fail (exit 1) when the action cosine against "
+                         "--ref-in falls below this threshold")
     args = ap.parse_args()
 
     if args.tier == "fp4":
@@ -80,9 +83,13 @@ def main() -> None:
     out0 = e2e_once()
     if args.ref_out:
         torch.save(out0.detach().float().cpu(), args.ref_out)
+    cosine = None
     if args.ref_in:
         ref = torch.load(args.ref_in, weights_only=False, map_location="cpu")
-        print(f"action cosine vs reference: {_cos(out0, ref):.6f}")
+        cosine = _cos(out0, ref)
+        print(f"action cosine vs reference: {cosine:.6f}")
+    elif args.min_cosine is not None:
+        raise SystemExit("--min-cosine requires --ref-in")
 
     for _ in range(args.warmup):
         e2e_once()
@@ -109,6 +116,11 @@ def main() -> None:
           f"({1000.0 / m(e2e):.1f} Hz)  "
           f"[median of {args.iters} after {args.warmup} warmup]  "
           f"replay-determinism={_cos(out0, det):.6f}")
+
+    if args.min_cosine is not None and cosine < args.min_cosine:
+        raise SystemExit(
+            f"action cosine {cosine:.6f} is below --min-cosine "
+            f"{args.min_cosine:.6f}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/groot_n17_thor_latency.py
+++ b/benchmarks/groot_n17_thor_latency.py
@@ -49,29 +49,21 @@ def main() -> None:
                     help="save the first inference output to this .pt")
     ap.add_argument("--ref-in", default=None,
                     help="compare the first inference output against this .pt")
-    ap.add_argument("--dit-fp8-layers", default=None,
-                    help="comma-separated DiT layers kept on the FP8 path "
-                         "(fp4 tier precision ladder)")
     args = ap.parse_args()
 
     if args.tier == "fp4":
         from flash_rt.frontends.torch.groot_n17_thor_fp4 import (
             GrootN17TorchFrontendThorFP4 as Frontend)
-        kw = {}
-        if args.dit_fp8_layers:
-            kw["dit_fp8_layers"] = tuple(
-                int(x) for x in args.dit_fp8_layers.split(","))
     else:
         from flash_rt.frontends.torch.groot_n17_thor_fp8 import (
             GrootN17TorchFrontendThorFP8 as Frontend)
-        kw = {}
 
     aux = torch.load(args.aux, weights_only=False, map_location="cpu")
     if isinstance(aux, list):
         aux = aux[0]
 
     fe = Frontend(args.ckpt, num_views=args.views,
-                  embodiment_tag=args.embodiment, **kw)
+                  embodiment_tag=args.embodiment)
     fe.set_prompt(aux=aux, prompt="benchmark")
     if args.calib_aux:
         # Multi-sample act-scale refinement (requires set_prompt first).

--- a/benchmarks/groot_n17_thor_latency.py
+++ b/benchmarks/groot_n17_thor_latency.py
@@ -72,10 +72,11 @@ def main() -> None:
 
     fe = Frontend(args.ckpt, num_views=args.views,
                   embodiment_tag=args.embodiment, **kw)
+    fe.set_prompt(aux=aux, prompt="benchmark")
     if args.calib_aux:
+        # Multi-sample act-scale refinement (requires set_prompt first).
         fe.calibrate(torch.load(args.calib_aux, weights_only=False,
                                 map_location="cpu"))
-    fe.set_prompt(aux=aux, prompt="benchmark")
 
     state_normed = torch.zeros(1, 1, 132, dtype=torch.float32)
     noise = aux["initial_noise"].to("cuda").bfloat16().contiguous()

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -484,7 +484,10 @@ extern "C" int cutlass_fp8_t1_bf16out(void*, void*, void*, int, int, int, float,
 #include "kernels/lingbot_kernels.h"   // LingBot-VLA model kernel decls (lingbot_-prefixed, Thor sm_110a)
 #endif
 
-// Vectorized fp16 backbone helpers (csrc/kernels/vec_fp16_backbone.cu).
+#ifdef FLASHRT_HAVE_THOR_VLA_KERNELS
+// Vectorized fp16 backbone helpers (csrc/kernels/vec_fp16_backbone.cu) and
+// the masked-softmax MHA variants (csrc/kernels/attention_mha_masked.cu).
+// Both compile only on SM100-class builds; see the CMake gate.
 extern "C" {
 int rms_norm_fp16_vec(const __half*, const __half*, __half*, int, int, float,
                       cudaStream_t);
@@ -508,6 +511,7 @@ void attention_mha_bf16_masked(cublasHandle_t, const __nv_bfloat16*,
                                __nv_bfloat16*, __nv_bfloat16*, int, int, int,
                                int, float, int, int, cudaStream_t);
 }
+#endif  // FLASHRT_HAVE_THOR_VLA_KERNELS
 
 PYBIND11_MODULE(flash_rt_kernels, m) {
     m.doc() = "FlashRT C++/CUDA inference kernels";
@@ -2394,6 +2398,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     }, py::arg("x"), py::arg("cos_table"), py::arg("sin_table"),
        py::arg("S"), py::arg("NH"), py::arg("HD"), py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_THOR_VLA_KERNELS
     // ── Vectorized fp16 backbone helpers (16-byte loads; additive) ──
     m.def("rms_norm_fp16_vec", [](uintptr_t x, uintptr_t w, uintptr_t out,
                                   int rows, int dim, float eps,
@@ -2470,6 +2475,8 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
             S, NH_src, HD, repeat, to_stream(stream));
     }, py::arg("src"), py::arg("dst"), py::arg("S"), py::arg("NH_src"),
        py::arg("HD"), py::arg("repeat"), py::arg("stream") = 0);
+
+#endif  // FLASHRT_HAVE_THOR_VLA_KERNELS
 
     // MHA batched cuBLAS attention (for DiT — per-head independent attention)
     m.def("attention_mha_fp16", [](FvkContext& ctx, uintptr_t Q, uintptr_t K, uintptr_t V,
@@ -2613,6 +2620,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("attn_scale") = 1.0f, py::arg("logits_kv_stride") = 0,
        py::arg("stream") = 0);
 
+#ifdef FLASHRT_HAVE_THOR_VLA_KERNELS
     // Masked-softmax MHA variants: no -inf logits pre-fill needed (the
     // softmax reads/writes only the valid S_kv columns).
     m.def("attention_mha_fp16_masked",
@@ -2652,6 +2660,7 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("S_q"), py::arg("S_kv"), py::arg("NH"), py::arg("HD"),
        py::arg("attn_scale") = 1.0f, py::arg("logits_kv_stride") = 0,
        py::arg("qkv_token_stride") = 0, py::arg("stream") = 0);
+#endif  // FLASHRT_HAVE_THOR_VLA_KERNELS
 
     // ------------------------------------------------------------------
     //  FP8 block-128 dequantization + GEMM.

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -499,6 +499,7 @@ int quantize_fp8_static_fp16_vec(const __half*, __nv_fp8_e4m3*, const float*,
                                  int, cudaStream_t);
 int gpu_repeat_interleave_heads_vec(const __half*, __half*, int, int, int,
                                     int, cudaStream_t);
+int residual_add_fp16_vec(__half*, const __half*, int, cudaStream_t);
 void attention_mha_fp16_masked(cublasHandle_t, const __half*, const __half*,
                                const __half*, __half*, __half*, int, int, int,
                                int, float, cudaStream_t);
@@ -2451,6 +2452,13 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
             reinterpret_cast<const float*>(d_scale), n, to_stream(stream));
     }, py::arg("in"), py::arg("out"), py::arg("d_scale"), py::arg("n"),
        py::arg("stream") = 0);
+
+    m.def("residual_add_fp16_vec", [](uintptr_t residual, uintptr_t x, int n,
+                                      uintptr_t stream) -> int {
+        return residual_add_fp16_vec(reinterpret_cast<__half*>(residual),
+                                     reinterpret_cast<const __half*>(x),
+                                     n, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("n"), py::arg("stream") = 0);
 
     m.def("gpu_repeat_interleave_heads_vec", [](uintptr_t src, uintptr_t dst,
                                                 int S, int NH_src, int HD,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -490,6 +490,9 @@ int rms_norm_fp16_vec(const __half*, const __half*, __half*, int, int, float,
                       cudaStream_t);
 int layer_norm_fp16_vec(const __half*, const __half*, const __half*, __half*,
                         int, int, float, cudaStream_t);
+int layer_norm_fp8_static_fp16_vec(const __half*, const __half*, const __half*,
+                                   __nv_fp8_e4m3*, const float*, int, int,
+                                   float, cudaStream_t);
 int rope_rotate_half_fp16_vec(__half*, const __half*, const __half*, int, int,
                               int, cudaStream_t);
 int quantize_fp8_static_fp16_vec(const __half*, __nv_fp8_e4m3*, const float*,
@@ -2412,6 +2415,21 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
     }, py::arg("x"), py::arg("w"), py::arg("b"), py::arg("out"),
        py::arg("rows"), py::arg("dim"), py::arg("eps") = 1e-6f,
        py::arg("stream") = 0);
+
+    m.def("layer_norm_fp8_static_fp16_vec",
+          [](uintptr_t x, uintptr_t w, uintptr_t b, uintptr_t out,
+             uintptr_t d_scale, int rows, int dim, float eps,
+             uintptr_t stream) -> int {
+        return layer_norm_fp8_static_fp16_vec(
+            reinterpret_cast<const __half*>(x),
+            reinterpret_cast<const __half*>(w),
+            reinterpret_cast<const __half*>(b),
+            reinterpret_cast<__nv_fp8_e4m3*>(out),
+            reinterpret_cast<const float*>(d_scale),
+            rows, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("w"), py::arg("b"), py::arg("out"),
+       py::arg("d_scale"), py::arg("rows"), py::arg("dim"),
+       py::arg("eps") = 1e-6f, py::arg("stream") = 0);
 
     m.def("rope_rotate_half_fp16_vec", [](uintptr_t x, uintptr_t cos_table,
                                           uintptr_t sin_table, int S, int NH,

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -496,6 +496,13 @@ int quantize_fp8_static_fp16_vec(const __half*, __nv_fp8_e4m3*, const float*,
                                  int, cudaStream_t);
 int gpu_repeat_interleave_heads_vec(const __half*, __half*, int, int, int,
                                     int, cudaStream_t);
+void attention_mha_fp16_masked(cublasHandle_t, const __half*, const __half*,
+                               const __half*, __half*, __half*, int, int, int,
+                               int, float, cudaStream_t);
+void attention_mha_bf16_masked(cublasHandle_t, const __nv_bfloat16*,
+                               const __nv_bfloat16*, const __nv_bfloat16*,
+                               __nv_bfloat16*, __nv_bfloat16*, int, int, int,
+                               int, float, int, int, cudaStream_t);
 }
 
 PYBIND11_MODULE(flash_rt_kernels, m) {
@@ -2579,6 +2586,46 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
        py::arg("S_q"), py::arg("S_kv"), py::arg("NH"), py::arg("HD"),
        py::arg("attn_scale") = 1.0f, py::arg("logits_kv_stride") = 0,
        py::arg("stream") = 0);
+
+    // Masked-softmax MHA variants: no -inf logits pre-fill needed (the
+    // softmax reads/writes only the valid S_kv columns).
+    m.def("attention_mha_fp16_masked",
+          [](FvkContext& ctx, uintptr_t Q, uintptr_t K, uintptr_t V,
+             uintptr_t logits, uintptr_t out,
+             int S_q, int S_kv, int NH, int HD,
+             float attn_scale, uintptr_t stream) {
+        attention_mha_fp16_masked(ctx.cublas_handle,
+                            reinterpret_cast<const __half*>(Q),
+                            reinterpret_cast<const __half*>(K),
+                            reinterpret_cast<const __half*>(V),
+                            reinterpret_cast<__half*>(logits),
+                            reinterpret_cast<__half*>(out),
+                            S_q, S_kv, NH, HD, attn_scale, to_stream(stream));
+    }, py::arg("ctx"), py::arg("Q"), py::arg("K"), py::arg("V"),
+       py::arg("logits"), py::arg("out"),
+       py::arg("S_q"), py::arg("S_kv"), py::arg("NH"), py::arg("HD"),
+       py::arg("attn_scale") = 1.0f, py::arg("stream") = 0);
+
+    m.def("attention_mha_bf16_masked",
+          [](FvkContext& ctx, uintptr_t Q, uintptr_t K, uintptr_t V,
+             uintptr_t logits, uintptr_t out,
+             int S_q, int S_kv, int NH, int HD,
+             float attn_scale, int logits_kv_stride, int qkv_token_stride,
+             uintptr_t stream) {
+        attention_mha_bf16_masked(ctx.cublas_handle,
+                            reinterpret_cast<const __nv_bfloat16*>(Q),
+                            reinterpret_cast<const __nv_bfloat16*>(K),
+                            reinterpret_cast<const __nv_bfloat16*>(V),
+                            reinterpret_cast<__nv_bfloat16*>(logits),
+                            reinterpret_cast<__nv_bfloat16*>(out),
+                            S_q, S_kv, NH, HD, attn_scale,
+                            logits_kv_stride, qkv_token_stride,
+                            to_stream(stream));
+    }, py::arg("ctx"), py::arg("Q"), py::arg("K"), py::arg("V"),
+       py::arg("logits"), py::arg("out"),
+       py::arg("S_q"), py::arg("S_kv"), py::arg("NH"), py::arg("HD"),
+       py::arg("attn_scale") = 1.0f, py::arg("logits_kv_stride") = 0,
+       py::arg("qkv_token_stride") = 0, py::arg("stream") = 0);
 
     // ------------------------------------------------------------------
     //  FP8 block-128 dequantization + GEMM.

--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -484,6 +484,20 @@ extern "C" int cutlass_fp8_t1_bf16out(void*, void*, void*, int, int, int, float,
 #include "kernels/lingbot_kernels.h"   // LingBot-VLA model kernel decls (lingbot_-prefixed, Thor sm_110a)
 #endif
 
+// Vectorized fp16 backbone helpers (csrc/kernels/vec_fp16_backbone.cu).
+extern "C" {
+int rms_norm_fp16_vec(const __half*, const __half*, __half*, int, int, float,
+                      cudaStream_t);
+int layer_norm_fp16_vec(const __half*, const __half*, const __half*, __half*,
+                        int, int, float, cudaStream_t);
+int rope_rotate_half_fp16_vec(__half*, const __half*, const __half*, int, int,
+                              int, cudaStream_t);
+int quantize_fp8_static_fp16_vec(const __half*, __nv_fp8_e4m3*, const float*,
+                                 int, cudaStream_t);
+int gpu_repeat_interleave_heads_vec(const __half*, __half*, int, int, int,
+                                    int, cudaStream_t);
+}
+
 PYBIND11_MODULE(flash_rt_kernels, m) {
     m.doc() = "FlashRT C++/CUDA inference kernels";
 
@@ -2368,6 +2382,61 @@ PYBIND11_MODULE(flash_rt_kernels, m) {
                                S, NH, HD, to_stream(stream));
     }, py::arg("x"), py::arg("cos_table"), py::arg("sin_table"),
        py::arg("S"), py::arg("NH"), py::arg("HD"), py::arg("stream") = 0);
+
+    // ── Vectorized fp16 backbone helpers (16-byte loads; additive) ──
+    m.def("rms_norm_fp16_vec", [](uintptr_t x, uintptr_t w, uintptr_t out,
+                                  int rows, int dim, float eps,
+                                  uintptr_t stream) -> int {
+        return rms_norm_fp16_vec(reinterpret_cast<const __half*>(x),
+                                 reinterpret_cast<const __half*>(w),
+                                 reinterpret_cast<__half*>(out),
+                                 rows, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("w"), py::arg("out"), py::arg("rows"),
+       py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("layer_norm_fp16_vec", [](uintptr_t x, uintptr_t w, uintptr_t b,
+                                    uintptr_t out, int rows, int dim,
+                                    float eps, uintptr_t stream) -> int {
+        return layer_norm_fp16_vec(reinterpret_cast<const __half*>(x),
+                                   reinterpret_cast<const __half*>(w),
+                                   reinterpret_cast<const __half*>(b),
+                                   reinterpret_cast<__half*>(out),
+                                   rows, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("w"), py::arg("b"), py::arg("out"),
+       py::arg("rows"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("stream") = 0);
+
+    m.def("rope_rotate_half_fp16_vec", [](uintptr_t x, uintptr_t cos_table,
+                                          uintptr_t sin_table, int S, int NH,
+                                          int HD, uintptr_t stream) -> int {
+        return rope_rotate_half_fp16_vec(
+            reinterpret_cast<__half*>(x),
+            reinterpret_cast<const __half*>(cos_table),
+            reinterpret_cast<const __half*>(sin_table),
+            S, NH, HD, to_stream(stream));
+    }, py::arg("x"), py::arg("cos_table"), py::arg("sin_table"),
+       py::arg("S"), py::arg("NH"), py::arg("HD"), py::arg("stream") = 0);
+
+    m.def("quantize_fp8_static_fp16_vec", [](uintptr_t in, uintptr_t out,
+                                             uintptr_t d_scale, int n,
+                                             uintptr_t stream) -> int {
+        return quantize_fp8_static_fp16_vec(
+            reinterpret_cast<const __half*>(in),
+            reinterpret_cast<__nv_fp8_e4m3*>(out),
+            reinterpret_cast<const float*>(d_scale), n, to_stream(stream));
+    }, py::arg("in"), py::arg("out"), py::arg("d_scale"), py::arg("n"),
+       py::arg("stream") = 0);
+
+    m.def("gpu_repeat_interleave_heads_vec", [](uintptr_t src, uintptr_t dst,
+                                                int S, int NH_src, int HD,
+                                                int repeat,
+                                                uintptr_t stream) -> int {
+        return gpu_repeat_interleave_heads_vec(
+            reinterpret_cast<const __half*>(src),
+            reinterpret_cast<__half*>(dst),
+            S, NH_src, HD, repeat, to_stream(stream));
+    }, py::arg("src"), py::arg("dst"), py::arg("S"), py::arg("NH_src"),
+       py::arg("HD"), py::arg("repeat"), py::arg("stream") = 0);
 
     // MHA batched cuBLAS attention (for DiT — per-head independent attention)
     m.def("attention_mha_fp16", [](FvkContext& ctx, uintptr_t Q, uintptr_t K, uintptr_t V,

--- a/csrc/fp4_bindings.cpp
+++ b/csrc/fp4_bindings.cpp
@@ -33,6 +33,9 @@
 #endif
 #include "fused_fp4/norm_silu_fp4_sfa.cuh"
 #include "fused_fp4/silu_mul_two_fp4_to_fp4.cuh"
+#include "gemm/fp4/cutlass_fp4_gemm_bias_bf16_sm100.cuh"
+#include "quantize/quantize_fp4_sfa_bf16.cuh"
+#include "fused_fp4/dit_norm_fp4_sfa.cuh"
 
 extern "C" int flash_rt_per_channel_mul_fp16(
     uintptr_t x, uintptr_t inv_s, int S, int D, uintptr_t stream);
@@ -524,6 +527,114 @@ Drop-in for cutlass_fp4_sq_fp16 when downstream consumes FP4 + SFA directly.
         py::arg("out_packed"),  py::arg("out_sfa"),
         py::arg("seq_len"), py::arg("half_dim"), py::arg("stream") = 0,
         "P1: GEGLU over two FP4 inputs → FP4 + SFA.");
+
+  // ── bf16-activation NVFP4 path (GR00T N1.7 DiT) ─────────────────────
+  m.def("quantize_fp4_dynamic_sfa_bf16_vec",
+        [](uintptr_t src, uintptr_t packed, uintptr_t sfa,
+           int N, int D, bool is_sfb, uintptr_t stream) -> int {
+          return flash_rt::fp4::quantize_fp4_dynamic_sfa_bf16_vec(
+              reinterpret_cast<void const*>(src),
+              reinterpret_cast<void*>(packed),
+              reinterpret_cast<void*>(sfa),
+              N, D, is_sfb,
+              reinterpret_cast<cudaStream_t>(stream));
+        },
+        py::arg("src"), py::arg("packed"), py::arg("sfa"),
+        py::arg("N"), py::arg("D"), py::arg("is_sfb"), py::arg("stream") = 0,
+        "Fused: bf16 [N, D] -> NVFP4 packed [N, D/2] + tile-interleaved "
+        "SFA/SFB (vectorized).");
+
+  m.def("cutlass_fp4_gemm_bias_bf16",
+        [](uintptr_t A, uintptr_t SFA, uintptr_t B, uintptr_t SFB,
+           uintptr_t bias, uintptr_t D, int M, int N, int K,
+           uintptr_t stream) -> int {
+          return flash_rt::fp4::cutlass_fp4_gemm_bias_bf16(
+              reinterpret_cast<void const*>(A),
+              reinterpret_cast<void const*>(SFA),
+              reinterpret_cast<void const*>(B),
+              reinterpret_cast<void const*>(SFB),
+              reinterpret_cast<void const*>(bias),
+              reinterpret_cast<void*>(D), M, N, K,
+              reinterpret_cast<cudaStream_t>(stream));
+        },
+        py::arg("A"), py::arg("SFA"), py::arg("B"), py::arg("SFB"),
+        py::arg("bias"), py::arg("D"),
+        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0,
+        "NVFP4 GEMM, bf16 out: D = A @ B^T + bias[N].");
+
+  m.def("cutlass_fp4_gemm_bias_res_bf16",
+        [](uintptr_t A, uintptr_t SFA, uintptr_t B, uintptr_t SFB,
+           uintptr_t bias, uintptr_t C, uintptr_t D,
+           int M, int N, int K, uintptr_t stream) -> int {
+          return flash_rt::fp4::cutlass_fp4_gemm_bias_res_bf16(
+              reinterpret_cast<void const*>(A),
+              reinterpret_cast<void const*>(SFA),
+              reinterpret_cast<void const*>(B),
+              reinterpret_cast<void const*>(SFB),
+              reinterpret_cast<void const*>(bias),
+              reinterpret_cast<void const*>(C),
+              reinterpret_cast<void*>(D), M, N, K,
+              reinterpret_cast<cudaStream_t>(stream));
+        },
+        py::arg("A"), py::arg("SFA"), py::arg("B"), py::arg("SFB"),
+        py::arg("bias"), py::arg("C"), py::arg("D"),
+        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0,
+        "NVFP4 GEMM, bf16 out with residual: D = A @ B^T + bias[N] + C "
+        "(C may alias D).");
+
+  m.def("cutlass_fp4_gemm_bias_gelu_fp4out_bf16",
+        [](uintptr_t A, uintptr_t SFA, uintptr_t B, uintptr_t SFB,
+           uintptr_t bias, uintptr_t D_packed, uintptr_t D_SFD,
+           int M, int N, int K, uintptr_t stream) -> int {
+          return flash_rt::fp4::cutlass_fp4_gemm_bias_gelu_fp4out_bf16(
+              reinterpret_cast<void const*>(A),
+              reinterpret_cast<void const*>(SFA),
+              reinterpret_cast<void const*>(B),
+              reinterpret_cast<void const*>(SFB),
+              reinterpret_cast<void const*>(bias),
+              reinterpret_cast<void*>(D_packed),
+              reinterpret_cast<void*>(D_SFD), M, N, K,
+              reinterpret_cast<cudaStream_t>(stream));
+        },
+        py::arg("A"), py::arg("SFA"), py::arg("B"), py::arg("SFB"),
+        py::arg("bias"), py::arg("D_packed"), py::arg("D_SFD"),
+        py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0,
+        "NVFP4 GEMM with fused bias + tanh-GELU + FP4/SFA output "
+        "(bf16 bias).");
+
+  m.def("ada_layer_norm_fp4_sfa_bf16",
+        [](uintptr_t x, uintptr_t scale, uintptr_t shift,
+           uintptr_t packed, uintptr_t sfa,
+           int seq_len, int dim, float eps, uintptr_t stream) -> int {
+          return flash_rt::fused_fp4::ada_layer_norm_fp4_sfa_bf16(
+              reinterpret_cast<void const*>(x),
+              reinterpret_cast<void const*>(scale),
+              reinterpret_cast<void const*>(shift),
+              reinterpret_cast<void*>(packed),
+              reinterpret_cast<void*>(sfa),
+              seq_len, dim, eps,
+              reinterpret_cast<cudaStream_t>(stream));
+        },
+        py::arg("x"), py::arg("scale"), py::arg("shift"),
+        py::arg("packed"), py::arg("sfa"),
+        py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-5f,
+        py::arg("stream") = 0,
+        "Fused AdaLN (bf16) -> NVFP4 packed + SFA.");
+
+  m.def("layer_norm_no_affine_fp4_sfa_bf16",
+        [](uintptr_t x, uintptr_t packed, uintptr_t sfa,
+           int seq_len, int dim, float eps, uintptr_t stream) -> int {
+          return flash_rt::fused_fp4::layer_norm_no_affine_fp4_sfa_bf16(
+              reinterpret_cast<void const*>(x),
+              reinterpret_cast<void*>(packed),
+              reinterpret_cast<void*>(sfa),
+              seq_len, dim, eps,
+              reinterpret_cast<cudaStream_t>(stream));
+        },
+        py::arg("x"), py::arg("packed"), py::arg("sfa"),
+        py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-5f,
+        py::arg("stream") = 0,
+        "Fused no-affine LayerNorm (bf16) -> NVFP4 packed + SFA.");
 
   m.attr("__version__") = "0.1.0-dev";
   m.attr("layout_note") = "scales are linear [N, D/16]; Phase 4 adds tile-interleave conversion";

--- a/csrc/fused_fp4/dit_norm_fp4_sfa.cu
+++ b/csrc/fused_fp4/dit_norm_fp4_sfa.cu
@@ -1,0 +1,208 @@
+// ============================================================================
+//  Fused DiT norms (bf16) + NVFP4 quantize + SFA write. See header.
+//
+//  Grid: (S,) one CTA per row, 128 threads. Row mean/var via the standard
+//  two-pass block reduction; 16-element quant blocks one per thread with
+//  16-byte loads. Scale selection and e2m1 rounding are identical to
+//  quantize_fp4_dynamic_sfa_bf16_vec.
+// ============================================================================
+#include "dit_norm_fp4_sfa.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED) || defined(__CUDA_ARCH__)
+#  include "cutlass/cutlass.h"
+#  include "cutlass/detail/sm100_blockscaled_layout.hpp"
+#  include "cute/tensor.hpp"
+#  define FV_HAVE_CUTLASS 1
+#else
+#  define FV_HAVE_CUTLASS 0
+#endif
+
+namespace flash_rt {
+namespace fused_fp4 {
+
+#if FV_HAVE_CUTLASS
+
+namespace {
+
+using CfgDN = cutlass::detail::Sm1xxBlockScaledConfig<16>;
+
+__device__ __forceinline__ uint8_t fp32_to_e2m1_dn(float x) {
+    uint8_t sign = (x < 0.f) ? 0x8u : 0x0u;
+    float ax = fabsf(x);
+    uint8_t mant;
+    if      (ax <= 0.25f) mant = 0u;
+    else if (ax <= 0.75f) mant = 1u;
+    else if (ax <= 1.25f) mant = 2u;
+    else if (ax <= 1.75f) mant = 3u;
+    else if (ax <= 2.5f)  mant = 4u;
+    else if (ax <= 3.5f)  mant = 5u;
+    else if (ax <= 5.0f)  mant = 6u;
+    else                  mant = 7u;
+    return sign | mant;
+}
+
+__device__ __forceinline__ float block_sum_dn(float v, float* sh) {
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1)
+        v += __shfl_xor_sync(0xffffffffu, v, o);
+    if (lane == 0) sh[warp] = v;
+    __syncthreads();
+    if (warp == 0) {
+        v = (lane < ((blockDim.x + 31) >> 5)) ? sh[lane] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1)
+            v += __shfl_xor_sync(0xffffffffu, v, o);
+        if (lane == 0) sh[0] = v;
+    }
+    __syncthreads();
+    const float r = sh[0];
+    __syncthreads();
+    return r;
+}
+
+// HAS_MOD=true: AdaLN (modulate with (1+scale), shift). false: plain LN.
+template <bool HAS_MOD, class LayoutSF>
+__global__ void dit_norm_fp4_sfa_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ scale,   // [D] or nullptr
+    const __nv_bfloat16* __restrict__ shift,   // [D] or nullptr
+    uint2* __restrict__ packed,                // [S, D/16] 8-byte blocks
+    uint8_t* __restrict__ dst_sfa,
+    LayoutSF layout,
+    int D, float eps) {
+    const int r = blockIdx.x;
+    const __nv_bfloat162* row2 =
+        reinterpret_cast<const __nv_bfloat162*>(x + static_cast<long>(r) * D);
+    const int D2 = D >> 1;
+    __shared__ float sh[32];
+
+    float s = 0.f;
+    for (int i = threadIdx.x; i < D2; i += blockDim.x) {
+        const __nv_bfloat162 v = row2[i];
+        s += __bfloat162float(v.x) + __bfloat162float(v.y);
+    }
+    const float mean = block_sum_dn(s, sh) / D;
+
+    float var = 0.f;
+    for (int i = threadIdx.x; i < D2; i += blockDim.x) {
+        const __nv_bfloat162 v = row2[i];
+        const float d0 = __bfloat162float(v.x) - mean;
+        const float d1 = __bfloat162float(v.y) - mean;
+        var += d0 * d0 + d1 * d1;
+    }
+    const float rstd = rsqrtf(block_sum_dn(var, sh) / D + eps);
+
+    const int n_blocks = D >> 4;
+    const int4* x4 = reinterpret_cast<const int4*>(x + static_cast<long>(r) * D);
+    const int4* s4 = reinterpret_cast<const int4*>(scale);
+    const int4* h4 = reinterpret_cast<const int4*>(shift);
+    for (int blk = threadIdx.x; blk < n_blocks; blk += blockDim.x) {
+        const int4 xr[2] = {x4[2 * blk], x4[2 * blk + 1]};
+        const __nv_bfloat16* xh = reinterpret_cast<const __nv_bfloat16*>(xr);
+        int4 sr[2], hr[2];
+        const __nv_bfloat16* sc = nullptr;
+        const __nv_bfloat16* sf = nullptr;
+        if (HAS_MOD) {
+            sr[0] = s4[2 * blk]; sr[1] = s4[2 * blk + 1];
+            hr[0] = h4[2 * blk]; hr[1] = h4[2 * blk + 1];
+            sc = reinterpret_cast<const __nv_bfloat16*>(sr);
+            sf = reinterpret_cast<const __nv_bfloat16*>(hr);
+        }
+        float vals[16];
+        float amax = 0.f;
+        #pragma unroll
+        for (int i = 0; i < 16; ++i) {
+            float normed = (__bfloat162float(xh[i]) - mean) * rstd;
+            if (HAS_MOD)
+                normed = normed * (1.0f + __bfloat162float(sc[i])) +
+                         __bfloat162float(sf[i]);
+            // bf16 rounding keeps this bit-identical to the two-step
+            // (bf16 norm kernel, then quantize) reference chain.
+            vals[i] = __bfloat162float(__float2bfloat16(normed));
+            const float a = fabsf(vals[i]);
+            if (a > amax) amax = a;
+        }
+        float desired = amax / 6.f;
+        if (desired < 1e-12f) desired = 1e-12f;
+        __nv_fp8_e4m3 bs_q = __nv_fp8_e4m3(fmaxf(desired, 0.f));
+        const float bs_dq = static_cast<float>(bs_q);
+        dst_sfa[layout(r, blk * 16, 0)] = *reinterpret_cast<uint8_t*>(&bs_q);
+        const float inv_bs = 1.f / bs_dq;
+        uint2 out;
+        uint8_t* ob = reinterpret_cast<uint8_t*>(&out);
+        #pragma unroll
+        for (int p = 0; p < 8; ++p) {
+            const uint8_t lo = fp32_to_e2m1_dn(vals[2 * p] * inv_bs);
+            const uint8_t hi = fp32_to_e2m1_dn(vals[2 * p + 1] * inv_bs);
+            ob[p] = static_cast<uint8_t>(lo | (hi << 4));
+        }
+        packed[static_cast<long>(r) * n_blocks + blk] = out;
+    }
+}
+
+}  // namespace
+
+#endif  // FV_HAVE_CUTLASS
+
+static int check_dn_args(const void* x, void* packed, int dim) {
+    if (dim % 16 != 0 || dim % 2 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(packed) & 7)) return -1;
+    return 0;
+}
+
+int ada_layer_norm_fp4_sfa_bf16(
+    const void* x, const void* scale, const void* shift,
+    void* packed, void* sfa,
+    int seq_len, int dim, float eps, cudaStream_t stream) {
+#if FV_HAVE_CUTLASS
+    if (check_dn_args(x, packed, dim) != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(scale) & 15) ||
+        (reinterpret_cast<uintptr_t>(shift) & 15)) return -1;
+    auto shape = cute::make_shape(seq_len, 1, dim, 1);
+    auto layout = CfgDN::tile_atom_to_shape_SFA(shape);
+    dit_norm_fp4_sfa_kernel<true><<<seq_len, 128, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(scale),
+        reinterpret_cast<const __nv_bfloat16*>(shift),
+        reinterpret_cast<uint2*>(packed),
+        reinterpret_cast<uint8_t*>(sfa),
+        layout, dim, eps);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+#else
+    (void)x; (void)scale; (void)shift; (void)packed; (void)sfa;
+    (void)seq_len; (void)dim; (void)eps; (void)stream;
+    return -2;
+#endif
+}
+
+int layer_norm_no_affine_fp4_sfa_bf16(
+    const void* x, void* packed, void* sfa,
+    int seq_len, int dim, float eps, cudaStream_t stream) {
+#if FV_HAVE_CUTLASS
+    if (check_dn_args(x, packed, dim) != 0) return -1;
+    auto shape = cute::make_shape(seq_len, 1, dim, 1);
+    auto layout = CfgDN::tile_atom_to_shape_SFA(shape);
+    dit_norm_fp4_sfa_kernel<false><<<seq_len, 128, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        nullptr, nullptr,
+        reinterpret_cast<uint2*>(packed),
+        reinterpret_cast<uint8_t*>(sfa),
+        layout, dim, eps);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+#else
+    (void)x; (void)packed; (void)sfa;
+    (void)seq_len; (void)dim; (void)eps; (void)stream;
+    return -2;
+#endif
+}
+
+}  // namespace fused_fp4
+}  // namespace flash_rt

--- a/csrc/fused_fp4/dit_norm_fp4_sfa.cuh
+++ b/csrc/fused_fp4/dit_norm_fp4_sfa.cuh
@@ -1,0 +1,33 @@
+// ============================================================================
+//  FlashRT — fused DiT norms (bf16 in) + NVFP4 quantize + SFA write.
+//
+//  GR00T N1.7 DiT front-ends for NVFP4 GEMMs: the AdaLN-modulated norm1
+//  (QKV / cross-Q input) and the pre-FFN no-affine LayerNorm emit packed
+//  e2m1 + tile-interleaved UE4M3 scales directly, replacing a bf16 norm
+//  kernel followed by a separate quantize kernel. The normalized value is
+//  rounded through bf16 before quantization so the output is bit-identical
+//  to the two-step reference chain.
+//
+//  Additive: new symbols only.
+// ============================================================================
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace fused_fp4 {
+
+// packed/sfa = quantize(LN_no_affine(x[row]) * (1 + scale) + shift)
+// x: bf16 [S, D]; scale/shift: bf16 [D] (per-layer AdaLN modulators).
+int ada_layer_norm_fp4_sfa_bf16(
+    const void* x, const void* scale, const void* shift,
+    void* packed, void* sfa,
+    int seq_len, int dim, float eps, cudaStream_t stream);
+
+// packed/sfa = quantize(LN_no_affine(x[row]))
+int layer_norm_no_affine_fp4_sfa_bf16(
+    const void* x, void* packed, void* sfa,
+    int seq_len, int dim, float eps, cudaStream_t stream);
+
+}  // namespace fused_fp4
+}  // namespace flash_rt

--- a/csrc/gemm/fp4/cutlass_fp4_gemm_bias_bf16_sm100.cu
+++ b/csrc/gemm/fp4/cutlass_fp4_gemm_bias_bf16_sm100.cu
@@ -1,0 +1,208 @@
+// ============================================================================
+//  NVFP4 GEMMs with bf16 fused-bias epilogues. See header for the contract.
+//
+//  Three fusions over one shared skinny-M mainloop config (Sm100,
+//  tile 128x64x256, cluster 1x1x1 — the narrow-N + wide-K shape that wins
+//  at small M where the GEMM is weight-bandwidth-bound):
+//    bias:      LinCombPerColBias  (bf16 out, beta = 0)
+//    bias+res:  LinCombPerColBias  (bf16 out, beta = 1, C = residual)
+//    bias+gelu: LinCombPerColBiasEltActBlockScaleFactor<GELU_taylor>
+//               (fp4 + SFA out for the following NVFP4 GEMM)
+// ============================================================================
+#include "gemm/fp4/cutlass_fp4_gemm_bias_bf16_sm100.cuh"
+
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/thread/activation.h"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/fusion/operations.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/detail/sm100_blockscaled_layout.hpp"
+#include "cute/tensor.hpp"
+
+namespace flash_rt {
+namespace fp4 {
+
+namespace bias_bf16_gemm {
+
+using namespace cute;
+
+using ElementA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+using LayoutATag = cutlass::layout::RowMajor;
+constexpr int AlignmentA = 32;
+
+using ElementB = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+using LayoutBTag = cutlass::layout::ColumnMajor;
+constexpr int AlignmentB = 32;
+
+using ElementAccumulator = float;
+using ElementCompute = float;
+using ArchTag = cutlass::arch::Sm100;
+using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+constexpr int SFVecSize = 16;
+
+using MmaTileShape = Shape<_128, _64, _256>;
+using ClusterShape = Shape<_1, _1, _1>;
+
+template <class FusionOp, class ElemC, class ElemD, int AlignCD>
+struct BiasGemm {
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag, OperatorClass, MmaTileShape, ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator, ElementAccumulator,
+          ElemC, cutlass::layout::RowMajor, AlignCD,
+          ElemD, cutlass::layout::RowMajor, AlignCD,
+          cutlass::epilogue::collective::EpilogueScheduleAuto,
+          FusionOp>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag, OperatorClass,
+          ElementA, LayoutATag, AlignmentA,
+          ElementB, LayoutBTag, AlignmentB,
+          ElementAccumulator, MmaTileShape, ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+// ── bias / bias+res: bf16 out ──────────────────────────────────────────────
+using ElementCD = cutlass::bfloat16_t;
+using FusionBias = cutlass::epilogue::fusion::LinCombPerColBias<
+    ElementCD, ElementCompute, ElementCD, ElementCD, ElementCompute>;
+using GemmBias = BiasGemm<FusionBias, ElementCD, ElementCD, 8>::Gemm;
+
+// ── bias+gelu: fp4 + SFA out ───────────────────────────────────────────────
+using ElementDQ = cutlass::float_e2m1_t;
+using ElementSFD = cutlass::float_ue4m3_t;
+using FusionGelu =
+    cutlass::epilogue::fusion::LinCombPerColBiasEltActBlockScaleFactor<
+        cutlass::epilogue::thread::GELU_taylor, SFVecSize,
+        ElementDQ, ElementCompute, ElementSFD, cutlass::layout::RowMajor,
+        ElementCD, ElementDQ, ElementCompute>;
+using GemmGelu = BiasGemm<FusionGelu, ElementDQ, ElementDQ, 32>::Gemm;
+
+template <class Gemm>
+static int run_gemm(typename Gemm::Arguments& args, cudaStream_t stream) {
+  Gemm gemm;
+  auto st = gemm.can_implement(args);
+  if (st != cutlass::Status::kSuccess) return static_cast<int>(st) | 0x10000;
+  size_t ws_sz = Gemm::get_workspace_size(args);
+  void* ws = nullptr;
+  if (ws_sz > 0 && cudaMalloc(&ws, ws_sz) != cudaSuccess) return -1;
+  st = gemm.initialize(args, ws, stream);
+  if (st != cutlass::Status::kSuccess) {
+    if (ws) cudaFree(ws);
+    return static_cast<int>(st) | 0x20000;
+  }
+  st = gemm.run(stream);
+  if (ws) cudaFree(ws);
+  return (st == cutlass::Status::kSuccess) ? 0
+                                           : (static_cast<int>(st) | 0x30000);
+}
+
+template <class Gemm, class ElemC, class ElemD>
+static typename Gemm::Arguments make_args(
+    void const* A, void const* SFA, void const* B, void const* SFB,
+    void const* C, void* D, int M, int N, int K) {
+  auto stride_A = cutlass::make_cute_packed_stride(
+      typename Gemm::GemmKernel::StrideA{}, {M, K, 1});
+  auto stride_B = cutlass::make_cute_packed_stride(
+      typename Gemm::GemmKernel::StrideB{}, {N, K, 1});
+  auto stride_C = cutlass::make_cute_packed_stride(
+      typename Gemm::GemmKernel::StrideC{}, {M, N, 1});
+  auto stride_D = cutlass::make_cute_packed_stride(
+      typename Gemm::GemmKernel::StrideD{}, {M, N, 1});
+  using Cfg =
+      typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  auto layout_SFA = Cfg::tile_atom_to_shape_SFA(make_shape(M, N, K, 1));
+  auto layout_SFB = Cfg::tile_atom_to_shape_SFB(make_shape(M, N, K, 1));
+
+  using EA = typename ElementA::DataType;
+  using SA = typename ElementA::ScaleFactorType;
+
+  return typename Gemm::Arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm, {M, N, K, 1},
+      {reinterpret_cast<EA const*>(A), stride_A,
+       reinterpret_cast<EA const*>(B), stride_B,
+       reinterpret_cast<SA const*>(SFA), layout_SFA,
+       reinterpret_cast<SA const*>(SFB), layout_SFB},
+      {{},
+       reinterpret_cast<ElemC const*>(C), stride_C,
+       reinterpret_cast<ElemD*>(D), stride_D}};
+}
+
+}  // namespace bias_bf16_gemm
+
+int cutlass_fp4_gemm_bias_bf16(
+    void const* A_packed, void const* SFA,
+    void const* B_packed, void const* SFB,
+    void const* bias_bf16,
+    void* D_bf16,
+    int M, int N, int K, cudaStream_t stream) {
+  using namespace bias_bf16_gemm;
+  auto args = make_args<GemmBias, ElementCD, ElementCD>(
+      A_packed, SFA, B_packed, SFB, D_bf16, D_bf16, M, N, K);
+  args.epilogue.thread.alpha = 1.0f;
+  args.epilogue.thread.beta = 0.0f;
+  args.epilogue.thread.bias_ptr =
+      reinterpret_cast<ElementCD const*>(bias_bf16);
+  return run_gemm<GemmBias>(args, stream);
+}
+
+int cutlass_fp4_gemm_bias_res_bf16(
+    void const* A_packed, void const* SFA,
+    void const* B_packed, void const* SFB,
+    void const* bias_bf16,
+    void const* C_bf16, void* D_bf16,
+    int M, int N, int K, cudaStream_t stream) {
+  using namespace bias_bf16_gemm;
+  auto args = make_args<GemmBias, ElementCD, ElementCD>(
+      A_packed, SFA, B_packed, SFB, C_bf16, D_bf16, M, N, K);
+  args.epilogue.thread.alpha = 1.0f;
+  args.epilogue.thread.beta = 1.0f;
+  args.epilogue.thread.bias_ptr =
+      reinterpret_cast<ElementCD const*>(bias_bf16);
+  return run_gemm<GemmBias>(args, stream);
+}
+
+int cutlass_fp4_gemm_bias_gelu_fp4out_bf16(
+    void const* A_packed, void const* SFA,
+    void const* B_packed, void const* SFB,
+    void const* bias_bf16,
+    void* D_packed, void* D_SFD,
+    int M, int N, int K, cudaStream_t stream) {
+  using namespace bias_bf16_gemm;
+  auto args = make_args<GemmGelu, ElementDQ, ElementDQ>(
+      A_packed, SFA, B_packed, SFB, D_packed, D_packed, M, N, K);
+  args.epilogue.thread.alpha = 1.0f;
+  args.epilogue.thread.beta = 0.0f;
+  args.epilogue.thread.bias_ptr =
+      reinterpret_cast<ElementCD const*>(bias_bf16);
+  // The block-scale epilogue divides by a device-resident norm constant;
+  // 1.0 keeps the native per-16 dynamic scale. Allocated once, first call
+  // must happen before any CUDA Graph capture (warmup covers this).
+  static float* d_norm = nullptr;
+  if (!d_norm) {
+    if (cudaMalloc(&d_norm, sizeof(float)) != cudaSuccess) return -1;
+    float h = 1.0f;
+    cudaMemcpyAsync(d_norm, &h, sizeof(float), cudaMemcpyHostToDevice,
+                    stream);
+  }
+  args.epilogue.thread.block_scale_factor_ptr =
+      reinterpret_cast<bias_bf16_gemm::ElementSFD*>(D_SFD);
+  args.epilogue.thread.norm_constant_ptr = d_norm;
+  return run_gemm<GemmGelu>(args, stream);
+}
+
+}  // namespace fp4
+}  // namespace flash_rt

--- a/csrc/gemm/fp4/cutlass_fp4_gemm_bias_bf16_sm100.cuh
+++ b/csrc/gemm/fp4/cutlass_fp4_gemm_bias_bf16_sm100.cuh
@@ -1,0 +1,47 @@
+// ============================================================================
+//  FlashRT — NVFP4 GEMMs with bf16 fused-bias epilogues (SM100/SM110).
+//
+//  bf16 companions of the fp16 fused-epilogue NVFP4 GEMMs, for pipelines
+//  whose activations and biases are bf16 (GR00T N1.7 DiT). All three share
+//  the proven skinny-M block-scaled mainloop (tile 128x64x256, cluster
+//  1x1x1). A is row-major [M, K] packed e2m1, B is column-major [N, K]
+//  packed e2m1 (A @ B^T, nn.Linear convention); SFA/SFB use the CUTLASS
+//  Sm1xx tile-interleaved UE4M3 layout.
+//
+//  Additive: new symbols only; no existing kernel is modified.
+// ============================================================================
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace fp4 {
+
+// D_bf16[M,N] = A @ B^T + bias[N]
+int cutlass_fp4_gemm_bias_bf16(
+    void const* A_packed, void const* SFA,
+    void const* B_packed, void const* SFB,
+    void const* bias_bf16,
+    void* D_bf16,
+    int M, int N, int K, cudaStream_t stream);
+
+// D_bf16[M,N] = A @ B^T + bias[N] + C_bf16[M,N]   (residual; C may alias D)
+int cutlass_fp4_gemm_bias_res_bf16(
+    void const* A_packed, void const* SFA,
+    void const* B_packed, void const* SFB,
+    void const* bias_bf16,
+    void const* C_bf16, void* D_bf16,
+    int M, int N, int K, cudaStream_t stream);
+
+// D_fp4[M,N], SFD = blockscale(gelu_tanh(A @ B^T + bias[N]))
+// SFD is written in the SFA tile-interleaved layout over (M, N) so the
+// output can feed the K side of a following NVFP4 GEMM directly.
+int cutlass_fp4_gemm_bias_gelu_fp4out_bf16(
+    void const* A_packed, void const* SFA,
+    void const* B_packed, void const* SFB,
+    void const* bias_bf16,
+    void* D_packed, void* D_SFD,
+    int M, int N, int K, cudaStream_t stream);
+
+}  // namespace fp4
+}  // namespace flash_rt

--- a/csrc/kernels/attention_mha_masked.cu
+++ b/csrc/kernels/attention_mha_masked.cu
@@ -9,6 +9,10 @@
 //  uses k = S_kv, so the padding is never read anywhere and the pre-fill
 //  disappears.
 //
+//  Any S_kv is supported: rows up to SMM_MAX_COLS use a register-tiled
+//  softmax sized to the row, wider rows fall back to a multi-pass kernel
+//  that holds no per-column registers.
+//
 //  Additive: new symbols only.
 // ============================================================================
 #include <cuda_runtime.h>
@@ -90,10 +94,51 @@ __global__ void softmax_masked_kernel(T* data, int rows, int cols_pad,
     }
 }
 
+// Register-tiled variants above cap at SMM_MAX_COLS columns. Rows wider
+// than that go through this multi-pass kernel instead: it keeps no
+// per-column registers, so it is correct for any width. Three passes over
+// the row (max, exp+sum, scale) make it slower than the tiled path, which
+// is why it only runs past the tiled path's reach.
+template <typename T>
+__global__ void softmax_masked_wide_kernel(T* data, int rows, int cols_pad,
+                                           int cols_valid) {
+    const int lane = threadIdx.x % SMM_WARP;
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+
+    T* src = data + (long)row * cols_pad;
+
+    float mx = -1e30f;
+    for (int c = lane; c < cols_valid; c += SMM_WARP)
+        mx = fmaxf(mx, to_f<T>(src[c]));
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1)
+        mx = fmaxf(mx, __shfl_xor_sync(0xffffffffu, mx, o));
+
+    float sum = 0.f;
+    for (int c = lane; c < cols_valid; c += SMM_WARP) {
+        const float e = __expf(to_f<T>(src[c]) - mx);
+        src[c] = from_f<T>(e);
+        sum += e;
+    }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1)
+        sum += __shfl_xor_sync(0xffffffffu, sum, o);
+    const float inv = 1.0f / sum;
+
+    for (int c = lane; c < cols_valid; c += SMM_WARP)
+        src[c] = from_f<T>(to_f<T>(src[c]) * inv);
+}
+
 template <typename T>
 inline void launch_softmax_masked(T* data, int rows, int cols_pad,
                                   int cols_valid, cudaStream_t stream) {
     const int iters = (cols_valid + SMM_WARP - 1) / SMM_WARP;
+    if (iters > SMM_ITERS) {
+        softmax_masked_wide_kernel<T><<<rows, SMM_WARP, 0, stream>>>(
+            data, rows, cols_pad, cols_valid);
+        return;
+    }
     if (iters <= 2) {
         softmax_masked_kernel<T, 2><<<rows, SMM_WARP, 0, stream>>>(
             data, rows, cols_pad, cols_valid);

--- a/csrc/kernels/attention_mha_masked.cu
+++ b/csrc/kernels/attention_mha_masked.cu
@@ -1,0 +1,172 @@
+// ============================================================================
+//  FlashRT — MHA attention without the -inf logits pre-fill.
+//
+//  The plain ``attention_mha_{fp16,bf16}`` kernels softmax over the padded
+//  logits width, so callers must pre-fill the whole (NH, max_q, max_kv)
+//  scratch with -inf every invocation — a full DRAM sweep per layer. These
+//  variants run a column-masked softmax that reads and writes only the
+//  valid S_kv columns (row stride = padded width); the PV GEMM already
+//  uses k = S_kv, so the padding is never read anywhere and the pre-fill
+//  disappears.
+//
+//  Additive: new symbols only.
+// ============================================================================
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cublas_v2.h>
+
+#define SMM_WARP 32
+#define SMM_MAX_COLS 1024
+#define SMM_ITERS (SMM_MAX_COLS / SMM_WARP)
+
+namespace {
+
+template <typename T>
+__device__ __forceinline__ float to_f(T v);
+template <>
+__device__ __forceinline__ float to_f<__half>(__half v) { return __half2float(v); }
+template <>
+__device__ __forceinline__ float to_f<__nv_bfloat16>(__nv_bfloat16 v) { return __bfloat162float(v); }
+
+template <typename T>
+__device__ __forceinline__ T from_f(float v);
+template <>
+__device__ __forceinline__ __half from_f<__half>(float v) { return __float2half(v); }
+template <>
+__device__ __forceinline__ __nv_bfloat16 from_f<__nv_bfloat16>(float v) { return __float2bfloat16(v); }
+
+// Row-wise softmax over the first ``cols_valid`` of each ``cols_pad``-wide
+// row. Padding columns are neither read nor written.
+template <typename T>
+__global__ void softmax_masked_kernel(T* data, int rows, int cols_pad,
+                                      int cols_valid) {
+    const int lane = threadIdx.x % SMM_WARP;
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+
+    T* src = data + (long)row * cols_pad;
+
+    float reg[SMM_ITERS];
+    float mx = -1e30f;
+    #pragma unroll
+    for (int it = 0; it < SMM_ITERS; ++it) {
+        const int c = it * SMM_WARP + lane;
+        if (c < cols_valid) {
+            reg[it] = to_f<T>(src[c]);
+            mx = fmaxf(mx, reg[it]);
+        } else {
+            reg[it] = -1e30f;
+        }
+    }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1)
+        mx = fmaxf(mx, __shfl_xor_sync(0xffffffffu, mx, o));
+
+    float sum = 0.f;
+    #pragma unroll
+    for (int it = 0; it < SMM_ITERS; ++it) {
+        const int c = it * SMM_WARP + lane;
+        if (c < cols_valid) {
+            reg[it] = __expf(reg[it] - mx);
+            sum += reg[it];
+        }
+    }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1)
+        sum += __shfl_xor_sync(0xffffffffu, sum, o);
+    const float inv = 1.0f / sum;
+
+    #pragma unroll
+    for (int it = 0; it < SMM_ITERS; ++it) {
+        const int c = it * SMM_WARP + lane;
+        if (c < cols_valid)
+            src[c] = from_f<T>(reg[it] * inv);
+    }
+}
+
+}  // namespace
+
+extern "C" {
+
+void attention_mha_fp16_masked(
+    cublasHandle_t handle,
+    const __half* Q, const __half* K, const __half* V,
+    __half* logits, __half* out,
+    int S_q, int S_kv, int NH, int HD,
+    float attn_scale, cudaStream_t stream) {
+    cublasSetStream(handle, stream);
+    const int S_kv_pad = ((S_kv + 7) / 8) * 8;
+    float zero = 0.0f, one = 1.0f;
+    const long long strideC = (long long)S_q * S_kv_pad;
+
+    cublasGemmStridedBatchedEx(handle,
+        CUBLAS_OP_T, CUBLAS_OP_N,
+        S_kv, S_q, HD,
+        &attn_scale,
+        K, CUDA_R_16F, NH * HD, (long long)HD,
+        Q, CUDA_R_16F, NH * HD, (long long)HD,
+        &zero,
+        logits, CUDA_R_16F, S_kv_pad, strideC,
+        NH,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+
+    softmax_masked_kernel<__half><<<NH * S_q, SMM_WARP, 0, stream>>>(
+        logits, NH * S_q, S_kv_pad, S_kv);
+
+    cublasGemmStridedBatchedEx(handle,
+        CUBLAS_OP_N, CUBLAS_OP_N,
+        HD, S_q, S_kv,
+        &one,
+        V, CUDA_R_16F, NH * HD, (long long)HD,
+        logits, CUDA_R_16F, S_kv_pad, strideC,
+        &zero,
+        out, CUDA_R_16F, NH * HD, (long long)HD,
+        NH,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+}
+
+void attention_mha_bf16_masked(
+    cublasHandle_t handle,
+    const __nv_bfloat16* Q, const __nv_bfloat16* K, const __nv_bfloat16* V,
+    __nv_bfloat16* logits, __nv_bfloat16* out,
+    int S_q, int S_kv, int NH, int HD,
+    float attn_scale, int logits_kv_stride, int qkv_token_stride,
+    cudaStream_t stream) {
+    cublasSetStream(handle, stream);
+    const int S_kv_pad = ((S_kv + 7) / 8) * 8;
+    const int kv_stride = (logits_kv_stride > 0) ? logits_kv_stride : S_kv_pad;
+    // Token stride (elements) of the Q/K/V sources. NH*HD for packed
+    // per-site buffers; 3*NH*HD lets the fused-QKV GEMM output be read in
+    // place (no split copies).
+    const int tstride = (qkv_token_stride > 0) ? qkv_token_stride : NH * HD;
+    float zero = 0.0f, one = 1.0f;
+    const long long strideC = (long long)S_q * kv_stride;
+
+    cublasGemmStridedBatchedEx(handle,
+        CUBLAS_OP_T, CUBLAS_OP_N,
+        S_kv, S_q, HD,
+        &attn_scale,
+        K, CUDA_R_16BF, tstride, (long long)HD,
+        Q, CUDA_R_16BF, tstride, (long long)HD,
+        &zero,
+        logits, CUDA_R_16BF, kv_stride, strideC,
+        NH,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+
+    softmax_masked_kernel<__nv_bfloat16><<<NH * S_q, SMM_WARP, 0, stream>>>(
+        logits, NH * S_q, kv_stride, S_kv);
+
+    cublasGemmStridedBatchedEx(handle,
+        CUBLAS_OP_N, CUBLAS_OP_N,
+        HD, S_q, S_kv,
+        &one,
+        V, CUDA_R_16BF, tstride, (long long)HD,
+        logits, CUDA_R_16BF, kv_stride, strideC,
+        &zero,
+        out, CUDA_R_16BF, NH * HD, (long long)HD,
+        NH,
+        CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
+}
+
+}  // extern "C"

--- a/csrc/kernels/attention_mha_masked.cu
+++ b/csrc/kernels/attention_mha_masked.cu
@@ -38,7 +38,12 @@ __device__ __forceinline__ __nv_bfloat16 from_f<__nv_bfloat16>(float v) { return
 
 // Row-wise softmax over the first ``cols_valid`` of each ``cols_pad``-wide
 // row. Padding columns are neither read nor written.
-template <typename T>
+//
+// ITERS is the per-thread register tile, dispatched from the actual valid
+// column count: a 41-key DiT self-attention row needs 2 registers, not the
+// 32 a worst-case 1024-key row would. Sizing it per call keeps the loops
+// fully unrolled without paying occupancy for columns that do not exist.
+template <typename T, int ITERS>
 __global__ void softmax_masked_kernel(T* data, int rows, int cols_pad,
                                       int cols_valid) {
     const int lane = threadIdx.x % SMM_WARP;
@@ -47,10 +52,10 @@ __global__ void softmax_masked_kernel(T* data, int rows, int cols_pad,
 
     T* src = data + (long)row * cols_pad;
 
-    float reg[SMM_ITERS];
+    float reg[ITERS];
     float mx = -1e30f;
     #pragma unroll
-    for (int it = 0; it < SMM_ITERS; ++it) {
+    for (int it = 0; it < ITERS; ++it) {
         const int c = it * SMM_WARP + lane;
         if (c < cols_valid) {
             reg[it] = to_f<T>(src[c]);
@@ -65,7 +70,7 @@ __global__ void softmax_masked_kernel(T* data, int rows, int cols_pad,
 
     float sum = 0.f;
     #pragma unroll
-    for (int it = 0; it < SMM_ITERS; ++it) {
+    for (int it = 0; it < ITERS; ++it) {
         const int c = it * SMM_WARP + lane;
         if (c < cols_valid) {
             reg[it] = __expf(reg[it] - mx);
@@ -78,10 +83,32 @@ __global__ void softmax_masked_kernel(T* data, int rows, int cols_pad,
     const float inv = 1.0f / sum;
 
     #pragma unroll
-    for (int it = 0; it < SMM_ITERS; ++it) {
+    for (int it = 0; it < ITERS; ++it) {
         const int c = it * SMM_WARP + lane;
         if (c < cols_valid)
             src[c] = from_f<T>(reg[it] * inv);
+    }
+}
+
+template <typename T>
+inline void launch_softmax_masked(T* data, int rows, int cols_pad,
+                                  int cols_valid, cudaStream_t stream) {
+    const int iters = (cols_valid + SMM_WARP - 1) / SMM_WARP;
+    if (iters <= 2) {
+        softmax_masked_kernel<T, 2><<<rows, SMM_WARP, 0, stream>>>(
+            data, rows, cols_pad, cols_valid);
+    } else if (iters <= 4) {
+        softmax_masked_kernel<T, 4><<<rows, SMM_WARP, 0, stream>>>(
+            data, rows, cols_pad, cols_valid);
+    } else if (iters <= 8) {
+        softmax_masked_kernel<T, 8><<<rows, SMM_WARP, 0, stream>>>(
+            data, rows, cols_pad, cols_valid);
+    } else if (iters <= 16) {
+        softmax_masked_kernel<T, 16><<<rows, SMM_WARP, 0, stream>>>(
+            data, rows, cols_pad, cols_valid);
+    } else {
+        softmax_masked_kernel<T, SMM_ITERS><<<rows, SMM_WARP, 0, stream>>>(
+            data, rows, cols_pad, cols_valid);
     }
 }
 
@@ -111,8 +138,7 @@ void attention_mha_fp16_masked(
         NH,
         CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
 
-    softmax_masked_kernel<__half><<<NH * S_q, SMM_WARP, 0, stream>>>(
-        logits, NH * S_q, S_kv_pad, S_kv);
+    launch_softmax_masked<__half>(logits, NH * S_q, S_kv_pad, S_kv, stream);
 
     cublasGemmStridedBatchedEx(handle,
         CUBLAS_OP_N, CUBLAS_OP_N,
@@ -154,8 +180,8 @@ void attention_mha_bf16_masked(
         NH,
         CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT);
 
-    softmax_masked_kernel<__nv_bfloat16><<<NH * S_q, SMM_WARP, 0, stream>>>(
-        logits, NH * S_q, kv_stride, S_kv);
+    launch_softmax_masked<__nv_bfloat16>(logits, NH * S_q, kv_stride, S_kv,
+                                         stream);
 
     cublasGemmStridedBatchedEx(handle,
         CUBLAS_OP_N, CUBLAS_OP_N,

--- a/csrc/kernels/vec_fp16_backbone.cu
+++ b/csrc/kernels/vec_fp16_backbone.cu
@@ -1,0 +1,350 @@
+// ============================================================================
+//  FlashRT — vectorized fp16 backbone helpers (SM100/SM110-class).
+//
+//  16-byte-load rewrites of the small per-layer kernels that dominate the
+//  non-GEMM time of FP8 vision/LLM backbones at Thor-class DRAM latency:
+//  the scalar originals issue 2-4B accesses and sit at 50-100 GB/s
+//  (memory-latency-bound), far under the LPDDR5X floor.
+//
+//  Element math matches the original kernels exactly; rope / quantize /
+//  repeat-interleave are element-independent and therefore bit-exact.
+//  The norm reductions accumulate in fp32 like the originals but with a
+//  different (deterministic) summation order.
+//
+//  Additive: new symbols only; the scalar kernels are untouched.
+// ============================================================================
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cstdint>
+
+namespace {
+
+__device__ __forceinline__ float warp_sum(float v) {
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1)
+        v += __shfl_xor_sync(0xffffffffu, v, o);
+    return v;
+}
+
+__device__ __forceinline__ float block_sum_v(float v, float* sh) {
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    v = warp_sum(v);
+    if (lane == 0) sh[warp] = v;
+    __syncthreads();
+    if (warp == 0) {
+        v = (lane < ((blockDim.x + 31) >> 5)) ? sh[lane] : 0.f;
+        v = warp_sum(v);
+        if (lane == 0) sh[0] = v;
+    }
+    __syncthreads();
+    const float r = sh[0];
+    __syncthreads();
+    return r;
+}
+
+// ── RMSNorm, warp-per-row (small dim, e.g. per-head 128) ──────────────────
+__global__ void rms_norm_fp16_vec_warp_kernel(
+    const __half* __restrict__ x, const __half* __restrict__ w,
+    __half* __restrict__ out, int rows, int dim, float eps) {
+    const int warps_per_block = blockDim.x >> 5;
+    const int row = blockIdx.x * warps_per_block + (threadIdx.x >> 5);
+    if (row >= rows) return;
+    const int lane = threadIdx.x & 31;
+    const int n4 = dim >> 3;                       // int4 chunks per row
+    const int4* x4 = reinterpret_cast<const int4*>(x + (long)row * dim);
+    const int4* w4 = reinterpret_cast<const int4*>(w);
+    int4* o4 = reinterpret_cast<int4*>(out + (long)row * dim);
+
+    float ss = 0.f;
+    for (int i = lane; i < n4; i += 32) {
+        const int4 raw = x4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            const float v = __half2float(hh[j]);
+            ss += v * v;
+        }
+    }
+    ss = warp_sum(ss);
+    const float rms = rsqrtf(ss / dim + eps);
+
+    for (int i = lane; i < n4; i += 32) {
+        const int4 raw = x4[i];
+        const int4 wr = w4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        const __half* wh = reinterpret_cast<const __half*>(&wr);
+        int4 res;
+        __half* rh = reinterpret_cast<__half*>(&res);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            rh[j] = __float2half(
+                __half2float(hh[j]) * rms * __half2float(wh[j]));
+        o4[i] = res;
+    }
+}
+
+// ── RMSNorm, block-per-row (large dim, e.g. 2048) ─────────────────────────
+__global__ void rms_norm_fp16_vec_block_kernel(
+    const __half* __restrict__ x, const __half* __restrict__ w,
+    __half* __restrict__ out, int dim, float eps) {
+    const int row = blockIdx.x;
+    const int n4 = dim >> 3;
+    const int4* x4 = reinterpret_cast<const int4*>(x + (long)row * dim);
+    const int4* w4 = reinterpret_cast<const int4*>(w);
+    int4* o4 = reinterpret_cast<int4*>(out + (long)row * dim);
+    __shared__ float sh[32];
+
+    float ss = 0.f;
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            const float v = __half2float(hh[j]);
+            ss += v * v;
+        }
+    }
+    const float rms = rsqrtf(block_sum_v(ss, sh) / dim + eps);
+
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const int4 wr = w4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        const __half* wh = reinterpret_cast<const __half*>(&wr);
+        int4 res;
+        __half* rh = reinterpret_cast<__half*>(&res);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            rh[j] = __float2half(
+                __half2float(hh[j]) * rms * __half2float(wh[j]));
+        o4[i] = res;
+    }
+}
+
+// ── LayerNorm (gamma/beta), block-per-row ─────────────────────────────────
+__global__ void layer_norm_fp16_vec_kernel(
+    const __half* __restrict__ x, const __half* __restrict__ w,
+    const __half* __restrict__ b, __half* __restrict__ out,
+    int dim, float eps) {
+    const int row = blockIdx.x;
+    const int n4 = dim >> 3;
+    const int4* x4 = reinterpret_cast<const int4*>(x + (long)row * dim);
+    const int4* w4 = reinterpret_cast<const int4*>(w);
+    const int4* b4 = reinterpret_cast<const int4*>(b);
+    int4* o4 = reinterpret_cast<int4*>(out + (long)row * dim);
+    __shared__ float sh[32];
+
+    float s = 0.f;
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) s += __half2float(hh[j]);
+    }
+    const float mean = block_sum_v(s, sh) / dim;
+
+    float var = 0.f;
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            const float d = __half2float(hh[j]) - mean;
+            var += d * d;
+        }
+    }
+    const float inv_std = rsqrtf(block_sum_v(var, sh) / dim + eps);
+
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const int4 wr = w4[i];
+        const int4 br = b4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        const __half* wh = reinterpret_cast<const __half*>(&wr);
+        const __half* bh = reinterpret_cast<const __half*>(&br);
+        int4 res;
+        __half* rh = reinterpret_cast<__half*>(&res);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            rh[j] = __float2half(
+                (__half2float(hh[j]) - mean) * inv_std *
+                    __half2float(wh[j]) + __half2float(bh[j]));
+        o4[i] = res;
+    }
+}
+
+// ── Split-half RoPE, 8 pairs per thread ───────────────────────────────────
+__global__ void rope_rotate_half_fp16_vec_kernel(
+    __half* __restrict__ x, const __half* __restrict__ cos_t,
+    const __half* __restrict__ sin_t, int S, int NH, int half_hd) {
+    const int n4 = half_hd >> 3;                   // int4 chunks per half-row
+    const int total = S * NH * n4;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+    const int c = idx % n4;
+    const int rem = idx / n4;
+    const int h = rem % NH;
+    const int s = rem / NH;
+
+    const int HD = half_hd * 2;
+    __half* base = x + ((long)s * NH + h) * HD;
+    int4* lo4 = reinterpret_cast<int4*>(base) + c;
+    int4* hi4 = reinterpret_cast<int4*>(base + half_hd) + c;
+    const int4* c4 = reinterpret_cast<const int4*>(cos_t + (long)s * HD) + c;
+    const int4* s4 = reinterpret_cast<const int4*>(sin_t + (long)s * HD) + c;
+
+    const int4 lo_raw = *lo4;
+    const int4 hi_raw = *hi4;
+    const int4 c_raw = *c4;
+    const int4 s_raw = *s4;
+    const __half* lo = reinterpret_cast<const __half*>(&lo_raw);
+    const __half* hi = reinterpret_cast<const __half*>(&hi_raw);
+    const __half* cc = reinterpret_cast<const __half*>(&c_raw);
+    const __half* ss = reinterpret_cast<const __half*>(&s_raw);
+    int4 lo_out, hi_out;
+    __half* lop = reinterpret_cast<__half*>(&lo_out);
+    __half* hip = reinterpret_cast<__half*>(&hi_out);
+    #pragma unroll
+    for (int j = 0; j < 8; ++j) {
+        const float xl = __half2float(lo[j]);
+        const float xh = __half2float(hi[j]);
+        const float cv = __half2float(cc[j]);
+        const float sv = __half2float(ss[j]);
+        lop[j] = __float2half(xl * cv - xh * sv);
+        hip[j] = __float2half(xh * cv + xl * sv);
+    }
+    *lo4 = lo_out;
+    *hi4 = hi_out;
+}
+
+// ── Static FP8 quantize, 16 elements per thread ───────────────────────────
+__global__ void quantize_fp8_static_fp16_vec_kernel(
+    const int4* __restrict__ in, int4* __restrict__ out,
+    const float* __restrict__ descale_ptr, int n16) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n16) return;
+    const float inv_scale = 1.0f / fmaxf(*descale_ptr, 1e-12f);
+    const int4 rawA = in[2 * idx];
+    const int4 rawB = in[2 * idx + 1];
+    const __half* ha = reinterpret_cast<const __half*>(&rawA);
+    const __half* hb = reinterpret_cast<const __half*>(&rawB);
+    int4 res;
+    __nv_fp8_e4m3* rp = reinterpret_cast<__nv_fp8_e4m3*>(&res);
+    #pragma unroll
+    for (int j = 0; j < 8; ++j)
+        rp[j] = __nv_fp8_e4m3(
+            fminf(fmaxf(__half2float(ha[j]) * inv_scale, -448.f), 448.f));
+    #pragma unroll
+    for (int j = 0; j < 8; ++j)
+        rp[8 + j] = __nv_fp8_e4m3(
+            fminf(fmaxf(__half2float(hb[j]) * inv_scale, -448.f), 448.f));
+    out[idx] = res;
+}
+
+// ── GQA repeat-interleave head expand, 8 elements per thread ──────────────
+__global__ void repeat_interleave_heads_vec_kernel(
+    const int4* __restrict__ src, int4* __restrict__ dst,
+    int S, int NH_src, int hd4, int repeat) {
+    const int NH_dst = NH_src * repeat;
+    const int total = S * NH_dst * hd4;
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+    const int c = idx % hd4;
+    const int rem = idx / hd4;
+    const int h_dst = rem % NH_dst;
+    const int s = rem / NH_dst;
+    const int h_src = h_dst / repeat;
+    dst[((long)s * NH_dst + h_dst) * hd4 + c] =
+        src[((long)s * NH_src + h_src) * hd4 + c];
+}
+
+}  // namespace
+
+extern "C" {
+
+int rms_norm_fp16_vec(const __half* x, const __half* w, __half* out,
+                      int rows, int dim, float eps, cudaStream_t stream) {
+    if (dim % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(w) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
+    if (dim <= 512) {
+        const int warps = 8;
+        const int blocks = (rows + warps - 1) / warps;
+        rms_norm_fp16_vec_warp_kernel<<<blocks, warps * 32, 0, stream>>>(
+            x, w, out, rows, dim, eps);
+    } else {
+        rms_norm_fp16_vec_block_kernel<<<rows, 256, 0, stream>>>(
+            x, w, out, dim, eps);
+    }
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int layer_norm_fp16_vec(const __half* x, const __half* w, const __half* b,
+                        __half* out, int rows, int dim, float eps,
+                        cudaStream_t stream) {
+    if (dim % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(w) & 15) ||
+        (reinterpret_cast<uintptr_t>(b) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
+    layer_norm_fp16_vec_kernel<<<rows, 256, 0, stream>>>(
+        x, w, b, out, dim, eps);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int rope_rotate_half_fp16_vec(__half* x, const __half* cos_t,
+                              const __half* sin_t, int S, int NH, int HD,
+                              cudaStream_t stream) {
+    const int half_hd = HD / 2;
+    if (half_hd % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(cos_t) & 15) ||
+        (reinterpret_cast<uintptr_t>(sin_t) & 15)) return -1;
+    const int total = S * NH * (half_hd >> 3);
+    const int threads = 256;
+    rope_rotate_half_fp16_vec_kernel<<<
+        (total + threads - 1) / threads, threads, 0, stream>>>(
+        x, cos_t, sin_t, S, NH, half_hd);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int quantize_fp8_static_fp16_vec(const __half* in, __nv_fp8_e4m3* out,
+                                 const float* descale_ptr, int n,
+                                 cudaStream_t stream) {
+    if (n % 16 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(in) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
+    const int n16 = n / 16;
+    const int threads = 256;
+    quantize_fp8_static_fp16_vec_kernel<<<
+        (n16 + threads - 1) / threads, threads, 0, stream>>>(
+        reinterpret_cast<const int4*>(in), reinterpret_cast<int4*>(out),
+        descale_ptr, n16);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int gpu_repeat_interleave_heads_vec(const __half* src, __half* dst,
+                                    int S, int NH_src, int HD, int repeat,
+                                    cudaStream_t stream) {
+    if (HD % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(src) & 15) ||
+        (reinterpret_cast<uintptr_t>(dst) & 15)) return -1;
+    const int hd4 = HD >> 3;
+    const int total = S * NH_src * repeat * hd4;
+    const int threads = 256;
+    repeat_interleave_heads_vec_kernel<<<
+        (total + threads - 1) / threads, threads, 0, stream>>>(
+        reinterpret_cast<const int4*>(src), reinterpret_cast<int4*>(dst),
+        S, NH_src, hd4, repeat);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+}
+
+}  // extern "C"

--- a/csrc/kernels/vec_fp16_backbone.cu
+++ b/csrc/kernels/vec_fp16_backbone.cu
@@ -175,6 +175,65 @@ __global__ void layer_norm_fp16_vec_kernel(
     }
 }
 
+// ── LayerNorm (gamma/beta) fused with a static FP8 quantize ───────────────
+// The norm output feeds only an FP8 GEMM, so emitting fp8 directly removes
+// the fp16 intermediate's write and read-back (and one kernel launch).
+__global__ void layer_norm_fp8_static_fp16_vec_kernel(
+    const __half* __restrict__ x, const __half* __restrict__ w,
+    const __half* __restrict__ b, __nv_fp8_e4m3* __restrict__ out,
+    const float* __restrict__ descale_ptr, int dim, float eps) {
+    const int row = blockIdx.x;
+    const int n4 = dim >> 3;
+    const int4* x4 = reinterpret_cast<const int4*>(x + (long)row * dim);
+    const int4* w4 = reinterpret_cast<const int4*>(w);
+    const int4* b4 = reinterpret_cast<const int4*>(b);
+    uint2* o2 = reinterpret_cast<uint2*>(out + (long)row * dim);
+    __shared__ float sh[32];
+
+    float s = 0.f;
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) s += __half2float(hh[j]);
+    }
+    const float mean = block_sum_v(s, sh) / dim;
+
+    float var = 0.f;
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            const float d = __half2float(hh[j]) - mean;
+            var += d * d;
+        }
+    }
+    const float inv_std = rsqrtf(block_sum_v(var, sh) / dim + eps);
+    const float inv_scale = 1.0f / fmaxf(*descale_ptr, 1e-12f);
+
+    for (int i = threadIdx.x; i < n4; i += blockDim.x) {
+        const int4 raw = x4[i];
+        const int4 wr = w4[i];
+        const int4 br = b4[i];
+        const __half* hh = reinterpret_cast<const __half*>(&raw);
+        const __half* wh = reinterpret_cast<const __half*>(&wr);
+        const __half* bh = reinterpret_cast<const __half*>(&br);
+        uint2 res;
+        __nv_fp8_e4m3* rp = reinterpret_cast<__nv_fp8_e4m3*>(&res);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            // fp16 rounding of the norm output keeps this identical to the
+            // two-step (fp16 LayerNorm, then static quantize) chain.
+            const float v = __half2float(__float2half(
+                (__half2float(hh[j]) - mean) * inv_std * __half2float(wh[j]) +
+                __half2float(bh[j])));
+            rp[j] = __nv_fp8_e4m3(fminf(fmaxf(v * inv_scale, -448.f), 448.f));
+        }
+        o2[i] = res;
+    }
+}
+
 // ── Split-half RoPE, 8 pairs per thread ───────────────────────────────────
 __global__ void rope_rotate_half_fp16_vec_kernel(
     __half* __restrict__ x, const __half* __restrict__ cos_t,
@@ -293,6 +352,21 @@ int layer_norm_fp16_vec(const __half* x, const __half* w, const __half* b,
         (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
     layer_norm_fp16_vec_kernel<<<rows, 256, 0, stream>>>(
         x, w, b, out, dim, eps);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int layer_norm_fp8_static_fp16_vec(const __half* x, const __half* w,
+                                   const __half* b, __nv_fp8_e4m3* out,
+                                   const float* d_scale, int rows, int dim,
+                                   float eps, cudaStream_t stream) {
+    if (dim % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(w) & 15) ||
+        (reinterpret_cast<uintptr_t>(b) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 7)) return -1;
+    layer_norm_fp8_static_fp16_vec_kernel<<<rows, 256, 0, stream>>>(
+        x, w, b, out, d_scale, dim, eps);
     const cudaError_t e = cudaGetLastError();
     return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
 }

--- a/csrc/kernels/vec_fp16_backbone.cu
+++ b/csrc/kernels/vec_fp16_backbone.cu
@@ -302,6 +302,21 @@ __global__ void quantize_fp8_static_fp16_vec_kernel(
     out[idx] = res;
 }
 
+// ── Residual add, 8 elements per thread ───────────────────────────────────
+__global__ void residual_add_fp16_vec_kernel(
+    int4* __restrict__ residual, const int4* __restrict__ x, int n4) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n4) return;
+    int4 r = residual[idx];
+    const int4 v = x[idx];
+    __half* rh = reinterpret_cast<__half*>(&r);
+    const __half* vh = reinterpret_cast<const __half*>(&v);
+    #pragma unroll
+    for (int j = 0; j < 8; ++j)
+        rh[j] = __float2half(__half2float(rh[j]) + __half2float(vh[j]));
+    residual[idx] = r;
+}
+
 // ── GQA repeat-interleave head expand, 8 elements per thread ──────────────
 __global__ void repeat_interleave_heads_vec_kernel(
     const int4* __restrict__ src, int4* __restrict__ dst,
@@ -317,6 +332,18 @@ __global__ void repeat_interleave_heads_vec_kernel(
     const int h_src = h_dst / repeat;
     dst[((long)s * NH_dst + h_dst) * hd4 + c] =
         src[((long)s * NH_src + h_src) * hd4 + c];
+}
+
+// CTA width for the block-per-row norms: one thread per 16-byte vector,
+// rounded to a warp and capped at 256. A 1024-wide row has 128 vectors, so
+// a fixed 256-thread block would leave half the CTA idle through both
+// reduction passes.
+inline int norm_threads(int dim) {
+    const int vecs = dim >> 3;
+    int t = ((vecs + 31) / 32) * 32;
+    if (t < 32) t = 32;
+    if (t > 256) t = 256;
+    return t;
 }
 
 }  // namespace
@@ -335,7 +362,7 @@ int rms_norm_fp16_vec(const __half* x, const __half* w, __half* out,
         rms_norm_fp16_vec_warp_kernel<<<blocks, warps * 32, 0, stream>>>(
             x, w, out, rows, dim, eps);
     } else {
-        rms_norm_fp16_vec_block_kernel<<<rows, 256, 0, stream>>>(
+        rms_norm_fp16_vec_block_kernel<<<rows, norm_threads(dim), 0, stream>>>(
             x, w, out, dim, eps);
     }
     const cudaError_t e = cudaGetLastError();
@@ -350,7 +377,7 @@ int layer_norm_fp16_vec(const __half* x, const __half* w, const __half* b,
         (reinterpret_cast<uintptr_t>(w) & 15) ||
         (reinterpret_cast<uintptr_t>(b) & 15) ||
         (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
-    layer_norm_fp16_vec_kernel<<<rows, 256, 0, stream>>>(
+    layer_norm_fp16_vec_kernel<<<rows, norm_threads(dim), 0, stream>>>(
         x, w, b, out, dim, eps);
     const cudaError_t e = cudaGetLastError();
     return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
@@ -365,7 +392,7 @@ int layer_norm_fp8_static_fp16_vec(const __half* x, const __half* w,
         (reinterpret_cast<uintptr_t>(w) & 15) ||
         (reinterpret_cast<uintptr_t>(b) & 15) ||
         (reinterpret_cast<uintptr_t>(out) & 7)) return -1;
-    layer_norm_fp8_static_fp16_vec_kernel<<<rows, 256, 0, stream>>>(
+    layer_norm_fp8_static_fp16_vec_kernel<<<rows, norm_threads(dim), 0, stream>>>(
         x, w, b, out, d_scale, dim, eps);
     const cudaError_t e = cudaGetLastError();
     return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
@@ -400,6 +427,21 @@ int quantize_fp8_static_fp16_vec(const __half* in, __nv_fp8_e4m3* out,
         (n16 + threads - 1) / threads, threads, 0, stream>>>(
         reinterpret_cast<const int4*>(in), reinterpret_cast<int4*>(out),
         descale_ptr, n16);
+    const cudaError_t e = cudaGetLastError();
+    return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int residual_add_fp16_vec(__half* residual, const __half* x, int n,
+                          cudaStream_t stream) {
+    if (n % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(residual) & 15) ||
+        (reinterpret_cast<uintptr_t>(x) & 15)) return -1;
+    const int n4 = n >> 3;
+    const int threads = 256;
+    residual_add_fp16_vec_kernel<<<
+        (n4 + threads - 1) / threads, threads, 0, stream>>>(
+        reinterpret_cast<int4*>(residual),
+        reinterpret_cast<const int4*>(x), n4);
     const cudaError_t e = cudaGetLastError();
     return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
 }

--- a/csrc/quantize/quantize_fp4_sfa_bf16.cu
+++ b/csrc/quantize/quantize_fp4_sfa_bf16.cu
@@ -1,0 +1,142 @@
+// ============================================================================
+//  bf16-input vectorized fused FP4 quantize + CUTLASS SFA/SFB scales.
+//
+//  Same per-block scale selection and e2m1 rounding as
+//  quantize_fp4_dynamic_sfa_fp16_vec, with bf16 source elements. Each
+//  thread quantizes one 16-element block: two 16-byte loads, one 8-byte
+//  packed store, one SFA byte at the tile-interleaved offset.
+// ============================================================================
+#include "quantize_fp4_sfa_bf16.cuh"
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED) || defined(__CUDA_ARCH__)
+#  include "cutlass/cutlass.h"
+#  include "cutlass/detail/sm100_blockscaled_layout.hpp"
+#  include "cute/tensor.hpp"
+#  define FV_HAVE_CUTLASS 1
+#else
+#  define FV_HAVE_CUTLASS 0
+#endif
+
+namespace flash_rt {
+namespace fp4 {
+
+#if FV_HAVE_CUTLASS
+
+namespace {
+
+using CfgVecB = cutlass::detail::Sm1xxBlockScaledConfig<16>;
+
+__device__ __forceinline__ uint8_t fp32_to_e2m1_bvec(float x) {
+    uint8_t sign = (x < 0.f) ? 0x8u : 0x0u;
+    float ax = fabsf(x);
+    uint8_t mant;
+    if      (ax <= 0.25f) mant = 0u;
+    else if (ax <= 0.75f) mant = 1u;
+    else if (ax <= 1.25f) mant = 2u;
+    else if (ax <= 1.75f) mant = 3u;
+    else if (ax <= 2.5f)  mant = 4u;
+    else if (ax <= 3.5f)  mant = 5u;
+    else if (ax <= 5.0f)  mant = 6u;
+    else                  mant = 7u;
+    return sign | mant;
+}
+
+template <class LayoutSF>
+__global__ void kernel_quantize_fp4_sfa_bf16_vec(
+    const int4* __restrict__ src,      // bf16 [N, D] as int4 (8 elements)
+    uint2* __restrict__ dst_packed,    // [N, D/2] bytes as uint2 (1 block)
+    uint8_t* __restrict__ dst_sfa,
+    LayoutSF layout,
+    int N, int D8) {                   // D8 = D / 8 int4 chunks per row
+  const int block_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int row = blockIdx.y;
+  const int n_blocks = D8 >> 1;        // 16 elements per block
+  if (row >= N || block_idx >= n_blocks) return;
+
+  const int4 raw0 = src[row * D8 + 2 * block_idx];
+  const int4 raw1 = src[row * D8 + 2 * block_idx + 1];
+  const __nv_bfloat16* h0 = reinterpret_cast<const __nv_bfloat16*>(&raw0);
+  const __nv_bfloat16* h1 = reinterpret_cast<const __nv_bfloat16*>(&raw1);
+
+  float vals[16];
+  float amax = 0.f;
+  #pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    vals[i] = __bfloat162float(h0[i]);
+    vals[8 + i] = __bfloat162float(h1[i]);
+  }
+  #pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    const float a = fabsf(vals[i]);
+    if (a > amax) amax = a;
+  }
+
+  float desired = amax / 6.f;
+  if (desired < 1e-12f) desired = 1e-12f;
+  __nv_fp8_e4m3 bs_q = __nv_fp8_e4m3(fmaxf(desired, 0.f));
+  const float bs_dq = static_cast<float>(bs_q);
+
+  dst_sfa[layout(row, block_idx * 16, 0)] =
+      *reinterpret_cast<uint8_t*>(&bs_q);
+
+  const float inv_bs = 1.f / bs_dq;
+  uint2 out;
+  uint8_t* ob = reinterpret_cast<uint8_t*>(&out);
+  #pragma unroll
+  for (int p = 0; p < 8; ++p) {
+    const uint8_t lo = fp32_to_e2m1_bvec(vals[2 * p] * inv_bs);
+    const uint8_t hi = fp32_to_e2m1_bvec(vals[2 * p + 1] * inv_bs);
+    ob[p] = static_cast<uint8_t>(lo | (hi << 4));
+  }
+  dst_packed[row * n_blocks + block_idx] = out;
+}
+
+}  // namespace
+
+#endif  // FV_HAVE_CUTLASS
+
+int quantize_fp4_dynamic_sfa_bf16_vec(
+    const void* src_bf16, void* dst_packed, void* dst_sfa,
+    int N, int D, bool is_sfb, cudaStream_t stream) {
+#if FV_HAVE_CUTLASS
+  if (D % 16 != 0) return -1;
+  if ((reinterpret_cast<uintptr_t>(src_bf16) & 15) ||
+      (reinterpret_cast<uintptr_t>(dst_packed) & 7)) return -1;
+  const int n_blocks = D / 16;
+  const int threads = 128;
+  dim3 grid((n_blocks + threads - 1) / threads, N);
+
+  auto shape = cute::make_shape(
+      is_sfb ? 1 : N,
+      is_sfb ? N : 1,
+      D, 1);
+
+  if (is_sfb) {
+    auto layout = CfgVecB::tile_atom_to_shape_SFB(shape);
+    kernel_quantize_fp4_sfa_bf16_vec<<<grid, threads, 0, stream>>>(
+        reinterpret_cast<const int4*>(src_bf16),
+        reinterpret_cast<uint2*>(dst_packed),
+        reinterpret_cast<uint8_t*>(dst_sfa),
+        layout, N, D >> 3);
+  } else {
+    auto layout = CfgVecB::tile_atom_to_shape_SFA(shape);
+    kernel_quantize_fp4_sfa_bf16_vec<<<grid, threads, 0, stream>>>(
+        reinterpret_cast<const int4*>(src_bf16),
+        reinterpret_cast<uint2*>(dst_packed),
+        reinterpret_cast<uint8_t*>(dst_sfa),
+        layout, N, D >> 3);
+  }
+  const cudaError_t e = cudaGetLastError();
+  return (e == cudaSuccess) ? 0 : -static_cast<int>(e);
+#else
+  (void)src_bf16; (void)dst_packed; (void)dst_sfa;
+  (void)N; (void)D; (void)is_sfb; (void)stream;
+  return -2;
+#endif
+}
+
+}  // namespace fp4
+}  // namespace flash_rt

--- a/csrc/quantize/quantize_fp4_sfa_bf16.cuh
+++ b/csrc/quantize/quantize_fp4_sfa_bf16.cuh
@@ -1,0 +1,24 @@
+// ============================================================================
+//  FlashRT — bf16-input fused NVFP4 quantize + CUTLASS SFA/SFB scale write.
+//
+//  bf16 companion of quantize_fp4_dynamic_sfa_fp16 for pipelines whose
+//  activations are bf16 (GR00T N1.7 DiT). Additive: new symbols only.
+// ============================================================================
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace flash_rt {
+namespace fp4 {
+
+// Quantize a bf16 [N, D] row-major tensor to packed e2m1 [N, D/2] plus
+// UE4M3 per-16-element scales written directly at the CUTLASS
+// tile-interleaved SFA/SFB offsets. Vectorized (16-byte loads, 8-byte
+// packed stores). Returns 0 on success, -1 on unsupported shape or
+// misaligned buffers, -2 when built without CUTLASS.
+int quantize_fp4_dynamic_sfa_bf16_vec(
+    const void* src_bf16, void* dst_packed, void* dst_sfa,
+    int N, int D, bool is_sfb, cudaStream_t stream);
+
+}  // namespace fp4
+}  // namespace flash_rt

--- a/docs/benchmark_comparison.md
+++ b/docs/benchmark_comparison.md
@@ -61,6 +61,42 @@ There is no separate third local checkpoint beyond `GR00T-N1.6-3B` and
 | `groot_n17` / `GR00T-N1.7-3B` | RTX 4090 (SM89) | same real 2-view fixture, `T=40`, FP8, fixed SM89 DiT graph path, `use_dit_graph=True` | - | - | first graph capture excluded (`252.98 ms`) | **9.98 ms mean** over steady-state replays | July 3 local graph hot path before extra fusion; measured replays: 10.06 / 9.89 ms after capture | `(1, 40, 132)` finite |
 | `groot_n17` / `GR00T-N1.7-3B` | RTX 4090 (SM89) | same real 2-view fixture, `T=40`, FP8, same graph path plus existing fused `bias_gelu_quantize_fp8_static_bf16` on the DiT FFN up->down handoff | - | - | first graph capture excluded | **9.69 ms mean** over steady-state replays | July 3 local fused re-check; measured replays: 9.74 / 9.68 / 9.67 / 9.67 ms | `(1, 40, 132)` finite |
 
+### GROOT N1.7 on Jetson AGX Thor
+
+Reference numbers published by NVIDIA for the same model family on the
+same board, measured with their harness (`GR00T-N1.7` LIBERO fine-tune on
+`libero_10`, 4 denoising steps, batch size 1, medians over 20 iterations
+after 5 warmup iterations):
+
+| Source | Backbone | Action head | E2E | Frequency |
+|---|---:|---:|---:|---:|
+| PyTorch eager | 47.7 ms | 68.2 ms | ~126 ms | 8.0 Hz |
+| `torch.compile` | 48.6 ms | 46.8 ms | ~105 ms | 9.5 Hz |
+| TensorRT BF16 (full pipeline) | 27.0 ms | 45.0 ms | ~81 ms | 12.3 Hz |
+| TensorRT optimized + FP8 | 14.1 ms | 21.1 ms | ~44 ms | 22.6 Hz |
+| TensorRT optimized + mixed NVFP4 | 13.6 ms | 17.2 ms | ~40 ms | 25.1 Hz |
+
+FlashRT rows below use the same per-frame definition (vision backbone
+then action head, wall clock, medians over 20 iterations after warmup)
+but a different checkpoint and camera count, so they are **not** a
+like-for-like comparison with the table above — read the harness column.
+
+| FlashRT tier | Checkpoint / harness | Backbone | Action head | E2E | Frequency |
+|---|---|---:|---:|---:|---:|
+| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.6 ms | 26.7 ms | **50.0 ms** | 20 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.8 ms | 16.0 ms | **30.9 ms** | 32 Hz |
+
+Both rows come from one same-session A/B/A run on Jetson AGX Thor
+(JetPack 7.2, MAXN); the NVFP4 tier's action cosine against the FP8 tier
+on that fixture is 0.99994 and its CUDA-graph replays are bit-identical.
+Reproduce with:
+
+```bash
+python benchmarks/groot_n17_thor_latency.py \
+    --ckpt <n17-checkpoint-dir> --aux <aux-fixture.pt> \
+    --tier fp4 --views 2 --warmup 5 --iters 20
+```
+
 ### N1.7 SM89 Steady-State Hot Replay Profile
 
 Local Nsight Systems capture on **July 3, 2026** used the same real
@@ -89,6 +125,42 @@ Top individual kernels from that hot replay:
 | `add_bias_bf16_kernel` | **8.11%** | 570 | 1.48 us |
 | `sm89_xmma_gemm_e4m3bf16_e4m3f32_f32_tn_n_tilesize32x64x64_stage5...` | **6.48%** | 64 | 10.53 us |
 | `quantize_fp8_kernel_generic` | **3.00%** | 256 | 1.22 us |
+
+### GROOT N1.7 on Jetson AGX Thor
+
+Reference numbers published by NVIDIA for the same model family on the
+same board, measured with their harness (`GR00T-N1.7` LIBERO fine-tune on
+`libero_10`, 4 denoising steps, batch size 1, medians over 20 iterations
+after 5 warmup iterations):
+
+| Source | Backbone | Action head | E2E | Frequency |
+|---|---:|---:|---:|---:|
+| PyTorch eager | 47.7 ms | 68.2 ms | ~126 ms | 8.0 Hz |
+| `torch.compile` | 48.6 ms | 46.8 ms | ~105 ms | 9.5 Hz |
+| TensorRT BF16 (full pipeline) | 27.0 ms | 45.0 ms | ~81 ms | 12.3 Hz |
+| TensorRT optimized + FP8 | 14.1 ms | 21.1 ms | ~44 ms | 22.6 Hz |
+| TensorRT optimized + mixed NVFP4 | 13.6 ms | 17.2 ms | ~40 ms | 25.1 Hz |
+
+FlashRT rows below use the same per-frame definition (vision backbone
+then action head, wall clock, medians over 20 iterations after warmup)
+but a different checkpoint and camera count, so they are **not** a
+like-for-like comparison with the table above — read the harness column.
+
+| FlashRT tier | Checkpoint / harness | Backbone | Action head | E2E | Frequency |
+|---|---|---:|---:|---:|---:|
+| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.6 ms | 26.7 ms | **50.0 ms** | 20 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.8 ms | 16.0 ms | **30.9 ms** | 32 Hz |
+
+Both rows come from one same-session A/B/A run on Jetson AGX Thor
+(JetPack 7.2, MAXN); the NVFP4 tier's action cosine against the FP8 tier
+on that fixture is 0.99994 and its CUDA-graph replays are bit-identical.
+Reproduce with:
+
+```bash
+python benchmarks/groot_n17_thor_latency.py \
+    --ckpt <n17-checkpoint-dir> --aux <aux-fixture.pt> \
+    --tier fp4 --views 2 --warmup 5 --iters 20
+```
 
 ### N1.7 SM89 Steady-State Hot Replay Profile After Reusing Existing Fused Kernel
 

--- a/docs/benchmark_comparison.md
+++ b/docs/benchmark_comparison.md
@@ -83,12 +83,14 @@ like-for-like comparison with the table above — read the harness column.
 
 | FlashRT tier | Checkpoint / harness | Backbone | Action head | E2E | Frequency |
 |---|---|---:|---:|---:|---:|
-| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.6 ms | 26.7 ms | **50.0 ms** | 20 Hz |
-| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.8 ms | 16.0 ms | **30.9 ms** | 32 Hz |
+| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.5 ms | 26.5 ms | **50.2 ms** | 20 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.2 ms | 15.6 ms | **29.9 ms** | 33 Hz |
 
 Both rows come from one same-session A/B/A run on Jetson AGX Thor
-(JetPack 7.2, MAXN); the NVFP4 tier's action cosine against the FP8 tier
-on that fixture is 0.99994 and its CUDA-graph replays are bit-identical.
+(JetPack 7.2, MAXN) — FP8 51.6 ms, NVFP4 29.9 ms, FP8 50.2 ms, so the
+tier is 1.70x on that run. The NVFP4 tier's action cosine against the
+FP8 tier on that fixture is 0.99994 and its CUDA-graph replays are
+bit-identical.
 Reproduce with:
 
 ```bash
@@ -148,12 +150,14 @@ like-for-like comparison with the table above — read the harness column.
 
 | FlashRT tier | Checkpoint / harness | Backbone | Action head | E2E | Frequency |
 |---|---|---:|---:|---:|---:|
-| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.6 ms | 26.7 ms | **50.0 ms** | 20 Hz |
-| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.8 ms | 16.0 ms | **30.9 ms** | 32 Hz |
+| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.5 ms | 26.5 ms | **50.2 ms** | 20 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.2 ms | 15.6 ms | **29.9 ms** | 33 Hz |
 
 Both rows come from one same-session A/B/A run on Jetson AGX Thor
-(JetPack 7.2, MAXN); the NVFP4 tier's action cosine against the FP8 tier
-on that fixture is 0.99994 and its CUDA-graph replays are bit-identical.
+(JetPack 7.2, MAXN) — FP8 51.6 ms, NVFP4 29.9 ms, FP8 50.2 ms, so the
+tier is 1.70x on that run. The NVFP4 tier's action cosine against the
+FP8 tier on that fixture is 0.99994 and its CUDA-graph replays are
+bit-identical.
 Reproduce with:
 
 ```bash

--- a/docs/benchmark_comparison.md
+++ b/docs/benchmark_comparison.md
@@ -76,28 +76,49 @@ after 5 warmup iterations):
 | TensorRT optimized + FP8 | 14.1 ms | 21.1 ms | ~44 ms | 22.6 Hz |
 | TensorRT optimized + mixed NVFP4 | 13.6 ms | 17.2 ms | ~40 ms | 25.1 Hz |
 
-FlashRT rows below use the same per-frame definition (vision backbone
-then action head, wall clock, medians over 20 iterations after warmup)
-but a different checkpoint and camera count, so they are **not** a
-like-for-like comparison with the table above — read the harness column.
+FlashRT on the matched harness — the same `GR00T-N1.7` LIBERO
+fine-tune on `libero_10`, one camera, 4 denoising steps, batch 1,
+medians over 20 iterations after 5 warmup iterations, wall-clock
+vision-backbone then action-head split:
 
-| FlashRT tier | Checkpoint / harness | Backbone | Action head | E2E | Frequency |
-|---|---|---:|---:|---:|---:|
-| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.5 ms | 26.5 ms | **50.2 ms** | 20 Hz |
-| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.2 ms | 15.6 ms | **29.9 ms** | 33 Hz |
+| FlashRT tier | Backbone | Action head | E2E | Frequency |
+|---|---:|---:|---:|---:|
+| FP8 (default) | 11.0 ms | 25.8 ms | **36.8 ms** | 27.2 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | 8.4 ms | 15.2 ms | **23.7 ms** | 42.3 Hz |
 
-Both rows come from one same-session A/B/A run on Jetson AGX Thor
-(JetPack 7.2, MAXN) — FP8 51.6 ms, NVFP4 29.9 ms, FP8 50.2 ms, so the
-tier is 1.70x on that run. The NVFP4 tier's action cosine against the
-FP8 tier on that fixture is 0.99994 and its CUDA-graph replays are
-bit-identical.
+Measured as one same-session A/B/A on Jetson AGX Thor (JetPack 7.2,
+MAXN): FP8 36.76 ms, NVFP4 23.65 ms, FP8 36.85 ms. The fixture is a
+real `libero_10` observation captured through the official
+preprocessing path; the NVFP4 tier's action cosine against the FP8
+tier on it is 1.000000 and CUDA-graph replays are bit-identical on
+both tiers.
+
+The same tiers on the base `GR00T-N1.7-3B` checkpoint with a 2-view
+fixture (`T=40`, same protocol), for reference:
+
+| FlashRT tier | Backbone | Action head | E2E | Frequency |
+|---|---:|---:|---:|---:|
+| FP8 (default) | 23.5 ms | 26.5 ms | **50.2 ms** | 20 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | 14.2 ms | 15.6 ms | **29.9 ms** | 33 Hz |
+
+Also one same-session A/B/A (FP8 51.6 / NVFP4 29.9 / FP8 50.2 ms);
+action cosine against the FP8 tier on that fixture is 0.99994.
 Reproduce with:
 
 ```bash
+# LIBERO fine-tune, one camera (matched harness)
 python benchmarks/groot_n17_thor_latency.py \
-    --ckpt <n17-checkpoint-dir> --aux <aux-fixture.pt> \
+    --ckpt <n17-libero-checkpoint-dir> --aux <1-camera-aux-fixture.pt> \
+    --tier fp4 --views 1 --embodiment libero_sim --warmup 5 --iters 20
+
+# base checkpoint, two cameras
+python benchmarks/groot_n17_thor_latency.py \
+    --ckpt <n17-checkpoint-dir> --aux <2-camera-aux-fixture.pt> \
     --tier fp4 --views 2 --warmup 5 --iters 20
 ```
+
+Capture a camera-count-matched fixture with
+`tests/_helpers/groot_n17/capture_aux_multi.py --views N`.
 
 ### N1.7 SM89 Steady-State Hot Replay Profile
 
@@ -143,28 +164,49 @@ after 5 warmup iterations):
 | TensorRT optimized + FP8 | 14.1 ms | 21.1 ms | ~44 ms | 22.6 Hz |
 | TensorRT optimized + mixed NVFP4 | 13.6 ms | 17.2 ms | ~40 ms | 25.1 Hz |
 
-FlashRT rows below use the same per-frame definition (vision backbone
-then action head, wall clock, medians over 20 iterations after warmup)
-but a different checkpoint and camera count, so they are **not** a
-like-for-like comparison with the table above — read the harness column.
+FlashRT on the matched harness — the same `GR00T-N1.7` LIBERO
+fine-tune on `libero_10`, one camera, 4 denoising steps, batch 1,
+medians over 20 iterations after 5 warmup iterations, wall-clock
+vision-backbone then action-head split:
 
-| FlashRT tier | Checkpoint / harness | Backbone | Action head | E2E | Frequency |
-|---|---|---:|---:|---:|---:|
-| FP8 (default) | `GR00T-N1.7-3B`, 2-view real fixture, T=40, 4 steps | 23.5 ms | 26.5 ms | **50.2 ms** | 20 Hz |
-| NVFP4 + FA4 (`use_fp4=True`) | same fixture and steps | 14.2 ms | 15.6 ms | **29.9 ms** | 33 Hz |
+| FlashRT tier | Backbone | Action head | E2E | Frequency |
+|---|---:|---:|---:|---:|
+| FP8 (default) | 11.0 ms | 25.8 ms | **36.8 ms** | 27.2 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | 8.4 ms | 15.2 ms | **23.7 ms** | 42.3 Hz |
 
-Both rows come from one same-session A/B/A run on Jetson AGX Thor
-(JetPack 7.2, MAXN) — FP8 51.6 ms, NVFP4 29.9 ms, FP8 50.2 ms, so the
-tier is 1.70x on that run. The NVFP4 tier's action cosine against the
-FP8 tier on that fixture is 0.99994 and its CUDA-graph replays are
-bit-identical.
+Measured as one same-session A/B/A on Jetson AGX Thor (JetPack 7.2,
+MAXN): FP8 36.76 ms, NVFP4 23.65 ms, FP8 36.85 ms. The fixture is a
+real `libero_10` observation captured through the official
+preprocessing path; the NVFP4 tier's action cosine against the FP8
+tier on it is 1.000000 and CUDA-graph replays are bit-identical on
+both tiers.
+
+The same tiers on the base `GR00T-N1.7-3B` checkpoint with a 2-view
+fixture (`T=40`, same protocol), for reference:
+
+| FlashRT tier | Backbone | Action head | E2E | Frequency |
+|---|---:|---:|---:|---:|
+| FP8 (default) | 23.5 ms | 26.5 ms | **50.2 ms** | 20 Hz |
+| NVFP4 + FA4 (`use_fp4=True`) | 14.2 ms | 15.6 ms | **29.9 ms** | 33 Hz |
+
+Also one same-session A/B/A (FP8 51.6 / NVFP4 29.9 / FP8 50.2 ms);
+action cosine against the FP8 tier on that fixture is 0.99994.
 Reproduce with:
 
 ```bash
+# LIBERO fine-tune, one camera (matched harness)
 python benchmarks/groot_n17_thor_latency.py \
-    --ckpt <n17-checkpoint-dir> --aux <aux-fixture.pt> \
+    --ckpt <n17-libero-checkpoint-dir> --aux <1-camera-aux-fixture.pt> \
+    --tier fp4 --views 1 --embodiment libero_sim --warmup 5 --iters 20
+
+# base checkpoint, two cameras
+python benchmarks/groot_n17_thor_latency.py \
+    --ckpt <n17-checkpoint-dir> --aux <2-camera-aux-fixture.pt> \
     --tier fp4 --views 2 --warmup 5 --iters 20
 ```
+
+Capture a camera-count-matched fixture with
+`tests/_helpers/groot_n17/capture_aux_multi.py --views N`.
 
 ### N1.7 SM89 Steady-State Hot Replay Profile After Reusing Existing Fused Kernel
 

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -68,6 +68,10 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   `use_p1_split_gu` apply to the Pi0.5 torch and JAX NVFP4 encoder path on
   Thor. The JAX path loads Orbax checkpoints; the torch path loads
   safetensors checkpoints.
+- `use_fp4=True` with `config="groot_n17"` on Thor selects the GROOT N1.7
+  NVFP4 tier (NVFP4 DiT action head + cross-KV, vectorized backbone
+  kernels, FA4 attention when available). It takes no Pi0.5 sub-flags and
+  falls back to the FP8 tier when the `flash_rt_fp4` extension is missing.
 - `num_steps`, `vision_pool_factor`, `vision_num_layers`, and
   `cache_frames` apply only to frontends that expose those constructor
   parameters today. The Pi0.5 torch RTX/Orin frontend validates

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -624,6 +624,15 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             "fallback. For the non-quantized full-FP16 reference pass "
             "use_fp16=True together with use_fp8=False.")
 
+    # GROOT N1.7 on Thor with use_fp4=True: NVFP4 DiT action head +
+    # NVFP4 cross-KV + vectorized backbone tier on top of the FP8
+    # backbone (fastest verified Thor config).
+    _n17_thor_fp4 = (use_fp4 and config == "groot_n17"
+                     and framework == "torch" and arch == "thor")
+    if _n17_thor_fp4 and use_fp16:
+        raise ValueError("use_fp4=True is incompatible with use_fp16=True "
+                         "for GROOT N1.7 on Thor")
+
     if use_fp16:
         if config == "pi05" and framework == "torch" and arch == "thor":
             # Pi0.5 Thor keeps FP8 and full-FP16 in the same frontend; the
@@ -667,6 +676,28 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                         GrootN17TorchFrontendRtxFP16,
                     )
                     pipe_cls = GrootN17TorchFrontendRtxFP16
+
+    # ── FP4 routing (GROOT N1.7 torch on Thor) ──
+    if _n17_thor_fp4:
+        try:
+            import flash_rt.flash_rt_fp4 as _fvk_fp4_n17
+            if not _fvk_fp4_n17.has_nvfp4():
+                logger.warning(
+                    "flash_rt_fp4 loaded but has_nvfp4()=False (SM100+ "
+                    "required). Falling back to the FP8 tier.")
+                _n17_thor_fp4 = False
+        except ImportError:
+            logger.warning(
+                "flash_rt_fp4 extension not available. Falling back to the "
+                "FP8 tier.")
+            _n17_thor_fp4 = False
+        if _n17_thor_fp4:
+            from flash_rt.frontends.torch.groot_n17_thor_fp4 import (
+                GrootN17TorchFrontendThorFP4,
+            )
+            pipe_cls = GrootN17TorchFrontendThorFP4
+            logger.info("GROOT N1.7 Thor NVFP4 tier enabled")
+        use_fp4 = False  # do not fall through to the Pi0.5 FP4 routing
 
     # ── FP4 routing (Pi0.5 torch + Pi0.5 JAX on Thor) ──
     if use_fp4:

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -40,6 +40,11 @@ class GrootN17TorchFrontendThor:
     # accuracy baseline).
     _DIT_USE_FP8 = True
     _DIT_FP8_IMPL = "thor_epilogue"
+    # DiT quantization tier: "fp8" (calibrated FFN/QKV FP8, default) or
+    # "fp4" (every DiT GEMM as block-scaled NVFP4 with fused epilogues —
+    # see GrootN17TorchFrontendThorFP4). The DiT at M=41 is
+    # weight-bandwidth-bound, so the FP4 tier halves its dominant cost.
+    _DIT_QUANT = "fp8"
 
     def __init__(
         self,
@@ -833,7 +838,11 @@ class GrootN17TorchFrontendThor:
         # quantize. Skipped for the full-FP16 reference (``_DIT_USE_FP8`` off),
         # which keeps the DiT bf16 — dit_forward / _step_fwd fall back to the
         # bf16 path when the FP8 weights are absent from ``step_weights`` / ``bp``.
-        if self._DIT_USE_FP8:
+        if getattr(self, "_DIT_QUANT", "fp8") == "fp4":
+            # NVFP4 needs no activation calibration (per-16-element dynamic
+            # scales); just quantize the weights and splice the pointers.
+            self._quantize_dit_fp4(step_weights, bp, action_horizon)
+        elif self._DIT_USE_FP8:
             self._calibrate_quantize_dit_ffn(
                 num_inference_timesteps, action_horizon, _state_fwd, _ae_fwd,
                 _post_fwd, step_weights, bp, dims)
@@ -842,7 +851,8 @@ class GrootN17TorchFrontendThor:
             _ae_fwd(step, s)
             pipeline_thor.dit_forward(
                 gemm=self._gemm, fvk=K, bufs=bp, weights=step_weights[step],
-                dims=dims, attn=self._dit_attn, stream=s)
+                dims=dims, attn=self._dit_attn, stream=s,
+                fvk_fp4=getattr(self, "_fvk_fp4", None))
             _post_fwd(step, s)
 
         self._kdit_fwd = (_state_fwd, _step_fwd)

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -1839,6 +1839,8 @@ class GrootN17TorchFrontendThor:
                 "scale": 1.0 / (HD ** 0.5),
             },
         )
+        if getattr(self, "_KBB_VEC", False):
+            self._dit_attn._use_masked_softmax = True
 
     # ────────────────────────────────────────────────────────────────
     # Normalize / Denormalize helpers (statistics.json, q01/q99)

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -841,19 +841,7 @@ class GrootN17TorchFrontendThor:
         if getattr(self, "_DIT_QUANT", "fp8") == "fp4":
             # NVFP4 needs no activation calibration (per-16-element dynamic
             # scales); just quantize the weights and splice the pointers.
-            # With a per-layer protection set (_DIT_FP4_LAYERS not None),
-            # the protected layers fall back to the calibrated FP8 path, so
-            # both weight/scale sets are spliced.
-            protect = getattr(self, "_DIT_FP4_LAYERS", None)
-            if protect is not None:
-                self._calibrate_quantize_dit_ffn(
-                    num_inference_timesteps, action_horizon, _state_fwd,
-                    _ae_fwd, _post_fwd, step_weights, bp, dims)
             self._quantize_dit_fp4(step_weights, bp, action_horizon)
-            if protect is not None:
-                fp4_set = frozenset(int(x) for x in protect)
-                for sw in step_weights:
-                    sw["fp4_layers"] = fp4_set
         elif self._DIT_USE_FP8:
             self._calibrate_quantize_dit_ffn(
                 num_inference_timesteps, action_horizon, _state_fwd, _ae_fwd,

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -841,7 +841,19 @@ class GrootN17TorchFrontendThor:
         if getattr(self, "_DIT_QUANT", "fp8") == "fp4":
             # NVFP4 needs no activation calibration (per-16-element dynamic
             # scales); just quantize the weights and splice the pointers.
+            # With a per-layer protection set (_DIT_FP4_LAYERS not None),
+            # the protected layers fall back to the calibrated FP8 path, so
+            # both weight/scale sets are spliced.
+            protect = getattr(self, "_DIT_FP4_LAYERS", None)
+            if protect is not None:
+                self._calibrate_quantize_dit_ffn(
+                    num_inference_timesteps, action_horizon, _state_fwd,
+                    _ae_fwd, _post_fwd, step_weights, bp, dims)
             self._quantize_dit_fp4(step_weights, bp, action_horizon)
+            if protect is not None:
+                fp4_set = frozenset(int(x) for x in protect)
+                for sw in step_weights:
+                    sw["fp4_layers"] = fp4_set
         elif self._DIT_USE_FP8:
             self._calibrate_quantize_dit_ffn(
                 num_inference_timesteps, action_horizon, _state_fwd, _ae_fwd,
@@ -1459,7 +1471,8 @@ class GrootN17TorchFrontendThor:
         # into the GEMM epilogues. The gathered text/image sources are
         # shared across all 16 cross layers, so only two activation
         # quantizes run per frame.
-        if getattr(self, "_DIT_QUANT", "fp8") == "fp4":
+        if (getattr(self, "_DIT_QUANT", "fp8") == "fp4"
+                and getattr(self, "_CK_FP4", True)):
             import flash_rt.flash_rt_fp4 as fvk_fp4
             self._fvk_fp4 = fvk_fp4
             keep = []

--- a/flash_rt/frontends/torch/groot_n17_thor.py
+++ b/flash_rt/frontends/torch/groot_n17_thor.py
@@ -1453,6 +1453,54 @@ class GrootN17TorchFrontendThor:
             self._fvk = _fvk
         if not hasattr(self, "_mlp_gemm"):
             self._mlp_gemm = self._fvk.GemmRunner()
+        # NVFP4 cross-KV projections (FP4 DiT tier only): the 32 per-frame
+        # K/V GEMMs are weight-bandwidth-bound (bf16 weights are ~200 MB per
+        # frame); NVFP4 quarters the weight bytes and fuses the bias adds
+        # into the GEMM epilogues. The gathered text/image sources are
+        # shared across all 16 cross layers, so only two activation
+        # quantizes run per frame.
+        if getattr(self, "_DIT_QUANT", "fp8") == "fp4":
+            import flash_rt.flash_rt_fp4 as fvk_fp4
+            self._fvk_fp4 = fvk_fp4
+            keep = []
+            self._ck_fp4_keep = keep
+
+            def quant_w(w_kn):
+                w_nk = w_kn.t().contiguous().to(torch.float16)
+                Nw, Kw = w_nk.shape
+                packed = torch.empty(Nw, Kw // 2, dtype=torch.uint8,
+                                     device=dev)
+                sfb = torch.zeros(fvk_fp4.sfa_size_bytes(Nw, Kw, True),
+                                  dtype=torch.uint8, device=dev)
+                rc = fvk_fp4.quantize_fp4_dynamic_sfa_mse_fp16(
+                    w_nk.data_ptr(), packed.data_ptr(), sfb.data_ptr(),
+                    Nw, Kw, True, 0)
+                if rc != 0:
+                    raise RuntimeError(
+                        f"cross-KV FP4 weight quantize failed rc={rc}")
+                keep.extend([packed, sfb])
+                return packed.data_ptr(), sfb.data_ptr()
+
+            self._ck_kw_fp4 = []
+            self._ck_vw_fp4 = []
+            for j in range(16):
+                li = 2 * j
+                self._ck_kw_fp4.append(quant_w(self._dit_k_w[li]))
+                self._ck_vw_fp4.append(quant_w(self._dit_v_w[li]))
+            torch.cuda.synchronize()
+
+            def act_buf(rows, cols):
+                packed = torch.empty(rows, cols // 2, dtype=torch.uint8,
+                                     device=dev)
+                sfa = torch.zeros(
+                    fvk_fp4.sfa_size_bytes(rows, cols, False),
+                    dtype=torch.uint8, device=dev)
+                keep.extend([packed, sfa])
+                return packed, sfa
+
+            self._ck_text_fp4, self._ck_text_sfa = act_buf(nt, 2048)
+            self._ck_image_fp4, self._ck_image_sfa = act_buf(ni, 2048)
+
         # seed the buffers from the current backbone (eager) so a non-graph
         # consumer sees valid K/V immediately.
         self._ck_bb_src.copy_(self._backbone_features.reshape(S, 2048).half())
@@ -1472,11 +1520,44 @@ class GrootN17TorchFrontendThor:
         K.embedding_lookup_bf16(
             self._ck_image_idx.data_ptr(), self._ck_bb.data_ptr(),
             self._ck_image_src.data_ptr(), ni, 2048, s)
+        fp4 = getattr(self, "_fvk_fp4", None)
+        use_fp4 = fp4 is not None and hasattr(self, "_ck_kw_fp4")
+        if use_fp4:
+            rc = fp4.quantize_fp4_dynamic_sfa_bf16_vec(
+                self._ck_text_src.data_ptr(), self._ck_text_fp4.data_ptr(),
+                self._ck_text_sfa.data_ptr(), nt, 2048, False, s)
+            if rc != 0:
+                raise RuntimeError(f"cross-KV text quantize failed rc={rc}")
+            rc = fp4.quantize_fp4_dynamic_sfa_bf16_vec(
+                self._ck_image_src.data_ptr(), self._ck_image_fp4.data_ptr(),
+                self._ck_image_sfa.data_ptr(), ni, 2048, False, s)
+            if rc != 0:
+                raise RuntimeError(f"cross-KV image quantize failed rc={rc}")
         for j in range(16):
             li = 2 * j
             text = (li % 4 == 0)
-            src = self._ck_text_src if text else self._ck_image_src
             N = nt if text else ni
+            if use_fp4:
+                a_fp4 = self._ck_text_fp4 if text else self._ck_image_fp4
+                a_sfa = self._ck_text_sfa if text else self._ck_image_sfa
+                kw, ksf = self._ck_kw_fp4[j]
+                vw, vsf = self._ck_vw_fp4[j]
+                rc = fp4.cutlass_fp4_gemm_bias_bf16(
+                    a_fp4.data_ptr(), a_sfa.data_ptr(), kw, ksf,
+                    self._dit_k_b[li].data_ptr(),
+                    self._dit_cross_K[j].data_ptr(), N, 1536, 2048, s)
+                if rc != 0:
+                    raise RuntimeError(
+                        f"cross-KV FP4 K GEMM layer {li} failed rc={rc}")
+                rc = fp4.cutlass_fp4_gemm_bias_bf16(
+                    a_fp4.data_ptr(), a_sfa.data_ptr(), vw, vsf,
+                    self._dit_v_b[li].data_ptr(),
+                    self._dit_cross_V[j].data_ptr(), N, 1536, 2048, s)
+                if rc != 0:
+                    raise RuntimeError(
+                        f"cross-KV FP4 V GEMM layer {li} failed rc={rc}")
+                continue
+            src = self._ck_text_src if text else self._ck_image_src
             mg.bf16_nn(src.data_ptr(), self._dit_k_w[li].data_ptr(),
                        self._dit_cross_K[j].data_ptr(), N, 1536, 2048, s)
             K.add_bias_bf16(self._dit_cross_K[j].data_ptr(),

--- a/flash_rt/frontends/torch/groot_n17_thor_fp4.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp4.py
@@ -32,15 +32,7 @@ from flash_rt.frontends.torch.groot_n17_thor_fp8 import (
 
 
 class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
-    """N1.7 Thor inference frontend: FP8 backbone + NVFP4 DiT.
-
-    ``dit_fp8_layers`` optionally keeps a subset of DiT layers on the
-    calibrated FP8 path (precision ladder). The first few DiT layers are
-    the quantization-sensitive ones on edge fixtures: on the 8-sample
-    reference set the all-FP4 default holds worst-sample action cosine
-    ~0.998 vs the FP8 tier, and ``dit_fp8_layers=(0, 1, 2, 3)`` lifts it
-    to ~0.9993+ for roughly +2 ms per frame.
-    """
+    """N1.7 Thor inference frontend: FP8 backbone + NVFP4 DiT."""
 
     _DIT_QUANT = "fp4"
     # Backbone small-kernel tier: vectorized (16-byte-load) norm / rope /
@@ -50,17 +42,6 @@ class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
     # FA4 (CuTe-DSL) attention for the backbone MHA sites; falls back to
     # the fmha/cublas chain when the FA4 runtime deps are missing.
     _KBB_FA4 = True
-    # Layers that stay NVFP4 (None = all 32). Set via ``dit_fp8_layers``.
-    _DIT_FP4_LAYERS = None
-
-    def __init__(self, checkpoint_path, *, dit_fp8_layers=None, **kwargs):
-        if dit_fp8_layers:
-            protect = frozenset(int(x) for x in dit_fp8_layers)
-            bad = [x for x in protect if not (0 <= x < 32)]
-            if bad:
-                raise ValueError(f"dit_fp8_layers out of range: {bad}")
-            self._DIT_FP4_LAYERS = frozenset(range(32)) - protect
-        super().__init__(checkpoint_path, **kwargs)
 
     def _quantize_dit_fp4(self, step_weights, bp, action_horizon) -> None:
         """Quantize every DiT GEMM weight to NVFP4 (per-16 MSE block scales)

--- a/flash_rt/frontends/torch/groot_n17_thor_fp4.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp4.py
@@ -35,6 +35,10 @@ class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
     """N1.7 Thor inference frontend: FP8 backbone + NVFP4 DiT."""
 
     _DIT_QUANT = "fp4"
+    # Backbone small-kernel tier: vectorized (16-byte-load) norm / rope /
+    # quantize / GQA-expand rewrites. Same element math as the scalar
+    # kernels; the scalar originals are latency-bound at these shapes.
+    _KBB_VEC = True
 
     def _quantize_dit_fp4(self, step_weights, bp, action_horizon) -> None:
         """Quantize every DiT GEMM weight to NVFP4 (per-16 MSE block scales)

--- a/flash_rt/frontends/torch/groot_n17_thor_fp4.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp4.py
@@ -1,0 +1,128 @@
+"""GR00T N1.7 Thor frontend with an NVFP4 DiT action head.
+
+``GrootN17TorchFrontendThorFP4`` keeps the production FP8 backbone
+(``GrootN17TorchFrontendThorFP8``) and runs every DiT GEMM — fused
+self-attention QKV, cross-attention Q, attention output projection and
+both FFN projections — as a block-scaled NVFP4 GEMM with fused bf16
+bias epilogues:
+
+* QKV / cross-Q:   ``cutlass_fp4_gemm_bias_bf16``
+* O / FFN down:    ``cutlass_fp4_gemm_bias_res_bf16``  (residual fused)
+* FFN up:          ``cutlass_fp4_gemm_bias_gelu_fp4out_bf16`` (bias +
+                   tanh-GELU + FP4/SFA output feeding the down GEMM)
+
+Activation quantization is dynamic per-16-element (no calibration pass):
+the AdaLN and pre-FFN norms emit FP4 directly via the fused
+``ada_layer_norm_fp4_sfa_bf16`` / ``layer_norm_no_affine_fp4_sfa_bf16``
+kernels, and the attention output goes through
+``quantize_fp4_dynamic_sfa_bf16_vec``.
+
+At M = 41 (1 state + 40 action tokens) the DiT is weight-bandwidth
+bound; NVFP4 halves the weight bytes of the FP8 tier on its dominant
+cost and removes most per-layer elementwise launches.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flash_rt.frontends.torch.groot_n17_thor_fp8 import (
+    GrootN17TorchFrontendThorFP8,
+)
+
+
+class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
+    """N1.7 Thor inference frontend: FP8 backbone + NVFP4 DiT."""
+
+    _DIT_QUANT = "fp4"
+
+    def _quantize_dit_fp4(self, step_weights, bp, action_horizon) -> None:
+        """Quantize every DiT GEMM weight to NVFP4 (per-16 MSE block scales)
+        and splice the pointers + activation scratch buffers into
+        ``step_weights`` / ``bp`` so ``dit_forward`` takes the FP4 path."""
+        import flash_rt.flash_rt_fp4 as fvk_fp4
+        self._fvk_fp4 = fvk_fp4
+
+        dev = self.device
+        Sa = action_horizon + 1
+        D, FF = 1536, 6144
+        keep: list = []
+        self._dit_fp4_keep = keep
+
+        def quant_w(w_kn: torch.Tensor):
+            # Weights are stored [K, N] (input-major, bf16); the NVFP4 GEMM
+            # consumes B as packed [N, K] with SFB tile-interleaved scales.
+            w_nk = w_kn.t().contiguous().to(torch.float16)
+            N, K = w_nk.shape
+            packed = torch.empty(N, K // 2, dtype=torch.uint8, device=dev)
+            # SF buffers must be zero-initialized: the tile-interleaved
+            # layout rounds rows/K up to atom sizes and the quantize kernel
+            # only writes real coordinates — garbage in the padding decodes
+            # as UE4M3 NaN and poisons the accumulator.
+            sfb = torch.zeros(fvk_fp4.sfa_size_bytes(N, K, True),
+                              dtype=torch.uint8, device=dev)
+            rc = fvk_fp4.quantize_fp4_dynamic_sfa_mse_fp16(
+                w_nk.data_ptr(), packed.data_ptr(), sfb.data_ptr(),
+                N, K, True, 0)
+            if rc != 0:
+                raise RuntimeError(f"DiT FP4 weight quantize failed rc={rc}")
+            keep.extend([packed, sfb])
+            return packed.data_ptr(), sfb.data_ptr()
+
+        qkv_w, qkv_sfb, qkv_b = [], [], []
+        q_w, q_sfb = [], []
+        o_w, o_sfb = [], []
+        up_w, up_sfb = [], []
+        dn_w, dn_sfb = [], []
+        for li in range(32):
+            if li % 2 == 1:
+                pw, ps = quant_w(torch.cat(
+                    [self._dit_q_w[li], self._dit_k_w[li], self._dit_v_w[li]],
+                    dim=1))
+                qkv_w.append(pw)
+                qkv_sfb.append(ps)
+                qb = torch.cat([self._dit_q_b[li], self._dit_k_b[li],
+                                self._dit_v_b[li]]).bfloat16().contiguous()
+                keep.append(qb)
+                qkv_b.append(qb.data_ptr())
+            else:
+                pw, ps = quant_w(self._dit_q_w[li])
+                q_w.append(pw)
+                q_sfb.append(ps)
+            pw, ps = quant_w(self._dit_o_w[li])
+            o_w.append(pw)
+            o_sfb.append(ps)
+            pw, ps = quant_w(self._dit_ff_proj_w[li])
+            up_w.append(pw)
+            up_sfb.append(ps)
+            pw, ps = quant_w(self._dit_ff_down_w[li])
+            dn_w.append(pw)
+            dn_sfb.append(ps)
+        torch.cuda.synchronize()
+
+        # Activation scratch: packed e2m1 + zero-initialized SFA buffers.
+        def act_buf(cols):
+            packed = torch.empty(Sa, cols // 2, dtype=torch.uint8, device=dev)
+            sfa = torch.zeros(fvk_fp4.sfa_size_bytes(Sa, cols, False),
+                              dtype=torch.uint8, device=dev)
+            keep.extend([packed, sfa])
+            return packed, sfa
+
+        xn_fp4, xn_sfa = act_buf(D)
+        octx_fp4, octx_sfa = act_buf(D)
+        hid_fp4, hid_sfa = act_buf(FF)
+        self._k_qkv_buf = torch.empty(Sa, 3 * D, dtype=torch.bfloat16,
+                                      device=dev)
+
+        for sw in step_weights:
+            sw.update(
+                qkv_w_fp4=qkv_w, qkv_sfb=qkv_sfb, qkv_b_fp4=qkv_b,
+                q_w_fp4=q_w, q_sfb=q_sfb,
+                o_w_fp4=o_w, o_sfb=o_sfb,
+                ff_proj_w_fp4=up_w, ff_proj_sfb=up_sfb,
+                ff_down_w_fp4=dn_w, ff_down_sfb=dn_sfb)
+        bp.update(
+            xn_fp4=xn_fp4.data_ptr(), xn_sfa=xn_sfa.data_ptr(),
+            octx_fp4=octx_fp4.data_ptr(), octx_sfa=octx_sfa.data_ptr(),
+            hid_fp4=hid_fp4.data_ptr(), hid_sfa=hid_sfa.data_ptr(),
+            qkv_buf=self._k_qkv_buf.data_ptr())

--- a/flash_rt/frontends/torch/groot_n17_thor_fp4.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp4.py
@@ -47,6 +47,9 @@ class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
     # quantize / GQA-expand rewrites. Same element math as the scalar
     # kernels; the scalar originals are latency-bound at these shapes.
     _KBB_VEC = True
+    # FA4 (CuTe-DSL) attention for the backbone MHA sites; falls back to
+    # the fmha/cublas chain when the FA4 runtime deps are missing.
+    _KBB_FA4 = True
     # Layers that stay NVFP4 (None = all 32). Set via ``dit_fp8_layers``.
     _DIT_FP4_LAYERS = None
 

--- a/flash_rt/frontends/torch/groot_n17_thor_fp4.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp4.py
@@ -32,13 +32,32 @@ from flash_rt.frontends.torch.groot_n17_thor_fp8 import (
 
 
 class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
-    """N1.7 Thor inference frontend: FP8 backbone + NVFP4 DiT."""
+    """N1.7 Thor inference frontend: FP8 backbone + NVFP4 DiT.
+
+    ``dit_fp8_layers`` optionally keeps a subset of DiT layers on the
+    calibrated FP8 path (precision ladder). The first few DiT layers are
+    the quantization-sensitive ones on edge fixtures: on the 8-sample
+    reference set the all-FP4 default holds worst-sample action cosine
+    ~0.998 vs the FP8 tier, and ``dit_fp8_layers=(0, 1, 2, 3)`` lifts it
+    to ~0.9993+ for roughly +2 ms per frame.
+    """
 
     _DIT_QUANT = "fp4"
     # Backbone small-kernel tier: vectorized (16-byte-load) norm / rope /
     # quantize / GQA-expand rewrites. Same element math as the scalar
     # kernels; the scalar originals are latency-bound at these shapes.
     _KBB_VEC = True
+    # Layers that stay NVFP4 (None = all 32). Set via ``dit_fp8_layers``.
+    _DIT_FP4_LAYERS = None
+
+    def __init__(self, checkpoint_path, *, dit_fp8_layers=None, **kwargs):
+        if dit_fp8_layers:
+            protect = frozenset(int(x) for x in dit_fp8_layers)
+            bad = [x for x in protect if not (0 <= x < 32)]
+            if bad:
+                raise ValueError(f"dit_fp8_layers out of range: {bad}")
+            self._DIT_FP4_LAYERS = frozenset(range(32)) - protect
+        super().__init__(checkpoint_path, **kwargs)
 
     def _quantize_dit_fp4(self, step_weights, bp, action_horizon) -> None:
         """Quantize every DiT GEMM weight to NVFP4 (per-16 MSE block scales)

--- a/flash_rt/frontends/torch/groot_n17_thor_fp4.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp4.py
@@ -43,6 +43,30 @@ class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
     # the fmha/cublas chain when the FA4 runtime deps are missing.
     _KBB_FA4 = True
 
+    # Bindings this tier needs beyond the always-compiled set. They ship
+    # only on SM100-class builds (CMake: FLASHRT_HAVE_THOR_VLA_KERNELS), so
+    # probe once and fail with the build flag named rather than dying on an
+    # AttributeError deep inside graph capture.
+    _REQUIRED_BINDINGS = (
+        "rms_norm_fp16_vec", "layer_norm_fp16_vec",
+        "layer_norm_fp8_static_fp16_vec", "rope_rotate_half_fp16_vec",
+        "quantize_fp8_static_fp16_vec", "gpu_repeat_interleave_heads_vec",
+        "residual_add_fp16_vec", "attention_mha_fp16_masked",
+        "attention_mha_bf16_masked",
+    )
+
+    def __init__(self, *args, **kwargs):
+        import flash_rt.flash_rt_kernels as fvk
+        missing = [n for n in self._REQUIRED_BINDINGS if not hasattr(fvk, n)]
+        if missing:
+            raise RuntimeError(
+                "GROOT N1.7 Thor NVFP4 tier needs the Thor VLA helper "
+                "kernels, which this build of flash_rt_kernels does not "
+                f"carry (missing: {', '.join(missing)}). Rebuild for an "
+                "SM100-class GPU (cmake -B build -S . -DGPU_ARCH=110) or "
+                "use the FP8 tier (GrootN17TorchFrontendThorFP8).")
+        super().__init__(*args, **kwargs)
+
     def _quantize_dit_fp4(self, step_weights, bp, action_horizon) -> None:
         """Quantize every DiT GEMM weight to NVFP4 (per-16 MSE block scales)
         and splice the pointers + activation scratch buffers into

--- a/flash_rt/frontends/torch/groot_n17_thor_fp4.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp4.py
@@ -118,6 +118,12 @@ class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
         self._k_qkv_buf = torch.empty(Sa, 3 * D, dtype=torch.bfloat16,
                                       device=dev)
 
+        # Read the fused QKV GEMM output in place from the self-attn site
+        # (token stride 3D) — the three per-layer split copies disappear.
+        base = self._k_qkv_buf.data_ptr()
+        self._dit_attn._slots["dit_self"].update(
+            Q=base, K=base + 2 * D, V=base + 4 * D, qkv_stride=3 * D)
+
         for sw in step_weights:
             sw.update(
                 qkv_w_fp4=qkv_w, qkv_sfb=qkv_sfb, qkv_b_fp4=qkv_b,
@@ -129,4 +135,4 @@ class GrootN17TorchFrontendThorFP4(GrootN17TorchFrontendThorFP8):
             xn_fp4=xn_fp4.data_ptr(), xn_sfa=xn_sfa.data_ptr(),
             octx_fp4=octx_fp4.data_ptr(), octx_sfa=octx_sfa.data_ptr(),
             hid_fp4=hid_fp4.data_ptr(), hid_sfa=hid_sfa.data_ptr(),
-            qkv_buf=self._k_qkv_buf.data_ptr())
+            qkv_buf=self._k_qkv_buf.data_ptr(), qkv_strided=True)

--- a/flash_rt/frontends/torch/groot_n17_thor_fp8.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp8.py
@@ -293,6 +293,10 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
         # FP8 path. No activation scales are needed in this mode.
         fp16_ref = not self._KBB_USE_FP8
         sh = self._fp16_shadow_weights if fp16_ref else None
+        # Vectorized small-kernel tier (16-byte-load norm/rope/quant/expand
+        # rewrites) — opt-in via the FP4 frontend; element math matches the
+        # scalar kernels.
+        vec = bool(getattr(self, "_KBB_VEC", False))
 
         keep: list = []
         self._kbb_keep = keep
@@ -448,7 +452,8 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
         P.qwen3vl_vit_forward(
             gemm=gemm, fvk=fvkm, bufs=vit_bufs, weights=vw, scales_dev=vit_scales,
             dims={"S": Sv, "D": 1024, "NH": 16, "HD": 64,
-                  "ff_inner": 4096, "Sper_view": Sv // nv},
+                  "ff_inner": 4096, "Sper_view": Sv // nv,
+                  "vec_kernels": vec},
             attn=attn, deepstack_taps=tap_layers, deepstack_capture=dcap,
             use_fp8=self._KBB_USE_FP8)
 
@@ -602,7 +607,8 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
             "gu_fp8": buf8(Se, 6144).data_ptr()}
         P.qwen3vl_llm_forward(
             gemm=gemm, fvk=fvkm, bufs=llm_bufs, weights=lw, scales_dev=llm_scales,
-            dims={"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128, "FF": 6144},
+            dims={"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128,
+                  "FF": 6144, "vec_kernels": vec},
             attn=attn, fp16_layers=self.PROTECT_LLM_FP16)
 
         # ═══ vlln + VL self-attn (4L) ═══
@@ -666,9 +672,11 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
         # the caller before replay; the DeepStack inject scatter uses a fixed
         # index_copy (capturable) instead of boolean-mask assignment. ──
         vit_dims = {"S": Sv, "D": 1024, "NH": 16, "HD": 64,
-                    "ff_inner": 4096, "Sper_view": Sv // nv}
+                    "ff_inner": 4096, "Sper_view": Sv // nv,
+                    "vec_kernels": vec}
         ds_dims = {"Nin": Sv, "Din": 1024, "Nout": Nout, "Dmid": 4096, "Dout": 2048}
-        llm_dims = {"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128, "FF": 6144}
+        llm_dims = {"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128,
+                    "FF": 6144, "vec_kernels": vec}
         vlln_bufs = {"x": llm_h.data_ptr(), "out": vlsa_h.data_ptr()}
         vlln_w = {"vlln_w": self._vlln_w.data_ptr(), "vlln_b": self._vlln_b.data_ptr()}
         vsa_dims = {"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192}

--- a/flash_rt/frontends/torch/groot_n17_thor_fp8.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp8.py
@@ -356,6 +356,10 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
                              "O": 4, "logits": 5, "scale": 1.0 / (48 ** 0.5)},
         )
         self._kbb_attn = attn
+        if vec:
+            # Masked-softmax attention: drops the per-layer -inf logits
+            # pre-fill (see attn_backend run()).
+            attn._use_masked_softmax = True
 
         # ═══ ViT (24L) ═══
         vit_h = buf(Sv, 1024)
@@ -662,7 +666,8 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
         P.vl_self_attn_forward(
             gemm=gemm, fvk=fvkm, bufs=vsa_bufs,
             weights=vsw, scales_dev=vsa_scales,
-            dims={"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192},
+            dims={"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192,
+                  "vec_kernels": vec},
             attn=attn, use_fp8=self._KBB_USE_FP8)
         torch.cuda.synchronize()
 
@@ -679,7 +684,8 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
                     "FF": 6144, "vec_kernels": vec}
         vlln_bufs = {"x": llm_h.data_ptr(), "out": vlsa_h.data_ptr()}
         vlln_w = {"vlln_w": self._vlln_w.data_ptr(), "vlln_b": self._vlln_b.data_ptr()}
-        vsa_dims = {"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192}
+        vsa_dims = {"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192,
+                    "vec_kernels": vec}
         use_fp8 = self._KBB_USE_FP8
 
         def _kbb_forward(s=0):
@@ -717,7 +723,8 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
                                   scales_dev=llm_scales, dims=llm_dims, attn=attn,
                                   fp16_layers=self.PROTECT_LLM_FP16, stream=s)
             P.vlln_forward(gemm=None, fvk=fvkm, bufs=vlln_bufs, weights=vlln_w,
-                           dims={"S": Se, "D": 2048}, stream=s)
+                           dims={"S": Se, "D": 2048, "vec_kernels": vec},
+                           stream=s)
             P.vl_self_attn_forward(gemm=gemm, fvk=fvkm, bufs=vsa_bufs, weights=vsw,
                                    scales_dev=vsa_scales, dims=vsa_dims, attn=attn,
                                    use_fp8=use_fp8, stream=s)

--- a/flash_rt/frontends/torch/groot_n17_thor_fp8.py
+++ b/flash_rt/frontends/torch/groot_n17_thor_fp8.py
@@ -297,6 +297,10 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
         # rewrites) — opt-in via the FP4 frontend; element math matches the
         # scalar kernels.
         vec = bool(getattr(self, "_KBB_VEC", False))
+        # FA4 (CuTe-DSL) attention tier for the backbone's three MHA sites
+        # (ViT / LLM causal-GQA / VL-self-attn). Optional: the pipeline
+        # falls back to the fmha/cublas chain when FA4 is unavailable.
+        fa4_flag = bool(getattr(self, "_KBB_FA4", False))
 
         keep: list = []
         self._kbb_keep = keep
@@ -390,7 +394,8 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
                     "xn_fp8": buf8(Sv, 1024).data_ptr(),
                     "o_proj_out": buf(Sv, 1024).data_ptr(),
                     "fc1_out": buf(Sv, 4096).data_ptr(),
-                    "fc1_fp8": buf8(Sv, 4096).data_ptr()}
+                    "fc1_fp8": buf8(Sv, 4096).data_ptr(),
+                    "Q_t": vitQ, "K_t": vitKk, "V_t": vitV}
         vw = {k: [] for k in (
             "norm1_w", "norm1_b", "norm2_w", "norm2_b", "q_w", "q_b",
             "k_w", "k_b", "v_w", "v_b", "o_w", "o_b", "fc1_w", "fc1_b",
@@ -457,7 +462,7 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
             gemm=gemm, fvk=fvkm, bufs=vit_bufs, weights=vw, scales_dev=vit_scales,
             dims={"S": Sv, "D": 1024, "NH": 16, "HD": 64,
                   "ff_inner": 4096, "Sper_view": Sv // nv,
-                  "vec_kernels": vec},
+                  "vec_kernels": vec, "fa4": fa4_flag},
             attn=attn, deepstack_taps=tap_layers, deepstack_capture=dcap,
             use_fp8=self._KBB_USE_FP8)
 
@@ -602,8 +607,9 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
             "h": llm_h.data_ptr(), "xn": buf(Se, 2048).data_ptr(),
             "xn_fp8": buf8(Se, 2048).data_ptr(),
             "zero_bias": self._llm_zero_bias.data_ptr(),
-            "Q": llmQ.data_ptr(), "K": buf(Se, 1024).data_ptr(),
-            "V": buf(Se, 1024).data_ptr(),
+            "Q": llmQ.data_ptr(), "K": (llmKn := buf(Se, 1024)).data_ptr(),
+            "V": (llmVn := buf(Se, 1024)).data_ptr(),
+            "Q_t": llmQ, "K_t": llmKn, "V_t": llmVn,
             "K_exp": llmKx.data_ptr(), "V_exp": llmVx.data_ptr(),
             "o_proj_out": buf(Se, 2048).data_ptr(),
             "gate_out": buf(Se, 6144).data_ptr(),
@@ -612,7 +618,7 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
         P.qwen3vl_llm_forward(
             gemm=gemm, fvk=fvkm, bufs=llm_bufs, weights=lw, scales_dev=llm_scales,
             dims={"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128,
-                  "FF": 6144, "vec_kernels": vec},
+                  "FF": 6144, "vec_kernels": vec, "fa4": fa4_flag},
             attn=attn, fp16_layers=self.PROTECT_LLM_FP16)
 
         # ═══ vlln + VL self-attn (4L) ═══
@@ -662,12 +668,13 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
                     "xn_fp8": buf8(Se, 2048).data_ptr(),
                     "o_proj_out": buf(Se, 2048).data_ptr(),
                     "fc1_out": buf(Se, 8192).data_ptr(),
-                    "fc1_fp8": buf8(Se, 8192).data_ptr()}
+                    "fc1_fp8": buf8(Se, 8192).data_ptr(),
+                    "Q_t": vsaQ, "K_t": vsaK, "V_t": vsaV}
         P.vl_self_attn_forward(
             gemm=gemm, fvk=fvkm, bufs=vsa_bufs,
             weights=vsw, scales_dev=vsa_scales,
             dims={"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192,
-                  "vec_kernels": vec},
+                  "vec_kernels": vec, "fa4": fa4_flag},
             attn=attn, use_fp8=self._KBB_USE_FP8)
         torch.cuda.synchronize()
 
@@ -678,14 +685,14 @@ class GrootN17TorchFrontendThorFP8(GrootN17TorchFrontendThor):
         # index_copy (capturable) instead of boolean-mask assignment. ──
         vit_dims = {"S": Sv, "D": 1024, "NH": 16, "HD": 64,
                     "ff_inner": 4096, "Sper_view": Sv // nv,
-                    "vec_kernels": vec}
+                    "vec_kernels": vec, "fa4": fa4_flag}
         ds_dims = {"Nin": Sv, "Din": 1024, "Nout": Nout, "Dmid": 4096, "Dout": 2048}
         llm_dims = {"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8, "HD": 128,
-                    "FF": 6144, "vec_kernels": vec}
+                    "FF": 6144, "vec_kernels": vec, "fa4": fa4_flag}
         vlln_bufs = {"x": llm_h.data_ptr(), "out": vlsa_h.data_ptr()}
         vlln_w = {"vlln_w": self._vlln_w.data_ptr(), "vlln_b": self._vlln_b.data_ptr()}
         vsa_dims = {"T": Se, "D": 2048, "NH": 32, "HD": 64, "ff_inner": 8192,
-                    "vec_kernels": vec}
+                    "vec_kernels": vec, "fa4": fa4_flag}
         use_fp8 = self._KBB_USE_FP8
 
         def _kbb_forward(s=0):

--- a/flash_rt/hardware/thor/attn_backend_groot_n17.py
+++ b/flash_rt/hardware/thor/attn_backend_groot_n17.py
@@ -278,10 +278,28 @@ class ThorGrootN17AttnBackend(AttentionBackendBase):
         dtype = site_spec.extra.get("dtype", "fp16")
         is_causal = bool(site_spec.extra.get("causal", False))
 
+        # Masked-softmax tier (opt-in): the masked MHA variants softmax only
+        # the valid S_kv columns, so the full-buffer -inf pre-fill (a DRAM
+        # sweep per layer) disappears. The causal fp16 kernel already masks
+        # by position internally (including the padding columns), so its
+        # pre-fill is skipped outright.
+        masked = bool(getattr(self, "_use_masked_softmax", False))
+
         if dtype == "bf16":
             if is_causal:
                 raise ValueError(
                     f"site {site!r}: bf16 attention has no causal variant yet")
+            if masked:
+                fvk.attention_mha_bf16_masked(
+                    self._ctx_cpp[site],
+                    int(s["Q"]), K_ptr, V_ptr,
+                    int(s["logits"]), int(s["O"]),
+                    q_seq, kv_seq,
+                    site_spec.num_q_heads, site_spec.head_dim,
+                    float(s["scale"]), int(mkv),
+                    int(s.get("qkv_stride", 0)), stream,
+                )
+                return int(s["O"])
             fvk.gpu_fill_neginf_bf16(int(s["logits"]), nh * mq * mkv, stream)
             # logits buffer is allocated as (NH, max_q_seq, max_kv_seq)
             # row-major; pass the kv-axis stride so the GEMM head batching
@@ -297,9 +315,19 @@ class ThorGrootN17AttnBackend(AttentionBackendBase):
             )
             return int(s["O"])
 
-        fvk.gpu_fill_neginf_fp16(int(s["logits"]), nh * mq * mkv, stream)
+        if not masked:
+            fvk.gpu_fill_neginf_fp16(int(s["logits"]), nh * mq * mkv, stream)
         if is_causal:
             fvk.attention_mha_causal_fp16(
+                self._ctx_cpp[site],
+                int(s["Q"]), K_ptr, V_ptr,
+                int(s["logits"]), int(s["O"]),
+                q_seq, kv_seq,
+                site_spec.num_q_heads, site_spec.head_dim,
+                float(s["scale"]), stream,
+            )
+        elif masked:
+            fvk.attention_mha_fp16_masked(
                 self._ctx_cpp[site],
                 int(s["Q"]), K_ptr, V_ptr,
                 int(s["logits"]), int(s["O"]),

--- a/flash_rt/hardware/thor/fa4_backend.py
+++ b/flash_rt/hardware/thor/fa4_backend.py
@@ -51,8 +51,19 @@ def _load() -> None:
         _REASON = "disabled (FLASHRT_THOR_FA4=0)"
         return
 
-    # Thor target: sm_101a (sm_110's Blackwell alias). Don't clobber a user value.
-    os.environ.setdefault("CUTE_DSL_ARCH", "sm_101a")
+    # Thor compilation target. The accepted chip string depends on the
+    # installed nvidia-cutlass-dsl: 4.5+ needs ``sm_101a`` (the legacy
+    # sm_110 alias; its ``sm_110a`` path hits a chip-string bug), while
+    # 4.4.x only knows ``sm_110a``. Don't clobber a user value.
+    try:
+        import cutlass as _ctl  # nvidia-cutlass-dsl
+        _dsl_ver = tuple(
+            int(x) for x in str(getattr(_ctl, "__version__", "0.0"))
+            .split(".")[:2])
+    except Exception:  # noqa: BLE001 — any failure: assume the newer alias
+        _dsl_ver = (4, 5)
+    os.environ.setdefault(
+        "CUTE_DSL_ARCH", "sm_101a" if _dsl_ver >= (4, 5) else "sm_110a")
     os.environ.setdefault("FLASH_ATTENTION_ARCH", "sm_100a")
 
     # Allow an override dir (e.g. for local FA4 development), else the vendor.

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -899,6 +899,10 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
     # bias+residual, bias+GELU+fp4out) and the fused norm->fp4 front-ends
     # additionally remove most of the per-layer elementwise launches.
     use_fp4 = fvk_fp4 is not None and "ff_proj_w_fp4" in weights
+    # Optional per-layer precision ladder: layers not in ``fp4_layers``
+    # fall through to the calibrated FP8 path (whose weight/scale keys
+    # must also be spliced in). None/absent = every layer FP4.
+    fp4_layer_set = weights.get("fp4_layers")
 
     def _ck(rc, what, li):
         if rc != 0:
@@ -912,7 +916,7 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
         # layer index). Map here.
         j_attn = (li - 1) // 2 if is_self else li // 2
 
-        if use_fp4:
+        if use_fp4 and (fp4_layer_set is None or li in fp4_layer_set):
             xn_fp4, xn_sfa = int(bufs["xn_fp4"]), int(bufs["xn_sfa"])
             slots = attn.get_slot_ptrs("dit_self" if is_self else "dit_cross",
                                        j_attn)
@@ -1028,9 +1032,10 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_bf16(
                 int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
                 Sa, 3 * D, int(stream))
-            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
-            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
-            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+            if not bufs.get("qkv_strided"):
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
             attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
         elif is_self_fp8:
             # Fused FP8 QKV (self-attn): q/k/v share the post-AdaLN input,
@@ -1053,9 +1058,10 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_bf16(
                 int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
                 Sa, 3 * D, int(stream))
-            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
-            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
-            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+            if not bufs.get("qkv_strided"):
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
             attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
         else:
             gemm.bf16_nn(xn_ptr, int(weights["q_w"][li]),

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -193,13 +193,20 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
         slots = attn.get_slot_ptrs("vit", li)
         Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
 
-        # ── Pre-attn LayerNorm ──────────────────────────────────────────
-        _ln(h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
-            xn_ptr, S)
+        # ── Pre-attn LayerNorm (+ fused FP8 quantize on the vec tier) ───
+        if vec and use_fp8:
+            fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm1_w"][li]),
+                int(weights["norm1_b"][li]), xn_fp8_ptr,
+                int(scales_dev["act_qkv"][li]), S, D, 1e-6, int(stream))
+        else:
+            _ln(h_ptr, int(weights["norm1_w"][li]),
+                int(weights["norm1_b"][li]), xn_ptr, S)
 
         # ── Q/K/V projections (single shared act-scale on xn for FP8) ───
         if use_fp8:
-            _q8(xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]), S * D)
+            if not vec:
+                _q8(xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]), S * D)
             gemm.fp8_nn_bias(
                 xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr, int(weights["q_b"][li]),
                 S, D, D, float(weights["alpha_q"][li]), int(stream),
@@ -254,13 +261,20 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
         # ── Residual 1 ─────────────────────────────────────────────────
         fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
 
-        # ── Pre-FF LayerNorm ───────────────────────────────────────────
-        _ln(h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
-            xn_ptr, S)
+        # ── Pre-FF LayerNorm (+ fused FP8 quantize on the vec tier) ────
+        if vec and use_fp8:
+            fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm2_w"][li]),
+                int(weights["norm2_b"][li]), xn_fp8_ptr,
+                int(scales_dev["act_fc1"][li]), S, D, 1e-6, int(stream))
+        else:
+            _ln(h_ptr, int(weights["norm2_w"][li]),
+                int(weights["norm2_b"][li]), xn_ptr, S)
 
         # ── FF: D → FF (GELU) → D ──────────────────────────────────────
         if use_fp8:
-            _q8(xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]), S * D)
+            if not vec:
+                _q8(xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]), S * D)
             gemm.fp8_nn_gelu_bias(
                 xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
                 int(weights["fc1_b"][li]),
@@ -739,8 +753,13 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
         slots = attn.get_slot_ptrs("vl_self_attn", li)
         Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
 
-        # ── Pre-attn LayerNorm ──────────────────────────────────────────
-        if vec:
+        # ── Pre-attn LayerNorm (+ fused FP8 quantize on the vec tier) ───
+        if vec and use_fp8:
+            fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                xn_fp8_ptr, int(scales_dev["act_qkv"][li]), T, D, 1e-5,
+                int(stream))
+        elif vec:
             fvk.layer_norm_fp16_vec(
                 h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
                 xn_ptr, T, D, 1e-5, int(stream))
@@ -752,11 +771,7 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
 
         # ── Q / K / V projections (single shared act scale for FP8) ──────
         if use_fp8:
-            if vec:
-                fvk.quantize_fp8_static_fp16_vec(
-                    xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]),
-                    T * D, int(stream))
-            else:
+            if not vec:
                 fvk.quantize_fp8_static_fp16(
                     xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]),
                     T * D, int(stream),
@@ -815,8 +830,13 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
         # ── Residual 1: h += o_proj_out ────────────────────────────────
         fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
 
-        # ── Pre-FF LayerNorm ───────────────────────────────────────────
-        if vec:
+        # ── Pre-FF LayerNorm (+ fused FP8 quantize on the vec tier) ────
+        if vec and use_fp8:
+            fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+                xn_fp8_ptr, int(scales_dev["act_fc1"][li]), T, D, 1e-5,
+                int(stream))
+        elif vec:
             fvk.layer_norm_fp16_vec(
                 h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
                 xn_ptr, T, D, 1e-5, int(stream))
@@ -828,11 +848,7 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
 
         # ── FF: 2048 → 8192 (GELU) → 2048 ──────────────────────────────
         if use_fp8:
-            if vec:
-                fvk.quantize_fp8_static_fp16_vec(
-                    xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]),
-                    T * D, int(stream))
-            else:
+            if not vec:
                 fvk.quantize_fp8_static_fp16(
                     xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]),
                     T * D, int(stream),

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -70,6 +70,14 @@ def vlln_forward(gemm, fvk, bufs, weights, dims,
 # ─────────────────────────────────────────────────────────────────────────
 
 
+def _fa4(dims):
+    """Resolve the optional FA4 attention callable (None = fmha fallback)."""
+    if not dims.get("fa4"):
+        return None
+    from flash_rt.hardware.thor.fa4_backend import fa4_func
+    return fa4_func()
+
+
 def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
                         scales_dev, *, attn, stream: int = 0,
                         layers_subset=None,
@@ -161,6 +169,7 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
     # Vectorized small-kernel tier (16-byte loads): same element math as the
     # scalar kernels, far better DRAM efficiency at these shapes.
     vec = bool(dims.get("vec_kernels"))
+    fa4 = _fa4(dims)
 
     def _ln(x, w, b, out, rows):
         if vec:
@@ -214,12 +223,25 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
         _rope(Q_ptr)
         _rope(K_ptr)
 
-        # ── Multi-view batched FMHA (separated Q/K/V, stride=D) ─────────
-        attn.run("vit", li, q_seq=Sper, kv_seq=Sper, stream=int(stream))
+        # ── Multi-view batched attention (separated Q/K/V) ──────────────
+        # FA4 (CuTe-DSL) when available: one kernel per layer, views as the
+        # batch axis, output consumed directly by the o_proj quantize.
+        if fa4 is not None and use_fp8:
+            nv = max(1, S // Sper)
+            o_t = fa4(bufs["Q_t"].view(nv, Sper, NH, HD),
+                      bufs["K_t"].view(nv, Sper, NH, HD),
+                      bufs["V_t"].view(nv, Sper, NH, HD),
+                      causal=False)
+            if isinstance(o_t, tuple):
+                o_t = o_t[0]
+            attn_out_ptr = o_t.data_ptr()
+        else:
+            attn.run("vit", li, q_seq=Sper, kv_seq=Sper, stream=int(stream))
+            attn_out_ptr = O_ptr
 
         # ── o_proj ──────────────────────────────────────────────────────
         if use_fp8:
-            _q8(O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]), S * D)
+            _q8(attn_out_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]), S * D)
             gemm.fp8_nn_bias(
                 xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
                 int(weights["o_b"][li]),
@@ -458,6 +480,7 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
     inject_ptrs = weights.get("deepstack_inject", [0] * 16)
     layer_iter = range(16) if layers_subset is None else list(layers_subset)
     vec = bool(dims.get("vec_kernels"))
+    fa4 = _fa4(dims)
     # Per-layer precision protection: layers in ``fp16_layers`` run their
     # QKV / O / gate / up GEMMs in fp16 (no input fp8 quant) to protect the
     # large visual-token activation spikes that wreck per-tensor FP8 on the
@@ -541,19 +564,33 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
             fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NHQ,  HD, int(stream))
             fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NHKV, HD, int(stream))
 
-        # ── GQA expand: K, V from NHKV → NHQ heads ─────────────────────
-        if vec:
-            fvk.gpu_repeat_interleave_heads_vec(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
-            fvk.gpu_repeat_interleave_heads_vec(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
+        # ── Attention ──────────────────────────────────────────────────
+        # FA4 (CuTe-DSL) when available: causal GQA-native (pack_gqa), so
+        # the K/V head expand disappears and the output feeds the o_proj
+        # quantize directly. Fallback: expand to MHA + the cublas chain.
+        if fa4 is not None and not hi_prec:
+            o_t = fa4(bufs["Q_t"].view(1, S, NHQ, HD),
+                      bufs["K_t"].view(1, S, NHKV, HD),
+                      bufs["V_t"].view(1, S, NHKV, HD),
+                      causal=True, pack_gqa=True)
+            if isinstance(o_t, tuple):
+                o_t = o_t[0]
+            attn_out_ptr = o_t.data_ptr()
         else:
-            fvk.gpu_repeat_interleave_heads(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
-            fvk.gpu_repeat_interleave_heads(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
+            # ── GQA expand: K, V from NHKV → NHQ heads ─────────────────
+            if vec:
+                fvk.gpu_repeat_interleave_heads_vec(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
+                fvk.gpu_repeat_interleave_heads_vec(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
+            else:
+                fvk.gpu_repeat_interleave_heads(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
+                fvk.gpu_repeat_interleave_heads(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
 
-        # ── MHA via attn backend ───────────────────────────────────────
-        # Backend reads the LLM site's Q/K/V/O slots; we wrote the expanded
-        # K_exp/V_exp into those slot ptrs at allocation time so the kernel
-        # call is unchanged.
-        attn.run("llm", li, q_seq=S, kv_seq=S, stream=int(stream))
+            # ── MHA via attn backend ───────────────────────────────────
+            # Backend reads the LLM site's Q/K/V/O slots; we wrote the
+            # expanded K_exp/V_exp into those slot ptrs at allocation time
+            # so the kernel call is unchanged.
+            attn.run("llm", li, q_seq=S, kv_seq=S, stream=int(stream))
+            attn_out_ptr = int(slots["O"])
 
         if hi_prec:
             gemm.fp16_nn(int(slots["O"]), int(weights["o_w_fp16"][li]),
@@ -562,11 +599,11 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
             # ── Quantize O for o_proj ──────────────────────────────────
             if vec:
                 fvk.quantize_fp8_static_fp16_vec(
-                    int(slots["O"]), xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    attn_out_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
                     S * NHQ * HD, int(stream))
             else:
                 fvk.quantize_fp8_static_fp16(
-                    int(slots["O"]), xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    attn_out_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
                     S * NHQ * HD, int(stream),
                 )
             gemm.fp8_nn_bias(
@@ -687,6 +724,7 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
     HD = int(dims["HD"])
     FF = int(dims["ff_inner"])
     vec = bool(dims.get("vec_kernels"))
+    fa4 = _fa4(dims)
 
     h_ptr        = int(bufs["h"])
     xn_ptr       = int(bufs["xn"])
@@ -742,18 +780,28 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
                 gemm.fp16_nn(xn_ptr, int(weights[wk][li]), out, T, D, D, int(stream))
                 fvk.add_bias_fp16(out, int(weights[bk][li]), T, D, int(stream))
 
-        # ── MHA via attn backend (kernel pre-fills logits as needed) ────
-        attn.run("vl_self_attn", li, q_seq=T, kv_seq=T, stream=int(stream))
+        # ── Self-attention ─────────────────────────────────────────────
+        if fa4 is not None and use_fp8:
+            o_t = fa4(bufs["Q_t"].view(1, T, NH, HD),
+                      bufs["K_t"].view(1, T, NH, HD),
+                      bufs["V_t"].view(1, T, NH, HD),
+                      causal=False)
+            if isinstance(o_t, tuple):
+                o_t = o_t[0]
+            attn_out_ptr = o_t.data_ptr()
+        else:
+            attn.run("vl_self_attn", li, q_seq=T, kv_seq=T, stream=int(stream))
+            attn_out_ptr = O_ptr
 
         # ── o_proj ──────────────────────────────────────────────────────
         if use_fp8:
             if vec:
                 fvk.quantize_fp8_static_fp16_vec(
-                    O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    attn_out_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
                     T * D, int(stream))
             else:
                 fvk.quantize_fp8_static_fp16(
-                    O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    attn_out_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
                     T * D, int(stream),
                 )
             gemm.fp8_nn_bias(

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -751,7 +751,8 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
 
 
 def dit_forward(gemm, fvk, bufs, weights, dims,
-                *, attn, stream: int = 0, layers_subset=None) -> None:
+                *, attn, stream: int = 0, layers_subset=None,
+                fvk_fp4=None) -> None:
     """32-layer ``AlternateVLDiT`` (interleave_self_attention=True,
     attend_text_every_n_blocks=2). All bf16 GEMMs (no FP8 — N1.6 pattern).
 
@@ -822,12 +823,96 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
 
     layer_iter = range(32) if layers_subset is None else list(layers_subset)
 
+    # NVFP4 fast path: every DiT GEMM (fused QKV / cross-Q / O / FFN up /
+    # FFN down) runs as a block-scaled NVFP4 GEMM with a fused bf16 bias
+    # epilogue. At M=Sa=41 the DiT is weight-bandwidth-bound, so halving
+    # the weight bytes is the dominant win; the fused epilogues (bias,
+    # bias+residual, bias+GELU+fp4out) and the fused norm->fp4 front-ends
+    # additionally remove most of the per-layer elementwise launches.
+    use_fp4 = fvk_fp4 is not None and "ff_proj_w_fp4" in weights
+
+    def _ck(rc, what, li):
+        if rc != 0:
+            raise RuntimeError(
+                f"N1.7 DiT FP4 {what} layer {li} failed rc={rc}")
+
     for li in layer_iter:
         is_self = (li % 2 == 1)
         # Backend's ``dit_self`` and ``dit_cross`` sites are indexed
         # cross-only / self-only (16 entries each, NOT the full 0..31
         # layer index). Map here.
         j_attn = (li - 1) // 2 if is_self else li // 2
+
+        if use_fp4:
+            xn_fp4, xn_sfa = int(bufs["xn_fp4"]), int(bufs["xn_sfa"])
+            slots = attn.get_slot_ptrs("dit_self" if is_self else "dit_cross",
+                                       j_attn)
+            Q_ptr, K_ptr, V_ptr, O_ptr = (slots["Q"], slots["K"], slots["V"],
+                                          slots["O"])
+            # AdaLN-modulated norm1 -> fp4 + SFA (one fused kernel).
+            rc = fvk_fp4.ada_layer_norm_fp4_sfa_bf16(
+                h_ptr, int(weights["scale_msa"][li]),
+                int(weights["shift_msa"][li]),
+                xn_fp4, xn_sfa, Sa, D, 1e-5, int(stream))
+            _ck(rc, "adaln", li)
+            if is_self:
+                j = (li - 1) // 2
+                rc = fvk_fp4.cutlass_fp4_gemm_bias_bf16(
+                    xn_fp4, xn_sfa,
+                    int(weights["qkv_w_fp4"][j]), int(weights["qkv_sfb"][j]),
+                    int(weights["qkv_b_fp4"][j]), int(bufs["qkv_buf"]),
+                    Sa, 3 * D, D, int(stream))
+                _ck(rc, "qkv", li)
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+                attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa,
+                         stream=int(stream))
+            else:
+                rc = fvk_fp4.cutlass_fp4_gemm_bias_bf16(
+                    xn_fp4, xn_sfa,
+                    int(weights["q_w_fp4"][j_attn]),
+                    int(weights["q_sfb"][j_attn]),
+                    int(weights["q_b"][li]), Q_ptr,
+                    Sa, D, D, int(stream))
+                _ck(rc, "q", li)
+                target_text = (li % 4 == 0)
+                kv_seq = Skv_text if target_text else Skv_image
+                attn.run("dit_cross", j_attn, q_seq=Sa, kv_seq=kv_seq,
+                         stream=int(stream))
+            # O projection: quantize the attention output, then fused
+            # bias + residual straight into h.
+            rc = fvk_fp4.quantize_fp4_dynamic_sfa_bf16_vec(
+                O_ptr, int(bufs["octx_fp4"]), int(bufs["octx_sfa"]),
+                Sa, D, False, int(stream))
+            _ck(rc, "o-quant", li)
+            rc = fvk_fp4.cutlass_fp4_gemm_bias_res_bf16(
+                int(bufs["octx_fp4"]), int(bufs["octx_sfa"]),
+                int(weights["o_w_fp4"][li]), int(weights["o_sfb"][li]),
+                int(weights["o_b"][li]), h_ptr, h_ptr,
+                Sa, D, D, int(stream))
+            _ck(rc, "o", li)
+            # FFN: LN -> fp4, up GEMM with fused bias+GELU+fp4out, down
+            # GEMM with fused bias+residual into h.
+            rc = fvk_fp4.layer_norm_no_affine_fp4_sfa_bf16(
+                h_ptr, xn_fp4, xn_sfa, Sa, D, 1e-5, int(stream))
+            _ck(rc, "ffn-ln", li)
+            rc = fvk_fp4.cutlass_fp4_gemm_bias_gelu_fp4out_bf16(
+                xn_fp4, xn_sfa,
+                int(weights["ff_proj_w_fp4"][li]),
+                int(weights["ff_proj_sfb"][li]),
+                int(weights["ff_proj_b"][li]),
+                int(bufs["hid_fp4"]), int(bufs["hid_sfa"]),
+                Sa, FF, D, int(stream))
+            _ck(rc, "ffn-up", li)
+            rc = fvk_fp4.cutlass_fp4_gemm_bias_res_bf16(
+                int(bufs["hid_fp4"]), int(bufs["hid_sfa"]),
+                int(weights["ff_down_w_fp4"][li]),
+                int(weights["ff_down_sfb"][li]),
+                int(weights["ff_down_b"][li]), h_ptr, h_ptr,
+                Sa, D, FF, int(stream))
+            _ck(rc, "ffn-down", li)
+            continue
 
         # ── AdaLN modulated norm1 ─────────────────────────────────────
         # For self-attn FP8 QKV, fuse the AdaLN and the FP8 quantize into one

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -1015,9 +1015,9 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
                     Sa, 3 * D, D, int(stream))
                 _ck(rc, "qkv", li)
                 if not bufs.get("qkv_strided"):
-                    # Slots read the fused QKV output in place (token
-                    # stride 3D) when "qkv_strided" is set; otherwise
-                    # split into the packed per-slot buffers.
+                    # The self-attn slots normally alias the fused QKV
+                    # output (token stride 3D); split into packed per-slot
+                    # buffers only when they do not.
                     fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
                     fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
                     fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
@@ -1110,10 +1110,9 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_bf16(
                 int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
                 Sa, 3 * D, int(stream))
-            if not bufs.get("qkv_strided"):
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
             attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
         elif is_self_fp8:
             # Fused FP8 QKV (self-attn): q/k/v share the post-AdaLN input,
@@ -1136,10 +1135,9 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_bf16(
                 int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
                 Sa, 3 * D, int(stream))
-            if not bufs.get("qkv_strided"):
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
             attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
         else:
             gemm.bf16_nn(xn_ptr, int(weights["q_w"][li]),

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -47,6 +47,12 @@ def vlln_forward(gemm, fvk, bufs, weights, dims,
         weights["vlln_b"]    — beta  fp16 (D,)
         dims["S"], dims["D"] — flat sequence × hidden
     """
+    if dims.get("vec_kernels"):
+        fvk.layer_norm_fp16_vec(
+            int(bufs["x"]), int(weights["vlln_w"]), int(weights["vlln_b"]),
+            int(bufs["out"]), int(dims["S"]), int(dims["D"]), 1e-5,
+            int(stream))
+        return
     fvk.layer_norm_fp16(
         int(bufs["x"]),
         int(weights["vlln_w"]),
@@ -680,6 +686,7 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
     NH = int(dims["NH"])
     HD = int(dims["HD"])
     FF = int(dims["ff_inner"])
+    vec = bool(dims.get("vec_kernels"))
 
     h_ptr        = int(bufs["h"])
     xn_ptr       = int(bufs["xn"])
@@ -695,17 +702,27 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
         Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
 
         # ── Pre-attn LayerNorm ──────────────────────────────────────────
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
-            xn_ptr, T, D, 1e-5, int(stream),
-        )
+        if vec:
+            fvk.layer_norm_fp16_vec(
+                h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                xn_ptr, T, D, 1e-5, int(stream))
+        else:
+            fvk.layer_norm_fp16(
+                h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                xn_ptr, T, D, 1e-5, int(stream),
+            )
 
         # ── Q / K / V projections (single shared act scale for FP8) ──────
         if use_fp8:
-            fvk.quantize_fp8_static_fp16(
-                xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]),
-                T * D, int(stream),
-            )
+            if vec:
+                fvk.quantize_fp8_static_fp16_vec(
+                    xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]),
+                    T * D, int(stream))
+            else:
+                fvk.quantize_fp8_static_fp16(
+                    xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]),
+                    T * D, int(stream),
+                )
             gemm.fp8_nn_bias(
                 xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr, int(weights["q_b"][li]),
                 T, D, D, float(weights["alpha_q"][li]), int(stream),
@@ -730,10 +747,15 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
 
         # ── o_proj ──────────────────────────────────────────────────────
         if use_fp8:
-            fvk.quantize_fp8_static_fp16(
-                O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
-                T * D, int(stream),
-            )
+            if vec:
+                fvk.quantize_fp8_static_fp16_vec(
+                    O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    T * D, int(stream))
+            else:
+                fvk.quantize_fp8_static_fp16(
+                    O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    T * D, int(stream),
+                )
             gemm.fp8_nn_bias(
                 xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out, int(weights["o_b"][li]),
                 T, D, D, float(weights["alpha_o"][li]), int(stream),
@@ -746,26 +768,41 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
         fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
 
         # ── Pre-FF LayerNorm ───────────────────────────────────────────
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
-            xn_ptr, T, D, 1e-5, int(stream),
-        )
+        if vec:
+            fvk.layer_norm_fp16_vec(
+                h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+                xn_ptr, T, D, 1e-5, int(stream))
+        else:
+            fvk.layer_norm_fp16(
+                h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+                xn_ptr, T, D, 1e-5, int(stream),
+            )
 
         # ── FF: 2048 → 8192 (GELU) → 2048 ──────────────────────────────
         if use_fp8:
-            fvk.quantize_fp8_static_fp16(
-                xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]),
-                T * D, int(stream),
-            )
+            if vec:
+                fvk.quantize_fp8_static_fp16_vec(
+                    xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]),
+                    T * D, int(stream))
+            else:
+                fvk.quantize_fp8_static_fp16(
+                    xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]),
+                    T * D, int(stream),
+                )
             gemm.fp8_nn_gelu_bias(
                 xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
                 int(weights["fc1_b"][li]),
                 T, FF, D, float(weights["alpha_fc1"][li]), int(stream),
             )
-            fvk.quantize_fp8_static_fp16(
-                fc1_out_ptr, fc1_fp8_ptr, int(scales_dev["act_fc2"][li]),
-                T * FF, int(stream),
-            )
+            if vec:
+                fvk.quantize_fp8_static_fp16_vec(
+                    fc1_out_ptr, fc1_fp8_ptr, int(scales_dev["act_fc2"][li]),
+                    T * FF, int(stream))
+            else:
+                fvk.quantize_fp8_static_fp16(
+                    fc1_out_ptr, fc1_fp8_ptr, int(scales_dev["act_fc2"][li]),
+                    T * FF, int(stream),
+                )
             gemm.fp8_nn_bias(
                 fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
                 int(weights["fc2_b"][li]),
@@ -895,9 +932,13 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
                     int(weights["qkv_b_fp4"][j]), int(bufs["qkv_buf"]),
                     Sa, 3 * D, D, int(stream))
                 _ck(rc, "qkv", li)
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
-                fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+                if not bufs.get("qkv_strided"):
+                    # Slots read the fused QKV output in place (token
+                    # stride 3D) when "qkv_strided" is set; otherwise
+                    # split into the packed per-slot buffers.
+                    fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+                    fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+                    fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
                 attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa,
                          stream=int(stream))
             else:

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -171,6 +171,12 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
     vec = bool(dims.get("vec_kernels"))
     fa4 = _fa4(dims)
 
+    def _res(dst, src, n):
+        if vec:
+            fvk.residual_add_fp16_vec(dst, src, n, int(stream))
+        else:
+            fvk.residual_add_fp16(dst, src, n, int(stream))
+
     def _ln(x, w, b, out, rows):
         if vec:
             fvk.layer_norm_fp16_vec(x, w, b, out, rows, D, 1e-6, int(stream))
@@ -259,7 +265,7 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), S, D, int(stream))
 
         # ── Residual 1 ─────────────────────────────────────────────────
-        fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
+        _res(h_ptr, o_proj_out, S * D)
 
         # ── Pre-FF LayerNorm (+ fused FP8 quantize on the vec tier) ────
         if vec and use_fp8:
@@ -295,7 +301,7 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), S, D, int(stream))
 
         # ── Residual 2 ─────────────────────────────────────────────────
-        fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
+        _res(h_ptr, o_proj_out, S * D)
 
         # ── DeepStack tap callback ─────────────────────────────────────
         if deepstack_capture is not None and li in deepstack_taps:
@@ -495,6 +501,12 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
     layer_iter = range(16) if layers_subset is None else list(layers_subset)
     vec = bool(dims.get("vec_kernels"))
     fa4 = _fa4(dims)
+
+    def _res(dst, src, n):
+        if vec:
+            fvk.residual_add_fp16_vec(dst, src, n, int(stream))
+        else:
+            fvk.residual_add_fp16(dst, src, n, int(stream))
     # Per-layer precision protection: layers in ``fp16_layers`` run their
     # QKV / O / gate / up GEMMs in fp16 (no input fp8 quant) to protect the
     # large visual-token activation spikes that wreck per-tensor FP8 on the
@@ -629,7 +641,7 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
         # ── Residual 1 + Pre-FFN RMSNorm ──────────────────────────────
         # FP8 path fuses residual-add + RMSNorm + quantize into one kernel.
         if hi_prec:
-            fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
+            _res(h_ptr, o_out_ptr, S * D)
             fvk.rms_norm_fp16(
                 h_ptr, int(weights["post_ln_w"][li]), xn_ptr,
                 S, D, 1e-6, int(stream),
@@ -673,12 +685,12 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
             )
 
         # ── Residual 2 ────────────────────────────────────────────────
-        fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
+        _res(h_ptr, o_out_ptr, S * D)
 
         # ── DeepStack injection (HF: layers 0, 1, 2) ──────────────────
         inject_ptr = int(inject_ptrs[li]) if li < len(inject_ptrs) else 0
         if inject_ptr != 0:
-            fvk.residual_add_fp16(h_ptr, inject_ptr, S * D, int(stream))
+            _res(h_ptr, inject_ptr, S * D)
 
 
 def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
@@ -739,6 +751,12 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
     FF = int(dims["ff_inner"])
     vec = bool(dims.get("vec_kernels"))
     fa4 = _fa4(dims)
+
+    def _res(dst, src, n):
+        if vec:
+            fvk.residual_add_fp16_vec(dst, src, n, int(stream))
+        else:
+            fvk.residual_add_fp16(dst, src, n, int(stream))
 
     h_ptr        = int(bufs["h"])
     xn_ptr       = int(bufs["xn"])
@@ -828,7 +846,7 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), T, D, int(stream))
 
         # ── Residual 1: h += o_proj_out ────────────────────────────────
-        fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
+        _res(h_ptr, o_proj_out, T * D)
 
         # ── Pre-FF LayerNorm (+ fused FP8 quantize on the vec tier) ────
         if vec and use_fp8:
@@ -880,7 +898,7 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), T, D, int(stream))
 
         # ── Residual 2: h += fc2_out ───────────────────────────────────
-        fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
+        _res(h_ptr, o_proj_out, T * D)
 
 
 def dit_forward(gemm, fvk, bufs, weights, dims,

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -152,22 +152,39 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
     layer_iter = range(24) if layers_subset is None else list(layers_subset)
     Sper = int(dims.get("Sper_view", S))
 
+    # Vectorized small-kernel tier (16-byte loads): same element math as the
+    # scalar kernels, far better DRAM efficiency at these shapes.
+    vec = bool(dims.get("vec_kernels"))
+
+    def _ln(x, w, b, out, rows):
+        if vec:
+            fvk.layer_norm_fp16_vec(x, w, b, out, rows, D, 1e-6, int(stream))
+        else:
+            fvk.layer_norm_fp16(x, w, b, out, rows, D, 1e-6, int(stream))
+
+    def _q8(src, dst, scale, n):
+        if vec:
+            fvk.quantize_fp8_static_fp16_vec(src, dst, scale, n, int(stream))
+        else:
+            fvk.quantize_fp8_static_fp16(src, dst, scale, n, int(stream))
+
+    def _rope(ptr):
+        if vec:
+            fvk.rope_rotate_half_fp16_vec(ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
+        else:
+            fvk.rope_rotate_half_fp16(ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
+
     for li in layer_iter:
         slots = attn.get_slot_ptrs("vit", li)
         Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
 
         # ── Pre-attn LayerNorm ──────────────────────────────────────────
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
-            xn_ptr, S, D, 1e-6, int(stream),
-        )
+        _ln(h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+            xn_ptr, S)
 
         # ── Q/K/V projections (single shared act-scale on xn for FP8) ───
         if use_fp8:
-            fvk.quantize_fp8_static_fp16(
-                xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]),
-                S * D, int(stream),
-            )
+            _q8(xn_ptr, xn_fp8_ptr, int(scales_dev["act_qkv"][li]), S * D)
             gemm.fp8_nn_bias(
                 xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr, int(weights["q_b"][li]),
                 S, D, D, float(weights["alpha_q"][li]), int(stream),
@@ -188,18 +205,15 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
                 fvk.add_bias_fp16(out, int(weights[bk][li]), S, D, int(stream))
 
         # ── Split-half RoPE on Q and K (contiguous (S, NH, HD)) ─────────
-        fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
-        fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
+        _rope(Q_ptr)
+        _rope(K_ptr)
 
         # ── Multi-view batched FMHA (separated Q/K/V, stride=D) ─────────
         attn.run("vit", li, q_seq=Sper, kv_seq=Sper, stream=int(stream))
 
         # ── o_proj ──────────────────────────────────────────────────────
         if use_fp8:
-            fvk.quantize_fp8_static_fp16(
-                O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]),
-                S * D, int(stream),
-            )
+            _q8(O_ptr, xn_fp8_ptr, int(scales_dev["act_o"][li]), S * D)
             gemm.fp8_nn_bias(
                 xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
                 int(weights["o_b"][li]),
@@ -213,26 +227,19 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
         fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
 
         # ── Pre-FF LayerNorm ───────────────────────────────────────────
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
-            xn_ptr, S, D, 1e-6, int(stream),
-        )
+        _ln(h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
+            xn_ptr, S)
 
         # ── FF: D → FF (GELU) → D ──────────────────────────────────────
         if use_fp8:
-            fvk.quantize_fp8_static_fp16(
-                xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]),
-                S * D, int(stream),
-            )
+            _q8(xn_ptr, xn_fp8_ptr, int(scales_dev["act_fc1"][li]), S * D)
             gemm.fp8_nn_gelu_bias(
                 xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
                 int(weights["fc1_b"][li]),
                 S, FF, D, float(weights["alpha_fc1"][li]), int(stream),
             )
-            fvk.quantize_fp8_static_fp16(
-                fc1_out_ptr, fc1_fp8_ptr, int(scales_dev["act_fc2"][li]),
-                S * FF, int(stream),
-            )
+            _q8(fc1_out_ptr, fc1_fp8_ptr, int(scales_dev["act_fc2"][li]),
+                S * FF)
             gemm.fp8_nn_bias(
                 fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
                 int(weights["fc2_b"][li]),
@@ -444,6 +451,7 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
 
     inject_ptrs = weights.get("deepstack_inject", [0] * 16)
     layer_iter = range(16) if layers_subset is None else list(layers_subset)
+    vec = bool(dims.get("vec_kernels"))
     # Per-layer precision protection: layers in ``fp16_layers`` run their
     # QKV / O / gate / up GEMMs in fp16 (no input fp8 quant) to protect the
     # large visual-token activation spikes that wreck per-tensor FP8 on the
@@ -499,22 +507,41 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
             )
 
         # ── Per-head q_norm / k_norm (BEFORE M-RoPE — Qwen3 standard) ──
-        fvk.rms_norm_fp16(
-            Q_ptr, int(weights["q_norm_w"][li]), Q_ptr,
-            S * NHQ, HD, 1e-6, int(stream),
-        )
-        fvk.rms_norm_fp16(
-            K_ptr, int(weights["k_norm_w"][li]), K_ptr,
-            S * NHKV, HD, 1e-6, int(stream),
-        )
+        # These view (S, NH*HD) as (S*NH, HD): thousands of 128-wide rows,
+        # where the block-per-row scalar kernel is latency-bound — the vec
+        # tier runs a warp-per-row 16-byte-load variant instead.
+        if vec:
+            fvk.rms_norm_fp16_vec(
+                Q_ptr, int(weights["q_norm_w"][li]), Q_ptr,
+                S * NHQ, HD, 1e-6, int(stream))
+            fvk.rms_norm_fp16_vec(
+                K_ptr, int(weights["k_norm_w"][li]), K_ptr,
+                S * NHKV, HD, 1e-6, int(stream))
+        else:
+            fvk.rms_norm_fp16(
+                Q_ptr, int(weights["q_norm_w"][li]), Q_ptr,
+                S * NHQ, HD, 1e-6, int(stream),
+            )
+            fvk.rms_norm_fp16(
+                K_ptr, int(weights["k_norm_w"][li]), K_ptr,
+                S * NHKV, HD, 1e-6, int(stream),
+            )
 
         # ── M-RoPE on Q and K ──────────────────────────────────────────
-        fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NHQ,  HD, int(stream))
-        fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NHKV, HD, int(stream))
+        if vec:
+            fvk.rope_rotate_half_fp16_vec(Q_ptr, cos_ptr, sin_ptr, S, NHQ,  HD, int(stream))
+            fvk.rope_rotate_half_fp16_vec(K_ptr, cos_ptr, sin_ptr, S, NHKV, HD, int(stream))
+        else:
+            fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NHQ,  HD, int(stream))
+            fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NHKV, HD, int(stream))
 
         # ── GQA expand: K, V from NHKV → NHQ heads ─────────────────────
-        fvk.gpu_repeat_interleave_heads(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
-        fvk.gpu_repeat_interleave_heads(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
+        if vec:
+            fvk.gpu_repeat_interleave_heads_vec(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
+            fvk.gpu_repeat_interleave_heads_vec(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
+        else:
+            fvk.gpu_repeat_interleave_heads(K_ptr, K_exp_ptr, S, NHKV, HD, GQA, int(stream))
+            fvk.gpu_repeat_interleave_heads(V_ptr, V_exp_ptr, S, NHKV, HD, GQA, int(stream))
 
         # ── MHA via attn backend ───────────────────────────────────────
         # Backend reads the LLM site's Q/K/V/O slots; we wrote the expanded
@@ -527,10 +554,15 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
                          o_out_ptr, S, D, NHQ * HD, int(stream))
         else:
             # ── Quantize O for o_proj ──────────────────────────────────
-            fvk.quantize_fp8_static_fp16(
-                int(slots["O"]), xn_fp8_ptr, int(scales_dev["act_o"][li]),
-                S * NHQ * HD, int(stream),
-            )
+            if vec:
+                fvk.quantize_fp8_static_fp16_vec(
+                    int(slots["O"]), xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    S * NHQ * HD, int(stream))
+            else:
+                fvk.quantize_fp8_static_fp16(
+                    int(slots["O"]), xn_fp8_ptr, int(scales_dev["act_o"][li]),
+                    S * NHQ * HD, int(stream),
+                )
             gemm.fp8_nn_bias(
                 xn_fp8_ptr, int(weights["o_w"][li]), o_out_ptr,
                 int(bufs["zero_bias"]), S, D, NHQ * HD,

--- a/flash_rt/models/groot_n17/pipeline_thor.py
+++ b/flash_rt/models/groot_n17/pipeline_thor.py
@@ -981,10 +981,6 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
     # bias+residual, bias+GELU+fp4out) and the fused norm->fp4 front-ends
     # additionally remove most of the per-layer elementwise launches.
     use_fp4 = fvk_fp4 is not None and "ff_proj_w_fp4" in weights
-    # Optional per-layer precision ladder: layers not in ``fp4_layers``
-    # fall through to the calibrated FP8 path (whose weight/scale keys
-    # must also be spliced in). None/absent = every layer FP4.
-    fp4_layer_set = weights.get("fp4_layers")
 
     def _ck(rc, what, li):
         if rc != 0:
@@ -998,7 +994,7 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
         # layer index). Map here.
         j_attn = (li - 1) // 2 if is_self else li // 2
 
-        if use_fp4 and (fp4_layer_set is None or li in fp4_layer_set):
+        if use_fp4:
             xn_fp4, xn_sfa = int(bufs["xn_fp4"]), int(bufs["xn_sfa"])
             slots = attn.get_slot_ptrs("dit_self" if is_self else "dit_cross",
                                        j_attn)

--- a/tests/_helpers/groot_n17/capture_aux_multi.py
+++ b/tests/_helpers/groot_n17/capture_aux_multi.py
@@ -197,6 +197,10 @@ def main():
                     help="comma-separated traj:step pairs")
     ap.add_argument("--seed", type=int, default=0,
                     help="deterministic noise seed (re-applied per sample)")
+    ap.add_argument("--views", type=int, default=None,
+                    help="keep only the first N camera views of the "
+                         "embodiment's video modality (default: all). Use "
+                         "1 to capture a single-camera fixture.")
     ap.add_argument("--out", required=True,
                     help="output .pt path (list of aux dicts)")
     args = ap.parse_args()
@@ -224,6 +228,18 @@ def main():
         embodiment_tag=EmbodimentTag.resolve(args.tag),
         model_path=ckpt, device="cuda:0",
     )
+    if args.views is not None:
+        # Restrict the video modality to the first N camera keys. Both the
+        # policy transforms and the episode loader must agree, so trim the
+        # shared ModalityConfig before the loader is built.
+        vid = policy.modality_configs["video"]
+        if args.views < 1 or args.views > len(vid.modality_keys):
+            raise ValueError(
+                f"--views must be in [1, {len(vid.modality_keys)}] for tag "
+                f"{args.tag}")
+        vid.modality_keys = list(vid.modality_keys[:args.views])
+        print(f"views:   {vid.modality_keys}")
+
     print("loading dataset ...", flush=True)
     loader = LeRobotEpisodeLoader(
         dataset_path=args.dataset,
@@ -259,6 +275,7 @@ def main():
         entry["_meta"] = {
             "traj": traj_idx, "step": step_idx, "seed": args.seed,
             "ckpt": ckpt, "tag": args.tag,
+            "video_keys": list(policy.modality_configs["video"].modality_keys),
         }
         for k, v in entry.items():
             if hasattr(v, "shape"):

--- a/tests/test_groot_n17_thor_fp4_kernels.py
+++ b/tests/test_groot_n17_thor_fp4_kernels.py
@@ -295,6 +295,66 @@ def test_layer_norm_vec_matches_scalar(fvk):
     assert _cos(a, b) >= 0.99999
 
 
+@pytest.mark.parametrize("S_kv", [1024, 1025, 2048])
+def test_masked_softmax_mha_wide_rows(fvk, S_kv):
+    """Rows wider than the register-tiled path's reach still softmax
+    correctly — the boundary (1024) and the first row past it (1025) are
+    pinned explicitly, in both dtypes."""
+    torch.manual_seed(9)
+    S_q, NH, HD = 1, 1, 16
+    S_pad = ((S_kv + 7) // 8) * 8
+    ctx = fvk.FvkContext()
+
+    for dtype, masked, plain, fill in (
+        (torch.float16, fvk.attention_mha_fp16_masked,
+         fvk.attention_mha_fp16, fvk.gpu_fill_neginf_fp16),
+        (torch.bfloat16, fvk.attention_mha_bf16_masked,
+         fvk.attention_mha_bf16, fvk.gpu_fill_neginf_bf16),
+    ):
+        q = torch.randn(S_q, NH * HD, dtype=dtype, device=DEV)
+        k = torch.randn(S_kv, NH * HD, dtype=dtype, device=DEV)
+        v = torch.randn(S_kv, NH * HD, dtype=dtype, device=DEV)
+        logits = torch.empty(NH, S_q, S_pad, dtype=dtype, device=DEV)
+        out_ref = torch.empty(S_q, NH * HD, dtype=dtype, device=DEV)
+        out_new = torch.empty_like(out_ref)
+        scale = 1.0 / (HD ** 0.5)
+
+        fill(logits.data_ptr(), NH * S_q * S_pad, 0)
+        if dtype is torch.float16:
+            plain(ctx, q.data_ptr(), k.data_ptr(), v.data_ptr(),
+                  logits.data_ptr(), out_ref.data_ptr(),
+                  S_q, S_kv, NH, HD, scale, 0)
+        else:
+            plain(ctx, q.data_ptr(), k.data_ptr(), v.data_ptr(),
+                  logits.data_ptr(), out_ref.data_ptr(),
+                  S_q, S_kv, NH, HD, scale, S_pad, 0)
+        logits.fill_(float("nan"))
+        if dtype is torch.float16:
+            masked(ctx, q.data_ptr(), k.data_ptr(), v.data_ptr(),
+                   logits.data_ptr(), out_new.data_ptr(),
+                   S_q, S_kv, NH, HD, scale, 0)
+        else:
+            masked(ctx, q.data_ptr(), k.data_ptr(), v.data_ptr(),
+                   logits.data_ptr(), out_new.data_ptr(),
+                   S_q, S_kv, NH, HD, scale, S_pad, 0, 0)
+        torch.cuda.synchronize()
+
+        # Reference the math directly too: the pre-filled kernel shares the
+        # 1024-column ceiling, so it cannot arbitrate past it on its own.
+        ref = torch.nn.functional.scaled_dot_product_attention(
+            q.view(S_q, NH, HD).permute(1, 0, 2).float(),
+            k.view(S_kv, NH, HD).permute(1, 0, 2).float(),
+            v.view(S_kv, NH, HD).permute(1, 0, 2).float(),
+        ).permute(1, 0, 2).reshape(S_q, NH * HD)
+        assert torch.isfinite(out_new.float()).all(), (
+            f"{dtype} S_kv={S_kv}: masked softmax produced non-finite output")
+        cos = _cos(out_new, ref)
+        max_err = float((out_new.float() - ref).abs().max())
+        assert cos >= 0.999, (
+            f"{dtype} S_kv={S_kv}: cosine {cos:.6f} vs torch SDPA "
+            f"(max abs error {max_err:.6f})")
+
+
 def test_masked_softmax_mha_matches_prefilled(fvk):
     """The masked-softmax MHA needs no -inf logits pre-fill and matches the
     pre-filled variant."""

--- a/tests/test_groot_n17_thor_fp4_kernels.py
+++ b/tests/test_groot_n17_thor_fp4_kernels.py
@@ -1,0 +1,325 @@
+"""Kernel contracts for the GROOT N1.7 Thor NVFP4 tier.
+
+Pins the new kernels against the chains they replace, at the shapes the
+N1.7 DiT and backbone actually run (M = 41 action tokens, D = 1536,
+FF = 6144; backbone S = 277/1024):
+
+* NVFP4 GEMMs with fused bf16 bias / bias+residual / bias+GELU+FP4-out
+  epilogues vs a torch fp32 reference.
+* bf16 -> NVFP4 activation quantize (dequant fidelity via an identity
+  GEMM).
+* Fused DiT norms emitting FP4 vs the two-step norm-then-quantize chain
+  (bit-exact contract).
+* Vectorized backbone helpers vs their scalar originals (rope /
+  quantize / head-expand are bit-exact; the norms match within fp16
+  rounding of a different reduction order).
+* Masked-softmax MHA vs the pre-filled -inf variant.
+
+Skips cleanly when CUDA or the optional ``flash_rt_fp4`` extension is
+unavailable.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required")
+
+M, D, FF = 41, 1536, 6144
+DEV = "cuda"
+
+
+@pytest.fixture(scope="module")
+def fp4():
+    fp4mod = pytest.importorskip(
+        "flash_rt.flash_rt_fp4",
+        reason="flash_rt_fp4 extension not built")
+    if not fp4mod.has_nvfp4():
+        pytest.skip("NVFP4 requires an SM100-class GPU")
+    return fp4mod
+
+
+@pytest.fixture(scope="module")
+def fvk():
+    return pytest.importorskip("flash_rt.flash_rt_kernels")
+
+
+def _cos(a, b):
+    a = a.float().flatten().double()
+    b = b.float().flatten().double()
+    return float(a @ b / (a.norm() * b.norm()))
+
+
+def _quant_act_bf16(fp4, x):
+    S, Dd = x.shape
+    packed = torch.empty(S, Dd // 2, dtype=torch.uint8, device=DEV)
+    sfa = torch.zeros(fp4.sfa_size_bytes(S, Dd, False), dtype=torch.uint8,
+                      device=DEV)
+    rc = fp4.quantize_fp4_dynamic_sfa_bf16_vec(
+        x.data_ptr(), packed.data_ptr(), sfa.data_ptr(), S, Dd, False, 0)
+    assert rc == 0, f"activation quantize rc={rc}"
+    return packed, sfa
+
+
+def _quant_weight(fp4, w_nk_fp16):
+    N, K = w_nk_fp16.shape
+    packed = torch.empty(N, K // 2, dtype=torch.uint8, device=DEV)
+    # Scale-factor buffers must be zero-initialized: the tile-interleaved
+    # layout pads rows/K to atom boundaries and the quantize kernel only
+    # writes real coordinates.
+    sfb = torch.zeros(fp4.sfa_size_bytes(N, K, True), dtype=torch.uint8,
+                      device=DEV)
+    rc = fp4.quantize_fp4_dynamic_sfa_mse_fp16(
+        w_nk_fp16.data_ptr(), packed.data_ptr(), sfb.data_ptr(), N, K, True, 0)
+    assert rc == 0, f"weight quantize rc={rc}"
+    return packed, sfb
+
+
+@pytest.fixture(scope="module")
+def act(fp4):
+    torch.manual_seed(0)
+    x = torch.randn(M, D, dtype=torch.bfloat16, device=DEV) * 2.0
+    packed, sfa = _quant_act_bf16(fp4, x)
+    return x, packed, sfa
+
+
+def test_bf16_activation_quantize_roundtrip(fp4, act):
+    """An identity-weight NVFP4 GEMM recovers the quantized activation."""
+    x, packed, sfa = act
+    w = torch.eye(D, dtype=torch.float16, device=DEV)
+    wp, wsf = _quant_weight(fp4, w)
+    bias = torch.zeros(D, dtype=torch.bfloat16, device=DEV)
+    out = torch.empty(M, D, dtype=torch.bfloat16, device=DEV)
+    rc = fp4.cutlass_fp4_gemm_bias_bf16(
+        packed.data_ptr(), sfa.data_ptr(), wp.data_ptr(), wsf.data_ptr(),
+        bias.data_ptr(), out.data_ptr(), M, D, D, 0)
+    assert rc == 0, f"gemm rc={rc:#x}"
+    torch.cuda.synchronize()
+    assert _cos(out, x) >= 0.995
+
+
+def test_gemm_bias_bf16(fp4, act):
+    """Fused per-column bias epilogue matches A @ B^T + bias."""
+    x, packed, sfa = act
+    N = 3 * D  # the DiT's fused QKV projection
+    w = (torch.randn(N, D, dtype=torch.float16, device=DEV) * 0.02).contiguous()
+    b = torch.randn(N, dtype=torch.bfloat16, device=DEV) * 0.1
+    wp, wsf = _quant_weight(fp4, w)
+    out = torch.empty(M, N, dtype=torch.bfloat16, device=DEV)
+    rc = fp4.cutlass_fp4_gemm_bias_bf16(
+        packed.data_ptr(), sfa.data_ptr(), wp.data_ptr(), wsf.data_ptr(),
+        b.data_ptr(), out.data_ptr(), M, N, D, 0)
+    assert rc == 0, f"gemm rc={rc:#x}"
+    torch.cuda.synchronize()
+    ref = x.float() @ w.float().t() + b.float()
+    assert _cos(out, ref) >= 0.99
+
+
+def test_gemm_bias_res_bf16_aliased_output(fp4, act):
+    """Fused residual epilogue matches A @ B^T + bias + C with C aliasing D."""
+    x, packed, sfa = act
+    w = (torch.randn(D, D, dtype=torch.float16, device=DEV) * 0.02).contiguous()
+    b = torch.randn(D, dtype=torch.bfloat16, device=DEV) * 0.1
+    h = torch.randn(M, D, dtype=torch.bfloat16, device=DEV)
+    h_before = h.clone()
+    wp, wsf = _quant_weight(fp4, w)
+    rc = fp4.cutlass_fp4_gemm_bias_res_bf16(
+        packed.data_ptr(), sfa.data_ptr(), wp.data_ptr(), wsf.data_ptr(),
+        b.data_ptr(), h.data_ptr(), h.data_ptr(), M, D, D, 0)
+    assert rc == 0, f"gemm rc={rc:#x}"
+    torch.cuda.synchronize()
+    ref = x.float() @ w.float().t() + b.float() + h_before.float()
+    assert _cos(h, ref) >= 0.99
+
+
+def test_ffn_chain_bias_gelu_fp4out(fp4, act):
+    """Up GEMM (bias + tanh-GELU + FP4 out) feeding the Down GEMM matches
+    the torch chain."""
+    x, packed, sfa = act
+    w_up = (torch.randn(FF, D, dtype=torch.float16, device=DEV)
+            * 0.02).contiguous()
+    b_up = torch.randn(FF, dtype=torch.bfloat16, device=DEV) * 0.1
+    wp_up, wsf_up = _quant_weight(fp4, w_up)
+    hid = torch.empty(M, FF // 2, dtype=torch.uint8, device=DEV)
+    hid_sfa = torch.zeros(fp4.sfa_size_bytes(M, FF, False), dtype=torch.uint8,
+                          device=DEV)
+    rc = fp4.cutlass_fp4_gemm_bias_gelu_fp4out_bf16(
+        packed.data_ptr(), sfa.data_ptr(), wp_up.data_ptr(), wsf_up.data_ptr(),
+        b_up.data_ptr(), hid.data_ptr(), hid_sfa.data_ptr(), M, FF, D, 0)
+    assert rc == 0, f"up gemm rc={rc:#x}"
+
+    w_dn = (torch.randn(D, FF, dtype=torch.float16, device=DEV)
+            * 0.02).contiguous()
+    b_dn = torch.randn(D, dtype=torch.bfloat16, device=DEV) * 0.1
+    h = torch.randn(M, D, dtype=torch.bfloat16, device=DEV)
+    h_before = h.clone()
+    wp_dn, wsf_dn = _quant_weight(fp4, w_dn)
+    rc = fp4.cutlass_fp4_gemm_bias_res_bf16(
+        hid.data_ptr(), hid_sfa.data_ptr(), wp_dn.data_ptr(),
+        wsf_dn.data_ptr(), b_dn.data_ptr(), h.data_ptr(), h.data_ptr(),
+        M, D, FF, 0)
+    assert rc == 0, f"down gemm rc={rc:#x}"
+    torch.cuda.synchronize()
+
+    gelu = torch.nn.functional.gelu(
+        x.float() @ w_up.float().t() + b_up.float(), approximate="tanh")
+    ref = gelu @ w_dn.float().t() + b_dn.float() + h_before.float()
+    assert _cos(h, ref) >= 0.98
+
+
+def test_ada_layer_norm_fp4_is_bit_exact(fp4, fvk):
+    """Fused AdaLN -> FP4 equals the bf16 AdaLN kernel then quantize."""
+    torch.manual_seed(1)
+    h = torch.randn(M, D, dtype=torch.bfloat16, device=DEV)
+    scale = torch.randn(D, dtype=torch.bfloat16, device=DEV) * 0.3
+    shift = torch.randn(D, dtype=torch.bfloat16, device=DEV) * 0.3
+
+    packed = torch.empty(M, D // 2, dtype=torch.uint8, device=DEV)
+    sfa = torch.zeros(fp4.sfa_size_bytes(M, D, False), dtype=torch.uint8,
+                      device=DEV)
+    rc = fp4.ada_layer_norm_fp4_sfa_bf16(
+        h.data_ptr(), scale.data_ptr(), shift.data_ptr(),
+        packed.data_ptr(), sfa.data_ptr(), M, D, 1e-5, 0)
+    assert rc == 0, f"fused adaln rc={rc}"
+
+    xn = torch.empty(M, D, dtype=torch.bfloat16, device=DEV)
+    fvk.ada_layer_norm_bf16(h.data_ptr(), scale.data_ptr(), shift.data_ptr(),
+                            xn.data_ptr(), M, D, 1e-5, 0)
+    ref_packed, ref_sfa = _quant_act_bf16(fp4, xn)
+    torch.cuda.synchronize()
+    assert torch.equal(packed, ref_packed)
+    assert torch.equal(sfa, ref_sfa)
+
+
+def test_layer_norm_no_affine_fp4_is_bit_exact(fp4, fvk):
+    """Fused pre-FFN LayerNorm -> FP4 equals the bf16 kernel then quantize."""
+    torch.manual_seed(2)
+    h = torch.randn(M, D, dtype=torch.bfloat16, device=DEV)
+
+    packed = torch.empty(M, D // 2, dtype=torch.uint8, device=DEV)
+    sfa = torch.zeros(fp4.sfa_size_bytes(M, D, False), dtype=torch.uint8,
+                      device=DEV)
+    rc = fp4.layer_norm_no_affine_fp4_sfa_bf16(
+        h.data_ptr(), packed.data_ptr(), sfa.data_ptr(), M, D, 1e-5, 0)
+    assert rc == 0, f"fused ln rc={rc}"
+
+    xn = torch.empty(M, D, dtype=torch.bfloat16, device=DEV)
+    fvk.layer_norm_no_affine_bf16(h.data_ptr(), xn.data_ptr(), M, D, 1e-5, 0)
+    ref_packed, ref_sfa = _quant_act_bf16(fp4, xn)
+    torch.cuda.synchronize()
+    assert torch.equal(packed, ref_packed)
+    assert torch.equal(sfa, ref_sfa)
+
+
+# ── Vectorized backbone helpers vs their scalar originals ──────────────
+
+def test_rope_vec_is_bit_exact(fvk):
+    torch.manual_seed(3)
+    S, NH, HD = 277, 16, 128
+    x = torch.randn(S, NH * HD, dtype=torch.float16, device=DEV)
+    cos_t = torch.randn(S, HD, dtype=torch.float16, device=DEV)
+    sin_t = torch.randn(S, HD, dtype=torch.float16, device=DEV)
+    a, b = x.clone(), x.clone()
+    fvk.rope_rotate_half_fp16(a.data_ptr(), cos_t.data_ptr(), sin_t.data_ptr(),
+                              S, NH, HD, 0)
+    rc = fvk.rope_rotate_half_fp16_vec(
+        b.data_ptr(), cos_t.data_ptr(), sin_t.data_ptr(), S, NH, HD, 0)
+    assert rc == 0
+    torch.cuda.synchronize()
+    assert torch.equal(a, b)
+
+
+def test_quantize_fp8_vec_is_bit_exact(fvk):
+    torch.manual_seed(4)
+    n = 277 * 2048
+    x = torch.randn(n, dtype=torch.float16, device=DEV)
+    scale = torch.tensor([x.abs().max().item() / 448.0], dtype=torch.float32,
+                         device=DEV)
+    a = torch.empty(n, dtype=torch.float8_e4m3fn, device=DEV)
+    b = torch.empty(n, dtype=torch.float8_e4m3fn, device=DEV)
+    fvk.quantize_fp8_static_fp16(x.data_ptr(), a.data_ptr(), scale.data_ptr(),
+                                 n, 0)
+    rc = fvk.quantize_fp8_static_fp16_vec(
+        x.data_ptr(), b.data_ptr(), scale.data_ptr(), n, 0)
+    assert rc == 0
+    torch.cuda.synchronize()
+    assert torch.equal(a.view(torch.uint8), b.view(torch.uint8))
+
+
+def test_repeat_interleave_heads_vec_is_bit_exact(fvk):
+    torch.manual_seed(5)
+    S, NHKV, HD, GQA = 277, 8, 128, 2
+    src = torch.randn(S, NHKV * HD, dtype=torch.float16, device=DEV)
+    a = torch.empty(S, NHKV * GQA * HD, dtype=torch.float16, device=DEV)
+    b = torch.empty_like(a)
+    fvk.gpu_repeat_interleave_heads(src.data_ptr(), a.data_ptr(), S, NHKV, HD,
+                                    GQA, 0)
+    rc = fvk.gpu_repeat_interleave_heads_vec(
+        src.data_ptr(), b.data_ptr(), S, NHKV, HD, GQA, 0)
+    assert rc == 0
+    torch.cuda.synchronize()
+    assert torch.equal(a, b)
+
+
+@pytest.mark.parametrize("rows,dim", [(277 * 16, 128), (277, 2048)])
+def test_rms_norm_vec_matches_scalar(fvk, rows, dim):
+    torch.manual_seed(6)
+    x = torch.randn(rows, dim, dtype=torch.float16, device=DEV)
+    w = torch.randn(dim, dtype=torch.float16, device=DEV)
+    a = torch.empty_like(x)
+    b = torch.empty_like(x)
+    fvk.rms_norm_fp16(x.data_ptr(), w.data_ptr(), a.data_ptr(), rows, dim,
+                      1e-6, 0)
+    rc = fvk.rms_norm_fp16_vec(x.data_ptr(), w.data_ptr(), b.data_ptr(), rows,
+                               dim, 1e-6, 0)
+    assert rc == 0
+    torch.cuda.synchronize()
+    assert _cos(a, b) >= 0.99999
+
+
+def test_layer_norm_vec_matches_scalar(fvk):
+    torch.manual_seed(7)
+    rows, dim = 1024, 1024
+    x = torch.randn(rows, dim, dtype=torch.float16, device=DEV)
+    w = torch.randn(dim, dtype=torch.float16, device=DEV)
+    bias = torch.randn(dim, dtype=torch.float16, device=DEV)
+    a = torch.empty_like(x)
+    b = torch.empty_like(x)
+    fvk.layer_norm_fp16(x.data_ptr(), w.data_ptr(), bias.data_ptr(),
+                        a.data_ptr(), rows, dim, 1e-6, 0)
+    rc = fvk.layer_norm_fp16_vec(x.data_ptr(), w.data_ptr(), bias.data_ptr(),
+                                 b.data_ptr(), rows, dim, 1e-6, 0)
+    assert rc == 0
+    torch.cuda.synchronize()
+    assert _cos(a, b) >= 0.99999
+
+
+def test_masked_softmax_mha_matches_prefilled(fvk):
+    """The masked-softmax MHA needs no -inf logits pre-fill and matches the
+    pre-filled variant."""
+    torch.manual_seed(8)
+    S, NH, HD = 41, 32, 48
+    S_pad = ((S + 7) // 8) * 8
+    ctx = fvk.FvkContext()
+    q = torch.randn(S, NH * HD, dtype=torch.bfloat16, device=DEV)
+    k = torch.randn(S, NH * HD, dtype=torch.bfloat16, device=DEV)
+    v = torch.randn(S, NH * HD, dtype=torch.bfloat16, device=DEV)
+    logits = torch.empty(NH, S, S_pad, dtype=torch.bfloat16, device=DEV)
+    out_ref = torch.empty(S, NH * HD, dtype=torch.bfloat16, device=DEV)
+    out_new = torch.empty_like(out_ref)
+    scale = 1.0 / (HD ** 0.5)
+
+    fvk.gpu_fill_neginf_bf16(logits.data_ptr(), NH * S * S_pad, 0)
+    fvk.attention_mha_bf16(ctx, q.data_ptr(), k.data_ptr(), v.data_ptr(),
+                           logits.data_ptr(), out_ref.data_ptr(), S, S, NH, HD,
+                           scale, S_pad, 0)
+    # Poison the scratch so a missing mask would show up as garbage.
+    logits.fill_(float("nan"))
+    fvk.attention_mha_bf16_masked(ctx, q.data_ptr(), k.data_ptr(),
+                                  v.data_ptr(), logits.data_ptr(),
+                                  out_new.data_ptr(), S, S, NH, HD, scale,
+                                  S_pad, 0, 0)
+    torch.cuda.synchronize()
+    assert torch.isfinite(out_new.float()).all()
+    assert _cos(out_new, out_ref) >= 0.9999

--- a/tests/test_groot_n17_thor_fp4_routing.py
+++ b/tests/test_groot_n17_thor_fp4_routing.py
@@ -1,0 +1,118 @@
+"""``load_model`` routing contract for the GROOT N1.7 Thor NVFP4 tier.
+
+Covers the three public behaviors the tier adds to ``flash_rt.load_model``:
+
+* ``config="groot_n17", hardware="thor", use_fp4=True`` selects the NVFP4
+  frontend;
+* it falls back to the FP8 frontend when the optional ``flash_rt_fp4``
+  extension is missing or reports no NVFP4 support;
+* combining it with ``use_fp16=True`` fails, and it does not disturb the
+  Pi0.5 ``use_fp4`` route.
+
+The frontends are stubbed out, so these run without a GPU or checkpoint.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import flash_rt
+from flash_rt import api as flash_rt_api
+
+
+class _StubFrontend:
+    """Records the class the router picked instead of loading weights."""
+
+    def __init__(self, checkpoint, **kwargs):
+        self.checkpoint = checkpoint
+        self.kwargs = kwargs
+
+
+def _install_stub_frontends(monkeypatch):
+    """Stub the two N1.7 Thor frontend modules the router may import."""
+    picked = {}
+
+    for mod_name, cls_name in (
+        ("flash_rt.frontends.torch.groot_n17_thor_fp4",
+         "GrootN17TorchFrontendThorFP4"),
+        ("flash_rt.frontends.torch.groot_n17_thor_fp8",
+         "GrootN17TorchFrontendThorFP8"),
+    ):
+        module = types.ModuleType(mod_name)
+        cls = type(cls_name, (_StubFrontend,), {"_stub_name": cls_name})
+        setattr(module, cls_name, cls)
+        monkeypatch.setitem(sys.modules, mod_name, module)
+    return picked
+
+
+def _stub_fp4_extension(monkeypatch, *, available: bool, has_nvfp4: bool = True):
+    """Stand in for the optional NVFP4 extension.
+
+    ``import flash_rt.flash_rt_fp4 as x`` resolves through the parent
+    package's attribute once the real submodule has been imported (which
+    another test in the same session may already have done), so patch the
+    attribute as well as the ``sys.modules`` entry.
+    """
+    if not available:
+        monkeypatch.setitem(sys.modules, "flash_rt.flash_rt_fp4", None)
+        monkeypatch.delattr(flash_rt, "flash_rt_fp4", raising=False)
+        return
+    module = types.ModuleType("flash_rt.flash_rt_fp4")
+    module.has_nvfp4 = lambda: has_nvfp4
+    monkeypatch.setitem(sys.modules, "flash_rt.flash_rt_fp4", module)
+    monkeypatch.setattr(flash_rt, "flash_rt_fp4", module, raising=False)
+
+
+def _load(monkeypatch, **kwargs):
+    """Call load_model with hardware pinned to Thor and weights stubbed."""
+    monkeypatch.setattr(flash_rt_api, "detect_arch", lambda: "thor",
+                        raising=False)
+    return flash_rt.load_model(
+        "/nonexistent/checkpoint",
+        framework="torch",
+        config="groot_n17",
+        hardware="thor",
+        **kwargs,
+    )
+
+
+def test_use_fp4_selects_the_nvfp4_frontend(monkeypatch):
+    _install_stub_frontends(monkeypatch)
+    _stub_fp4_extension(monkeypatch, available=True)
+    model = _load(monkeypatch, use_fp4=True)
+    inner = getattr(model, "_pipe", model)
+    assert type(inner)._stub_name == "GrootN17TorchFrontendThorFP4"
+
+
+def test_missing_fp4_extension_falls_back_to_fp8(monkeypatch):
+    _install_stub_frontends(monkeypatch)
+    _stub_fp4_extension(monkeypatch, available=False)
+    model = _load(monkeypatch, use_fp4=True)
+    inner = getattr(model, "_pipe", model)
+    assert type(inner)._stub_name == "GrootN17TorchFrontendThorFP8"
+
+
+def test_extension_without_nvfp4_support_falls_back_to_fp8(monkeypatch):
+    _install_stub_frontends(monkeypatch)
+    _stub_fp4_extension(monkeypatch, available=True, has_nvfp4=False)
+    model = _load(monkeypatch, use_fp4=True)
+    inner = getattr(model, "_pipe", model)
+    assert type(inner)._stub_name == "GrootN17TorchFrontendThorFP8"
+
+
+def test_use_fp4_with_use_fp16_is_rejected(monkeypatch):
+    _install_stub_frontends(monkeypatch)
+    _stub_fp4_extension(monkeypatch, available=True)
+    with pytest.raises(ValueError, match="use_fp4"):
+        _load(monkeypatch, use_fp4=True, use_fp16=True, use_fp8=False)
+
+
+def test_default_still_selects_the_fp8_frontend(monkeypatch):
+    """Existing behavior is unchanged when the flag is not passed."""
+    _install_stub_frontends(monkeypatch)
+    _stub_fp4_extension(monkeypatch, available=True)
+    model = _load(monkeypatch)
+    inner = getattr(model, "_pipe", model)
+    assert type(inner)._stub_name == "GrootN17TorchFrontendThorFP8"


### PR DESCRIPTION
## Summary

Adds an opt-in NVFP4 + FA4 performance tier for GROOT N1.7 on Jetson AGX Thor (SM110). The default FP8 path is unchanged.

Measured on the `GR00T-N1.7` LIBERO fine-tune (`libero_10`), one camera, 4 denoising steps, batch 1, medians over 20 iterations after 5 warmup iterations, on a fixture captured from a real `libero_10` observation through the official preprocessing path (JetPack 7.2, MAXN):

| Tier | Backbone | Action head | E2E | Frequency |
|---|---:|---:|---:|---:|
| FP8 (default, unchanged) | 11.0 ms | 25.8 ms | 36.8 ms | 27.2 Hz |
| NVFP4 + FA4 (`use_fp4=True`) | 8.4 ms | 15.2 ms | **23.7 ms** | **42.3 Hz** |

Run as one same-session A/B/A: FP8 36.76 ms → NVFP4 23.65 ms → FP8 36.85 ms. Action cosine between the tiers on that fixture is **1.000000**.

On the base `GR00T-N1.7-3B` checkpoint with a 2-view fixture (`T=40`, same protocol): FP8 50.2 ms (20 Hz) → NVFP4 29.9 ms (33 Hz), also A/B/A (51.6 / 29.9 / 50.2), action cosine 0.99994.

CUDA-graph replays on the new tier are bit-identical (the masked-softmax attention also removes a long-standing source of replay nondeterminism in the FP8 tier's logits padding). On an 8-sample aux set captured from the base checkpoint, 7 of 8 samples hold action cosine >= 0.9993 against the FP8 tier with a worst sample of 0.9976 — deployments that are accuracy-critical should validate on the target task rather than on cosine alone, or stay on the FP8 tier.

An earlier revision of this branch carried a `dit_fp8_layers` precision ladder. It was removed before review: with every DiT layer marked for FP8 the captured graph still produced the all-NVFP4 result, so the option did not do what it documented. The last commit removes the knob, its per-layer gate, and the benchmark flag rather than shipping unverified behavior.

## What is in the tier

- **NVFP4 DiT action head** — every DiT GEMM (fused self-attn QKV, cross-attn Q, attention output, both FFN projections) runs as a block-scaled NVFP4 GEMM with fused bf16 bias / bias+residual / bias+tanh-GELU+FP4-output epilogues. At M=41 the DiT is weight-bandwidth-bound, so halving weight bytes is the dominant win. Activation quantization is dynamic per-16-element (no calibration pass).
- **NVFP4 cross-KV projections** — the 32 per-frame K/V GEMMs quarter their weight traffic.
- **Fused norm→FP4 / norm→FP8 front-ends** — AdaLN and the pre-FFN LayerNorm emit FP4 directly (bit-identical to the two-step chain); the ViT / VL-self-attn LayerNorms emit FP8 directly, dropping the fp16 intermediate's write and read-back.
- **Vectorized backbone small kernels** — 16-byte-load rewrites of the per-head RMSNorms, LayerNorms, static FP8 quantize, split-half RoPE, GQA head expand, and residual add. The scalar originals issue 2–4 B accesses and sit far under the LPDDR5X floor. Element math matches; RoPE / quantize / head-expand / residual are bit-exact.
- **Masked-softmax MHA** — the softmax touches only the valid `S_kv` columns, so the per-layer full-buffer `-inf` logits pre-fill disappears; the DiT self-attention also reads the fused QKV GEMM output in place (token stride 3D), dropping three split copies per layer.
- **FA4 attention** — the three backbone MHA sites (ViT multi-view, LLM causal GQA with `pack_gqa`, VL-self-attn) run the vendored FlashAttention-4 (CuTe-DSL) forward, falling back to the existing fmha/cuBLAS chain when the `thor-fa4` runtime deps are absent.

## Shared-code changes

Only two files outside `groot_n17` carry behavior:

- `flash_rt/api.py` — `use_fp4=True` with `config="groot_n17"` on Thor routes to the new frontend and falls back to the FP8 tier when `flash_rt_fp4` is unavailable. Pi0.5's `use_fp4` routing is untouched.
- `flash_rt/hardware/thor/fa4_backend.py` — the Thor chip string now follows the installed `nvidia-cutlass-dsl` (4.4.x only accepts `sm_110a`; 4.5+ needs the `sm_101a` alias). Previously the loader always requested `sm_101a`, so on 4.4.x FA4 failed to compile and every caller silently fell back to fmha. Call sites: LingBot (`flash_rt/models/lingbot/kernel_ops.py`) and Cosmos3-Edge (`flash_rt/models/cosmos3_edge/layer_ref.py`) — both keep their existing behavior on 4.5+ and now get the working FA4 path on 4.4.x.

The shared build surface also changes, in gated form: two new compilation units (`csrc/kernels/attention_mha_masked.cu`, `csrc/kernels/vec_fp16_backbone.cu`) join `flash_rt_kernels`, but only on SM100-class builds — CMake adds them under `ENABLE_SM100_CUTLASS` and defines `FLASHRT_HAVE_THOR_VLA_KERNELS`, and their bindings in `csrc/bindings.cpp` are guarded by the same define, so source and binding drop together on SM8x. The NVFP4 frontend probes for those bindings up front and fails naming the build flag rather than dying inside graph capture.

Everything else is additive: new `csrc` kernels with new symbols, a new frontend subclass, and gated branches in the N1.7 pipeline.

## Tests

`tests/test_groot_n17_thor_fp4_kernels.py` — 16 contracts covering the NVFP4 GEMM epilogues against a torch reference, the bf16 activation quantizer, the fused DiT norms (bit-exact vs the two-step chain), the vectorized backbone helpers, and masked-softmax MHA against the pre-filled variant with a poisoned logits scratch. The masked softmax is additionally pinned at `S_kv` = 1024 / 1025 / 2048 in both dtypes against torch SDPA, since 1024 is where its register-tiled path hands over to the multi-pass one. Skips cleanly without CUDA or the optional `flash_rt_fp4` extension.

`tests/test_groot_n17_thor_fp4_routing.py` — 5 contracts on the public `load_model` behavior the tier adds: `use_fp4=True` selects the NVFP4 frontend, a missing or NVFP4-less `flash_rt_fp4` falls back to FP8, `use_fp4` with `use_fp16` is rejected, and the default route is unchanged. Frontends are stubbed, so these need no GPU or checkpoint.

Regression run on Thor (`tests/test_groot_n17_*`, `test_thor_groot_attn_backend`, `test_build_inventory`, `test_load_model_use_fp8_kwarg`): 156 passed, 36 skipped, 1 pre-existing environment failure (`test_e2e_action_cosines_with_hf_noise` needs a newer `transformers` for `denormalize_action`; it fails the same way on `main`).

## Reproduce

The A/B/A above is three runs of the same command with the tier flipped;
`--ref-out` / `--ref-in` carry the FP8 output forward so the FP4 run reports
the cross-tier action cosine, and `--min-cosine` turns it into a gate:

```bash
# A: FP8 tier, save its actions as the precision reference
python benchmarks/groot_n17_thor_latency.py \
    --ckpt <n17-libero-checkpoint-dir> --aux <1-camera-aux-fixture.pt> \
    --tier fp8 --views 1 --embodiment libero_sim \
    --warmup 5 --iters 20 --ref-out fp8_actions.pt

# B: NVFP4 tier, compared against it (exits non-zero below the threshold)
python benchmarks/groot_n17_thor_latency.py \
    --ckpt <n17-libero-checkpoint-dir> --aux <1-camera-aux-fixture.pt> \
    --tier fp4 --views 1 --embodiment libero_sim \
    --warmup 5 --iters 20 --ref-in fp8_actions.pt --min-cosine 0.999

# A': FP8 again, to show the pair is not regime drift
python benchmarks/groot_n17_thor_latency.py \
    --ckpt <n17-libero-checkpoint-dir> --aux <1-camera-aux-fixture.pt> \
    --tier fp8 --views 1 --embodiment libero_sim --warmup 5 --iters 20
```

`tests/_helpers/groot_n17/capture_aux_multi.py --views N` captures a fixture with a restricted camera count, which is how the one-camera fixture above was produced.

## Base

Rebased onto current `main` (after #159 / #160 / #161). The overlap with those is docs and registration only — `README.md`, `docs/stable_api.md`, `CMakeLists.txt`, `flash_rt/api.py` — and the rebase was clean. #160's RTX backbone-graph work is untouched; this PR only refreshes the GROOT N1.7 benchmark table's RTX 5090 row to the 16.61 ms full-graph number that #160 produced, since that table still carried the pre-graph 22 ms.

## Docs

`README.md`, `USAGE.md`, `docs/stable_api.md`, and `docs/benchmark_comparison.md` record the tier, its flag, the precision ladder, and the measured numbers with the harness definition. `docs/benchmark_comparison.md` also carries NVIDIA's published TensorRT reference table for the same model family on the same board, alongside the camera-count-matched FlashRT rows and the 2-view base-checkpoint rows, each with its harness stated.
