### PR TITLE
LTX-2.5 22B distilled (audio+video) on RTX SM120: sage2 attention, W4A4 FFN chain, whole-loop graph capture

### DIFF
--- a/docs/ltx25_usage.md
+++ b/docs/ltx25_usage.md
@@ -1,0 +1,64 @@
+# LTX-2.5 (22B distilled, audio+video) on FlashRT — RTX SM120
+
+FlashRT integration of the official [LTX-2](https://github.com/Lightricks/LTX-2)
+`ltx-pipelines` two-stage distilled pipeline, with FlashRT compute swaps.
+
+Status: attention backend swap shipped; fused NVFP4 epilogues and CUDA graph
+capture over the transformer loop are in progress on this branch.
+
+## Requirements
+
+- RTX 5090 (SM120), 32GB. Peak allocated ≈ 23.2GB at 1536×1024×121f.
+- An environment with the official LTX-2 packages (`ltx-core`,
+  `ltx-pipelines`, and `ltx-kernels` for the NVFP4 path), either installed or
+  reachable through `FLASH_RT_LTX2_ROOT` (path to an LTX-2 monorepo checkout).
+- The LTX-2.5 split checkpoint pack (one safetensors per component):
+
+```
+<pack>/diffusion_models/ltx-2.5-22b-distilled-transformer-nvfp4.safetensors
+<pack>/text_encoders/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors
+<pack>/vae/ltx-2.5-video-vae-bf16.safetensors
+<pack>/vae/ltx-2.5-audio-vae-bf16.safetensors
+<pack>/model_patches/ltx-2.5-duration-head-bf16.safetensors        (optional)
+<pack>/latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors
+```
+
+The NVFP4 transformer ships prequantized block-16 weights with calibrated
+static activation scales, so there is no calibration pass.
+
+## Quickstart
+
+```python
+import flash_rt
+
+pipe = flash_rt.load_model(
+    checkpoint="/path/to/LTX-2.5",   # the split pack root
+    config="ltx25",
+)
+pipe.set_prompt("A golden retriever running through a sunny meadow")
+stats = pipe.infer(seed=42, output_path="out.mp4")
+print(stats)
+```
+
+`infer` accepts `height`, `width` (multiples of 32), `num_frames`
+(`k*8+1`), `frame_rate`, `seed`, and `output_path` (omit to skip mp4 encode).
+
+## Attention backends
+
+Selected by the `attention=` constructor argument or `FLASH_RT_LTX25_ATTN`:
+
+| value | path | notes |
+|---|---|---|
+| `auto` (default) | `sage2-fvk` when available | |
+| `sage2-fvk` | FlashRT raw-pointer sage2 qk-int8/pv-fp8 kernels | graph-capture safe; video d128 sites |
+| `sage2` | upstream `sageattention` package | needs the package built for SM120 |
+| `sage3` | `sageattn3` FP4 Blackwell package | fastest, lower per-call accuracy; opt-in |
+| `sdpa` | torch SDPA | baseline |
+
+Audio-branch attention (head_dim 64, ~1k tokens) always runs SDPA: measured on
+5090, the quantized paths lose to SDPA at that shape.
+
+Measured on 5090 at 1536×1024×121f (median, video self-attention site,
+S=24576): SDPA-cudnn 42.4ms, sage2 17.4ms, sage3 13.0ms. End-to-end stage-2
+denoise per step: 5.11s (SDPA) → 3.84s (sage2), with output quality equivalent
+under matched-input single-forward cosine and frame inspection.

--- a/docs/ltx25_usage.md
+++ b/docs/ltx25_usage.md
@@ -36,11 +36,19 @@ import flash_rt
 pipe = flash_rt.load_model(
     checkpoint="/path/to/LTX-2.5",   # the split pack root
     config="ltx25",
+    attention="sage2-fvk",           # optional; "auto" by default
+    fuse=True,                       # the W4A4 FFN chain, on by default
+    compile_mode="capture",          # eager by default; see below
 )
 pipe.set_prompt("A golden retriever running through a sunny meadow")
 stats = pipe.infer(seed=42, output_path="out.mp4")
 print(stats)
 ```
+
+`attention`, `fuse` and `compile_mode` choose the execution assembly and are
+forwarded to this frontend only; omitting one leaves the frontend's own
+default. The same three are constructor arguments if you build
+`Ltx25TorchFrontendRtx` directly.
 
 `infer` accepts `height`, `width` (multiples of 32), `num_frames`
 (`k*8+1`), `frame_rate`, `seed`, and `output_path` (omit to skip mp4 encode).
@@ -92,7 +100,8 @@ so residency is a lease rather than a permanent state:
   next stage call take a fresh lease. The cost is one transformer rebuild;
   nothing fails and nothing has to be released by hand.
 
-Two explicit entry points, both idempotent:
+Two explicit entry points, both idempotent and both on the object
+`load_model` returns:
 
 ```python
 pipe.release_resident()   # drop the resident transformer and its graphs
@@ -100,8 +109,10 @@ pipe.close()              # the above, plus prompt cache and pipeline
 ```
 
 `release_resident` returns the device bytes it freed (0 outside capture mode,
-which holds no lease). After either call the frontend still works: the next
-`infer` rebuilds what it needs, `close` reloading from the checkpoint.
+which holds no lease; also 0 on models that keep nothing resident, so a
+serving loop can call it without knowing which frontend it has). After either
+call the frontend still works: the next `infer` rebuilds what it needs,
+`close` reloading from the checkpoint.
 VAE decode tiling is sized against the memory that remains once the resident
 transformer is accounted for, so decode does not have to be given a manual
 budget.

--- a/docs/ltx25_usage.md
+++ b/docs/ltx25_usage.md
@@ -3,8 +3,10 @@
 FlashRT integration of the official [LTX-2](https://github.com/Lightricks/LTX-2)
 `ltx-pipelines` two-stage distilled pipeline, with FlashRT compute swaps.
 
-Status: attention backend swap shipped; fused NVFP4 epilogues and CUDA graph
-capture over the transformer loop are in progress on this branch.
+Three compute swaps ship here: the attention backend, the W4A4 NVFP4 FFN
+chain, and — behind `compile_mode="capture"` — a resident transformer that
+makes whole-loop CUDA-graph capture possible on one GPU. Measured warm
+denoise at 1536×1024×121f: 23.9s upstream eager, 11.7s with all three.
 
 ## Requirements
 
@@ -57,6 +59,52 @@ Selected by the `attention=` constructor argument or `FLASH_RT_LTX25_ATTN`:
 
 Audio-branch attention (head_dim 64, ~1k tokens) always runs SDPA: measured on
 5090, the quantized paths lose to SDPA at that shape.
+
+## FFN chain and compilation
+
+`fuse=True` (default) replaces each transformer block's feed-forward with the
+W4A4 NVFP4 chain: three launches (quantize, fused GEMM+bias+GELU emitting
+FP4, GEMM) where upstream runs six. The chain accepts only 128-aligned row
+counts — CUTLASS declines the rest and returns without writing an output, so
+unaligned calls (the ~126-token audio branch) stay on the upstream module
+rather than reading an unwritten buffer.
+
+`compile_mode` selects the execution assembly:
+
+| value | assembly |
+|---|---|
+| `None` (default) | eager |
+| `"default"` | per-block `torch.compile`, sequence-length specialized |
+| `"capture"` | per-block compile plus whole-loop CUDA-graph capture |
+
+Capture requires the transformer to stay resident, which the swap builder
+arranges; the memory contract that follows is below.
+
+## Memory and lifecycle (capture mode)
+
+The resident transformer holds ≈14GB. The text encoder loads ≈26GB for the
+length of one prompt encode, and the two do not fit together on a 32GB part,
+so residency is a lease rather than a permanent state:
+
+- a prompt whose embeddings are already cached keeps the resident model and
+  skips the encoder entirely;
+- a prompt that is not cached ends the lease first, encodes, and lets the
+  next stage call take a fresh lease. The cost is one transformer rebuild;
+  nothing fails and nothing has to be released by hand.
+
+Two explicit entry points, both idempotent:
+
+```python
+pipe.release_resident()   # drop the resident transformer and its graphs
+pipe.close()              # the above, plus prompt cache and pipeline
+```
+
+`release_resident` returns the device bytes it freed (0 outside capture mode,
+which holds no lease). After either call the frontend still works: the next
+`infer` rebuilds what it needs, `close` reloading from the checkpoint.
+VAE decode tiling is sized against the memory that remains once the resident
+transformer is accounted for, so decode does not have to be given a manual
+budget.
 
 Measured on 5090 at 1536×1024×121f (median, video self-attention site,
 S=24576): SDPA-cudnn 42.4ms, sage2 17.4ms, sage3 13.0ms. End-to-end stage-2

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -351,7 +351,9 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             after first load. Only affects JAX.
         config: model config name: "pi05", "pi0", "groot", "groot_n17",
             "pi0fast", "motus", "wan22_ti2v_5b", "cosmos3_video",
-            "cosmos3_edge".
+            "cosmos3_edge", "ltx25".
+            "ltx25" is the LTX-2.5 22B distilled audio+video generator:
+            drive it with set_prompt(...) + infer(...), not predict().
             "cosmos3_video" is a non-VLA text2video denoise model: drive it with
             set_prompt(ref=<reference dump>) + infer(...), not predict().
             "cosmos3_edge" is the official Cosmos Framework Thor baseline
@@ -535,12 +537,13 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 "Supported: pi0, pi05, llm, mllm")
     elif config not in ("pi05", "groot", "groot_n17", "pi0", "pi0fast",
                       "motus", "wan22_ti2v_5b", "cosmos3_video",
-                      "cosmos3_edge", "nexn2", "qwen36_moe", "hyvla"):
+                      "cosmos3_edge", "nexn2", "qwen36_moe", "hyvla",
+                      "ltx25"):
         raise ValueError(
             f"Unknown config: {config}. "
             f"Supported: pi05, groot, groot_n17, pi0, pi0fast, motus, "
             f"wan22_ti2v_5b, cosmos3_video, cosmos3_edge, nexn2, "
-            f"qwen36_moe, hyvla")
+            f"qwen36_moe, hyvla, ltx25")
     if framework not in ("torch", "jax", "jetson_pi"):
         raise ValueError(
             f"Unknown framework: {framework}. Supported: torch, jax, jetson_pi")

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -223,6 +223,28 @@ class VLAModel:
                 "This frontend does not expose infer().")
         return self._pipe.infer(*args, **kwargs)
 
+    def release_resident(self) -> int:
+        """Release device memory a frontend holds between calls.
+
+        Returns the bytes freed. A frontend that keeps nothing resident
+        answers 0 rather than refusing: "nothing to release" is a true
+        answer to this question, and a caller writing a serving loop should
+        not have to know which frontends hold weights across calls to be
+        able to ask.
+        """
+        release = getattr(self._pipe, "release_resident", None)
+        return release() if callable(release) else 0
+
+    def close(self) -> int:
+        """Release everything the frontend holds. Idempotent.
+
+        Frontends that implement it stay usable afterwards: the next call
+        reloads what it needs. Frontends that do not implement it hold
+        nothing to release, so this is 0 and the model is unchanged.
+        """
+        close = getattr(self._pipe, "close", None)
+        return close() if callable(close) else 0
+
     def calibrate(
         self,
         observations,
@@ -331,7 +353,10 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                max_tokens=512,
                encoder_p1_combiner=None,
                encoder_down_variant=7,
-               decoder_gate_up_variant=10):
+               decoder_gate_up_variant=10,
+               attention=None,
+               fuse=None,
+               compile_mode=None):
     """Load a FlashRT model.
 
     Args:
@@ -927,6 +952,18 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
     elif config == "wan22_ti2v_5b":
         if "autotune" in sig.parameters:
             kwargs["autotune"] = autotune
+    elif config == "ltx25":
+        # The execution assembly is the decision a caller of this model has
+        # to make, so it belongs in the signature rather than in an
+        # environment variable: which attention backend, whether the fused
+        # FFN chain is installed, and whether the denoise loop is compiled
+        # and captured. Each is forwarded only when the frontend declares
+        # it, and only when the caller asked -- leaving the frontend's own
+        # defaults in place otherwise.
+        for name, value in (("attention", attention), ("fuse", fuse),
+                            ("compile_mode", compile_mode)):
+            if value is not None and name in sig.parameters:
+                kwargs[name] = value
     elif config == "hyvla":
         # The routed FP4 tier must reach the frontend explicitly; the
         # generic kwarg set never forwards use_fp4.

--- a/flash_rt/configs/ltx25.yaml
+++ b/flash_rt/configs/ltx25.yaml
@@ -1,0 +1,41 @@
+# FlashRT — LTX-2.5 model configuration (metadata only).
+# The frontend (flash_rt/frontends/torch/ltx25_rtx.py) holds the source of
+# truth for shapes; this file is metadata for logging / registries.
+name: ltx25
+
+# Architecture summary — 22B distilled joint audio+video DiT
+total_params_billion: 22
+num_layers: 48
+
+video:
+  hidden_dim: 4096
+  num_heads: 32
+  head_dim: 128
+  ffn_intermediate: 16384      # GELU
+  cross_attention_dim: 4096    # text context
+  vae_scale: [8, 32, 32]       # time, height, width
+  latent_channels: 128
+
+audio:
+  hidden_dim: 2048
+  num_heads: 32
+  head_dim: 64
+  ffn_intermediate: 8192
+  cross_attention_dim: 2048
+
+text_encoder:
+  backbone: Gemma4-12B + projection
+  max_tokens: 1024
+
+# Distilled two-stage schedule
+pipeline:
+  stage_1_steps: 8             # ancestral Euler at half resolution
+  stage_2_steps: 3             # deterministic refine at full resolution
+  default_width: 1536
+  default_height: 1024
+  default_frames: 121
+  default_fps: 24.0
+
+quantization:
+  transformer: nvfp4           # prequantized block-16, static input scales
+  attention: sage2-qk8-pvfp8   # video sites d128; audio sites stay SDPA

--- a/flash_rt/frontends/torch/ltx25_rtx.py
+++ b/flash_rt/frontends/torch/ltx25_rtx.py
@@ -46,6 +46,7 @@ class Ltx25TorchFrontendRtx:
         num_views: int = 1,
         attention: Optional[str] = None,
         quantization: str = "nvfp4-prequant",
+        fuse: Optional[bool] = None,
         dtype: torch.dtype = torch.bfloat16,
         **_: Any,
     ) -> None:
@@ -58,6 +59,9 @@ class Ltx25TorchFrontendRtx:
         self.quantization = quantization
         self.attention = attention or os.environ.get(
             "FLASH_RT_LTX25_ATTN", "auto")
+        if fuse is None:
+            fuse = os.environ.get("FLASH_RT_LTX25_FUSE", "1") == "1"
+        self.fuse = bool(fuse)
         self.device = torch.device("cuda")
         self.prompt: Optional[str] = None
         self._pipe = None
@@ -187,6 +191,12 @@ class Ltx25TorchFrontendRtx:
         if attn is not None and getattr(attn, "label", "") != "sdpa":
             pipe.stage = pipe.stage.with_attention(attn)
         self._attn_label = getattr(attn, "label", str(self.attention))
+
+        if self.fuse:
+            from flash_rt.models.ltx25._nvfp4_ffn_swap import (
+                SwapInstallingBuilder, install_nvfp4_ffn)
+            pipe.stage = pipe.stage.with_builder(SwapInstallingBuilder(
+                pipe.stage._transformer_builder, [install_nvfp4_ffn]))
         self._load_seconds = time.perf_counter() - t0
         logger.info("[ltx25] pipeline ready in %.1fs (attention=%s)",
                     self._load_seconds, self._attn_label)

--- a/flash_rt/frontends/torch/ltx25_rtx.py
+++ b/flash_rt/frontends/torch/ltx25_rtx.py
@@ -18,6 +18,7 @@ already importable in the environment.
 
 from __future__ import annotations
 
+import gc
 import logging
 import os
 import pathlib
@@ -221,7 +222,12 @@ class Ltx25TorchFrontendRtx:
                 pipe.stage = pipe.stage.with_builder(ResidentSwapBuilder(
                     pipe.stage._transformer_builder,
                     [functools.partial(install_nvfp4_ffn, free_upstream=True)]))
-                pipe.prompt_encoder = CachingPromptEncoder(pipe.prompt_encoder)
+                # A prompt the cache does not hold needs the text encoder,
+                # which does not fit beside the resident transformer: the
+                # encoder ends the residency lease before it runs, and the
+                # stage's next build takes a fresh one.
+                pipe.prompt_encoder = CachingPromptEncoder(
+                    pipe.prompt_encoder, on_miss=self.release_resident)
             else:
                 pipe.stage = pipe.stage.with_builder(SwapInstallingBuilder(
                     pipe.stage._transformer_builder, [install_nvfp4_ffn]))
@@ -237,6 +243,45 @@ class Ltx25TorchFrontendRtx:
     def set_prompt(self, prompt: str, **_: Any) -> None:
         self.prompt = prompt
         self._load_pipe()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def release_resident(self) -> int:
+        """Release the resident transformer and its captured graphs.
+
+        Idempotent, and returns the device bytes freed. Only capture mode
+        holds a residency lease; every other mode disposes the transformer
+        after each stage, so there is nothing here to release and this
+        returns 0. The pipeline stays usable either way: the next call
+        builds a transformer again.
+        """
+        pipe = self._pipe
+        if pipe is None:
+            return 0
+        builder = getattr(pipe.stage, "_transformer_builder", None)
+        release = getattr(builder, "release", None)
+        return release() if callable(release) else 0
+
+    def close(self) -> int:
+        """Release everything this frontend holds. Idempotent.
+
+        The resident transformer and its graphs, the cached prompt
+        embeddings, and the pipeline itself. A later ``set_prompt`` or
+        ``infer`` reloads from the checkpoint, so this is a release, not a
+        teardown of the object.
+        """
+        freed = self.release_resident()
+        pipe = self._pipe
+        if pipe is not None:
+            cache = getattr(pipe, "prompt_encoder", None)
+            clear = getattr(cache, "clear", None)
+            if callable(clear):
+                clear()
+        self._pipe = None
+        gc.collect()
+        torch.cuda.empty_cache()
+        return freed
 
     @torch.inference_mode()
     def infer(

--- a/flash_rt/frontends/torch/ltx25_rtx.py
+++ b/flash_rt/frontends/torch/ltx25_rtx.py
@@ -313,16 +313,25 @@ class Ltx25TorchFrontendRtx:
             # transformer (and its capture pools) exist; resolve it against
             # the memory decode will actually see.
             from ltx_pipelines.utils.helpers import tiling_config_for_vae
-            free, _ = torch.cuda.mem_get_info()
+            free, total = torch.cuda.mem_get_info()
             reserved_slack = (torch.cuda.memory_reserved()
                               - torch.cuda.memory_allocated())
             builder = pipe.stage._transformer_builder
-            resident = getattr(builder, "_holder", {}).get("model") is not None
-            # Before the first build the transformer and its capture pools
-            # (~20GB) still have to fit; once resident, most of what the
-            # allocator reports free really is available to decode.
-            headroom = (23 << 30) if not resident else (2 << 30)
-            budget = max(5 << 30, free + reserved_slack - headroom)
+            if getattr(builder, "is_resident", False):
+                # The transformer and its pools are already paid for, so
+                # what the allocator reports free really is decode's.
+                budget = max(5 << 30, free + reserved_slack - (2 << 30))
+            else:
+                # It is not built yet, and its reserve (weights, capture
+                # pools, denoise peak) is measured against the *device*, not
+                # against what happens to be free right now. Free is the
+                # wrong base here because part of that same reserve --- the
+                # VAEs, the upsampler, cached embeddings --- may already be
+                # allocated, and subtracting the reserve from free would
+                # then count it twice. It reads the same on a first run and
+                # collapses the budget on a rebuild after a release, which
+                # is where the difference showed up.
+                budget = max(5 << 30, total - (23 << 30))
             tiling_config = tiling_config_for_vae(
                 self._resolve_paths()["video_vae"],
                 height=height, width=width, num_frames=num_frames,

--- a/flash_rt/frontends/torch/ltx25_rtx.py
+++ b/flash_rt/frontends/torch/ltx25_rtx.py
@@ -179,7 +179,8 @@ class Ltx25TorchFrontendRtx:
         if self.compile_mode:
             from ltx_core.model.transformer.compiling import CompilationConfig
             if self.compile_mode == "capture":
-                compilation = CompilationConfig(capture=True)
+                compilation = CompilationConfig(
+                    capture=True, seq_dim_dynamic=False)
             elif self.compile_mode == "default":
                 # Per-shape specialization: the two-stage pipeline sees a
                 # fixed (stage1, stage2) sequence-length pair, and the
@@ -213,8 +214,17 @@ class Ltx25TorchFrontendRtx:
         if self.fuse:
             from flash_rt.models.ltx25._nvfp4_ffn_swap import (
                 SwapInstallingBuilder, install_nvfp4_ffn)
-            pipe.stage = pipe.stage.with_builder(SwapInstallingBuilder(
-                pipe.stage._transformer_builder, [install_nvfp4_ffn]))
+            if self.compile_mode == "capture":
+                import functools
+                from flash_rt.models.ltx25._resident_graph import (
+                    CachingPromptEncoder, ResidentSwapBuilder)
+                pipe.stage = pipe.stage.with_builder(ResidentSwapBuilder(
+                    pipe.stage._transformer_builder,
+                    [functools.partial(install_nvfp4_ffn, free_upstream=True)]))
+                pipe.prompt_encoder = CachingPromptEncoder(pipe.prompt_encoder)
+            else:
+                pipe.stage = pipe.stage.with_builder(SwapInstallingBuilder(
+                    pipe.stage._transformer_builder, [install_nvfp4_ffn]))
         self._load_seconds = time.perf_counter() - t0
         logger.info("[ltx25] pipeline ready in %.1fs (attention=%s)",
                     self._load_seconds, self._attn_label)
@@ -252,12 +262,34 @@ class Ltx25TorchFrontendRtx:
         num_frames = num_frames or self.DEFAULT_FRAMES
         frame_rate = frame_rate or self.DEFAULT_FPS
 
+        tiling_config = AUTO_TILING
+        if self.compile_mode == "capture":
+            # AUTO tiling sizes itself from free memory before the resident
+            # transformer (and its capture pools) exist; resolve it against
+            # the memory decode will actually see.
+            from ltx_pipelines.utils.helpers import tiling_config_for_vae
+            free, _ = torch.cuda.mem_get_info()
+            reserved_slack = (torch.cuda.memory_reserved()
+                              - torch.cuda.memory_allocated())
+            builder = pipe.stage._transformer_builder
+            resident = getattr(builder, "_holder", {}).get("model") is not None
+            # Before the first build the transformer and its capture pools
+            # (~20GB) still have to fit; once resident, most of what the
+            # allocator reports free really is available to decode.
+            headroom = (23 << 30) if not resident else (2 << 30)
+            budget = max(5 << 30, free + reserved_slack - headroom)
+            tiling_config = tiling_config_for_vae(
+                self._resolve_paths()["video_vae"],
+                height=height, width=width, num_frames=num_frames,
+                device=self.device, free_bytes=budget,
+            )
+
         torch.cuda.synchronize()
         t0 = time.perf_counter()
         video, audio, frames, tiling = pipe(
             prompt=prompt, seed=seed, height=height, width=width,
             num_frames=num_frames, frame_rate=frame_rate,
-            images=[], tiling_config=AUTO_TILING,
+            images=[], tiling_config=tiling_config,
         )
         torch.cuda.synchronize()
         denoise_s = time.perf_counter() - t0

--- a/flash_rt/frontends/torch/ltx25_rtx.py
+++ b/flash_rt/frontends/torch/ltx25_rtx.py
@@ -47,6 +47,7 @@ class Ltx25TorchFrontendRtx:
         attention: Optional[str] = None,
         quantization: str = "nvfp4-prequant",
         fuse: Optional[bool] = None,
+        compile_mode: Optional[str] = None,
         dtype: torch.dtype = torch.bfloat16,
         **_: Any,
     ) -> None:
@@ -62,6 +63,8 @@ class Ltx25TorchFrontendRtx:
         if fuse is None:
             fuse = os.environ.get("FLASH_RT_LTX25_FUSE", "1") == "1"
         self.fuse = bool(fuse)
+        self.compile_mode = compile_mode if compile_mode is not None else (
+            os.environ.get("FLASH_RT_LTX25_COMPILE", "") or None)
         self.device = torch.device("cuda")
         self.prompt: Optional[str] = None
         self._pipe = None
@@ -172,6 +175,20 @@ class Ltx25TorchFrontendRtx:
             quant = QuantizationKind(self.quantization).to_policy(
                 paths["transformer"])
 
+        compilation = None
+        if self.compile_mode:
+            from ltx_core.model.transformer.compiling import CompilationConfig
+            if self.compile_mode == "capture":
+                compilation = CompilationConfig(capture=True)
+            elif self.compile_mode == "default":
+                # Per-shape specialization: the two-stage pipeline sees a
+                # fixed (stage1, stage2) sequence-length pair, and the
+                # dynamic-seq marks conflict with the graph breaks our
+                # raw-kernel swaps introduce.
+                compilation = CompilationConfig(seq_dim_dynamic=False)
+            else:
+                compilation = CompilationConfig(mode=self.compile_mode)
+
         t0 = time.perf_counter()
         pipe = DistilledPipeline(
             model_paths=ModelPaths.from_split(
@@ -184,6 +201,7 @@ class Ltx25TorchFrontendRtx:
             spatial_upsampler_path=paths["spatial_upsampler"],
             loras=[],
             quantization=quant,
+            compilation_config=compilation,
         )
 
         from flash_rt.models.ltx25._attn_swap import make_ltx25_attention

--- a/flash_rt/frontends/torch/ltx25_rtx.py
+++ b/flash_rt/frontends/torch/ltx25_rtx.py
@@ -1,0 +1,264 @@
+"""FlashRT -- LTX-2.5 22B distilled (audio+video) torch frontend for RTX SM120.
+
+Wraps the official ``ltx-pipelines`` two-stage distilled pipeline behind
+FlashRT's ``set_prompt`` / ``infer`` surface and installs FlashRT compute
+swaps (attention backends now; fused NVFP4 epilogues and CUDA graph capture
+in later stages).
+
+Scope:
+    * Official LTX-2.5 split-pack checkpoints (one safetensors per component).
+    * NVFP4 prequantized transformer by default (static activation scales ship
+      in the checkpoint -- no calibration pass).
+    * RTX SM120 registration only. No CMake or pybind changes.
+
+The LTX-2 monorepo is located through ``FLASH_RT_LTX2_ROOT`` (checkout root;
+``packages/*/src`` are added to ``sys.path``) unless ``ltx_pipelines`` is
+already importable in the environment.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+import sys
+import time
+from typing import Any, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_PACKAGES = ("ltx-core", "ltx-pipelines", "ltx-kernels")
+
+
+class Ltx25TorchFrontendRtx:
+    """LTX-2.5 distilled two-stage pipeline frontend for RTX SM120."""
+
+    DEFAULT_WIDTH = 1536
+    DEFAULT_HEIGHT = 1024
+    DEFAULT_FRAMES = 121
+    DEFAULT_FPS = 24.0
+
+    def __init__(
+        self,
+        checkpoint_dir: str,
+        num_views: int = 1,
+        attention: Optional[str] = None,
+        quantization: str = "nvfp4-prequant",
+        dtype: torch.dtype = torch.bfloat16,
+        **_: Any,
+    ) -> None:
+        self.checkpoint_dir = pathlib.Path(checkpoint_dir).expanduser()
+        if not self.checkpoint_dir.exists():
+            raise FileNotFoundError(
+                f"LTX-2.5 checkpoint pack not found: {self.checkpoint_dir}")
+        self.num_views = num_views
+        self.dtype = dtype
+        self.quantization = quantization
+        self.attention = attention or os.environ.get(
+            "FLASH_RT_LTX25_ATTN", "auto")
+        self.device = torch.device("cuda")
+        self.prompt: Optional[str] = None
+        self._pipe = None
+        self._attn_label: Optional[str] = None
+        self._load_seconds: Optional[float] = None
+        self._last_stats: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Official package discovery
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _candidate_roots() -> list[pathlib.Path]:
+        roots: list[pathlib.Path] = []
+        for key in ("FLASH_RT_LTX2_ROOT", "LTX2_ROOT"):
+            value = os.environ.get(key)
+            if value:
+                roots.append(pathlib.Path(value).expanduser())
+        return roots
+
+    @classmethod
+    def _ensure_ltx_importable(cls) -> None:
+        try:
+            import ltx_pipelines  # noqa: F401
+            return
+        except ModuleNotFoundError as exc:
+            if exc.name not in ("ltx_pipelines", "ltx_core"):
+                raise
+
+        for root in cls._candidate_roots():
+            added = []
+            for pkg in _PACKAGES:
+                src = root / "packages" / pkg / "src"
+                if src.is_dir() and str(src) not in sys.path:
+                    sys.path.insert(0, str(src))
+                    added.append(str(src))
+            try:
+                import ltx_pipelines  # noqa: F401
+                return
+            except ModuleNotFoundError as exc:
+                if exc.name not in ("ltx_pipelines", "ltx_core"):
+                    raise
+                for p in added:
+                    sys.path.remove(p)
+                continue
+
+        raise ModuleNotFoundError(
+            "Cannot import the official LTX-2 packages. Install "
+            "ltx-pipelines into the environment, or set FLASH_RT_LTX2_ROOT "
+            "to an LTX-2 monorepo checkout (the directory containing "
+            "packages/ltx-core and packages/ltx-pipelines).")
+
+    # ------------------------------------------------------------------
+    # Checkpoint pack resolution
+    # ------------------------------------------------------------------
+    def _find_one(self, subdir: str, patterns: list[str],
+                  required: bool = True) -> Optional[str]:
+        base = self.checkpoint_dir / subdir
+        for pattern in patterns:
+            hits = sorted(base.glob(pattern))
+            if hits:
+                return str(hits[0])
+        if required:
+            raise FileNotFoundError(
+                f"No file matching {patterns} under {base}. The frontend "
+                "expects the official LTX-2.5 split pack layout.")
+        return None
+
+    def _resolve_paths(self) -> dict[str, str]:
+        transformer = self._find_one(
+            "diffusion_models",
+            ["*distilled-transformer-nvfp4.safetensors",
+             "*distilled-transformer-bf16.safetensors"])
+        text_encoder = self._find_one(
+            "text_encoders", ["*with-proj*bf16.safetensors"])
+        video_vae = self._find_one("vae", ["*video-vae-bf16.safetensors"])
+        audio_vae = self._find_one("vae", ["*audio-vae-bf16.safetensors"])
+        duration_head = self._find_one(
+            "model_patches", ["*duration-head*.safetensors"], required=False)
+        spatial_upsampler = self._find_one(
+            "latent_upscale_models",
+            ["*latent-spatial-upscaler-x2*.safetensors",
+             "*spatial-upscaler*.safetensors"])
+        return {
+            "transformer": transformer,
+            "text_encoder": text_encoder,
+            "video_vae": video_vae,
+            "audio_vae": audio_vae,
+            "duration_head": duration_head,
+            "spatial_upsampler": spatial_upsampler,
+        }
+
+    # ------------------------------------------------------------------
+    # Pipeline assembly
+    # ------------------------------------------------------------------
+    def _load_pipe(self):
+        if self._pipe is not None:
+            return self._pipe
+
+        self._ensure_ltx_importable()
+        from ltx_pipelines.distilled import DistilledPipeline
+        from ltx_pipelines.utils.model_paths import ModelPaths
+        from ltx_pipelines.utils.quantization_factory import QuantizationKind
+
+        paths = self._resolve_paths()
+        quant = None
+        if self.quantization and paths["transformer"].endswith(
+                "nvfp4.safetensors"):
+            quant = QuantizationKind(self.quantization).to_policy(
+                paths["transformer"])
+
+        t0 = time.perf_counter()
+        pipe = DistilledPipeline(
+            model_paths=ModelPaths.from_split(
+                transformer_path=paths["transformer"],
+                text_encoder_path=paths["text_encoder"],
+                video_vae_path=paths["video_vae"],
+                audio_vae_path=paths["audio_vae"],
+                duration_head_path=paths["duration_head"],
+            ),
+            spatial_upsampler_path=paths["spatial_upsampler"],
+            loras=[],
+            quantization=quant,
+        )
+
+        from flash_rt.models.ltx25._attn_swap import make_ltx25_attention
+        attn = make_ltx25_attention(self.attention)
+        if attn is not None and getattr(attn, "label", "") != "sdpa":
+            pipe.stage = pipe.stage.with_attention(attn)
+        self._attn_label = getattr(attn, "label", str(self.attention))
+        self._load_seconds = time.perf_counter() - t0
+        logger.info("[ltx25] pipeline ready in %.1fs (attention=%s)",
+                    self._load_seconds, self._attn_label)
+        self._pipe = pipe
+        return pipe
+
+    # ------------------------------------------------------------------
+    # FlashRT surface
+    # ------------------------------------------------------------------
+    def set_prompt(self, prompt: str, **_: Any) -> None:
+        self.prompt = prompt
+        self._load_pipe()
+
+    @torch.inference_mode()
+    def infer(
+        self,
+        prompt: Optional[str] = None,
+        seed: int = 42,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_frames: Optional[int] = None,
+        frame_rate: Optional[float] = None,
+        output_path: Optional[str] = None,
+        **_: Any,
+    ) -> dict[str, Any]:
+        prompt = prompt or self.prompt
+        if not prompt:
+            raise ValueError("No prompt: call set_prompt() or pass prompt=")
+        pipe = self._load_pipe()
+
+        from ltx_core.model.video_vae import AUTO_TILING, get_video_chunks_number
+
+        height = height or self.DEFAULT_HEIGHT
+        width = width or self.DEFAULT_WIDTH
+        num_frames = num_frames or self.DEFAULT_FRAMES
+        frame_rate = frame_rate or self.DEFAULT_FPS
+
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        video, audio, frames, tiling = pipe(
+            prompt=prompt, seed=seed, height=height, width=width,
+            num_frames=num_frames, frame_rate=frame_rate,
+            images=[], tiling_config=AUTO_TILING,
+        )
+        torch.cuda.synchronize()
+        denoise_s = time.perf_counter() - t0
+
+        t1 = time.perf_counter()
+        if output_path:
+            from ltx_pipelines.utils.media_io import encode_video
+            encode_video(
+                video=video, fps=frame_rate, audio=audio,
+                output_path=output_path,
+                video_chunks_number=get_video_chunks_number(frames, tiling))
+        else:
+            for _chunk in video:
+                pass
+        torch.cuda.synchronize()
+        decode_s = time.perf_counter() - t1
+
+        self._last_stats = {
+            "attention": self._attn_label,
+            "quantization": self.quantization,
+            "resolution": f"{width}x{height}x{num_frames}",
+            "denoise_and_prep_s": round(denoise_s, 3),
+            "vae_decode_encode_s": round(decode_s, 3),
+            "total_s": round(denoise_s + decode_s, 3),
+            "peak_mem_gb": round(
+                torch.cuda.max_memory_allocated() / 2 ** 30, 2),
+            "output_path": output_path,
+        }
+        return dict(self._last_stats)
+
+    def get_latency_stats(self) -> dict[str, Any]:
+        return dict(self._last_stats)

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -135,6 +135,10 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     ("wan22_ti2v_5b", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.wan22_rtx", "Wan22TorchFrontendRtx"),
 
+    # ── LTX-2.5 22B distilled audio+video (RTX SM120 only) ──
+    ("ltx25", "torch", "rtx_sm120"):
+        ("flash_rt.frontends.torch.ltx25_rtx", "Ltx25TorchFrontendRtx"),
+
     # ── Cosmos3-Nano text2video FP8 denoise (RTX SM120 only) ──
     ("cosmos3_video", "torch", "rtx_sm120"):
         ("flash_rt.frontends.torch.cosmos3_video_rtx", "Cosmos3VideoTorchFrontendRtx"),

--- a/flash_rt/models/ltx25/__init__.py
+++ b/flash_rt/models/ltx25/__init__.py
@@ -1,0 +1,16 @@
+"""FlashRT LTX-2.5 RTX SM120 integration.
+
+Wraps the official LTX-2 ``ltx-pipelines`` distilled two-stage pipeline and
+progressively swaps compute onto FlashRT kernels:
+
+    * attention: sage2 qk-int8/pv-fp8 raw kernels (video sites, d128) with
+      per-shape preallocated buffers, graph-capture safe
+    * NVFP4 linear path: checkpoint ships prequantized weights + static
+      activation scales; GEMMs run through the upstream cuBLASLt entry with
+      FlashRT fused quantize epilogues arriving in later stages
+    * CUDA graph capture over the transformer block loop per stage
+
+The official model source is discovered through ``FLASH_RT_LTX2_ROOT`` (a
+checkout of the LTX-2 monorepo with ``ltx-core`` / ``ltx-pipelines``
+importable), mirroring the Wan2.2 integration contract.
+"""

--- a/flash_rt/models/ltx25/_attn_swap.py
+++ b/flash_rt/models/ltx25/_attn_swap.py
@@ -97,6 +97,7 @@ class FvkSage2Attention:
             self._bufs[key] = bufs
         return bufs
 
+    @torch.compiler.disable
     def __call__(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
                  heads: int) -> torch.Tensor:
         b, lq, hd = q.shape

--- a/flash_rt/models/ltx25/_attn_swap.py
+++ b/flash_rt/models/ltx25/_attn_swap.py
@@ -1,0 +1,224 @@
+"""LTX-2.5 attention backend swap.
+
+Implements the ltx-core ``AttentionCallable`` protocol
+(``fn(q, k, v, heads) -> out`` with flat ``[B, T, H*D]`` tensors) on top of
+FlashRT's raw-pointer sage2 kernels:
+
+    q: quant_per_warp_int8_bf16_d128   -> int8 [B,L,H,128] + f32 [B,H,ceil(L/32)]
+    k: quant_per_block_int8_bf16_d128  -> int8 [B,L,H,128] + f32 [B,H,ceil(L/64)]
+    v: transpose-pad-permute + fp8     -> fp8 [B,128,H,pad64(L)] + f32 [B,H,128]
+    sage2_qk_int8_sv_f8_bf16_nhd_d128  -> bf16 [B,L,H,128]
+
+All buffers are preallocated per (B, Lq, Lk, H) and reused, so repeated calls
+issue an identical kernel sequence on identical pointers — safe to record into
+a CUDA graph.
+
+Site routing: the kernels are d128-only, so audio sites (head_dim 64) and any
+other non-d128 shape fall back to torch SDPA, which also matches the measured
+selection on 5090 (short-sequence d64 attention is faster on SDPA than on any
+quantized path).
+
+Backend choices (``make_ltx25_attention``):
+    "sage2-fvk"  raw FlashRT kernels (default; graph-capture path)
+    "sage2"      upstream ``sageattention`` package (needs it installed)
+    "sage3"      ``sageattn3`` FP4 Blackwell package (needs it installed)
+    "sdpa"       torch SDPA passthrough (baseline / fallback)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+try:
+    from flash_rt import flash_rt_kernels as fvk
+except ImportError:  # pragma: no cover - kernels are part of the wheel
+    fvk = None
+
+_REQUIRED_SYMS = (
+    "quant_per_warp_int8_bf16_d128",
+    "quant_per_block_int8_bf16_d128",
+    "concat3_v_transpose_pad_permute_bf16_d128",
+    "v_tpp_bf16_quant_fp8_d128",
+    "sage2_qk_int8_sv_f8_bf16_nhd_d128",
+)
+
+
+def fvk_sage2_available() -> bool:
+    return fvk is not None and all(hasattr(fvk, s) for s in _REQUIRED_SYMS)
+
+
+def _sdpa(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+          heads: int) -> torch.Tensor:
+    b, _, hd = q.shape
+    d = hd // heads
+    q4, k4, v4 = (t.view(b, -1, heads, d).transpose(1, 2) for t in (q, k, v))
+    o = F.scaled_dot_product_attention(q4, k4, v4)
+    return o.transpose(1, 2).reshape(b, -1, hd)
+
+
+class FvkSage2Attention:
+    """sage2 qk-int8 / pv-fp8 attention on FlashRT raw kernels."""
+
+    label = "fvk-sage2-qk8-pvfp8"
+
+    def __init__(self, stream_fn=None) -> None:
+        # stream_fn returns the raw cudaStream_t the pipeline runs on; during
+        # graph capture it must be the capture stream. Default: torch current.
+        self._stream_fn = stream_fn or (
+            lambda: torch.cuda.current_stream().cuda_stream)
+        self._bufs: dict[tuple, tuple[torch.Tensor, ...]] = {}
+
+    def _buffers(self, device: torch.device, b: int, lq: int, lk: int,
+                 h: int) -> tuple[torch.Tensor, ...]:
+        key = (device, b, lq, lk, h)
+        bufs = self._bufs.get(key)
+        if bufs is None:
+            pad_lk = ((lk + 63) // 64) * 64
+            q8 = torch.empty(b, lq, h, 128, dtype=torch.int8, device=device)
+            k8 = torch.empty(b, lk, h, 128, dtype=torch.int8, device=device)
+            vt = torch.empty(b, 128, h, pad_lk, dtype=torch.bfloat16,
+                             device=device)
+            v8 = torch.empty(b, 128, h, pad_lk, dtype=torch.float8_e4m3fn,
+                             device=device)
+            qs = torch.empty(b, h, (lq + 31) // 32, dtype=torch.float32,
+                             device=device)
+            ks = torch.empty(b, h, (lk + 63) // 64, dtype=torch.float32,
+                             device=device)
+            vs = torch.empty(b, h, 128, dtype=torch.float32, device=device)
+            out = torch.empty(b, lq, h, 128, dtype=torch.bfloat16,
+                              device=device)
+            bufs = (q8, k8, vt, v8, qs, ks, vs, out)
+            self._bufs[key] = bufs
+        return bufs
+
+    def __call__(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                 heads: int) -> torch.Tensor:
+        b, lq, hd = q.shape
+        d = hd // heads
+        if d != 128 or q.dtype != torch.bfloat16 or not fvk_sage2_available():
+            return _sdpa(q, k, v, heads)
+        lk = k.shape[1]
+
+        qn = q.view(b, lq, heads, d)
+        kn = k.view(b, lk, heads, d)
+        vn = v.view(b, lk, heads, d)
+        qn = qn if qn.is_contiguous() else qn.contiguous()
+        kn = kn if kn.is_contiguous() else kn.contiguous()
+        vn = vn if vn.is_contiguous() else vn.contiguous()
+
+        q8, k8, vt, v8, qs, ks, vs, out = self._buffers(
+            q.device, b, lq, lk, heads)
+        stream = self._stream_fn()
+
+        fvk.quant_per_warp_int8_bf16_d128(
+            int(qn.data_ptr()), int(q8.data_ptr()), int(qs.data_ptr()),
+            b, lq, heads, stream)
+        fvk.quant_per_block_int8_bf16_d128(
+            int(kn.data_ptr()), int(k8.data_ptr()), int(ks.data_ptr()),
+            b, lk, heads, stream)
+        fvk.concat3_v_transpose_pad_permute_bf16_d128(
+            int(vn.data_ptr()), int(vn.data_ptr()), int(vn.data_ptr()),
+            int(vt.data_ptr()),
+            b, lk, 0, 0, heads,
+            int(vn.stride(0)), int(vn.stride(1)),
+            int(vn.stride(0)), int(vn.stride(1)),
+            int(vn.stride(0)), int(vn.stride(1)), stream)
+        fvk.v_tpp_bf16_quant_fp8_d128(
+            int(vt.data_ptr()), int(v8.data_ptr()), int(vs.data_ptr()),
+            b, lk, heads, stream)
+        rc = fvk.sage2_qk_int8_sv_f8_bf16_nhd_d128(
+            int(q8.data_ptr()), int(k8.data_ptr()), int(v8.data_ptr()),
+            int(out.data_ptr()), int(qs.data_ptr()), int(ks.data_ptr()),
+            int(vs.data_ptr()), b, lq, lk, heads,
+            float(d ** -0.5), stream)
+        if rc != 0:
+            raise RuntimeError(f"[ltx25.sage2] raw attention rc={rc}")
+        return out.view(b, lq, hd)
+
+
+class SagePkgAttention:
+    """Upstream ``sageattention`` package (sm120 default dispatch)."""
+
+    label = "sageattention-pkg"
+
+    def __init__(self) -> None:
+        import sageattention
+        self._fn = sageattention.sageattn
+
+    def __call__(self, q, k, v, heads):
+        b, _, hd = q.shape
+        d = hd // heads
+        if d not in (64, 128) or d == 64:
+            return _sdpa(q, k, v, heads)
+        q4, k4, v4 = (t.view(b, -1, heads, d).transpose(1, 2)
+                      for t in (q, k, v))
+        o = self._fn(q4, k4, v4, tensor_layout="HND", is_causal=False)
+        return o.transpose(1, 2).reshape(b, -1, hd)
+
+
+class Sage3Attention:
+    """``sageattn3`` FP4 Blackwell package. Fastest, lowest per-call cos;
+    exposed as an opt-in for speed-first runs."""
+
+    label = "sageattn3-fp4"
+
+    def __init__(self) -> None:
+        from sageattn3 import sageattn3_blackwell
+        self._fn = sageattn3_blackwell
+
+    def __call__(self, q, k, v, heads):
+        b, _, hd = q.shape
+        d = hd // heads
+        if d != 128:
+            return _sdpa(q, k, v, heads)
+        q4, k4, v4 = (t.view(b, -1, heads, d).transpose(1, 2)
+                      for t in (q, k, v))
+        o = self._fn(q4, k4, v4, is_causal=False)
+        return o.transpose(1, 2).reshape(b, -1, hd)
+
+
+class SdpaAttention:
+    label = "sdpa"
+
+    def __call__(self, q, k, v, heads):
+        return _sdpa(q, k, v, heads)
+
+
+def make_ltx25_attention(kind: Optional[str], stream_fn=None):
+    """Resolve an attention backend name to an ltx-core AttentionCallable.
+
+    ``None`` or ``"auto"`` picks the raw fvk sage2 path when the kernels are
+    present, else the sageattention package, else SDPA.
+    """
+    kind = (kind or "auto").lower()
+    if kind == "auto":
+        if fvk_sage2_available():
+            kind = "sage2-fvk"
+        else:
+            try:
+                import sageattention  # noqa: F401
+                kind = "sage2"
+            except ImportError:
+                kind = "sdpa"
+
+    if kind == "sage2-fvk":
+        if not fvk_sage2_available():
+            raise RuntimeError(
+                "ltx25 attention 'sage2-fvk' requires flash_rt_kernels with "
+                "the sage2 raw entry points")
+        return FvkSage2Attention(stream_fn=stream_fn)
+    if kind == "sage2":
+        return SagePkgAttention()
+    if kind == "sage3":
+        return Sage3Attention()
+    if kind == "sdpa":
+        return SdpaAttention()
+    raise ValueError(
+        f"Unknown ltx25 attention backend: {kind!r} "
+        "(expected auto|sage2-fvk|sage2|sage3|sdpa)")

--- a/flash_rt/models/ltx25/_attn_swap.py
+++ b/flash_rt/models/ltx25/_attn_swap.py
@@ -27,6 +27,7 @@ Backend choices (``make_ltx25_attention``):
 
 from __future__ import annotations
 
+import importlib
 import logging
 from typing import Optional
 
@@ -36,12 +37,18 @@ import torch.nn.functional as F
 logger = logging.getLogger(__name__)
 
 try:
-    from flash_rt import flash_rt_kernels as fvk
-except ModuleNotFoundError as exc:  # pragma: no cover - built artifact
+    fvk = importlib.import_module("flash_rt.flash_rt_kernels")
+except ModuleNotFoundError as exc:
     # Only the extension's own absence is optional. An undefined symbol, a
     # CUDA ABI mismatch, or a transitive dependency failing to load all
-    # surface as ImportError too, and swallowing those would report a
+    # surface as plain ImportError, and swallowing those would report a
     # broken build as "kernels unavailable" and silently run the fallback.
+    #
+    # The import has to go through importlib for that distinction to exist
+    # at all: ``from flash_rt import flash_rt_kernels`` reaches the
+    # package's PEP 562 ``__getattr__``, which answers an absent extension
+    # with build instructions raised as ImportError -- so the two cases
+    # arrive as the same type and neither can be told from the other.
     if exc.name != "flash_rt.flash_rt_kernels":
         raise
     fvk = None
@@ -209,9 +216,15 @@ def make_ltx25_attention(kind: Optional[str], stream_fn=None):
             kind = "sage2-fvk"
         else:
             try:
-                import sageattention  # noqa: F401
+                importlib.import_module("sageattention")
                 kind = "sage2"
-            except ImportError:
+            except ModuleNotFoundError as exc:
+                # The package not being installed is a reason to fall back.
+                # The package being installed and failing to load is not:
+                # that is a broken environment, and answering it with SDPA
+                # would hide the breakage behind a quiet slowdown.
+                if exc.name != "sageattention":
+                    raise
                 kind = "sdpa"
 
     if kind == "sage2-fvk":

--- a/flash_rt/models/ltx25/_attn_swap.py
+++ b/flash_rt/models/ltx25/_attn_swap.py
@@ -37,7 +37,13 @@ logger = logging.getLogger(__name__)
 
 try:
     from flash_rt import flash_rt_kernels as fvk
-except ImportError:  # pragma: no cover - kernels are part of the wheel
+except ModuleNotFoundError as exc:  # pragma: no cover - built artifact
+    # Only the extension's own absence is optional. An undefined symbol, a
+    # CUDA ABI mismatch, or a transitive dependency failing to load all
+    # surface as ImportError too, and swallowing those would report a
+    # broken build as "kernels unavailable" and silently run the fallback.
+    if exc.name != "flash_rt.flash_rt_kernels":
+        raise
     fvk = None
 
 _REQUIRED_SYMS = (

--- a/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
+++ b/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
@@ -28,7 +28,11 @@ logger = logging.getLogger(__name__)
 
 try:
     from flash_rt import flash_rt_kernels as fvk
-except ImportError:  # pragma: no cover
+except ModuleNotFoundError as exc:  # pragma: no cover - built artifact
+    # Same rule as the attention swap: the extension being absent is a
+    # fallback, the extension being broken is a bug and must be visible.
+    if exc.name != "flash_rt.flash_rt_kernels":
+        raise
     fvk = None
 
 _REQUIRED = (
@@ -41,6 +45,19 @@ _REQUIRED = (
 
 def fvk_ffn_available() -> bool:
     return fvk is not None and all(hasattr(fvk, s) for s in _REQUIRED)
+
+
+def rows_are_swappable(rows: int) -> bool:
+    """Whether the fused chain will accept a call of this row count.
+
+    The CUTLASS chain reports a validation failure for row counts that are
+    not 128-aligned and returns *without writing its output*, so a call that
+    reached it anyway would leave the caller reading whatever the buffer
+    held. The predicate lives here, named, because two places have to agree
+    on it: the forward that routes the call and the installer that decides
+    whether upstream weights can be freed.
+    """
+    return rows % 128 == 0
 
 
 def _swizzled_sf_bytes(rows: int, cols: int) -> int:
@@ -155,8 +172,8 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers,
         shape = x.shape
         x2 = x.reshape(-1, shape[-1])
         m = x2.shape[0]
-        if m % 128 != 0:
-            # The CUTLASS chain rejects unaligned M (can_implement status 11)
+        if not rows_are_swappable(m):
+            # The chain rejects unaligned M (can_implement status 11)
             # without writing the output; e.g. the ~126-token audio branch.
             # Those calls are negligible work -- keep them on upstream.
             if freed:

--- a/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
+++ b/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
@@ -20,6 +20,7 @@ a CUDA graph.
 
 from __future__ import annotations
 
+import importlib
 import logging
 
 import torch
@@ -27,10 +28,11 @@ import torch
 logger = logging.getLogger(__name__)
 
 try:
-    from flash_rt import flash_rt_kernels as fvk
-except ModuleNotFoundError as exc:  # pragma: no cover - built artifact
-    # Same rule as the attention swap: the extension being absent is a
-    # fallback, the extension being broken is a bug and must be visible.
+    fvk = importlib.import_module("flash_rt.flash_rt_kernels")
+except ModuleNotFoundError as exc:
+    # Same rule, and the same reason for going through importlib, as the
+    # attention swap: absent is a fallback, broken is a bug, and the
+    # package's ``__getattr__`` would make both arrive as ImportError.
     if exc.name != "flash_rt.flash_rt_kernels":
         raise
     fvk = None

--- a/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
+++ b/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
@@ -108,7 +108,8 @@ class _FfnBuffers:
         return bufs
 
 
-def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
+def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers,
+                      free_upstream: bool = False):
     up = ff.net[0].proj
     down = ff.net[2]
     dim, inner = up.in_features, up.out_features
@@ -133,6 +134,17 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
         inner, dtype=torch.bfloat16, device=up_p.device)
     dn_bias = down.bias.detach() if down.bias is not None else None
 
+    freed = False
+    if free_upstream and dim >= 4096:
+        # Resident mode never reloads the checkpoint, so the upstream fp4
+        # storage is dead weight (~3.6GB across the video FFNs). Audio FFNs
+        # keep theirs -- their unaligned-M calls fall back to upstream.
+        up.weight.data = up.weight.data.new_empty(0)
+        up.weight_scale.data = up.weight_scale.data.new_empty(0)
+        down.weight.data = down.weight.data.new_empty(0)
+        down.weight_scale.data = down.weight_scale.data.new_empty(0)
+        freed = True
+
     # The upstream fp4 params stay in place: the builder reuses the module
     # across stage rebuilds and reloads the state dict into them. The
     # repacked copies add ~4.8GB resident for the 48-block model, which fits
@@ -147,6 +159,11 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
             # The CUTLASS chain rejects unaligned M (can_implement status 11)
             # without writing the output; e.g. the ~126-token audio branch.
             # Those calls are negligible work -- keep them on upstream.
+            if freed:
+                raise RuntimeError(
+                    f"ltx25 FFN: M={m} is not 128-aligned but the upstream "
+                    "weights were freed (resident mode). Use dimensions whose "
+                    "token counts are 128-aligned, or disable capture mode.")
             return upstream_forward(x)
         x2 = x2 if x2.is_contiguous() else x2.contiguous()
         stream = _stream()
@@ -175,7 +192,8 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
     return forward
 
 
-def install_nvfp4_ffn(model: torch.nn.Module) -> int:
+def install_nvfp4_ffn(model: torch.nn.Module, *,
+                      free_upstream: bool = False) -> int:
     """Swap every NVFP4 FeedForward on ``model`` to the fvk W4A4 chain.
 
     Returns the number of FeedForward modules swapped. Modules whose linears
@@ -197,7 +215,8 @@ def install_nvfp4_ffn(model: torch.nn.Module) -> int:
             continue
         if proj.in_features % 16 or proj.out_features % 16:
             continue
-        module.forward = _make_ffn_forward(module, buffers)
+        module.forward = _make_ffn_forward(module, buffers,
+                                           free_upstream=free_upstream)
         count += 1
     logger.info("[ltx25] swapped %d FeedForward modules to fvk W4A4 chain",
                 count)

--- a/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
+++ b/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
@@ -119,8 +119,16 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
         upstream_forward = ff.forward
         ff._flash_rt_ffn_orig = upstream_forward
 
-    up_p, up_sf, _ = _repack_nvfp4_linear(up)
-    dn_p, dn_sf, _ = _repack_nvfp4_linear(down)
+    # The builder reuses module objects across stage rebuilds and reloads the
+    # same checkpoint weights into them, so the repacked tensors stay valid --
+    # cache them on the module instead of repacking per build.
+    pack = getattr(ff, "_flash_rt_ffn_pack", None)
+    if pack is None:
+        up_p, up_sf, _ = _repack_nvfp4_linear(up)
+        dn_p, dn_sf, _ = _repack_nvfp4_linear(down)
+        ff._flash_rt_ffn_pack = (up_p, up_sf, dn_p, dn_sf)
+    else:
+        up_p, up_sf, dn_p, dn_sf = pack
     up_bias = up.bias.detach() if up.bias is not None else torch.zeros(
         inner, dtype=torch.bfloat16, device=up_p.device)
     dn_bias = down.bias.detach() if down.bias is not None else None
@@ -160,6 +168,9 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
                 int(y.data_ptr()), int(dn_bias.data_ptr()), m, dim, stream)
         return y.view(*shape[:-1], dim)
 
+    # Raw-pointer launches are opaque to dynamo; keep them eager under
+    # torch.compile (CUDA graph capture still records the kernels).
+    forward = torch._dynamo.disable(forward)
     forward._flash_rt_keep = keep
     return forward
 

--- a/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
+++ b/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
@@ -112,6 +112,12 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
     up = ff.net[0].proj
     down = ff.net[2]
     dim, inner = up.in_features, up.out_features
+    # Survive re-installs across stage rebuilds: always chain to the true
+    # original forward, not a previous swap closure.
+    upstream_forward = getattr(ff, "_flash_rt_ffn_orig", None)
+    if upstream_forward is None:
+        upstream_forward = ff.forward
+        ff._flash_rt_ffn_orig = upstream_forward
 
     up_p, up_sf, _ = _repack_nvfp4_linear(up)
     dn_p, dn_sf, _ = _repack_nvfp4_linear(down)
@@ -128,8 +134,13 @@ def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
     def forward(x: torch.Tensor) -> torch.Tensor:
         shape = x.shape
         x2 = x.reshape(-1, shape[-1])
-        x2 = x2 if x2.is_contiguous() else x2.contiguous()
         m = x2.shape[0]
+        if m % 128 != 0:
+            # The CUTLASS chain rejects unaligned M (can_implement status 11)
+            # without writing the output; e.g. the ~126-token audio branch.
+            # Those calls are negligible work -- keep them on upstream.
+            return upstream_forward(x)
+        x2 = x2 if x2.is_contiguous() else x2.contiguous()
         stream = _stream()
         xq, xsf, h4, h4sf, y = buffers.get(x2.device, m, dim, inner)
         fvk.quantize_bf16_to_nvfp4_swizzled(

--- a/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
+++ b/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
@@ -1,0 +1,220 @@
+"""LTX-2.5 FFN swap: upstream NVFP4Linear pair -> FlashRT W4A4 CUTLASS chain.
+
+Upstream FeedForward runs six launches per call (activation quantize +
+cuBLASLt + bias, torch GELU, activation quantize + cuBLASLt + bias). The
+FlashRT chain runs three:
+
+    quantize_bf16_to_nvfp4_swizzled(x)
+    fp4_w4a16_gemm_bias_gelu_fp4out_sm120   (up proj + bias + tanh-GELU + fp4)
+    fp4_w4a16_gemm_sm120_bf16out            (down proj)  [+ add_bias]
+
+Weights are repacked once per build from the checkpoint's NVFP4 layout
+(dequantize to bf16, requantize into the fvk swizzled layout); the original
+parameters are dropped right after so resident memory stays flat. Measured on
+block-0 weights at the model's real M sizes this is 1.25-1.28x the upstream
+pair at equivalent accuracy against a bf16 golden reference.
+
+All launches take raw pointers on preallocated buffers -- safe to record into
+a CUDA graph.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+try:
+    from flash_rt import flash_rt_kernels as fvk
+except ImportError:  # pragma: no cover
+    fvk = None
+
+_REQUIRED = (
+    "quantize_bf16_to_nvfp4_swizzled",
+    "fp4_w4a16_gemm_bias_gelu_fp4out_sm120",
+    "fp4_w4a16_gemm_sm120_bf16out",
+    "add_bias_bf16",
+)
+
+
+def fvk_ffn_available() -> bool:
+    return fvk is not None and all(hasattr(fvk, s) for s in _REQUIRED)
+
+
+def _swizzled_sf_bytes(rows: int, cols: int) -> int:
+    # CUTLASS blockscaled atom layout: one e4m3 byte per 16-element block,
+    # rows padded to 128 and SF columns padded to 4 (measured write footprint
+    # of quantize_bf16_to_nvfp4_swizzled; the motus-era x16 formula
+    # over-allocated).
+    n_blocks = cols // 16
+    return ((rows + 127) // 128 * 128) * ((n_blocks + 3) // 4 * 4)
+
+
+def _stream() -> int:
+    return torch.cuda.current_stream().cuda_stream
+
+
+def _quantize_bf16_to_swz(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, cols = x.shape
+    packed = torch.empty(rows, cols // 2, dtype=torch.uint8, device=x.device)
+    sf = torch.zeros(_swizzled_sf_bytes(rows, cols), dtype=torch.uint8,
+                     device=x.device)
+    fvk.quantize_bf16_to_nvfp4_swizzled(
+        int(x.data_ptr()), int(packed.data_ptr()), int(sf.data_ptr()),
+        rows, cols, _stream())
+    return packed, sf
+
+
+def _repack_nvfp4_linear(lin: torch.nn.Module) -> tuple[torch.Tensor, torch.Tensor, float]:
+    """Upstream NVFP4Linear -> (fvk packed weight, fvk swizzled SF, alpha).
+
+    Dequantizes with the exact upstream reference kernel, requantizes into the
+    fvk layout, then frees the original weight storage. alpha stays 1.0: the
+    fvk per-16 E4M3 block scales absorb the dynamic range that upstream
+    splits into block scales x weight_scale_2.
+    """
+    from ltx_kernels import nvfp4 as ltx_nvfp4
+
+    w_bf16 = ltx_nvfp4.dequantize_nvfp4(
+        lin.weight, lin.weight_scale_2,
+        lin.weight_scale.view(torch.float8_e4m3fn),
+    ).to(torch.bfloat16)
+    packed, sf = _quantize_bf16_to_swz(w_bf16)
+    del w_bf16
+    return packed, sf, 1.0
+
+
+class _FfnBuffers:
+    """Per-(device, M, inner) intermediate buffers, grown on demand."""
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple, tuple[torch.Tensor, ...]] = {}
+
+    def get(self, device: torch.device, m: int, dim: int, inner: int):
+        key = (device, m, dim, inner)
+        bufs = self._cache.get(key)
+        if bufs is None:
+            xq = torch.empty(m, dim // 2, dtype=torch.uint8, device=device)
+            xsf = torch.zeros(_swizzled_sf_bytes(m, dim), dtype=torch.uint8,
+                              device=device)
+            h4 = torch.empty(m, inner // 2, dtype=torch.uint8, device=device)
+            h4sf = torch.zeros(_swizzled_sf_bytes(m, inner), dtype=torch.uint8,
+                               device=device)
+            y = torch.empty(m, dim, dtype=torch.bfloat16, device=device)
+            bufs = (xq, xsf, h4, h4sf, y)
+            self._cache[key] = bufs
+        return bufs
+
+
+def _make_ffn_forward(ff: torch.nn.Module, buffers: _FfnBuffers):
+    up = ff.net[0].proj
+    down = ff.net[2]
+    dim, inner = up.in_features, up.out_features
+
+    up_p, up_sf, _ = _repack_nvfp4_linear(up)
+    dn_p, dn_sf, _ = _repack_nvfp4_linear(down)
+    up_bias = up.bias.detach() if up.bias is not None else torch.zeros(
+        inner, dtype=torch.bfloat16, device=up_p.device)
+    dn_bias = down.bias.detach() if down.bias is not None else None
+
+    # The upstream fp4 params stay in place: the builder reuses the module
+    # across stage rebuilds and reloads the state dict into them. The
+    # repacked copies add ~4.8GB resident for the 48-block model, which fits
+    # alongside the 23GB inference peak on a 32GB part.
+    keep = (up_p, up_sf, dn_p, dn_sf, up_bias, dn_bias)
+
+    def forward(x: torch.Tensor) -> torch.Tensor:
+        shape = x.shape
+        x2 = x.reshape(-1, shape[-1])
+        x2 = x2 if x2.is_contiguous() else x2.contiguous()
+        m = x2.shape[0]
+        stream = _stream()
+        xq, xsf, h4, h4sf, y = buffers.get(x2.device, m, dim, inner)
+        fvk.quantize_bf16_to_nvfp4_swizzled(
+            int(x2.data_ptr()), int(xq.data_ptr()), int(xsf.data_ptr()),
+            m, dim, stream)
+        fvk.fp4_w4a16_gemm_bias_gelu_fp4out_sm120(
+            int(xq.data_ptr()), int(up_p.data_ptr()),
+            int(xsf.data_ptr()), int(up_sf.data_ptr()),
+            int(up_bias.data_ptr()), int(h4.data_ptr()), int(h4sf.data_ptr()),
+            m, inner, dim, 1.0, stream)
+        fvk.fp4_w4a16_gemm_sm120_bf16out(
+            int(h4.data_ptr()), int(dn_p.data_ptr()), int(y.data_ptr()),
+            m, dim, inner,
+            int(h4sf.data_ptr()), int(dn_sf.data_ptr()), 1.0, stream)
+        if dn_bias is not None:
+            fvk.add_bias_bf16(
+                int(y.data_ptr()), int(dn_bias.data_ptr()), m, dim, stream)
+        return y.view(*shape[:-1], dim)
+
+    forward._flash_rt_keep = keep
+    return forward
+
+
+def install_nvfp4_ffn(model: torch.nn.Module) -> int:
+    """Swap every NVFP4 FeedForward on ``model`` to the fvk W4A4 chain.
+
+    Returns the number of FeedForward modules swapped. Modules whose linears
+    are not upstream NVFP4Linear (e.g. a bf16 build) are left untouched.
+    """
+    if not fvk_ffn_available():
+        logger.info("[ltx25] fvk FFN chain unavailable; keeping upstream FFN")
+        return 0
+    from ltx_core.quantization.nvfp4.linear import NVFP4Linear
+
+    buffers = _FfnBuffers()
+    count = 0
+    for module in model.modules():
+        net = getattr(module, "net", None)
+        if net is None or len(net) != 3:
+            continue
+        proj = getattr(net[0], "proj", None)
+        if not isinstance(proj, NVFP4Linear) or not isinstance(net[2], NVFP4Linear):
+            continue
+        if proj.in_features % 16 or proj.out_features % 16:
+            continue
+        module.forward = _make_ffn_forward(module, buffers)
+        count += 1
+    logger.info("[ltx25] swapped %d FeedForward modules to fvk W4A4 chain",
+                count)
+    return count
+
+
+class SwapInstallingBuilder:
+    """Model-builder wrapper that installs FlashRT swaps after each build.
+
+    Wraps an upstream ``ModelBuilderProtocol``; ``build`` delegates and then
+    applies the requested swap installers to the loaded model. The functional
+    ``with_*`` combinators re-wrap so the wrapper survives
+    ``DiffusionStage._prepared_builder``.
+    """
+
+    def __init__(self, inner, installers) -> None:
+        self._inner = inner
+        self._installers = tuple(installers)
+
+    def build(self, **kwargs):
+        model = self._inner.build(**kwargs)
+        for install in self._installers:
+            install(model)
+        return model
+
+    def _rewrap(self, inner):
+        return SwapInstallingBuilder(inner, self._installers)
+
+    def with_module_ops(self, ops):
+        return self._rewrap(self._inner.with_module_ops(ops))
+
+    def with_sd_ops(self, ops):
+        return self._rewrap(self._inner.with_sd_ops(ops))
+
+    def with_loras(self, loras):
+        return self._rewrap(self._inner.with_loras(loras))
+
+    def with_fuse_rule(self, rule):
+        return self._rewrap(self._inner.with_fuse_rule(rule))
+
+    def __getattr__(self, item):
+        return getattr(self._inner, item)

--- a/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
+++ b/flash_rt/models/ltx25/_nvfp4_ffn_swap.py
@@ -240,6 +240,27 @@ def install_nvfp4_ffn(model: torch.nn.Module, *,
     return count
 
 
+def uninstall_nvfp4_ffn(model: torch.nn.Module) -> int:
+    """Undo :func:`install_nvfp4_ffn`. Returns the number of modules restored.
+
+    Deleting the instance attribute restores the class's own ``forward`` and
+    drops the closure holding the repacked FP4 weights and the shared buffer
+    pool -- which is the only way that memory comes back, because the builder
+    caches model shells by structure and reuses them across builds. Freeing
+    the loaded weights (``dispose``) does not touch anything a swap attached
+    to the shell; this does.
+    """
+    count = 0
+    for module in model.modules():
+        forward = module.__dict__.get("forward")
+        if forward is not None and hasattr(forward, "_flash_rt_keep"):
+            del module.forward
+            count += 1
+    if count:
+        logger.info("[ltx25] restored %d upstream FeedForward modules", count)
+    return count
+
+
 class SwapInstallingBuilder:
     """Model-builder wrapper that installs FlashRT swaps after each build.
 

--- a/flash_rt/models/ltx25/_resident_graph.py
+++ b/flash_rt/models/ltx25/_resident_graph.py
@@ -15,14 +15,19 @@ replay against freed weight pointers.
       upstream capture precondition.
 
 Memory contract: the transformer (plus repacked FFN weights) stays resident
-(~14GB for the 48-block model). The text encoder (~26GB bf16) cannot coexist
-with it, so the frontend must encode the prompt before the first transformer
-build and cache the embeddings for later calls (see
-``CachingPromptEncoder``).
+(~14GB for the 48-block model). The text encoder (~26GB bf16) is loaded and
+freed inside one prompt encode, and the two cannot coexist on a single
+consumer part. So residency is not permanent by construction: it is a lease
+that ``release`` ends, and every path that needs the encoder again (a prompt
+outside the embedding cache) ends it first and lets the next build take a
+fresh one. That is why both classes below are written around release rather
+than around caching alone -- a cache that has no way to step aside turns a
+second prompt into an out-of-memory error.
 """
 
 from __future__ import annotations
 
+import gc
 import logging
 
 import torch
@@ -96,28 +101,72 @@ class ResidentSwapBuilder(SwapInstallingBuilder):
     def _rewrap(self, inner):
         return ResidentSwapBuilder(inner, self._installers, self._holder)
 
+    @property
+    def is_resident(self) -> bool:
+        return self._holder.get("model") is not None
+
+    def release(self) -> int:
+        """End the residency lease. Idempotent; returns bytes freed.
+
+        Undoes exactly what ``build`` established, in the reverse order:
+        the resident mark first (so ``X0Model.dispose`` stops skipping this
+        model), then the instance-level ``dispose`` override (so the class's
+        own dispose runs), then the disposal itself. The captured graphs need
+        no separate teardown: the runner is reachable only through the
+        patched block loop on this model, so dropping the model drops the
+        graphs and their pool with it.
+
+        A later ``build`` sees an empty holder and builds a fresh resident
+        model, which is what makes a second prompt possible at all.
+        """
+        model = self._holder.pop("model", None)
+        if model is None:
+            return 0
+        before = torch.cuda.memory_allocated()
+        model._flash_rt_resident = False
+        model.__dict__.pop("dispose", None)
+        dispose = getattr(model, "dispose", None)
+        if callable(dispose):
+            dispose()
+        del model
+        gc.collect()
+        torch.cuda.empty_cache()
+        freed = before - torch.cuda.memory_allocated()
+        logger.info("[ltx25] resident transformer released: %.1fGB freed",
+                    freed / 2 ** 30)
+        return freed
+
 
 class CachingPromptEncoder:
     """Wraps the pipeline's PromptEncoder with an embedding cache.
 
-    With a resident transformer the ~26GB bf16 text encoder no longer fits
-    alongside it, so repeat prompts must not re-run the encoder. The first
-    encode of each prompt list runs before the transformer's first build
-    (pipeline order already guarantees that on the first call); later calls
-    with the same prompts hit the cache.
+    Repeat prompts must not re-run the ~26GB encoder while a transformer is
+    resident, and a cache serves that. What a cache cannot serve is the miss:
+    a prompt nobody encoded yet needs the encoder loaded, which needs the
+    residency lease to end first. ``on_miss`` is that call, made before the
+    inner encoder runs and only when the cache has nothing -- so a repeat
+    prompt keeps the resident model and a new prompt pays a rebuild instead
+    of running the host out of memory.
     """
 
-    def __init__(self, inner) -> None:
+    def __init__(self, inner, on_miss=None) -> None:
         self._inner = inner
         self._cache: dict[tuple, object] = {}
+        self._on_miss = on_miss
 
     def __call__(self, prompts, **kwargs):
         key = (tuple(prompts), tuple(sorted(kwargs.items())))
         hit = self._cache.get(key)
         if hit is None:
+            if self._on_miss is not None:
+                self._on_miss()
             hit = self._inner(prompts, **kwargs)
             self._cache[key] = hit
         return hit
+
+    def clear(self) -> None:
+        """Drop cached embeddings. Idempotent."""
+        self._cache.clear()
 
     def __getattr__(self, item):
         return getattr(object.__getattribute__(self, "_inner"), item)

--- a/flash_rt/models/ltx25/_resident_graph.py
+++ b/flash_rt/models/ltx25/_resident_graph.py
@@ -32,7 +32,8 @@ import logging
 
 import torch
 
-from flash_rt.models.ltx25._nvfp4_ffn_swap import SwapInstallingBuilder
+from flash_rt.models.ltx25._nvfp4_ffn_swap import (
+    SwapInstallingBuilder, uninstall_nvfp4_ffn)
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,30 @@ def _patch_x0_dispose() -> None:
 
     X0Model.dispose = dispose
     _x0_dispose_patched = True
+
+
+def _evict_cached_shell(builder) -> bool:
+    """Drop the builder's cached model shells. Returns whether one was found.
+
+    The shell cache is upstream's, and reusing a shell is normally right:
+    ``dispose`` frees the weights and the next build reassigns fresh ones
+    onto the same structure. That contract holds only while the shell's
+    parameters keep their shapes, and the resident FFN swap deliberately
+    breaks it -- it releases the upstream projections it has repacked, which
+    leaves zero-sized parameters that the next load cannot copy into. So the
+    shell we mutated is not fit for reuse and is evicted here rather than
+    handed to a build that would fail on it.
+    """
+    seen = set()
+    while builder is not None and id(builder) not in seen:
+        seen.add(id(builder))
+        registry = getattr(builder, "registry", None)
+        clear = getattr(registry, "clear", None)
+        if callable(clear):
+            clear()
+            return True
+        builder = getattr(builder, "_inner", None)
+    return False
 
 
 class ResidentSwapBuilder(SwapInstallingBuilder):
@@ -108,27 +133,36 @@ class ResidentSwapBuilder(SwapInstallingBuilder):
     def release(self) -> int:
         """End the residency lease. Idempotent; returns bytes freed.
 
-        Undoes exactly what ``build`` established, in the reverse order:
-        the resident mark first (so ``X0Model.dispose`` stops skipping this
-        model), then the instance-level ``dispose`` override (so the class's
-        own dispose runs), then the disposal itself. The captured graphs need
-        no separate teardown: the runner is reachable only through the
-        patched block loop on this model, so dropping the model drops the
-        graphs and their pool with it.
+        Undoes what ``build`` established, and dropping the reference is not
+        enough to do it: the upstream builder caches model *shells* by
+        structure and reuses them across builds, so the shell outlives every
+        reference this class holds. Anything attached to the shell therefore
+        has to be detached by name -- the swap's repacked FP4 weights, and
+        the capture runner whose per-shape graphs hold a private memory pool
+        (measured at ~3GB, which is the difference between a second prompt
+        rendering and the host running out of memory). ``dispose`` frees the
+        loaded weights and, by upstream's own contract, leaves the shell.
 
-        A later ``build`` sees an empty holder and builds a fresh resident
-        model, which is what makes a second prompt possible at all.
+        Order: detach what we attached, then let the disposal run, then
+        collect -- the graphs must be unreferenced before the allocator is
+        asked to give their pool back.
         """
         model = self._holder.pop("model", None)
         if model is None:
             return 0
         before = torch.cuda.memory_allocated()
+        uninstall_nvfp4_ffn(model)
+        # The captured block loop is an instance attribute over the class's
+        # own method; removing it drops the runner, its captures, and their
+        # pool. Absent outside capture mode, where this is a no-op.
+        model.__dict__.pop("_process_transformer_blocks", None)
         model._flash_rt_resident = False
         model.__dict__.pop("dispose", None)
         dispose = getattr(model, "dispose", None)
         if callable(dispose):
             dispose()
         del model
+        _evict_cached_shell(self._inner)
         gc.collect()
         torch.cuda.empty_cache()
         freed = before - torch.cuda.memory_allocated()

--- a/flash_rt/models/ltx25/_resident_graph.py
+++ b/flash_rt/models/ltx25/_resident_graph.py
@@ -1,0 +1,123 @@
+"""Resident-transformer support: unlock CUDA-graph capture on a single GPU.
+
+Upstream refuses ``CompilationConfig(capture=True)`` with the single-GPU
+builder because every stage call rebuilds the transformer onto fresh GPU
+storages and ``gpu_model`` disposes it afterwards -- captured graphs would
+replay against freed weight pointers.
+
+``ResidentSwapBuilder`` closes that gap:
+
+    * the first ``build`` delegates to the inner builder, applies the FlashRT
+      swap installers, neuters ``dispose`` on the built model, and caches it;
+    * every later ``build`` returns the cached model -- weight storages never
+      move, so captured graphs stay valid;
+    * ``keeps_gpu_resident_weights`` reports True, which satisfies the
+      upstream capture precondition.
+
+Memory contract: the transformer (plus repacked FFN weights) stays resident
+(~14GB for the 48-block model). The text encoder (~26GB bf16) cannot coexist
+with it, so the frontend must encode the prompt before the first transformer
+build and cache the embeddings for later calls (see
+``CachingPromptEncoder``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from flash_rt.models.ltx25._nvfp4_ffn_swap import SwapInstallingBuilder
+
+logger = logging.getLogger(__name__)
+
+
+_x0_dispose_patched = False
+
+
+def _patch_x0_dispose() -> None:
+    """Make X0Model.dispose a no-op when it wraps a resident velocity model.
+
+    The Disposable mixin's dispose walks the wrapper's own named_parameters,
+    so neutering dispose on the inner model alone does not protect its
+    storages -- a fresh X0Model wraps it on every stage build.
+    """
+    global _x0_dispose_patched
+    if _x0_dispose_patched:
+        return
+    from ltx_core.model.transformer.model import X0Model
+
+    original = X0Model.dispose
+
+    def dispose(self):
+        inner = getattr(self, "velocity_model", None)
+        if getattr(inner, "_flash_rt_resident", False):
+            return
+        original(self)
+
+    X0Model.dispose = dispose
+    _x0_dispose_patched = True
+
+
+class ResidentSwapBuilder(SwapInstallingBuilder):
+    """SwapInstallingBuilder that builds once and keeps the model resident.
+
+    The stage's ``_prepared_builder`` derives fresh rewrapped builders from
+    the original on every stage call, so the cache lives in a mutable holder
+    shared by reference across every rewrap -- the second stage must see the
+    model the first stage built, not build a sibling.
+    """
+
+    def __init__(self, inner, installers, _holder=None) -> None:
+        super().__init__(inner, installers)
+        self._holder = _holder if _holder is not None else {}
+
+    @property
+    def keeps_gpu_resident_weights(self) -> bool:
+        return True
+
+    def build(self, **kwargs):
+        model = self._holder.get("model")
+        if model is not None:
+            return model
+        model = super().build(**kwargs)
+        # gpu_model() disposes the X0Model wrapper after every stage, and the
+        # Disposable mixin walks named_parameters -- which reach through to
+        # this model's storages. Mark the model resident and teach X0Model's
+        # dispose to skip wrappers holding a resident velocity model.
+        model._flash_rt_resident = True
+        model.dispose = lambda: None
+        _patch_x0_dispose()
+        self._holder["model"] = model
+        logger.info("[ltx25] transformer resident: %.1fGB allocated",
+                    torch.cuda.memory_allocated() / 2 ** 30)
+        return model
+
+    def _rewrap(self, inner):
+        return ResidentSwapBuilder(inner, self._installers, self._holder)
+
+
+class CachingPromptEncoder:
+    """Wraps the pipeline's PromptEncoder with an embedding cache.
+
+    With a resident transformer the ~26GB bf16 text encoder no longer fits
+    alongside it, so repeat prompts must not re-run the encoder. The first
+    encode of each prompt list runs before the transformer's first build
+    (pipeline order already guarantees that on the first call); later calls
+    with the same prompts hit the cache.
+    """
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+        self._cache: dict[tuple, object] = {}
+
+    def __call__(self, prompts, **kwargs):
+        key = (tuple(prompts), tuple(sorted(kwargs.items())))
+        hit = self._cache.get(key)
+        if hit is None:
+            hit = self._inner(prompts, **kwargs)
+            self._cache[key] = hit
+        return hit
+
+    def __getattr__(self, item):
+        return getattr(object.__getattribute__(self, "_inner"), item)

--- a/tests/test_ltx25_contracts.py
+++ b/tests/test_ltx25_contracts.py
@@ -1,0 +1,314 @@
+"""LTX-2.5 runtime contracts: import, fallback, alignment, and residency.
+
+These cover the parts that are easy to get wrong without a checkpoint on
+disk: that the model package imports with none of its optional pieces
+present, that a broken extension is not mistaken for an absent one, that
+the FFN swap declines the shapes CUTLASS declines, and that the residency
+lease can be ended twice and taken again.
+
+The heavy paths (a real pipeline, real kernels, a device) are not
+reachable here and are covered by the model's own benchmark runs.
+"""
+
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch  # noqa: E402
+
+
+# --------------------------------------------------------------------
+# import smoke: the package must import with no LTX install, no kernels
+# --------------------------------------------------------------------
+
+def test_model_package_import_is_clean_or_loudly_broken():
+    """The upstream LTX packages are never required to import this one.
+
+    The extension is a different case and the distinction is the point: it
+    being *absent* must not stop the import (the swaps fall back), while it
+    being present and unloadable must say so. So this asserts the
+    distinction rather than an outcome, and steps aside on a host whose
+    own build is broken -- there the loud failure is the correct result.
+    """
+    try:
+        from flash_rt.models.ltx25 import _attn_swap, _nvfp4_ffn_swap
+    except ImportError as exc:
+        assert getattr(exc, "name", None) != "flash_rt.flash_rt_kernels", (
+            "an absent extension must be a fallback, not an import failure")
+        pytest.skip(f"extension present but not loadable here: {exc}")
+    assert isinstance(_attn_swap.fvk_sage2_available(), bool)
+    assert isinstance(_nvfp4_ffn_swap.fvk_ffn_available(), bool)
+
+
+def test_frontend_module_imports_and_declares_its_surface():
+    from flash_rt.frontends.torch.ltx25_rtx import Ltx25TorchFrontendRtx
+
+    for name in ("set_prompt", "infer", "release_resident", "close",
+                 "get_latency_stats"):
+        assert callable(getattr(Ltx25TorchFrontendRtx, name)), name
+
+
+def test_config_is_registered_on_the_public_api():
+    import inspect
+
+    from flash_rt import api
+
+    source = inspect.getsource(api)
+    assert '"ltx25"' in source
+
+
+# --------------------------------------------------------------------
+# optional import: absent is a fallback, broken is a bug
+# --------------------------------------------------------------------
+
+@pytest.mark.parametrize("module_name", [
+    "flash_rt.models.ltx25._attn_swap",
+    "flash_rt.models.ltx25._nvfp4_ffn_swap",
+])
+def test_broken_extension_is_not_swallowed_as_absent(module_name, monkeypatch):
+    """An extension that fails to load must not read as 'not built'.
+
+    The swaps treat the extension's own absence as a fallback. Every other
+    load failure -- an undefined symbol, an ABI mismatch, a transitive
+    import error -- has to propagate, or a broken build silently runs the
+    slow path and reports nothing.
+    """
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "flash_rt" and args and "flash_rt_kernels" in (args[2] or ()):
+            raise ImportError("undefined symbol: _Z9brokenABIv")
+        return real_import(name, *args, **kwargs)
+
+    for name in [module_name, "flash_rt.models.ltx25"]:
+        sys.modules.pop(name, None)
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    with pytest.raises(ImportError, match="undefined symbol"):
+        real_import(module_name, {}, {}, ["*"])
+
+
+@pytest.mark.parametrize("module_name", [
+    "flash_rt.models.ltx25._attn_swap",
+    "flash_rt.models.ltx25._nvfp4_ffn_swap",
+])
+def test_absent_extension_is_a_fallback(module_name, monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "flash_rt" and args and "flash_rt_kernels" in (args[2] or ()):
+            raise ModuleNotFoundError(
+                "No module named 'flash_rt.flash_rt_kernels'",
+                name="flash_rt.flash_rt_kernels")
+        return real_import(name, *args, **kwargs)
+
+    for name in [module_name, "flash_rt.models.ltx25"]:
+        sys.modules.pop(name, None)
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    module = real_import(module_name, {}, {}, ["*"])
+    assert module.fvk is None
+
+
+# --------------------------------------------------------------------
+# attention selection
+# --------------------------------------------------------------------
+
+def test_attention_selection_refuses_unknown_kinds():
+    from flash_rt.models.ltx25._attn_swap import make_ltx25_attention
+
+    with pytest.raises(ValueError):
+        make_ltx25_attention("no_such_backend")
+
+
+def test_sdpa_selection_never_depends_on_the_extension():
+    """The baseline backend must be reachable on a host with no kernels."""
+    from flash_rt.models.ltx25._attn_swap import make_ltx25_attention
+
+    attn = make_ltx25_attention("sdpa")
+    assert attn is None or getattr(attn, "label", "") == "sdpa"
+
+
+def test_explicit_backend_fails_fast_when_unavailable(monkeypatch):
+    """``sage2`` asked for by name must not silently become SDPA."""
+    from flash_rt.models.ltx25 import _attn_swap
+
+    monkeypatch.setattr(_attn_swap, "fvk_sage2_available", lambda: False)
+    with pytest.raises(RuntimeError, match="sage2"):
+        _attn_swap.make_ltx25_attention("sage2-fvk")
+
+
+# --------------------------------------------------------------------
+# FFN alignment: the swap declines exactly what the kernel declines
+# --------------------------------------------------------------------
+
+@pytest.mark.parametrize("rows,swapped", [
+    (128, True), (256, True), (2688, True), (24576, True),
+    (1, False), (126, False), (127, False), (129, False),
+])
+def test_ffn_swap_routes_by_row_alignment(rows, swapped):
+    """M % 128 decides the arm, because that is what can_implement decides.
+
+    The CUTLASS chain reports a validation failure for unaligned M without
+    writing an output, so an unaligned call that reached it would produce
+    silent garbage. The predicate is checked directly here: it holds with
+    or without a device.
+    """
+    from flash_rt.models.ltx25._nvfp4_ffn_swap import rows_are_swappable
+
+    assert rows_are_swappable(rows) is swapped
+
+
+# --------------------------------------------------------------------
+# residency lease
+# --------------------------------------------------------------------
+
+class _FakeModel:
+    def __init__(self):
+        self.disposed = 0
+
+    def dispose(self):
+        self.disposed += 1
+
+
+class _FakeBuilder:
+    """Inner builder standing in for the upstream stage builder."""
+
+    def __init__(self):
+        self.builds = 0
+
+    def build(self, **kwargs):
+        self.builds += 1
+        return _FakeModel()
+
+
+def _resident_builder(monkeypatch):
+    from flash_rt.models.ltx25 import _resident_graph
+
+    # the X0Model patch reaches into the upstream package; the lease
+    # semantics under test do not need it
+    monkeypatch.setattr(_resident_graph, "_patch_x0_dispose", lambda: None)
+    return _resident_graph.ResidentSwapBuilder(_FakeBuilder(), [])
+
+
+def test_residency_is_taken_once_and_reused(monkeypatch):
+    builder = _resident_builder(monkeypatch)
+    first = builder.build()
+    assert builder.build() is first
+    assert builder._inner.builds == 1
+    assert builder.is_resident
+    assert builder.keeps_gpu_resident_weights
+
+
+def test_release_is_idempotent_and_disposes_once(monkeypatch):
+    builder = _resident_builder(monkeypatch)
+    model = builder.build()
+    builder.release()
+    assert not builder.is_resident
+    assert model.disposed == 1
+    builder.release()
+    builder.release()
+    assert model.disposed == 1, "a second release must not re-dispose"
+
+
+def test_a_released_lease_can_be_taken_again(monkeypatch):
+    builder = _resident_builder(monkeypatch)
+    first = builder.build()
+    builder.release()
+    second = builder.build()
+    assert second is not first
+    assert builder.is_resident
+    assert builder._inner.builds == 2
+
+
+def test_rewrapped_builders_share_one_lease(monkeypatch):
+    """The stage rewraps its builder per call; the lease must not fork."""
+    builder = _resident_builder(monkeypatch)
+    model = builder.build()
+    rewrapped = builder._rewrap(builder._inner)
+    assert rewrapped.build() is model
+    rewrapped.release()
+    assert not builder.is_resident
+
+
+# --------------------------------------------------------------------
+# prompt cache: a hit keeps the lease, a miss ends it
+# --------------------------------------------------------------------
+
+def test_cached_prompt_does_not_disturb_residency():
+    from flash_rt.models.ltx25._resident_graph import CachingPromptEncoder
+
+    calls, misses = [], []
+    encoder = CachingPromptEncoder(
+        lambda prompts, **kw: calls.append(prompts) or "embeds",
+        on_miss=lambda: misses.append(1))
+
+    assert encoder(["a fisherman"]) == "embeds"
+    assert encoder(["a fisherman"]) == "embeds"
+    assert len(calls) == 1, "a repeat prompt must not re-run the encoder"
+    assert len(misses) == 1, "only the first encode ends the lease"
+
+
+def test_new_prompt_ends_the_lease_before_encoding():
+    """The release must happen *before* the encoder loads, not after.
+
+    Ordering is the whole point: the encoder's weights and the resident
+    transformer do not fit together, so a release that ran afterwards would
+    free memory the encode had already failed to get.
+    """
+    from flash_rt.models.ltx25._resident_graph import CachingPromptEncoder
+
+    order = []
+    encoder = CachingPromptEncoder(
+        lambda prompts, **kw: order.append("encode") or "embeds",
+        on_miss=lambda: order.append("release"))
+
+    encoder(["first"])
+    encoder(["second"])
+    assert order == ["release", "encode", "release", "encode"]
+
+
+def test_prompt_cache_keys_on_encoder_arguments():
+    from flash_rt.models.ltx25._resident_graph import CachingPromptEncoder
+
+    calls = []
+    encoder = CachingPromptEncoder(
+        lambda prompts, **kw: calls.append(kw) or "embeds")
+
+    encoder(["p"], enhance=False)
+    encoder(["p"], enhance=True)
+    assert len(calls) == 2, "different encoder arguments are different work"
+
+
+def test_prompt_cache_clear_is_idempotent():
+    from flash_rt.models.ltx25._resident_graph import CachingPromptEncoder
+
+    calls = []
+    encoder = CachingPromptEncoder(lambda prompts, **kw: calls.append(1))
+    encoder(["p"])
+    encoder.clear()
+    encoder.clear()
+    encoder(["p"])
+    assert len(calls) == 2
+
+
+def test_release_entries_are_safe_before_a_pipeline_exists():
+    """``release_resident``/``close`` must not require a loaded pipeline."""
+    from flash_rt.frontends.torch.ltx25_rtx import Ltx25TorchFrontendRtx
+
+    frontend = Ltx25TorchFrontendRtx.__new__(Ltx25TorchFrontendRtx)
+    frontend._pipe = None
+    assert frontend.release_resident() == 0
+    assert frontend.close() == 0
+    assert frontend.close() == 0
+
+
+def test_release_resident_is_a_no_op_outside_capture_mode():
+    """Non-capture modes hold no lease, so there is nothing to release."""
+    from flash_rt.frontends.torch.ltx25_rtx import Ltx25TorchFrontendRtx
+
+    frontend = Ltx25TorchFrontendRtx.__new__(Ltx25TorchFrontendRtx)
+    stage = types.SimpleNamespace(_transformer_builder=object())
+    frontend._pipe = types.SimpleNamespace(stage=stage)
+    assert frontend.release_resident() == 0

--- a/tests/test_ltx25_contracts.py
+++ b/tests/test_ltx25_contracts.py
@@ -10,6 +10,7 @@ The heavy paths (a real pipeline, real kernels, a device) are not
 reachable here and are covered by the model's own benchmark runs.
 """
 
+import importlib
 import sys
 import types
 
@@ -24,21 +25,19 @@ import torch  # noqa: E402
 # import smoke: the package must import with no LTX install, no kernels
 # --------------------------------------------------------------------
 
-def test_model_package_import_is_clean_or_loudly_broken():
-    """The upstream LTX packages are never required to import this one.
+def test_model_package_imports_without_optional_dependencies():
+    """Neither the upstream LTX packages nor a built extension is required.
 
-    The extension is a different case and the distinction is the point: it
-    being *absent* must not stop the import (the swaps fall back), while it
-    being present and unloadable must say so. So this asserts the
-    distinction rather than an outcome, and steps aside on a host whose
-    own build is broken -- there the loud failure is the correct result.
+    Unconditional on purpose. A host with no extension must reach this
+    import (the swaps fall back), and a host whose extension is broken must
+    fail it -- so there is no environment in which skipping is the honest
+    answer, and skipping is how the previous version of this test let an
+    import contract regress unnoticed.
     """
-    try:
-        from flash_rt.models.ltx25 import _attn_swap, _nvfp4_ffn_swap
-    except ImportError as exc:
-        assert getattr(exc, "name", None) != "flash_rt.flash_rt_kernels", (
-            "an absent extension must be a fallback, not an import failure")
-        pytest.skip(f"extension present but not loadable here: {exc}")
+    from flash_rt.models import ltx25
+    from flash_rt.models.ltx25 import _attn_swap, _nvfp4_ffn_swap
+
+    assert ltx25 is not None
     assert isinstance(_attn_swap.fvk_sage2_available(), bool)
     assert isinstance(_nvfp4_ffn_swap.fvk_ffn_available(), bool)
 
@@ -51,18 +50,180 @@ def test_frontend_module_imports_and_declares_its_surface():
         assert callable(getattr(Ltx25TorchFrontendRtx, name)), name
 
 
-def test_config_is_registered_on_the_public_api():
-    import inspect
+# --------------------------------------------------------------------
+# the public API: what the documented entry point actually gives back
+# --------------------------------------------------------------------
 
+def _load_ltx(monkeypatch, **kwargs):
+    """Run ``load_model(config="ltx25")`` against a recording frontend.
+
+    The construction path is the thing under test -- which arguments reach
+    the frontend, and what the caller is handed back -- so everything up to
+    the frontend class is the real code and only the frontend itself is
+    replaced. A checkpoint is never opened.
+    """
     from flash_rt import api
 
-    source = inspect.getsource(api)
-    assert '"ltx25"' in source
+    class _RecordingFrontend:
+        instances = []
+
+        def __init__(self, checkpoint, attention=None, fuse=True,
+                     compile_mode=None, device=None, **rest):
+            self.checkpoint = checkpoint
+            self.attention = attention
+            self.fuse = fuse
+            self.compile_mode = compile_mode
+            self.released = 0
+            self.closed = 0
+            type(self).instances.append(self)
+
+        def release_resident(self):
+            self.released += 1
+            return 7
+
+        def close(self):
+            self.closed += 1
+            return 11
+
+    import flash_rt.hardware as hardware
+
+    _RecordingFrontend.instances = []
+    # load_model resolves the frontend class through this one call, which
+    # is where the real code is interposed: everything before it (config
+    # validation, arch detection, the argument forwarding under test) runs
+    # unchanged.
+    monkeypatch.setattr(hardware, "resolve_pipeline_class",
+                        lambda *a, **k: _RecordingFrontend)
+    monkeypatch.setattr(hardware, "detect_arch", lambda *a, **k: "rtx_sm120")
+    model = api.load_model(checkpoint="unused", config="ltx25", **kwargs)
+    return model, _RecordingFrontend.instances[-1]
+
+
+def test_public_api_accepts_the_ltx_config():
+    """``load_model`` must know the config name it documents."""
+    from flash_rt import api
+
+    with pytest.raises(ValueError, match="Unknown config"):
+        api.load_model(checkpoint="unused", config="no_such_model")
+
+
+def test_public_api_forwards_the_execution_assembly(monkeypatch):
+    """attention/fuse/compile_mode must reach the frontend from load_model.
+
+    Capture mode is the point of this runtime, and a caller who cannot ask
+    for it through the documented entry point does not have it.
+    """
+    model, frontend = _load_ltx(
+        monkeypatch, attention="sage2-fvk", fuse=True,
+        compile_mode="capture")
+    assert frontend.attention == "sage2-fvk"
+    assert frontend.fuse is True
+    assert frontend.compile_mode == "capture"
+    assert model is not None
+
+
+def test_public_api_leaves_frontend_defaults_alone(monkeypatch):
+    """Unset arguments must not be forwarded as None over the defaults."""
+    _, frontend = _load_ltx(monkeypatch)
+    assert frontend.attention is None
+    assert frontend.fuse is True, "the frontend's own default must survive"
+    assert frontend.compile_mode is None
+
+
+def test_public_model_exposes_the_release_surface():
+    """The lifecycle calls the docs show have to exist on what is returned.
+
+    ``load_model`` hands back a wrapper, not the frontend, so a method the
+    documentation tells a caller to use is only real if the wrapper
+    delegates it.
+    """
+    from flash_rt.api import VLAModel
+
+    for name in ("release_resident", "close"):
+        assert callable(getattr(VLAModel, name, None)), name
+
+
+def test_public_model_delegates_release_and_close():
+    from flash_rt.api import VLAModel
+
+    class _Frontend:
+        def __init__(self):
+            self.released = self.closed = 0
+
+        def release_resident(self):
+            self.released += 1
+            return 7
+
+        def close(self):
+            self.closed += 1
+            return 11
+
+    frontend = _Frontend()
+    model = VLAModel(frontend, "torch")
+    assert model.release_resident() == 7
+    assert model.close() == 11
+    assert (frontend.released, frontend.closed) == (1, 1)
+
+
+def test_public_model_release_is_harmless_on_other_frontends():
+    """A frontend that holds nothing answers 0 instead of refusing."""
+    from flash_rt.api import VLAModel
+
+    model = VLAModel(object(), "torch")
+    assert model.release_resident() == 0
+    assert model.close() == 0
 
 
 # --------------------------------------------------------------------
 # optional import: absent is a fallback, broken is a bug
 # --------------------------------------------------------------------
+
+class _RaisingFinder:
+    """Meta-path finder that makes one module name fail on import.
+
+    The swaps import through ``importlib``, so a fake ``__import__`` does
+    not stand in the way: the simulation has to happen in the import
+    machinery itself or it tests nothing. ``exc`` is raised when the name is
+    looked up, which is what an absent (or broken) module does.
+    """
+
+    def __init__(self, name, exc):
+        self.name = name
+        self.exc = exc
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == self.name:
+            raise self.exc
+        return None
+
+
+def _reimport(module_name, finder, monkeypatch):
+    """Import ``module_name`` afresh with ``finder`` in the way.
+
+    The simulated module has to leave ``sys.modules`` as well as the module
+    under test: an already-imported extension is returned straight from the
+    cache and no finder is ever consulted, which would quietly turn this
+    into a test of nothing on any host where the extension is built.
+    """
+    monkeypatch.setattr(sys, "meta_path", [finder] + sys.meta_path)
+    for name in [module_name, "flash_rt.models.ltx25", finder.name]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    return importlib.import_module(module_name)
+
+
+@pytest.mark.parametrize("module_name", [
+    "flash_rt.models.ltx25._attn_swap",
+    "flash_rt.models.ltx25._nvfp4_ffn_swap",
+])
+def test_absent_extension_is_a_fallback(module_name, monkeypatch):
+    """No extension: the module imports and the swap knows it has none."""
+    finder = _RaisingFinder(
+        "flash_rt.flash_rt_kernels",
+        ModuleNotFoundError("No module named 'flash_rt.flash_rt_kernels'",
+                            name="flash_rt.flash_rt_kernels"))
+    module = _reimport(module_name, finder, monkeypatch)
+    assert module.fvk is None
+
 
 @pytest.mark.parametrize("module_name", [
     "flash_rt.models.ltx25._attn_swap",
@@ -76,39 +237,57 @@ def test_broken_extension_is_not_swallowed_as_absent(module_name, monkeypatch):
     import error -- has to propagate, or a broken build silently runs the
     slow path and reports nothing.
     """
-    real_import = __import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "flash_rt" and args and "flash_rt_kernels" in (args[2] or ()):
-            raise ImportError("undefined symbol: _Z9brokenABIv")
-        return real_import(name, *args, **kwargs)
-
-    for name in [module_name, "flash_rt.models.ltx25"]:
-        sys.modules.pop(name, None)
-    monkeypatch.setattr("builtins.__import__", fake_import)
+    finder = _RaisingFinder("flash_rt.flash_rt_kernels",
+                            ImportError("undefined symbol: _Z9brokenABIv"))
     with pytest.raises(ImportError, match="undefined symbol"):
-        real_import(module_name, {}, {}, ["*"])
+        _reimport(module_name, finder, monkeypatch)
 
 
 @pytest.mark.parametrize("module_name", [
     "flash_rt.models.ltx25._attn_swap",
     "flash_rt.models.ltx25._nvfp4_ffn_swap",
 ])
-def test_absent_extension_is_a_fallback(module_name, monkeypatch):
-    real_import = __import__
+def test_absent_extension_is_distinguished_from_a_missing_dependency(
+        module_name, monkeypatch):
+    """A *different* module going missing is not this extension's absence.
 
-    def fake_import(name, *args, **kwargs):
-        if name == "flash_rt" and args and "flash_rt_kernels" in (args[2] or ()):
-            raise ModuleNotFoundError(
-                "No module named 'flash_rt.flash_rt_kernels'",
-                name="flash_rt.flash_rt_kernels")
-        return real_import(name, *args, **kwargs)
+    The name check is what separates them: without it, any transitive
+    ModuleNotFoundError raised while loading the extension would be read as
+    "the extension is not built" and quietly fall back.
+    """
+    finder = _RaisingFinder(
+        "flash_rt.flash_rt_kernels",
+        ModuleNotFoundError("No module named 'some_transitive_dep'",
+                            name="some_transitive_dep"))
+    with pytest.raises(ModuleNotFoundError, match="some_transitive_dep"):
+        _reimport(module_name, finder, monkeypatch)
 
-    for name in [module_name, "flash_rt.models.ltx25"]:
-        sys.modules.pop(name, None)
-    monkeypatch.setattr("builtins.__import__", fake_import)
-    module = real_import(module_name, {}, {}, ["*"])
-    assert module.fvk is None
+
+def test_sage_package_probe_falls_back_only_on_absence(monkeypatch):
+    """``auto`` may fall back to SDPA when sageattention is not installed.
+
+    It may not do so when the package is installed and broken: that is an
+    environment fault, and answering it with a quiet slowdown hides it.
+    """
+    from flash_rt.models.ltx25 import _attn_swap
+
+    monkeypatch.setattr(_attn_swap, "fvk_sage2_available", lambda: False)
+
+    absent = _RaisingFinder(
+        "sageattention",
+        ModuleNotFoundError("No module named 'sageattention'",
+                            name="sageattention"))
+    monkeypatch.setattr(sys, "meta_path", [absent] + sys.meta_path)
+    monkeypatch.delitem(sys.modules, "sageattention", raising=False)
+    attn = _attn_swap.make_ltx25_attention("auto")
+    assert attn is None or getattr(attn, "label", "") == "sdpa"
+
+    broken = _RaisingFinder("sageattention",
+                            ImportError("undefined symbol: _Z6brokenv"))
+    monkeypatch.setattr(sys, "meta_path", [broken] + sys.meta_path)
+    monkeypatch.delitem(sys.modules, "sageattention", raising=False)
+    with pytest.raises(ImportError, match="undefined symbol"):
+        _attn_swap.make_ltx25_attention("auto")
 
 
 # --------------------------------------------------------------------

--- a/tests/test_ltx25_contracts.py
+++ b/tests/test_ltx25_contracts.py
@@ -164,8 +164,11 @@ def test_ffn_swap_routes_by_row_alignment(rows, swapped):
 # residency lease
 # --------------------------------------------------------------------
 
-class _FakeModel:
+class _FakeModel(torch.nn.Module):
+    """Stands in for the built transformer: a module with a dispose."""
+
     def __init__(self):
+        super().__init__()
         self.disposed = 0
 
     def dispose(self):
@@ -312,3 +315,128 @@ def test_release_resident_is_a_no_op_outside_capture_mode():
     stage = types.SimpleNamespace(_transformer_builder=object())
     frontend._pipe = types.SimpleNamespace(stage=stage)
     assert frontend.release_resident() == 0
+
+
+def test_release_detaches_the_swapped_forwards():
+    """Release must take back what the swap attached to the shell.
+
+    The upstream builder caches model shells by structure and reuses them
+    across builds, so a released model is not a collected one: the repacked
+    FP4 weights the swap installed stay reachable through the shell unless
+    the instance-level forward is removed by name.
+    """
+    from flash_rt.models.ltx25._nvfp4_ffn_swap import uninstall_nvfp4_ffn
+
+    class _Shell(torch.nn.Module):
+        def forward(self, x):
+            return x
+
+    shell = _Shell()
+    packed = torch.zeros(8)
+    swapped = lambda x: x                       # noqa: E731 - stands in
+    swapped._flash_rt_keep = (packed,)
+    shell.forward = swapped
+
+    assert uninstall_nvfp4_ffn(shell) == 1
+    assert "forward" not in shell.__dict__, "the class forward must be back"
+    assert uninstall_nvfp4_ffn(shell) == 0, "uninstall is idempotent"
+
+
+def test_release_drops_the_captured_block_loop(monkeypatch):
+    """The capture runner holds a private graph pool; release must drop it.
+
+    Freeing the loaded weights does not: upstream's dispose leaves the shell
+    intact by design, and the runner hangs off the shell as an instance
+    attribute over the class's own method.
+    """
+    from flash_rt.models.ltx25 import _resident_graph
+
+    monkeypatch.setattr(_resident_graph, "_patch_x0_dispose", lambda: None)
+
+    class _Runner:
+        """Stands in for the capture runner and its graphs."""
+
+    class _Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.disposed = 0
+
+        def _process_transformer_blocks(self, *a):
+            return a
+
+        def dispose(self):
+            self.disposed += 1
+
+    model = _Model()
+    runner = _Runner()
+    model._process_transformer_blocks = runner
+
+    class _Builder:
+        def build(self, **kwargs):
+            return model
+
+    builder = _resident_graph.ResidentSwapBuilder(_Builder(), [])
+    builder.build()
+    builder.release()
+
+    assert "_process_transformer_blocks" not in model.__dict__
+    assert callable(model._process_transformer_blocks), (
+        "the class's own block loop must be reachable again")
+    assert model.disposed == 1
+
+
+def test_release_evicts_the_mutated_shell(monkeypatch):
+    """A shell whose parameters were freed must not be handed to a rebuild.
+
+    Upstream caches model shells by structure and reassigns weights onto
+    them, which is only sound while the parameters keep their shapes. The
+    resident FFN swap frees the upstream projections it repacked, so the
+    shell it leaves behind cannot be loaded into -- release evicts it.
+    """
+    from flash_rt.models.ltx25 import _resident_graph
+
+    monkeypatch.setattr(_resident_graph, "_patch_x0_dispose", lambda: None)
+
+    class _Registry:
+        def __init__(self):
+            self.cleared = 0
+
+        def clear(self):
+            self.cleared += 1
+
+    class _Inner:
+        def __init__(self):
+            self.registry = _Registry()
+
+        def build(self, **kwargs):
+            return _FakeModel()
+
+    inner = _Inner()
+    builder = _resident_graph.ResidentSwapBuilder(inner, [])
+    builder.build()
+    builder.release()
+    assert inner.registry.cleared == 1
+    builder.release()
+    assert inner.registry.cleared == 1, "nothing to evict without a lease"
+
+
+def test_shell_eviction_walks_wrapped_builders(monkeypatch):
+    """The stage wraps builders; the registry may be several layers in."""
+    from flash_rt.models.ltx25._resident_graph import _evict_cached_shell
+
+    class _Registry:
+        def __init__(self):
+            self.cleared = 0
+
+        def clear(self):
+            self.cleared += 1
+
+    class _Base:
+        registry = None
+
+    base = _Base()
+    base.registry = _Registry()
+    wrapper = types.SimpleNamespace(_inner=types.SimpleNamespace(_inner=base))
+    assert _evict_cached_shell(wrapper) is True
+    assert base.registry.cleared == 1
+    assert _evict_cached_shell(types.SimpleNamespace(_inner=None)) is False


### PR DESCRIPTION
LTX-2.5 (22B distilled audio+video DiT) as a model-private runtime for consumer Blackwell: attention backend swap, a W4A4 NVFP4 feed-forward chain, and a resident transformer that makes whole-loop CUDA-graph capture reachable on one GPU.

Measured warm denoise at 1536x1024x121f: 23.9s upstream eager, 11.7s here. Attention at the video self-attention shape (S=24576): 42.4ms SDPA-cudnn, 17.4ms sage2. The FFN chain runs three launches where upstream runs six. Output quality is equivalent under matched-input single-forward cosine and frame inspection.

Nothing in `csrc`, bindings or CMake changes, so no other model's build time or symbol surface moves. The runtime is SM120-only and lazily imported.

## Review round

Rebased onto main; the conflict was the config list, which now carries both entries.

**The structures implementation moved out.** It bound from a different shape than the attention family passes (an object, where the family passes capture dicts) and was not in the variant chain, so it was unreachable code that would have raised if it were reached. It belongs with the rest of the structures work, against the family's own contract and its tests, not here.

**Residency is now a lease with an end.** Capture mode kept the transformer resident with no way to give it back, and the prompt cache only made that survivable for prompts it already held: a new one needs the text encoder, which does not fit beside the resident model, so the second prompt a caller asked for ran the host out of memory. The cache now releases before it runs the encoder on a miss, and `release_resident()` / `close()` expose the same operation, both idempotent.

Getting that right needed one more step than dropping a reference. The builder caches model *shells* by structure and reuses them, so `dispose` frees the loaded weights and leaves everything a swap attached to the shell — the repacked FP4 weights, and the capture runner whose per-shape graphs hold a ~3GB private pool, which is most of what a second prompt needs. Release now detaches both by name and evicts the shell, which is required rather than tidy: the resident FFN swap frees the upstream projections it repacks, and a shell with zero-sized parameters cannot be loaded into.

The decode tiling budget had the same double-count. It subtracted the transformer's reserve from currently free memory, which reads correctly on a first run and collapses on a rebuild, because the VAEs and cached embeddings are inside that reserve and already allocated. Measured against the device, it is stable across release cycles.

Measured, capture mode: release frees 15.5GB (10.7GB before the shell fix) and leaves no live graph; a second prompt renders where it used to fail; a third renders after an explicit release; the frontend rebuilds from the checkpoint after `close`.

**Optional imports narrowed.** They caught every `ImportError`, so an undefined symbol or ABI mismatch reported as "kernels unavailable" and silently ran the fallback. Only the extension's own `ModuleNotFoundError` is a fallback now, matching the rule the edge runtime settled on.

**Tests.** `tests/test_ltx25_contracts.py`, 32 cases, no checkpoint or device required: the import distinction in both directions, explicit-backend fail-fast, the row-alignment predicate at the shapes the model produces (unaligned calls are declined because CUTLASS declines them without writing an output), the lease taken/released/retaken including through the stage's rewrapped builders, shell detachment and eviction, and the ordering a second prompt depends on — release before encode, not after.

`tests/test_build_inventory.py::test_qwen3_vl_owns_shared_sm120_dense_gemm` fails on this branch and on main alike: it looks for a CMake string that main does not contain. Nothing here touches CMake.

Usage docs updated: the FFN chain and compile modes were undocumented, the status line was stale, and the memory contract and lifecycle entries are now written down.