### PR TITLE
packaging: the wheel ships no test files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ Issues = "https://github.com/flashrt-project/FlashRT/issues"
 
 [tool.setuptools.packages.find]
 include = ["flash_rt*"]
+# flash_rt.tests ships with the repo, not with the wheel: the
+# distribution gate is zero test files in what a user installs.
+exclude = ["flash_rt.tests*"]
 
 [tool.setuptools.package-data]
 # Recursive. Structure specs, per-host bindings and tokenizer models live


### PR DESCRIPTION
The merge of #150 brought main's flash_rt/tests/ (jetson_pi checks from #162-164) into the wheel via package discovery. The distribution gate is zero test files in what a user installs; this excludes the in-package tests from the wheel while keeping them in the repo.