### PR TITLE
feat(hyvla): Hy-Embodied-0.5-VLA Orin SM87 — INT8 W8A8 + fused kernels

### DIFF
--- a/docs/hyvla05_orin_sm87.md
+++ b/docs/hyvla05_orin_sm87.md
@@ -1,0 +1,282 @@
+# Hy-Embodied-0.5-VLA on Jetson Orin SM87
+
+> Orin SM87 adaptation of the existing HyVLA Thor path. SM87 has no native
+> FP8/FP4 tensor cores, so Thor FP8/NVFP4 kernels are not compiled or used.
+> The Orin frontend keeps the validated HyVLA IO/prefix/graph path and maps the
+> lower-precision GEMM slots to SM80-family INT8 W8A8 rowwise CUTLASS kernels.
+
+## Platform
+
+| Field | Value |
+|---|---|
+| Device | Jetson AGX Orin / SM87 |
+| GPU family | Ampere, SM87 |
+| Native FP8 / FP4 | No |
+| Build target | `-DGPU_ARCH=87` |
+| Attention | PyTorch SDPA efficient backend baseline |
+| Low-bit GEMM | SM80 INT8 rowwise W8A8 (`ENABLE_SM80_INT8_CUTLASS`) |
+
+## Dispatch
+
+`flash_rt/hardware/__init__.py` registers:
+
+```python
+("hyvla", "torch", "rtx_sm87") -> (
+    "flash_rt.frontends.torch.hyvla_orin",
+    "HyVLATorchFrontendOrin",
+)
+```
+
+The key is also included in `_SM87_ALLOWED`, so
+`flash_rt.load_model(ckpt, config="hyvla", framework="torch")` resolves on
+Orin.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `flash_rt/frontends/torch/hyvla_orin.py` | Orin frontend; inherits Thor tokenizer/preprocess/prefix/graph orchestration; disables Thor-only FP8/FP4 fused options; materializes INT8 per-row weights. |
+| `flash_rt/models/hyvla/pipeline_orin.py` | Orin pipeline subclass; inherits BF16 math and overrides the lower-precision GEMM slot with INT8 W8A8 rowwise CUTLASS; fused ViT forward (pending-add+LN, efficient SDPA). |
+| `csrc/kernels/hyvla_vit_fuse.cu` | Fused ViT residual-add + LayerNorm kernel (SM87 + SM110 builds). |
+| `tests/test_orin_hyvla05_e2e_check.py` | HF/transformers eager vs Orin native action cosine with fixed noise. |
+| `tests/test_orin_hyvla05_graphsafe.py` | Graph-vs-eager and replay-stability gate. |
+| `tests/test_orin_hyvla05_stageprof.py` | Stage timing split for ViT, prefix assembly, and prefill+denoise graph replay. |
+
+## Precision policy
+
+| Component | Orin v2 precision (current default) |
+|---|---|
+| Embeddings / token assembly | BF16 |
+| HYViT2 + merger | BF16 graph (INT8 opt-in, fails gate — see dead ends) |
+| MoT VLM prefill QKV/O | BF16 (outputs feed the KV cache read by 10 denoise steps) |
+| MoT VLM prefill FFN (gate/up/down) | **INT8 W8A8 by default** (`use_int8_vlm_ffn`) |
+| Expert denoise QKV/O/FFN GEMMs | **INT8 W8A8 by default** (`use_int8_exp`) |
+| RMSNorm / RoPE / QK-Norm | BF16 |
+| Attention | BF16/SDPA |
+| State/time/action head | BF16/FP32 update as in Thor path |
+| FP4 / Thor FP8 fused kernels | Unsupported on SM87 |
+
+`HyVLATorchFrontendOrin(..., use_fp8=True)` maps to the precision-safe Orin
+INT8 tier: expert denoise INT8 **plus prefill FFN INT8** (gate/up/down; QKV/O
+stay BF16 to protect the KV cache). Pass `use_fp8=False, use_int8=False` for
+the BF16 baseline. Diagnostic flags: `use_int8_vlm=True` (all-tower prefill
+INT8) and `use_int8_vit=True` (ViT INT8) both fail the 0.999 gate — see dead
+ends.
+
+## Measured gates
+
+Measured on the downloaded checkpoint at
+`/path/to/checkpoint/Hy-Embodied-0.5-VLA-RoboTwin`, fixed
+noise, three random 6-frame cameras, prompt `pick up the bottle`.
+
+| Config | Reference action cosine | MAE | Graph safety |
+|---|---:|---:|---|
+| BF16 baseline | 0.999911 | 2.45e-3 | PASS (`graph==eager`, replay max diff 0) |
+| **BF16 + ViT fusion (Stage 4)** | **0.999931** | 1.75e-3 | PASS |
+| INT8 default + Stage 3 fused kernels | 0.999531 | 6.46e-3 | PASS (`graph==eager`, replay max diff 0) |
+| **INT8 + ViT fusion (Stage 4, current default)** | **0.999442** | 6.69e-3 | PASS (`graph==eager`, replay max diff 0) |
+| INT8 default (expert + prefill FFN) | 0.999580 | 6.12e-3 | PASS |
+| INT8 expert-only (Stage 1) | 0.999681 | 5.56e-3 | PASS |
+| all-tower INT8 (`use_int8_vlm=True`) | 0.998843 | 8.77e-3 | graph-safe but below gate |
+| ViT INT8 (`use_int8_vit=True`) | 0.997459 | 1.38e-2 | FAIL — dead end |
+
+Stage latency, sequential median of 20 iterations:
+
+| Config | E2E `predict_actions` | ViT+merger graph | Prefix assembly* | Prefill+denoise graph |
+|---|---:|---:|---:|---:|
+| BF16 baseline | 403.6 ms | 170.7 ms | 7.6 ms | 205.2 ms |
+| INT8 Stage 1 (expert-only) | 384.4 ms | 173.9 ms | 7.2 ms | 187.5 ms |
+| INT8 Stage 2 (expert + prefill FFN + prefix cache) | 353.6 ms | 171.4 ms | — | 167.3 ms |
+| INT8 Stage 3 (Stage 2 + fused norm/rope kernels) | 293.2 ms | 170.9 ms | 7.1 ms | 107.0 ms |
+| **INT8 Stage 4 (Stage 3 + ViT fusion, default)** | **277.5 ms** | 156.9 ms | 7.3 ms | 106.9 ms |
+| BF16 Stage 4 (ViT fusion) | 315.2 ms | 156.5 ms | 7.8 ms | 143.8 ms |
+| BF16 Stage 2 (prefix cache only) | 391.9 ms | 172.6 ms | — | 204.9 ms |
+
+\* stageprof's assembly line re-runs the uncached reproduction for
+measurement; inside `predict_actions` the Orin frontend caches the
+prompt/camera-static artifacts (segment mask, permutation, bf16-rounded RoPE
+tables, suffix mask) per `(prompt, num_cam)`, which removed ~12 ms/call from
+E2E in both BF16 and INT8 tiers (403.6→391.9 and 365.7→353.6).
+
+Stage 2 levers: prefill FFN INT8 took the main graph 187.5→167.3 ms; the
+static-prefix cache removed the per-call mask/RoPE recomputation. Both
+preserve the 0.999 action-cosine gate.
+
+Stage 3 levers (main graph 167.3→107.0 ms, E2E 353.6→293.2 ms):
+
+1. **Kernel-backed RMSNorm shim** — torch 2.3 has no `F.rms_norm`; the eager
+   Python fallback was a hot elementwise chain. Dispatching the existing
+   `fvk.rms_norm` (bit-equal math: fp32 sum-of-squares, single bf16 round)
+   removed ~38 ms from the main graph.
+2. **Fused residual-add + RMSNorm** (`fvk.residual_add_rms_norm`) in the
+   expert denoise loop: one kernel replaces add + norm, and the fp32
+   accumulation before rounding keeps drift at ≤1 ULP vs torch.
+3. **Fused RoPE + QK-Norm + KV-write megakernel** — Thor's
+   `hyvla_rope_qknorm_kvwrite_bf16` is plain CUDA and was compiled for SM87
+   (CMake gate `FLASHRT_HAVE_HYVLA_ORIN`; `csrc/bindings.cpp` needed the
+   HyVLA def block moved out of the `ENABLE_NVFP4` guard, which silently
+   excluded it on SM87). Collapses ~11 launches per attention block × 352
+   blocks/step into one kernel. Auto-enabled in the Orin frontend when the
+   symbol is present (`use_fused=True`).
+
+All three preserve graph safety (max diff 0) and the 0.999 gate (cos drops
+0.999580→0.999531 from the fused RoPE rounding order, still comfortably
+above gate).
+
+Stage 4 levers (ViT 170.9→156.9 ms, E2E 293.2→277.5 ms):
+
+1. **Memory-efficient SDPA for ViT spatial attention** — the q/k/v slices
+   from the packed QKV GEMM are strided; the flash backend force-copies all
+   three (plus the output) contiguous, ~25 ms of `copy_` per ViT pass. The
+   memory-efficient backend reads the strides natively (2.89→0.62 ms per
+   attention segment in µbench). Same finding as Thor's efficient-SDPA lever:
+   accuracy *improves* vs flash (BF16 E2E cos 0.999911→0.999931).
+2. **Fused residual-add + LayerNorm** — new kernel
+   `hyvla_vit_add_layer_norm_bf16` (`csrc/kernels/hyvla_vit_fuse.cu`):
+   in-place bf16-rounded residual add (bit-equal to torch add) + LayerNorm
+   matching this repo's `layer_norm_kernel`. The Orin `vit_forward` override
+   carries each block's MLP output as `pending` and fuses it into the next
+   block's entry LN; spacetime blocks keep the torch path (their entry LN
+   also adds the time positional embedding). LN deviates from torch's Welford
+   reduction by ≤1 bf16 ULP on ~2e-5 of elements — unbiased rounding noise,
+   no gate impact.
+
+Note: the "drop history frames after the final spacetime block" lever from
+Thor is already inherited via the base pipeline (blocks 24-26 run on 3
+frames instead of 18) — the Stage 3 ViT estimate of 171 ms already included
+it.
+
+## Dead ends (Stage 2, measured)
+
+| Scheme | Result | Mechanism |
+|---|---|---|
+| **ViT INT8** (`use_int8_vit`) | FAIL: E2E cos 0.997459; only −7 ms (166.7 vs 173.9 ms) | ViT merged-output cos only 0.999006 vs BF16 (MAE 3.4e-2); INT8 GEMM saves ~52 ms but per-GEMM activation quant (+14 ms) and extra elementwise (+28 ms) eat most of it; ViT errors propagate through 32-layer prefill + 10 denoise steps. MLP-only variant worse (merged cos 0.998638) |
+| **All-tower prefill INT8** (`use_int8_vlm`) | cos 0.998843 < 0.999 | QKV INT8 error lands in the KV cache and compounds over 10 denoise steps; FFN-only variant avoids the KV path and passes |
+| ViT INT8 t64x128 tile | slower than 128×128 at ViT shapes | µbench: (588,3456,1152) 0.556 vs 0.436 ms |
+| **ViT elementwise fusion via existing kernels** | rejected pre-integration | `bias_gelu_bf16_strict` uses tanh-approx gelu (the reference uses exact erf; bit-mismatch max 0.0156); `bias_residual_layer_norm_bf16` LN drifts 1-2 ULP vs `F.layer_norm` on ViT shapes — both would erode the 0.999 gate |
+
+**Reference eager anchor (measured on this Orin, same fixed inputs, warmup 3 +
+median of 5): 3137.3 ms.** FlashRT speedups vs the reference eager path:
+
+| Config | E2E | Speedup vs reference eager |
+|---|---:|---:|
+| **INT8 + ViT fusion (Stage 4, default)** | **277.5 ms** | **11.3×** |
+| INT8 Stage 3 (fused norm/rope kernels) | 293.2 ms | 10.7× |
+| INT8 Stage 2 (expert + prefill FFN + prefix cache) | 353.6 ms | 8.87× |
+| INT8 Stage 2 before prefix cache | 365.7 ms | 8.58× |
+| INT8 Stage 1 (expert-only) | 384.4 ms | 8.16× |
+| BF16 Stage 2 | 391.9 ms | 8.00× |
+| BF16 baseline | 403.6 ms | 7.77× |
+
+Cross-platform comparison (Thor numbers from `hyvla05_thor_sm110.md`):
+
+| Platform | Reference eager | Native BF16 (graph) | Production | Speedup |
+|---|---:|---:|---:|---:|
+| Thor SM110 | ~930 ms | 248.6 ms | 158.3 ms (FP8+fused+autotune) | 5.9× |
+| Orin SM87 | 3137 ms | 315.2 ms | 277.5 ms (INT8 + fused norm/rope/ViT kernels) | 11.3× |
+
+The reference eager path is much slower on Orin than Thor (3.1 s vs 0.93 s) because the
+eager PyTorch path is launch/dispatch-bound on 16 SMs and falls back to the
+slow SDPA math backend; the CUDA-Graph capture collapses most of that. The
+Orin absolute latency (~278 ms) is ~1.8× Thor's because SM87 lacks FP8 and
+has lower bandwidth (~204 vs 243 GB/s) and compute; the remaining gap is
+dominated by the ViT stage (~157 ms, 57% of E2E), whose ~100 ms of BF16
+GEMMs run near the cuBLAS compute ceiling on both platforms.
+
+## Roofline (Stage 4, measured anchors)
+
+Hardware anchors measured on this unit (warm, unlocked clocks):
+
+| Anchor | Value |
+|---|---:|
+| >>L2 read bandwidth (1 GB buffer) | **97 GB/s** |
+| bf16 cuBLAS peak (4096³, warm) | 29.9 TFLOPS |
+| bf16 at ViT qkv shape (3528,1152,3456) | 9.5 TFLOPS |
+| bf16 at FFN shapes (3528,·,4304/1152) | 21–24 TFLOPS |
+| INT8 CUTLASS peak (4096³) | 38.7 TOPS |
+| INT8 at prefill FFN (240,2048,12288) | 18.9 TOPS |
+| INT8 at denoise M=41 shapes | 6–8 TOPS, weight-streaming at ~71–95 GB/s |
+
+Stage floors vs measured (median of 20):
+
+| Stage | Dominant regime | Floor | Measured | Headroom |
+|---|---|---:|---:|---:|
+| ViT+merger (156.9 ms) | GEMM compute: ~106 ms cuBLAS bf16 (profiler) | ~150 ms | 156.9 ms | ~5% |
+| Prefill graph | FFN INT8 ≈47 ms (18.9 TOPS) + QKV/O bf16 + attn + quant | ~65 ms | — | — |
+| Denoise graph (×10 steps) | INT8 weight streaming: 369 MB/step ≈ 97 GB/s → ~38 ms floor + quant/attn | ~70 ms | prefill+denoise combined: 106.9 ms | — |
+| Main graph total | | ~135 ms | 106.9 ms graph replay (faster than eager-shape µbench sum) | ~0–20% |
+| E2E | | ~230 ms | 277.5 ms | ~17% |
+
+Reading: the ViT stage sits within ~5% of its measured cuBLAS+bandwidth
+floor — its qkv GEMM (9.5 TFLOPS, N=3456 K=1152) is the single slowest
+shape and alone costs ~71 ms of the 106 ms GEMM budget. The main graph's
+denoise portion is weight-streaming-bound at M=41 (INT8 weights read at
+71–95 GB/s, i.e. already at the measured memory ceiling); the prefill
+portion is compute-bound in the FFN INT8 GEMMs. The ~17% E2E headroom
+splits between prefix assembly (7.3 ms eager), graph-replay gaps, and
+elementwise tails (GELU ~9 ms, spacetime mixes ~14 ms) that are already
+near-bandwidth. Conclusion: no >1 ms framework-side lever remains; the
+quantifiable floor for this model shape on SM87 is ~230–250 ms.
+
+## Assets
+
+Official model repository: see the Hy-Embodied-0.5-VLA project page on
+Hugging Face.
+
+Checkpoint target:
+
+```bash
+/path/to/checkpoint/Hy-Embodied-0.5-VLA-RoboTwin
+```
+
+Direct Hugging Face access may be reset; use `HF_ENDPOINT=https://hf-mirror.com`
+when needed.
+
+## Build
+
+```bash
+cmake -B build_orin_sm87 -S . \
+  -DGPU_ARCH=87 \
+  -DFA2_ARCH_NATIVE_ONLY=ON \
+  -DFA2_HDIMS='128;256' \
+  -DFA2_DTYPES='bf16'
+cmake --build build_orin_sm87 -j4
+```
+
+For SM87, CMake enables `ENABLE_SM80_INT8_CUTLASS` and builds the existing
+rowwise INT8 CUTLASS kernels into `flash_rt_kernels`.
+
+## Verification
+
+BF16 baseline:
+
+```bash
+PYTHONPATH=. python tests/test_orin_hyvla05_e2e_check.py --bf16
+PYTHONPATH=. python tests/test_orin_hyvla05_graphsafe.py --bf16
+PYTHONPATH=. python tests/test_orin_hyvla05_stageprof.py --bf16
+```
+
+INT8 path:
+
+```bash
+PYTHONPATH=. python tests/test_orin_hyvla05_e2e_check.py --int8
+PYTHONPATH=. python tests/test_orin_hyvla05_graphsafe.py --int8
+PYTHONPATH=. python tests/test_orin_hyvla05_stageprof.py --int8
+```
+
+## Current caveats
+
+- The fused RoPE/QKNorm/KV-write megakernel (plain CUDA) is compiled for SM87
+  and enabled by default (`use_fused=True`); Thor-only fused FP8 quant, FFN
+  megakernels, and NVFP4 remain deliberately disabled.
+- INT8 uses dynamic per-row activation scales and BF16 GEMM outputs; static
+  calibration and FP16-output epilogues are possible next steps if profiling
+  shows the quant kernels on the critical path.
+- `predict_actions` caches prompt/camera-static prefix artifacts; the first
+  call per prompt pays the full mask/RoPE build (~7 ms), later calls reuse it.
+- Remaining ceiling: ViT (~157 ms, 57% of E2E) is the largest stage — ~100 ms
+  of BF16 GEMMs near the cuBLAS compute ceiling plus near-bandwidth-bound
+  elementwise (GELU, spacetime ops). INT8 there fails the precision gate, so
+  further ViT cuts need model-side changes (fewer history frames, smaller
+  ViT) rather than framework-side work.
+- The reference E2E oracle requires the official HyVLA repo and checkpoint assets.

--- a/docs/hyvla05_orin_sm87.md
+++ b/docs/hyvla05_orin_sm87.md
@@ -38,9 +38,9 @@ Orin.
 | `flash_rt/frontends/torch/hyvla_orin.py` | Orin frontend; inherits Thor tokenizer/preprocess/prefix/graph orchestration; disables Thor-only FP8/FP4 fused options; materializes INT8 per-row weights. |
 | `flash_rt/models/hyvla/pipeline_orin.py` | Orin pipeline subclass; inherits BF16 math and overrides the lower-precision GEMM slot with INT8 W8A8 rowwise CUTLASS; fused ViT forward (pending-add+LN, efficient SDPA). |
 | `csrc/kernels/hyvla_vit_fuse.cu` | Fused ViT residual-add + LayerNorm kernel (SM87 + SM110 builds). |
-| `tests/test_orin_hyvla05_e2e_check.py` | HF/transformers eager vs Orin native action cosine with fixed noise. |
-| `tests/test_orin_hyvla05_graphsafe.py` | Graph-vs-eager and replay-stability gate. |
-| `tests/test_orin_hyvla05_stageprof.py` | Stage timing split for ViT, prefix assembly, and prefill+denoise graph replay. |
+| `tests/test_orin_hyvla05_e2e_check.py` | BF16 baseline vs default-INT8 fixed-noise action cosine gate (>= 0.999) plus state/noise/prompt input boundaries. |
+| `tests/test_orin_hyvla05_graphsafe.py` | Graph-vs-eager, replay-stability, and fused-vs-unfused (attention-prep, ViT add+LN) gates. |
+| `tests/test_orin_hyvla05_arch_gate.py` | SM87 fail-fast hardware gate and FP4 rejection (mocked CUDA, no device needed). |
 
 ## Precision policy
 
@@ -237,6 +237,7 @@ when needed.
 ```bash
 cmake -B build_orin_sm87 -S . \
   -DGPU_ARCH=87 \
+  -DFLASHRT_ENABLE_HYVLA=ON \
   -DFA2_ARCH_NATIVE_ONLY=ON \
   -DFA2_HDIMS='128;256' \
   -DFA2_DTYPES='bf16'
@@ -248,20 +249,22 @@ rowwise INT8 CUTLASS kernels into `flash_rt_kernels`.
 
 ## Verification
 
-BF16 baseline:
+Checkpoint-gated precision and graph-safety gates (skipped automatically when
+`FLASHRT_HYVLA_CHECKPOINT` is unset):
 
 ```bash
-PYTHONPATH=. python tests/test_orin_hyvla05_e2e_check.py --bf16
-PYTHONPATH=. python tests/test_orin_hyvla05_graphsafe.py --bf16
-PYTHONPATH=. python tests/test_orin_hyvla05_stageprof.py --bf16
+FLASHRT_HYVLA_CHECKPOINT=/path/to/Hy-Embodied-0.5-VLA-RoboTwin \
+  PYTHONPATH=. python -m pytest \
+  tests/test_orin_hyvla05_e2e_check.py \
+  tests/test_orin_hyvla05_graphsafe.py -v
 ```
 
-INT8 path:
+Hardware fail-fast and dispatch gates run without a device or checkpoint:
 
 ```bash
-PYTHONPATH=. python tests/test_orin_hyvla05_e2e_check.py --int8
-PYTHONPATH=. python tests/test_orin_hyvla05_graphsafe.py --int8
-PYTHONPATH=. python tests/test_orin_hyvla05_stageprof.py --int8
+PYTHONPATH=. python -m pytest \
+  tests/test_orin_hyvla05_arch_gate.py \
+  tests/test_orin_hyvla05_dispatch.py -v
 ```
 
 ## Current caveats

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -309,6 +309,8 @@ Wan2.2 TI2V-5B is registered for `(config="wan22_ti2v_5b",
 framework="torch", arch="rtx_sm120")`.
 Chameleon-7B is registered for `(config="chameleon", framework="torch",
 arch in {"rtx_sm87", "thor"})`.
+Hy-Embodied-0.5-VLA is registered for `(config="hyvla",
+framework="torch", arch in {"thor", "rtx_sm87"})`.
 
 ### `_PIPELINE_MAP`
 

--- a/flash_rt/frontends/torch/hyvla_orin.py
+++ b/flash_rt/frontends/torch/hyvla_orin.py
@@ -37,16 +37,19 @@ def _quantize_per_row_int8(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Te
 
 
 class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
+    _REQUIRED_CAPABILITY = (8, 7)
+    _ARCH_NAME = "Jetson Orin SM87"
+
     def __init__(self, checkpoint_dir: str, *, hardware: str = "rtx_sm87",
                  use_fp8: bool = True, use_fp8_vit: bool = False,
                  use_fused: bool = True, use_fp4: bool = False,
                  use_fused_quant: bool = False, use_autotune: bool = False,
                  use_ffn_mega: bool = False, use_int8: bool | None = None,
-                 use_int8_vlm: bool = False,  # experimental: not validated at cosine >= 0.999
-                 use_int8_vlm_ffn: bool | None = None,  # experimental: not validated at cosine >= 0.999
-                 use_int8_exp: bool = True,  # experimental: not validated at cosine >= 0.999
-                 use_int8_vit: bool | None = None,  # experimental: not validated at cosine >= 0.999
-                 vit_int8_parts: tuple = ("qkv", "proj", "fc1", "fc2"),  # experimental: not validated at cosine >= 0.999
+                 use_int8_vlm: bool = False,  # opt-in: fails the 0.999 E2E cosine gate
+                 use_int8_vlm_ffn: bool | None = None,  # validated default tier (cosine >= 0.999)
+                 use_int8_exp: bool = True,  # validated default tier (cosine >= 0.999)
+                 use_int8_vit: bool | None = None,  # opt-in: fails the 0.999 E2E cosine gate
+                 vit_int8_parts: tuple = ("qkv", "proj", "fc1", "fc2"),  # only used by opt-in use_int8_vit
                  **kwargs):
         if use_fp4:
             raise RuntimeError(
@@ -210,7 +213,8 @@ class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
         rebuilt each call."""
         if prompt is not None and prompt != self._prompt:
             self.set_prompt(prompt)
-        assert self._lang_tokens is not None, "call set_prompt() first"
+        if self._lang_tokens is None:
+            raise RuntimeError("call set_prompt() before predict_actions()")
         dev = self.device
 
         if not torch.is_tensor(images):
@@ -223,6 +227,10 @@ class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
             state_t = torch.zeros(1, self.max_state_dim, device=dev, dtype=_BF16)
         else:
             st = torch.as_tensor(np.asarray(state), device=dev, dtype=_BF16).reshape(1, -1)
+            if st.shape[1] > self.max_state_dim:
+                raise ValueError(
+                    f"state has {st.shape[1]} dims, max_state_dim is "
+                    f"{self.max_state_dim}")
             if st.shape[1] < self.max_state_dim:
                 st = F.pad(st, (0, self.max_state_dim - st.shape[1]))
             state_t = st
@@ -267,6 +275,13 @@ class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
                                   dtype=torch.float32, device=dev)
         else:
             noise_t = torch.as_tensor(np.asarray(noise), device=dev, dtype=torch.float32)
+            want = self.chunk * self.max_action_dim
+            if noise_t.numel() != want:
+                raise ValueError(
+                    f"noise must have {want} elements "
+                    f"(chunk={self.chunk} x max_action_dim={self.max_action_dim}), "
+                    f"got {noise_t.numel()}")
+            noise_t = noise_t.reshape(1, self.chunk, self.max_action_dim)
 
         x_t = self._graph_forward(stat["S_p"], stat["n_vis"], prefix_embs,
                                   stat["pmask"], stat["pcos"], stat["psin"],
@@ -276,4 +291,3 @@ class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
 
 
 __all__ = ["HyVLATorchFrontendOrin"]
-

--- a/flash_rt/frontends/torch/hyvla_orin.py
+++ b/flash_rt/frontends/torch/hyvla_orin.py
@@ -1,0 +1,279 @@
+"""HyVLA frontend for Jetson Orin SM87.
+
+SM87 has no native FP8/FP4 tensor cores, so the Thor FP8/NVFP4 paths are
+mapped to the existing SM80-family INT8 W8A8 rowwise kernels. The public IO,
+preprocessing, prefix assembly, graph cache, and weight spec are inherited from
+``HyVLATorchFrontendThor``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from flash_rt.frontends.torch.hyvla_thor import HyVLATorchFrontendThor, _BF16
+from flash_rt.models.hyvla.pipeline_orin import HyVLAOrinBF16Pipeline
+
+logger = logging.getLogger(__name__)
+
+INT8_QUANT_MAX = 127.0
+INT8_QUANT_EPS = 1e-12
+
+
+def _quantize_per_row_int8(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    w_f32 = w_bf16.float().contiguous()
+    scale = torch.clamp(
+        w_f32.abs().amax(dim=1) / INT8_QUANT_MAX,
+        min=INT8_QUANT_EPS,
+    ).to(device=w_bf16.device, dtype=torch.float32).contiguous()
+    q = torch.clamp(
+        torch.round(w_f32 / scale[:, None]),
+        -127, 127,
+    ).to(torch.int8).contiguous()
+    return q, scale
+
+
+class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
+    def __init__(self, checkpoint_dir: str, *, hardware: str = "rtx_sm87",
+                 use_fp8: bool = True, use_fp8_vit: bool = False,
+                 use_fused: bool = True, use_fp4: bool = False,
+                 use_fused_quant: bool = False, use_autotune: bool = False,
+                 use_ffn_mega: bool = False, use_int8: bool | None = None,
+                 use_int8_vlm: bool = False,  # experimental: not validated at cosine >= 0.999
+                 use_int8_vlm_ffn: bool | None = None,  # experimental: not validated at cosine >= 0.999
+                 use_int8_exp: bool = True,  # experimental: not validated at cosine >= 0.999
+                 use_int8_vit: bool | None = None,  # experimental: not validated at cosine >= 0.999
+                 vit_int8_parts: tuple = ("qkv", "proj", "fc1", "fc2"),  # experimental: not validated at cosine >= 0.999
+                 **kwargs):
+        if use_fp4:
+            raise RuntimeError(
+                "HyVLATorchFrontendOrin does not support FP4: SM87 has no "
+                "native FP4 tensor cores. Use the default INT8 W8A8 path or "
+                "pass use_fp8=False, use_int8=False for BF16.")
+        if use_fp8_vit:
+            logger.warning(
+                "HyVLA Orin ignores Thor's use_fp8_vit; ViT quantization on "
+                "SM87 uses the INT8 path (use_int8_vit).")
+        if use_fused_quant:
+            logger.warning("HyVLA Orin disables Thor-only fused FP8 quantization.")
+        if use_ffn_mega:
+            logger.warning("HyVLA Orin disables Thor-only FP8 FFN megakernels.")
+        if use_autotune:
+            logger.warning("HyVLA Orin INT8 path does not use Thor FP8 autotune.")
+
+        self.use_int8 = bool(use_fp8) if use_int8 is None else bool(use_int8)
+        self.use_int8_vlm = bool(use_int8_vlm)
+        self.use_int8_exp = bool(use_int8_exp)
+        self.use_int8_vit = False if use_int8_vit is None else bool(use_int8_vit)
+        self.vit_int8_parts = tuple(vit_int8_parts)
+        vlm_ffn = self.use_int8 if use_int8_vlm_ffn is None else bool(use_int8_vlm_ffn)
+        if use_fp8 and self.use_int8:
+            logger.info(
+                "HyVLA Orin maps use_fp8=True to SM87 INT8 W8A8 rowwise GEMMs "
+                "(expert tower + prefill FFN by default; use_int8_vlm=True "
+                "quantizes prefill QKV/O too, use_int8_vit=True is opt-in and "
+                "fails the 0.999 E2E gate).")
+
+        super().__init__(
+            checkpoint_dir,
+            hardware=hardware,
+            use_fp8=False,
+            use_fp8_vit=False,
+            use_fused=False,
+            use_fp4=False,
+            use_fused_quant=False,
+            use_autotune=False,
+            use_ffn_mega=False,
+            **kwargs,
+        )
+        if self.use_int8_vit:
+            self._quantize_vit_int8()
+        self.pipe = HyVLAOrinBF16Pipeline(self)
+        import flash_rt.flash_rt_kernels as fvk
+        # ViT levers: memory-efficient SDPA reads the strided QKV slices
+        # directly (the flash backend force-copies them), and the fused
+        # residual-add+LayerNorm kernel collapses the ViT elementwise pairs.
+        self.pipe._vit_eff_sdpa = True
+        self.pipe._vit_fuse_ln = hasattr(fvk, "hyvla_vit_add_layer_norm_bf16")
+        if use_fused:
+            if hasattr(fvk, "hyvla_rope_qknorm_kvwrite_bf16"):
+                self.pipe._fused_attn = True
+            else:
+                logger.warning(
+                    "HyVLA Orin: fused RoPE/QKNorm/KV-write kernel not in "
+                    "this build; falling back to the torch attention-prep path.")
+        if self.use_int8:
+            self._quantize_int8()
+            self._vlm_fp8_ready = self.use_int8_vlm
+            self._exp_fp8_ready = self.use_int8_exp
+            self.pipe.enable_int8()
+            if vlm_ffn and not self.use_int8_vlm:
+                self._quantize_vlm_ffn_int8()
+                self.pipe._vlm_ffn_int8 = True
+
+    def _quantize_int8(self):
+        def q_list(src):
+            qs, ss = [], []
+            for w in src:
+                q, s = _quantize_per_row_int8(w)
+                qs.append(q)
+                ss.append(s)
+            return qs, ss
+
+        if self.use_int8_exp:
+            self._exp_qkv8, self._exp_qkv_ws = q_list(self._exp_qkv_v)
+            self._exp_o8, self._exp_o_ws = q_list(self._exp_o_v)
+            self._exp_gu8, self._exp_gu_ws = q_list(self._exp_gu_v)
+            self._exp_d8, self._exp_d_ws = q_list(self._exp_d_v)
+            self._exp_fp8_ready = True
+        else:
+            self._exp_fp8_ready = False
+
+        if self.use_int8_vlm:
+            self._vlm_qkv_v8, self._vlm_qkv_v_ws = q_list(self._vlm_qkv_v)
+            self._vlm_o_v8, self._vlm_o_v_ws = q_list(self._vlm_o_v)
+            self._vlm_gu_v8, self._vlm_gu_v_ws = q_list(self._vlm_gu_v)
+            self._vlm_d_v8, self._vlm_d_v_ws = q_list(self._vlm_d_v)
+            self._vlm_qkv_t8, self._vlm_qkv_t_ws = q_list(self._vlm_qkv_t)
+            self._vlm_o_t8, self._vlm_o_t_ws = q_list(self._vlm_o_t)
+            self._vlm_gu_t8, self._vlm_gu_t_ws = q_list(self._vlm_gu_t)
+            self._vlm_d_t8, self._vlm_d_t_ws = q_list(self._vlm_d_t)
+            self._vlm_fp8_ready = True
+        else:
+            self._vlm_fp8_ready = False
+        torch.cuda.synchronize()
+
+    def _quantize_vlm_ffn_int8(self):
+        """INT8-quantize only the VLM prefill FFN weights (gate/up + down,
+        vision and text branches). QKV/O stay BF16 so the KV cache written by
+        prefill — and read by all 10 denoise steps — keeps full precision."""
+        def q_list(src):
+            qs, ss = [], []
+            for w in src:
+                q, s = _quantize_per_row_int8(w)
+                qs.append(q)
+                ss.append(s)
+            return qs, ss
+
+        self._vlm_gu_v8, self._vlm_gu_v_ws = q_list(self._vlm_gu_v)
+        self._vlm_d_v8, self._vlm_d_v_ws = q_list(self._vlm_d_v)
+        self._vlm_gu_t8, self._vlm_gu_t_ws = q_list(self._vlm_gu_t)
+        self._vlm_d_t8, self._vlm_d_t_ws = q_list(self._vlm_d_t)
+        torch.cuda.synchronize()
+        logger.info(
+            "HyVLA Orin: VLM prefill FFN (gate/up/down) quantized to INT8; "
+            "QKV/O remain BF16.")
+
+    def _quantize_vit_int8(self):
+        """Replace the 27-block ViT GEMM weights (qkv/proj/fc1/fc2) in-place
+        with per-row INT8 + FP32 scale wrappers consumed by
+        ``HyVLAOrinBF16Pipeline._vit_*``. LayerNorm weights/biases and the
+        patch-embed conv stay BF16."""
+        from flash_rt.models.hyvla.pipeline_orin import _W8Int8
+
+        part_attrs = {
+            "qkv": "_vit_qkv_w",
+            "proj": "_vit_proj_w",
+            "fc1": "_vit_fc1_w",
+            "fc2": "_vit_fc2_w",
+        }
+        for part in self.vit_int8_parts:
+            if part not in part_attrs:
+                raise ValueError(
+                    f"unknown vit_int8_parts entry {part!r}; "
+                    f"valid: {sorted(part_attrs)}")
+            attr = part_attrs[part]
+            src = getattr(self, attr)
+            wrapped = []
+            for w in src:
+                q, s = _quantize_per_row_int8(w)
+                wrapped.append(_W8Int8(q, s))
+            setattr(self, attr, wrapped)
+            del src
+        torch.cuda.synchronize()
+        logger.info(
+            "HyVLA Orin: ViT INT8 W8A8 enabled for parts %s.",
+            list(self.vit_int8_parts))
+
+
+    @torch.no_grad()
+    def predict_actions(self, images, prompt=None, state=None, noise=None,
+                        use_graph=True):
+        """Orin variant of the Thor ``predict_actions`` with a static-prefix
+        cache: everything that depends only on (prompt, num_cam) — the segment
+        mask, the [vision|text] permutation, the bf16-rounded RoPE tables
+        (fp64 math), and the suffix mask — is computed once per prompt and
+        reused across frames. Only the image-dependent ``prefix_embs`` are
+        rebuilt each call."""
+        if prompt is not None and prompt != self._prompt:
+            self.set_prompt(prompt)
+        assert self._lang_tokens is not None, "call set_prompt() first"
+        dev = self.device
+
+        if not torch.is_tensor(images):
+            images = torch.as_tensor(np.asarray(images))
+        cam_imgs = self._preprocess_images(images)
+        imgs5 = torch.cat(cam_imgs, 0)
+        merged = self._vit_merge(imgs5, use_graph=use_graph)
+
+        if state is None:
+            state_t = torch.zeros(1, self.max_state_dim, device=dev, dtype=_BF16)
+        else:
+            st = torch.as_tensor(np.asarray(state), device=dev, dtype=_BF16).reshape(1, -1)
+            if st.shape[1] < self.max_state_dim:
+                st = F.pad(st, (0, self.max_state_dim - st.shape[1]))
+            state_t = st
+
+        key = (self._prompt, merged.shape[0])
+        stat = getattr(self, "_static_prefix_cache", None)
+        if stat is None or stat["key"] != key:
+            (prefix_embs, pad_masks, att_masks, mm_prefix,
+             idx_ranges, full_ranges) = self._assemble_prefix(merged)
+            att2d = self._make_att_2d(pad_masks, att_masks)
+            att2d = self._apply_segment_mask(att2d, idx_ranges, full_ranges)
+            prefix_pos = torch.cumsum(pad_masks.long(), dim=1) - 1
+            mm = mm_prefix[0]
+            perm = torch.cat([torch.nonzero(mm).squeeze(-1),
+                              torch.nonzero(~mm).squeeze(-1)])
+            n_vis = int(mm.sum().item())
+            att2d = att2d[:, perm][:, :, perm]
+            prefix_pos = prefix_pos[:, perm]
+            pcos, psin = self._rope_cos_sin(prefix_pos)
+            S_p = pad_masks.shape[1]
+            S_s = 1 + self.chunk
+            suffix_pad = torch.ones(1, S_s, dtype=torch.bool, device=dev)
+            suffix_att = torch.tensor([1, 1] + [0] * (self.chunk - 1),
+                                      dtype=torch.bool, device=dev)[None]
+            suffix_att2d = self._make_att_2d(suffix_pad, suffix_att)
+            prefix_pad_2d = pad_masks[:, perm][:, None, :].expand(1, S_s, S_p)
+            smask = torch.cat([prefix_pad_2d, suffix_att2d], 2)[:, None]
+            suffix_pos = (pad_masks.long().sum(-1)[:, None]
+                          + torch.cumsum(suffix_pad.long(), 1) - 1)
+            scos, ssin = self._rope_cos_sin(suffix_pos)
+            stat = {"key": key, "perm": perm, "n_vis": n_vis, "S_p": S_p,
+                    "pmask": att2d[:, None], "pcos": pcos, "psin": psin,
+                    "smask": smask, "scos": scos, "ssin": ssin}
+            self._static_prefix_cache = stat
+
+        (prefix_embs, _pad_masks, _att_masks, _mm_prefix,
+         _idx_ranges, _full_ranges) = self._assemble_prefix(merged)
+        prefix_embs = prefix_embs[:, stat["perm"]]
+
+        if noise is None:
+            noise_t = torch.randn(1, self.chunk, self.max_action_dim,
+                                  dtype=torch.float32, device=dev)
+        else:
+            noise_t = torch.as_tensor(np.asarray(noise), device=dev, dtype=torch.float32)
+
+        x_t = self._graph_forward(stat["S_p"], stat["n_vis"], prefix_embs,
+                                  stat["pmask"], stat["pcos"], stat["psin"],
+                                  stat["smask"], stat["scos"], stat["ssin"],
+                                  state_t, noise_t, use_graph=use_graph)
+        return x_t.float().cpu().numpy()
+
+
+__all__ = ["HyVLATorchFrontendOrin"]
+

--- a/flash_rt/frontends/torch/hyvla_orin.py
+++ b/flash_rt/frontends/torch/hyvla_orin.py
@@ -211,6 +211,27 @@ class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
         (fp64 math), and the suffix mask — is computed once per prompt and
         reused across frames. Only the image-dependent ``prefix_embs`` are
         rebuilt each call."""
+        if state is not None:
+            state_size = (
+                state.numel() if torch.is_tensor(state)
+                else np.asarray(state).size
+            )
+            if state_size > self.max_state_dim:
+                raise ValueError(
+                    f"state has {state_size} dims, max_state_dim is "
+                    f"{self.max_state_dim}")
+        if noise is not None:
+            noise_size = (
+                noise.numel() if torch.is_tensor(noise)
+                else np.asarray(noise).size
+            )
+            want = self.chunk * self.max_action_dim
+            if noise_size != want:
+                raise ValueError(
+                    f"noise must have {want} elements "
+                    f"(chunk={self.chunk} x max_action_dim={self.max_action_dim}), "
+                    f"got {noise_size}")
+
         if prompt is not None and prompt != self._prompt:
             self.set_prompt(prompt)
         if self._lang_tokens is None:
@@ -226,11 +247,8 @@ class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
         if state is None:
             state_t = torch.zeros(1, self.max_state_dim, device=dev, dtype=_BF16)
         else:
-            st = torch.as_tensor(np.asarray(state), device=dev, dtype=_BF16).reshape(1, -1)
-            if st.shape[1] > self.max_state_dim:
-                raise ValueError(
-                    f"state has {st.shape[1]} dims, max_state_dim is "
-                    f"{self.max_state_dim}")
+            source = state if torch.is_tensor(state) else np.asarray(state)
+            st = torch.as_tensor(source, device=dev, dtype=_BF16).reshape(1, -1)
             if st.shape[1] < self.max_state_dim:
                 st = F.pad(st, (0, self.max_state_dim - st.shape[1]))
             state_t = st
@@ -274,13 +292,8 @@ class HyVLATorchFrontendOrin(HyVLATorchFrontendThor):
             noise_t = torch.randn(1, self.chunk, self.max_action_dim,
                                   dtype=torch.float32, device=dev)
         else:
-            noise_t = torch.as_tensor(np.asarray(noise), device=dev, dtype=torch.float32)
-            want = self.chunk * self.max_action_dim
-            if noise_t.numel() != want:
-                raise ValueError(
-                    f"noise must have {want} elements "
-                    f"(chunk={self.chunk} x max_action_dim={self.max_action_dim}), "
-                    f"got {noise_t.numel()}")
+            source = noise if torch.is_tensor(noise) else np.asarray(noise)
+            noise_t = torch.as_tensor(source, device=dev, dtype=torch.float32)
             noise_t = noise_t.reshape(1, self.chunk, self.max_action_dim)
 
         x_t = self._graph_forward(stat["S_p"], stat["n_vis"], prefix_embs,

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -105,6 +105,8 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     # ── Hy-Embodied-0.5-VLA (HunYuan MoT dual-tower + flow matching) ──
     ("hyvla", "torch", "thor"):
         ("flash_rt.frontends.torch.hyvla_thor", "HyVLATorchFrontendThor"),
+    ("hyvla", "torch", "rtx_sm87"):
+        ("flash_rt.frontends.torch.hyvla_orin", "HyVLATorchFrontendOrin"),
 
     # ── GROOT N1.6 ──
     ("groot", "torch", "thor"):
@@ -219,6 +221,7 @@ _SM87_ALLOWED = {
     ("pi05", "torch", "rtx_sm87"),
     ("chameleon", "torch", "rtx_sm87"),
     ("qwen3_vl", "torch", "rtx_sm87"),
+    ("hyvla", "torch", "rtx_sm87"),
 }
 
 

--- a/flash_rt/models/hyvla/pipeline_orin.py
+++ b/flash_rt/models/hyvla/pipeline_orin.py
@@ -1,0 +1,434 @@
+"""HyVLA forward path for Jetson Orin SM87.
+
+The BF16 math is inherited from the Thor correctness path. When enabled, the
+GEMM slots that Thor names ``fp8`` are backed by SM87 INT8 W8A8 rowwise kernels.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+try:
+    from torch.nn.attention import sdpa_kernel, SDPBackend
+except ImportError:  # pragma: no cover - torch < 2.2
+    sdpa_kernel = None
+    SDPBackend = None
+
+import flash_rt.flash_rt_kernels as fvk
+import flash_rt.models.hyvla.pipeline_thor as _thor_pipeline
+from flash_rt.models.hyvla.pipeline_thor import HyVLAThorBF16Pipeline, _rot_half
+
+
+if not hasattr(_thor_pipeline.F, "rms_norm"):
+    def _rms_norm_torch(x, weight, eps):
+        y = x.float() * torch.rsqrt(x.float().pow(2).mean(dim=-1, keepdim=True) + eps)
+        if weight is not None:
+            y = y * weight.float()
+        return y.to(x.dtype)
+
+    def _rms_norm(x, normalized_shape, weight=None, eps=1e-5):
+        # torch 2.3 lacks F.rms_norm. The single-launch fvk.rms_norm kernel
+        # implements the exact reference math (fp32 sum-of-squares -> rsqrt ->
+        # weight multiply -> bf16 rounding) and is bit-equal to the torch
+        # expansion on contiguous rows; fall back for anything exotic.
+        if (x.is_cuda and x.dtype == torch.bfloat16 and weight is not None
+                and weight.dtype == torch.bfloat16
+                and len(normalized_shape) == 1
+                and normalized_shape[0] == x.shape[-1]):
+            xc = x if x.is_contiguous() else x.contiguous()
+            wc = weight if weight.is_contiguous() else weight.contiguous()
+            rows = xc.numel() // xc.shape[-1]
+            out = torch.empty_like(xc)
+            fvk.rms_norm(xc.data_ptr(), wc.data_ptr(), out.data_ptr(),
+                         rows, xc.shape[-1], eps,
+                         torch.cuda.current_stream().cuda_stream)
+            return out.reshape(x.shape)
+        return _rms_norm_torch(x, weight, eps)
+
+    _thor_pipeline.F.rms_norm = _rms_norm
+
+
+class _W8Int8:
+    """Per-output-row INT8 weight + FP32 scale pair for the ViT INT8 path."""
+
+    __slots__ = ("w", "s")
+
+    def __init__(self, w, s):
+        self.w = w
+        self.s = s
+
+
+def _vit_int8_linear(x, w8, bias):
+    """x (..., K) bf16 @ W8_int8.T -> (..., N) bf16 + bias via SM87 rowwise INT8."""
+    wq, ws = w8.w, w8.s
+    N, K = wq.shape
+    orig = x.shape
+    xc = x.reshape(-1, K).contiguous()
+    M = xc.shape[0]
+    st = torch.cuda.current_stream().cuda_stream
+    a8 = torch.empty(M, K, dtype=torch.int8, device=x.device)
+    act_scale = torch.empty(M, dtype=torch.float32, device=x.device)
+    fvk.quantize_int8_rowwise(
+        xc.data_ptr(), a8.data_ptr(), act_scale.data_ptr(), M, K, st)
+    out = torch.empty(M, N, dtype=torch.bfloat16, device=x.device)
+    status = fvk.cutlass_int8_rowwise_bf16out(
+        a8.data_ptr(), wq.data_ptr(), act_scale.data_ptr(), ws.data_ptr(),
+        out.data_ptr(), M, N, K, st)
+    if status != 0:
+        raise RuntimeError(
+            f"cutlass_int8_rowwise_bf16out failed: status={status} "
+            f"shape=({M},{N},{K})")
+    out = out + bias
+    return out.reshape(*orig[:-1], N)
+
+
+class HyVLAOrinBF16Pipeline(HyVLAThorBF16Pipeline):
+    def enable_fp8(self):
+        raise RuntimeError(
+            "HyVLA Orin does not support Thor FP8 GEMMs; use enable_int8().")
+
+    def enable_fp4(self):
+        raise RuntimeError(
+            "HyVLA Orin does not support FP4 because SM87 has no native FP4 tensor cores.")
+
+    def enable_int8(self):
+        self._fp8 = True
+        self._orin_int8 = True
+        self.gemm = None
+
+    def autotune_gemms(self, shapes, num_algos=16):
+        return 0
+
+    def _attn(self, q, k, v, mask):
+        out = super()._attn(q, k, v, mask)
+        return torch.nan_to_num(out)
+
+    # ------------------------------------------------------------------
+    #  ViT INT8 GEMM sites (SM87). Weight lists are replaced in-place by
+    #  the frontend with _W8Int8 wrappers when use_int8_vit is enabled;
+    #  otherwise the parent BF16 F.linear path is kept.
+    # ------------------------------------------------------------------
+    def _vit_qkv(self, h):
+        if isinstance(self._vit_qkv_w_cur, _W8Int8):
+            qkv = _vit_int8_linear(h, self._vit_qkv_w_cur, self._vit_qkv_b_cur)
+            bk, N, _ = h.shape
+            qkv = qkv.reshape(bk, N, 3, self.vit_heads, self.vit_hd).permute(2, 0, 3, 1, 4)
+            return qkv[0], qkv[1], qkv[2]
+        return super()._vit_qkv(h)
+
+    def _vit_spatial_attn(self, q, k, v):
+        bk, _, N, _ = q.shape
+        if getattr(self, "_vit_eff_sdpa", False):
+            # The q/k/v slices out of the packed QKV GEMM are strided; the
+            # flash backend force-copies them contiguous (4 copy_ per block,
+            # ~25% of ViT time). The memory-efficient backend accepts the
+            # strides directly and reads the strided layout natively.
+            if sdpa_kernel is not None:
+                ctx = sdpa_kernel(SDPBackend.EFFICIENT_ATTENTION)
+            else:
+                ctx = torch.backends.cuda.sdp_kernel(
+                    enable_flash=False, enable_math=False, enable_mem_efficient=True)
+            with ctx:
+                out = F.scaled_dot_product_attention(q, k, v, scale=self.vit_scale)
+        else:
+            out = F.scaled_dot_product_attention(q, k, v, scale=self.vit_scale)
+        out = out.transpose(1, 2).reshape(bk, N, -1)
+        if isinstance(self._vit_proj_w_cur, _W8Int8):
+            return _vit_int8_linear(out, self._vit_proj_w_cur, self._vit_proj_b_cur)
+        return F.linear(out, self._vit_proj_w_cur, self._vit_proj_b_cur)
+
+    def _vit_mlp(self, x):
+        if isinstance(self._vit_fc1_w_cur, _W8Int8):
+            x = _vit_int8_linear(x, self._vit_fc1_w_cur, self._vit_fc1_b_cur)
+            x = F.gelu(x)
+            return _vit_int8_linear(x, self._vit_fc2_w_cur, self._vit_fc2_b_cur)
+        return super()._vit_mlp(x)
+
+    # ------------------------------------------------------------------
+    #  Fused ViT forward: residual-add + LayerNorm pairs collapse into one
+    #  hyvla_vit_add_layer_norm_bf16 launch. The previous block's MLP
+    #  output is carried as ``pending`` and fused into the next block's
+    #  entry LN; the post-attention add is fused into the pre-MLP LN.
+    #  Spacetime blocks keep the torch path (their entry LN also adds the
+    #  time positional embedding).
+    # ------------------------------------------------------------------
+    def _vit_add_ln(self, x, add, lnw, lnb):
+        bk, n, d = x.shape
+        out = torch.empty_like(x)
+        fvk.hyvla_vit_add_layer_norm_bf16(
+            x.data_ptr(), add.data_ptr(), lnw.data_ptr(), lnb.data_ptr(),
+            out.data_ptr(), bk * n, d, self.vit_eps,
+            torch.cuda.current_stream().cuda_stream)
+        return out
+
+    def _vit_ln(self, x, lnw, lnb):
+        bk, n, d = x.shape
+        out = torch.empty_like(x)
+        fvk.layer_norm(x.data_ptr(), lnw.data_ptr(), lnb.data_ptr(),
+                       out.data_ptr(), bk * n, d, self.vit_eps,
+                       torch.cuda.current_stream().cuda_stream)
+        return out
+
+    @torch.no_grad()
+    def vit_forward(self, imgs):
+        if not getattr(self, "_vit_fuse_ln", False):
+            return super().vit_forward(imgs)
+        W = self.W
+        num_cam, K = imgs.shape[0], imgs.shape[1]
+        bk = num_cam * K
+        x = imgs.reshape(bk, 3, 224, 224)
+        x = F.conv2d(x, W._vit_patch_w, W._vit_patch_b, stride=16)
+        hh = ww = x.shape[-1]
+        n = hh * ww
+        d = x.shape[1]
+        x = x.flatten(2).transpose(1, 2)
+        x = (x + self._vit_pos_embed_rescale(hh, ww, x.dtype)).contiguous()
+        last_st = max(self.vit_spacetime_ids) if K > 1 else -1
+        sliced = False
+        pending = None
+        for li in range(27):
+            Wcur = self.W
+            self._vit_qkv_w_cur = Wcur._vit_qkv_w[li]; self._vit_qkv_b_cur = Wcur._vit_qkv_b[li]
+            self._vit_proj_w_cur = Wcur._vit_proj_w[li]; self._vit_proj_b_cur = Wcur._vit_proj_b[li]
+            self._vit_fc1_w_cur = Wcur._vit_fc1_w[li]; self._vit_fc1_b_cur = Wcur._vit_fc1_b[li]
+            self._vit_fc2_w_cur = Wcur._vit_fc2_w[li]; self._vit_fc2_b_cur = Wcur._vit_fc2_b[li]
+            self._vit_f8 = self._fp8 and getattr(Wcur, "_vit_fp8_ready", False)
+            if self._vit_f8:
+                self._vit_qkv_w8c = Wcur._vit_qkv_w8[li]; self._vit_qkv_wsc = Wcur._vit_qkv_ws[li]
+                self._vit_proj_w8c = Wcur._vit_proj_w8[li]; self._vit_proj_wsc = Wcur._vit_proj_ws[li]
+                self._vit_fc1_w8c = Wcur._vit_fc1_w8[li]; self._vit_fc1_wsc = Wcur._vit_fc1_ws[li]
+                self._vit_fc2_w8c = Wcur._vit_fc2_w8[li]; self._vit_fc2_wsc = Wcur._vit_fc2_ws[li]
+            ln1w, ln1b = Wcur._vit_ln1_w[li], Wcur._vit_ln1_b[li]
+            ln2w, ln2b = Wcur._vit_ln2_w[li], Wcur._vit_ln2_b[li]
+
+            if li in self.vit_spacetime_ids and K > 1:
+                if pending is not None:
+                    x = x + pending
+                    pending = None
+                b, kf = bk // K, K
+                pe = self._vit_time_pe(kf, x.device, x.dtype)
+                h = F.layer_norm(x.view(b, kf, n, d) + pe.view(1, kf, 1, d),
+                                 (d,), ln1w, ln1b, self.vit_eps).view(bk, n, d)
+                q, k, v = self._vit_qkv(h)
+                v = self._vit_time_mix(q, k, v, b, kf)
+                attn_out = self._vit_spatial_attn(q, k, v)
+            else:
+                if pending is not None:
+                    h = self._vit_add_ln(x, pending, ln1w, ln1b)
+                else:
+                    h = self._vit_ln(x, ln1w, ln1b)
+                q, k, v = self._vit_qkv(h)
+                attn_out = self._vit_spatial_attn(q, k, v)
+
+            h2 = self._vit_add_ln(x, attn_out, ln2w, ln2b)
+            pending = self._vit_mlp(h2)
+            if li == last_st and li < 26:
+                x = (x + pending).contiguous()
+                pending = None
+                x = x.view(num_cam, K, n, d)[:, -1].contiguous()
+                sliced = True
+        if pending is not None:
+            x = x + pending
+        if not sliced:
+            x = x.view(num_cam, K, n, d)[:, -1]
+        return x
+
+    def _int8_rowwise_gemm(self, x, wq, ws):
+        """x (..., K) bf16 -> (M, N) bf16 via dynamic per-row INT8 W8A8."""
+        N, K = wq.shape
+        xc = x.reshape(-1, K).contiguous()
+        M = xc.shape[0]
+        st = torch.cuda.current_stream().cuda_stream
+        a8 = torch.empty(M, K, dtype=torch.int8, device=x.device)
+        act_scale = torch.empty(M, dtype=torch.float32, device=x.device)
+        fvk.quantize_int8_rowwise(
+            xc.data_ptr(), a8.data_ptr(), act_scale.data_ptr(), M, K, st)
+        out = torch.empty(M, N, dtype=torch.bfloat16, device=x.device)
+        status = fvk.cutlass_int8_rowwise_bf16out(
+            a8.data_ptr(), wq.data_ptr(), act_scale.data_ptr(), ws.data_ptr(),
+            out.data_ptr(), M, N, K, st)
+        if status != 0:
+            raise RuntimeError(
+                f"cutlass_int8_rowwise_bf16out failed: status={status} "
+                f"shape=({M},{N},{K})")
+        return out
+
+    def _fp8_gemm(self, x, w8, ws):
+        if not getattr(self, "_orin_int8", False):
+            raise RuntimeError("HyVLA Orin lower-precision GEMM requires enable_int8().")
+        return self._int8_rowwise_gemm(x, w8, ws)
+
+    # ------------------------------------------------------------------
+    #  Prefill FFN-only INT8: QKV / O stay BF16 (their outputs feed the KV
+    #  cache read by 10 denoise steps), gate/up/down run INT8 W8A8.
+    # ------------------------------------------------------------------
+    def _block_ffn8(self, hs, n_vis, w_text, w_vis, qk_w, mask, cos, sin,
+                    kbuf, vbuf, off, ffnv, ffnt):
+        S = hs.shape[1]
+        D = hs.shape[2]
+        hd, nh, nkv = self.head_dim, self.n_heads, self.n_kv
+
+        hs_v = F.rms_norm(hs[0, :n_vis], (D,), w_vis[4], self.rms_eps)
+        hs_t = F.rms_norm(hs[0, n_vis:], (D,), w_text[4], self.rms_eps)
+        qkv = torch.cat([hs_v @ w_vis[0].t(), hs_t @ w_text[0].t()], 0)
+
+        if getattr(self, "_fused_attn", False):
+            q = torch.empty(1, nh, S, hd, dtype=torch.bfloat16, device=hs.device)
+            self._rope_qknorm_kvwrite(qkv, cos, sin, qk_w, q, kbuf, vbuf, S, off)
+        else:
+            q, k, v = qkv.split([self.q_dim, self.kv_dim, self.kv_dim], -1)
+            q = q.view(S, nh, hd).transpose(0, 1)[None]
+            k = k.view(S, nkv, hd).transpose(0, 1)[None]
+            v = v.view(S, nkv, hd).transpose(0, 1)[None]
+            q = q * cos + _rot_half(q) * sin
+            k = k * cos + _rot_half(k) * sin
+            q = F.rms_norm(q, (hd,), qk_w[0], self.rms_eps)
+            k = F.rms_norm(k, (hd,), qk_w[1], self.rms_eps)
+            if kbuf.shape[1] != nkv:
+                r = kbuf.shape[1] // nkv
+                k = k.repeat_interleave(r, dim=1)
+                v = v.repeat_interleave(r, dim=1)
+            kbuf[:, :, off:off + S].copy_(k)
+            vbuf[:, :, off:off + S].copy_(v)
+        att = self._attn(q, kbuf[:, :, : off + S], vbuf[:, :, : off + S], mask)
+        att = att.transpose(1, 2).reshape(1, S, self.q_dim)
+
+        o_v = att[0, :n_vis] @ w_vis[1].t()
+        o_t = att[0, n_vis:] @ w_text[1].t()
+        hs = hs + torch.cat([o_v, o_t], 0)[None]
+
+        hs_v = F.rms_norm(hs[0, :n_vis], (D,), w_vis[5], self.rms_eps)
+        hs_t = F.rms_norm(hs[0, n_vis:], (D,), w_text[5], self.rms_eps)
+        gu = torch.cat([self._int8_rowwise_gemm(hs_v, ffnv[0], ffnv[1]),
+                        self._int8_rowwise_gemm(hs_t, ffnt[0], ffnt[1])], 0)
+        g, u = gu.chunk(2, -1)
+        act = F.silu(g) * u
+        dn = torch.cat([self._int8_rowwise_gemm(act[:n_vis], ffnv[2], ffnv[3]),
+                        self._int8_rowwise_gemm(act[n_vis:], ffnt[2], ffnt[3])], 0)
+        return hs + dn[None]
+
+    @torch.no_grad()
+    def prefill(self, prefix_embs, n_vis, pmask, pcos, psin, kbuf, vbuf):
+        if getattr(self, "_vlm_ffn_int8", False):
+            W = self.W
+            hs = prefix_embs
+            for li in range(32):
+                text, vis = self._vlm_w(li)
+                qk = (W._qk_norm_q[li], W._qk_norm_k[li])
+                ffnv = (W._vlm_gu_v8[li], W._vlm_gu_v_ws[li],
+                        W._vlm_d_v8[li], W._vlm_d_v_ws[li])
+                ffnt = (W._vlm_gu_t8[li], W._vlm_gu_t_ws[li],
+                        W._vlm_d_t8[li], W._vlm_d_t_ws[li])
+                hs = self._block_ffn8(hs, n_vis, text, vis, qk, pmask,
+                                      pcos, psin, kbuf[li], vbuf[li], 0,
+                                      ffnv, ffnt)
+            return hs
+        return super().prefill(prefix_embs, n_vis, pmask, pcos, psin, kbuf, vbuf)
+
+    # ------------------------------------------------------------------
+    #  Expert denoise with fused residual-add + RMSNorm. The down-proj
+    #  output of layer N is carried as ``pending`` and fused into layer
+    #  N+1's input norm (and into the final norm after layer 31), turning
+    #  (add + norm) pairs into single launches across all 32x10 blocks.
+    # ------------------------------------------------------------------
+    def _res_add_rms_norm(self, residual, x, weight):
+        rows = residual.shape[-2]
+        dim = residual.shape[-1]
+        out = torch.empty_like(residual)
+        fvk.residual_add_rms_norm(
+            residual.data_ptr(), x.data_ptr(), weight.data_ptr(),
+            out.data_ptr(), rows, dim, self.rms_eps,
+            torch.cuda.current_stream().cuda_stream)
+        return out
+
+    def _rope_qknorm_kvwrite(self, qkv, cos, sin, qk_w, q, kbuf, vbuf, S, off):
+        """Fused RoPE(q,k)+QK-Norm+KV-write (1 launch). ``qkv`` must be a
+        contiguous (S, (nq+2*nkv)*hd) bf16 tensor; writes ``q`` and the
+        GQA-pre-expanded KV cache rows at ``off``."""
+        hd = self.head_dim
+        S_tot = kbuf.shape[2]
+        kv_rep = kbuf.shape[1] // self.n_kv
+        fvk.hyvla_rope_qknorm_kvwrite_bf16(
+            qkv.data_ptr(),
+            cos.reshape(S, hd).contiguous().data_ptr(),
+            sin.reshape(S, hd).contiguous().data_ptr(),
+            qk_w[0].data_ptr(), qk_w[1].data_ptr(),
+            q.data_ptr(), kbuf.data_ptr(), vbuf.data_ptr(),
+            S, self.n_heads, self.n_kv, hd, S_tot, off, self.rms_eps,
+            kv_rep, torch.cuda.current_stream().cuda_stream)
+
+    def _exp_block_r(self, hs, w, qk_w, mask, cos, sin, kbuf, vbuf, off,
+                     fp8w, pending):
+        S = hs.shape[1]
+        D = hs.shape[2]
+        hd, nh, nkv = self.head_dim, self.n_heads, self.n_kv
+
+        if pending is None:
+            hs_n = F.rms_norm(hs, (D,), w[4], self.rms_eps)
+        else:
+            hs_n = self._res_add_rms_norm(hs, pending, w[4])
+
+        qkv = self._int8_rowwise_gemm(hs_n[0], fp8w[0], fp8w[1])
+        if getattr(self, "_fused_attn", False):
+            q = torch.empty(1, nh, S, hd, dtype=torch.bfloat16, device=hs.device)
+            self._rope_qknorm_kvwrite(qkv, cos, sin, qk_w, q, kbuf, vbuf, S, off)
+        else:
+            q, k, v = qkv.split([self.q_dim, self.kv_dim, self.kv_dim], -1)
+            q = q.view(S, nh, hd).transpose(0, 1)[None]
+            k = k.view(S, nkv, hd).transpose(0, 1)[None]
+            v = v.view(S, nkv, hd).transpose(0, 1)[None]
+            q = q * cos + _rot_half(q) * sin
+            k = k * cos + _rot_half(k) * sin
+            q = F.rms_norm(q, (hd,), qk_w[0], self.rms_eps)
+            k = F.rms_norm(k, (hd,), qk_w[1], self.rms_eps)
+            if kbuf.shape[1] != nkv:
+                r = kbuf.shape[1] // nkv
+                k = k.repeat_interleave(r, dim=1)
+                v = v.repeat_interleave(r, dim=1)
+            kbuf[:, :, off:off + S].copy_(k)
+            vbuf[:, :, off:off + S].copy_(v)
+        att = self._attn(q, kbuf[:, :, : off + S], vbuf[:, :, : off + S], mask)
+        att = att.transpose(1, 2).reshape(1, S, self.q_dim)
+
+        o = self._int8_rowwise_gemm(att[0], fp8w[2], fp8w[3])
+        hs_n2 = self._res_add_rms_norm(hs, o[None], w[5])
+        gu = self._int8_rowwise_gemm(hs_n2[0], fp8w[4], fp8w[5])
+        g, u = gu.chunk(2, -1)
+        act = F.silu(g) * u
+        dn = self._int8_rowwise_gemm(act, fp8w[6], fp8w[7])
+        return hs, dn[None]
+
+    @torch.no_grad()
+    def denoise(self, state, x_t, time_embs, smask, scos, ssin,
+                kbuf, vbuf, S_p, num_steps=10):
+        W = self.W
+        if not (getattr(self, "_orin_int8", False)
+                and getattr(W, "_exp_fp8_ready", False)):
+            return super().denoise(state, x_t, time_embs, smask, scos, ssin,
+                                   kbuf, vbuf, S_p, num_steps=num_steps)
+        S_s = 1 + x_t.shape[1]
+        dt = -1.0 / num_steps
+        state_emb = (F.linear(state.to(torch.bfloat16), W._state_w, W._state_b))[:, None]
+        for s in range(num_steps):
+            action_emb = F.linear(x_t.to(torch.bfloat16), W._ain_w, W._ain_b)
+            t_emb = time_embs[s].expand_as(action_emb)
+            ate = torch.cat([action_emb, t_emb], 2)
+            ate = F.linear(ate, W._atmlp_in_w, W._atmlp_in_b)
+            ate = F.silu(ate)
+            ate = F.linear(ate, W._atmlp_out_w, W._atmlp_out_b)
+            hs = torch.cat([state_emb, ate], 1)
+            pending = None
+            for li in range(32):
+                exp = self._exp_w(li)
+                qk = (W._qk_norm_q[li], W._qk_norm_k[li])
+                hs, pending = self._exp_block_r(
+                    hs, exp, qk, smask, scos, ssin,
+                    kbuf[li], vbuf[li], S_p, self._exp_w_fp8(li), pending)
+            hs_n = self._res_add_rms_norm(hs, pending, W._exp_final_norm_w)
+            v_t = F.linear(hs_n[:, -x_t.shape[1]:], W._aout_w, W._aout_b)
+            x_t.add_(dt * v_t.to(x_t.dtype))
+        return x_t
+
+
+__all__ = ["HyVLAOrinBF16Pipeline"]

--- a/flash_rt/models/hyvla/pipeline_orin.py
+++ b/flash_rt/models/hyvla/pipeline_orin.py
@@ -16,37 +16,37 @@ except ImportError:  # pragma: no cover - torch < 2.2
     SDPBackend = None
 
 import flash_rt.flash_rt_kernels as fvk
-import flash_rt.models.hyvla.pipeline_thor as _thor_pipeline
 from flash_rt.models.hyvla.pipeline_thor import HyVLAThorBF16Pipeline, _rot_half
 
 
-if not hasattr(_thor_pipeline.F, "rms_norm"):
-    def _rms_norm_torch(x, weight, eps):
-        y = x.float() * torch.rsqrt(x.float().pow(2).mean(dim=-1, keepdim=True) + eps)
-        if weight is not None:
-            y = y * weight.float()
-        return y.to(x.dtype)
+def _rms_norm_torch(x, weight, eps):
+    y = x.float() * torch.rsqrt(
+        x.float().pow(2).mean(dim=-1, keepdim=True) + eps)
+    if weight is not None:
+        y = y * weight.float()
+    return y.to(x.dtype)
 
-    def _rms_norm(x, normalized_shape, weight=None, eps=1e-5):
-        # torch 2.3 lacks F.rms_norm. The single-launch fvk.rms_norm kernel
-        # implements the exact reference math (fp32 sum-of-squares -> rsqrt ->
-        # weight multiply -> bf16 rounding) and is bit-equal to the torch
-        # expansion on contiguous rows; fall back for anything exotic.
-        if (x.is_cuda and x.dtype == torch.bfloat16 and weight is not None
-                and weight.dtype == torch.bfloat16
-                and len(normalized_shape) == 1
-                and normalized_shape[0] == x.shape[-1]):
-            xc = x if x.is_contiguous() else x.contiguous()
-            wc = weight if weight.is_contiguous() else weight.contiguous()
-            rows = xc.numel() // xc.shape[-1]
-            out = torch.empty_like(xc)
-            fvk.rms_norm(xc.data_ptr(), wc.data_ptr(), out.data_ptr(),
-                         rows, xc.shape[-1], eps,
-                         torch.cuda.current_stream().cuda_stream)
-            return out.reshape(x.shape)
-        return _rms_norm_torch(x, weight, eps)
 
-    _thor_pipeline.F.rms_norm = _rms_norm
+def _rms_norm(x, normalized_shape, weight=None, eps=1e-5):
+    native = getattr(F, "rms_norm", None)
+    if native is not None:
+        return native(x, normalized_shape, weight, eps)
+
+    # Torch 2.3 lacks F.rms_norm. Keep the compatibility path local to HyVLA
+    # so importing this module never modifies torch.nn.functional globally.
+    if (x.is_cuda and x.dtype == torch.bfloat16 and weight is not None
+            and weight.dtype == torch.bfloat16
+            and len(normalized_shape) == 1
+            and normalized_shape[0] == x.shape[-1]):
+        xc = x if x.is_contiguous() else x.contiguous()
+        wc = weight if weight.is_contiguous() else weight.contiguous()
+        rows = xc.numel() // xc.shape[-1]
+        out = torch.empty_like(xc)
+        fvk.rms_norm(xc.data_ptr(), wc.data_ptr(), out.data_ptr(),
+                     rows, xc.shape[-1], eps,
+                     torch.cuda.current_stream().cuda_stream)
+        return out.reshape(x.shape)
+    return _rms_norm_torch(x, weight, eps)
 
 
 class _W8Int8:
@@ -99,10 +99,6 @@ class HyVLAOrinBF16Pipeline(HyVLAThorBF16Pipeline):
 
     def autotune_gemms(self, shapes, num_algos=16):
         return 0
-
-    def _attn(self, q, k, v, mask):
-        out = super()._attn(q, k, v, mask)
-        return torch.nan_to_num(out)
 
     # ------------------------------------------------------------------
     #  ViT INT8 GEMM sites (SM87). Weight lists are replaced in-place by
@@ -269,8 +265,8 @@ class HyVLAOrinBF16Pipeline(HyVLAThorBF16Pipeline):
         D = hs.shape[2]
         hd, nh, nkv = self.head_dim, self.n_heads, self.n_kv
 
-        hs_v = F.rms_norm(hs[0, :n_vis], (D,), w_vis[4], self.rms_eps)
-        hs_t = F.rms_norm(hs[0, n_vis:], (D,), w_text[4], self.rms_eps)
+        hs_v = _rms_norm(hs[0, :n_vis], (D,), w_vis[4], self.rms_eps)
+        hs_t = _rms_norm(hs[0, n_vis:], (D,), w_text[4], self.rms_eps)
         qkv = torch.cat([hs_v @ w_vis[0].t(), hs_t @ w_text[0].t()], 0)
 
         if getattr(self, "_fused_attn", False):
@@ -283,8 +279,8 @@ class HyVLAOrinBF16Pipeline(HyVLAThorBF16Pipeline):
             v = v.view(S, nkv, hd).transpose(0, 1)[None]
             q = q * cos + _rot_half(q) * sin
             k = k * cos + _rot_half(k) * sin
-            q = F.rms_norm(q, (hd,), qk_w[0], self.rms_eps)
-            k = F.rms_norm(k, (hd,), qk_w[1], self.rms_eps)
+            q = _rms_norm(q, (hd,), qk_w[0], self.rms_eps)
+            k = _rms_norm(k, (hd,), qk_w[1], self.rms_eps)
             if kbuf.shape[1] != nkv:
                 r = kbuf.shape[1] // nkv
                 k = k.repeat_interleave(r, dim=1)
@@ -298,8 +294,8 @@ class HyVLAOrinBF16Pipeline(HyVLAThorBF16Pipeline):
         o_t = att[0, n_vis:] @ w_text[1].t()
         hs = hs + torch.cat([o_v, o_t], 0)[None]
 
-        hs_v = F.rms_norm(hs[0, :n_vis], (D,), w_vis[5], self.rms_eps)
-        hs_t = F.rms_norm(hs[0, n_vis:], (D,), w_text[5], self.rms_eps)
+        hs_v = _rms_norm(hs[0, :n_vis], (D,), w_vis[5], self.rms_eps)
+        hs_t = _rms_norm(hs[0, n_vis:], (D,), w_text[5], self.rms_eps)
         gu = torch.cat([self._int8_rowwise_gemm(hs_v, ffnv[0], ffnv[1]),
                         self._int8_rowwise_gemm(hs_t, ffnt[0], ffnt[1])], 0)
         g, u = gu.chunk(2, -1)
@@ -365,7 +361,7 @@ class HyVLAOrinBF16Pipeline(HyVLAThorBF16Pipeline):
         hd, nh, nkv = self.head_dim, self.n_heads, self.n_kv
 
         if pending is None:
-            hs_n = F.rms_norm(hs, (D,), w[4], self.rms_eps)
+            hs_n = _rms_norm(hs, (D,), w[4], self.rms_eps)
         else:
             hs_n = self._res_add_rms_norm(hs, pending, w[4])
 
@@ -380,8 +376,8 @@ class HyVLAOrinBF16Pipeline(HyVLAThorBF16Pipeline):
             v = v.view(S, nkv, hd).transpose(0, 1)[None]
             q = q * cos + _rot_half(q) * sin
             k = k * cos + _rot_half(k) * sin
-            q = F.rms_norm(q, (hd,), qk_w[0], self.rms_eps)
-            k = F.rms_norm(k, (hd,), qk_w[1], self.rms_eps)
+            q = _rms_norm(q, (hd,), qk_w[0], self.rms_eps)
+            k = _rms_norm(k, (hd,), qk_w[1], self.rms_eps)
             if kbuf.shape[1] != nkv:
                 r = kbuf.shape[1] // nkv
                 k = k.repeat_interleave(r, dim=1)

--- a/tests/test_orin_hyvla05_arch_gate.py
+++ b/tests/test_orin_hyvla05_arch_gate.py
@@ -1,4 +1,6 @@
-"""HyVLA Orin hardware-gate (fail-fast) tests — torch.cuda is mocked, no GPU needed."""
+"""HyVLA Orin hardware-gate and isolation tests (no GPU needed)."""
+
+import importlib
 
 import pytest
 
@@ -6,8 +8,10 @@ torch = pytest.importorskip("torch")
 
 try:
     import flash_rt.frontends.torch.hyvla_orin as orin_mod
-except ImportError as exc:  # pragma: no cover
-    pytest.skip(f"hyvla_orin frontend not importable: {exc}", allow_module_level=True)
+except ModuleNotFoundError as exc:  # pragma: no cover
+    if exc.name != "flash_rt.flash_rt_kernels":
+        raise
+    pytest.skip("flash_rt_kernels was not built", allow_module_level=True)
 
 
 class _Probe:
@@ -62,3 +66,53 @@ def test_missing_prompt_raises_runtime_error():
     fe._lang_tokens = None
     with pytest.raises(RuntimeError, match="set_prompt"):
         orin_mod.HyVLATorchFrontendOrin.predict_actions(fe, images=None)
+
+
+def _bare_frontend():
+    fe = orin_mod.HyVLATorchFrontendOrin.__new__(
+        orin_mod.HyVLATorchFrontendOrin)
+    fe.max_state_dim = 8
+    fe.chunk = 4
+    fe.max_action_dim = 3
+    fe._prompt = None
+    fe._lang_tokens = object()
+    fe._vit_merge = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        AssertionError("invalid inputs reached ViT"))
+    return fe
+
+
+def test_invalid_state_rejected_before_gpu_or_cache_work():
+    with pytest.raises(ValueError, match="state has 9 dims"):
+        _bare_frontend().predict_actions(None, state=[0] * 9)
+
+
+def test_invalid_noise_rejected_before_gpu_or_cache_work():
+    with pytest.raises(ValueError, match="noise must have 12 elements"):
+        _bare_frontend().predict_actions(None, noise=[0] * 11)
+
+
+def test_old_torch_rms_norm_fallback_is_module_local(monkeypatch):
+    import torch.nn.functional as functional
+    import flash_rt.models.hyvla.pipeline_orin as pipeline_orin
+
+    monkeypatch.delattr(functional, "rms_norm", raising=False)
+    pipeline_orin = importlib.reload(pipeline_orin)
+
+    assert not hasattr(functional, "rms_norm")
+    x = torch.tensor([[3.0, 4.0]])
+    expected = x * torch.rsqrt(x.square().mean(dim=-1, keepdim=True) + 1e-5)
+    assert torch.allclose(pipeline_orin._rms_norm(x, (2,)), expected)
+
+
+def test_attention_does_not_hide_nonfinite_output(monkeypatch):
+    from flash_rt.models.hyvla.pipeline_orin import HyVLAOrinBF16Pipeline
+    from flash_rt.models.hyvla.pipeline_thor import HyVLAThorBF16Pipeline
+
+    expected = torch.tensor([float("nan")])
+    monkeypatch.setattr(
+        HyVLAThorBF16Pipeline, "_attn",
+        lambda _self, _q, _k, _v, _mask: expected,
+    )
+    pipe = object.__new__(HyVLAOrinBF16Pipeline)
+    result = pipe._attn(None, None, None, None)
+    assert torch.isnan(result).all()

--- a/tests/test_orin_hyvla05_arch_gate.py
+++ b/tests/test_orin_hyvla05_arch_gate.py
@@ -1,0 +1,64 @@
+"""HyVLA Orin hardware-gate (fail-fast) tests — torch.cuda is mocked, no GPU needed."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+try:
+    import flash_rt.frontends.torch.hyvla_orin as orin_mod
+except ImportError as exc:  # pragma: no cover
+    pytest.skip(f"hyvla_orin frontend not importable: {exc}", allow_module_level=True)
+
+
+class _Probe:
+    """Run _require_arch against mocked CUDA state."""
+
+    _cls = orin_mod.HyVLATorchFrontendOrin
+
+    def run(self):
+        obj = object.__new__(self._cls)
+        return self._cls._require_arch(obj)
+
+
+def test_rejects_when_cuda_unavailable(monkeypatch):
+    monkeypatch.delenv("FLASHRT_HYVLA_FORCE_ARCH", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    with pytest.raises(RuntimeError, match="CUDA is not available"):
+        _Probe().run()
+
+
+def test_rejects_wrong_capability(monkeypatch):
+    monkeypatch.delenv("FLASHRT_HYVLA_FORCE_ARCH", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (11, 0))
+    with pytest.raises(RuntimeError, match="requires Jetson Orin SM87"):
+        _Probe().run()
+
+
+def test_accepts_sm87(monkeypatch):
+    monkeypatch.delenv("FLASHRT_HYVLA_FORCE_ARCH", raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda: (8, 7))
+    _Probe().run()  # must not raise
+
+
+def test_documented_env_override_skips_probe(monkeypatch):
+    monkeypatch.setenv("FLASHRT_HYVLA_FORCE_ARCH", "1")
+    # No CUDA mocking: the override must return before touching torch.cuda.
+    _Probe().run()
+
+
+def test_fp4_rejected_before_any_cuda_work():
+    # SM87 has no FP4 tensor cores; the constructor must fail fast,
+    # before checkpoint loading or CUDA allocation.
+    with pytest.raises(RuntimeError, match="does not support FP4"):
+        orin_mod.HyVLATorchFrontendOrin("/nonexistent/fake-ckpt", use_fp4=True)
+
+
+def test_missing_prompt_raises_runtime_error():
+    fe = orin_mod.HyVLATorchFrontendOrin.__new__(orin_mod.HyVLATorchFrontendOrin)
+    # Minimal state to reach the prompt contract check only.
+    fe._prompt = None
+    fe._lang_tokens = None
+    with pytest.raises(RuntimeError, match="set_prompt"):
+        orin_mod.HyVLATorchFrontendOrin.predict_actions(fe, images=None)

--- a/tests/test_orin_hyvla05_dispatch.py
+++ b/tests/test_orin_hyvla05_dispatch.py
@@ -9,6 +9,11 @@ pytest.importorskip("torch")
 def test_hyvla_orin_dispatch_resolves():
     from flash_rt.hardware import resolve_pipeline_class
 
-    cls = resolve_pipeline_class("hyvla", "torch", "rtx_sm87")
+    try:
+        cls = resolve_pipeline_class("hyvla", "torch", "rtx_sm87")
+    except ModuleNotFoundError as exc:
+        if exc.name != "flash_rt.flash_rt_kernels":
+            raise
+        pytest.skip("flash_rt_kernels was not built")
     assert cls.__module__ == "flash_rt.frontends.torch.hyvla_orin"
     assert cls.__name__ == "HyVLATorchFrontendOrin"

--- a/tests/test_orin_hyvla05_dispatch.py
+++ b/tests/test_orin_hyvla05_dispatch.py
@@ -1,0 +1,9 @@
+"""Dispatch smoke for HyVLA on Jetson Orin SM87."""
+
+
+def test_hyvla_orin_dispatch_resolves():
+    from flash_rt.hardware import resolve_pipeline_class
+
+    cls = resolve_pipeline_class("hyvla", "torch", "rtx_sm87")
+    assert cls.__module__ == "flash_rt.frontends.torch.hyvla_orin"
+    assert cls.__name__ == "HyVLATorchFrontendOrin"

--- a/tests/test_orin_hyvla05_dispatch.py
+++ b/tests/test_orin_hyvla05_dispatch.py
@@ -1,5 +1,10 @@
 """Dispatch smoke for HyVLA on Jetson Orin SM87."""
 
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("torch")
+
 
 def test_hyvla_orin_dispatch_resolves():
     from flash_rt.hardware import resolve_pipeline_class

--- a/tests/test_orin_hyvla05_e2e_check.py
+++ b/tests/test_orin_hyvla05_e2e_check.py
@@ -24,10 +24,7 @@ if not CKPT or not os.path.isdir(CKPT):
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)
 
-try:
-    from flash_rt.frontends.torch.hyvla_orin import HyVLATorchFrontendOrin
-except ImportError as exc:  # pragma: no cover
-    pytest.skip(f"hyvla_orin frontend not importable: {exc}", allow_module_level=True)
+from flash_rt.frontends.torch.hyvla_orin import HyVLATorchFrontendOrin
 
 PROMPT = "pick up the bottle"
 

--- a/tests/test_orin_hyvla05_e2e_check.py
+++ b/tests/test_orin_hyvla05_e2e_check.py
@@ -1,0 +1,111 @@
+"""Fixed-noise precision gate for HyVLATorchFrontendOrin (requires SM87 + checkpoint).
+
+Loads the BF16 baseline first, captures the fixed-noise reference action,
+frees it, then loads the default INT8 W8A8 tier and asserts action cosine
+>= 0.999 against the reference — the documented Orin precision gate. Also
+covers the public input boundaries inherited by the Orin override.
+
+Set FLASHRT_HYVLA_CHECKPOINT to the Hy-Embodied-0.5-VLA directory to run.
+"""
+
+import os
+
+import pytest
+
+torch = pytest.importorskip("torch")
+np = pytest.importorskip("numpy")
+
+CKPT = os.environ.get("FLASHRT_HYVLA_CHECKPOINT", "")
+if not CKPT or not os.path.isdir(CKPT):
+    pytest.skip(
+        "set FLASHRT_HYVLA_CHECKPOINT to the Hy-Embodied-0.5-VLA checkpoint "
+        "directory to run this gate", allow_module_level=True)
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+try:
+    from flash_rt.frontends.torch.hyvla_orin import HyVLATorchFrontendOrin
+except ImportError as exc:  # pragma: no cover
+    pytest.skip(f"hyvla_orin frontend not importable: {exc}", allow_module_level=True)
+
+PROMPT = "pick up the bottle"
+
+
+def _inputs(fe):
+    """Deterministic synthetic inputs (identical across runs and machines)."""
+    g = torch.Generator(device="cpu").manual_seed(0)
+    img = torch.rand(1, 6, 3, 224, 224, generator=g)
+    state = torch.rand(1, fe.max_state_dim, generator=g) * 0.1
+    images = torch.stack([img[0], img[0].clone(), img[0].clone()], 0)
+    noise = np.random.RandomState(0).randn(
+        1, fe.chunk, fe.max_action_dim).astype(np.float32)
+    return images.numpy(), state.numpy(), noise
+
+
+def _cos(a, b):
+    a = a.ravel().astype(np.float64)
+    b = b.ravel().astype(np.float64)
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+
+
+@pytest.fixture(scope="module")
+def ref_and_int8():
+    # Sequential loads: Orin unified memory should not hold two 9 GB weight
+    # copies at once. Capture the BF16 reference, free it, then load INT8.
+    fe_bf16 = HyVLATorchFrontendOrin(CKPT, use_fp8=False, use_int8=False)
+    fe_bf16.set_prompt(PROMPT)
+    images, state, noise = _inputs(fe_bf16)
+    a_bf16 = fe_bf16.predict_actions(images, state=state, noise=noise,
+                                     use_graph=False)
+    del fe_bf16
+    torch.cuda.empty_cache()
+
+    fe_int8 = HyVLATorchFrontendOrin(CKPT)  # default INT8 W8A8 tier
+    fe_int8.set_prompt(PROMPT)
+    return a_bf16, fe_int8
+
+
+def test_default_int8_tier_enables_validated_fusion(ref_and_int8):
+    _, fe_int8 = ref_and_int8
+    pipe = fe_int8.pipe
+    assert pipe._fused_attn, \
+        "default tier must use the fused RoPE/QKNorm/KV-write kernel"
+    assert pipe._vit_fuse_ln or pipe._vit_eff_sdpa, \
+        "default tier must enable at least one ViT fusion lever"
+    assert pipe._vlm_ffn_int8, "default tier must INT8-quantize the prefill FFN"
+
+
+def test_int8_vs_bf16_fixed_noise_cosine(ref_and_int8):
+    a_bf16, fe_int8 = ref_and_int8
+    images, state, noise = _inputs(fe_int8)
+    a_int8 = fe_int8.predict_actions(images, state=state, noise=noise,
+                                     use_graph=False)
+    assert np.isfinite(a_int8).all()
+    assert a_int8.shape == (1, fe_int8.chunk, fe_int8.max_action_dim)
+    cos = _cos(a_int8, a_bf16)
+    assert cos >= 0.999, f"INT8 vs BF16 cosine {cos:.6f} < 0.999 gate"
+
+
+def test_eager_is_deterministic_with_fixed_noise(ref_and_int8):
+    _, fe_int8 = ref_and_int8
+    images, state, noise = _inputs(fe_int8)
+    a1 = fe_int8.predict_actions(images, state=state, noise=noise, use_graph=False)
+    a2 = fe_int8.predict_actions(images, state=state, noise=noise, use_graph=False)
+    assert np.array_equal(a1, a2), "eager path must be deterministic for fixed noise"
+
+
+def test_oversized_state_rejected(ref_and_int8):
+    _, fe_int8 = ref_and_int8
+    images, _, noise = _inputs(fe_int8)
+    big_state = np.zeros((1, fe_int8.max_state_dim + 1), dtype=np.float32)
+    with pytest.raises(ValueError, match="max_state_dim"):
+        fe_int8.predict_actions(images, state=big_state, noise=noise, use_graph=False)
+
+
+def test_wrong_noise_size_rejected(ref_and_int8):
+    _, fe_int8 = ref_and_int8
+    images, state, _ = _inputs(fe_int8)
+    bad_noise = np.zeros((1, 7), dtype=np.float32)
+    with pytest.raises(ValueError, match="noise must have"):
+        fe_int8.predict_actions(images, state=state, noise=bad_noise, use_graph=False)

--- a/tests/test_orin_hyvla05_graphsafe.py
+++ b/tests/test_orin_hyvla05_graphsafe.py
@@ -1,0 +1,111 @@
+"""Graph-safety gate for HyVLATorchFrontendOrin (requires SM87 + checkpoint).
+
+Verifies the invariants the CUDA-graph capture relies on:
+
+  1. graph == eager — replaying the captured graph produces the same action
+     chunk as the un-captured eager path for identical inputs.
+  2. replay-stable — replaying the graph twice on the same static inputs
+     yields identical output (no transient-buffer aliasing).
+  3. fused == unfused — the fused RoPE/QKNorm/KV-write attention-prep and
+     the ViT fused add+LayerNorm produce the same actions (within FP noise)
+     as the torch fallback paths.
+
+Inputs are fully synthetic and deterministic (seed-0 torch.rand images/state,
+RandomState(0) noise), so the gate is reproducible with only the checkpoint.
+Set FLASHRT_HYVLA_CHECKPOINT to the Hy-Embodied-0.5-VLA directory to run.
+"""
+
+import os
+
+import pytest
+
+torch = pytest.importorskip("torch")
+np = pytest.importorskip("numpy")
+
+CKPT = os.environ.get("FLASHRT_HYVLA_CHECKPOINT", "")
+if not CKPT or not os.path.isdir(CKPT):
+    pytest.skip(
+        "set FLASHRT_HYVLA_CHECKPOINT to the Hy-Embodied-0.5-VLA checkpoint "
+        "directory to run this gate", allow_module_level=True)
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+try:
+    from flash_rt.frontends.torch.hyvla_orin import HyVLATorchFrontendOrin
+except ImportError as exc:  # pragma: no cover
+    pytest.skip(f"hyvla_orin frontend not importable: {exc}", allow_module_level=True)
+
+
+def _inputs(fe):
+    """Deterministic synthetic inputs (identical across runs and machines)."""
+    g = torch.Generator(device="cpu").manual_seed(0)
+    img = torch.rand(1, 6, 3, 224, 224, generator=g)
+    state = torch.rand(1, fe.max_state_dim, generator=g) * 0.1
+    images = torch.stack([img[0], img[0].clone(), img[0].clone()], 0)
+    noise = np.random.RandomState(0).randn(
+        1, fe.chunk, fe.max_action_dim).astype(np.float32)
+    return images.numpy(), state.numpy(), noise
+
+
+def _cos(a, b):
+    a = a.ravel().astype(np.float64)
+    b = b.ravel().astype(np.float64)
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+
+
+@pytest.fixture(scope="module")
+def frontend():
+    fe = HyVLATorchFrontendOrin(CKPT)  # default INT8 W8A8 tier
+    fe.set_prompt("pick up the bottle")
+    return fe
+
+
+def test_graph_matches_eager(frontend):
+    images, state, noise = _inputs(frontend)
+    a_eager = frontend.predict_actions(images, state=state, noise=noise,
+                                       use_graph=False)
+    a_graph = frontend.predict_actions(images, state=state, noise=noise,
+                                       use_graph=True)
+    cos = _cos(a_eager, a_graph)
+    assert cos >= 0.9999, f"graph vs eager cosine {cos} < 0.9999"
+
+
+def test_replay_is_stable(frontend):
+    images, state, noise = _inputs(frontend)
+    a1 = frontend.predict_actions(images, state=state, noise=noise, use_graph=True)
+    a2 = frontend.predict_actions(images, state=state, noise=noise, use_graph=True)
+    assert np.array_equal(a1, a2), \
+        "replayed graph output differs run-to-run on identical static inputs"
+
+
+def test_fused_matches_unfused_attention_prep(frontend):
+    images, state, noise = _inputs(frontend)
+    if not frontend.pipe._fused_attn:
+        pytest.skip("fused RoPE/QKNorm/KV-write kernel not in this build")
+    a_fused = frontend.predict_actions(images, state=state, noise=noise,
+                                       use_graph=False)
+    frontend.pipe._fused_attn = False
+    try:
+        a_unfused = frontend.predict_actions(images, state=state, noise=noise,
+                                             use_graph=False)
+    finally:
+        frontend.pipe._fused_attn = True
+    cos = _cos(a_fused, a_unfused)
+    assert cos >= 0.999, f"fused vs unfused attention-prep cosine {cos} < 0.999"
+
+
+def test_fused_matches_unfused_vit_layer_norm(frontend):
+    images, state, noise = _inputs(frontend)
+    if not frontend.pipe._vit_fuse_ln:
+        pytest.skip("hyvla_vit_add_layer_norm_bf16 not in this build")
+    a_fused = frontend.predict_actions(images, state=state, noise=noise,
+                                       use_graph=False)
+    frontend.pipe._vit_fuse_ln = False
+    try:
+        a_unfused = frontend.predict_actions(images, state=state, noise=noise,
+                                             use_graph=False)
+    finally:
+        frontend.pipe._vit_fuse_ln = True
+    cos = _cos(a_fused, a_unfused)
+    assert cos >= 0.999, f"fused vs unfused ViT add+LN cosine {cos} < 0.999"

--- a/tests/test_orin_hyvla05_graphsafe.py
+++ b/tests/test_orin_hyvla05_graphsafe.py
@@ -31,10 +31,7 @@ if not CKPT or not os.path.isdir(CKPT):
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)
 
-try:
-    from flash_rt.frontends.torch.hyvla_orin import HyVLATorchFrontendOrin
-except ImportError as exc:  # pragma: no cover
-    pytest.skip(f"hyvla_orin frontend not importable: {exc}", allow_module_level=True)
+from flash_rt.frontends.torch.hyvla_orin import HyVLATorchFrontendOrin
 
 
 def _inputs(fe):


### PR DESCRIPTION
## Summary

Adds the Jetson Orin SM87 port of Hy-Embodied-0.5-VLA using INT8 W8A8 quantization.

#167 has been merged. This branch is rebased directly onto its merge commit on current `main` (`9b74a2f2`) and now contains only the Orin model-layer delta: nine model, registry, documentation, and test files, with no duplicated Thor commits, CMake changes, or csrc changes.

### Orin-specific additions

- `frontends/torch/hyvla_orin.py`: `HyVLATorchFrontendOrin`
- `models/hyvla/pipeline_orin.py`: INT8 SM87 compute path with BF16 fallback
- `_PIPELINE_MAP`: `("hyvla", "torch", "rtx_sm87")`
- SM87 dispatch, precision, graph-safety, and architecture-gate tests

### Review hardening

- The Torch 2.3 RMSNorm compatibility path is a HyVLA-local helper and never mutates `torch.nn.functional`.
- State and noise contracts are checked before ViT, static-prefix cache work, graph lookup, or capture.
- Attention does not apply unconditional `torch.nan_to_num`; non-finite output remains observable.
- Tests verify global functional-module isolation, early input rejection, non-finite propagation, and strict import behavior.

### Performance receipt

Contributor-reported Orin SM87 result with a real image:

| Metric | Value |
|---|--:|
| E2E predict | **277.5 ms** (~11.3x vs reference eager) |
| Action cosine vs reference | **>= 0.999** |

### Validation

- Rebase onto merged #167 completed without conflict.
- Final diff contains only nine Orin files and no Thor/CMake/csrc duplication.
- `GPU_ARCH=87`, `FLASHRT_ENABLE_HYVLA=ON`, Chameleon/Motus OFF: configure and `flash_rt_kernels` build passed before the history-only final rebase.
- Extension and `HyVLATorchFrontendOrin` imports passed after the final rebase.
- SM87 build exports the shared Orin fused symbol and does not export the Thor-only FP8 quant symbol.
- Importing the Orin frontend leaves `torch.nn.functional` unchanged.
- Focused Thor + Orin + model-loading suite: **99 passed, 7 skipped**.
- Changed Python `compileall` and `git diff --check` passed.

The validation host is not SM87, so the final numerical, graph-safe, and E2E tests remain hardware-gated. A real Orin smoke is the remaining device-level merge gate.
