### PR TITLE
fix(kernels): honor ROCm backend and gfx metadata

### DIFF
--- a/flash_rt/structures/impls/__init__.py
+++ b/flash_rt/structures/impls/__init__.py
@@ -6,18 +6,18 @@ depend on the same kernel repo must share one loaded module — a second
 ops and torch.library raises.
 
 The loader also checks the package's own hardware declaration. A Hub
-kernel package ships ``metadata.json`` with the CUDA archs it was built
-for; that file is maintained on the kernels side and is the single
+kernel package ships ``metadata.json`` with the backend and archs it was
+built for; that file is maintained on the kernels side and is the single
 source of truth for hardware support — this layer reads it, it does not
-keep a second table. A device outside the declared archs gets a clean
-refusal here, before the kernel produces an unrelated-looking runtime
-error; the refusal is caught by the binder and recorded in the plan
-notes like any other. A package without metadata is loaded as before —
+keep a second table. A device outside the declared backend or archs gets
+a clean refusal here, before the kernel produces an unrelated-looking
+runtime error; the refusal is caught by the binder and recorded in the
+plan notes like any other. A package without metadata is loaded as before —
 absence of a declaration is not evidence of incompatibility.
 """
 
-import os
 import json
+import os
 import pathlib
 import re
 from functools import lru_cache
@@ -30,6 +30,40 @@ def _device_cc() -> tuple[int, int] | None:
     if not torch.cuda.is_available():
         return None
     return torch.cuda.get_device_capability()
+
+
+def _rocm_runtime() -> bool:
+    """Whether this torch build uses HIP rather than CUDA."""
+    import torch
+
+    return bool(getattr(torch.version, "hip", None))
+
+
+_ROCM_ARCH = re.compile(r"^(gfx[0-9a-f]+)(?::.*)?$", re.IGNORECASE)
+
+
+def _device_rocm_arch() -> str | None:
+    """GCN architecture of the current HIP device, without feature suffixes."""
+    import torch
+
+    if not _rocm_runtime() or not torch.cuda.is_available():
+        return None
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    raw = getattr(props, "gcnArchName", None)
+    match = _ROCM_ARCH.fullmatch(str(raw or ""))
+    return match.group(1).lower() if match is not None else None
+
+
+def _declared_backend(module) -> str | None:
+    """The package's own ``backend.type`` declaration, if present."""
+    try:
+        meta = pathlib.Path(module.__file__).parent / "metadata.json"
+        if not meta.is_file():
+            return None
+        backend = json.loads(meta.read_text()).get("backend", {}).get("type")
+        return str(backend).lower() if backend else None
+    except (OSError, ValueError, AttributeError):
+        return None
 
 
 def _declared_archs(module) -> list[str] | None:
@@ -121,15 +155,43 @@ def _record_unavailable(repo: str, version: str, cause: BaseException):
 
 def _check_arch(repo: str, module) -> None:
     archs = _declared_archs(module)
-    if archs is None:
+    backend = _declared_backend(module)
+    if archs is None and backend is None:
         return
+    if _rocm_runtime():
+        gfx = _device_rocm_arch()
+        if gfx is None:
+            # no usable HIP device: binding fails later at weight transfer;
+            # the arch check has nothing truthful to compare
+            return
+        if backend not in (None, "rocm"):
+            refusal = KernelUnavailable(
+                f"refused: kernel package {repo!r} declares backend "
+                f"{backend!r} archs {archs}, device is rocm {gfx}")
+            _record_unavailable(repo, "declared-archs", refusal)
+            raise refusal
+        if archs is None or any(str(a).lower() == gfx for a in archs):
+            return
+        refusal = KernelUnavailable(
+            f"refused: kernel package {repo!r} declares backend 'rocm' "
+            f"archs {archs}, device is rocm {gfx}")
+        _record_unavailable(repo, "declared-archs", refusal)
+        raise refusal
+
     cc = _device_cc()
     if cc is None:
         # no CUDA device: binding fails later at weight transfer anyway;
         # the arch check has nothing truthful to say here
         return
+    if backend not in (None, "cuda"):
+        want = f"{cc[0]}.{cc[1]}"
+        refusal = KernelUnavailable(
+            f"refused: kernel package {repo!r} declares backend "
+            f"{backend!r} archs {archs}, device is cuda sm {want}")
+        _record_unavailable(repo, "declared-archs", refusal)
+        raise refusal
     want = f"{cc[0]}.{cc[1]}"
-    if any(_cuda_arch_supports_device(a, cc) for a in archs):
+    if archs is None or any(_cuda_arch_supports_device(a, cc) for a in archs):
         return
     refusal = KernelUnavailable(
         f"refused: kernel package {repo!r} declares archs {archs}, "
@@ -167,6 +229,28 @@ def hub_kernel(repo: str, version: str):
             f"    pip install 'flash-rt[hub]'") from absent
 
     key = (repo, version)
+    slug = re.sub(r"[^A-Za-z0-9]", "_", repo).upper()
+    var_dir = os.environ.get("FRT_KERNEL_DIR_" + slug)
+    if var_dir and key not in _LOADED:
+        # Filesystem-direct variant loading was delivered upstream in
+        # e8f8e938. The directory remains a formally built package variant;
+        # this bypasses only client/network resolution, not metadata checks.
+        import importlib.util
+        import sys as _sys
+
+        init = os.path.join(var_dir, "__init__.py")
+        if not os.path.isfile(init):
+            raise KernelUnavailable(
+                f"kernel package {repo!r}: FRT_KERNEL_DIR_{slug} does "
+                f"not point at a build variant (no __init__.py in "
+                f"{var_dir!r})")
+        mod_name = "_frt_kernel_" + slug.lower()
+        spec = importlib.util.spec_from_file_location(
+            mod_name, init, submodule_search_locations=[var_dir])
+        module = importlib.util.module_from_spec(spec)
+        _sys.modules[mod_name] = module
+        spec.loader.exec_module(module)
+        _LOADED[key] = module
     if key not in _LOADED:
         # author pin for artifact bisection: an exact hub revision
         # outranks version resolution for this repo only. A perf or

--- a/tests/test_kernel_unavailable.py
+++ b/tests/test_kernel_unavailable.py
@@ -49,6 +49,7 @@ def test_arch_refusal_uses_the_same_type(monkeypatch):
 
     monkeypatch.setattr("kernels.get_kernel", lambda *a, **k: Module())
     monkeypatch.setattr(impls, "_declared_archs", lambda module: ["9.0"])
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: False)
     monkeypatch.setattr(impls, "_device_cc", lambda: (11, 0))
 
     with pytest.raises(impls.KernelUnavailable) as caught:
@@ -57,6 +58,38 @@ def test_arch_refusal_uses_the_same_type(monkeypatch):
 
     impls.hub_kernel.cache_clear()
     impls._LOADED.clear()
+
+
+def test_formal_variant_directory_bypasses_client_resolution(
+        monkeypatch, tmp_path):
+    variant = tmp_path / "variant"
+    variant.mkdir()
+    (variant / "__init__.py").write_text("VALUE = 'formal-variant'\n")
+    monkeypatch.setenv("FRT_KERNEL_DIR_TEST_DIRECT", str(variant))
+    monkeypatch.setattr(
+        "kernels.get_kernel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("client resolution must not run")),
+    )
+    impls.hub_kernel.cache_clear()
+    impls._LOADED.pop(("test/direct", ">=1"), None)
+
+    module = impls.hub_kernel("test/direct", ">=1")
+
+    assert module.VALUE == "formal-variant"
+    impls._LOADED.pop(("test/direct", ">=1"), None)
+    impls.hub_kernel.cache_clear()
+
+
+def test_variant_directory_must_be_a_package(monkeypatch, tmp_path):
+    monkeypatch.setenv("FRT_KERNEL_DIR_TEST_BAD_DIRECT", str(tmp_path))
+    impls.hub_kernel.cache_clear()
+    impls._LOADED.pop(("test/bad-direct", ">=1"), None)
+
+    with pytest.raises(impls.KernelUnavailable, match="no __init__.py"):
+        impls.hub_kernel("test/bad-direct", ">=1")
+
+    impls.hub_kernel.cache_clear()
 
 
 def test_the_run_keeps_going_but_the_failure_is_on_the_record(monkeypatch):

--- a/tests/test_structures_hwcap.py
+++ b/tests/test_structures_hwcap.py
@@ -1,8 +1,8 @@
-"""The hardware line: the package's own arch declaration is the truth.
+"""The hardware line: the package's own backend/arch declaration is truth.
 
-A Hub kernel package ships ``metadata.json`` naming the CUDA archs it
-was built for; the shared loader reads that declaration and refuses a
-device outside it with a message a person can act on — before the
+A Hub kernel package ships ``metadata.json`` naming the backend and archs it
+was built for; the shared loader reads that declaration and refuses a device
+outside either with a message a person can act on — before the
 kernel produces an unrelated-looking runtime error. The structures
 layer keeps no arch table of its own: hardware support is maintained on
 the kernels side, and absence of a declaration loads as before.
@@ -31,12 +31,75 @@ def test_declared_archs_read_from_package_metadata(tmp_path):
         {"backend": {"type": "cuda", "archs": ["12.0a", "12.1"]}},
     )
     assert impls._declared_archs(mod) == ["12.0a", "12.1"]
+    assert impls._declared_backend(mod) == "cuda"
 
 
 def test_missing_metadata_means_no_declaration(tmp_path):
     assert impls._declared_archs(_fake_module(tmp_path)) is None
     mod = _fake_module(tmp_path, {"backend": {}})
     assert impls._declared_archs(mod) is None
+    assert impls._declared_backend(mod) is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "gfx950",
+        "gfx950:sramecc+:xnack-",
+        "GFX950:SRAMECC+:XNACK-",
+    ],
+)
+def test_rocm_device_arch_strips_feature_suffixes(monkeypatch, raw):
+    import torch
+
+    props = types.SimpleNamespace(gcnArchName=raw)
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda *_: props)
+    assert impls._device_rocm_arch() == "gfx950"
+
+
+def test_compatible_rocm_arch_declaration_passes(tmp_path, monkeypatch):
+    mod = _fake_module(
+        tmp_path,
+        {"backend": {"type": "rocm", "archs": ["gfx942", "gfx950"]}},
+    )
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: True)
+    monkeypatch.setattr(impls, "_device_rocm_arch", lambda: "gfx950")
+    impls._check_arch("kernels-community/aiter-flash-attn-ck", mod)
+
+
+def test_incompatible_rocm_arch_gets_a_clean_refusal(tmp_path, monkeypatch):
+    mod = _fake_module(
+        tmp_path,
+        {"backend": {"type": "rocm", "archs": ["gfx942"]}},
+    )
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: True)
+    monkeypatch.setattr(impls, "_device_rocm_arch", lambda: "gfx950")
+    with pytest.raises(ValueError, match="device is rocm gfx950"):
+        impls._check_arch("flashrt/x", mod)
+
+
+@pytest.mark.parametrize(
+    ("package_backend", "runtime_rocm", "message"),
+    [
+        ("cuda", True, "device is rocm gfx950"),
+        ("rocm", False, "device is cuda sm 12.0"),
+    ],
+)
+def test_backend_mismatch_gets_a_clean_refusal(
+        tmp_path, monkeypatch, package_backend, runtime_rocm, message):
+    arch = "gfx950" if package_backend == "rocm" else "12.0a"
+    mod = _fake_module(
+        tmp_path,
+        {"backend": {"type": package_backend, "archs": [arch]}},
+    )
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: runtime_rocm)
+    monkeypatch.setattr(impls, "_device_rocm_arch", lambda: "gfx950")
+    monkeypatch.setattr(impls, "_device_cc", lambda: (12, 0))
+    with pytest.raises(ValueError, match=message):
+        impls._check_arch("flashrt/x", mod)
 
 
 @pytest.mark.parametrize(
@@ -56,6 +119,7 @@ def test_compatible_cuda_arch_declarations_pass(
         tmp_path,
         {"backend": {"type": "cuda", "archs": archs}},
     )
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: False)
     monkeypatch.setattr(impls, "_device_cc", lambda: device_cc)
     impls._check_arch("flashrt/x", mod)
 
@@ -77,6 +141,7 @@ def test_incompatible_cuda_arch_gets_a_clean_refusal(
         tmp_path,
         {"backend": {"type": "cuda", "archs": archs}},
     )
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: False)
     monkeypatch.setattr(impls, "_device_cc", lambda: device_cc)
     with pytest.raises(ValueError, match="refused"):
         impls._check_arch("flashrt/x", mod)
@@ -89,11 +154,13 @@ def test_no_cuda_device_defers_to_the_bind_path(tmp_path, monkeypatch):
         tmp_path,
         {"backend": {"type": "cuda", "archs": ["12.0a"]}},
     )
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: False)
     monkeypatch.setattr(impls, "_device_cc", lambda: None)
     impls._check_arch("flashrt/x", mod)
 
 
 def test_undeclared_package_is_not_refused(tmp_path, monkeypatch):
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: False)
     monkeypatch.setattr(impls, "_device_cc", lambda: (8, 0))
     impls._check_arch("flashrt/x", _fake_module(tmp_path))
 
@@ -115,6 +182,7 @@ def test_refusal_does_not_reload_the_package(monkeypatch, tmp_path):
     import kernels
 
     monkeypatch.setattr(kernels, "get_kernel", fake_get_kernel)
+    monkeypatch.setattr(impls, "_rocm_runtime", lambda: False)
     monkeypatch.setattr(impls, "_device_cc", lambda: (8, 9))
     impls._LOADED.pop(("test/arch-refused", ">=1"), None)
     impls.hub_kernel.cache_clear()


### PR DESCRIPTION
Makes the shared Hub loader backend-aware on ROCm and lets formal build variants load in-process without forcing the host to upgrade its Hugging Face kernel client.

Changes:
- read package-owned `backend.type` and `backend.archs`
- normalize HIP `gcnArchName` feature suffixes and match exact `gfx*` targets
- refuse CUDA/ROCm backend mismatches cleanly
- reuse the direct formal-variant loader delivered upstream in `e8f8e938`
- keep CUDA cubin/PTX compatibility semantics unchanged
- pin backend-explicit CPU tests, including real ROCm-PyTorch execution

Validation:
- [x] 31 local loader/hardware tests
- [x] 292 source-only structure/loader regressions passed, 5 skipped, 1 compiled-install assertion deselected
- [x] 31/31 tests under ROCm PyTorch 2.11 on matx1
- [x] 31/31 tests under ROCm PyTorch 2.11 on matx2
- [x] formal signed CK gfx950 artifact imported twice through `hub_kernel` with pinned OpenPI dependencies and `kernels==0.12.3`
- [x] MI350X metadata acceptance and launch probe: PyTorch `2.11.0+rocm7.2`, HIP `7.2.26015`, `gfx950:sramecc+:xnack-`, capability tuple `(9, 5)`, no unavailable variant
- [x] lint and diff checks

The deselected install assertion requires a locally built `flash_rt_kernels` shared library and is unrelated to the Python loader delta. The loader's hardware gate is complete; this remains draft only for maintainer review.
