### PR TITLE
Release 0.1.0: a pure-Python distribution that says what it needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ like. Follow it literally. When unsure, stop and ask; do not guess.
 | Document | What you take from it |
 |---|---|
 | `docs/structures.md` | The norm: what a structure is, the three-layer split, calibration reuse, accuracy bands, runtime contract and ledger, how to add structures/backends/hosts/schemes, and §7 — norms that came from being wrong |
+| `docs/structure_contributing.md` | The external contribution boundary and copyable PR self-review checklist |
 | `docs/calibration.md` | The house calibration standard (statistics, two-level reduction, diagnostics). You must not invent a second one |
 | `catalog/*/structure.yaml` + `reference.py` | Worked precedents; copy the format of `decoder_ffn` |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ Before opening a PR:
    - New model integration: [`docs/adding_new_model.md`](docs/adding_new_model.md)
    - Kernel catalog: [`docs/kernel_catalog.md`](docs/kernel_catalog.md)
    - Calibration contract: [`docs/calibration.md`](docs/calibration.md)
+   - Structures contributions and self-review:
+     [`docs/structure_contributing.md`](docs/structure_contributing.md)
 2. Build the extension modules locally.
 3. Run the smallest test set that covers your change.
 4. Include the exact GPU, CUDA, command lines, and latency/precision numbers
@@ -362,6 +364,9 @@ Open the pull request from:
 
 Before requesting review:
 
+- For changes under `flash_rt/structures/`, complete the dedicated
+  [`structures contribution and PR self-review`](docs/structure_contributing.md)
+  checklist.
 - Read the full public review standard in
   [`docs/pr_review_checklist.md`](docs/pr_review_checklist.md) for the
   long-term maintenance rules reviewers will apply.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ the source tree under `flash_rt/`, so non-editable installs commonly import
 a stale copy.
 
 ```bash
-git clone https://github.com/LiangSu8899/FlashRT.git
+git clone https://github.com/flashrt-project/FlashRT.git
 cd FlashRT
 git clone --depth 1 --branch v4.4.2 \
     https://github.com/NVIDIA/cutlass.git third_party/cutlass
@@ -335,12 +335,12 @@ say so in the PR and include the reason.
 For external contributors, use the standard fork workflow:
 
 ```bash
-# 1. Fork LiangSu8899/FlashRT on GitHub, then clone your fork.
+# 1. Fork flashrt-project/FlashRT on GitHub, then clone your fork.
 git clone git@github.com:<your-user>/FlashRT.git
 cd FlashRT
 
 # 2. Keep the upstream repository available for sync.
-git remote add upstream git@github.com:LiangSu8899/FlashRT.git
+git remote add upstream git@github.com:flashrt-project/FlashRT.git
 git fetch upstream
 
 # 3. Start from the latest upstream main.

--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ If you need a different GPU arch, want to pin a specific commit, or
 prefer to vet the image source:
 
 ```bash
-git clone https://github.com/LiangSu8899/FlashRT.git
+git clone https://github.com/flashrt-project/FlashRT.git
 cd FlashRT
 docker build -t flashrt:dev -f docker/Dockerfile .
 docker run --rm --gpus all -it flashrt:dev
@@ -871,7 +871,7 @@ pip install jax==0.5.3 jax-cuda12-pjrt==0.5.3 jax-cuda12-plugin==0.5.3 ml_dtypes
 Then build:
 
 ```bash
-git clone https://github.com/LiangSu8899/FlashRT.git
+git clone https://github.com/flashrt-project/FlashRT.git
 cd FlashRT
 git clone --depth 1 --branch v4.4.2 \
     https://github.com/NVIDIA/cutlass.git third_party/cutlass

--- a/README.md
+++ b/README.md
@@ -734,11 +734,15 @@ kernel hub at bind time. It is *not* enough for the native
 them without a build produces a refusal that names the cmake line rather
 than a missing-module traceback. Build them with the section below.
 
-To attach the layer inside a serving engine — vLLM or SGLang, without
-forking either — see **[`docs/serving_engines.md`](docs/serving_engines.md)**:
-the four-line integration, why it hooks the loader rather than the model,
-the batch band and its knob, air-gapped kernel staging, and what each
-refusal means.
+Start at **[`docs/hosts.md`](docs/hosts.md)**: which door your host takes,
+how to tell a seated run from a refused one from a door that never fired,
+how to read a refusal, and what has actually been measured where.
+
+To attach inside a serving engine — vLLM or SGLang, without forking
+either — see **[`docs/serving_engines.md`](docs/serving_engines.md)**: the
+four-line integration, why it hooks the loader rather than the model, the
+start-method trap that makes the hook silently do nothing, the batch band
+and its knob, air-gapped kernel staging, and what each refusal means.
 
 Three boundaries are worth knowing before you start, because each one
 produces a refusal that looks like a bug and is not:

--- a/README.md
+++ b/README.md
@@ -734,6 +734,12 @@ kernel hub at bind time. It is *not* enough for the native
 them without a build produces a refusal that names the cmake line rather
 than a missing-module traceback. Build them with the section below.
 
+To attach the layer inside a serving engine — vLLM or SGLang, without
+forking either — see **[`docs/serving_engines.md`](docs/serving_engines.md)**:
+the four-line integration, why it hooks the loader rather than the model,
+the batch band and its knob, air-gapped kernel staging, and what each
+refusal means.
+
 Three boundaries are worth knowing before you start, because each one
 produces a refusal that looks like a bug and is not:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,7 +11,7 @@ for the full walkthrough (Docker and non-Docker paths). The short
 version:
 
 ```bash
-git clone https://github.com/LiangSu8899/FlashRT.git
+git clone https://github.com/flashrt-project/FlashRT.git
 cd FlashRT
 git clone --depth 1 --branch v4.4.2 \
     https://github.com/NVIDIA/cutlass.git third_party/cutlass

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,7 @@ Flash-Attention 2, so its image deliberately does NOT produce
 
 > **Note on the prebuilt registry image.** Following the
 > `flash_vla → flash_rt` package-rename refactor that landed in
-> [#6](https://github.com/LiangSu8899/FlashRT/pull/6), the
+> [#6](https://github.com/flashrt-project/FlashRT/pull/6), the
 > `ghcr.io/liangsu8899/flashrt` image has not been re-pushed yet —
 > we plan to push the new image once the post-rename surface is
 > fully stable. Until then, build the image yourself with the

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -1,0 +1,144 @@
+# Which host you have, which door to use, what to expect
+
+This page answers three questions in order: *does this layer apply to my
+host*, *what do I call*, and *what should I see afterwards*. For the
+mechanism behind any of it see [`structures.md`](structures.md); for the
+serving engines specifically see
+[`serving_engines.md`](serving_engines.md).
+
+## What the layer does
+
+It replaces sub-blocks of a model you did not write with qualified
+implementations, in place, without forking the host. It does not
+reimplement the model, does not own the loop, and does not require the
+host to know it exists. The host keeps its weights loading, its memory
+planning, its graph capture and its scheduler.
+
+Two consequences worth stating up front, because they set expectations
+better than any number:
+
+- **A seam it cannot claim stays with the host, exactly.** Not
+  approximately — the host's own module runs, so that region is
+  bit-identical to not using this at all. "Refused" is an outcome the
+  layer is built to produce, not a failure it is trying to avoid.
+- **Kernels come from the kernel hub, per host.** The distribution is
+  pure Python. What is available to you depends on your architecture and
+  your torch version, which is why the same call gives different seat
+  counts on different machines and why the refusal trail matters more
+  than the speedup.
+
+## Which door
+
+| your host | door | what it seats |
+|---|---|---|
+| a model library tree you can reach (`transformers`-style) | `structures.attach(model, forward)` | whatever discovery claims: projections, feed-forwards, norms, attention, gated-delta |
+| the same, but you want to choose the seams yourself | `structures.get(name)` + `swap.attach` | exactly what you list |
+| a diffusion transformer (`diffusers`-style) | `structures.attach`, adapters recognise the attention and feed-forward shapes | attention, feed-forward, modulation chains |
+| **vLLM** | `vllm_engine.install_load_hook()` | dense projections, routed expert banks, LM head |
+| **SGLang** | `sglang_engine.install()` | dense projections |
+| an already-quantized checkpoint | `structures.adopt_prequantized(model, fmt=...)` | converts packed projections into structure impls |
+| a decode loop you want captured whole | `structures.decode_loop(...)` | the step, as one graphed region |
+
+`structures.explain(plan)` prints what a pass decided, including every
+refusal, before anything is swapped. On an unfamiliar host that is the
+first thing to run.
+
+## The three states, and how to tell them apart
+
+Almost every confusing result is one of these, and they need different
+fixes. Distinguishing them costs one line each.
+
+| state | what you see | what it means |
+|---|---|---|
+| **seated** | `N seats, M refused` in the log; `handle.summary()["seams"] > 0` | working; read `M` before reading the speedup |
+| **refused** | seats reported, `refused` non-empty, each with a reason | the layer looked and declined — a coverage or boundary fact, not a bug |
+| **never ran** | no log line at all; `handle` never created | the door did not fire. On vLLM this is the start-method trap; see [`serving_engines.md`](serving_engines.md) |
+
+The third is the dangerous one because it looks like "no benefit". It
+produces no error, and a strict mode cannot catch it, because the code
+that would be strict never executes. Assert that the door fired.
+
+## Reading a refusal
+
+Refusals name the form and the shape. They are not "this cannot be
+bound"; they are "this shape, declined for this reason".
+
+```python
+handle.notes["refused"]                       # (site, reason) per seat
+from flash_rt.structures import impls
+impls.unavailable_report()                    # per kernel package
+```
+
+Common ones and what each is telling you:
+
+| reason | what to change |
+|---|---|
+| the kernel client is not installed | `pip install 'flash-rt[hub]'` |
+| no build variant for this host | usually the torch version, not the package — see the README |
+| `does not match system CPU` | the resolved *revision* has no build for your architecture, even if a newer one does |
+| a required slot is absent on this host | the structure needs a weight this host does not carry; a binding can supply it |
+| the boundary includes a norm / a mask form | the host's region is genuinely outside the declared boundary |
+
+A large refused count concentrated on one seam family is a coverage
+report. If it is the family that carries your gain — expert banks on a
+routed-MoE host, for instance — the number you measure afterwards is
+about that, not about the layer.
+
+## What to expect
+
+Measured, on the hosts named. These are receipts from specific machines,
+not promises about yours: the band, the gates and the refusal trail exist
+precisely so that your host decides rather than this table.
+
+| host | model | measured |
+|---|---|---|
+| vLLM, consumer GPU (sm_120) | Qwen3-8B | 99.4 → 157.0 tok/s, 144 seats + 5 head slabs |
+| SGLang, consumer GPU (sm_120) | Qwen3-8B | 101.0 → 201.5 tok/s, 144 seats |
+| vLLM, edge module (sm_110) | 35B-A3B MoE | 37.2 → 76.0 tok/s, 200 seats + 4 head slabs |
+
+Single-stream steady decode. Concurrency on the edge module with the MoE
+model: **2.05× / 2.31× / 2.46× / 1.65×** at 1 / 4 / 8 / 16 — peaking at 8
+and still positive at 16, which is not what a dense model does.
+
+For a worked model-library example with its own receipts, see
+[`adopt_in_20_lines.md`](adopt_in_20_lines.md).
+
+Three things shape whether you see numbers like these:
+
+- **Batch.** A dense host's gain thins as the batch grows — one weight
+  read serves every row. A routed-MoE host's does not, because each
+  token picks its own experts. Expect different curves, and do not carry
+  a number from one family to the other.
+- **Which seams got claimed.** More seats is not better. Small
+  projections can cost more in per-operator overhead than they save in
+  bytes; large sparse ones are where the gain is. A pass that claims 160
+  extra seams and gets slower is a real, observed outcome.
+- **What your host already does well.** This layer is worth most where
+  per-operator fixed costs dominate — small batch, latency-sensitive,
+  edge and consumer parts. At large batch the host's own tuned path is
+  usually already in its element.
+
+## What it does not do
+
+- It is not a replacement for the engine, the scheduler or the loop.
+- It does not tune for you: the band constants and the ladder order are
+  measured defaults, and a host that differs should re-measure them
+  rather than inherit them.
+- It does not ship kernels. The pure-Python distribution carries
+  specifications, implementations and adapters; the compiled halves come
+  from the kernel hub, or from a local build for the native path.
+
+## Verifying on your own host
+
+Nothing here needs a benchmark harness to check:
+
+```python
+import flash_rt.structures as S
+S.list_structures()          # the catalog this install carries
+plan = S.auto_swaps(model, forward)
+print(S.explain(plan))       # what would be claimed, and every refusal
+```
+
+Then attach, read `summary()` and `notes["refused"]`, and compare a
+paired run — same process, same prompts, prefill and steady decode
+reported separately. An end-to-end average hides which of the two moved.

--- a/docs/serving_engines.md
+++ b/docs/serving_engines.md
@@ -72,6 +72,56 @@ Three engine facts, each of which cost a debugging session:
   registered at import. A plain `if rows > N` freezes at trace time and
   the arm that looks enabled is dead code.
 
+### Call it before anything touches CUDA
+
+This is the one trap that costs a debugging session, because it fails
+without raising anything.
+
+The engine **forks** its worker by default, which is what carries the
+patch into the process that loads the model. But it switches to
+**spawning** one the moment CUDA is already initialized in your process —
+and a spawned worker re-imports the engine from scratch, so the patch
+simply is not there. Checking free memory, calling
+`torch.cuda.is_available()`, setting a device, a warm-up, or importing
+any library that initializes CUDA is enough to flip it.
+
+```python
+import torch
+torch.cuda.mem_get_info()          # ← now the worker will be spawned
+vllm_engine.install_load_hook()    # patches this process, which is not
+llm = LLM(model=...)               #   the one that loads the model
+```
+
+Nothing raises. `install_load_hook()` really did patch, so it does not
+report "no vLLM model runner found"; the callback just never fires, and
+the run comes out at baseline speed. It reads exactly like "this layer
+does nothing".
+
+`install_load_hook()` refuses this state rather than let it happen
+silently. If you have a reason to proceed anyway, pass
+`allow_spawn=True`. Two ways out:
+
+- call `install_load_hook()` before anything touches CUDA, or
+- run the engine in this process with `VLLM_ENABLE_V1_MULTIPROCESSING=0`,
+  which is independent of initialization order.
+
+**Verify rather than assume.** The seats are in if and only if this line
+appeared:
+
+```
+[structures.vllm] 144 seats (5 head slabs), 0 refused
+```
+
+For a test or a service that should not start unaccelerated, assert it:
+
+```python
+llm = LLM(model=...)
+assert vllm_engine.attached(), "the hook never fired"
+```
+
+`strict=True` does not help here — it governs what happens when seats
+refuse, and in this failure attach never runs at all.
+
 ### Reading what happened
 
 ```
@@ -199,6 +249,35 @@ or correctness drift that arrived with a rebuild:
 ```bash
 export FRT_KERNEL_REV_<REPO_NAME_UPPERCASED_WITH_UNDERSCORES>=<revision>
 ```
+
+### Coverage is per package *and per version*, which is where it bites
+
+A package having a build for your architecture is not the same as the
+version being resolved having one. A repository whose newest revision
+covers aarch64 can have an older one that does not, and a request that
+resolves to the older revision refuses on that architecture with
+
+```
+CPU (x86_64) does not match system CPU (aarch64)
+```
+
+This has a specific consequence worth knowing before you read a
+disappointing number: on a routed-MoE host it is the **expert bank**
+seats that carry the concurrency gain, so if that one package resolves
+to a build without your architecture, every expert seat refuses while
+the dense seats attach normally. The run is correct and the log says
+`N seats, 40 refused` — but the batch-16 gain is most of what is gone.
+
+So read the refusal count, not just the speedup:
+
+```python
+handle.notes["refused"]        # (site, reason) per seat that declined
+impls.unavailable_report()     # per package: repo, version, error, detail
+```
+
+A large refused count concentrated on one seam family is a coverage
+report, not a mystery. Pin a revision that has your architecture with
+`FRT_KERNEL_REV_*`, or stage it and point at it with `LOCAL_KERNELS`.
 
 ---
 

--- a/docs/serving_engines.md
+++ b/docs/serving_engines.md
@@ -1,0 +1,257 @@
+# Attaching structures to a serving engine
+
+A model library is a friendly host: you own the module tree and can put
+anything anywhere. A serving engine is not. It owns its own model
+implementation, its own memory planner and its own graph capture, and it
+compiles the model before you get a chance to touch it.
+
+This page is how to attach anyway — on vLLM and on SGLang — what the
+engine facts are that shape the call, and what the refusals mean when it
+does not work.
+
+Nothing here forks or patches the engine. The engine stays in charge; the
+layer replaces sub-blocks of the model it executes.
+
+---
+
+## 1. Install
+
+```bash
+pip install flash-rt              # the layer: catalog, adapters, specs
+pip install 'flash-rt[hub]'       # + the kernel-hub client
+```
+
+The distribution is pure Python and carries **no compiled artifact**. Two
+things follow:
+
+- Kernels arrive at bind time from the kernel hub. Without the hub client
+  every bind refuses — legibly, naming the package it wanted.
+- The native `flash_rt.load_model` path is a different thing entirely and
+  needs a local build. See the README's Build section.
+
+Bring your own torch. The extra deliberately does not name it, because
+**which kernels exist is decided by your torch version** — the published
+face is thickest at torch 2.11 and thin at the newest release. A bind
+that refuses on a fresh install is usually saying that, not saying the
+package is broken.
+
+Qualified on Python 3.10 / 3.11 / 3.12 / 3.13, Linux x86-64 and aarch64.
+
+---
+
+## 2. vLLM
+
+### The four lines
+
+```python
+from flash_rt.structures.adapters import vllm_engine
+vllm_engine.install_load_hook()
+
+from vllm import LLM
+llm = LLM(model="Qwen/Qwen3-8B", max_model_len=1024)
+```
+
+That is the whole integration. `install_load_hook()` must run **before**
+the engine is constructed.
+
+### Why a hook and not "attach the model"
+
+Three engine facts, each of which cost a debugging session:
+
+- **Seats go in after weights load and before the first trace.** vLLM's
+  compiled artifact resolves parameters by tree path, so a swap made
+  after compilation either raises `KeyError` or is silently bypassed.
+  `install_load_hook` patches the model runner's `load_model` for exactly
+  that window.
+- **The compile cache does not see the module tree.** A stale artifact
+  would resolve parameters the seats replaced, so the hook sets
+  `VLLM_DISABLE_COMPILE_CACHE=1` for you.
+- **A Python shape branch dies under tracing.** vLLM traces with guard
+  evaluation off, so the MoE band (decode rows to the packed bank,
+  prefill rows back to the host) lives inside a `torch.library.custom_op`
+  registered at import. A plain `if rows > N` freezes at trace time and
+  the arm that looks enabled is dead code.
+
+### Reading what happened
+
+```
+[structures.vllm] 144 seats (5 head slabs), 0 refused
+```
+
+`on_attached` hands you the handle if you want the detail:
+
+```python
+def note(handle):
+    print(handle.summary())          # seams, guarded_calls, fallbacks, clean
+    print(handle.notes["refused"])   # [(site, reason), ...]
+
+vllm_engine.install_load_hook(on_attached=note)
+```
+
+`handle.detach()` restores the module tree, the expert modules and the
+head's quant method — same objects, bit-identical outputs.
+
+### Options
+
+```python
+vllm_engine.install_load_hook(
+    seats=vllm_engine.DENSE_SEAT_SUFFIXES,  # dense projection positions
+    experts=True,                           # routed expert banks
+    head=True,                              # LM head, row-sliced
+    strict=False,                           # see below
+)
+```
+
+`strict=False` (the default) means a host where **every** seat refuses
+still starts, unaccelerated, with every refusal reported. A server that
+fails to boot because its accelerator was absent is worse than one that
+boots slow. In CI use `strict=True`: a silent zero-seat run is a fallback
+nobody reads.
+
+---
+
+## 3. SGLang
+
+SGLang runs its scheduler in a **spawned subprocess**, so patching in the
+parent does not reach the process that owns the model. The door writes a
+`sitecustomize` onto `PYTHONPATH` instead, and the child picks it up:
+
+```python
+from flash_rt.structures.adapters import sglang_engine
+sglang_engine.install()
+
+import sglang as sgl
+llm = sgl.Engine(model_path="Qwen/Qwen3-8B", mem_fraction_static=0.75)
+```
+
+`install()` must run before the engine is constructed, and it sets
+`FRT_SGLANG_ATTACH=1` so other processes that happen to inherit the path
+see a dormant flag rather than an attach.
+
+Two things that bite:
+
+- **Your driver script needs an `if __name__ == "__main__":` guard.** The
+  spawned child re-imports the main module by path; without the guard it
+  re-enters `Engine(...)` and rank 0 dies during init.
+- `mem_fraction_static` needs headroom for the bind. Binding packs weights
+  on the device, and the transient peak is what fails under a tight budget.
+
+For a host where the weights barely fit, `install(release=True)` attaches
+in slabs and releases each original as its replacement lands, instead of
+holding both for the whole pass.
+
+---
+
+## 4. Batch size, and the knob that decides it
+
+The MoE seat declares a **band**: at or below a row count it serves the
+batch from the packed bank; above it, the host's own fused-MoE module
+serves. Prefill always goes back to the host.
+
+```bash
+FRT_MOE_BAND_T=16   # default; the largest batch measured to pay
+```
+
+The default is measured, not assumed. On a routed-MoE host the gain does
+**not** thin out with batch the way it does on a dense host — each token
+picks its own experts, so expert weight traffic grows with the batch
+instead of being shared, and a 4-bit bank keeps paying well past batch 1.
+An earlier value of 8 handed batch-16 traffic back to the host and threw
+that away.
+
+Sweep it on your own host before changing it. `tests/thor_parasite_kit/`
+carries a concurrency probe that runs paired arms at a given concurrency:
+
+```bash
+MODEL=<your-model> ARM=base   CONC=8 OUT=base.json  python 04_concurrency_probe.py
+MODEL=<your-model> ARM=attach CONC=8 OUT=attach.json python 04_concurrency_probe.py
+```
+
+Use distinct prompts (the probe does): identical ones share prefix-cache
+blocks and quietly turn N requests into one request's worth of work.
+
+Two measurement notes, both learned the hard way:
+
+- **Report prefill and steady decode separately.** An end-to-end average
+  hides which one moved.
+- **Some hosts run per-process bimodal.** A single pair can land in the
+  slow mode and misstate the result by 10%. Run repeats and read the fast
+  mode; a spread wider than the effect means you have not measured yet.
+
+---
+
+## 5. Kernels: where they come from, and air-gapped hosts
+
+Binds pull packages from the kernel hub through the `kernels` client.
+
+**`HF_HUB_OFFLINE=1` does not work as an air-gap strategy**: a version
+specifier has to resolve refs online, so offline mode makes every package
+unavailable even against a fully warm cache. Stage the packages and point
+at them instead:
+
+```bash
+export LOCAL_KERNELS="<repo>=<path>:<repo>=<path>"
+```
+
+To pin one repository to an exact artifact — for bisecting a performance
+or correctness drift that arrived with a rebuild:
+
+```bash
+export FRT_KERNEL_REV_<REPO_NAME_UPPERCASED_WITH_UNDERSCORES>=<revision>
+```
+
+---
+
+## 6. Refusals
+
+A refusal is an outcome, not a crash. `KernelUnavailable` is a
+`ValueError` on purpose, so layers that record a refusal and keep going
+can catch it.
+
+| what you see | what it means | what to do |
+|---|---|---|
+| `the kernel client is not installed` | no hub client in this environment | `pip install 'flash-rt[hub]'` |
+| `unavailable on this host: OfflineModeIsEnabled` | offline mode defeats version resolution | use `LOCAL_KERNELS`, see §5 |
+| `no build variant for this host` | the package has no build for your torch/CUDA/arch | check torch version first, §1 |
+| `quantize ... rc=-1` on a large head | shape outside the entry's support | the head binds as row slabs; this is the refusal that strategy exists for |
+| `refused: no vLLM model runner found to hook` | the engine layout is outside this adapter's profile | a host version this adapter has not been fitted to |
+| `0 seats, N refused — host runs unmodified` | nothing could be seated | read the reasons; the engine is up and correct, just unaccelerated |
+
+Everything the process could not get is on the ledger:
+
+```python
+from flash_rt.structures import impls
+impls.unavailable_report()   # [{repo, version, error, detail}, ...]
+```
+
+The original failure is kept verbatim, because a package that is *broken*
+here and one that was simply never *shipped* here both look like "skipped"
+and only the first is somebody's bug.
+
+---
+
+## 7. What has actually been measured
+
+Numbers below are single-stream steady decode unless stated. They are
+receipts from specific hosts, not promises about yours — the point of the
+band and the gates is that your host decides.
+
+| host | engine | model | base → attached |
+|---|---|---|---|
+| consumer GPU (sm_120) | vLLM 0.22 | Qwen3-8B | 99.4 → 157.1 tok/s (144 seats + 5 head slabs) |
+| consumer GPU (sm_120) | SGLang 0.5.13 | Qwen3-8B | 101.0 → 201.5 tok/s (144 seats) |
+| edge module (sm_110) | vLLM 0.26 | 35B-A3B MoE | 37.2 → 76.0 tok/s (200 seats + 4 head slabs) |
+
+Concurrency, on the edge module with the MoE model — the shape is the
+point, not the absolutes:
+
+| concurrency | 1 | 4 | 8 | 16 |
+|---|---|---|---|---|
+| gain | 2.05× | 2.31× | 2.46× | 1.65× |
+
+It **peaks at 8 and is still positive at 16**, which is not what a dense
+model would do. Above the band the MoE seat stands down by design, so
+"out of band" means "no worse than the host", not "broken".
+
+Verified interpreter and platform coverage: Python 3.10–3.13, Linux
+x86-64 and aarch64, with and without a GPU present.

--- a/docs/structure_contributing.md
+++ b/docs/structure_contributing.md
@@ -1,0 +1,198 @@
+# Contributing to the structures layer
+
+This is the contributor entry point and pull-request self-review standard for
+`flash_rt/structures/`. It applies to external and internal contributors. Its
+goal is to keep additions portable across hosts, explicit about unsupported
+cases, and removable without changing the host model.
+
+The normative design is [`structures.md`](structures.md). Release performance
+claims additionally follow
+[`structure_release_qualification.md`](structure_release_qualification.md).
+This document does not replace either contract; it tells a contributor what a
+reviewable change must contain.
+
+## 1. Choose the layer before changing files
+
+Put each fact in the narrowest owner below. If a change needs two layers, keep
+the boundary visible in the diff rather than teaching either layer about the
+other one's concerns.
+
+| Fact or behavior | Owner | Must not contain |
+|---|---|---|
+| Framework-neutral dataflow boundary, slots, state, calibration points, gates | `catalog/<structure>/` | Model IDs, host class names, GPU architecture, package selection |
+| Where that boundary exists in one host | `discover.py` or `bindings/*.yaml` | Kernel choice, benchmark policy, device tuning |
+| Executable form for a structure | `impls/<structure>/` | Model routing, private source loading, duplicated calibration |
+| Engine lifecycle integration | `adapters/` | Structure definitions or model-specific kernels |
+| Precision/statistics policy | `schemes.py`, `points.py`, `gates.py` | A second calibration API or hidden defaults |
+| Runtime replacement, refusal, ledger, rollback | `guard.py`, `swap.py`, `frontdoor.py` | Silent fallback or process-global policy |
+| Hardware support and entry-point availability | Published kernel package metadata | A second architecture table in FlashRT |
+
+A recurring boundary found in at least two unrelated host families may be a
+structure. A model-only path is a binding or host stage. A faster kernel for an
+existing boundary is an implementation. A new device build with unchanged
+symbols normally requires no structures-layer change.
+
+## 2. Required reading by change type
+
+All structure changes start with [`structures.md`](structures.md). Then read
+only the material needed for the proposed surface:
+
+| Change | Also read |
+|---|---|
+| Catalog, discovery, binding, implementation, or adapter | Repository [`AGENTS.md`](../AGENTS.md), especially its ordered workflow and red lines |
+| Calibration or precision | [`calibration.md`](calibration.md) |
+| Engine integration | [`hosts.md`](hosts.md) and [`serving_engines.md`](serving_engines.md) |
+| A release or performance claim | [`structure_release_qualification.md`](structure_release_qualification.md) |
+| Public API or packaging | [`stable_api.md`](stable_api.md) and the root [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+
+Before adding a mechanism, search the catalog, discovery rules, schemes,
+adapters, diagnostics, and tests. Reuse an existing structure or executable
+form when its contract fits. Keep a PR focused on one structure boundary or
+one independently reviewable behavior; kernel-package work belongs in its own
+repository and review.
+
+## 3. Contribution workflow
+
+### 3.1 State the contract first
+
+The PR description must name:
+
+- the structure boundary and why it belongs at this layer;
+- affected hosts, models, phases, shapes, dtypes, layouts, and devices;
+- the baseline behavior, including whether unsupported cases refuse or retain
+  the host path;
+- files and public behavior intentionally not changed.
+
+For a new structure, record the same dataflow in two unrelated host families.
+If only one host is known, keep the work in a binding or mark the catalog entry
+provisional; do not encode the first host as a universal abstraction.
+
+### 3.2 Implement through existing extension seams
+
+- Additive changes are preferred. Do not change a shared schema or helper
+  contract without enumerating and testing every reader.
+- Recognition uses slots, shapes, dataflow relations, and forward contracts;
+  model IDs and concrete class-name allowlists are not discovery evidence.
+- Resolve, detach, cast, pack, and smoke-test at bind time. The installed
+  forward must contain no loader call or Python-side hot-path bookkeeping.
+- Use the shared Hub loader. Symbol presence is a capability hint, not proof
+  that a shape, dtype, layout, or architecture is qualified.
+- Route unsupported cases through an explicit refusal or declared host
+  fallback. Record the reason in the ledger.
+- Use the house calibration collector and scheme interface. Do not add private
+  hooks, statistics, caches, or precision entry points.
+- Preserve the original host module and prove detach restores it exactly.
+
+When a required published kernel capability is absent, stop that region and
+report `blocked_on_kernel`: nearest public API, missing signature or envelope,
+real shapes/dtypes/layout/device, consumers, and acceptance gates. Do not copy
+kernel source into this repository or load from a contributor's checkout.
+
+### 3.3 Add evidence proportional to risk
+
+Every behavior change needs focused tests. New structures and executable forms
+normally need:
+
+- reference or boundary correctness;
+- positive discovery and a negative non-match;
+- supported dispatch plus unsupported shape/capability refusal;
+- target-path call count greater than zero and unexpected fallback count zero;
+- attach/detach and repeated-call lifecycle checks;
+- compile/capture checks when the path claims to support them.
+
+GPU and end-to-end evidence is required only when the PR changes GPU behavior
+or makes a hardware, precision, compatibility, or performance claim. Use real
+host preprocessing and representative inputs; compare the same boundary and
+execution assembly. Report commands, versions, device, shape band, numerical
+result, latency distribution, ledger, and rollback result. A microbenchmark
+does not establish end-to-end speedup, and identical output without path and
+fallback counts does not establish that the implementation ran.
+
+Documentation-only changes may report link and source-signature checks instead
+of runtime tests. State that exception explicitly.
+
+## 4. Pull-request self-review
+
+Copy the following block into the PR description and remove inapplicable rows
+with a short reason. Do not check a box when evidence is unavailable.
+
+```markdown
+### Structures self-review
+
+Scope
+- [ ] I identified the owning layer and kept unrelated model/kernel work out.
+- [ ] I listed affected and intentionally unaffected hosts, shapes, dtypes,
+      phases, devices, and public APIs.
+- [ ] A new catalog boundary has cross-host evidence; otherwise it remains a
+      binding/host concern or is explicitly provisional.
+
+Contracts and failure modes
+- [ ] Discovery is structural, with positive and negative cases.
+- [ ] Hardware capability comes from the kernel package; this change adds no
+      duplicate architecture table.
+- [ ] Unsupported or missing capability refuses clearly or takes a declared
+      host fallback, and the ledger records it.
+- [ ] Calibration and precision use the existing collector/scheme entry point.
+- [ ] Attach/detach, state ownership, repeated calls, and compile/capture
+      behavior are preserved where applicable.
+
+Evidence
+- [ ] I added focused public tests for the changed contract.
+- [ ] The intended path ran (call count > 0) and unexpected fallback count is 0.
+- [ ] Numerical comparison uses the declared boundary and tolerance.
+- [ ] Performance claims use paired final-form measurements, not summed
+      microbenchmarks, and include the qualification cell.
+- [ ] I recorded exact commands and results below, or explained each test that
+      could not run.
+
+Maintenance and hygiene
+- [ ] I checked every changed shared helper/schema reader and every documented
+      API against source.
+- [ ] The diff contains no secrets, credentials, private/local paths,
+      checkpoints, generated binaries, logs, or benchmark traces.
+- [ ] Optional dependencies remain optional at import time; errors name the
+      missing capability and a supported remedy.
+- [ ] User-facing behavior, support limits, and invalidated performance
+      receipts are documented.
+
+Validation
+- Environment: <GPU/compute capability, CUDA, framework, host/package versions>
+- Commands and results: <exact commands; pass/fail/skip counts>
+- Correctness/path/ledger: <metric, tolerance, call count, fallback count>
+- Performance, if claimed: <baseline and candidate P50/spread, timed boundary,
+  eager/compiled/captured assembly>
+- Not run or not covered: <reason and resulting limitation>
+```
+
+## 5. Reviewer stop conditions
+
+Request changes before performance discussion when any of the following is
+present:
+
+- a model ID, class allowlist, or incidental module name is the only discovery
+  evidence;
+- a structure definition contains hardware routing or a binding selects a
+  kernel package;
+- unsupported behavior silently degrades, or success can be explained by host
+  fallback;
+- calibration, precision selection, diagnostics, or receipts are duplicated;
+- a kernel is loaded or probed inside the swapped forward;
+- local source injection, unpublished artifacts, private paths/data, generated
+  binaries, or credentials enter the diff;
+- a benchmark crosses different boundaries, inputs, stochastic windows, or
+  compile/capture assemblies;
+- rollback, ownership, optional-dependency import behavior, or negative
+  discovery is untested for a change that can affect it.
+
+When hardware or fixtures are unavailable but the structure is otherwise
+sound, label the result as needing qualification; do not convert missing
+evidence into either a performance claim or a universal rejection.
+
+## 6. Definition of done
+
+A structures PR is ready for review when its boundary and ownership are clear,
+unsupported cases are explicit, focused tests cover the contract and rollback,
+and the PR description contains reproducible evidence at the level of its
+claims. Release readiness is a separate decision: only qualification cells
+that satisfy [`structure_release_qualification.md`](structure_release_qualification.md)
+may be published as certified fast.

--- a/docs/structure_contributing.md
+++ b/docs/structure_contributing.md
@@ -74,7 +74,10 @@ provisional; do not encode the first host as a universal abstraction.
 - Recognition uses slots, shapes, dataflow relations, and forward contracts;
   model IDs and concrete class-name allowlists are not discovery evidence.
 - Resolve, detach, cast, pack, and smoke-test at bind time. The installed
-  forward must contain no loader call or Python-side hot-path bookkeeping.
+  forward must contain no resolution: no loader call, symbol lookup,
+  capability probe, or plan construction. A route decided at bind and read
+  per call, such as a declared shape band or an already-chosen variant, is not
+  bookkeeping; it is the form that was bound.
 - Use the shared Hub loader. Symbol presence is a capability hint, not proof
   that a shape, dtype, layout, or architecture is qualified.
 - Route unsupported cases through an explicit refusal or declared host
@@ -128,6 +131,8 @@ Scope
 
 Contracts and failure modes
 - [ ] Discovery is structural, with positive and negative cases.
+- [ ] No catalog spec bytes changed, or the change carries a version bump with
+      its coexistence window and re-qualification note.
 - [ ] Hardware capability comes from the kernel package; this change adds no
       duplicate architecture table.
 - [ ] Unsupported or missing capability refuses clearly or takes a declared
@@ -173,6 +178,8 @@ present:
   evidence;
 - a structure definition contains hardware routing or a binding selects a
   kernel package;
+- a catalog `structure.yaml` is edited without a version decision: any byte
+  change alters `spec_digest` and orphans every receipt that cites it;
 - unsupported behavior silently degrades, or success can be explained by host
   fallback;
 - calibration, precision selection, diagnostics, or receipts are duplicated;

--- a/flash_rt/structures/adapters/vllm_engine.py
+++ b/flash_rt/structures/adapters/vllm_engine.py
@@ -373,6 +373,27 @@ def install_load_hook(*, on_attached=None, allow_spawn=False,
     import importlib
     import os
 
+    # Find the runners before changing anything: "there is no host here"
+    # is the more fundamental refusal, and a caller without vLLM should
+    # hear that rather than a lecture about start methods. Nothing is
+    # mutated until both questions have been answered.
+    found = []
+    for modname in ("vllm.v1.worker.gpu.model_runner",
+                    "vllm.v1.worker.gpu_model_runner",
+                    "vllm.v2.worker.gpu_model_runner"):
+        try:
+            module = importlib.import_module(modname)
+        except ImportError:
+            continue
+        runner = getattr(module, "GPUModelRunner", None)
+        if runner is None or not hasattr(runner, "load_model"):
+            continue
+        found.append((modname, runner))
+    if not found:
+        raise RuntimeError(
+            "refused: no vLLM model runner found to hook; the engine "
+            "layout is outside this adapter's profile")
+
     lost = None if allow_spawn else _patch_would_not_survive()
     if lost is not None:
         raise RuntimeError(
@@ -389,16 +410,7 @@ def install_load_hook(*, on_attached=None, allow_spawn=False,
 
     os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
     patched = []
-    for modname in ("vllm.v1.worker.gpu.model_runner",
-                    "vllm.v1.worker.gpu_model_runner",
-                    "vllm.v2.worker.gpu_model_runner"):
-        try:
-            module = importlib.import_module(modname)
-        except ImportError:
-            continue
-        runner = getattr(module, "GPUModelRunner", None)
-        if runner is None or not hasattr(runner, "load_model"):
-            continue
+    for modname, runner in found:
         orig = runner.load_model
 
         def load_model(self, *a, __orig=orig, **kw):
@@ -409,8 +421,4 @@ def install_load_hook(*, on_attached=None, allow_spawn=False,
                 on_attached(handle)
         runner.load_model = load_model
         patched.append(modname)
-    if not patched:
-        raise RuntimeError(
-            "refused: no vLLM model runner found to hook; the engine "
-            "layout is outside this adapter's profile")
     return patched

--- a/flash_rt/structures/adapters/vllm_engine.py
+++ b/flash_rt/structures/adapters/vllm_engine.py
@@ -315,14 +315,77 @@ def attach_engine(model, *, seats=DENSE_SEAT_SUFFIXES, experts=True,
     return handle
 
 
-def install_load_hook(*, on_attached=None, **attach_kwargs):
+#: every handle :func:`install_load_hook` has seated, in order. A caller
+#: that wants certainty rather than a log line asserts on this after the
+#: engine is up: empty means the hook never fired.
+_ATTACHED: list = []
+
+
+def attached() -> list:
+    """The handles seated so far. Empty after an engine came up means the
+    patch never reached the process that loaded the model — see
+    :func:`install_load_hook` on the start method."""
+    return list(_ATTACHED)
+
+
+def _patch_would_not_survive() -> str | None:
+    """Why a patch made here would not exist in the worker process.
+
+    The engine starts its worker with ``fork`` by default, which
+    inherits this patch, and that is why the four-line integration
+    works at all. But it switches to ``spawn`` under conditions the
+    caller can walk into without noticing — a spawned worker re-imports
+    the engine from scratch and the patch is simply not there.
+
+    The failure is silent: patching succeeds here, the hook never fires,
+    and the run comes out at baseline speed with no error anywhere. That
+    is the one outcome this layer refuses to produce, so it is checked
+    before the caller builds an engine rather than discovered afterwards
+    from a missing log line.
+    """
+    if os.environ.get("VLLM_ENABLE_V1_MULTIPROCESSING", "1") == "0":
+        return None                     # the engine runs in this process
+    if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") == "spawn":
+        return "VLLM_WORKER_MULTIPROC_METHOD is set to 'spawn'"
+    if torch.cuda.is_initialized():
+        return ("CUDA is already initialized in this process, and the "
+                "engine forces 'spawn' when it is")
+    return None
+
+
+def install_load_hook(*, on_attached=None, allow_spawn=False,
+                      **attach_kwargs):
     """Patch every importable vLLM model-runner so :func:`attach_engine`
     runs after weights load and before the engine's first trace. Set
     ``VLLM_DISABLE_COMPILE_CACHE=1``: the engine's compile cache key
     does not see the module tree, and a stale artifact resolves
-    parameters that the seats replaced."""
+    parameters that the seats replaced.
+
+    Call this before touching CUDA. The engine forks its worker by
+    default, which is what carries this patch into the process that
+    loads the model, but it switches to spawning one the moment CUDA is
+    already initialized here — and a spawned worker re-imports the
+    engine without the patch. Nothing raises in that case: the seats
+    simply never go in and the run comes out at baseline. So the
+    condition is refused here instead, with the two ways out. Pass
+    ``allow_spawn=True`` to proceed anyway.
+    """
     import importlib
     import os
+
+    lost = None if allow_spawn else _patch_would_not_survive()
+    if lost is not None:
+        raise RuntimeError(
+            "refused: this patch would not reach the process that loads "
+            "the model — " + lost + ".\n"
+            "The engine would start its worker with 'spawn', which "
+            "re-imports it from scratch, so the seats would never be "
+            "installed and the run would come out at baseline speed "
+            "with nothing raised anywhere.\n"
+            "Either call install_load_hook() before anything touches "
+            "CUDA, or run the engine in this process with "
+            "VLLM_ENABLE_V1_MULTIPROCESSING=0. Pass allow_spawn=True to "
+            "proceed regardless.")
 
     os.environ.setdefault("VLLM_DISABLE_COMPILE_CACHE", "1")
     patched = []
@@ -341,6 +404,7 @@ def install_load_hook(*, on_attached=None, **attach_kwargs):
         def load_model(self, *a, __orig=orig, **kw):
             __orig(self, *a, **kw)
             handle = attach_engine(self.model, **attach_kwargs)
+            _ATTACHED.append(handle)
             if on_attached is not None:
                 on_attached(handle)
         runner.load_model = load_model

--- a/flash_rt/structures/discover.py
+++ b/flash_rt/structures/discover.py
@@ -516,12 +516,32 @@ def discover(
                         and isinstance(fc2, nn.Linear)):
                     continue
                 if (fc1.out_features != fc2.in_features
-                        or fc1.in_features != fc2.out_features
-                        or fc1.bias is None or fc2.bias is None):
+                        or fc1.in_features != fc2.out_features):
+                    continue  # not an FFN pair: silence is right here
+                # Past this point the seam has been recognised, and every
+                # exit is a refusal against a declared boundary. Those
+                # must reach the trail: a silent skip reads as "nothing
+                # here" when the truth is "this shape, refused for this
+                # reason", and the difference is a debugging session.
+                if fc1.bias is None or fc2.bias is None:
+                    if refused is not None:
+                        refused.append((
+                            path,
+                            "vision_ffn refused: b_fc1/b_fc2 are required "
+                            "slots and this host's projections carry no "
+                            "bias",
+                        ))
                     continue
                 norm_attr = _norm_attr_of(model, parent_path)
                 if norm_attr is None:
-                    continue  # vision_ffn boundary includes a LayerNorm
+                    if refused is not None:
+                        refused.append((
+                            path,
+                            "vision_ffn refused: the boundary includes a "
+                            "norm and no norm attribute was found beside "
+                            "this feed-forward",
+                        ))
+                    continue
                 norm = _resolve(
                     model,
                     (parent_path + "." + norm_attr).lstrip("."),

--- a/flash_rt/structures/impls/__init__.py
+++ b/flash_rt/structures/impls/__init__.py
@@ -147,7 +147,24 @@ _LOADED: dict[tuple[str, str], object] = {}
 
 @lru_cache(maxsize=None)
 def hub_kernel(repo: str, version: str):
-    from kernels import get_kernel
+    try:
+        from kernels import get_kernel
+    except ImportError as absent:
+        # The client itself is missing or shadowed. This is the same
+        # event as every other way a package fails to arrive - "not
+        # here" - and it must travel as one, or the layers that catch a
+        # refusal to record it and keep going will instead abort on the
+        # one unavailability nobody declared. It is also the state a
+        # fresh ``pip install flash-rt`` is in, since the client is not
+        # a hard dependency, so the message says how to leave it.
+        _record_unavailable(repo, version, absent)
+        raise KernelUnavailable(
+            f"kernel package {repo!r} ({version}) is unavailable on this "
+            f"host: the kernel client is not installed "
+            f"({type(absent).__name__}: {absent}).\n"
+            f"    pip install kernels\n"
+            f"or install this distribution with its hub extra:\n"
+            f"    pip install 'flash-rt[hub]'") from absent
 
     key = (repo, version)
     if key not in _LOADED:

--- a/flash_rt/structures/impls/linear_proj/nvfp4_dynamic.py
+++ b/flash_rt/structures/impls/linear_proj/nvfp4_dynamic.py
@@ -107,8 +107,18 @@ class LinearProjNvfp4Dynamic(GuardedSeam, torch.nn.Module):
         # K a multiple of 64*warps). Absence is not a refusal - the
         # tiled GEMM serves every shape correctly, the GEMV just fills
         # the SMs it underfills at long-K decode shapes.
+        # The entry's presence in the build is not its qualification to
+        # run: the aarch64 package carries it and the kernel refuses at
+        # call time on anything below SM120, which surfaces as a runtime
+        # error on the first M=1 row rather than as a choice made here.
+        # The engine adapters already withhold it off SM120; deciding it
+        # once, where the arm is selected, means an impl bound directly -
+        # through structures.get(), or any hand assembly - behaves the
+        # same as one bound through a door.
         gemv = getattr(kern, "fp4_w4a4_gemv_warpsplit_bf16", None)
-        self._gemv = (gemv if gemv is not None
+        cc = (torch.cuda.get_device_capability(w_packed.device)
+              if w_packed.is_cuda else (0, 0))
+        self._gemv = (gemv if gemv is not None and cc >= (12, 0)
                       and n % 8 == 0 and k % (64 * 4) == 0 else None)
         self._frt_arm(dtypes=CAST_OK, device=w_packed.device, k=int(k))
 

--- a/flash_rt/structures/impls/vision_ffn/nvfp4_balance.py
+++ b/flash_rt/structures/impls/vision_ffn/nvfp4_balance.py
@@ -62,39 +62,63 @@ class FusedGeluMlpNvfp4(GuardedSeam, torch.nn.Module):
             self.register_buffer(name, t)
         self._d = d
         self._f = f
-        self._chain_min_m = (self._audition_chain()
-                             if self._chain is not None else None)
+        self._chain_band = (self._audition_chain()
+                            if self._chain is not None else None)
         if original is not None:
             self.host_mlp = original
         self._frt_arm(dtypes=CAST_OK, device=wp1.device, k=d)
 
-    def _audition_chain(self) -> int | None:
-        """The smallest row count the wire chain will actually serve.
+    #: Row counts probed at bind. The first that runs anchors the band;
+    #: the two probes after it say which kind of band it is.
+    _PROBE_M = (1, 2, 4, 8, 16, 32, 64, 128)
+
+    def _chain_runs(self, m: int) -> bool:
+        try:
+            z = torch.zeros(m, self._d, device=self.wp1.device,
+                            dtype=torch.float16)
+            ap, sfa = self._kern.quantize_fp4_sfa_fp16(z)
+            hp, hsfa = self._chain(ap, self.wp1, sfa, self.sfb1, self.b1)
+            self._gemm_bias(hp, self.wp2, hsfa, self.sfb2, self.b2)
+            return True
+        except (RuntimeError, ValueError):
+            return False
+
+    def _audition_chain(self):
+        """Measure which row counts the wire chain will serve.
 
         Presence is not qualification, and this qualification is
-        shape-dependent: a chain entry can decline the single row a
-        decode-shaped call brings while serving every larger one. One
-        launch would answer the wrong question — disqualifying a chain
-        over the one shape it declines, or admitting it and failing on
-        the first M=1 call. Two launches at bind measure the band.
+        shape-dependent — but *how* it depends on shape is itself
+        something to measure rather than assume. A tile-structured entry
+        can decline every row count that is not a multiple of its tile
+        while serving all of them that are, which no lower bound
+        describes: reading such an entry as "serves M >= n" turns off a
+        chain that would have served the aligned shapes a real workload
+        actually has.
 
-        Returns the smallest M that ran, or ``None`` when nothing did,
-        in which case the two-step form carries every call and stays
-        numerically exact.
+        So the probes anchor the band and then ask which kind it is. If
+        the row after the anchor also runs, the band is a floor. If the
+        anchor's double runs but its successor does not, the band is an
+        alignment. If neither, the band is not describable from here and
+        the chain stands down rather than guess.
+
+        Returns ``("min", n)``, ``("align", n)``, or ``None`` — and on
+        ``None`` the two-step form carries every call, exactly.
         """
-        for m in (1, 2):
-            try:
-                z = torch.zeros(m, self._d, device=self.wp1.device,
-                                dtype=torch.float16)
-                ap, sfa = self._kern.quantize_fp4_sfa_fp16(z)
-                hp, hsfa = self._chain(ap, self.wp1, sfa, self.sfb1,
-                                       self.b1)
-                self._gemm_bias(hp, self.wp2, hsfa, self.sfb2, self.b2)
-                return m
-            except (RuntimeError, ValueError):
-                continue
+        anchor = next((m for m in self._PROBE_M if self._chain_runs(m)),
+                      None)
+        if anchor is None:
+            self._chain = None
+            return None
+        if self._chain_runs(anchor + 1):
+            return ("min", anchor)
+        if anchor > 1 and self._chain_runs(anchor * 2):
+            return ("align", anchor)
         self._chain = None
         return None
+
+    def _chain_serves(self, rows: int) -> bool:
+        kind, n = self._chain_band
+        return rows >= n if kind == "min" else rows % n == 0
 
     def __getattr__(self, name):
         try:
@@ -112,7 +136,7 @@ class FusedGeluMlpNvfp4(GuardedSeam, torch.nn.Module):
         flat = (hidden.reshape(-1, shape[-1]).to(torch.float16)
                 * self.inv1).contiguous()
         ap, sfa = self._kern.quantize_fp4_sfa_fp16(flat)
-        if self._chain is not None and flat.shape[0] >= self._chain_min_m:
+        if self._chain is not None and self._chain_serves(flat.shape[0]):
             hp, hsfa = self._chain(ap, self.wp1, sfa, self.sfb1, self.b1)
             y = self._gemm_bias(hp, self.wp2, hsfa, self.sfb2, self.b2)
             return y.reshape(*shape[:-1], self._d).to(hidden.dtype)

--- a/flash_rt/structures/impls/vision_ffn/nvfp4_balance.py
+++ b/flash_rt/structures/impls/vision_ffn/nvfp4_balance.py
@@ -62,9 +62,39 @@ class FusedGeluMlpNvfp4(GuardedSeam, torch.nn.Module):
             self.register_buffer(name, t)
         self._d = d
         self._f = f
+        self._chain_min_m = (self._audition_chain()
+                             if self._chain is not None else None)
         if original is not None:
             self.host_mlp = original
         self._frt_arm(dtypes=CAST_OK, device=wp1.device, k=d)
+
+    def _audition_chain(self) -> int | None:
+        """The smallest row count the wire chain will actually serve.
+
+        Presence is not qualification, and this qualification is
+        shape-dependent: a chain entry can decline the single row a
+        decode-shaped call brings while serving every larger one. One
+        launch would answer the wrong question — disqualifying a chain
+        over the one shape it declines, or admitting it and failing on
+        the first M=1 call. Two launches at bind measure the band.
+
+        Returns the smallest M that ran, or ``None`` when nothing did,
+        in which case the two-step form carries every call and stays
+        numerically exact.
+        """
+        for m in (1, 2):
+            try:
+                z = torch.zeros(m, self._d, device=self.wp1.device,
+                                dtype=torch.float16)
+                ap, sfa = self._kern.quantize_fp4_sfa_fp16(z)
+                hp, hsfa = self._chain(ap, self.wp1, sfa, self.sfb1,
+                                       self.b1)
+                self._gemm_bias(hp, self.wp2, hsfa, self.sfb2, self.b2)
+                return m
+            except (RuntimeError, ValueError):
+                continue
+        self._chain = None
+        return None
 
     def __getattr__(self, name):
         try:
@@ -82,7 +112,7 @@ class FusedGeluMlpNvfp4(GuardedSeam, torch.nn.Module):
         flat = (hidden.reshape(-1, shape[-1]).to(torch.float16)
                 * self.inv1).contiguous()
         ap, sfa = self._kern.quantize_fp4_sfa_fp16(flat)
-        if self._chain is not None:
+        if self._chain is not None and flat.shape[0] >= self._chain_min_m:
             hp, hsfa = self._chain(ap, self.wp1, sfa, self.sfb1, self.b1)
             y = self._gemm_bias(hp, self.wp2, hsfa, self.sfb2, self.b2)
             return y.reshape(*shape[:-1], self._d).to(hidden.dtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# The structures layer obtains kernels through the Hugging Face kernel
+# hub client. It is optional because the catalog, the specs and the
+# adapters are all readable without it; a bind refuses legibly and names
+# this extra when it is absent.
+hub = ["kernels>=0.12", "torch"]
 torch = ["torch", "safetensors", "sentencepiece"]
 jax = ["jax", "jaxlib", "ml_dtypes", "orbax-checkpoint", "flax"]
 server = ["fastapi", "uvicorn"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,16 @@ dependencies = [
 
 [project.optional-dependencies]
 # The structures layer obtains kernels through the Hugging Face kernel
-# hub client. It is optional because the catalog, the specs and the
-# adapters are all readable without it; a bind refuses legibly and names
-# this extra when it is absent.
-hub = ["kernels>=0.12", "torch"]
+# hub client. Optional because the catalog, the specs and the adapters
+# are all readable without it; a bind refuses legibly and names this
+# extra when it is absent.
+#
+# Deliberately only the client. Naming torch here makes pip install the
+# newest one into an environment that had none, and which kernels exist
+# is decided by the torch version: the hub's published face is thickest
+# at torch 2.11, thin at the newest. Bring your own torch, and see the
+# README for what that choice costs you.
+hub = ["kernels>=0.12"]
 torch = ["torch", "safetensors", "sentencepiece"]
 jax = ["jax", "jaxlib", "ml_dtypes", "orbax-checkpoint", "flax"]
 server = ["fastapi", "uvicorn"]


### PR DESCRIPTION
Prepares the first PyPI release of `flash-rt` as a **pure-Python distribution**: the
frontends, the structure catalog, the engine adapters and the kernel sources, with
no compiled artifact. Kernels arrive from the kernel hub at bind time, or from a
local build for the models actually being run.

Five commits, three of which change behaviour. Each was found by a test that failed,
not by inspection.

## Packaging

`package-data` used a non-recursive glob, so the wheel shipped **0 of 54** structure
specs and per-host bindings — a structures distribution with an empty catalog. Also
adds `py.typed`, ships the kernel sources so the extensions can be built from an
installed tree, and lists only interpreters qualified by a clean-room install.

The `hub` extra deliberately declares the kernel client and **not** torch. Naming
torch made pip install the newest one into an environment that had none, and the
torch version is what decides which kernels exist — the published face is thickest
at torch 2.11 and thin at the newest, so the extra was assembling precisely the
combination the README warns about.

## An absent kernel client is a refusal, not a traceback

`hub_kernel` imported the client outside the block that turns "not here" into
`KernelUnavailable`, so the client being missing raised `ModuleNotFoundError`. The
type is not cosmetic: `KernelUnavailable` is a `ValueError` so that layers which
record a refusal and keep going can catch it. A `ModuleNotFoundError` walks past all
of them and aborts a run that should have skipped a lever and been written down —
the empty `unavailable_report()` next to the traceback was the visible symptom.

This is the state a fresh `pip install` is in, since the client is not a hard
dependency: the first bind a new user attempts.

## The warp-split GEMV is chosen by architecture, not presence

The aarch64 build carries the entry and the kernel refuses at call time below SM120,
so an impl bound on an edge module took the GEMV arm for its first M=1 row and raised
there — presence read as qualification. The engine adapters had been compensating by
patching the constructor afterwards, which protected anyone arriving through a door
and nobody arriving through `structures.get()`. Now decided where the arm is
selected, with the adapters' own predicate, so SM120 keeps it.

## A host whose seats all refuse now starts

`swap.attach` is right to refuse an empty swap set, but `attach_engine` calls it from
inside the engine's `load_model`, so an unreachable hub or an architecture without a
build propagated out and killed engine startup. A server that fails to boot is worse
than one that boots unaccelerated: the refusals are reported and the host is handed
back untouched, behind a handle of the same shape. `strict=True` restores the old
behaviour for CI, where a silent zero-seat run is a fallback nobody reads.

## Documentation

`install_load_hook` appeared nowhere in the docs or the README — someone reading the
repository had no way to learn that vLLM and SGLang are supported, let alone how.
`docs/serving_engines.md` covers the integration on both engines and the reasons the
call looks the way it does (the loader hook rather than the model, the compile cache,
why the batch band lives inside a custom op), then the parts learned by getting them
wrong: the spawn guard SGLang needs, why offline mode is not an air-gap strategy,
that identical prompts collapse into one request's work, and that a host running
per-process bimodal will misstate a paired measurement by more than the effect being
measured. Plus a table mapping every refusal message to the one thing to change.

## Qualification

Twenty cells against the built artifact rather than a working tree, on two
architectures and two engines.

**Package** — no compiled artifact; 55/55 data files; zero hygiene hits and zero test
leakage in wheel and sdist; `py.typed`, LICENSE, classifiers, project URLs; sdist and
wheel install to an identical file set; `twine check` passes both.

**Import contract** — Python 3.10 / 3.11 / 3.12 / 3.13, x86-64 and aarch64. `import
flash_rt` costs 0.4–2.7 ms and pulls neither torch nor any compiled extension; the
catalog reads with numpy and PyYAML as the entire install; everything works with no
GPU present.

**Refusal and transaction** — a cold cache refuses with the reason recorded on the
ledger; a shape outside an entry's support refuses instead of crashing; a bad path
leaves the module tree untouched; `detach` is bit-exact (max abs diff 0.0).

**Host seams** — structural predicates, the `(out, bias)` contract, and band dispatch
verified under `torch.compile` on a hand-built module tree in seconds, plus against a
real vLLM 0.26 install where both runner paths are found.

**Efficacy**, single-stream steady decode, measured through the packaged door:

| host | engine | model | base → attached |
|---|---|---|---|
| consumer GPU (sm_120) | vLLM 0.22 | Qwen3-8B | 99.4 → 157.1 tok/s |
| consumer GPU (sm_120) | SGLang 0.5.13 | Qwen3-8B | 101.0 → 201.5 tok/s |
| edge module (sm_110) | vLLM 0.26 | 35B-A3B MoE | 37.2 → 76.0 tok/s |

Concurrency on the edge module: 2.05× / 2.31× / 2.46× / 1.65× at 1 / 4 / 8 / 16 —
peaking at 8 and still positive at 16, which is not what a dense model would do.
Repeat chains are bit-identical on every arm.

## Known limits

- Efficacy is measured on the models above; other families stand on their own
  earlier receipts.
- One engine version per platform. The host-seam probe needs no model and no GPU and
  finishes in seconds; it is the cheap check to run against any new engine release.
- The native frontends in this tree are verified as shipped and import-safe, not as
  working — those need compiled kernels and their own runs.
- The "present but wrong ABI" branch of the extension refusal has not fired anywhere
  yet.
