### PR TITLE
AMD MI350X (CDNA4) backend — Pi0.5 at 16.4 ms FP8

### DIFF
--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CMAKE_HIP_ARCHITECTURES "${GPU_ARCH}")
 set(CMAKE_HIP_STANDARD 17)
 
 find_package(hip REQUIRED)
+find_package(hipblaslt REQUIRED)
 
 # ── pybind11 (same resolution as root CMake: ask the interpreter) ──
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
@@ -56,6 +57,11 @@ find_package(pybind11 CONFIG REQUIRED)
 set(FLASHRT_AMD_SOURCES
   bindings.cpp
   kernels/norm.hip
+  kernels/activation.hip
+  kernels/elementwise.hip
+  kernels/rope.hip
+  kernels/patch_embed.hip
+  gemm/hipblaslt_runner.hip
 )
 set_source_files_properties(${FLASHRT_AMD_SOURCES} PROPERTIES LANGUAGE HIP)
 
@@ -65,7 +71,7 @@ target_compile_definitions(flash_rt_amd_kernels PRIVATE
   FLASHRT_AMD_GPU_ARCH="${GPU_ARCH}")
 target_compile_options(flash_rt_amd_kernels PRIVATE
   $<$<COMPILE_LANGUAGE:HIP>:-O3 -ffp-contract=fast>)
-target_link_libraries(flash_rt_amd_kernels PRIVATE hip::host)
+target_link_libraries(flash_rt_amd_kernels PRIVATE hip::host roc::hipblaslt)
 
 set_target_properties(flash_rt_amd_kernels PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../flash_rt/amd")

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -63,7 +63,9 @@ set(FLASHRT_AMD_SOURCES
   kernels/patch_embed.hip
   kernels/fusion.hip
   kernels/quantize_fp8.hip
+  attention/decoder_flash.hip
   gemm/hipblaslt_runner.hip
+  gemm/smallm_fp8.hip
 )
 set_source_files_properties(${FLASHRT_AMD_SOURCES} PROPERTIES LANGUAGE HIP)
 

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -61,6 +61,8 @@ set(FLASHRT_AMD_SOURCES
   kernels/elementwise.hip
   kernels/rope.hip
   kernels/patch_embed.hip
+  kernels/fusion.hip
+  kernels/quantize_fp8.hip
   gemm/hipblaslt_runner.hip
 )
 set_source_files_properties(${FLASHRT_AMD_SOURCES} PROPERTIES LANGUAGE HIP)

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -67,6 +67,7 @@ set(FLASHRT_AMD_SOURCES
   kernels/ew_tune.hip
   attention/decoder_flash.hip
   attention/attn_probe.hip
+  attention/encoder_flash.hip
   gemm/hipblaslt_runner.hip
   gemm/smallm_fp8.hip
   gemm/smallm_mfma.hip

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -66,6 +66,7 @@ set(FLASHRT_AMD_SOURCES
   kernels/stream_probe.hip
   kernels/ew_tune.hip
   attention/decoder_flash.hip
+  attention/attn_probe.hip
   gemm/hipblaslt_runner.hip
   gemm/smallm_fp8.hip
   gemm/smallm_mfma.hip

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -64,9 +64,11 @@ set(FLASHRT_AMD_SOURCES
   kernels/fusion.hip
   kernels/quantize_fp8.hip
   kernels/stream_probe.hip
+  kernels/ew_tune.hip
   attention/decoder_flash.hip
   gemm/hipblaslt_runner.hip
   gemm/smallm_fp8.hip
+  gemm/smallm_mfma.hip
   gemm/decoder_ffn_fused.hip
 )
 set_source_files_properties(${FLASHRT_AMD_SOURCES} PROPERTIES LANGUAGE HIP)

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -63,9 +63,11 @@ set(FLASHRT_AMD_SOURCES
   kernels/patch_embed.hip
   kernels/fusion.hip
   kernels/quantize_fp8.hip
+  kernels/stream_probe.hip
   attention/decoder_flash.hip
   gemm/hipblaslt_runner.hip
   gemm/smallm_fp8.hip
+  gemm/decoder_ffn_fused.hip
 )
 set_source_files_properties(${FLASHRT_AMD_SOURCES} PROPERTIES LANGUAGE HIP)
 

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -1,0 +1,71 @@
+# ================================================================
+# FlashRT AMD — standalone HIP build (never wired into root CMake).
+#
+#   cmake -B build-amd -S csrc/amd [-DGPU_ARCH=gfx950]
+#   cmake --build build-amd -j 8
+#
+# Output: flash_rt/amd/flash_rt_amd_kernels*.so
+# The root CMakeLists (CUDA) is untouched; the two builds never mix.
+# ================================================================
+cmake_minimum_required(VERSION 3.21)
+project(flash_rt_amd LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ── ROCm location ──
+if(NOT DEFINED ROCM_PATH)
+  if(DEFINED ENV{ROCM_PATH})
+    set(ROCM_PATH "$ENV{ROCM_PATH}")
+  else()
+    set(ROCM_PATH "/opt/rocm")
+  endif()
+endif()
+list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}")
+
+# ── GPU_ARCH: gfx string, auto-detected from rocminfo when not given ──
+if(NOT DEFINED GPU_ARCH)
+  execute_process(
+    COMMAND bash -c "${ROCM_PATH}/bin/rocminfo 2>/dev/null | grep -om1 'gfx[0-9a-f]\\+'"
+    OUTPUT_VARIABLE GPU_ARCH_DETECTED
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(GPU_ARCH_DETECTED STREQUAL "")
+    set(GPU_ARCH "gfx950")
+    message(STATUS "flash_rt_amd: no GPU visible, defaulting GPU_ARCH=${GPU_ARCH}")
+  else()
+    set(GPU_ARCH "${GPU_ARCH_DETECTED}")
+  endif()
+endif()
+message(STATUS "flash_rt_amd: GPU_ARCH=${GPU_ARCH}")
+
+enable_language(HIP)
+set(CMAKE_HIP_ARCHITECTURES "${GPU_ARCH}")
+set(CMAKE_HIP_STANDARD 17)
+
+find_package(hip REQUIRED)
+
+# ── pybind11 (same resolution as root CMake: ask the interpreter) ──
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m pybind11 --cmakedir
+  OUTPUT_VARIABLE pybind11_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_package(pybind11 CONFIG REQUIRED)
+
+# ── Kernel module ──
+set(FLASHRT_AMD_SOURCES
+  bindings.cpp
+  kernels/norm.hip
+)
+set_source_files_properties(${FLASHRT_AMD_SOURCES} PROPERTIES LANGUAGE HIP)
+
+pybind11_add_module(flash_rt_amd_kernels ${FLASHRT_AMD_SOURCES})
+
+target_compile_definitions(flash_rt_amd_kernels PRIVATE
+  FLASHRT_AMD_GPU_ARCH="${GPU_ARCH}")
+target_compile_options(flash_rt_amd_kernels PRIVATE
+  $<$<COMPILE_LANGUAGE:HIP>:-O3 -ffp-contract=fast>)
+target_link_libraries(flash_rt_amd_kernels PRIVATE hip::host)
+
+set_target_properties(flash_rt_amd_kernels PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../flash_rt/amd")

--- a/csrc/amd/README.md
+++ b/csrc/amd/README.md
@@ -1,0 +1,46 @@
+# FlashRT AMD Source
+
+`csrc/amd` is the AMD/ROCm kernel tree. The existing `csrc` tree stays
+CUDA-only; the two never build together.
+
+## Contract
+
+Same raw-pointer ABI as the CUDA module: every binding takes `uintptr_t`
+device pointers plus a `uintptr_t` stream, never tensors. Entries keep the
+CUDA-side names and signatures so pipeline code stays portable text.
+
+Kernels are written in plain HIP C++ against CDNA (wave64) — MFMA compiler
+intrinsics, LDS, no third-party template libraries. `hipBLASLt` (shipped
+with ROCm) backs the `GemmRunner` and is the baseline every hand-written
+GEMM must beat standalone before entering the pipeline.
+
+## Build
+
+Standalone CMake project (the root `CMakeLists.txt` is CUDA and untouched):
+
+```bash
+cmake -B build-amd -S csrc/amd [-DGPU_ARCH=gfx950]
+cmake --build build-amd -j 8
+```
+
+or via the wrapper (with hipcc fallback for cmake-less environments):
+
+```bash
+bash scripts/amd/build_amd.sh gfx950
+```
+
+Output: `flash_rt/amd/flash_rt_amd_kernels*.so`, imported as
+`from flash_rt.amd import flash_rt_amd_kernels`.
+
+## Layout
+
+```
+bindings.cpp        pybind11 module flash_rt_amd_kernels (raw-pointer ABI)
+kernels/            elementwise/norm/activation/quantize kernels (.hip)
+  common_hip.h      wave64 reductions, dtype templates (mirrors common.cuh)
+gemm/               hipBLASLt runner + probe (added with the pipeline port)
+attention/          hand-written CDNA attention (added with the pipeline port)
+```
+
+Python runtime twins live in `flash_rt/amd/core/` (`hip_buffer.py`,
+`hip_graph.py`).

--- a/csrc/amd/attention/attn_probe.hip
+++ b/csrc/amd/attention/attn_probe.hip
@@ -204,7 +204,31 @@ void attn_partial_probe_kernel(
             const float* sp = &s_lds[q * APROBE_S_PITCH];
             const __hip_bfloat162* vp = &kv_lds[dp];
             float ax, ay;
-            if (mask & 128) {
+            if (mask & 512) {
+                // ILP8 PV: 8 independent chains.
+                float axs[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+                float ays[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+                int j = 0;
+                for (; j + 7 < cn; j += 8) {
+                    #pragma unroll
+                    for (int t = 0; t < 8; ++t) {
+                        const __hip_bfloat162 v = vp[(j + t) * APROBE_KV_PITCH];
+                        const float pj = sp[j + t];
+                        axs[t] = fmaf(pj, __bfloat162float(v.x), axs[t]);
+                        ays[t] = fmaf(pj, __bfloat162float(v.y), ays[t]);
+                    }
+                }
+                for (; j < cn; ++j) {
+                    const __hip_bfloat162 v = vp[j * APROBE_KV_PITCH];
+                    const float pj = sp[j];
+                    axs[0] = fmaf(pj, __bfloat162float(v.x), axs[0]);
+                    ays[0] = fmaf(pj, __bfloat162float(v.y), ays[0]);
+                }
+                ax = ((axs[0] + axs[1]) + (axs[2] + axs[3]))
+                   + ((axs[4] + axs[5]) + (axs[6] + axs[7]));
+                ay = ((ays[0] + ays[1]) + (ays[2] + ays[3]))
+                   + ((ays[4] + ays[5]) + (ays[6] + ays[7]));
+            } else if (mask & 128) {
                 // ILP4 PV: 4 independent accumulator chains, fixed
                 // combine order.
                 float ax0 = 0.0f, ay0 = 0.0f, ax1 = 0.0f, ay1 = 0.0f;

--- a/csrc/amd/attention/attn_probe.hip
+++ b/csrc/amd/attention/attn_probe.hip
@@ -1,0 +1,270 @@
+// ================================================================
+// FlashRT AMD — decoder-attention phase-ablation probe (CDNA4)
+//
+// Companion to kernels/stream_probe.h and kernels/ew_tune.h. The
+// production split-KV partial kernel measures ~17us in an in-graph
+// chain while a work model predicts ~4-5: this probe replicates the
+// kernel with a runtime phase mask so each phase's cost is measured,
+// not guessed. Mask bits: 1=stage Q+K, 2=phase A scores, 4=stage V,
+// 8=phase B softmax, 16=phase C PV, 32=workspace store. Phases build
+// on garbage inputs when earlier bits are off — the probe measures
+// TIME only; outputs are never checked (never route production here).
+// ================================================================
+
+#include "../kernels/common_hip.h"
+#include <cfloat>
+#include <hip/hip_fp8.h>
+#include <stdexcept>
+
+#define APROBE_NTHREADS  256
+#define APROBE_SQ_MAX    16
+#define APROBE_D_MAX     256
+#define APROBE_CHUNK_MAX 64
+#define APROBE_KV_PITCH  (APROBE_D_MAX / 2 + 1)
+#define APROBE_Q_PITCH   (APROBE_D_MAX + 2)
+#define APROBE_S_PITCH   (APROBE_CHUNK_MAX + 1)
+
+namespace {
+
+__device__ __forceinline__ void aprobe_stage_ilp4(
+    __hip_bfloat162* __restrict__ dst,
+    const __hip_bfloat162* __restrict__ src,
+    int cn, int dh, int tid) {
+    const int total = cn * dh;
+    int idx = tid;
+    for (; idx + 3 * APROBE_NTHREADS < total; idx += 4 * APROBE_NTHREADS) {
+        const int i0 = idx, i1 = idx + APROBE_NTHREADS;
+        const int i2 = idx + 2 * APROBE_NTHREADS, i3 = idx + 3 * APROBE_NTHREADS;
+        const __hip_bfloat162 v0 = src[i0], v1 = src[i1];
+        const __hip_bfloat162 v2 = src[i2], v3 = src[i3];
+        const int r0 = i0 / dh, e0 = i0 - r0 * dh;
+        const int r1 = i1 / dh, e1 = i1 - r1 * dh;
+        const int r2 = i2 / dh, e2 = i2 - r2 * dh;
+        const int r3 = i3 / dh, e3 = i3 - r3 * dh;
+        dst[r0 * APROBE_KV_PITCH + e0] = v0;
+        dst[r1 * APROBE_KV_PITCH + e1] = v1;
+        dst[r2 * APROBE_KV_PITCH + e2] = v2;
+        dst[r3 * APROBE_KV_PITCH + e3] = v3;
+    }
+    for (; idx < total; idx += APROBE_NTHREADS) {
+        const int r = idx / dh, e = idx - r * dh;
+        dst[r * APROBE_KV_PITCH + e] = src[idx];
+    }
+}
+
+template <int NSPLIT>
+__global__ __launch_bounds__(APROBE_NTHREADS)
+void attn_partial_probe_kernel(
+    const __hip_bfloat16* __restrict__ Q,
+    const __hip_bfloat16* __restrict__ K,
+    const __hip_bfloat16* __restrict__ V,
+    float* __restrict__ ws,
+    int Sq, int Skv, int Hq, int D, float scale, int mask) {
+    const int split = blockIdx.x;
+    const int h     = blockIdx.y;
+    const int tid   = threadIdx.x;
+
+    alignas(16) __shared__ __hip_bfloat162 kv_lds[APROBE_CHUNK_MAX * APROBE_KV_PITCH];
+    alignas(16) __shared__ float q_lds[APROBE_SQ_MAX * APROBE_Q_PITCH];
+    alignas(16) __shared__ float s_lds[APROBE_SQ_MAX * APROBE_S_PITCH];
+
+    int skv_eff = Skv;
+    if (skv_eff > NSPLIT * APROBE_CHUNK_MAX) skv_eff = NSPLIT * APROBE_CHUNK_MAX;
+    const int chunk = (skv_eff + NSPLIT - 1) / NSPLIT;
+    const int start = split * chunk;
+    int end = start + chunk;
+    if (end > skv_eff) end = skv_eff;
+    const int cn = end - start;
+    const int dh = D >> 1;
+
+    const size_t base = (size_t)(split * Hq + h) * (size_t)Sq * (size_t)(D + 2);
+    float* acc_ws = ws + base;
+    float* m_ws   = ws + base + (size_t)Sq * D;
+    float* l_ws   = m_ws + Sq;
+    if (cn <= 0) {
+        if (tid < Sq) { m_ws[tid] = -FLT_MAX; l_ws[tid] = 0.0f; }
+        return;
+    }
+
+    if (mask & 1) {
+        for (int idx = tid; idx < Sq * D; idx += APROBE_NTHREADS) {
+            const int q = idx / D;
+            const int d = idx - q * D;
+            q_lds[q * APROBE_Q_PITCH + d] =
+                __bfloat162float(Q[((size_t)q * Hq + h) * D + d]);
+        }
+        const __hip_bfloat162* K2 = reinterpret_cast<const __hip_bfloat162*>(K);
+        aprobe_stage_ilp4(kv_lds, K2 + (size_t)start * dh, cn, dh, tid);
+    }
+    __syncthreads();
+
+    if (mask & 2) {
+        const int npairs = Sq * cn;
+        for (int p = tid; p < npairs; p += APROBE_NTHREADS) {
+            const int q = p / cn;
+            const int r = p - q * cn;
+            const __hip_bfloat162* kr = &kv_lds[r * APROBE_KV_PITCH];
+            const float2* qr =
+                reinterpret_cast<const float2*>(&q_lds[q * APROBE_Q_PITCH]);
+            float a0 = 0.0f, a1 = 0.0f, a2 = 0.0f, a3 = 0.0f;
+            if (mask & 256) {
+                // 8-deep explicit load batching (dh % 8: D % 16 == 0
+                // at the site). Per-chain accumulation order is
+                // identical to the baseline loop — bit-exact.
+                for (int i = 0; i < dh; i += 8) {
+                    __hip_bfloat162 kk[8];
+                    float2 qq[8];
+                    #pragma unroll
+                    for (int t = 0; t < 8; ++t) { kk[t] = kr[i + t]; qq[t] = qr[i + t]; }
+                    #pragma unroll
+                    for (int t = 0; t < 8; t += 2) {
+                        a0 = fmaf(__bfloat162float(kk[t].x),     qq[t].x,     a0);
+                        a1 = fmaf(__bfloat162float(kk[t].y),     qq[t].y,     a1);
+                        a2 = fmaf(__bfloat162float(kk[t + 1].x), qq[t + 1].x, a2);
+                        a3 = fmaf(__bfloat162float(kk[t + 1].y), qq[t + 1].y, a3);
+                    }
+                }
+            } else {
+                #pragma unroll 4
+                for (int i = 0; i < dh; i += 2) {
+                    const __hip_bfloat162 k0 = kr[i];
+                    const __hip_bfloat162 k1 = kr[i + 1];
+                    const float2 q0 = qr[i];
+                    const float2 q1 = qr[i + 1];
+                    a0 = fmaf(__bfloat162float(k0.x), q0.x, a0);
+                    a1 = fmaf(__bfloat162float(k0.y), q0.y, a1);
+                    a2 = fmaf(__bfloat162float(k1.x), q1.x, a2);
+                    a3 = fmaf(__bfloat162float(k1.y), q1.y, a3);
+                }
+            }
+            s_lds[q * APROBE_S_PITCH + r] = ((a0 + a1) + (a2 + a3)) * scale;
+        }
+    }
+    __syncthreads();
+
+    if (mask & 4) {
+        const __hip_bfloat162* V2 = reinterpret_cast<const __hip_bfloat162*>(V);
+        aprobe_stage_ilp4(kv_lds, V2 + (size_t)start * dh, cn, dh, tid);
+    }
+    if (mask & 8) {
+        if (tid < Sq) {
+            float* sp = &s_lds[tid * APROBE_S_PITCH];
+            if (mask & 64) {
+                // ILP4 softmax: 4 independent chains break the serial
+                // LDS-latency dependency (max is order-free; the exp
+                // sum combines chains in fixed order).
+                float m0 = -FLT_MAX, m1 = -FLT_MAX, m2 = -FLT_MAX, m3 = -FLT_MAX;
+                int j = 0;
+                for (; j + 3 < cn; j += 4) {
+                    m0 = fmaxf(m0, sp[j]);
+                    m1 = fmaxf(m1, sp[j + 1]);
+                    m2 = fmaxf(m2, sp[j + 2]);
+                    m3 = fmaxf(m3, sp[j + 3]);
+                }
+                for (; j < cn; ++j) m0 = fmaxf(m0, sp[j]);
+                const float m = fmaxf(fmaxf(m0, m1), fmaxf(m2, m3));
+                float l0 = 0.0f, l1 = 0.0f, l2 = 0.0f, l3 = 0.0f;
+                j = 0;
+                for (; j + 3 < cn; j += 4) {
+                    const float e0 = __expf(sp[j] - m);
+                    const float e1 = __expf(sp[j + 1] - m);
+                    const float e2 = __expf(sp[j + 2] - m);
+                    const float e3 = __expf(sp[j + 3] - m);
+                    sp[j] = e0; sp[j + 1] = e1; sp[j + 2] = e2; sp[j + 3] = e3;
+                    l0 += e0; l1 += e1; l2 += e2; l3 += e3;
+                }
+                for (; j < cn; ++j) {
+                    const float e = __expf(sp[j] - m);
+                    sp[j] = e;
+                    l0 += e;
+                }
+                m_ws[tid] = m;
+                l_ws[tid] = (l0 + l1) + (l2 + l3);
+            } else {
+                float m = -FLT_MAX;
+                for (int j = 0; j < cn; ++j) m = fmaxf(m, sp[j]);
+                float l = 0.0f;
+                for (int j = 0; j < cn; ++j) {
+                    const float e = __expf(sp[j] - m);
+                    sp[j] = e;
+                    l += e;
+                }
+                m_ws[tid] = m;
+                l_ws[tid] = l;
+            }
+        }
+    }
+    __syncthreads();
+
+    if (mask & 16) {
+        const int nunits = Sq * dh;
+        for (int u = tid; u < nunits; u += APROBE_NTHREADS) {
+            const int q  = u / dh;
+            const int dp = u - q * dh;
+            const float* sp = &s_lds[q * APROBE_S_PITCH];
+            const __hip_bfloat162* vp = &kv_lds[dp];
+            float ax, ay;
+            if (mask & 128) {
+                // ILP4 PV: 4 independent accumulator chains, fixed
+                // combine order.
+                float ax0 = 0.0f, ay0 = 0.0f, ax1 = 0.0f, ay1 = 0.0f;
+                float ax2 = 0.0f, ay2 = 0.0f, ax3 = 0.0f, ay3 = 0.0f;
+                int j = 0;
+                for (; j + 3 < cn; j += 4) {
+                    const __hip_bfloat162 v0 = vp[(j)     * APROBE_KV_PITCH];
+                    const __hip_bfloat162 v1 = vp[(j + 1) * APROBE_KV_PITCH];
+                    const __hip_bfloat162 v2 = vp[(j + 2) * APROBE_KV_PITCH];
+                    const __hip_bfloat162 v3 = vp[(j + 3) * APROBE_KV_PITCH];
+                    const float p0 = sp[j], p1 = sp[j + 1];
+                    const float p2 = sp[j + 2], p3 = sp[j + 3];
+                    ax0 = fmaf(p0, __bfloat162float(v0.x), ax0);
+                    ay0 = fmaf(p0, __bfloat162float(v0.y), ay0);
+                    ax1 = fmaf(p1, __bfloat162float(v1.x), ax1);
+                    ay1 = fmaf(p1, __bfloat162float(v1.y), ay1);
+                    ax2 = fmaf(p2, __bfloat162float(v2.x), ax2);
+                    ay2 = fmaf(p2, __bfloat162float(v2.y), ay2);
+                    ax3 = fmaf(p3, __bfloat162float(v3.x), ax3);
+                    ay3 = fmaf(p3, __bfloat162float(v3.y), ay3);
+                }
+                for (; j < cn; ++j) {
+                    const __hip_bfloat162 v = vp[j * APROBE_KV_PITCH];
+                    const float pj = sp[j];
+                    ax0 = fmaf(pj, __bfloat162float(v.x), ax0);
+                    ay0 = fmaf(pj, __bfloat162float(v.y), ay0);
+                }
+                ax = (ax0 + ax1) + (ax2 + ax3);
+                ay = (ay0 + ay1) + (ay2 + ay3);
+            } else {
+                ax = 0.0f; ay = 0.0f;
+                for (int j = 0; j < cn; ++j) {
+                    const __hip_bfloat162 v = vp[j * APROBE_KV_PITCH];
+                    const float pj = sp[j];
+                    ax = fmaf(pj, __bfloat162float(v.x), ax);
+                    ay = fmaf(pj, __bfloat162float(v.y), ay);
+                }
+            }
+            if (mask & 32) {
+                float* out = acc_ws + (size_t)q * D + 2 * dp;
+                out[0] = ax;
+                out[1] = ay;
+            } else if (ax == 1234.5f && ay == 6789.0f) {
+                acc_ws[0] = ax;   // dead guard: keep the loop live
+            }
+        }
+    }
+}
+
+} // namespace
+
+void attn_partial_probe(const __hip_bfloat16* Q, const __hip_bfloat16* K,
+                        const __hip_bfloat16* V, float* ws,
+                        int Sq, int Skv, int Hq, int D, float scale,
+                        int nsplit, int mask, hipStream_t stream) {
+    dim3 grid(nsplit, Hq);
+    switch (nsplit) {
+    case 8:  attn_partial_probe_kernel<8><<<grid, APROBE_NTHREADS, 0, stream>>>(Q, K, V, ws, Sq, Skv, Hq, D, scale, mask); break;
+    case 16: attn_partial_probe_kernel<16><<<grid, APROBE_NTHREADS, 0, stream>>>(Q, K, V, ws, Sq, Skv, Hq, D, scale, mask); break;
+    case 32: attn_partial_probe_kernel<32><<<grid, APROBE_NTHREADS, 0, stream>>>(Q, K, V, ws, Sq, Skv, Hq, D, scale, mask); break;
+    default: throw std::runtime_error("attn_partial_probe: nsplit must be 8/16/32");
+    }
+}

--- a/csrc/amd/attention/decoder_flash.hip
+++ b/csrc/amd/attention/decoder_flash.hip
@@ -1,5 +1,6 @@
 // ================================================================
 // FlashRT AMD — decoder cross-attention, split-KV flash (CDNA wave64)
+// v2: thread-parallel dot products, zero cross-lane ops in hot loops.
 //
 // One fixed production site: tiny-M GQA cross-attention
 //     Q (Sq, Hq, D) bf16   — Sq ~ 10 query tokens, Hq query heads
@@ -7,91 +8,150 @@
 //     V (Skv, D)    bf16
 //     O (Sq, Hq, D) bf16   — bidirectional, no mask
 //
-// Why this shape needs its own kernel: total work is ~80 query
-// vectors x <1K keys x 256 dims — library FA tiles (128/256-row Q
-// blocks, MFMA pipelines) waste >90% of their lanes here and the
-// call is launch/bandwidth bound, not compute bound. MFMA is
-// deliberately NOT used: a 10-row score tile cannot feed the
-// 16x16x16 matrix pipes; packed FMA from LDS is already >10x above
-// the arithmetic demand of this site.
+// Why v1 was slow (76 us in-graph vs 49 us sdpa): v1 computed each
+// score with a wave_reduce_sum — per workgroup ~10 queries x ~26 KV
+// rows = ~260 serial 6-step shuffle trees, each a latency chain the
+// wave sits through. The site is ~34 MFLOP / ~850 KB — pure
+// structure/overhead, so shuffle latency dominated everything.
 //
-// Decomposition (mirrors the FlashRT RTX split-KV win on this site):
-//   kernel 1 (partial): grid (ATTN_NSPLIT=32, Hq) — 32*8 = 256
-//     workgroups, one per CU on a 256-CU MI350X. Workgroup (i, h)
-//     owns KV rows [i*chunk, min((i+1)*chunk, skv)) for head h,
-//     chunk = ceil(skv/32) (<= 28 rows at Skv=876). It computes a
-//     full online-softmax partial over its slice for ALL Sq queries:
-//     row max m[q], sum-of-exp l[q], and the UNNORMALIZED
-//     acc[q][d] = sum_j exp(s[q][j] - m[q]) * V[j][d],
-//     written to the caller-provided fp32 workspace.
-//   kernel 2 (reduce): grid (Sq, Hq) — 80 tiny workgroups combine
-//     the 32 partials per (q, h) with the standard flash rescale
-//     (global max, exp(m_i - gm) coefficients) and emit bf16 O.
-//   Two kernels on one stream: plain stream ordering, no atomics,
-//   no cooperative counters — trivially HIP-graph capturable.
+// v2 restructure — every hot phase is one THREAD per output value,
+// dots run serially in registers from LDS, no shuffles at all in
+// kernel 1:
+//   Phase 0 (stage):   Q (Sq x D, fp32) and this split's K tile
+//                      (chunk x D, bf16 pairs) into LDS, coalesced.
+//   Phase A (scores):  one thread per (query, kv-row) pair —
+//                      Sq*chunk pairs over 256 threads (chunk=26 at
+//                      the site -> 260 pairs, ~1 loop iteration).
+//                      Each thread runs the full D-dim dot serially
+//                      from LDS into 4 fp32 accumulators (fixed
+//                      combine order), writes one score to LDS.
+//   Phase A'(V stage): K tile is dead after A; the same LDS buffer
+//                      is refilled with the split's V tile.
+//   Phase B (softmax): one thread per query — serial ascending-j
+//                      max / exp / sum over <= chunk scores in LDS
+//                      (<= ~3*64 LDS ops on <= 16 threads; cheaper
+//                      than extra barriers + reduction round-trips).
+//   Phase C (PV):      one thread per (query, dim-pair) — Sq*D/2
+//                      units (1280 at site) over 256 threads = 5
+//                      serial rows each, accumulating over chunk V
+//                      rows from LDS, ascending j.
 //
-// K/V are read once per head (8x total through L2; K+V ~ 850 KB,
-// so ~7 MB of L2-resident traffic — well under 10 us at any
-// realistic L2/HBM bandwidth). The problem is launch bound; both
-// kernels are deliberately shallow.
+// Split-KV decomposition (unchanged from v1):
+//   kernel 1 (partial): grid (NSPLIT, Hq). Workgroup (i, h) owns KV
+//     rows [i*chunk, min((i+1)*chunk, skv)), chunk = ceil(skv/NSPLIT),
+//     and emits an online-softmax partial for ALL Sq queries: m[q],
+//     l[q], unnormalized acc[q][d] -> fp32 workspace.
+//   kernel 2 (reduce): grid (Sq, Hq) — combines the NSPLIT partials
+//     with the standard flash rescale and emits bf16 O. v2 change:
+//     the per-split m/l loads run on a full wave (lane i <-> split i)
+//     with fixed radix-2 shuffle trees, instead of v1's thread-0
+//     serial loop; the acc combine stays one thread per output dim.
+//   Two kernels on one stream: plain stream ordering, no atomics, no
+//   cooperative counters — trivially HIP-graph capturable. A fused
+//   single-kernel variant would need a last-WG-done flag (atomics —
+//   forbidden for determinism); two in-graph launches are ~2 x
+//   ~2.5 us and fit the 10 us budget.
 //
-// Sequence length modes (matches qkv_split_rope_devpos):
-//   exact mode:  seqused == nullptr, Skv host int is the length.
-//   fixed mode:  seqused != nullptr, kernel reads seqused[0] on
-//     device; host Skv is ignored. Rows >= seqused[0] are NEVER
-//     touched (loops bound by the device value), so a fixed-shape
-//     graph can run any valid prefix length and padding rows may
-//     hold garbage/NaN.
+// NSPLIT selection (compile-time template, instantiated 8/16/32):
+//   Kernel-1 latency scales with chunk (score dots per thread =
+//   ceil(Sq*chunk/256); PV inner trip = chunk), while the reduce
+//   kernel's cost in NSPLIT is a wave-parallel handful of loads —
+//   so smaller chunks win until launch/reduce overhead bites.
+//   Host heuristic keeps chunk ~<= 32:
+//       skv <= 256 -> NSPLIT 8;  skv <= 512 -> 16;  else -> 32.
+//   Capacity: skv <= NSPLIT * CHUNK_MAX(64), i.e. 512 / 1024 / 2048;
+//   the guard falls back to NSPLIT=32 when the pick can't hold Skv.
+//   Env FRT_ATTN_NSPLIT=8|16|32 overrides (read per call on the
+//   host, so a bench can sweep variants; inside a captured graph the
+//   choice is frozen at capture time — flipping the env later does
+//   NOT re-route an existing graph). In fixed/seqused mode the pick
+//   uses the host Skv (the padded capacity bound, >= seqused[0]).
 //
-// fp32 math order (deterministic, fixed for a given shape):
-//   - scores: per-lane partial over dims {lane, lane+64, lane+128,
-//     lane+192} in ascending order, then the wave64 shuffle tree of
-//     wave_reduce_sum (fixed radix-2 order). Scale applied once to
-//     the reduced fp32 score.
-//   - softmax: m = serial fmaxf over the slice in ascending j;
-//     p = __expf(s - m) (device fast exp, rel err ~2^-22 — far
-//     below bf16 input noise); l = serial sum ascending j.
-//   - acc: serial ascending j per output dim; fp32 FMA.
-//   - reduce: serial ascending split index. No atomics anywhere.
+// Occupancy (MI350X, 256 CUs = 8 XCDs x 32):
+//   kernel 1 WGs = NSPLIT x Hq(8): 256 WGs at NSPLIT=32 -> 1 WG/CU,
+//   every CU busy, per-WG serial work minimal (chunk 26 at skv 826:
+//   score = 1-2 dots x 128 packed iters/thread; PV = 5 x 26 FMAs).
+//   NSPLIT=16 -> 128 WGs on 256 CUs: half the CUs idle but each WG
+//   is still latency- not throughput-bound, so it's competitive only
+//   when skv is small enough that chunk stays ~<= 32; the heuristic
+//   encodes exactly that. NSPLIT=8 -> 64 WGs, only for tiny skv.
+//   kernel 2 = Sq x Hq = 80 tiny WGs (D threads live) — launch bound
+//   by design. LDS 54 KB/WG caps residency at 1 WG/CU on a 64 KB
+//   budget (2 on gfx950's 160 KB) — irrelevant: the grid itself is
+//   <= 1 WG/CU.
 //
-// LDS layout (kernel 1, ~20.3 KB static):
-//   q_lds  [Sq][D]  fp32 Q for this head (10x256 = 10 KB at site)
-//   s_lds  [SQ_MAX][CHUNK_MAX] scores -> exp'd probabilities
-//   m_lds  [SQ_MAX] row maxima
-//   Bank behavior: score dot reads q_lds[q*D + lane + 64*i] —
-//   consecutive lanes hit consecutive banks (conflict-free); the
-//   matching K global read is a 2 B/lane contiguous burst (128 B
-//   per quarter row per instruction, fully coalesced). Phase C
-//   reads s_lds at one address per wave (broadcast) and V rows as
-//   contiguous 2 B/lane bursts.
+// LDS layout (kernel 1, ~54 KB static) and bank reasoning
+// (CDNA banks are 4 B; row pads below keep row strides odd in
+// 4 B units, so distinct rows -> distinct banks for any power-of-2
+// bank count):
+//   kv_lds [CHUNK_MAX][D/2 + 1] bf16-pairs (4 B units), pitch 129:
+//     holds K for phase A, then V for phase C.
+//     Phase A: consecutive threads = consecutive kv rows (pair index
+//     p = q*chunk + r) reading element i -> bank (r*129 + i) % NB =
+//     (r + i) % NB: distinct rows hit distinct banks; threads from
+//     different q-groups reading the SAME row read the same address
+//     -> hardware broadcast, no serialization. Rows r and r+NB
+//     collide 2-way at chunk > NB (chunk 52 at NSPLIT=16) — accepted.
+//     Phase C: consecutive threads = consecutive dim-pairs of one
+//     query reading v[j*129 + dp] -> consecutive banks, conflict-free.
+//     The matching global K/V loads are linear 4 B/lane bursts
+//     (rows are contiguous), fully coalesced.
+//   q_lds [SQ_MAX][D + 2] fp32, pitch 258 (even, float2-aligned):
+//     Phase A reads q_lds[q*258 + 2i] as float2; lanes in the same
+//     q-group read the same address (broadcast); distinct q differ
+//     by 258*dq -> bank pair offset 2*dq % NB, distinct for q < 16.
+//   s_lds  [SQ_MAX][CHUNK_MAX + 1] fp32, pitch 65 (odd):
+//     Phase A writes one score/thread (consecutive r -> consecutive
+//     banks); phase C reads s[q*65 + j] at one address per q-group
+//     (broadcast).
 //
-// Workspace (partial_ws, caller-provided, NO allocation here):
-//   ATTN_NSPLIT * Hq * Sq * (D + 2) floats
-//   = 32 * Hq * Sq * (D + 2) * 4 bytes  (pi05 site: 32*8*10*258*4
+// fp32 math order (deterministic, fixed for a given shape + NSPLIT):
+//   - scores: single thread, serial ascending d in 4 accumulators
+//     (d%4 lanes), combined (a0+a1)+(a2+a3); scale applied once.
+//   - softmax: serial ascending j for max, exp (__expf, rel err
+//     ~2^-22, far below bf16 input noise), and sum — one thread per q.
+//   - acc: serial ascending j per (q, dim-pair), fp32 FMA.
+//   - reduce: fixed radix-2 wave trees over a fixed lane<->split map
+//     (max is order-free; the l-sum tree order is fixed), then serial
+//     ascending split index for the acc combine. No atomics anywhere.
+//
+// Workspace (partial_ws, caller-provided, NO allocation here), sized
+// for NSPLIT_MAX = 32 regardless of the runtime pick:
+//   32 * Hq * Sq * (D + 2) floats  (pi05 site: 32*8*10*258*4
 //   = 2,641,920 B ~ 2.52 MiB). Per-(split,head) block layout:
 //   [Sq*D unnormalized acc][Sq m][Sq l]. Never needs zeroing:
 //   empty tail slices mark l = 0 and the reducer skips them.
 //
-// Limits (asserted nowhere — this is a fixed-site kernel; the
-// wrapper documents them): Sq <= 16, D <= 256, D % 4 == 0,
-// skv <= ATTN_NSPLIT * ATTN_CHUNK_MAX = 2048 (in-kernel clamped),
-// single KV head (GQA Hq:1).
+// Sequence length modes (matches qkv_split_rope_devpos):
+//   exact mode:  seqused == nullptr, Skv host int is the length.
+//   fixed mode:  seqused != nullptr, kernel reads seqused[0] on
+//     device; host Skv is only the capacity bound for the NSPLIT
+//     pick. Rows >= seqused[0] are NEVER touched (all loops bound by
+//     the device value), so a fixed-shape graph can run any valid
+//     prefix length and padding rows may hold garbage/NaN.
+//
+// Limits (fixed-site kernel; wrapper documents, nothing asserts):
+//   Sq <= 16, D <= 256, D % 4 == 0, skv <= NSPLIT*64 (in-kernel
+//   clamped), single KV head (GQA Hq:1).
 // ================================================================
 
 #include "../kernels/common_hip.h"
 
 #include <cfloat>
+#include <cstdlib>
 
-#define ATTN_NSPLIT     32   // KV splits; 32 * Hq(8) = 256 WGs = 1/CU
+#define ATTN_NSPLIT_MAX 32   // workspace sizing bound (test allocates for 32)
 #define ATTN_NTHREADS   256  // 4 waves
-#define ATTN_NWAVES     (ATTN_NTHREADS / FVK_WAVE_SIZE)
-#define ATTN_SQ_MAX     16   // register/LDS sizing bound for Sq
+#define ATTN_SQ_MAX     16   // LDS sizing bound for Sq
 #define ATTN_D_MAX      256  // LDS sizing bound for D
-#define ATTN_CHUNK_MAX  64   // max KV rows per split -> skv <= 2048
-#define ATTN_KD_PER_LANE (ATTN_D_MAX / FVK_WAVE_SIZE)  // 4 dims/lane
+#define ATTN_CHUNK_MAX  64   // max KV rows per split -> skv <= NSPLIT*64
+#define ATTN_KV_PITCH   (ATTN_D_MAX / 2 + 1)   // 129 bf16-pairs: odd stride
+#define ATTN_Q_PITCH    (ATTN_D_MAX + 2)       // 258 floats: even, f2-aligned
+#define ATTN_S_PITCH    (ATTN_CHUNK_MAX + 1)   // 65 floats: odd stride
 
 // ── Kernel 1: per-slice flash partials ──
-// grid (ATTN_NSPLIT, Hq), block ATTN_NTHREADS.
+// grid (NSPLIT, Hq), block ATTN_NTHREADS.
+template <int NSPLIT>
 __global__ __launch_bounds__(ATTN_NTHREADS)
 void attention_decoder_gqa_partial_kernel(
     const __hip_bfloat16* __restrict__ Q,
@@ -103,24 +163,24 @@ void attention_decoder_gqa_partial_kernel(
     const int split = blockIdx.x;
     const int h     = blockIdx.y;
     const int tid   = threadIdx.x;
-    const int lane  = tid & (FVK_WAVE_SIZE - 1);
-    const int wave  = tid >> 6;
 
-    __shared__ float q_lds[ATTN_SQ_MAX * ATTN_D_MAX];
-    __shared__ float s_lds[ATTN_SQ_MAX * ATTN_CHUNK_MAX];
-    __shared__ float m_lds[ATTN_SQ_MAX];
+    // K tile for phase A, then (reused) V tile for phase C.
+    alignas(16) __shared__ __hip_bfloat162 kv_lds[ATTN_CHUNK_MAX * ATTN_KV_PITCH];
+    alignas(16) __shared__ float q_lds[ATTN_SQ_MAX * ATTN_Q_PITCH];
+    alignas(16) __shared__ float s_lds[ATTN_SQ_MAX * ATTN_S_PITCH];
 
     // Effective sequence length: device seqused[0] wins (fixed-shape
     // graph mode); otherwise the host int (exact mode).
     int skv_eff = (seqused != nullptr) ? seqused[0] : Skv;
-    if (skv_eff > ATTN_NSPLIT * ATTN_CHUNK_MAX)
-        skv_eff = ATTN_NSPLIT * ATTN_CHUNK_MAX;  // documented hard cap
+    if (skv_eff > NSPLIT * ATTN_CHUNK_MAX)
+        skv_eff = NSPLIT * ATTN_CHUNK_MAX;  // documented hard cap
 
-    const int chunk = (skv_eff + ATTN_NSPLIT - 1) / ATTN_NSPLIT;
+    const int chunk = (skv_eff + NSPLIT - 1) / NSPLIT;
     const int start = split * chunk;
     int end = start + chunk;
     if (end > skv_eff) end = skv_eff;
     const int cn = end - start;  // rows in this slice (may be <= 0)
+    const int dh = D >> 1;       // bf16-pairs per row
 
     // Workspace block for (split, head): [Sq*D acc][Sq m][Sq l]
     const size_t base = (size_t)(split * Hq + h) * (size_t)Sq * (size_t)(D + 2);
@@ -135,145 +195,141 @@ void attention_decoder_gqa_partial_kernel(
         return;
     }
 
-    // Stage this head's Q into LDS as fp32 (10x256 = 10 KB at site).
+    // ── Phase 0: stage Q (fp32) and the K tile (bf16 pairs) ──
     for (int idx = tid; idx < Sq * D; idx += ATTN_NTHREADS) {
         const int q = idx / D;
         const int d = idx - q * D;
-        q_lds[q * D + d] =
+        q_lds[q * ATTN_Q_PITCH + d] =
             __bfloat162float(Q[((size_t)q * Hq + h) * D + d]);
     }
-    __syncthreads();
-
-    // ── Phase A: scores s[q][j] = scale * <Q[q], K[j]> ──
-    // Waves interleave over slice rows (wave w -> rows start+w,
-    // start+w+4, ...). Lane l owns dims {l, l+64, l+128, l+192}:
-    // conflict-free LDS reads of Q, coalesced 2 B/lane K bursts.
-    for (int j = start + wave; j < end; j += ATTN_NWAVES) {
-        const __hip_bfloat16* krow = K + (size_t)j * D;
-        float kd[ATTN_KD_PER_LANE];
-        #pragma unroll
-        for (int i = 0; i < ATTN_KD_PER_LANE; ++i) {
-            const int d = lane + i * FVK_WAVE_SIZE;
-            kd[i] = (d < D) ? __bfloat162float(krow[d]) : 0.0f;
-        }
-        float p[ATTN_SQ_MAX];
-        #pragma unroll
-        for (int q = 0; q < ATTN_SQ_MAX; ++q) {
-            float a = 0.0f;
-            if (q < Sq) {
-                #pragma unroll
-                for (int i = 0; i < ATTN_KD_PER_LANE; ++i) {
-                    const int d = lane + i * FVK_WAVE_SIZE;
-                    if (d < D) a += kd[i] * q_lds[q * D + d];
-                }
-            }
-            p[q] = a;
-        }
-        #pragma unroll
-        for (int q = 0; q < ATTN_SQ_MAX; ++q) {
-            if (q < Sq) {
-                const float r = wave_reduce_sum(p[q]);  // fixed radix-2 tree
-                if (lane == 0)
-                    s_lds[q * ATTN_CHUNK_MAX + (j - start)] = r * scale;
-            }
-        }
+    const __hip_bfloat162* K2 = reinterpret_cast<const __hip_bfloat162*>(K);
+    for (int idx = tid; idx < cn * dh; idx += ATTN_NTHREADS) {
+        const int r = idx / dh;
+        const int c = idx - r * dh;
+        kv_lds[r * ATTN_KV_PITCH + c] = K2[(size_t)(start + r) * dh + c];
     }
     __syncthreads();
 
-    // ── Phase B: per-slice online softmax over the <= CHUNK_MAX rows ──
-    // Row maxima: one thread per query row, serial ascending j
-    // (<= 64 iterations — cheaper than another reduction round-trip).
+    // ── Phase A: one thread per (query, kv-row) pair ──
+    // Full D-dim dot serially from LDS; 4 accumulators break the FMA
+    // dependency chain to ~D/4; fixed combine order (a0+a1)+(a2+a3).
+    const int npairs = Sq * cn;
+    for (int p = tid; p < npairs; p += ATTN_NTHREADS) {
+        const int q = p / cn;
+        const int r = p - q * cn;
+        const __hip_bfloat162* kr = &kv_lds[r * ATTN_KV_PITCH];
+        const float2* qr =
+            reinterpret_cast<const float2*>(&q_lds[q * ATTN_Q_PITCH]);
+        float a0 = 0.0f, a1 = 0.0f, a2 = 0.0f, a3 = 0.0f;
+        #pragma unroll 4
+        for (int i = 0; i < dh; i += 2) {  // dh even (D % 4 == 0)
+            const __hip_bfloat162 k0 = kr[i];
+            const __hip_bfloat162 k1 = kr[i + 1];
+            const float2 q0 = qr[i];
+            const float2 q1 = qr[i + 1];
+            a0 = fmaf(__bfloat162float(k0.x), q0.x, a0);
+            a1 = fmaf(__bfloat162float(k0.y), q0.y, a1);
+            a2 = fmaf(__bfloat162float(k1.x), q1.x, a2);
+            a3 = fmaf(__bfloat162float(k1.y), q1.y, a3);
+        }
+        s_lds[q * ATTN_S_PITCH + r] = ((a0 + a1) + (a2 + a3)) * scale;
+    }
+    __syncthreads();  // scores done; K tile is dead from here
+
+    // ── Phase A': refill the tile with V (all threads) ──
+    const __hip_bfloat162* V2 = reinterpret_cast<const __hip_bfloat162*>(V);
+    for (int idx = tid; idx < cn * dh; idx += ATTN_NTHREADS) {
+        const int r = idx / dh;
+        const int c = idx - r * dh;
+        kv_lds[r * ATTN_KV_PITCH + c] = V2[(size_t)(start + r) * dh + c];
+    }
+
+    // ── Phase B: per-query serial softmax (interleaved with A') ──
+    // Serial ascending j: max, then exp in place + sum — fixed order,
+    // <= 3*chunk LDS ops on Sq threads; s_lds is untouched by A'.
     if (tid < Sq) {
+        float* sp = &s_lds[tid * ATTN_S_PITCH];
         float m = -FLT_MAX;
-        for (int jj = 0; jj < cn; ++jj)
-            m = fmaxf(m, s_lds[tid * ATTN_CHUNK_MAX + jj]);
-        m_lds[tid] = m;
-    }
-    __syncthreads();
-
-    // Exponentiate in place, all threads in parallel.
-    for (int idx = tid; idx < Sq * cn; idx += ATTN_NTHREADS) {
-        const int q  = idx / cn;
-        const int jj = idx - q * cn;
-        float* sp = &s_lds[q * ATTN_CHUNK_MAX + jj];
-        *sp = __expf(*sp - m_lds[q]);
-    }
-    __syncthreads();
-
-    // l[q]: serial ascending j — fixed summation order.
-    if (tid < Sq) {
+        for (int j = 0; j < cn; ++j) m = fmaxf(m, sp[j]);
         float l = 0.0f;
-        for (int jj = 0; jj < cn; ++jj)
-            l += s_lds[tid * ATTN_CHUNK_MAX + jj];
-        m_ws[tid] = m_lds[tid];
+        for (int j = 0; j < cn; ++j) {
+            const float e = __expf(sp[j] - m);
+            sp[j] = e;
+            l += e;
+        }
+        m_ws[tid] = m;
         l_ws[tid] = l;
     }
+    __syncthreads();  // V staged + probabilities final
 
-    // ── Phase C: unnormalized acc[q][d] = sum_j p[q][j] * V[j][d] ──
-    // Thread t owns output dim t for all Sq queries; V row reads are
-    // contiguous 2 B/lane, p reads are LDS broadcasts. Ascending j.
-    if (tid < D) {
-        float acc[ATTN_SQ_MAX];
-        #pragma unroll
-        for (int q = 0; q < ATTN_SQ_MAX; ++q) acc[q] = 0.0f;
-        for (int jj = 0; jj < cn; ++jj) {
-            const float v =
-                __bfloat162float(V[(size_t)(start + jj) * D + tid]);
-            #pragma unroll
-            for (int q = 0; q < ATTN_SQ_MAX; ++q)
-                if (q < Sq) acc[q] += s_lds[q * ATTN_CHUNK_MAX + jj] * v;
+    // ── Phase C: one thread per (query, dim-pair) ──
+    // acc[q][2dp..2dp+1] = sum_j p[q][j] * V[j][2dp..2dp+1], ascending j.
+    const int nunits = Sq * dh;
+    for (int u = tid; u < nunits; u += ATTN_NTHREADS) {
+        const int q  = u / dh;
+        const int dp = u - q * dh;
+        const float* sp = &s_lds[q * ATTN_S_PITCH];
+        const __hip_bfloat162* vp = &kv_lds[dp];
+        float ax = 0.0f, ay = 0.0f;
+        for (int j = 0; j < cn; ++j) {
+            const __hip_bfloat162 v = vp[j * ATTN_KV_PITCH];
+            const float pj = sp[j];
+            ax = fmaf(pj, __bfloat162float(v.x), ax);
+            ay = fmaf(pj, __bfloat162float(v.y), ay);
         }
-        #pragma unroll
-        for (int q = 0; q < ATTN_SQ_MAX; ++q)
-            if (q < Sq) acc_ws[(size_t)q * D + tid] = acc[q];
+        float* out = acc_ws + (size_t)q * D + 2 * dp;
+        out[0] = ax;   // adjacent 4 B stores; consecutive lanes are
+        out[1] = ay;   // consecutive pairs -> coalesced 8 B/lane
     }
 }
 
-// ── Kernel 2: combine the ATTN_NSPLIT partials per (q, h) ──
+// ── Kernel 2: combine the NSPLIT partials per (q, h) ──
 // grid (Sq, Hq), block ATTN_NTHREADS (thread t = output dim t).
 // Standard flash rescale: gm = max_i m_i, coeff_i = exp(m_i - gm),
 // O = (sum_i coeff_i * acc_i) / (sum_i coeff_i * l_i).
+// v2: wave 0 loads all m/l in parallel (lane i <-> split i) and
+// reduces with fixed shuffle trees; v1 looped serially on thread 0.
+template <int NSPLIT>
 __global__ __launch_bounds__(ATTN_NTHREADS)
 void attention_decoder_gqa_reduce_kernel(
     const float* __restrict__ ws,
     __hip_bfloat16* __restrict__ O,
     int Sq, int Hq, int D) {
-    const int q   = blockIdx.x;
-    const int h   = blockIdx.y;
-    const int tid = threadIdx.x;
+    const int q    = blockIdx.x;
+    const int h    = blockIdx.y;
+    const int tid  = threadIdx.x;
+    const int lane = tid & (FVK_WAVE_SIZE - 1);
+    const int wave = tid >> 6;
 
-    __shared__ float coeff[ATTN_NSPLIT];
+    __shared__ float coeff[NSPLIT];
     __shared__ float s_invL;
 
     const size_t blk = (size_t)Sq * (size_t)(D + 2);  // floats per (split,head)
     const size_t ml_off = (size_t)Sq * D;
 
-    // Serial over 32 splits on thread 0: ~64 independent fp32 loads,
-    // negligible next to launch cost; fixed ascending order.
-    if (tid == 0) {
-        float gm = -FLT_MAX;
-        for (int i = 0; i < ATTN_NSPLIT; ++i) {
-            const size_t b = (size_t)(i * Hq + h) * blk;
-            const float li = ws[b + ml_off + Sq + q];
-            const float mi = ws[b + ml_off + q];
-            if (li > 0.0f && mi > gm) gm = mi;
+    static_assert(NSPLIT <= FVK_WAVE_SIZE, "one wave covers all splits");
+    if (wave == 0) {
+        float mi = -FLT_MAX, li = 0.0f;
+        if (lane < NSPLIT) {
+            const size_t b = (size_t)(lane * Hq + h) * blk;
+            li = ws[b + ml_off + Sq + q];
+            mi = ws[b + ml_off + q];
         }
-        float L = 0.0f;
-        for (int i = 0; i < ATTN_NSPLIT; ++i) {
-            const size_t b = (size_t)(i * Hq + h) * blk;
-            const float li = ws[b + ml_off + Sq + q];
-            const float mi = ws[b + ml_off + q];
-            const float c = (li > 0.0f) ? __expf(mi - gm) : 0.0f;
-            coeff[i] = c;
-            L += c * li;
-        }
-        s_invL = (L > 0.0f) ? 1.0f / L : 0.0f;  // skv >= 1 => L > 0
+        // Global max: order-free; empty slices (li == 0) excluded.
+        float gm = wave_reduce_max((li > 0.0f) ? mi : -FLT_MAX);
+        gm = __shfl(gm, 0);  // tree result lives in lane 0 — broadcast
+        const float c = (lane < NSPLIT && li > 0.0f) ? __expf(mi - gm) : 0.0f;
+        if (lane < NSPLIT) coeff[lane] = c;
+        // L: fixed radix-2 tree over the fixed lane<->split map.
+        const float L = wave_reduce_sum(c * li);
+        if (lane == 0) s_invL = (L > 0.0f) ? 1.0f / L : 0.0f;  // skv>=1 => L>0
     }
     __syncthreads();
 
     if (tid < D) {
         float s = 0.0f;
-        for (int i = 0; i < ATTN_NSPLIT; ++i) {
+        #pragma unroll
+        for (int i = 0; i < NSPLIT; ++i) {
             const float c = coeff[i];
             // c == 0 also guards the never-written acc of empty slices.
             if (c != 0.0f) {
@@ -285,18 +341,38 @@ void attention_decoder_gqa_reduce_kernel(
     }
 }
 
+template <int NSPLIT>
+static void launch_decoder_gqa(const __hip_bfloat16* Q,
+                               const __hip_bfloat16* K,
+                               const __hip_bfloat16* V,
+                               __hip_bfloat16* O,
+                               float* partial_ws,
+                               int Sq, int Skv, int Hq, int D,
+                               const int* seqused,
+                               float softmax_scale,
+                               hipStream_t stream) {
+    dim3 grid1(NSPLIT, Hq);
+    attention_decoder_gqa_partial_kernel<NSPLIT><<<grid1, ATTN_NTHREADS, 0, stream>>>(Q, K, V, partial_ws, seqused, Sq, Skv, Hq, D, softmax_scale);
+    dim3 grid2(Sq, Hq);
+    attention_decoder_gqa_reduce_kernel<NSPLIT><<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, Sq, Hq, D);
+}
+
 // ── Host wrapper ──
 // partial_ws: caller-provided device fp32 scratch of at least
-//   ATTN_NSPLIT * Hq * Sq * (D + 2) floats
-//   (= 32 * Hq * Sq * (D + 2) * 4 bytes; pi05 decoder site
-//   32*8*10*258*4 = 2,641,920 bytes). No allocation, no memset, no
-//   host sync — safe inside HIP graph capture.
+//   ATTN_NSPLIT_MAX(32) * Hq * Sq * (D + 2) floats (pi05 decoder
+//   site: 32*8*10*258*4 = 2,641,920 bytes) — sized for the largest
+//   variant so the buffer works for any NSPLIT pick. No allocation,
+//   no memset, no host sync — safe inside HIP graph capture.
 // seqused: nullptr => exact mode (Skv host int is the length);
-//   else device int32, seqused[0] read in-kernel and Skv is ignored
-//   (fixed-shape graph mode; padding rows beyond seqused[0] are
-//   never read).
+//   else device int32, seqused[0] read in-kernel and the host Skv is
+//   only the padded capacity bound (fixed-shape graph mode; padding
+//   rows beyond seqused[0] are never read).
+// NSPLIT: heuristic on host Skv keeps chunk ~<= 32 (see header);
+//   FRT_ATTN_NSPLIT=8|16|32 overrides, re-read every call so a bench
+//   can sweep — but a captured graph keeps the capture-time choice.
 // Constraints (fixed-site kernel, not checked): 1 <= Sq <= 16,
-//   D <= 256, seq length <= 2048, single KV head (K/V are (Skv, D)).
+//   D <= 256, D % 4 == 0, seq length <= NSPLIT*64, single KV head
+//   (K/V are (Skv, D)).
 void attention_decoder_gqa(const __hip_bfloat16* Q,
                            const __hip_bfloat16* K,
                            const __hip_bfloat16* V,
@@ -306,8 +382,20 @@ void attention_decoder_gqa(const __hip_bfloat16* Q,
                            const int* seqused,
                            float softmax_scale,
                            hipStream_t stream) {
-    dim3 grid1(ATTN_NSPLIT, Hq);
-    attention_decoder_gqa_partial_kernel<<<grid1, ATTN_NTHREADS, 0, stream>>>(Q, K, V, partial_ws, seqused, Sq, Skv, Hq, D, softmax_scale);
-    dim3 grid2(Sq, Hq);
-    attention_decoder_gqa_reduce_kernel<<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, Sq, Hq, D);
+    int ns = 0;
+    if (const char* e = std::getenv("FRT_ATTN_NSPLIT")) ns = std::atoi(e);
+    if (ns != 8 && ns != 16 && ns != 32)
+        ns = (Skv <= 256) ? 8 : (Skv <= 512) ? 16 : 32;
+    if (Skv > ns * ATTN_CHUNK_MAX) ns = 32;  // capacity guard
+    switch (ns) {
+        case 8:
+            launch_decoder_gqa<8>(Q, K, V, O, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
+            break;
+        case 16:
+            launch_decoder_gqa<16>(Q, K, V, O, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
+            break;
+        default:
+            launch_decoder_gqa<32>(Q, K, V, O, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
+            break;
+    }
 }

--- a/csrc/amd/attention/decoder_flash.hip
+++ b/csrc/amd/attention/decoder_flash.hip
@@ -423,41 +423,36 @@ void attention_decoder_gqa_partial_kernel(
 
     // ── Phase C: one thread per (query, dim-pair) ──
     // acc[q][2dp..2dp+1] = sum_j p[q][j] * V[j][2dp..2dp+1], ascending j.
-    // ILP4 PV: 4 independent accumulator chains hide the serial LDS
-    // latency; chains combine in fixed order (a0+a1)+(a2+a3).
+    // ILP8 PV: 8 independent accumulator chains hide the serial LDS
+    // latency; chains combine in a fixed pairwise order.
     const int nunits = Sq * dh;
     for (int u = tid; u < nunits; u += ATTN_NTHREADS) {
         const int q  = u / dh;
         const int dp = u - q * dh;
         const float* sp = &s_lds[q * ATTN_S_PITCH];
         const __hip_bfloat162* vp = &kv_lds[dp];
-        float ax0 = 0.0f, ay0 = 0.0f, ax1 = 0.0f, ay1 = 0.0f;
-        float ax2 = 0.0f, ay2 = 0.0f, ax3 = 0.0f, ay3 = 0.0f;
+        float axs[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        float ays[8] = {0, 0, 0, 0, 0, 0, 0, 0};
         int j = 0;
-        for (; j + 3 < cn; j += 4) {
-            const __hip_bfloat162 v0 = vp[(j)     * ATTN_KV_PITCH];
-            const __hip_bfloat162 v1 = vp[(j + 1) * ATTN_KV_PITCH];
-            const __hip_bfloat162 v2 = vp[(j + 2) * ATTN_KV_PITCH];
-            const __hip_bfloat162 v3 = vp[(j + 3) * ATTN_KV_PITCH];
-            const float p0 = sp[j], p1 = sp[j + 1];
-            const float p2 = sp[j + 2], p3 = sp[j + 3];
-            ax0 = fmaf(p0, __bfloat162float(v0.x), ax0);
-            ay0 = fmaf(p0, __bfloat162float(v0.y), ay0);
-            ax1 = fmaf(p1, __bfloat162float(v1.x), ax1);
-            ay1 = fmaf(p1, __bfloat162float(v1.y), ay1);
-            ax2 = fmaf(p2, __bfloat162float(v2.x), ax2);
-            ay2 = fmaf(p2, __bfloat162float(v2.y), ay2);
-            ax3 = fmaf(p3, __bfloat162float(v3.x), ax3);
-            ay3 = fmaf(p3, __bfloat162float(v3.y), ay3);
+        for (; j + 7 < cn; j += 8) {
+            #pragma unroll
+            for (int t = 0; t < 8; ++t) {
+                const __hip_bfloat162 v = vp[(j + t) * ATTN_KV_PITCH];
+                const float pj = sp[j + t];
+                axs[t] = fmaf(pj, __bfloat162float(v.x), axs[t]);
+                ays[t] = fmaf(pj, __bfloat162float(v.y), ays[t]);
+            }
         }
         for (; j < cn; ++j) {
             const __hip_bfloat162 v = vp[j * ATTN_KV_PITCH];
             const float pj = sp[j];
-            ax0 = fmaf(pj, __bfloat162float(v.x), ax0);
-            ay0 = fmaf(pj, __bfloat162float(v.y), ay0);
+            axs[0] = fmaf(pj, __bfloat162float(v.x), axs[0]);
+            ays[0] = fmaf(pj, __bfloat162float(v.y), ays[0]);
         }
-        const float ax = (ax0 + ax1) + (ax2 + ax3);
-        const float ay = (ay0 + ay1) + (ay2 + ay3);
+        const float ax = ((axs[0] + axs[1]) + (axs[2] + axs[3]))
+                       + ((axs[4] + axs[5]) + (axs[6] + axs[7]));
+        const float ay = ((ays[0] + ays[1]) + (ays[2] + ays[3]))
+                       + ((ays[4] + ays[5]) + (ays[6] + ays[7]));
         float* out = acc_ws + (size_t)q * D + 2 * dp;
         out[0] = ax;   // adjacent 4 B stores; consecutive lanes are
         out[1] = ay;   // consecutive pairs -> coalesced 8 B/lane
@@ -528,19 +523,19 @@ void attention_decoder_gqa_reduce_kernel(
         static_assert(NSPLIT % 4 == 0, "ILP4 combine assumes 4 | NSPLIT");
         const size_t sstride = (size_t)Hq * blk;  // floats, split i -> i+1
         const float* ap = ws + (size_t)h * blk + (size_t)q * D + tid;
+        // Full-depth prefetch: all NSPLIT split loads issue before any
+        // consumer (NSPLIT <= 32 registers; occupancy is not the
+        // constraint here). The accumulate keeps the ascending-split
+        // fixed order — bit-identical to the 4-batch version.
+        float vv[NSPLIT];
+        #pragma unroll
+        for (int i = 0; i < NSPLIT; ++i)
+            vv[i] = ap[(size_t)i * sstride];
         float s = 0.0f;
         #pragma unroll
-        for (int i = 0; i < NSPLIT; i += 4) {
-            const float v0 = ap[(i + 0) * sstride];
-            const float v1 = ap[(i + 1) * sstride];
-            const float v2 = ap[(i + 2) * sstride];
-            const float v3 = ap[(i + 3) * sstride];
-            const float c0 = coeff[i + 0], c1 = coeff[i + 1];
-            const float c2 = coeff[i + 2], c3 = coeff[i + 3];
-            s = (c0 != 0.0f) ? fmaf(c0, v0, s) : s;
-            s = (c1 != 0.0f) ? fmaf(c1, v1, s) : s;
-            s = (c2 != 0.0f) ? fmaf(c2, v2, s) : s;
-            s = (c3 != 0.0f) ? fmaf(c3, v3, s) : s;
+        for (int i = 0; i < NSPLIT; ++i) {
+            const float c = coeff[i];
+            s = (c != 0.0f) ? fmaf(c, vv[i], s) : s;
         }
         const size_t o_off = ((size_t)q * Hq + h) * D + tid;
         const __hip_bfloat16 b = __float2bfloat16(s * s_invL);

--- a/csrc/amd/attention/decoder_flash.hip
+++ b/csrc/amd/attention/decoder_flash.hip
@@ -1,0 +1,313 @@
+// ================================================================
+// FlashRT AMD — decoder cross-attention, split-KV flash (CDNA wave64)
+//
+// One fixed production site: tiny-M GQA cross-attention
+//     Q (Sq, Hq, D) bf16   — Sq ~ 10 query tokens, Hq query heads
+//     K (Skv, D)    bf16   — single KV head (GQA Hq:1), Skv ~ 590-876
+//     V (Skv, D)    bf16
+//     O (Sq, Hq, D) bf16   — bidirectional, no mask
+//
+// Why this shape needs its own kernel: total work is ~80 query
+// vectors x <1K keys x 256 dims — library FA tiles (128/256-row Q
+// blocks, MFMA pipelines) waste >90% of their lanes here and the
+// call is launch/bandwidth bound, not compute bound. MFMA is
+// deliberately NOT used: a 10-row score tile cannot feed the
+// 16x16x16 matrix pipes; packed FMA from LDS is already >10x above
+// the arithmetic demand of this site.
+//
+// Decomposition (mirrors the FlashRT RTX split-KV win on this site):
+//   kernel 1 (partial): grid (ATTN_NSPLIT=32, Hq) — 32*8 = 256
+//     workgroups, one per CU on a 256-CU MI350X. Workgroup (i, h)
+//     owns KV rows [i*chunk, min((i+1)*chunk, skv)) for head h,
+//     chunk = ceil(skv/32) (<= 28 rows at Skv=876). It computes a
+//     full online-softmax partial over its slice for ALL Sq queries:
+//     row max m[q], sum-of-exp l[q], and the UNNORMALIZED
+//     acc[q][d] = sum_j exp(s[q][j] - m[q]) * V[j][d],
+//     written to the caller-provided fp32 workspace.
+//   kernel 2 (reduce): grid (Sq, Hq) — 80 tiny workgroups combine
+//     the 32 partials per (q, h) with the standard flash rescale
+//     (global max, exp(m_i - gm) coefficients) and emit bf16 O.
+//   Two kernels on one stream: plain stream ordering, no atomics,
+//   no cooperative counters — trivially HIP-graph capturable.
+//
+// K/V are read once per head (8x total through L2; K+V ~ 850 KB,
+// so ~7 MB of L2-resident traffic — well under 10 us at any
+// realistic L2/HBM bandwidth). The problem is launch bound; both
+// kernels are deliberately shallow.
+//
+// Sequence length modes (matches qkv_split_rope_devpos):
+//   exact mode:  seqused == nullptr, Skv host int is the length.
+//   fixed mode:  seqused != nullptr, kernel reads seqused[0] on
+//     device; host Skv is ignored. Rows >= seqused[0] are NEVER
+//     touched (loops bound by the device value), so a fixed-shape
+//     graph can run any valid prefix length and padding rows may
+//     hold garbage/NaN.
+//
+// fp32 math order (deterministic, fixed for a given shape):
+//   - scores: per-lane partial over dims {lane, lane+64, lane+128,
+//     lane+192} in ascending order, then the wave64 shuffle tree of
+//     wave_reduce_sum (fixed radix-2 order). Scale applied once to
+//     the reduced fp32 score.
+//   - softmax: m = serial fmaxf over the slice in ascending j;
+//     p = __expf(s - m) (device fast exp, rel err ~2^-22 — far
+//     below bf16 input noise); l = serial sum ascending j.
+//   - acc: serial ascending j per output dim; fp32 FMA.
+//   - reduce: serial ascending split index. No atomics anywhere.
+//
+// LDS layout (kernel 1, ~20.3 KB static):
+//   q_lds  [Sq][D]  fp32 Q for this head (10x256 = 10 KB at site)
+//   s_lds  [SQ_MAX][CHUNK_MAX] scores -> exp'd probabilities
+//   m_lds  [SQ_MAX] row maxima
+//   Bank behavior: score dot reads q_lds[q*D + lane + 64*i] —
+//   consecutive lanes hit consecutive banks (conflict-free); the
+//   matching K global read is a 2 B/lane contiguous burst (128 B
+//   per quarter row per instruction, fully coalesced). Phase C
+//   reads s_lds at one address per wave (broadcast) and V rows as
+//   contiguous 2 B/lane bursts.
+//
+// Workspace (partial_ws, caller-provided, NO allocation here):
+//   ATTN_NSPLIT * Hq * Sq * (D + 2) floats
+//   = 32 * Hq * Sq * (D + 2) * 4 bytes  (pi05 site: 32*8*10*258*4
+//   = 2,641,920 B ~ 2.52 MiB). Per-(split,head) block layout:
+//   [Sq*D unnormalized acc][Sq m][Sq l]. Never needs zeroing:
+//   empty tail slices mark l = 0 and the reducer skips them.
+//
+// Limits (asserted nowhere — this is a fixed-site kernel; the
+// wrapper documents them): Sq <= 16, D <= 256, D % 4 == 0,
+// skv <= ATTN_NSPLIT * ATTN_CHUNK_MAX = 2048 (in-kernel clamped),
+// single KV head (GQA Hq:1).
+// ================================================================
+
+#include "../kernels/common_hip.h"
+
+#include <cfloat>
+
+#define ATTN_NSPLIT     32   // KV splits; 32 * Hq(8) = 256 WGs = 1/CU
+#define ATTN_NTHREADS   256  // 4 waves
+#define ATTN_NWAVES     (ATTN_NTHREADS / FVK_WAVE_SIZE)
+#define ATTN_SQ_MAX     16   // register/LDS sizing bound for Sq
+#define ATTN_D_MAX      256  // LDS sizing bound for D
+#define ATTN_CHUNK_MAX  64   // max KV rows per split -> skv <= 2048
+#define ATTN_KD_PER_LANE (ATTN_D_MAX / FVK_WAVE_SIZE)  // 4 dims/lane
+
+// ── Kernel 1: per-slice flash partials ──
+// grid (ATTN_NSPLIT, Hq), block ATTN_NTHREADS.
+__global__ __launch_bounds__(ATTN_NTHREADS)
+void attention_decoder_gqa_partial_kernel(
+    const __hip_bfloat16* __restrict__ Q,
+    const __hip_bfloat16* __restrict__ K,
+    const __hip_bfloat16* __restrict__ V,
+    float* __restrict__ ws,
+    const int* __restrict__ seqused,
+    int Sq, int Skv, int Hq, int D, float scale) {
+    const int split = blockIdx.x;
+    const int h     = blockIdx.y;
+    const int tid   = threadIdx.x;
+    const int lane  = tid & (FVK_WAVE_SIZE - 1);
+    const int wave  = tid >> 6;
+
+    __shared__ float q_lds[ATTN_SQ_MAX * ATTN_D_MAX];
+    __shared__ float s_lds[ATTN_SQ_MAX * ATTN_CHUNK_MAX];
+    __shared__ float m_lds[ATTN_SQ_MAX];
+
+    // Effective sequence length: device seqused[0] wins (fixed-shape
+    // graph mode); otherwise the host int (exact mode).
+    int skv_eff = (seqused != nullptr) ? seqused[0] : Skv;
+    if (skv_eff > ATTN_NSPLIT * ATTN_CHUNK_MAX)
+        skv_eff = ATTN_NSPLIT * ATTN_CHUNK_MAX;  // documented hard cap
+
+    const int chunk = (skv_eff + ATTN_NSPLIT - 1) / ATTN_NSPLIT;
+    const int start = split * chunk;
+    int end = start + chunk;
+    if (end > skv_eff) end = skv_eff;
+    const int cn = end - start;  // rows in this slice (may be <= 0)
+
+    // Workspace block for (split, head): [Sq*D acc][Sq m][Sq l]
+    const size_t base = (size_t)(split * Hq + h) * (size_t)Sq * (size_t)(D + 2);
+    float* acc_ws = ws + base;
+    float* m_ws   = ws + base + (size_t)Sq * D;
+    float* l_ws   = m_ws + Sq;
+
+    if (cn <= 0) {
+        // Empty tail slice: l = 0 tells the reducer to skip this block
+        // (its acc region is never read), so ws needs no pre-zeroing.
+        if (tid < Sq) { m_ws[tid] = -FLT_MAX; l_ws[tid] = 0.0f; }
+        return;
+    }
+
+    // Stage this head's Q into LDS as fp32 (10x256 = 10 KB at site).
+    for (int idx = tid; idx < Sq * D; idx += ATTN_NTHREADS) {
+        const int q = idx / D;
+        const int d = idx - q * D;
+        q_lds[q * D + d] =
+            __bfloat162float(Q[((size_t)q * Hq + h) * D + d]);
+    }
+    __syncthreads();
+
+    // ── Phase A: scores s[q][j] = scale * <Q[q], K[j]> ──
+    // Waves interleave over slice rows (wave w -> rows start+w,
+    // start+w+4, ...). Lane l owns dims {l, l+64, l+128, l+192}:
+    // conflict-free LDS reads of Q, coalesced 2 B/lane K bursts.
+    for (int j = start + wave; j < end; j += ATTN_NWAVES) {
+        const __hip_bfloat16* krow = K + (size_t)j * D;
+        float kd[ATTN_KD_PER_LANE];
+        #pragma unroll
+        for (int i = 0; i < ATTN_KD_PER_LANE; ++i) {
+            const int d = lane + i * FVK_WAVE_SIZE;
+            kd[i] = (d < D) ? __bfloat162float(krow[d]) : 0.0f;
+        }
+        float p[ATTN_SQ_MAX];
+        #pragma unroll
+        for (int q = 0; q < ATTN_SQ_MAX; ++q) {
+            float a = 0.0f;
+            if (q < Sq) {
+                #pragma unroll
+                for (int i = 0; i < ATTN_KD_PER_LANE; ++i) {
+                    const int d = lane + i * FVK_WAVE_SIZE;
+                    if (d < D) a += kd[i] * q_lds[q * D + d];
+                }
+            }
+            p[q] = a;
+        }
+        #pragma unroll
+        for (int q = 0; q < ATTN_SQ_MAX; ++q) {
+            if (q < Sq) {
+                const float r = wave_reduce_sum(p[q]);  // fixed radix-2 tree
+                if (lane == 0)
+                    s_lds[q * ATTN_CHUNK_MAX + (j - start)] = r * scale;
+            }
+        }
+    }
+    __syncthreads();
+
+    // ── Phase B: per-slice online softmax over the <= CHUNK_MAX rows ──
+    // Row maxima: one thread per query row, serial ascending j
+    // (<= 64 iterations — cheaper than another reduction round-trip).
+    if (tid < Sq) {
+        float m = -FLT_MAX;
+        for (int jj = 0; jj < cn; ++jj)
+            m = fmaxf(m, s_lds[tid * ATTN_CHUNK_MAX + jj]);
+        m_lds[tid] = m;
+    }
+    __syncthreads();
+
+    // Exponentiate in place, all threads in parallel.
+    for (int idx = tid; idx < Sq * cn; idx += ATTN_NTHREADS) {
+        const int q  = idx / cn;
+        const int jj = idx - q * cn;
+        float* sp = &s_lds[q * ATTN_CHUNK_MAX + jj];
+        *sp = __expf(*sp - m_lds[q]);
+    }
+    __syncthreads();
+
+    // l[q]: serial ascending j — fixed summation order.
+    if (tid < Sq) {
+        float l = 0.0f;
+        for (int jj = 0; jj < cn; ++jj)
+            l += s_lds[tid * ATTN_CHUNK_MAX + jj];
+        m_ws[tid] = m_lds[tid];
+        l_ws[tid] = l;
+    }
+
+    // ── Phase C: unnormalized acc[q][d] = sum_j p[q][j] * V[j][d] ──
+    // Thread t owns output dim t for all Sq queries; V row reads are
+    // contiguous 2 B/lane, p reads are LDS broadcasts. Ascending j.
+    if (tid < D) {
+        float acc[ATTN_SQ_MAX];
+        #pragma unroll
+        for (int q = 0; q < ATTN_SQ_MAX; ++q) acc[q] = 0.0f;
+        for (int jj = 0; jj < cn; ++jj) {
+            const float v =
+                __bfloat162float(V[(size_t)(start + jj) * D + tid]);
+            #pragma unroll
+            for (int q = 0; q < ATTN_SQ_MAX; ++q)
+                if (q < Sq) acc[q] += s_lds[q * ATTN_CHUNK_MAX + jj] * v;
+        }
+        #pragma unroll
+        for (int q = 0; q < ATTN_SQ_MAX; ++q)
+            if (q < Sq) acc_ws[(size_t)q * D + tid] = acc[q];
+    }
+}
+
+// ── Kernel 2: combine the ATTN_NSPLIT partials per (q, h) ──
+// grid (Sq, Hq), block ATTN_NTHREADS (thread t = output dim t).
+// Standard flash rescale: gm = max_i m_i, coeff_i = exp(m_i - gm),
+// O = (sum_i coeff_i * acc_i) / (sum_i coeff_i * l_i).
+__global__ __launch_bounds__(ATTN_NTHREADS)
+void attention_decoder_gqa_reduce_kernel(
+    const float* __restrict__ ws,
+    __hip_bfloat16* __restrict__ O,
+    int Sq, int Hq, int D) {
+    const int q   = blockIdx.x;
+    const int h   = blockIdx.y;
+    const int tid = threadIdx.x;
+
+    __shared__ float coeff[ATTN_NSPLIT];
+    __shared__ float s_invL;
+
+    const size_t blk = (size_t)Sq * (size_t)(D + 2);  // floats per (split,head)
+    const size_t ml_off = (size_t)Sq * D;
+
+    // Serial over 32 splits on thread 0: ~64 independent fp32 loads,
+    // negligible next to launch cost; fixed ascending order.
+    if (tid == 0) {
+        float gm = -FLT_MAX;
+        for (int i = 0; i < ATTN_NSPLIT; ++i) {
+            const size_t b = (size_t)(i * Hq + h) * blk;
+            const float li = ws[b + ml_off + Sq + q];
+            const float mi = ws[b + ml_off + q];
+            if (li > 0.0f && mi > gm) gm = mi;
+        }
+        float L = 0.0f;
+        for (int i = 0; i < ATTN_NSPLIT; ++i) {
+            const size_t b = (size_t)(i * Hq + h) * blk;
+            const float li = ws[b + ml_off + Sq + q];
+            const float mi = ws[b + ml_off + q];
+            const float c = (li > 0.0f) ? __expf(mi - gm) : 0.0f;
+            coeff[i] = c;
+            L += c * li;
+        }
+        s_invL = (L > 0.0f) ? 1.0f / L : 0.0f;  // skv >= 1 => L > 0
+    }
+    __syncthreads();
+
+    if (tid < D) {
+        float s = 0.0f;
+        for (int i = 0; i < ATTN_NSPLIT; ++i) {
+            const float c = coeff[i];
+            // c == 0 also guards the never-written acc of empty slices.
+            if (c != 0.0f) {
+                const size_t b = (size_t)(i * Hq + h) * blk;
+                s += c * ws[b + (size_t)q * D + tid];
+            }
+        }
+        O[((size_t)q * Hq + h) * D + tid] = __float2bfloat16(s * s_invL);
+    }
+}
+
+// ── Host wrapper ──
+// partial_ws: caller-provided device fp32 scratch of at least
+//   ATTN_NSPLIT * Hq * Sq * (D + 2) floats
+//   (= 32 * Hq * Sq * (D + 2) * 4 bytes; pi05 decoder site
+//   32*8*10*258*4 = 2,641,920 bytes). No allocation, no memset, no
+//   host sync — safe inside HIP graph capture.
+// seqused: nullptr => exact mode (Skv host int is the length);
+//   else device int32, seqused[0] read in-kernel and Skv is ignored
+//   (fixed-shape graph mode; padding rows beyond seqused[0] are
+//   never read).
+// Constraints (fixed-site kernel, not checked): 1 <= Sq <= 16,
+//   D <= 256, seq length <= 2048, single KV head (K/V are (Skv, D)).
+void attention_decoder_gqa(const __hip_bfloat16* Q,
+                           const __hip_bfloat16* K,
+                           const __hip_bfloat16* V,
+                           __hip_bfloat16* O,
+                           float* partial_ws,
+                           int Sq, int Skv, int Hq, int D,
+                           const int* seqused,
+                           float softmax_scale,
+                           hipStream_t stream) {
+    dim3 grid1(ATTN_NSPLIT, Hq);
+    attention_decoder_gqa_partial_kernel<<<grid1, ATTN_NTHREADS, 0, stream>>>(Q, K, V, partial_ws, seqused, Sq, Skv, Hq, D, softmax_scale);
+    dim3 grid2(Sq, Hq);
+    attention_decoder_gqa_reduce_kernel<<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, Sq, Hq, D);
+}

--- a/csrc/amd/attention/decoder_flash.hip
+++ b/csrc/amd/attention/decoder_flash.hip
@@ -345,16 +345,35 @@ void attention_decoder_gqa_partial_kernel(
         const float2* qr =
             reinterpret_cast<const float2*>(&q_lds[q * ATTN_Q_PITCH]);
         float a0 = 0.0f, a1 = 0.0f, a2 = 0.0f, a3 = 0.0f;
-        #pragma unroll 4
-        for (int i = 0; i < dh; i += 2) {  // dh even (D % 4 == 0)
-            const __hip_bfloat162 k0 = kr[i];
-            const __hip_bfloat162 k1 = kr[i + 1];
-            const float2 q0 = qr[i];
-            const float2 q1 = qr[i + 1];
-            a0 = fmaf(__bfloat162float(k0.x), q0.x, a0);
-            a1 = fmaf(__bfloat162float(k0.y), q0.y, a1);
-            a2 = fmaf(__bfloat162float(k1.x), q1.x, a2);
-            a3 = fmaf(__bfloat162float(k1.y), q1.y, a3);
+        if ((dh & 7) == 0) {
+            // 8-deep explicit load batching (LDS latency hiding at the
+            // kernel's 1-wave/SIMD occupancy). Per-chain accumulation
+            // order matches the plain loop — bit-exact.
+            for (int i = 0; i < dh; i += 8) {
+                __hip_bfloat162 kk[8];
+                float2 qq[8];
+                #pragma unroll
+                for (int t = 0; t < 8; ++t) { kk[t] = kr[i + t]; qq[t] = qr[i + t]; }
+                #pragma unroll
+                for (int t = 0; t < 8; t += 2) {
+                    a0 = fmaf(__bfloat162float(kk[t].x),     qq[t].x,     a0);
+                    a1 = fmaf(__bfloat162float(kk[t].y),     qq[t].y,     a1);
+                    a2 = fmaf(__bfloat162float(kk[t + 1].x), qq[t + 1].x, a2);
+                    a3 = fmaf(__bfloat162float(kk[t + 1].y), qq[t + 1].y, a3);
+                }
+            }
+        } else {
+            #pragma unroll 4
+            for (int i = 0; i < dh; i += 2) {  // dh even (D % 4 == 0)
+                const __hip_bfloat162 k0 = kr[i];
+                const __hip_bfloat162 k1 = kr[i + 1];
+                const float2 q0 = qr[i];
+                const float2 q1 = qr[i + 1];
+                a0 = fmaf(__bfloat162float(k0.x), q0.x, a0);
+                a1 = fmaf(__bfloat162float(k0.y), q0.y, a1);
+                a2 = fmaf(__bfloat162float(k1.x), q1.x, a2);
+                a3 = fmaf(__bfloat162float(k1.y), q1.y, a3);
+            }
         }
         s_lds[q * ATTN_S_PITCH + r] = ((a0 + a1) + (a2 + a3)) * scale;
     }
@@ -367,36 +386,78 @@ void attention_decoder_gqa_partial_kernel(
     // ── Phase B: per-query serial softmax (interleaved with A') ──
     // Serial ascending j: max, then exp in place + sum — fixed order,
     // <= 3*chunk LDS ops on Sq threads; s_lds is untouched by A'.
+    // ILP4 softmax: 4 independent chains hide the serial LDS latency
+    // (only Sq threads are active here). max is order-free; the exp
+    // sum combines its chains in fixed order (l0+l1)+(l2+l3).
     if (tid < Sq) {
         float* sp = &s_lds[tid * ATTN_S_PITCH];
-        float m = -FLT_MAX;
-        for (int j = 0; j < cn; ++j) m = fmaxf(m, sp[j]);
-        float l = 0.0f;
-        for (int j = 0; j < cn; ++j) {
+        float m0 = -FLT_MAX, m1 = -FLT_MAX, m2 = -FLT_MAX, m3 = -FLT_MAX;
+        int j = 0;
+        for (; j + 3 < cn; j += 4) {
+            m0 = fmaxf(m0, sp[j]);
+            m1 = fmaxf(m1, sp[j + 1]);
+            m2 = fmaxf(m2, sp[j + 2]);
+            m3 = fmaxf(m3, sp[j + 3]);
+        }
+        for (; j < cn; ++j) m0 = fmaxf(m0, sp[j]);
+        const float m = fmaxf(fmaxf(m0, m1), fmaxf(m2, m3));
+        float l0 = 0.0f, l1 = 0.0f, l2 = 0.0f, l3 = 0.0f;
+        j = 0;
+        for (; j + 3 < cn; j += 4) {
+            const float e0 = __expf(sp[j] - m);
+            const float e1 = __expf(sp[j + 1] - m);
+            const float e2 = __expf(sp[j + 2] - m);
+            const float e3 = __expf(sp[j + 3] - m);
+            sp[j] = e0; sp[j + 1] = e1; sp[j + 2] = e2; sp[j + 3] = e3;
+            l0 += e0; l1 += e1; l2 += e2; l3 += e3;
+        }
+        for (; j < cn; ++j) {
             const float e = __expf(sp[j] - m);
             sp[j] = e;
-            l += e;
+            l0 += e;
         }
         m_ws[tid] = m;
-        l_ws[tid] = l;
+        l_ws[tid] = (l0 + l1) + (l2 + l3);
     }
     __syncthreads();  // V staged + probabilities final
 
     // ── Phase C: one thread per (query, dim-pair) ──
     // acc[q][2dp..2dp+1] = sum_j p[q][j] * V[j][2dp..2dp+1], ascending j.
+    // ILP4 PV: 4 independent accumulator chains hide the serial LDS
+    // latency; chains combine in fixed order (a0+a1)+(a2+a3).
     const int nunits = Sq * dh;
     for (int u = tid; u < nunits; u += ATTN_NTHREADS) {
         const int q  = u / dh;
         const int dp = u - q * dh;
         const float* sp = &s_lds[q * ATTN_S_PITCH];
         const __hip_bfloat162* vp = &kv_lds[dp];
-        float ax = 0.0f, ay = 0.0f;
-        for (int j = 0; j < cn; ++j) {
+        float ax0 = 0.0f, ay0 = 0.0f, ax1 = 0.0f, ay1 = 0.0f;
+        float ax2 = 0.0f, ay2 = 0.0f, ax3 = 0.0f, ay3 = 0.0f;
+        int j = 0;
+        for (; j + 3 < cn; j += 4) {
+            const __hip_bfloat162 v0 = vp[(j)     * ATTN_KV_PITCH];
+            const __hip_bfloat162 v1 = vp[(j + 1) * ATTN_KV_PITCH];
+            const __hip_bfloat162 v2 = vp[(j + 2) * ATTN_KV_PITCH];
+            const __hip_bfloat162 v3 = vp[(j + 3) * ATTN_KV_PITCH];
+            const float p0 = sp[j], p1 = sp[j + 1];
+            const float p2 = sp[j + 2], p3 = sp[j + 3];
+            ax0 = fmaf(p0, __bfloat162float(v0.x), ax0);
+            ay0 = fmaf(p0, __bfloat162float(v0.y), ay0);
+            ax1 = fmaf(p1, __bfloat162float(v1.x), ax1);
+            ay1 = fmaf(p1, __bfloat162float(v1.y), ay1);
+            ax2 = fmaf(p2, __bfloat162float(v2.x), ax2);
+            ay2 = fmaf(p2, __bfloat162float(v2.y), ay2);
+            ax3 = fmaf(p3, __bfloat162float(v3.x), ax3);
+            ay3 = fmaf(p3, __bfloat162float(v3.y), ay3);
+        }
+        for (; j < cn; ++j) {
             const __hip_bfloat162 v = vp[j * ATTN_KV_PITCH];
             const float pj = sp[j];
-            ax = fmaf(pj, __bfloat162float(v.x), ax);
-            ay = fmaf(pj, __bfloat162float(v.y), ay);
+            ax0 = fmaf(pj, __bfloat162float(v.x), ax0);
+            ay0 = fmaf(pj, __bfloat162float(v.y), ay0);
         }
+        const float ax = (ax0 + ax1) + (ax2 + ax3);
+        const float ay = (ay0 + ay1) + (ay2 + ay3);
         float* out = acc_ws + (size_t)q * D + 2 * dp;
         out[0] = ax;   // adjacent 4 B stores; consecutive lanes are
         out[1] = ay;   // consecutive pairs -> coalesced 8 B/lane

--- a/csrc/amd/attention/decoder_flash.hip
+++ b/csrc/amd/attention/decoder_flash.hip
@@ -112,6 +112,15 @@
 //     the per-split m/l loads run on a full wave (lane i <-> split i)
 //     with fixed radix-2 shuffle trees, instead of v1's thread-0
 //     serial loop; the acc combine stays one thread per output dim.
+//     Optional fused FP8 epilogue (same contract as the v3 fused
+//     kernel's): when O_fp8 != nullptr, after the bf16 O store each
+//     thread re-expands its ROUNDED bf16 value, multiplies by
+//     inv = 1/(*d_scale), pre-clamps to +-448 and converts
+//     __hip_fp8_e4m3 — byte-identical to a standalone
+//     quantize_fp8_static launch on the bf16 O with the same device
+//     scale. This makes attention_decoder_gqa_fp8out fully fused on
+//     BOTH wrapper paths (the production v2 split path included),
+//     deleting the ~180 standalone quantize launches per inference.
 //   Two kernels on one stream: plain stream ordering, no atomics, no
 //   cooperative counters — trivially HIP-graph capturable. A fused
 //   single-kernel variant would need a last-WG-done flag (atomics —
@@ -218,11 +227,6 @@
 #define ATTN_S_PITCH    (ATTN_CHUNK_MAX + 1)   // 65 floats: odd stride
 
 #define ATTN_FUSED_SKV_MAX 2048  // fused-path score buffer bound (8 KB LDS)
-
-// forward decl (csrc/amd/kernels/quantize_fp8.hip) — used by the
-// fp8out wrapper's v2-split fallback only.
-void quantize_fp8_static(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
-                         const float* d_scale, int n, hipStream_t stream);
 
 // ── ILP=4 GLOBAL->LDS K/V tile stage (v2 split path) ──
 // stream_probe (gfx950, stream_craft_gfx950.md): one outstanding load
@@ -399,11 +403,15 @@ void attention_decoder_gqa_partial_kernel(
 // O = (sum_i coeff_i * acc_i) / (sum_i coeff_i * l_i).
 // v2: wave 0 loads all m/l in parallel (lane i <-> split i) and
 // reduces with fixed shuffle trees; v1 looped serially on thread 0.
+// Optional FP8 epilogue: O_fp8/d_scale as in the fused kernel —
+// nullptr O_fp8 disables it (plain path, zero extra work).
 template <int NSPLIT>
 __global__ __launch_bounds__(ATTN_NTHREADS)
 void attention_decoder_gqa_reduce_kernel(
     const float* __restrict__ ws,
     __hip_bfloat16* __restrict__ O,
+    __hip_fp8_e4m3* __restrict__ O_fp8,  // optional epilogue (nullptr = off)
+    const float* __restrict__ d_scale,   // device scale, read iff O_fp8
     int Sq, int Hq, int D) {
     const int q    = blockIdx.x;
     const int h    = blockIdx.y;
@@ -447,7 +455,18 @@ void attention_decoder_gqa_reduce_kernel(
                 s += c * ws[b + (size_t)q * D + tid];
             }
         }
-        O[((size_t)q * Hq + h) * D + tid] = __float2bfloat16(s * s_invL);
+        const size_t o_off = ((size_t)q * Hq + h) * D + tid;
+        const __hip_bfloat16 b = __float2bfloat16(s * s_invL);
+        O[o_off] = b;
+        if (O_fp8 != nullptr) {
+            // Bit-exact quantize_fp8_static semantics: quantize the
+            // ROUNDED bf16 value, per-thread inv = 1/(*d_scale)
+            // (single division), pre-clamp +-448, e4m3 convert.
+            const float inv = 1.0f / (*d_scale);
+            const float f =
+                fminf(fmaxf(__bfloat162float(b) * inv, -448.0f), 448.0f);
+            O_fp8[o_off] = __hip_fp8_e4m3(f);
+        }
     }
 }
 
@@ -456,6 +475,8 @@ static void launch_decoder_gqa(const __hip_bfloat16* Q,
                                const __hip_bfloat16* K,
                                const __hip_bfloat16* V,
                                __hip_bfloat16* O,
+                               __hip_fp8_e4m3* O_fp8,
+                               const float* d_scale,
                                float* partial_ws,
                                int Sq, int Skv, int Hq, int D,
                                const int* seqused,
@@ -464,7 +485,7 @@ static void launch_decoder_gqa(const __hip_bfloat16* Q,
     dim3 grid1(NSPLIT, Hq);
     attention_decoder_gqa_partial_kernel<NSPLIT><<<grid1, ATTN_NTHREADS, 0, stream>>>(Q, K, V, partial_ws, seqused, Sq, Skv, Hq, D, softmax_scale);
     dim3 grid2(Sq, Hq);
-    attention_decoder_gqa_reduce_kernel<NSPLIT><<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, Sq, Hq, D);
+    attention_decoder_gqa_reduce_kernel<NSPLIT><<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, O_fp8, d_scale, Sq, Hq, D);
 }
 
 // ================================================================
@@ -652,6 +673,8 @@ static void launch_decoder_gqa_split(const __hip_bfloat16* Q,
                                      const __hip_bfloat16* K,
                                      const __hip_bfloat16* V,
                                      __hip_bfloat16* O,
+                                     __hip_fp8_e4m3* O_fp8,
+                                     const float* d_scale,
                                      float* partial_ws,
                                      int Sq, int Skv, int Hq, int D,
                                      const int* seqused,
@@ -664,13 +687,13 @@ static void launch_decoder_gqa_split(const __hip_bfloat16* Q,
     if (Skv > ns * ATTN_CHUNK_MAX) ns = 32;  // capacity guard
     switch (ns) {
         case 8:
-            launch_decoder_gqa<8>(Q, K, V, O, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
+            launch_decoder_gqa<8>(Q, K, V, O, O_fp8, d_scale, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
             break;
         case 16:
-            launch_decoder_gqa<16>(Q, K, V, O, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
+            launch_decoder_gqa<16>(Q, K, V, O, O_fp8, d_scale, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
             break;
         default:
-            launch_decoder_gqa<32>(Q, K, V, O, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
+            launch_decoder_gqa<32>(Q, K, V, O, O_fp8, d_scale, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
             break;
     }
 }
@@ -691,16 +714,18 @@ void attention_decoder_gqa(const __hip_bfloat16* Q,
             Skv, Hq, D, softmax_scale);
         return;
     }
-    launch_decoder_gqa_split(Q, K, V, O, partial_ws, Sq, Skv, Hq, D,
-                             seqused, softmax_scale, stream);
+    launch_decoder_gqa_split(Q, K, V, O, /*O_fp8=*/nullptr,
+                             /*d_scale=*/nullptr, partial_ws,
+                             Sq, Skv, Hq, D, seqused, softmax_scale, stream);
 }
 
 // Fused-epilogue variant: same attention, plus OCP e4m3 output
 // O_fp8 (Sq, Hq*D) row-major — byte-for-byte what quantize_fp8_static
 // would produce from the bf16 O with the same device scale. O (bf16)
-// is still written, identical to the plain path. On the (never hit at
-// the pi05 site) v2 fallback this degrades to split + a standalone
-// quantize_fp8_static launch — semantics preserved.
+// is still written, identical to the plain path. BOTH wrapper paths
+// are fully fused: the v3 fused kernel carries the epilogue inline,
+// and the v2 split path (the production default) carries it in the
+// reduce kernel — no standalone quantize launch anywhere.
 void attention_decoder_gqa_fp8out(const __hip_bfloat16* Q,
                                   const __hip_bfloat16* K,
                                   const __hip_bfloat16* V,
@@ -718,7 +743,6 @@ void attention_decoder_gqa_fp8out(const __hip_bfloat16* Q,
             Q, K, V, O, O_fp8, d_scale, seqused, Skv, Hq, D, softmax_scale);
         return;
     }
-    launch_decoder_gqa_split(Q, K, V, O, partial_ws, Sq, Skv, Hq, D,
-                             seqused, softmax_scale, stream);
-    quantize_fp8_static(O, O_fp8, d_scale, Sq * Hq * D, stream);
+    launch_decoder_gqa_split(Q, K, V, O, O_fp8, d_scale, partial_ws,
+                             Sq, Skv, Hq, D, seqused, softmax_scale, stream);
 }

--- a/csrc/amd/attention/decoder_flash.hip
+++ b/csrc/amd/attention/decoder_flash.hip
@@ -1,6 +1,68 @@
 // ================================================================
 // FlashRT AMD — decoder cross-attention, split-KV flash (CDNA wave64)
 // v2: thread-parallel dot products, zero cross-lane ops in hot loops.
+// v3: fused single kernel — no workspace, no reduce launch (below).
+//
+// ── v3 (default path, Skv <= 2048): one kernel per (h, q) ──
+// Iteration-2 measurement (rocprof, real captured pi05 graph):
+// partial<32> 21.4us + reduce<32> 12.4us = 33.8us/call. The reduce
+// kernel spends 12us on ~0.5us of real work — fp32 workspace
+// round-trip (2.5 MiB write + read) plus an 80-WG launch tail. v3
+// deletes both: grid (Hq, Sq) = 80 WGs, 256 threads, each WG owns one
+// (head, query) row end-to-end. K/V have ONE head (GQA Hq:1), so all
+// 80 WGs stream the SAME ~850 KB — it lives in L2/LLC after the first
+// touch and every later read is a cache hit; per-XCD L2 (4 MB) holds
+// it whole. No K/V LDS staging anywhere: LDS staging buys coalescing,
+// but here the data is cache-resident, so staging would only add
+// barriers and an LDS round-trip.
+//   Phase 0: Q(h,q) row -> LDS as fp32 (D floats; every later read is
+//     a same-address wave broadcast).
+//   Phase A (scores): thread t owns KV rows j = t, t+256, ... (~4 rows
+//     at skv 876). Full D-dim dot per row, K read straight from
+//     global as 16 B packets (8 bf16) x D/8, q side read as float4
+//     pairs from LDS; 8 fp32 accumulators, fixed combine
+//     ((a0+a1)+(a2+a3))+((a4+a5)+(a6+a7)). Lanes sit on different
+//     rows -> uncoalesced by design, L2-resident so latency-tolerant
+//     (unrolled independent 16 B loads). Scores -> s_lds[j].
+//   Phase B (softmax): grid-stride local max per thread (same fixed
+//     row map), fixed radix-2 wave tree, 4 wave partials -> LDS, every
+//     thread combines the 4 serially (max is order-free). Then exp in
+//     place + local sum (ascending j per thread), wave tree, 4
+//     partials combined in fixed order (r0+r1)+(r2+r3) -> L, invL.
+//     3 barriers total, no workspace.
+//   Phase C (PV): thread t owns dim-pair dp = t % (D/2) and j-half
+//     t / (D/2) — 128 pairs x 2 halves = 256 threads at D=256. For a
+//     fixed j the wave's lanes read CONSECUTIVE dims of V[j]: a
+//     contiguous coalesced 4 B/lane burst (it is phase A, not C, that
+//     is column-strided). Each thread accumulates its half [0,skv/2)
+//     or [skv/2,skv) ascending; high half parks its partial in LDS;
+//     low half combines fixed-order (low + high), scales by invL,
+//     emits bf16. Direct-global chosen over the 64-row LDS-tile
+//     alternative: same global traffic (every WG reads V exactly
+//     once), but zero extra barriers (tile version: ~13 tiles x 2
+//     barriers + 32 KB LDS round-trip) and the coalescing a tile
+//     stage would buy is already there.
+//   Optional fused FP8 epilogue (attention_decoder_gqa_fp8out): after
+//     the bf16 store, re-expand the ROUNDED bf16 value, multiply by
+//     inv = 1/(*d_scale) (device scalar, same per-thread single
+//     division as quantize_fp8_static), clamp to +-448, convert
+//     __hip_fp8_e4m3 — bit-identical to running quantize_fp8_static
+//     on the bf16 O, so the standalone quantize launch (~180/graph)
+//     disappears. O bf16 is still written unchanged for parity
+//     tooling and bf16 consumers.
+//   Occupancy: 80 WGs on 256 CUs = 31% of CUs, 4 waves each = 1
+//     wave/SIMD on the busy CUs — latency hiding comes from ILP
+//     (unrolled independent loads), not TLP. LDS ~10.3 KB/WG.
+//   Determinism: fixed thread<->row and thread<->dim maps, fixed-order
+//     serial + radix-2 tree reductions, no atomics. Bit-stable for a
+//     given (shape, skv_eff).
+//   Wrapper: fused path when Skv <= 2048 and D % 8 == 0 (always true
+//     at the pi05 site); v2 split path otherwise, and
+//     FRT_ATTN_FORCE_SPLIT=1 forces v2 for A/B benches (read per call,
+//     frozen into a graph at capture). partial_ws is accepted and
+//     ignored by the fused path. Signatures unchanged.
+//
+// ── v2 (fallback path) — original notes below ──
 //
 // One fixed production site: tiny-M GQA cross-attention
 //     Q (Sq, Hq, D) bf16   — Sq ~ 10 query tokens, Hq query heads
@@ -19,6 +81,10 @@
 // kernel 1:
 //   Phase 0 (stage):   Q (Sq x D, fp32) and this split's K tile
 //                      (chunk x D, bf16 pairs) into LDS, coalesced.
+//                      K/V staging batches 4 independent global loads
+//                      per thread before storing (ILP=4 — measured
+//                      gfx950 streaming recipe; pure copy, bytes and
+//                      mapping unchanged: attn_stage_tile_ilp4).
 //   Phase A (scores):  one thread per (query, kv-row) pair —
 //                      Sq*chunk pairs over 256 threads (chunk=26 at
 //                      the site -> 260 pairs, ~1 loop iteration).
@@ -137,6 +203,8 @@
 
 #include "../kernels/common_hip.h"
 
+#include <hip/hip_fp8.h>
+
 #include <cfloat>
 #include <cstdlib>
 
@@ -148,6 +216,56 @@
 #define ATTN_KV_PITCH   (ATTN_D_MAX / 2 + 1)   // 129 bf16-pairs: odd stride
 #define ATTN_Q_PITCH    (ATTN_D_MAX + 2)       // 258 floats: even, f2-aligned
 #define ATTN_S_PITCH    (ATTN_CHUNK_MAX + 1)   // 65 floats: odd stride
+
+#define ATTN_FUSED_SKV_MAX 2048  // fused-path score buffer bound (8 KB LDS)
+
+// forward decl (csrc/amd/kernels/quantize_fp8.hip) — used by the
+// fp8out wrapper's v2-split fallback only.
+void quantize_fp8_static(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
+                         const float* d_scale, int n, hipStream_t stream);
+
+// ── ILP=4 GLOBAL->LDS K/V tile stage (v2 split path) ──
+// stream_probe (gfx950, stream_craft_gfx950.md): one outstanding load
+// per lane is latency-window bound (~1373 GB/s @4MB footprints); four
+// INDEPENDENT loads issued before any consumer quadruple the bytes in
+// flight (co_x4_i4 winners). Here the per-thread stage loop was a
+// serial 4 B load chain — batch four grid-stride iterations so the
+// four global loads issue back-to-back before the LDS stores. Pure
+// copy: element mapping, staged bytes, and barrier placement are
+// identical to the plain loop, so kernel math is bit-unchanged.
+// src must be pre-offset to the slice (K/V base + start*dh, bf16 pairs);
+// the global side is then linear in idx; the LDS side keeps the
+// ATTN_KV_PITCH row pitch.
+__device__ __forceinline__ void attn_stage_tile_ilp4(
+    __hip_bfloat162* __restrict__ dst,          // kv_lds
+    const __hip_bfloat162* __restrict__ src,    // slice base (row `start`)
+    int cn, int dh, int tid) {
+    const int total = cn * dh;
+    int idx = tid;
+    for (; idx + 3 * ATTN_NTHREADS < total; idx += 4 * ATTN_NTHREADS) {
+        const int i0 = idx;
+        const int i1 = idx + ATTN_NTHREADS;
+        const int i2 = idx + 2 * ATTN_NTHREADS;
+        const int i3 = idx + 3 * ATTN_NTHREADS;
+        // four independent global loads, distinct destination registers
+        const __hip_bfloat162 v0 = src[i0];
+        const __hip_bfloat162 v1 = src[i1];
+        const __hip_bfloat162 v2 = src[i2];
+        const __hip_bfloat162 v3 = src[i3];
+        const int r0 = i0 / dh, e0 = i0 - r0 * dh;
+        const int r1 = i1 / dh, e1 = i1 - r1 * dh;
+        const int r2 = i2 / dh, e2 = i2 - r2 * dh;
+        const int r3 = i3 / dh, e3 = i3 - r3 * dh;
+        dst[r0 * ATTN_KV_PITCH + e0] = v0;
+        dst[r1 * ATTN_KV_PITCH + e1] = v1;
+        dst[r2 * ATTN_KV_PITCH + e2] = v2;
+        dst[r3 * ATTN_KV_PITCH + e3] = v3;
+    }
+    for (; idx < total; idx += ATTN_NTHREADS) {
+        const int r = idx / dh, e = idx - r * dh;
+        dst[r * ATTN_KV_PITCH + e] = src[idx];
+    }
+}
 
 // ── Kernel 1: per-slice flash partials ──
 // grid (NSPLIT, Hq), block ATTN_NTHREADS.
@@ -203,11 +321,7 @@ void attention_decoder_gqa_partial_kernel(
             __bfloat162float(Q[((size_t)q * Hq + h) * D + d]);
     }
     const __hip_bfloat162* K2 = reinterpret_cast<const __hip_bfloat162*>(K);
-    for (int idx = tid; idx < cn * dh; idx += ATTN_NTHREADS) {
-        const int r = idx / dh;
-        const int c = idx - r * dh;
-        kv_lds[r * ATTN_KV_PITCH + c] = K2[(size_t)(start + r) * dh + c];
-    }
+    attn_stage_tile_ilp4(kv_lds, K2 + (size_t)start * dh, cn, dh, tid);
     __syncthreads();
 
     // ── Phase A: one thread per (query, kv-row) pair ──
@@ -238,11 +352,7 @@ void attention_decoder_gqa_partial_kernel(
 
     // ── Phase A': refill the tile with V (all threads) ──
     const __hip_bfloat162* V2 = reinterpret_cast<const __hip_bfloat162*>(V);
-    for (int idx = tid; idx < cn * dh; idx += ATTN_NTHREADS) {
-        const int r = idx / dh;
-        const int c = idx - r * dh;
-        kv_lds[r * ATTN_KV_PITCH + c] = V2[(size_t)(start + r) * dh + c];
-    }
+    attn_stage_tile_ilp4(kv_lds, V2 + (size_t)start * dh, cn, dh, tid);
 
     // ── Phase B: per-query serial softmax (interleaved with A') ──
     // Serial ascending j: max, then exp in place + sum — fixed order,
@@ -357,31 +467,196 @@ static void launch_decoder_gqa(const __hip_bfloat16* Q,
     attention_decoder_gqa_reduce_kernel<NSPLIT><<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, Sq, Hq, D);
 }
 
-// ── Host wrapper ──
+// ================================================================
+// v3 fused single kernel — see the v3 section of the file header.
+// grid (Hq, Sq), block 256 (4 waves). One WG owns O(h, q, :) whole:
+// scores -> softmax -> PV, all in one launch, no workspace.
+// ================================================================
+
+// 16 B global-load packet: 8 bf16 (one dwordx4). Rows are 16 B
+// aligned whenever D % 8 == 0 and the tensor base is 16 B aligned.
+struct alignas(16) attn_bf16x8 {
+    __hip_bfloat162 p0, p1, p2, p3;
+};
+
+__global__ __launch_bounds__(ATTN_NTHREADS)
+void attention_decoder_gqa_fused_kernel(
+    const __hip_bfloat16* __restrict__ Q,
+    const __hip_bfloat16* __restrict__ K,
+    const __hip_bfloat16* __restrict__ V,
+    __hip_bfloat16* __restrict__ O,
+    __hip_fp8_e4m3* __restrict__ O_fp8,  // optional epilogue (nullptr = off)
+    const float* __restrict__ d_scale,   // device scale, read iff O_fp8
+    const int* __restrict__ seqused,
+    int Skv, int Hq, int D, float scale) {
+    static_assert(ATTN_NTHREADS == 256, "combine trees hardcode 4 waves");
+    const int h    = blockIdx.x;
+    const int q    = blockIdx.y;
+    const int tid  = threadIdx.x;
+    const int lane = tid & (FVK_WAVE_SIZE - 1);
+    const int wave = tid >> 6;
+
+    alignas(16) __shared__ float q_lds[ATTN_D_MAX];        // fp32 query row
+    alignas(16) __shared__ float s_lds[ATTN_FUSED_SKV_MAX];// scores -> probs
+    __shared__ float red_lds[8];                           // [0..3] max, [4..7] sum
+    __shared__ float c_lds[ATTN_D_MAX];                    // phase-C high-half partials
+
+    int skv = (seqused != nullptr) ? seqused[0] : Skv;
+    if (skv > ATTN_FUSED_SKV_MAX) skv = ATTN_FUSED_SKV_MAX;  // documented cap
+
+    // ── Phase 0: stage Q(h, q, :) as fp32 (later reads broadcast) ──
+    if (tid < D)
+        q_lds[tid] = __bfloat162float(Q[((size_t)q * Hq + h) * D + tid]);
+    __syncthreads();
+
+    // ── Phase A: scores — thread t owns rows j = t, t+256, ... ──
+    // K straight from global (L2-resident, shared by all 80 WGs);
+    // uncoalesced across lanes by design, hidden by unrolled
+    // independent 16 B loads. Fixed 8-acc combine order.
+    const int d8 = D >> 3;  // 16 B packets per row
+    for (int j = tid; j < skv; j += ATTN_NTHREADS) {
+        const attn_bf16x8* kr =
+            reinterpret_cast<const attn_bf16x8*>(K + (size_t)j * D);
+        float a0 = 0.0f, a1 = 0.0f, a2 = 0.0f, a3 = 0.0f;
+        float a4 = 0.0f, a5 = 0.0f, a6 = 0.0f, a7 = 0.0f;
+        #pragma unroll 4
+        for (int i = 0; i < d8; ++i) {
+            const attn_bf16x8 kb = kr[i];
+            const float4* qp =
+                reinterpret_cast<const float4*>(&q_lds[i << 3]);
+            const float4 qa = qp[0];
+            const float4 qb = qp[1];
+            a0 = fmaf(__bfloat162float(kb.p0.x), qa.x, a0);
+            a1 = fmaf(__bfloat162float(kb.p0.y), qa.y, a1);
+            a2 = fmaf(__bfloat162float(kb.p1.x), qa.z, a2);
+            a3 = fmaf(__bfloat162float(kb.p1.y), qa.w, a3);
+            a4 = fmaf(__bfloat162float(kb.p2.x), qb.x, a4);
+            a5 = fmaf(__bfloat162float(kb.p2.y), qb.y, a5);
+            a6 = fmaf(__bfloat162float(kb.p3.x), qb.z, a6);
+            a7 = fmaf(__bfloat162float(kb.p3.y), qb.w, a7);
+        }
+        s_lds[j] = (((a0 + a1) + (a2 + a3)) + ((a4 + a5) + (a6 + a7))) * scale;
+    }
+    __syncthreads();
+
+    // ── Phase B1: global max (order-free) ──
+    float lm = -FLT_MAX;
+    for (int j = tid; j < skv; j += ATTN_NTHREADS) lm = fmaxf(lm, s_lds[j]);
+    lm = wave_reduce_max(lm);
+    if (lane == 0) red_lds[wave] = lm;
+    __syncthreads();
+    const float gm =
+        fmaxf(fmaxf(red_lds[0], red_lds[1]), fmaxf(red_lds[2], red_lds[3]));
+
+    // ── Phase B2: exp in place + fixed-order sum ──
+    // Per-thread serial ascending j over the fixed row map, then the
+    // fixed radix-2 wave tree, then (r0+r1)+(r2+r3) — deterministic
+    // for a given (shape, skv). Every thread computes L redundantly
+    // (identical bits) — saves a broadcast barrier.
+    float ls = 0.0f;
+    for (int j = tid; j < skv; j += ATTN_NTHREADS) {
+        const float e = __expf(s_lds[j] - gm);
+        s_lds[j] = e;   // own rows only — no race
+        ls += e;
+    }
+    ls = wave_reduce_sum(ls);
+    if (lane == 0) red_lds[4 + wave] = ls;
+    __syncthreads();  // probs final + sum partials visible
+    const float L = (red_lds[4] + red_lds[5]) + (red_lds[6] + red_lds[7]);
+    const float invL = (L > 0.0f) ? 1.0f / L : 0.0f;
+
+    // ── Phase C: PV — thread t owns dim-pair (t % dh) in j-half (t / dh) ──
+    // For fixed j the wave reads consecutive dims of V[j]: contiguous
+    // coalesced 4 B/lane. s_lds[j] is a same-address broadcast.
+    const int dh   = D >> 1;            // dim-pairs; <= 128
+    const int half = tid / dh;          // 0 = low j-half, 1 = high; >= 2 idle
+    const int dp   = tid - half * dh;
+    const int jmid = skv >> 1;
+    float ax = 0.0f, ay = 0.0f;
+    if (half < 2) {
+        const int j0 = half ? jmid : 0;
+        const int j1 = half ? skv : jmid;
+        const __hip_bfloat162* vp =
+            reinterpret_cast<const __hip_bfloat162*>(V) + dp;
+        #pragma unroll 4
+        for (int j = j0; j < j1; ++j) {
+            const __hip_bfloat162 v = vp[(size_t)j * dh];
+            const float pj = s_lds[j];
+            ax = fmaf(pj, __bfloat162float(v.x), ax);
+            ay = fmaf(pj, __bfloat162float(v.y), ay);
+        }
+    }
+    if (half == 1) {          // SoA park: consecutive lanes, consecutive banks
+        c_lds[dp] = ax;
+        c_lds[dh + dp] = ay;
+    }
+    __syncthreads();
+    if (half == 0) {
+        const float sx = (ax + c_lds[dp]) * invL;       // fixed: low + high
+        const float sy = (ay + c_lds[dh + dp]) * invL;
+        const __hip_bfloat16 bx = __float2bfloat16(sx);
+        const __hip_bfloat16 by = __float2bfloat16(sy);
+        const size_t o_off = ((size_t)q * Hq + h) * D + 2 * (size_t)dp;
+        *reinterpret_cast<__hip_bfloat162*>(O + o_off) =
+            __halves2bfloat162(bx, by);
+        if (O_fp8 != nullptr) {
+            // Bit-exact quantize_fp8_static semantics: quantize the
+            // ROUNDED bf16 value, per-thread inv = 1/(*d_scale)
+            // (single division), pre-clamp +-448, e4m3 convert.
+            const float inv = 1.0f / (*d_scale);
+            const float fx =
+                fminf(fmaxf(__bfloat162float(bx) * inv, -448.0f), 448.0f);
+            const float fy =
+                fminf(fmaxf(__bfloat162float(by) * inv, -448.0f), 448.0f);
+            O_fp8[o_off]     = __hip_fp8_e4m3(fx);
+            O_fp8[o_off + 1] = __hip_fp8_e4m3(fy);
+        }
+    }
+}
+
+// ── Host wrappers ──
 // partial_ws: caller-provided device fp32 scratch of at least
 //   ATTN_NSPLIT_MAX(32) * Hq * Sq * (D + 2) floats (pi05 decoder
 //   site: 32*8*10*258*4 = 2,641,920 bytes) — sized for the largest
-//   variant so the buffer works for any NSPLIT pick. No allocation,
-//   no memset, no host sync — safe inside HIP graph capture.
+//   split variant. The fused path accepts and IGNORES it (kept so the
+//   signature and callers are unchanged). No allocation, no memset,
+//   no host sync — safe inside HIP graph capture.
 // seqused: nullptr => exact mode (Skv host int is the length);
 //   else device int32, seqused[0] read in-kernel and the host Skv is
 //   only the padded capacity bound (fixed-shape graph mode; padding
 //   rows beyond seqused[0] are never read).
-// NSPLIT: heuristic on host Skv keeps chunk ~<= 32 (see header);
-//   FRT_ATTN_NSPLIT=8|16|32 overrides, re-read every call so a bench
-//   can sweep — but a captured graph keeps the capture-time choice.
-// Constraints (fixed-site kernel, not checked): 1 <= Sq <= 16,
-//   D <= 256, D % 4 == 0, seq length <= NSPLIT*64, single KV head
-//   (K/V are (Skv, D)).
-void attention_decoder_gqa(const __hip_bfloat16* Q,
-                           const __hip_bfloat16* K,
-                           const __hip_bfloat16* V,
-                           __hip_bfloat16* O,
-                           float* partial_ws,
-                           int Sq, int Skv, int Hq, int D,
-                           const int* seqused,
-                           float softmax_scale,
-                           hipStream_t stream) {
+// Path pick (host, per call — frozen into a graph at capture time):
+//   fused single kernel when Skv <= 2048 and D % 8 == 0 (K/V rows
+//   16 B aligned); v2 split otherwise. FRT_ATTN_FORCE_SPLIT=1 forces
+//   the v2 path for A/B benches. On the v2 path the NSPLIT heuristic
+//   and FRT_ATTN_NSPLIT=8|16|32 behave as before.
+// Constraints (fixed-site kernel, not checked): D <= 256, D % 4 == 0
+//   (fused additionally wants D % 8 == 0), seq length <= 2048, single
+//   KV head (K/V are (Skv, D)). v2 also needs Sq <= 16; the fused
+//   path has no Sq cap (one WG per query).
+
+static bool attn_use_fused(int Skv, int D) {
+    // Default is the v2 split path: measured in-graph 36.5us vs the fused
+    // single kernel's 40.6us at the pi05 site, and the fused kernel's
+    // larger per-call L2 footprint degrades neighboring GEMMs in the real
+    // captured graph (E2E +2ms). FRT_ATTN_FUSED=1 opts back in for A/B.
+    if (const char* e = std::getenv("FRT_ATTN_FUSED"))
+        if (std::atoi(e) != 0)
+            return Skv <= ATTN_FUSED_SKV_MAX && D <= ATTN_D_MAX && (D % 8) == 0;
+    if (const char* e = std::getenv("FRT_ATTN_FORCE_SPLIT"))
+        (void)e;  // legacy switch, now the default
+    return false;
+}
+
+static void launch_decoder_gqa_split(const __hip_bfloat16* Q,
+                                     const __hip_bfloat16* K,
+                                     const __hip_bfloat16* V,
+                                     __hip_bfloat16* O,
+                                     float* partial_ws,
+                                     int Sq, int Skv, int Hq, int D,
+                                     const int* seqused,
+                                     float softmax_scale,
+                                     hipStream_t stream) {
     int ns = 0;
     if (const char* e = std::getenv("FRT_ATTN_NSPLIT")) ns = std::atoi(e);
     if (ns != 8 && ns != 16 && ns != 32)
@@ -398,4 +673,52 @@ void attention_decoder_gqa(const __hip_bfloat16* Q,
             launch_decoder_gqa<32>(Q, K, V, O, partial_ws, Sq, Skv, Hq, D, seqused, softmax_scale, stream);
             break;
     }
+}
+
+void attention_decoder_gqa(const __hip_bfloat16* Q,
+                           const __hip_bfloat16* K,
+                           const __hip_bfloat16* V,
+                           __hip_bfloat16* O,
+                           float* partial_ws,
+                           int Sq, int Skv, int Hq, int D,
+                           const int* seqused,
+                           float softmax_scale,
+                           hipStream_t stream) {
+    if (attn_use_fused(Skv, D)) {
+        dim3 grid(Hq, Sq);
+        attention_decoder_gqa_fused_kernel<<<grid, ATTN_NTHREADS, 0, stream>>>(
+            Q, K, V, O, /*O_fp8=*/nullptr, /*d_scale=*/nullptr, seqused,
+            Skv, Hq, D, softmax_scale);
+        return;
+    }
+    launch_decoder_gqa_split(Q, K, V, O, partial_ws, Sq, Skv, Hq, D,
+                             seqused, softmax_scale, stream);
+}
+
+// Fused-epilogue variant: same attention, plus OCP e4m3 output
+// O_fp8 (Sq, Hq*D) row-major — byte-for-byte what quantize_fp8_static
+// would produce from the bf16 O with the same device scale. O (bf16)
+// is still written, identical to the plain path. On the (never hit at
+// the pi05 site) v2 fallback this degrades to split + a standalone
+// quantize_fp8_static launch — semantics preserved.
+void attention_decoder_gqa_fp8out(const __hip_bfloat16* Q,
+                                  const __hip_bfloat16* K,
+                                  const __hip_bfloat16* V,
+                                  __hip_bfloat16* O,
+                                  __hip_fp8_e4m3* O_fp8,
+                                  const float* d_scale,
+                                  float* partial_ws,
+                                  int Sq, int Skv, int Hq, int D,
+                                  const int* seqused,
+                                  float softmax_scale,
+                                  hipStream_t stream) {
+    if (attn_use_fused(Skv, D)) {
+        dim3 grid(Hq, Sq);
+        attention_decoder_gqa_fused_kernel<<<grid, ATTN_NTHREADS, 0, stream>>>(
+            Q, K, V, O, O_fp8, d_scale, seqused, Skv, Hq, D, softmax_scale);
+        return;
+    }
+    launch_decoder_gqa_split(Q, K, V, O, partial_ws, Sq, Skv, Hq, D,
+                             seqused, softmax_scale, stream);
+    quantize_fp8_static(O, O_fp8, d_scale, Sq * Hq * D, stream);
 }

--- a/csrc/amd/attention/decoder_flash.hip
+++ b/csrc/amd/attention/decoder_flash.hip
@@ -111,7 +111,13 @@
 //     with the standard flash rescale and emits bf16 O. v2 change:
 //     the per-split m/l loads run on a full wave (lane i <-> split i)
 //     with fixed radix-2 shuffle trees, instead of v1's thread-0
-//     serial loop; the acc combine stays one thread per output dim.
+//     serial loop; the acc combine stays one thread per output dim,
+//     with the NSPLIT split loads batched 4-wide (ILP4) ahead of the
+//     ascending-split accumulate (sum order unchanged — see the
+//     in-kernel comment). Env FRT_ATTN_REDUCE_ALT=1 swaps in a
+//     512-thread alternate (2 (q,h) pairs per WG, grid halved to
+//     ceil(Sq*Hq/2)) with bit-identical outputs — read per call on
+//     the host, frozen into a graph at capture time.
 //     Optional fused FP8 epilogue (same contract as the v3 fused
 //     kernel's): when O_fp8 != nullptr, after the bf16 O store each
 //     thread re-expands its ROUNDED bf16 value, multiplies by
@@ -445,15 +451,35 @@ void attention_decoder_gqa_reduce_kernel(
     __syncthreads();
 
     if (tid < D) {
+        // ILP4 acc combine (stream_probe: one outstanding 4 B load per
+        // lane is latency-window bound; four INDEPENDENT loads issued
+        // before any consumer quadruple the bytes in flight). The old
+        // loop's guarded load-then-FMA compiled as one serial chain of
+        // NSPLIT latency windows per thread. Batch FOUR split loads
+        // into registers first, then accumulate — the ADDS stay in
+        // ascending split order, so the fixed deterministic fp32 sum
+        // order documented in the header is preserved; only the LOADS
+        // are hoisted. Loads are now unconditional: the workspace is
+        // allocated for all NSPLIT splits (never-written empty-tail acc
+        // may hold garbage/NaN), and the c == 0 SELECT on the
+        // accumulate still excludes them — select, not multiply, since
+        // 0 * NaN would poison the sum.
+        static_assert(NSPLIT % 4 == 0, "ILP4 combine assumes 4 | NSPLIT");
+        const size_t sstride = (size_t)Hq * blk;  // floats, split i -> i+1
+        const float* ap = ws + (size_t)h * blk + (size_t)q * D + tid;
         float s = 0.0f;
         #pragma unroll
-        for (int i = 0; i < NSPLIT; ++i) {
-            const float c = coeff[i];
-            // c == 0 also guards the never-written acc of empty slices.
-            if (c != 0.0f) {
-                const size_t b = (size_t)(i * Hq + h) * blk;
-                s += c * ws[b + (size_t)q * D + tid];
-            }
+        for (int i = 0; i < NSPLIT; i += 4) {
+            const float v0 = ap[(i + 0) * sstride];
+            const float v1 = ap[(i + 1) * sstride];
+            const float v2 = ap[(i + 2) * sstride];
+            const float v3 = ap[(i + 3) * sstride];
+            const float c0 = coeff[i + 0], c1 = coeff[i + 1];
+            const float c2 = coeff[i + 2], c3 = coeff[i + 3];
+            s = (c0 != 0.0f) ? fmaf(c0, v0, s) : s;
+            s = (c1 != 0.0f) ? fmaf(c1, v1, s) : s;
+            s = (c2 != 0.0f) ? fmaf(c2, v2, s) : s;
+            s = (c3 != 0.0f) ? fmaf(c3, v3, s) : s;
         }
         const size_t o_off = ((size_t)q * Hq + h) * D + tid;
         const __hip_bfloat16 b = __float2bfloat16(s * s_invL);
@@ -462,6 +488,89 @@ void attention_decoder_gqa_reduce_kernel(
             // Bit-exact quantize_fp8_static semantics: quantize the
             // ROUNDED bf16 value, per-thread inv = 1/(*d_scale)
             // (single division), pre-clamp +-448, e4m3 convert.
+            const float inv = 1.0f / (*d_scale);
+            const float f =
+                fminf(fmaxf(__bfloat162float(b) * inv, -448.0f), 448.0f);
+            O_fp8[o_off] = __hip_fp8_e4m3(f);
+        }
+    }
+}
+
+// ── Optional reduce alternate (env FRT_ATTN_REDUCE_ALT=1) ──
+// Same per-(q, h) math as attention_decoder_gqa_reduce_kernel, but 512
+// threads per WG covering TWO (q, h) pairs (half 0 = waves 0-3, half 1
+// = waves 4-7), so the grid halves from Sq*Hq tiny WGs to
+// ceil(Sq*Hq/2) — amortizing launch/WG setup, the dominant cost of a
+// kernel whose real work is ~0.5 us. Register pressure is tiny here
+// (unlike the partial kernel's w8 spill precedent), so doubling the
+// block is free. Pair p = q*Hq + h maps halves to ADJACENT output
+// D-blocks -> one WG stores 2*D contiguous bf16. The load/accumulate
+// code per pair is identical to the default kernel (same ILP4 batching,
+// same ascending-split fixed-order sum, same fp8 epilogue), so outputs
+// are bit-identical. Guarded per-phase for odd Sq*Hq (idle half still
+// reaches __syncthreads).
+template <int NSPLIT>
+__global__ __launch_bounds__(2 * ATTN_NTHREADS)
+void attention_decoder_gqa_reduce_alt_kernel(
+    const float* __restrict__ ws,
+    __hip_bfloat16* __restrict__ O,
+    __hip_fp8_e4m3* __restrict__ O_fp8,  // optional epilogue (nullptr = off)
+    const float* __restrict__ d_scale,   // device scale, read iff O_fp8
+    int Sq, int Hq, int D) {
+    const int hf   = (int)(threadIdx.x >> 8);            // half 0 / 1
+    const int tid  = (int)(threadIdx.x & (ATTN_NTHREADS - 1));
+    const int lane = tid & (FVK_WAVE_SIZE - 1);
+    const int wave = tid >> 6;                           // wave within half
+    const int np   = Sq * Hq;
+    const int p    = (int)blockIdx.x * 2 + hf;           // pair = q*Hq + h
+    const int q    = p / Hq;
+    const int h    = p - q * Hq;
+
+    __shared__ float coeff[2][NSPLIT];
+    __shared__ float s_invL[2];
+
+    const size_t blk = (size_t)Sq * (size_t)(D + 2);  // floats per (split,head)
+    const size_t ml_off = (size_t)Sq * D;
+
+    static_assert(NSPLIT <= FVK_WAVE_SIZE, "one wave covers all splits");
+    if (wave == 0 && p < np) {  // wave 0 of each half owns its pair's m/l
+        float mi = -FLT_MAX, li = 0.0f;
+        if (lane < NSPLIT) {
+            const size_t b = (size_t)(lane * Hq + h) * blk;
+            li = ws[b + ml_off + Sq + q];
+            mi = ws[b + ml_off + q];
+        }
+        float gm = wave_reduce_max((li > 0.0f) ? mi : -FLT_MAX);
+        gm = __shfl(gm, 0);
+        const float c = (lane < NSPLIT && li > 0.0f) ? __expf(mi - gm) : 0.0f;
+        if (lane < NSPLIT) coeff[hf][lane] = c;
+        const float L = wave_reduce_sum(c * li);
+        if (lane == 0) s_invL[hf] = (L > 0.0f) ? 1.0f / L : 0.0f;
+    }
+    __syncthreads();
+
+    if (tid < D && p < np) {
+        static_assert(NSPLIT % 4 == 0, "ILP4 combine assumes 4 | NSPLIT");
+        const size_t sstride = (size_t)Hq * blk;  // floats, split i -> i+1
+        const float* ap = ws + (size_t)h * blk + (size_t)q * D + tid;
+        float s = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < NSPLIT; i += 4) {
+            const float v0 = ap[(i + 0) * sstride];
+            const float v1 = ap[(i + 1) * sstride];
+            const float v2 = ap[(i + 2) * sstride];
+            const float v3 = ap[(i + 3) * sstride];
+            const float c0 = coeff[hf][i + 0], c1 = coeff[hf][i + 1];
+            const float c2 = coeff[hf][i + 2], c3 = coeff[hf][i + 3];
+            s = (c0 != 0.0f) ? fmaf(c0, v0, s) : s;
+            s = (c1 != 0.0f) ? fmaf(c1, v1, s) : s;
+            s = (c2 != 0.0f) ? fmaf(c2, v2, s) : s;
+            s = (c3 != 0.0f) ? fmaf(c3, v3, s) : s;
+        }
+        const size_t o_off = ((size_t)q * Hq + h) * D + tid;
+        const __hip_bfloat16 b = __float2bfloat16(s * s_invL[hf]);
+        O[o_off] = b;
+        if (O_fp8 != nullptr) {
             const float inv = 1.0f / (*d_scale);
             const float f =
                 fminf(fmaxf(__bfloat162float(b) * inv, -448.0f), 448.0f);
@@ -484,8 +593,19 @@ static void launch_decoder_gqa(const __hip_bfloat16* Q,
                                hipStream_t stream) {
     dim3 grid1(NSPLIT, Hq);
     attention_decoder_gqa_partial_kernel<NSPLIT><<<grid1, ATTN_NTHREADS, 0, stream>>>(Q, K, V, partial_ws, seqused, Sq, Skv, Hq, D, softmax_scale);
-    dim3 grid2(Sq, Hq);
-    attention_decoder_gqa_reduce_kernel<NSPLIT><<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, O_fp8, d_scale, Sq, Hq, D);
+    // FRT_ATTN_REDUCE_ALT=1 -> w8 alternate (2 pairs/WG, half the
+    // grid). Read per call on the host, like FRT_ATTN_NSPLIT: frozen
+    // into a captured graph at capture time, env flips later do NOT
+    // re-route an existing graph.
+    bool alt = false;
+    if (const char* e = std::getenv("FRT_ATTN_REDUCE_ALT")) alt = std::atoi(e) != 0;
+    if (alt) {
+        dim3 grid2((Sq * Hq + 1) / 2);
+        attention_decoder_gqa_reduce_alt_kernel<NSPLIT><<<grid2, 2 * ATTN_NTHREADS, 0, stream>>>(partial_ws, O, O_fp8, d_scale, Sq, Hq, D);
+    } else {
+        dim3 grid2(Sq, Hq);
+        attention_decoder_gqa_reduce_kernel<NSPLIT><<<grid2, ATTN_NTHREADS, 0, stream>>>(partial_ws, O, O_fp8, d_scale, Sq, Hq, D);
+    }
 }
 
 // ================================================================

--- a/csrc/amd/attention/encoder_flash.hip
+++ b/csrc/amd/attention/encoder_flash.hip
@@ -73,7 +73,17 @@ void encoder_attention_flash_kernel(
     const __hip_bfloat16* __restrict__ K,
     const __hip_bfloat16* __restrict__ V,
     __hip_bfloat16* __restrict__ O,
-    int S, int Hq, float scale, int mask) {
+    int S, int Hq, float scale, int mask,
+    const int* __restrict__ seqused) {
+    // Runtime valid length (FA2 seqused contract): S stays the padded
+    // capacity that sized the grid; the device value masks compute.
+    // Uniform across the workgroup, so the derived loop bounds and
+    // barriers stay convergent.
+    const int Scap = S;   // padded capacity (grid/store bound)
+    if (seqused != nullptr) {
+        const int se = seqused[0];
+        if (se > 0 && se < S) S = se;
+    }
     extern __shared__ unsigned char lds_raw[];
     EfaLds& lds = *reinterpret_cast<EfaLds*>(lds_raw);
 
@@ -268,22 +278,26 @@ void encoder_attention_flash_kernel(
         }
     }
 
-    // ── Epilogue: O = acc / l, store valid q rows ──
+    // ── Epilogue: O = acc / l for valid q rows; pad rows in
+    // [S, Scap) are ZEROED (never skipped) so downstream consumers of
+    // the padded buffer — including FP8 calibration's absmax — see
+    // well-defined finite values instead of stale/NaN memory. ──
     #pragma unroll
     for (int i = 0; i < 4; ++i) {
         const int m = 4 * kgrp + i;
         const int qrow = q0 + m;
-        if (qrow >= S) continue;
+        if (qrow >= Scap) continue;
         float lt = l_run[i];
         #pragma unroll
         for (int off = 8; off > 0; off >>= 1)
             lt += __shfl_xor(lt, off);
-        const float inv_l = (lt > 0.0f) ? 1.0f / lt : 0.0f;
+        const float inv_l =
+            (qrow < S && lt > 0.0f) ? 1.0f / lt : 0.0f;
         #pragma unroll
         for (int t = 0; t < EFA_D / 16; ++t) {
             const int d = 16 * t + fcol;
             O[((size_t)qrow * Hq + h) * EFA_D + d] =
-                __float2bfloat16(oacc[t][i] * inv_l);
+                __float2bfloat16(qrow < S ? oacc[t][i] * inv_l : 0.0f);
         }
     }
 }
@@ -293,7 +307,8 @@ void encoder_attention_flash_kernel(
 void encoder_attention_flash(const __hip_bfloat16* Q, const __hip_bfloat16* K,
                              const __hip_bfloat16* V, __hip_bfloat16* O,
                              int S, int Hq, int D, float scale,
-                             hipStream_t stream, int mask) {
+                             hipStream_t stream, int mask,
+                             const int* seqused) {
     if (D != EFA_D)
         throw std::runtime_error("encoder_attention_flash: D must be 256");
     if (S < 1 || S > 4096 || Hq < 1 || Hq > 16)
@@ -307,5 +322,5 @@ void encoder_attention_flash(const __hip_bfloat16* Q, const __hip_bfloat16* K,
     }
     dim3 grid((S + 63) / 64, Hq);
     encoder_attention_flash_kernel<<<grid, EFA_NTHREADS, sizeof(EfaLds), stream>>>(
-        Q, K, V, O, S, Hq, scale, mask);
+        Q, K, V, O, S, Hq, scale, mask, seqused);
 }

--- a/csrc/amd/attention/encoder_flash.hip
+++ b/csrc/amd/attention/encoder_flash.hip
@@ -1,0 +1,311 @@
+// ================================================================
+// FlashRT AMD — encoder/prefill self-attention, MFMA flash (gfx950)
+//
+// One fixed production site: bidirectional GQA self-attention
+//     Q (S, Hq, D) bf16 — S ~ encoder tokens (vision + prompt)
+//     K (S, D)     bf16 — single KV head (GQA Hq:1)
+//     V (S, D)     bf16
+//     O (S, Hq, D) bf16
+//
+// STATUS: EXPERIMENTAL — not routed by any production path yet. The
+// library engine (CK-tile FMHA, ~47us in-situ) reaches only a few
+// percent of the matrix-core rate at this shape (hd 256, GQA 8:1,
+// batch 1); this kernel currently measures ~71us (parity-green,
+// deterministic) and ships as the research vehicle for the remaining
+// iterations (softmax micro-arch, staging write cost, block sizing).
+// It is a from-scratch FA2-style kernel on V_MFMA_F32_16X16X32_BF16:
+//
+//   grid (ceil(S/64), Hq), block 256 (4 waves). Each wave owns one
+//   16-row q-tile; the workgroup's 4 waves share each staged 32-row
+//   K/V block (K row-major, V TRANSPOSED to d-major so both MFMA
+//   operand fragments are contiguous 16B LDS reads).
+//
+//   Per KV block: scores 16x32 = 2 MFMA chains over D (8 steps of
+//   k=32 each), online-softmax update in registers (row stats via
+//   16-lane xor shuffle trees), P rounded to bf16 and bounced through
+//   LDS into a-fragment layout, then PV accumulates the full 16x256
+//   O tile held in 16 f32x4 accumulator fragments per lane.
+//
+//   Determinism: fixed block order, fixed shuffle trees, fp32
+//   accumulate, no atomics. Numerics: P is rounded to bf16 before PV
+//   (standard flash practice) — parity is cos-gated vs an fp32
+//   reference.
+//
+// Constraints (checked): D == 256, S <= 4096, Hq <= 16. Tail q rows
+// are computed but not stored; tail kv columns are masked to -inf
+// before the softmax.
+// ================================================================
+
+#include "../kernels/common_hip.h"
+#include <cfloat>
+#include <stdexcept>
+
+namespace {
+
+typedef float floatx4 __attribute__((ext_vector_type(4)));
+typedef short shortx8 __attribute__((ext_vector_type(8)));
+
+#define EFA_D        256
+#define EFA_DSTEPS   (EFA_D / 32)    // MFMA k-steps over D
+#define EFA_KVBLK    32              // KV rows staged per block
+#define EFA_NTHREADS 256
+
+// LDS: K block row-major (32 x 256 bf16), V block d-major with the
+// row padded to 40 elements (80 B: 16-byte aligned for the b-frag
+// reads, and the 20-banks-per-row advance kills the transpose-write
+// conflicts a tight 64 B stride would have), plus a 16x32 bf16 P
+// bounce region per wave.
+#define EFA_VPITCH (EFA_KVBLK + 8)
+#define EFA_KPITCH (EFA_D + 8)
+// Double-buffered K/V tiles (~79 KB total): block b+1's staging writes
+// need no barrier against block b's reads, so the loop runs on ONE
+// workgroup barrier per block. Requires the gfx950 dynamic-LDS opt-in
+// (hipFuncSetAttribute, > 64 KB static limit).
+struct EfaLds {
+    __hip_bfloat16 kt[2][EFA_KVBLK][EFA_KPITCH];
+    __hip_bfloat16 vt[2][EFA_D][EFA_VPITCH];
+    __hip_bfloat16 p[4][16][EFA_KVBLK];
+};
+
+__global__ __launch_bounds__(EFA_NTHREADS)
+void encoder_attention_flash_kernel(
+    const __hip_bfloat16* __restrict__ Q,
+    const __hip_bfloat16* __restrict__ K,
+    const __hip_bfloat16* __restrict__ V,
+    __hip_bfloat16* __restrict__ O,
+    int S, int Hq, float scale, int mask) {
+    extern __shared__ unsigned char lds_raw[];
+    EfaLds& lds = *reinterpret_cast<EfaLds*>(lds_raw);
+
+    const int tid  = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int h    = blockIdx.y;
+    const int q0   = (blockIdx.x * 4 + wave) * 16;   // this wave's q-tile
+    const int fcol = lane & 15;
+    const int kgrp = lane >> 4;
+
+    // ── Stage the wave's Q fragments (pre-scaled) in registers ──
+    // a-frag step s: lane supplies Q[q0 + fcol][32*s + 8*kgrp .. +8].
+    // Pad q rows read row (S-1) (their outputs are never stored, but
+    // their softmax must stay finite).
+    shortx8 qf[EFA_DSTEPS];
+    {
+        const int qrow = (q0 + fcol < S) ? (q0 + fcol) : (S - 1);
+        const __hip_bfloat16* qp = Q + ((size_t)qrow * Hq + h) * EFA_D + kgrp * 8;
+        #pragma unroll
+        for (int s = 0; s < EFA_DSTEPS; ++s) {
+            #pragma unroll
+            for (int e = 0; e < 8; ++e) {
+                const float v = __bfloat162float(qp[s * 32 + e]) * scale;
+                reinterpret_cast<__hip_bfloat16*>(&qf[s])[e] = __float2bfloat16(v);
+            }
+        }
+    }
+
+    // ── Online-softmax state and O accumulators ──
+    float m_run[4], l_run[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) { m_run[i] = -FLT_MAX; l_run[i] = 0.0f; }
+    floatx4 oacc[EFA_D / 16];
+    #pragma unroll
+    for (int t = 0; t < EFA_D / 16; ++t) oacc[t] = (floatx4){0, 0, 0, 0};
+
+    const int nblk = (S + EFA_KVBLK - 1) / EFA_KVBLK;
+
+    // ── Software-pipelined K/V loads: the global reads for block b+1
+    // issue during block b's compute, so the staging phase is pure LDS
+    // writes. r-major mapping for the V transpose scatter (consecutive
+    // 2 B columns across lanes), slot-major 16 B vector writes for K.
+    // V: each thread owns a PAIR of adjacent rows (2r, 2r+1) of one
+    // 8-element window, so the transpose scatter becomes 8 x 4 B pair
+    // writes instead of 16 x 2 B — half the LDS write instructions,
+    // consecutive-bank pattern preserved.
+    uint4 vv[4], vv2[4], kk[4];
+    auto load_block = [&](int blk) {
+        const int kv0l = blk * EFA_KVBLK;
+        const int kvnl = (blk < nblk) ? min(EFA_KVBLK, S - kv0l) : 0;
+        #pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const int idxv = tid + j * EFA_NTHREADS;   // pair-slot id
+            const int rv = (idxv & (EFA_KVBLK / 2 - 1)) * 2;
+            const int ov = (idxv >> 4) * 8;
+            vv[j] = (rv < kvnl)
+                ? *reinterpret_cast<const uint4*>(V + (size_t)(kv0l + rv) * EFA_D + ov)
+                : (uint4){0, 0, 0, 0};
+            vv2[j] = (rv + 1 < kvnl)
+                ? *reinterpret_cast<const uint4*>(V + (size_t)(kv0l + rv + 1) * EFA_D + ov)
+                : (uint4){0, 0, 0, 0};
+        }
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const int idxk = tid + j * EFA_NTHREADS;
+            const int rk = idxk >> 5;
+            const int ok = (idxk & 31) * 8;
+            kk[j] = (rk < kvnl)
+                ? *reinterpret_cast<const uint4*>(K + (size_t)(kv0l + rk) * EFA_D + ok)
+                : (uint4){0, 0, 0, 0};
+        }
+    };
+    if (mask & 1) load_block(0);
+
+    for (int b = 0; b < nblk; ++b) {
+        const int kv0 = b * EFA_KVBLK;
+        const int kvn = min(EFA_KVBLK, S - kv0);
+
+        const int buf = b & 1;
+        if (mask & 1) {
+            #pragma unroll
+            for (int j = 0; j < 4; ++j) {
+                const int idx = tid + j * EFA_NTHREADS;
+                const int rk = idx >> 5;
+                const int ok = (idx & 31) * 8;
+                *reinterpret_cast<uint4*>(&lds.kt[buf][rk][ok]) = kk[j];
+            }
+            #pragma unroll
+            for (int j = 0; j < 2; ++j) {
+                const int idx = tid + j * EFA_NTHREADS;
+                const int rv = (idx & (EFA_KVBLK / 2 - 1)) * 2;
+                const int ov = (idx >> 4) * 8;
+                const __hip_bfloat16* v0 =
+                    reinterpret_cast<const __hip_bfloat16*>(&vv[j]);
+                const __hip_bfloat16* v1 =
+                    reinterpret_cast<const __hip_bfloat16*>(&vv2[j]);
+                #pragma unroll
+                for (int e = 0; e < 8; ++e) {
+                    __hip_bfloat162 pr = __halves2bfloat162(v0[e], v1[e]);
+                    *reinterpret_cast<__hip_bfloat162*>(&lds.vt[buf][ov + e][rv]) = pr;
+                }
+            }
+        }
+        __syncthreads();   // this block's kt/vt published (single barrier)
+        if (mask & 1) load_block(b + 1);   // overlaps this block's compute
+
+        // ── Scores: two 16x16 tiles (kv halves) over D ──
+        floatx4 sc[2];
+        sc[0] = (floatx4){0, 0, 0, 0};
+        sc[1] = (floatx4){0, 0, 0, 0};
+        if (mask & 2)
+        #pragma unroll
+        for (int half = 0; half < 2; ++half) {
+            floatx4 acc = {0, 0, 0, 0};
+            // b-frag from the shared LDS K tile; all 8 step fragments
+            // prefetched before the (serial) MFMA chain consumes them.
+            const __hip_bfloat16* kp = &lds.kt[buf][half * 16 + fcol][kgrp * 8];
+            shortx8 kf[EFA_DSTEPS];
+            #pragma unroll
+            for (int s = 0; s < EFA_DSTEPS; ++s)
+                kf[s] = *reinterpret_cast<const shortx8*>(kp + s * 32);
+            #pragma unroll
+            for (int s = 0; s < EFA_DSTEPS; ++s)
+                acc = __builtin_amdgcn_mfma_f32_16x16x32_bf16(
+                    qf[s], kf[s], acc, 0, 0, 0);
+            sc[half] = acc;
+        }
+
+        // ── Online softmax update (rows m = 4*kgrp + i) ──
+        float pvals[2][4];
+        #pragma unroll
+        for (int half = 0; half < 2; ++half)
+            #pragma unroll
+            for (int i = 0; i < 4; ++i) pvals[half][i] = 0.5f;
+        if (mask & 4)
+        #pragma unroll
+        for (int i = 0; i < 4; ++i) {
+            // Row max over the 32 kv columns of this block: each lane
+            // holds 2 candidates (one per half); mask the kv tail.
+            const int n = fcol;
+            float c0 = (n < kvn)      ? sc[0][i] : -FLT_MAX;
+            float c1 = (16 + n < kvn) ? sc[1][i] : -FLT_MAX;
+            float mx = fmaxf(c0, c1);
+            #pragma unroll
+            for (int off = 8; off > 0; off >>= 1)
+                mx = fmaxf(mx, __shfl_xor(mx, off));
+            // mx is now the block row max across the 16-lane group
+            const float m_new = fmaxf(m_run[i], mx);
+            const float rescale = __expf(m_run[i] - m_new);
+            const float p0 = (n < kvn)      ? __expf(c0 - m_new) : 0.0f;
+            const float p1 = (16 + n < kvn) ? __expf(c1 - m_new) : 0.0f;
+            // l stays a PER-LANE partial (this lane's two columns);
+            // the cross-lane tree runs once in the epilogue.
+            l_run[i] = l_run[i] * rescale + (p0 + p1);
+            m_run[i] = m_new;
+            pvals[0][i] = p0;
+            pvals[1][i] = p1;
+            #pragma unroll
+            for (int t = 0; t < EFA_D / 16; ++t) oacc[t][i] *= rescale;
+        }
+
+        // ── Bounce P (bf16) into a-frag layout via LDS ──
+        // C layout: lane holds P[m = 4*kgrp + i][n = fcol].
+        if (mask & 8)
+        #pragma unroll
+        for (int half = 0; half < 2; ++half)
+            #pragma unroll
+            for (int i = 0; i < 4; ++i)
+                lds.p[wave][4 * kgrp + i][half * 16 + fcol] =
+                    __float2bfloat16(pvals[half][i]);
+        // p is written and read by the SAME wave (its private region);
+        // per-wave LDS ordering makes a WG barrier unnecessary — a
+        // scheduling fence stops the compiler from hoisting the reads.
+        __builtin_amdgcn_wave_barrier();
+
+        // ── PV: O_tile(16 x 256) += P(16 x 32) x V(32 x 256) ──
+        // a-frag: lane supplies P[m = fcol][kv = 8*kgrp .. +8]
+        const shortx8 pf = *reinterpret_cast<const shortx8*>(
+            &lds.p[wave][fcol][kgrp * 8]);
+        if (mask & 16)
+        #pragma unroll
+        for (int t = 0; t < EFA_D / 16; ++t) {
+            // b-frag: lane supplies V[kv = 8*kgrp ..+8][d = 16t + fcol]
+            // from the transposed tile: vt[d][kv] -> 8 x 2B strided by
+            // EFA_KVBLK... transposed layout makes the D-index the row,
+            // so the fragment is vt[16t + fcol][8*kgrp ..+8]: contiguous.
+            const shortx8 vf = *reinterpret_cast<const shortx8*>(
+                &lds.vt[buf][16 * t + fcol][kgrp * 8]);
+            oacc[t] = __builtin_amdgcn_mfma_f32_16x16x32_bf16(
+                pf, vf, oacc[t], 0, 0, 0);
+        }
+    }
+
+    // ── Epilogue: O = acc / l, store valid q rows ──
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int m = 4 * kgrp + i;
+        const int qrow = q0 + m;
+        if (qrow >= S) continue;
+        float lt = l_run[i];
+        #pragma unroll
+        for (int off = 8; off > 0; off >>= 1)
+            lt += __shfl_xor(lt, off);
+        const float inv_l = (lt > 0.0f) ? 1.0f / lt : 0.0f;
+        #pragma unroll
+        for (int t = 0; t < EFA_D / 16; ++t) {
+            const int d = 16 * t + fcol;
+            O[((size_t)qrow * Hq + h) * EFA_D + d] =
+                __float2bfloat16(oacc[t][i] * inv_l);
+        }
+    }
+}
+
+} // namespace
+
+void encoder_attention_flash(const __hip_bfloat16* Q, const __hip_bfloat16* K,
+                             const __hip_bfloat16* V, __hip_bfloat16* O,
+                             int S, int Hq, int D, float scale,
+                             hipStream_t stream, int mask) {
+    if (D != EFA_D)
+        throw std::runtime_error("encoder_attention_flash: D must be 256");
+    if (S < 1 || S > 4096 || Hq < 1 || Hq > 16)
+        throw std::runtime_error("encoder_attention_flash: bad S/Hq");
+    static bool lds_configured = false;
+    if (!lds_configured) {
+        hipFuncSetAttribute(
+            reinterpret_cast<const void*>(&encoder_attention_flash_kernel),
+            hipFuncAttributeMaxDynamicSharedMemorySize, (int)sizeof(EfaLds));
+        lds_configured = true;
+    }
+    dim3 grid((S + 63) / 64, Hq);
+    encoder_attention_flash_kernel<<<grid, EFA_NTHREADS, sizeof(EfaLds), stream>>>(
+        Q, K, V, O, S, Hq, scale, mask);
+}

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -1,0 +1,86 @@
+// ================================================================
+// FlashRT AMD — pybind11 bindings (module: flash_rt_amd_kernels)
+//
+// Same ABI contract as csrc/bindings.cpp: every entry takes
+// uintptr_t device pointers + a uintptr_t stream, never tensors.
+// Entries keep the CUDA-side names and signatures so the pipeline
+// layer is portable text across platforms.
+//
+// This is the AMD-only module. The CUDA module (flash_rt_kernels)
+// is untouched; the two never build together.
+// ================================================================
+
+#include <pybind11/pybind11.h>
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+
+#include <cstdint>
+#include <string>
+
+namespace py = pybind11;
+
+// ── Pointer helpers (mirror csrc/bindings.cpp) ──
+static void* to_ptr(uintptr_t addr) { return reinterpret_cast<void*>(addr); }
+template<typename T> static T* typed_ptr(uintptr_t addr) { return reinterpret_cast<T*>(addr); }
+static hipStream_t to_stream(uintptr_t s) { return reinterpret_cast<hipStream_t>(s); }
+
+// ── Kernel declarations (defined in kernels/*.hip) ──
+void rms_norm(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+              __hip_bfloat16* out, int seq_len, int dim, float eps,
+              hipStream_t stream);
+void rms_norm_fp16(const __half* x, const __half* weight,
+                   __half* out, int seq_len, int dim, float eps,
+                   hipStream_t stream);
+void rms_norm_inplace(const __hip_bfloat16* weight,
+                      __hip_bfloat16* x, int seq_len, int dim, float eps,
+                      hipStream_t stream);
+
+PYBIND11_MODULE(flash_rt_amd_kernels, m) {
+    m.doc() = "FlashRT AMD (ROCm/HIP) kernels — raw-pointer ABI";
+
+    m.def("build_info", []() {
+        py::dict info;
+        info["platform"] = "hip";
+#ifdef FLASHRT_AMD_GPU_ARCH
+        info["gpu_arch"] = FLASHRT_AMD_GPU_ARCH;
+#endif
+        int rt_version = 0;
+        (void)hipRuntimeGetVersion(&rt_version);
+        info["hip_runtime_version"] = rt_version;
+        return info;
+    });
+
+    m.def("device_arch", []() {
+        int dev = 0;
+        if (hipGetDevice(&dev) != hipSuccess) return std::string("none");
+        hipDeviceProp_t prop{};
+        if (hipGetDeviceProperties(&prop, dev) != hipSuccess) return std::string("unknown");
+        return std::string(prop.gcnArchName);
+    });
+
+    // ── Norm ──
+    m.def("rms_norm", [](uintptr_t x, uintptr_t weight, uintptr_t out,
+                         int seq_len, int dim, float eps, uintptr_t stream) {
+        rms_norm(typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(weight),
+                 typed_ptr<__hip_bfloat16>(out), seq_len, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("weight"), py::arg("out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("rms_norm_fp16", [](uintptr_t x, uintptr_t weight, uintptr_t out,
+                              int seq_len, int dim, float eps, uintptr_t stream) {
+        rms_norm_fp16(typed_ptr<__half>(x), typed_ptr<__half>(weight),
+                      typed_ptr<__half>(out), seq_len, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("weight"), py::arg("out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("rms_norm_inplace", [](uintptr_t weight, uintptr_t x,
+                                 int seq_len, int dim, float eps, uintptr_t stream) {
+        rms_norm_inplace(typed_ptr<__hip_bfloat16>(weight), typed_ptr<__hip_bfloat16>(x),
+                         seq_len, dim, eps, to_stream(stream));
+    }, py::arg("weight"), py::arg("x"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    (void)to_ptr;  // silence unused warning until pointer-only entries land
+}

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -19,6 +19,9 @@
 #include <cstdint>
 #include <string>
 
+#include "context.h"
+#include "gemm/hipblaslt_runner.h"
+
 namespace py = pybind11;
 
 // ── Pointer helpers (mirror csrc/bindings.cpp) ──
@@ -36,6 +39,52 @@ void rms_norm_fp16(const __half* x, const __half* weight,
 void rms_norm_inplace(const __hip_bfloat16* weight,
                       __hip_bfloat16* x, int seq_len, int dim, float eps,
                       hipStream_t stream);
+void layer_norm(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                const __hip_bfloat16* bias, __hip_bfloat16* out,
+                int seq_len, int dim, float eps, hipStream_t stream);
+void ada_rms_norm_style(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                        const __hip_bfloat16* style,
+                        __hip_bfloat16* out, __hip_bfloat16* gate_out,
+                        int seq_len, int dim, float eps, hipStream_t stream);
+void bias_residual_layer_norm_bf16(
+    __hip_bfloat16* residual, const __hip_bfloat16* x,
+    const __hip_bfloat16* bias_pre,
+    const __hip_bfloat16* ln_weight, const __hip_bfloat16* ln_bias,
+    __hip_bfloat16* out, int seq_len, int dim, float eps,
+    hipStream_t stream);
+void avg_pool_vision_tokens(const __hip_bfloat16* x, __hip_bfloat16* out,
+                            int nv, int H, int W, int dim, int pool_factor,
+                            hipStream_t stream);
+void gate_geglu(const __hip_bfloat16* gate, const __hip_bfloat16* up,
+                __hip_bfloat16* out, int n, hipStream_t stream);
+void gelu_inplace(__hip_bfloat16* x, int n, hipStream_t stream);
+void bias_gelu_inplace_bf16_strict(__hip_bfloat16* x,
+                                   const __hip_bfloat16* bias,
+                                   int M, int N, hipStream_t stream);
+void gate_geglu_merged(const __hip_bfloat16* merged, __hip_bfloat16* out,
+                       int seq, int half_dim, hipStream_t stream);
+void gate_mul_residual(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                       const __hip_bfloat16* gate, int n, hipStream_t stream);
+void bias_residual(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                   const __hip_bfloat16* bias, int seq_len, int dim,
+                   hipStream_t stream);
+void residual_add(__hip_bfloat16* residual, const __hip_bfloat16* x, int n,
+                  hipStream_t stream);
+void add_bias_bf16(__hip_bfloat16* x, const __hip_bfloat16* b,
+                   int S, int D, hipStream_t stream);
+void qkv_split(const __hip_bfloat16* qkv,
+               __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+               int seq, int q_dim, int k_dim, int v_dim, hipStream_t stream);
+void qkv_split_rope(const __hip_bfloat16* qkv,
+                    const __hip_bfloat16* rope_weights,
+                    __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+                    int seq, int q_dim, int k_dim, int v_dim, int head_dim,
+                    hipStream_t stream);
+void patch_im2col(const __half* input, __half* output, int nv,
+                  hipStream_t stream);
+void patch_embed_bias_pos(__half* output, const __half* bias,
+                          const __half* pos_emb,
+                          int S, int D, int S_per_view, hipStream_t stream);
 
 PYBIND11_MODULE(flash_rt_amd_kernels, m) {
     m.doc() = "FlashRT AMD (ROCm/HIP) kernels — raw-pointer ABI";
@@ -82,5 +131,140 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
     }, py::arg("weight"), py::arg("x"),
        py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
 
-    (void)to_ptr;  // silence unused warning until pointer-only entries land
+    m.def("layer_norm", [](uintptr_t x, uintptr_t weight, uintptr_t bias,
+                            uintptr_t out, int seq_len, int dim, float eps, uintptr_t stream) {
+        layer_norm(typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(weight),
+                   typed_ptr<__hip_bfloat16>(bias), typed_ptr<__hip_bfloat16>(out),
+                   seq_len, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("weight"), py::arg("bias"), py::arg("out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("ada_rms_norm_style", [](uintptr_t x, uintptr_t weight, uintptr_t style,
+                                    uintptr_t out, uintptr_t gate_out,
+                                    int seq_len, int dim, float eps, uintptr_t stream) {
+        ada_rms_norm_style(typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(weight),
+                           typed_ptr<__hip_bfloat16>(style),
+                           typed_ptr<__hip_bfloat16>(out), typed_ptr<__hip_bfloat16>(gate_out),
+                           seq_len, dim, eps, to_stream(stream));
+    }, py::arg("x"), py::arg("weight"), py::arg("style"),
+       py::arg("out"), py::arg("gate_out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+    m.def("bias_residual_layer_norm_bf16", [](uintptr_t residual, uintptr_t x,
+                                                uintptr_t bias_pre,
+                                                uintptr_t ln_weight, uintptr_t ln_bias,
+                                                uintptr_t out,
+                                                int seq_len, int dim, float eps,
+                                                uintptr_t stream) {
+        bias_residual_layer_norm_bf16(
+            typed_ptr<__hip_bfloat16>(residual), typed_ptr<__hip_bfloat16>(x),
+            typed_ptr<__hip_bfloat16>(bias_pre),
+            typed_ptr<__hip_bfloat16>(ln_weight),
+            typed_ptr<__hip_bfloat16>(ln_bias),
+            typed_ptr<__hip_bfloat16>(out), seq_len, dim, eps,
+            to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("bias_pre"),
+       py::arg("ln_weight"), py::arg("ln_bias"), py::arg("out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("stream") = 0);
+
+    m.def("avg_pool_vision_tokens", [](uintptr_t x, uintptr_t out,
+                                        int nv, int H, int W, int dim,
+                                        int pool_factor, uintptr_t stream) {
+        avg_pool_vision_tokens(
+            typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(out),
+            nv, H, W, dim, pool_factor, to_stream(stream));
+    }, py::arg("x"), py::arg("out"), py::arg("nv"), py::arg("H"), py::arg("W"),
+       py::arg("dim"), py::arg("pool_factor"), py::arg("stream") = 0);
+
+    // ── Activation — GEGLU (tanh-approx GELU(gate) * up), not SiLU ──
+    m.def("gate_geglu", [](uintptr_t gate, uintptr_t up, uintptr_t out, int n, uintptr_t stream) {
+        gate_geglu(typed_ptr<__hip_bfloat16>(gate), typed_ptr<__hip_bfloat16>(up),
+                      typed_ptr<__hip_bfloat16>(out), n, to_stream(stream));
+    }, py::arg("gate"), py::arg("up"), py::arg("out"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("gelu_inplace", [](uintptr_t x, int n, uintptr_t stream) {
+        gelu_inplace(typed_ptr<__hip_bfloat16>(x), n, to_stream(stream));
+    }, py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("bias_gelu_bf16_strict", [](uintptr_t x, uintptr_t bias,
+                                       int seq_len, int dim, uintptr_t stream) {
+        bias_gelu_inplace_bf16_strict(typed_ptr<__hip_bfloat16>(x),
+                                      typed_ptr<__hip_bfloat16>(bias),
+                                      seq_len, dim, to_stream(stream));
+    }, py::arg("x"), py::arg("bias"), py::arg("seq_len"), py::arg("dim"),
+       py::arg("stream") = 0);
+
+    m.def("gate_geglu_merged", [](uintptr_t merged, uintptr_t out,
+                                   int seq, int half_dim, uintptr_t stream) {
+        gate_geglu_merged(typed_ptr<__hip_bfloat16>(merged),
+                              typed_ptr<__hip_bfloat16>(out), seq, half_dim, to_stream(stream));
+    }, py::arg("merged"), py::arg("out"), py::arg("seq"), py::arg("half_dim"), py::arg("stream") = 0);
+
+    // ── Elementwise ──
+    m.def("gate_mul_residual", [](uintptr_t residual, uintptr_t x, uintptr_t gate, int n, uintptr_t stream) {
+        gate_mul_residual(typed_ptr<__hip_bfloat16>(residual),
+                          typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(gate), n, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("gate"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("bias_residual", [](uintptr_t residual, uintptr_t x, uintptr_t bias,
+                               int seq_len, int dim, uintptr_t stream) {
+        bias_residual(typed_ptr<__hip_bfloat16>(residual),
+                      typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(bias),
+                      seq_len, dim, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("bias"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("stream") = 0);
+
+    m.def("residual_add", [](uintptr_t residual, uintptr_t x, int n, uintptr_t stream) {
+        residual_add(typed_ptr<__hip_bfloat16>(residual),
+                     typed_ptr<__hip_bfloat16>(x), n, to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("add_bias_bf16",
+          [](uintptr_t x, uintptr_t b, int S, int D, uintptr_t stream) {
+        add_bias_bf16(typed_ptr<__hip_bfloat16>(x),
+                       typed_ptr<__hip_bfloat16>(b),
+                       S, D, to_stream(stream));
+    }, py::arg("x"), py::arg("b"), py::arg("S"), py::arg("D"),
+       py::arg("stream") = 0);
+
+    // ── QKV split ──
+    m.def("qkv_split", [](uintptr_t qkv, uintptr_t Q, uintptr_t K, uintptr_t V,
+                           int seq, int q_dim, int k_dim, int v_dim, uintptr_t stream) {
+        qkv_split(typed_ptr<__hip_bfloat16>(qkv),
+                   typed_ptr<__hip_bfloat16>(Q), typed_ptr<__hip_bfloat16>(K),
+                   typed_ptr<__hip_bfloat16>(V), seq, q_dim, k_dim, v_dim, to_stream(stream));
+    }, py::arg("qkv"), py::arg("Q"), py::arg("K"), py::arg("V"),
+       py::arg("seq"), py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"), py::arg("stream") = 0);
+
+    m.def("qkv_split_rope", [](uintptr_t qkv, uintptr_t rope_weights,
+                                 uintptr_t Q, uintptr_t K, uintptr_t V,
+                                 int seq, int q_dim, int k_dim, int v_dim,
+                                 int head_dim, uintptr_t stream) {
+        qkv_split_rope(typed_ptr<__hip_bfloat16>(qkv), typed_ptr<__hip_bfloat16>(rope_weights),
+                        typed_ptr<__hip_bfloat16>(Q), typed_ptr<__hip_bfloat16>(K),
+                        typed_ptr<__hip_bfloat16>(V),
+                        seq, q_dim, k_dim, v_dim, head_dim, to_stream(stream));
+    }, py::arg("qkv"), py::arg("rope_weights"),
+       py::arg("Q"), py::arg("K"), py::arg("V"),
+       py::arg("seq"), py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"),
+       py::arg("head_dim"), py::arg("stream") = 0);
+
+    // ── Patch embedding (FP16, matching the CUDA surface) ──
+    m.def("patch_im2col", [](uintptr_t input, uintptr_t output, int nv, uintptr_t stream) {
+        patch_im2col(typed_ptr<__half>(input),
+                     typed_ptr<__half>(output), nv, to_stream(stream));
+    }, py::arg("input"), py::arg("output"), py::arg("nv"), py::arg("stream") = 0);
+
+    m.def("patch_embed_bias_pos", [](uintptr_t output, uintptr_t bias, uintptr_t pos_emb,
+                                      int S, int D, int S_per_view, uintptr_t stream) {
+        patch_embed_bias_pos(typed_ptr<__half>(output),
+                             typed_ptr<__half>(bias),
+                             typed_ptr<__half>(pos_emb),
+                             S, D, S_per_view, to_stream(stream));
+    }, py::arg("output"), py::arg("bias"), py::arg("pos_emb"),
+       py::arg("S"), py::arg("D"), py::arg("S_per_view"), py::arg("stream") = 0);
+
+    // ── GEMM: FvkContext + hipBLASLt GemmRunner ──
+#include "gemm/bindings_gemm.inc"
 }

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -503,6 +503,22 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
         return variants;
     });
 
+    // ── Encoder MFMA flash attention (see attention/encoder_flash.hip) ──
+    m.def("encoder_attention_flash", [](uintptr_t Q, uintptr_t K, uintptr_t V,
+                                        uintptr_t O, int S, int Hq, int D,
+                                        float scale, uintptr_t stream, int mask) {
+        extern void encoder_attention_flash(const __hip_bfloat16*, const __hip_bfloat16*,
+                                            const __hip_bfloat16*, __hip_bfloat16*,
+                                            int, int, int, float, hipStream_t, int);
+        encoder_attention_flash(typed_ptr<__hip_bfloat16>(Q),
+                                typed_ptr<__hip_bfloat16>(K),
+                                typed_ptr<__hip_bfloat16>(V),
+                                typed_ptr<__hip_bfloat16>(O),
+                                S, Hq, D, scale, to_stream(stream), mask);
+    }, py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"),
+       py::arg("S"), py::arg("Hq"), py::arg("D"),
+       py::arg("scale") = 0.0625f, py::arg("stream") = 0, py::arg("mask") = 31);
+
     // ── Decoder-attention phase-ablation probe (see attention/attn_probe.hip) ──
     m.def("attn_partial_probe", [](uintptr_t Q, uintptr_t K, uintptr_t V,
                                    uintptr_t ws, int Sq, int Skv, int Hq,

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -22,6 +22,7 @@
 
 #include "context.h"
 #include "gemm/hipblaslt_runner.h"
+#include "gemm/smallm_fp8.h"
 
 namespace py = pybind11;
 
@@ -119,6 +120,11 @@ void qkv_split_rope_devpos(const __hip_bfloat16* qkv,
                            const int* devpos,
                            int seq, int q_dim, int k_dim, int v_dim,
                            int head_dim, hipStream_t stream);
+void attention_decoder_gqa(const __hip_bfloat16* Q, const __hip_bfloat16* K,
+                           const __hip_bfloat16* V, __hip_bfloat16* O,
+                           float* partial_ws, int Sq, int Skv, int Hq, int D,
+                           const int* seqused, float softmax_scale,
+                           hipStream_t stream);
 
 PYBIND11_MODULE(flash_rt_amd_kernels, m) {
     m.doc() = "FlashRT AMD (ROCm/HIP) kernels — raw-pointer ABI";
@@ -350,6 +356,31 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
        py::arg("seq"), py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"),
        py::arg("head_dim"), py::arg("stream") = 0);
 
+    // ── Attention ──
+    // Split-KV flash decoder cross-attention (GQA Hq:1, bidirectional).
+    // Q/O: (Sq, Hq, D) bf16; K/V: (Skv, D) bf16 single KV head.
+    // partial_ws: caller device fp32 scratch >= 32*Hq*Sq*(D+2) floats
+    // (graph-capture-safe: no allocation inside). seqused = 0 => exact
+    // mode (Skv host int); else device int32 ptr, seqused[0] is the
+    // runtime length and Skv is ignored (fixed-shape graph mode).
+    m.def("attention_decoder_gqa", [](uintptr_t Q, uintptr_t K, uintptr_t V,
+                                      uintptr_t O, uintptr_t partial_ws,
+                                      int Sq, int Skv, int Hq, int D,
+                                      uintptr_t seqused, float softmax_scale,
+                                      uintptr_t stream) {
+        attention_decoder_gqa(typed_ptr<__hip_bfloat16>(Q),
+                              typed_ptr<__hip_bfloat16>(K),
+                              typed_ptr<__hip_bfloat16>(V),
+                              typed_ptr<__hip_bfloat16>(O),
+                              typed_ptr<float>(partial_ws),
+                              Sq, Skv, Hq, D,
+                              reinterpret_cast<const int*>(seqused),
+                              softmax_scale, to_stream(stream));
+    }, py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"),
+       py::arg("partial_ws"), py::arg("Sq"), py::arg("Skv"),
+       py::arg("Hq"), py::arg("D"), py::arg("seqused") = 0,
+       py::arg("softmax_scale") = 0.0625f, py::arg("stream") = 0);
+
     // ── Fusion ──
     m.def("gate_residual_ada_norm_fp8", [](uintptr_t residual, uintptr_t x,
                                             uintptr_t gate, uintptr_t weight,
@@ -418,4 +449,7 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
 
     // ── GEMM: FvkContext + hipBLASLt GemmRunner ──
 #include "gemm/bindings_gemm.inc"
+
+    // ── GEMM: hand-tuned small-M FP8 (weight-streaming) ──
+#include "gemm/bindings_smallm.inc"
 }

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -23,8 +23,10 @@
 #include "context.h"
 #include "gemm/hipblaslt_runner.h"
 #include "gemm/smallm_fp8.h"
+#include "gemm/smallm_mfma.h"
 #include "gemm/decoder_ffn_fused.h"
 #include "kernels/stream_probe.h"
+#include "kernels/ew_tune.h"
 
 namespace py = pybind11;
 
@@ -110,6 +112,14 @@ void gate_residual_ada_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* 
                                 __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
                                 int seq_len, int dim, float eps,
                                 const float* d_scale, hipStream_t stream);
+void gate_residual_ada_norm_fp8_ksum(
+    __hip_bfloat16* residual, const float* partial, int splits,
+    const float* d_scale_a, const float* d_scale_b,
+    const __hip_bfloat16* gate, const __hip_bfloat16* weight,
+    const __hip_bfloat16* style,
+    __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
+    int seq_len, int dim, float eps,
+    const float* d_scale, hipStream_t stream);
 void quantize_fp8_static(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
                          const float* d_scale, int n, hipStream_t stream);
 void quantize_fp8_device(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
@@ -493,6 +503,63 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
         return variants;
     });
 
+    // ── Elementwise launch-geometry tuning probe (see kernels/ew_tune.h) ──
+    m.def("ew_tune_quant", [](int variant, uintptr_t in, uintptr_t out,
+                              uintptr_t d_scale, int n, uintptr_t stream) {
+        ew_tune_quant(variant, typed_ptr<__hip_bfloat16>(in),
+                      typed_ptr<__hip_fp8_e4m3>(out),
+                      reinterpret_cast<const float*>(d_scale), n, to_stream(stream));
+    }, py::arg("variant"), py::arg("in"), py::arg("out"),
+       py::arg("d_scale"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("ew_tune_norm", [](int variant, uintptr_t residual, uintptr_t x,
+                             uintptr_t gate, uintptr_t weight, uintptr_t style,
+                             uintptr_t out, uintptr_t gate_out,
+                             int seq_len, int dim, float eps,
+                             uintptr_t d_scale, uintptr_t stream) {
+        ew_tune_norm(variant, typed_ptr<__hip_bfloat16>(residual),
+                     typed_ptr<__hip_bfloat16>(x),
+                     typed_ptr<__hip_bfloat16>(gate),
+                     typed_ptr<__hip_bfloat16>(weight),
+                     typed_ptr<__hip_bfloat16>(style),
+                     typed_ptr<__hip_fp8_e4m3>(out),
+                     typed_ptr<__hip_bfloat16>(gate_out),
+                     seq_len, dim, eps,
+                     reinterpret_cast<const float*>(d_scale), to_stream(stream));
+    }, py::arg("variant"), py::arg("residual"), py::arg("x"), py::arg("gate"),
+       py::arg("weight"), py::arg("style"), py::arg("out"), py::arg("gate_out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+    m.def("ew_tune_rope", [](int variant, uintptr_t qkv, uintptr_t rope_weights,
+                             uintptr_t Q, uintptr_t K, uintptr_t V,
+                             int seq, int q_dim, int k_dim, int v_dim,
+                             int head_dim, uintptr_t stream) {
+        ew_tune_rope(variant, typed_ptr<__hip_bfloat16>(qkv),
+                     typed_ptr<__hip_bfloat16>(rope_weights),
+                     typed_ptr<__hip_bfloat16>(Q), typed_ptr<__hip_bfloat16>(K),
+                     typed_ptr<__hip_bfloat16>(V),
+                     seq, q_dim, k_dim, v_dim, head_dim, to_stream(stream));
+    }, py::arg("variant"), py::arg("qkv"), py::arg("rope_weights"),
+       py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("seq"),
+       py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"),
+       py::arg("head_dim"), py::arg("stream") = 0);
+
+    m.def("ew_tune_variants", []() {
+        py::dict families;
+        py::list q, n, r;
+        for (int i = 0; i < ew_tune_quant_variant_count(); ++i)
+            q.append(ew_tune_quant_variant_name(i));
+        for (int i = 0; i < ew_tune_norm_variant_count(); ++i)
+            n.append(ew_tune_norm_variant_name(i));
+        for (int i = 0; i < ew_tune_rope_variant_count(); ++i)
+            r.append(ew_tune_rope_variant_name(i));
+        families["quant"] = q;
+        families["norm"] = n;
+        families["rope"] = r;
+        return families;
+    });
+
     // ── Patch embedding (FP16, matching the CUDA surface) ──
     m.def("patch_im2col", [](uintptr_t input, uintptr_t output, int nv, uintptr_t stream) {
         patch_im2col(typed_ptr<__half>(input),
@@ -513,6 +580,76 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
 
     // ── GEMM: hand-tuned small-M FP8 (weight-streaming) ──
 #include "gemm/bindings_smallm.inc"
+
+    // ── MFMA small-M FP8 GEMM (see gemm/smallm_mfma.h) ──
+    m.def("smallm_mfma_nt", [](int variant, uintptr_t A, uintptr_t W,
+                               uintptr_t D, int M, int N, int K,
+                               uintptr_t d_scale_a, uintptr_t d_scale_b,
+                               uintptr_t stream) {
+        smallm_mfma_nt(variant, to_ptr(A), to_ptr(W),
+                       typed_ptr<__hip_bfloat16>(D), M, N, K,
+                       reinterpret_cast<const float*>(d_scale_a),
+                       reinterpret_cast<const float*>(d_scale_b),
+                       to_stream(stream));
+    }, py::arg("variant"), py::arg("A"), py::arg("W"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("stream") = 0);
+
+    m.def("smallm_mfma_nt_partial", [](uintptr_t A, uintptr_t W, uintptr_t ws,
+                                       int M, int N, int K, int splits,
+                                       uintptr_t stream) {
+        smallm_mfma_nt_partial(to_ptr(A), to_ptr(W),
+                               reinterpret_cast<float*>(ws),
+                               M, N, K, splits, to_stream(stream));
+    }, py::arg("A"), py::arg("W"), py::arg("ws"),
+       py::arg("M"), py::arg("N"), py::arg("K"), py::arg("splits"),
+       py::arg("stream") = 0);
+
+    m.def("gate_residual_ada_norm_fp8_ksum",
+          [](uintptr_t residual, uintptr_t partial, int splits,
+             uintptr_t d_scale_a, uintptr_t d_scale_b,
+             uintptr_t gate, uintptr_t weight, uintptr_t style,
+             uintptr_t out, uintptr_t gate_out,
+             int seq_len, int dim, float eps,
+             uintptr_t d_scale, uintptr_t stream) {
+        gate_residual_ada_norm_fp8_ksum(
+            typed_ptr<__hip_bfloat16>(residual),
+            reinterpret_cast<const float*>(partial), splits,
+            reinterpret_cast<const float*>(d_scale_a),
+            reinterpret_cast<const float*>(d_scale_b),
+            typed_ptr<__hip_bfloat16>(gate),
+            typed_ptr<__hip_bfloat16>(weight),
+            typed_ptr<__hip_bfloat16>(style),
+            typed_ptr<__hip_fp8_e4m3>(out),
+            typed_ptr<__hip_bfloat16>(gate_out),
+            seq_len, dim, eps,
+            reinterpret_cast<const float*>(d_scale), to_stream(stream));
+    }, py::arg("residual"), py::arg("partial"), py::arg("splits"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"),
+       py::arg("gate"), py::arg("weight"), py::arg("style"),
+       py::arg("out"), py::arg("gate_out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+    m.def("smallm_mfma_nt_packed", [](uintptr_t A, uintptr_t Wp, uintptr_t D,
+                                      int M, int N, int K,
+                                      uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                      uintptr_t stream) {
+        smallm_mfma_nt_packed(to_ptr(A), to_ptr(Wp),
+                              typed_ptr<__hip_bfloat16>(D), M, N, K,
+                              reinterpret_cast<const float*>(d_scale_a),
+                              reinterpret_cast<const float*>(d_scale_b),
+                              to_stream(stream));
+    }, py::arg("A"), py::arg("Wp"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("stream") = 0);
+
+    m.def("smallm_mfma_variants", []() {
+        py::list v;
+        for (int i = 0; i < smallm_mfma_variant_count(); ++i)
+            v.append(smallm_mfma_variant_name(i));
+        return v;
+    });
 
     // ── GEMM: fused decoder-FFN pair (gate|up+geglu, down+gate*res) ──
 #include "gemm/bindings_ffn_fused.inc"

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -506,18 +506,22 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
     // ── Encoder MFMA flash attention (see attention/encoder_flash.hip) ──
     m.def("encoder_attention_flash", [](uintptr_t Q, uintptr_t K, uintptr_t V,
                                         uintptr_t O, int S, int Hq, int D,
-                                        float scale, uintptr_t stream, int mask) {
+                                        float scale, uintptr_t stream, int mask,
+                                        uintptr_t seqused) {
         extern void encoder_attention_flash(const __hip_bfloat16*, const __hip_bfloat16*,
                                             const __hip_bfloat16*, __hip_bfloat16*,
-                                            int, int, int, float, hipStream_t, int);
+                                            int, int, int, float, hipStream_t, int,
+                                            const int*);
         encoder_attention_flash(typed_ptr<__hip_bfloat16>(Q),
                                 typed_ptr<__hip_bfloat16>(K),
                                 typed_ptr<__hip_bfloat16>(V),
                                 typed_ptr<__hip_bfloat16>(O),
-                                S, Hq, D, scale, to_stream(stream), mask);
+                                S, Hq, D, scale, to_stream(stream), mask,
+                                reinterpret_cast<const int*>(seqused));
     }, py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"),
        py::arg("S"), py::arg("Hq"), py::arg("D"),
-       py::arg("scale") = 0.0625f, py::arg("stream") = 0, py::arg("mask") = 31);
+       py::arg("scale") = 0.0625f, py::arg("stream") = 0, py::arg("mask") = 31,
+       py::arg("seqused") = 0);
 
     // ── Decoder-attention phase-ablation probe (see attention/attn_probe.hip) ──
     m.def("attn_partial_probe", [](uintptr_t Q, uintptr_t K, uintptr_t V,

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -15,6 +15,7 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
+#include <hip/hip_fp8.h>
 
 #include <cstdint>
 #include <string>
@@ -85,6 +86,39 @@ void patch_im2col(const __half* input, __half* output, int nv,
 void patch_embed_bias_pos(__half* output, const __half* bias,
                           const __half* pos_emb,
                           int S, int D, int S_per_view, hipStream_t stream);
+void rms_norm_fp8(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                  __hip_fp8_e4m3* out, int seq_len, int dim, float eps,
+                  const float* d_scale, hipStream_t stream);
+void ada_rms_norm_style_fp8(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                            const __hip_bfloat16* style,
+                            __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
+                            int seq_len, int dim, float eps,
+                            const float* d_scale, hipStream_t stream);
+void residual_add_rms_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                               const __hip_bfloat16* weight, __hip_fp8_e4m3* out,
+                               int seq_len, int dim, float eps,
+                               const float* d_scale, hipStream_t stream);
+void gate_geglu_merged_fp8(const __hip_bfloat16* merged, __hip_fp8_e4m3* out,
+                           int seq, int half_dim,
+                           const float* d_scale, hipStream_t stream);
+void gate_residual_ada_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                                const __hip_bfloat16* gate, const __hip_bfloat16* weight,
+                                const __hip_bfloat16* style,
+                                __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
+                                int seq_len, int dim, float eps,
+                                const float* d_scale, hipStream_t stream);
+void quantize_fp8_static(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
+                         const float* d_scale, int n, hipStream_t stream);
+void quantize_fp8_device(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
+                         float* d_scale, int n, hipStream_t stream);
+void fp8_accumulate_scale_max(const float* src_scale, float* dst_scale,
+                              hipStream_t stream);
+void qkv_split_rope_devpos(const __hip_bfloat16* qkv,
+                           const __hip_bfloat16* rope_weights,
+                           __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+                           const int* devpos,
+                           int seq, int q_dim, int k_dim, int v_dim,
+                           int head_dim, hipStream_t stream);
 
 PYBIND11_MODULE(flash_rt_amd_kernels, m) {
     m.doc() = "FlashRT AMD (ROCm/HIP) kernels — raw-pointer ABI";
@@ -150,6 +184,45 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
        py::arg("out"), py::arg("gate_out"),
        py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
 
+    // Fused Norm → FP8
+    m.def("rms_norm_fp8", [](uintptr_t x, uintptr_t weight, uintptr_t out,
+                              int seq_len, int dim, float eps,
+                              uintptr_t d_scale, uintptr_t stream) {
+        rms_norm_fp8(typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(weight),
+                     typed_ptr<__hip_fp8_e4m3>(out), seq_len, dim, eps,
+                     reinterpret_cast<const float*>(d_scale), to_stream(stream));
+    }, py::arg("x"), py::arg("weight"), py::arg("out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+    m.def("ada_rms_norm_style_fp8", [](uintptr_t x, uintptr_t weight, uintptr_t style,
+                                        uintptr_t out, uintptr_t gate_out,
+                                        int seq_len, int dim, float eps,
+                                        uintptr_t d_scale, uintptr_t stream) {
+        ada_rms_norm_style_fp8(typed_ptr<__hip_bfloat16>(x), typed_ptr<__hip_bfloat16>(weight),
+                               typed_ptr<__hip_bfloat16>(style),
+                               typed_ptr<__hip_fp8_e4m3>(out), typed_ptr<__hip_bfloat16>(gate_out),
+                               seq_len, dim, eps,
+                               reinterpret_cast<const float*>(d_scale), to_stream(stream));
+    }, py::arg("x"), py::arg("weight"), py::arg("style"),
+       py::arg("out"), py::arg("gate_out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+    m.def("residual_add_rms_norm_fp8", [](uintptr_t residual, uintptr_t x,
+                                           uintptr_t weight, uintptr_t out,
+                                           int seq_len, int dim, float eps,
+                                           uintptr_t d_scale, uintptr_t stream) {
+        residual_add_rms_norm_fp8(typed_ptr<__hip_bfloat16>(residual),
+                                   typed_ptr<__hip_bfloat16>(x),
+                                   typed_ptr<__hip_bfloat16>(weight),
+                                   typed_ptr<__hip_fp8_e4m3>(out),
+                                   seq_len, dim, eps,
+                                   reinterpret_cast<const float*>(d_scale), to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("weight"), py::arg("out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("d_scale") = 0, py::arg("stream") = 0);
+
     m.def("bias_residual_layer_norm_bf16", [](uintptr_t residual, uintptr_t x,
                                                 uintptr_t bias_pre,
                                                 uintptr_t ln_weight, uintptr_t ln_bias,
@@ -201,6 +274,15 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
                               typed_ptr<__hip_bfloat16>(out), seq, half_dim, to_stream(stream));
     }, py::arg("merged"), py::arg("out"), py::arg("seq"), py::arg("half_dim"), py::arg("stream") = 0);
 
+    m.def("gate_geglu_merged_fp8", [](uintptr_t merged, uintptr_t out,
+                                       int seq, int half_dim,
+                                       uintptr_t d_scale, uintptr_t stream) {
+        gate_geglu_merged_fp8(typed_ptr<__hip_bfloat16>(merged),
+                                  typed_ptr<__hip_fp8_e4m3>(out), seq, half_dim,
+                                  reinterpret_cast<const float*>(d_scale), to_stream(stream));
+    }, py::arg("merged"), py::arg("out"), py::arg("seq"), py::arg("half_dim"),
+       py::arg("d_scale") = 0, py::arg("stream") = 0);
+
     // ── Elementwise ──
     m.def("gate_mul_residual", [](uintptr_t residual, uintptr_t x, uintptr_t gate, int n, uintptr_t stream) {
         gate_mul_residual(typed_ptr<__hip_bfloat16>(residual),
@@ -249,6 +331,75 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
        py::arg("Q"), py::arg("K"), py::arg("V"),
        py::arg("seq"), py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"),
        py::arg("head_dim"), py::arg("stream") = 0);
+
+    // QKV split + RoPE with a runtime device K/V-cache row offset (devpos).
+    // K/V are cache BASE pointers; row written = devpos[0] + token index.
+    m.def("qkv_split_rope_devpos", [](uintptr_t qkv, uintptr_t rope_weights,
+                                       uintptr_t Q, uintptr_t K, uintptr_t V,
+                                       uintptr_t devpos,
+                                       int seq, int q_dim, int k_dim, int v_dim,
+                                       int head_dim, uintptr_t stream) {
+        qkv_split_rope_devpos(typed_ptr<__hip_bfloat16>(qkv),
+                              typed_ptr<__hip_bfloat16>(rope_weights),
+                              typed_ptr<__hip_bfloat16>(Q), typed_ptr<__hip_bfloat16>(K),
+                              typed_ptr<__hip_bfloat16>(V),
+                              typed_ptr<int>(devpos),
+                              seq, q_dim, k_dim, v_dim, head_dim, to_stream(stream));
+    }, py::arg("qkv"), py::arg("rope_weights"),
+       py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("devpos"),
+       py::arg("seq"), py::arg("q_dim"), py::arg("k_dim"), py::arg("v_dim"),
+       py::arg("head_dim"), py::arg("stream") = 0);
+
+    // ── Fusion ──
+    m.def("gate_residual_ada_norm_fp8", [](uintptr_t residual, uintptr_t x,
+                                            uintptr_t gate, uintptr_t weight,
+                                            uintptr_t style,
+                                            uintptr_t out, uintptr_t gate_out,
+                                            int seq_len, int dim, float eps,
+                                            uintptr_t d_scale, uintptr_t stream) {
+        gate_residual_ada_norm_fp8(typed_ptr<__hip_bfloat16>(residual),
+                                    typed_ptr<__hip_bfloat16>(x),
+                                    typed_ptr<__hip_bfloat16>(gate),
+                                    typed_ptr<__hip_bfloat16>(weight),
+                                    typed_ptr<__hip_bfloat16>(style),
+                                    typed_ptr<__hip_fp8_e4m3>(out),
+                                    typed_ptr<__hip_bfloat16>(gate_out),
+                                    seq_len, dim, eps,
+                                    reinterpret_cast<const float*>(d_scale), to_stream(stream));
+    }, py::arg("residual"), py::arg("x"), py::arg("gate"), py::arg("weight"),
+       py::arg("style"), py::arg("out"), py::arg("gate_out"),
+       py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+       py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+    // ── Quantize ──
+    m.def("quantize_fp8_static", [](uintptr_t input, uintptr_t output,
+                                     uintptr_t d_scale, int n, uintptr_t stream) {
+        quantize_fp8_static(typed_ptr<__hip_bfloat16>(input),
+                            typed_ptr<__hip_fp8_e4m3>(output),
+                            reinterpret_cast<const float*>(d_scale), n, to_stream(stream));
+    }, py::arg("input"), py::arg("output"), py::arg("d_scale"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("quantize_fp8_device", [](uintptr_t input, uintptr_t output,
+                                     uintptr_t d_scale, int n, uintptr_t stream) {
+        quantize_fp8_device(typed_ptr<__hip_bfloat16>(input),
+                            typed_ptr<__hip_fp8_e4m3>(output),
+                            reinterpret_cast<float*>(d_scale), n, to_stream(stream));
+    }, py::arg("input"), py::arg("output"), py::arg("d_scale"), py::arg("n"), py::arg("stream") = 0);
+
+    m.def("fp8_accumulate_scale_max", [](uintptr_t src_scale,
+                                         uintptr_t dst_scale,
+                                         uintptr_t stream) {
+        fp8_accumulate_scale_max(reinterpret_cast<const float*>(src_scale),
+                                 reinterpret_cast<float*>(dst_scale),
+                                 to_stream(stream));
+    }, py::arg("src_scale"), py::arg("dst_scale"), py::arg("stream") = 0);
+
+    // ── GPU memory ops (HIP Graph compatible, explicit stream) ──
+    m.def("gpu_copy", [](uintptr_t dst, uintptr_t src, int nbytes, uintptr_t stream) {
+        extern void gpu_copy_async(void*, const void*, size_t, hipStream_t);
+        gpu_copy_async(reinterpret_cast<void*>(dst), reinterpret_cast<const void*>(src),
+                        nbytes, to_stream(stream));
+    }, py::arg("dst"), py::arg("src"), py::arg("nbytes"), py::arg("stream") = 0);
 
     // ── Patch embedding (FP16, matching the CUDA surface) ──
     m.def("patch_im2col", [](uintptr_t input, uintptr_t output, int nv, uintptr_t stream) {

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -503,6 +503,23 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
         return variants;
     });
 
+    // ── Decoder-attention phase-ablation probe (see attention/attn_probe.hip) ──
+    m.def("attn_partial_probe", [](uintptr_t Q, uintptr_t K, uintptr_t V,
+                                   uintptr_t ws, int Sq, int Skv, int Hq,
+                                   int D, float scale, int nsplit, int mask,
+                                   uintptr_t stream) {
+        extern void attn_partial_probe(const __hip_bfloat16*, const __hip_bfloat16*,
+                                       const __hip_bfloat16*, float*,
+                                       int, int, int, int, float, int, int,
+                                       hipStream_t);
+        attn_partial_probe(typed_ptr<__hip_bfloat16>(Q), typed_ptr<__hip_bfloat16>(K),
+                           typed_ptr<__hip_bfloat16>(V), typed_ptr<float>(ws),
+                           Sq, Skv, Hq, D, scale, nsplit, mask, to_stream(stream));
+    }, py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("ws"),
+       py::arg("Sq"), py::arg("Skv"), py::arg("Hq"), py::arg("D"),
+       py::arg("scale") = 0.0625f, py::arg("nsplit") = 32, py::arg("mask") = 63,
+       py::arg("stream") = 0);
+
     // ── Elementwise launch-geometry tuning probe (see kernels/ew_tune.h) ──
     m.def("ew_tune_quant", [](int variant, uintptr_t in, uintptr_t out,
                               uintptr_t d_scale, int n, uintptr_t stream) {

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -23,6 +23,8 @@
 #include "context.h"
 #include "gemm/hipblaslt_runner.h"
 #include "gemm/smallm_fp8.h"
+#include "gemm/decoder_ffn_fused.h"
+#include "kernels/stream_probe.h"
 
 namespace py = pybind11;
 
@@ -125,6 +127,12 @@ void attention_decoder_gqa(const __hip_bfloat16* Q, const __hip_bfloat16* K,
                            float* partial_ws, int Sq, int Skv, int Hq, int D,
                            const int* seqused, float softmax_scale,
                            hipStream_t stream);
+void attention_decoder_gqa_fp8out(const __hip_bfloat16* Q, const __hip_bfloat16* K,
+                                  const __hip_bfloat16* V, __hip_bfloat16* O,
+                                  __hip_fp8_e4m3* O_fp8, const float* d_scale,
+                                  float* partial_ws, int Sq, int Skv, int Hq, int D,
+                                  const int* seqused, float softmax_scale,
+                                  hipStream_t stream);
 
 PYBIND11_MODULE(flash_rt_amd_kernels, m) {
     m.doc() = "FlashRT AMD (ROCm/HIP) kernels — raw-pointer ABI";
@@ -381,6 +389,33 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
        py::arg("Hq"), py::arg("D"), py::arg("seqused") = 0,
        py::arg("softmax_scale") = 0.0625f, py::arg("stream") = 0);
 
+    // Same attention with a fused FP8-quantize epilogue: O_fp8 gets
+    // (Sq, Hq*D) OCP e4m3 bytes, byte-identical to quantize_fp8_static
+    // run on the bf16 O with the same device scale; O (bf16) is still
+    // written, identical to attention_decoder_gqa. d_scale = device
+    // float pointer (static per-layer scale, read in-kernel).
+    m.def("attention_decoder_gqa_fp8out", [](uintptr_t Q, uintptr_t K, uintptr_t V,
+                                             uintptr_t O, uintptr_t O_fp8,
+                                             uintptr_t d_scale, uintptr_t partial_ws,
+                                             int Sq, int Skv, int Hq, int D,
+                                             uintptr_t seqused, float softmax_scale,
+                                             uintptr_t stream) {
+        attention_decoder_gqa_fp8out(typed_ptr<__hip_bfloat16>(Q),
+                                     typed_ptr<__hip_bfloat16>(K),
+                                     typed_ptr<__hip_bfloat16>(V),
+                                     typed_ptr<__hip_bfloat16>(O),
+                                     typed_ptr<__hip_fp8_e4m3>(O_fp8),
+                                     reinterpret_cast<const float*>(d_scale),
+                                     typed_ptr<float>(partial_ws),
+                                     Sq, Skv, Hq, D,
+                                     reinterpret_cast<const int*>(seqused),
+                                     softmax_scale, to_stream(stream));
+    }, py::arg("Q"), py::arg("K"), py::arg("V"), py::arg("O"),
+       py::arg("O_fp8"), py::arg("d_scale"), py::arg("partial_ws"),
+       py::arg("Sq"), py::arg("Skv"), py::arg("Hq"), py::arg("D"),
+       py::arg("seqused") = 0, py::arg("softmax_scale") = 0.0625f,
+       py::arg("stream") = 0);
+
     // ── Fusion ──
     m.def("gate_residual_ada_norm_fp8", [](uintptr_t residual, uintptr_t x,
                                             uintptr_t gate, uintptr_t weight,
@@ -432,6 +467,32 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
                         nbytes, to_stream(stream));
     }, py::arg("dst"), py::arg("src"), py::arg("nbytes"), py::arg("stream") = 0);
 
+    // ── Weight-streaming read-bandwidth probe (see kernels/stream_probe.h) ──
+    m.def("stream_probe", [](int variant_id, uintptr_t src, size_t nbytes,
+                             uintptr_t out, uintptr_t stream) {
+        stream_probe(variant_id, to_ptr(src), nbytes,
+                     typed_ptr<unsigned>(out), to_stream(stream));
+    }, py::arg("variant_id"), py::arg("src"), py::arg("nbytes"),
+       py::arg("out"), py::arg("stream") = 0);
+
+    m.def("stream_probe_variants", []() {
+        py::list variants;
+        for (int i = 0; i < stream_probe_variant_count(); ++i) {
+            const StreamProbeVariant& v = stream_probe_variant(i);
+            py::dict d;
+            d["id"] = i;
+            d["name"] = v.name;
+            d["ilp"] = v.ilp;
+            d["waves"] = v.waves;
+            d["grid"] = v.grid;
+            d["load"] = v.load;          // 0=dwordx4, 1=dwordx4 nt, 2=dwordx2
+            d["strided"] = (bool)v.strided;
+            d["persistent"] = (bool)v.persistent;
+            variants.append(d);
+        }
+        return variants;
+    });
+
     // ── Patch embedding (FP16, matching the CUDA surface) ──
     m.def("patch_im2col", [](uintptr_t input, uintptr_t output, int nv, uintptr_t stream) {
         patch_im2col(typed_ptr<__half>(input),
@@ -452,4 +513,7 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
 
     // ── GEMM: hand-tuned small-M FP8 (weight-streaming) ──
 #include "gemm/bindings_smallm.inc"
+
+    // ── GEMM: fused decoder-FFN pair (gate|up+geglu, down+gate*res) ──
+#include "gemm/bindings_ffn_fused.inc"
 }

--- a/csrc/amd/context.h
+++ b/csrc/amd/context.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hipblaslt/hipblaslt.h>
+
+// ================================================================
+// FvkContext (AMD): per-instance runtime resources.
+//
+// Owns a single hipBLASLt handle shared by ALL kernel calls.
+// Created by Python (via pybind11), passed to every kernel.
+// Eliminates static handles — kernels are fully stateless.
+//
+// Mirrors csrc/context.h (CUDA), which owns a cublasHandle_t.
+// The AMD GEMM path is hipBLASLt-only, so the handle here is
+// hipblasLtHandle_t rather than a plain hipblasHandle_t.
+// ================================================================
+
+struct FvkContext {
+    hipblasLtHandle_t hipblaslt_handle;
+
+    FvkContext() : hipblaslt_handle(nullptr) {
+        hipblasLtCreate(&hipblaslt_handle);
+    }
+
+    ~FvkContext() {
+        if (hipblaslt_handle) {
+            hipblasLtDestroy(hipblaslt_handle);
+            hipblaslt_handle = nullptr;
+        }
+    }
+
+    // Non-copyable (handle is unique resource)
+    FvkContext(const FvkContext&) = delete;
+    FvkContext& operator=(const FvkContext&) = delete;
+
+    // Movable
+    FvkContext(FvkContext&& other) noexcept : hipblaslt_handle(other.hipblaslt_handle) {
+        other.hipblaslt_handle = nullptr;
+    }
+};

--- a/csrc/amd/gemm/bindings_ffn_fused.inc
+++ b/csrc/amd/gemm/bindings_ffn_fused.inc
@@ -1,0 +1,63 @@
+// ================================================================
+// FlashRT AMD — fused decoder-FFN bindings fragment
+//
+// #included INSIDE the PYBIND11_MODULE body of csrc/amd/bindings.cpp,
+// after bindings_smallm.inc. Reuses the pointer helpers defined there
+// (to_ptr / typed_ptr / to_stream). Raw-pointer ABI.
+//
+// Semantics: gemm/decoder_ffn_fused.h — the two megakernels that
+// replace the pi05 decoder FFN sub-chain (gate|up GEMM -> geglu ->
+// fp8 quant, and down GEMM -> gate*x + residual).
+// ================================================================
+
+    m.def("smallm_fp8_gateup_geglu", [](uintptr_t A, uintptr_t W, uintptr_t OutFp8,
+                                        int M, int N_half, int K,
+                                        uintptr_t d_scale_a, uintptr_t d_scale_w,
+                                        uintptr_t d_scale_out, uintptr_t stream) {
+        smallm_fp8_gateup_geglu(to_ptr(A), to_ptr(W), to_ptr(OutFp8),
+                                typed_ptr<float>(d_scale_a), typed_ptr<float>(d_scale_w),
+                                typed_ptr<float>(d_scale_out),
+                                M, N_half, K, to_stream(stream));
+    }, py::arg("A"), py::arg("W"), py::arg("OutFp8"),
+       py::arg("M"), py::arg("N_half"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_w"),
+       py::arg("d_scale_out"), py::arg("stream") = 0);
+
+    m.def("smallm_fp8_gateup_geglu_alt", [](uintptr_t A, uintptr_t W, uintptr_t OutFp8,
+                                            int M, int N_half, int K,
+                                            uintptr_t d_scale_a, uintptr_t d_scale_w,
+                                            uintptr_t d_scale_out, uintptr_t stream) {
+        smallm_fp8_gateup_geglu_alt(to_ptr(A), to_ptr(W), to_ptr(OutFp8),
+                                    typed_ptr<float>(d_scale_a), typed_ptr<float>(d_scale_w),
+                                    typed_ptr<float>(d_scale_out),
+                                    M, N_half, K, to_stream(stream));
+    }, py::arg("A"), py::arg("W"), py::arg("OutFp8"),
+       py::arg("M"), py::arg("N_half"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_w"),
+       py::arg("d_scale_out"), py::arg("stream") = 0);
+
+    m.def("smallm_fp8_down_gateres", [](uintptr_t H, uintptr_t W,
+                                        uintptr_t residual, uintptr_t gate,
+                                        int M, int N, int K,
+                                        uintptr_t d_scale_h, uintptr_t d_scale_w,
+                                        uintptr_t stream) {
+        smallm_fp8_down_gateres(to_ptr(H), to_ptr(W),
+                                to_ptr(residual), to_ptr(gate),
+                                typed_ptr<float>(d_scale_h), typed_ptr<float>(d_scale_w),
+                                M, N, K, to_stream(stream));
+    }, py::arg("H"), py::arg("W"), py::arg("residual"), py::arg("gate"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_h"), py::arg("d_scale_w"), py::arg("stream") = 0);
+
+    m.def("smallm_fp8_down_gateres_alt", [](uintptr_t H, uintptr_t W,
+                                            uintptr_t residual, uintptr_t gate,
+                                            int M, int N, int K,
+                                            uintptr_t d_scale_h, uintptr_t d_scale_w,
+                                            uintptr_t stream) {
+        smallm_fp8_down_gateres_alt(to_ptr(H), to_ptr(W),
+                                    to_ptr(residual), to_ptr(gate),
+                                    typed_ptr<float>(d_scale_h), typed_ptr<float>(d_scale_w),
+                                    M, N, K, to_stream(stream));
+    }, py::arg("H"), py::arg("W"), py::arg("residual"), py::arg("gate"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_h"), py::arg("d_scale_w"), py::arg("stream") = 0);

--- a/csrc/amd/gemm/bindings_gemm.inc
+++ b/csrc/amd/gemm/bindings_gemm.inc
@@ -1,0 +1,124 @@
+// ================================================================
+// FlashRT AMD — GEMM bindings fragment (hipBLASLt GemmRunner + FvkContext)
+//
+// This file is #included INSIDE the PYBIND11_MODULE body of
+// csrc/amd/bindings.cpp. It reuses the pointer helpers defined there
+// (to_ptr / typed_ptr / to_stream) and keeps the exact method and
+// py::arg names of the CUDA module (csrc/bindings.cpp:611-828).
+//
+// Integration steps (owner of bindings.cpp / CMakeLists.txt):
+//   1. At file scope in csrc/amd/bindings.cpp, add:
+//        #include "context.h"
+//        #include "gemm/hipblaslt_runner.h"
+//   2. Inside PYBIND11_MODULE(flash_rt_amd_kernels, m) { ... }, add:
+//        #include "gemm/bindings_gemm.inc"
+//   3. In csrc/amd/CMakeLists.txt:
+//        find_package(hipblaslt REQUIRED)
+//        target_link_libraries(<module_target> PRIVATE roc::hipblaslt)
+//        add gemm/hipblaslt_runner.hip to the module's source list
+//      (hipblaslt ships its CMake config with ROCm; if find_package
+//       needs help, add ${ROCM_PATH}/lib/cmake/hipblaslt to
+//       CMAKE_PREFIX_PATH.)
+//
+// Notes vs the CUDA bindings:
+//   - Only the ported subset is exposed: FvkContext, bf16_run,
+//     bf16_nn, bf16_nn_bias, bf16_nn_bias_gelu, fp8_nn_dev,
+//     fp8_nt_dev, autotune_bf16_nn, autotune_fp8_nn_dev,
+//     autotune_fp8_nt_dev.
+//   - bf16_run exists on the CUDA C++ class but is not exposed by the
+//     CUDA bindings; it is exposed here (same name/signature as the
+//     C++ method) because the AMD line needs a Python-reachable
+//     BF16 NT path.
+//   - FvkContext.handle_ptr returns the hipblasLtHandle_t address
+//     (the CUDA property returns the cublasHandle_t address).
+// ================================================================
+
+    // ── FvkContext: per-instance hipBLASLt handle ──
+    py::class_<FvkContext>(m, "FvkContext")
+        .def(py::init<>())
+        .def_property_readonly("handle_ptr", [](const FvkContext& ctx) {
+            return reinterpret_cast<uintptr_t>(ctx.hipblaslt_handle);
+        });
+
+    // ── GemmRunner ──
+    py::class_<GemmRunner>(m, "GemmRunner")
+        .def(py::init<>())
+        // Inference methods (stream-based, HIP Graph compatible)
+        .def("bf16_run", [](GemmRunner& self,
+                             uintptr_t A, uintptr_t B, uintptr_t D,
+                             int M, int N, int K, uintptr_t stream) {
+            self.bf16_run(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        .def("bf16_nn", [](GemmRunner& self,
+                            uintptr_t A, uintptr_t B, uintptr_t D,
+                            int M, int N, int K, uintptr_t stream) {
+            self.bf16_nn(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        .def("bf16_nn_bias", [](GemmRunner& self,
+                                 uintptr_t A, uintptr_t B, uintptr_t D, uintptr_t bias,
+                                 int M, int N, int K, uintptr_t stream) {
+            self.bf16_nn_bias(to_ptr(A), to_ptr(B), to_ptr(D), to_ptr(bias),
+                               M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"), py::arg("bias"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        .def("bf16_nn_bias_gelu", [](GemmRunner& self,
+                                      uintptr_t A, uintptr_t B, uintptr_t D, uintptr_t bias,
+                                      int M, int N, int K, uintptr_t stream) {
+            self.bf16_nn_bias_gelu(to_ptr(A), to_ptr(B), to_ptr(D), to_ptr(bias),
+                                    M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"), py::arg("bias"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        .def("fp8_nn_dev", [](GemmRunner& self,
+                               uintptr_t A, uintptr_t B, uintptr_t D,
+                               int M, int N, int K,
+                               uintptr_t d_scale_a, uintptr_t d_scale_b,
+                               uintptr_t stream) {
+            self.fp8_nn_dev(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                             typed_ptr<float>(d_scale_a),
+                             typed_ptr<float>(d_scale_b), to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("stream") = 0)
+        .def("fp8_nt_dev", [](GemmRunner& self,
+                               uintptr_t A, uintptr_t B, uintptr_t D,
+                               int M, int N, int K,
+                               uintptr_t d_scale_a, uintptr_t d_scale_b,
+                               uintptr_t stream) {
+            self.fp8_nt_dev(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                             typed_ptr<float>(d_scale_a),
+                             typed_ptr<float>(d_scale_b), to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("stream") = 0)
+        // Autotune
+        .def("autotune_bf16_nn", [](GemmRunner& self,
+                                     uintptr_t A, uintptr_t B, uintptr_t D,
+                                     int M, int N, int K, int num_algos) {
+            self.autotune_bf16_nn(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, num_algos);
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("num_algos") = 16)
+        .def("autotune_fp8_nn_dev", [](GemmRunner& self,
+                                        uintptr_t A, uintptr_t B, uintptr_t D,
+                                        int M, int N, int K,
+                                        uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                        int num_algos) {
+            self.autotune_fp8_nn_dev(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                                      typed_ptr<float>(d_scale_a),
+                                      typed_ptr<float>(d_scale_b), num_algos);
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("num_algos") = 16)
+        .def("autotune_fp8_nt_dev", [](GemmRunner& self,
+                                        uintptr_t A, uintptr_t B, uintptr_t D,
+                                        int M, int N, int K,
+                                        uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                        int num_algos) {
+            self.autotune_fp8_nt_dev(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                                      typed_ptr<float>(d_scale_a),
+                                      typed_ptr<float>(d_scale_b), num_algos);
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("num_algos") = 16)
+    ;

--- a/csrc/amd/gemm/bindings_gemm.inc
+++ b/csrc/amd/gemm/bindings_gemm.inc
@@ -25,6 +25,9 @@
 //     bf16_nn, bf16_nn_bias, bf16_nn_bias_gelu, fp8_nn_dev,
 //     fp8_nt_dev, autotune_bf16_nn, autotune_fp8_nn_dev,
 //     autotune_fp8_nt_dev.
+//   - AMD-only additions (no CUDA counterpart): mxfp4_nt_dev and
+//     autotune_mxfp4_nt_dev (gfx950 native MXFP4 a4w4 via hipBLASLt
+//     VEC32_UE8M0 block scales).
 //   - bf16_run exists on the CUDA C++ class but is not exposed by the
 //     CUDA bindings; it is exposed here (same name/signature as the
 //     C++ method) because the AMD line needs a Python-reachable
@@ -92,6 +95,18 @@
         }, py::arg("A"), py::arg("B"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"),
            py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("stream") = 0)
+        // MXFP4 a4w4 (E2M1 packed 2-per-byte + per-1x32-block ue8m0 uint8
+        // scale tensors; see hipblaslt_runner.h for the exact layouts)
+        .def("mxfp4_nt_dev", [](GemmRunner& self,
+                                 uintptr_t A, uintptr_t A_scales,
+                                 uintptr_t B, uintptr_t B_scales, uintptr_t D,
+                                 int M, int N, int K, uintptr_t stream) {
+            self.mxfp4_nt_dev(to_ptr(A), to_ptr(A_scales),
+                               to_ptr(B), to_ptr(B_scales), to_ptr(D),
+                               M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("A_scales"),
+           py::arg("B"), py::arg("B_scales"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
         // Autotune
         .def("autotune_bf16_nn", [](GemmRunner& self,
                                      uintptr_t A, uintptr_t B, uintptr_t D,
@@ -121,4 +136,14 @@
         }, py::arg("A"), py::arg("B"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"),
            py::arg("d_scale_a"), py::arg("d_scale_b"), py::arg("num_algos") = 16)
+        .def("autotune_mxfp4_nt_dev", [](GemmRunner& self,
+                                          uintptr_t A, uintptr_t A_scales,
+                                          uintptr_t B, uintptr_t B_scales, uintptr_t D,
+                                          int M, int N, int K, int num_algos) {
+            self.autotune_mxfp4_nt_dev(to_ptr(A), to_ptr(A_scales),
+                                        to_ptr(B), to_ptr(B_scales), to_ptr(D),
+                                        M, N, K, num_algos);
+        }, py::arg("A"), py::arg("A_scales"),
+           py::arg("B"), py::arg("B_scales"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("num_algos") = 16)
     ;

--- a/csrc/amd/gemm/bindings_smallm.inc
+++ b/csrc/amd/gemm/bindings_smallm.inc
@@ -1,0 +1,65 @@
+// ================================================================
+// FlashRT AMD — small-M FP8 GEMM bindings fragment
+//
+// #included INSIDE the PYBIND11_MODULE body of csrc/amd/bindings.cpp,
+// after bindings_gemm.inc. Reuses the pointer helpers defined there
+// (to_ptr / typed_ptr / to_stream). Raw-pointer ABI, same arg order
+// as GemmRunner.fp8_nn_dev / fp8_nt_dev plus a nullable split_ws.
+//
+// Semantics: exact drop-ins for the GemmRunner FP8 paths — see
+// gemm/smallm_fp8.h. split_ws (nn only; ignored by nt) is a device
+// FP32 buffer of >= smallm_fp8_nn_ws_bytes(M, N) bytes; pass 0 to
+// disable split-K.
+// ================================================================
+
+    m.def("smallm_fp8_nn_ws_bytes", [](int M, int N) {
+        return (size_t)smallm_fp8_nn_dev_ws_bytes(M, N);
+    }, py::arg("M"), py::arg("N"));
+
+    m.def("smallm_fp8_nn_dev", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                  int M, int N, int K,
+                                  uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                  uintptr_t split_ws, uintptr_t stream) {
+        smallm_fp8_nn_dev(to_ptr(A), to_ptr(B), to_ptr(D),
+                          typed_ptr<float>(d_scale_a), typed_ptr<float>(d_scale_b),
+                          M, N, K, typed_ptr<float>(split_ws), to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"),
+       py::arg("split_ws") = 0, py::arg("stream") = 0);
+
+    m.def("smallm_fp8_nn_dev_alt", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                      int M, int N, int K,
+                                      uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                      uintptr_t split_ws, uintptr_t stream) {
+        smallm_fp8_nn_dev_alt(to_ptr(A), to_ptr(B), to_ptr(D),
+                              typed_ptr<float>(d_scale_a), typed_ptr<float>(d_scale_b),
+                              M, N, K, typed_ptr<float>(split_ws), to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"),
+       py::arg("split_ws") = 0, py::arg("stream") = 0);
+
+    m.def("smallm_fp8_nt_dev", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                  int M, int N, int K,
+                                  uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                  uintptr_t split_ws, uintptr_t stream) {
+        smallm_fp8_nt_dev(to_ptr(A), to_ptr(B), to_ptr(D),
+                          typed_ptr<float>(d_scale_a), typed_ptr<float>(d_scale_b),
+                          M, N, K, typed_ptr<float>(split_ws), to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"),
+       py::arg("split_ws") = 0, py::arg("stream") = 0);
+
+    m.def("smallm_fp8_nt_dev_alt", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                      int M, int N, int K,
+                                      uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                      uintptr_t split_ws, uintptr_t stream) {
+        smallm_fp8_nt_dev_alt(to_ptr(A), to_ptr(B), to_ptr(D),
+                              typed_ptr<float>(d_scale_a), typed_ptr<float>(d_scale_b),
+                              M, N, K, typed_ptr<float>(split_ws), to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"),
+       py::arg("split_ws") = 0, py::arg("stream") = 0);

--- a/csrc/amd/gemm/bindings_smallm.inc
+++ b/csrc/amd/gemm/bindings_smallm.inc
@@ -52,6 +52,27 @@
        py::arg("d_scale_a"), py::arg("d_scale_b"),
        py::arg("split_ws") = 0, py::arg("stream") = 0);
 
+    // LDS double-buffered nt pipeline, explicit entry for A/B rows.
+    // Arg order mirrors smallm_fp8_nt_dev with use_async in the
+    // split_ws position, so bench/parity harnesses can drive all nt
+    // variants through one calling convention (use_async: 0 = sync
+    // register-hoisted staging, nonzero = gfx9 LDS-DMA staging).
+    m.def("smallm_fp8_nt_lds_dev", [](uintptr_t A, uintptr_t B, uintptr_t D,
+                                      int M, int N, int K,
+                                      uintptr_t d_scale_a, uintptr_t d_scale_b,
+                                      int use_async, uintptr_t stream) {
+        smallm_fp8_nt_lds_dev(to_ptr(A), to_ptr(B), to_ptr(D),
+                              typed_ptr<float>(d_scale_a), typed_ptr<float>(d_scale_b),
+                              M, N, K, use_async, to_stream(stream));
+    }, py::arg("A"), py::arg("B"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("d_scale_a"), py::arg("d_scale_b"),
+       py::arg("use_async") = 1, py::arg("stream") = 0);
+
+    m.def("smallm_fp8_nt_lds_async_available", []() {
+        return smallm_fp8_nt_lds_async_available() != 0;
+    });
+
     m.def("smallm_fp8_nt_dev_alt", [](uintptr_t A, uintptr_t B, uintptr_t D,
                                       int M, int N, int K,
                                       uintptr_t d_scale_a, uintptr_t d_scale_b,

--- a/csrc/amd/gemm/decoder_ffn_fused.h
+++ b/csrc/amd/gemm/decoder_ffn_fused.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+// ================================================================
+// FlashRT AMD — fused decoder-FFN kernel pair (CDNA4, wave64)
+//
+// Replaces the pi05 decoder's per-(layer,step) FFN sub-chain
+//
+//   gate|up fp8 GEMM (M=10, N=2*4096, K=1024)   [fp8_nt_dev]
+//     -> gate_geglu_merged_fp8 (geglu + fp8 quantize)
+//     -> down fp8 GEMM (M=10, N=1024, K=4096)   [fp8_nt_dev]
+//     -> gate_mul_residual (residual += x * gate)
+//
+// with TWO weight-streaming GEMM kernels whose epilogues absorb the
+// elementwise pieces. The chain is bandwidth-bound: weight bytes per
+// chain are 8.39 MB (gate|up) + 4.19 MB (down) fp8 = 12.6 MB, a
+// ~2.5 us floor at 5 TB/s, while the 4-kernel chain measures
+// ~25-30 us (hipBLASLt small-M tiles + 3 intermediate round trips +
+// launch gaps). Both kernels stream their weight matrix exactly once
+// with 16-byte lane loads (dwordx4), keep the tiny A operand in
+// registers, accumulate FP32, and fold with wave shuffles — the same
+// proven streaming skeleton as smallm_fp8_nt_dev (smallm_fp8.hip):
+// identical lane-K partition, chunk order, and shuffle tree, so the
+// GEMM accumulation order (and thus the fp32 result) is bit-identical
+// to smallm_fp8_nt_dev on the same inputs.
+//
+// Layout: weights are the frontend's "nk" layout, row-major (N, K)
+// with K contiguous — each output column owns one contiguous K-row of
+// the weight, the stream-friendliest layout (no split-K, no LDS, no
+// workspace, no atomics; replays inside captured graphs are
+// bit-identical).
+//
+// ── Kernel 1: smallm_fp8_gateup_geglu ──
+//   OutFp8(M, N_half) = quant_e4m3( geglu( A_fp8(M,K) @ W(2*N_half,K)^T
+//                                          * sa * sw ) / s_out )
+//   W row j       = gate column j   (j <  N_half)
+//   W row N_half+j = up  column j   (merged buffer convention of
+//   gate_geglu_merged_fp8: gate is the FIRST half, up the SECOND).
+//   Access pattern: geglu output column j needs BOTH W rows j and
+//   N_half + j, which sit N_half*K bytes apart in the nk layout. Each
+//   wave therefore streams two row groups per owned column — its
+//   gate-row (offset j*K) and its up-row (offset (N_half+j)*K) — off
+//   the same lane K-window, reusing the converted A chunk for both.
+//   Epilogue (per output element, replicating the unfused chain's
+//   rounding points EXACTLY):
+//     g = bf16_round(acc_gate * sa * sw)        // fp8_nt_dev's BF16 D
+//     u = bf16_round(acc_up   * sa * sw)
+//     gelu = g / (1 + exp(-1.5957691216057308*g*(1 + 0.044715*g*g)))
+//     v = clamp(gelu*u / s_out, ±448) -> __hip_fp8_e4m3 (RNE, sat)
+//
+//   Grid: 256-thread WGs (4 waves), NPW geglu-columns per wave.
+//   Default NPW=2 -> 8 columns (16 weight rows, 16 KB @ K=1024) per
+//   WG -> N_half/8 = 512 WGs at N_half=4096: 2 per CU on MI350X's 256
+//   CUs, and the same register footprint as the proven smallm nt
+//   NPW=4 config (4 B-row streams per converted A chunk). The _alt
+//   config uses NPW=4 (256 WGs, more A reuse, higher VGPR pressure).
+//
+// ── Kernel 2: smallm_fp8_down_gateres ──
+//   x(M, N)   = bf16_round( H_fp8(M,K) @ W_down(N,K)^T * sh * sw )
+//   residual(M, N) += x * gate        (in place, BF16)
+//   Epilogue replicates gate_mul_residual exactly: the GEMM result is
+//   rounded to BF16 FIRST (that is what the unfused kernel reads from
+//   the GEMM's BF16 output buffer), then
+//     r = f32(residual) + f32(x_bf16) * f32(gate_bf16) -> bf16_round.
+//   The intermediate x buffer is never materialized in HBM.
+//
+//   Grid: default NPW=1 -> 4 columns (4 KB @ K=4096) per WG ->
+//   N/4 = 256 WGs at N=1024: exactly one per CU with a 4-chunk serial
+//   K loop per wave. The _alt config uses NPW=2 (128 WGs, halves the
+//   per-byte A-convert ALU cost by reusing the converted A chunk
+//   across 2 columns — bench both on device).
+//
+// Bandwidth math (pi05 shapes, per chain):
+//   mega1: 8.39 MB weights + 10 KB A + 40 KB OutFp8  -> 1.69 us @ 5 TB/s
+//   mega2: 4.19 MB weights + 40 KB H + 60 KB res/gate -> 0.86 us @ 5 TB/s
+//   vs the unfused chain's ~13.0 MB + 460 KB of intermediates + 4
+//   launch/gap overheads.
+//
+// FP8 is OCP e4m3 (__hip_fp8_e4m3, HIP_R_8F_E4M3 — never fnuz).
+// Scales are DEVICE float pointers dereferenced in-kernel (HIP Graph
+// safe), matching the hipBLASLt A/B_SCALE_POINTER contract.
+//
+// Constraints (checked, throw std::runtime_error on violation):
+//   1 <= M <= 16, K % 16 == 0 (whole 16B lane loads); N / N_half is
+//   guarded per column. A/H/W must be 16-byte aligned.
+// ================================================================
+
+// Kernel 1: gate|up GEMM + GeGLU + static-scale FP8 quantize.
+//   A_fp8:        (M, K) fp8 e4m3, row-major
+//   W_gateup:     (2*N_half, K) fp8 e4m3, row-major "nk" (gate rows
+//                 [0, N_half), up rows [N_half, 2*N_half))
+//   OutFp8:       (M, N_half) fp8 e4m3, row-major
+//   d_scale_a/w:  device fp32 descales for A and W
+//   d_scale_out:  device fp32 quantization scale of the down-proj
+//                 activation (divides, exactly as gate_geglu_merged_fp8)
+void smallm_fp8_gateup_geglu(const void* A_fp8, const void* W_gateup,
+                             void* OutFp8,
+                             const float* d_scale_a, const float* d_scale_w,
+                             const float* d_scale_out,
+                             int M, int N_half, int K, hipStream_t stream);
+
+// Alternate config for A/B benching (NPW=4: 2x A reuse, half the WGs).
+void smallm_fp8_gateup_geglu_alt(const void* A_fp8, const void* W_gateup,
+                                 void* OutFp8,
+                                 const float* d_scale_a, const float* d_scale_w,
+                                 const float* d_scale_out,
+                                 int M, int N_half, int K, hipStream_t stream);
+
+// Kernel 2: down GEMM + gate*x + residual (in place).
+//   H_fp8:        (M, K) fp8 e4m3, row-major (kernel 1's output)
+//   W_down:       (N, K) fp8 e4m3, row-major "nk"
+//   residual:     (M, N) bf16, updated in place: residual += x * gate
+//   gate:         (M, N) bf16 (the ada-norm gate buffer)
+//   d_scale_h/w:  device fp32 descales for H and W
+void smallm_fp8_down_gateres(const void* H_fp8, const void* W_down,
+                             void* residual, const void* gate,
+                             const float* d_scale_h, const float* d_scale_w,
+                             int M, int N, int K, hipStream_t stream);
+
+// Alternate config for A/B benching (NPW=2: 2x A reuse, half the WGs).
+void smallm_fp8_down_gateres_alt(const void* H_fp8, const void* W_down,
+                                 void* residual, const void* gate,
+                                 const float* d_scale_h, const float* d_scale_w,
+                                 int M, int N, int K, hipStream_t stream);

--- a/csrc/amd/gemm/decoder_ffn_fused.hip
+++ b/csrc/amd/gemm/decoder_ffn_fused.hip
@@ -1,0 +1,425 @@
+#include "decoder_ffn_fused.h"
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp8.h>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+// ================================================================
+// FlashRT AMD — fused decoder-FFN kernel pair (CDNA4, wave64)
+//
+// See decoder_ffn_fused.h for the contract and design notes. The
+// streaming skeleton (lane-K partition in 16B chunks, sequential
+// chunk loop, fixed wave shuffle tree, no atomics) is copied verbatim
+// from smallm_fp8_nt_kernel (smallm_fp8.hip) so the fp32 GEMM
+// accumulation order — and therefore the pre-epilogue result — is
+// bit-identical to smallm_fp8_nt_dev on the same inputs.
+//
+// ILP=4 weight streaming (stream_probe measurement, see
+// FlashRT-amd-dev/notes/stream_craft_gfx950.md): both kernels keep 4
+// independent weight dwordx4 chains in flight per lane by ISSUING all
+// loads of a group before any convert/FMA consumes them — mega1 via
+// the 2*NPW gate/up rows of a chunk, mega2 via NPW columns x CG=4/NPW
+// consecutive chunks. Consumption keeps the ORIGINAL fixed order
+// (ascending chunk, ascending column, gate before up), so the fp32
+// accumulation order is UNCHANGED — the bit-equality contract vs the
+// smallm nt chain (test_amd_decoder_ffn_fused.py) still holds with no
+// relaxation.
+//
+// Rounding points (bit-comparability with the unfused chain):
+//   * both kernels round the scaled fp32 accumulator to BF16 before
+//     the epilogue math, because the unfused chain materializes the
+//     GEMM output as BF16 (fp8_nt_dev's D) and the elementwise
+//     kernels (gate_geglu_merged_fp8 / gate_mul_residual) read that
+//     BF16 buffer;
+//   * the geglu polynomial, 1/scale, ±448 clamp and __hip_fp8_e4m3
+//     construction are written with the exact same expressions as
+//     gate_geglu_merged_fp8 (activation.hip);
+//   * the residual update is f32(res) + f32(x_bf16)*f32(gate_bf16)
+//     rounded once to BF16, exactly gate_mul_res_kernel
+//     (elementwise.hip).
+// ================================================================
+
+#define FFN_FUSED_BLOCK 256   // threads per workgroup (4 waves)
+
+// ── fp8 e4m3 byte -> f32 (same as smallm_fp8.hip) ──
+__device__ __forceinline__ float ffn_fused_fp8_to_f32(unsigned char b) {
+    __hip_fp8_e4m3 v;
+    v.__x = b;
+    return static_cast<float>(v);
+}
+
+// Unpack 16 fp8 bytes (one dwordx4 load) to f32.
+__device__ __forceinline__ void ffn_fused_fp8x16_to_f32(const uint4& v, float* out) {
+    const unsigned char* b = reinterpret_cast<const unsigned char*>(&v);
+    #pragma unroll
+    for (int j = 0; j < 16; ++j) out[j] = ffn_fused_fp8_to_f32(b[j]);
+}
+
+// ================================================================
+// Kernel 1: gate|up GEMM + GeGLU + FP8 quantize.
+//   W stored (2*N_half, K) row-major; geglu output column n streams
+//   W rows n (gate) and N_half + n (up) — N_half*K bytes apart —
+//   off the same converted A chunk.
+//   grid = ceil(N_half / (4*NPW)), block = 256; wave w owns geglu
+//   columns nb + w*NPW .. +NPW-1. No LDS, no split-K, no atomics.
+// ================================================================
+template<int M_T, int NPW>
+__global__ __launch_bounds__(FFN_FUSED_BLOCK)
+void smallm_fp8_gateup_geglu_kernel(const unsigned char* __restrict__ A,
+                                    const unsigned char* __restrict__ W,
+                                    __hip_fp8_e4m3* __restrict__ out,
+                                    const float* __restrict__ d_scale_a,
+                                    const float* __restrict__ d_scale_w,
+                                    const float* __restrict__ d_scale_out,
+                                    int M, int N_half, int K) {
+    const int wave = threadIdx.x >> 6;
+    const int lane = threadIdx.x & 63;
+    const int nb   = blockIdx.x * (4 * NPW) + wave * NPW;
+
+    float acc_g[NPW][M_T];
+    float acc_u[NPW][M_T];
+    #pragma unroll
+    for (int p = 0; p < NPW; ++p)
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) { acc_g[p][m] = 0.0f; acc_u[p][m] = 0.0f; }
+
+    // K-chunks of 64 lanes x 16B = 1024 elements; sequential chunk
+    // loop per lane keeps accumulation order fixed (deterministic,
+    // bit-identical to smallm_fp8_nt_kernel).
+    //
+    // ILP (stream_craft_gfx950.md): all 2*NPW weight loads of a chunk
+    // (gate + up rows per owned column) are ISSUED first into distinct
+    // registers — 2*NPW >= 4 independent dwordx4 chains in flight per
+    // lane, the measured gfx950 saturation lever — then consumed in
+    // the ORIGINAL order (ascending p, gate before up), so each
+    // accumulator's fp32 order is unchanged and mega1 stays bit-equal
+    // to the smallm nt chain.
+    const int chunks = (K + 1023) >> 10;
+    for (int c = 0; c < chunks; ++c) {
+        const int kw = (c << 10) + (lane << 4);
+        if (kw >= K) continue;  // tail guard (K % 16 == 0 keeps loads whole)
+
+        // ── issue the 2*NPW independent gate/up loads (ILP >= 4) ──
+        uint4 graw[NPW], uraw[NPW];
+        bool  wok[NPW];
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int n = nb + p;
+            wok[p] = (n < N_half);
+            if (wok[p]) {
+                graw[p] = *reinterpret_cast<const uint4*>(
+                    W + (size_t)n * K + kw);
+                uraw[p] = *reinterpret_cast<const uint4*>(
+                    W + (size_t)(N_half + n) * K + kw);
+            }
+        }
+
+        // A window for this lane's 16 k's, all rows, converted once
+        // (A is L1/L2-hot — not the stream).
+        float a_f[M_T][16];
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) {
+            if (m < M) {
+                const uint4 av = *reinterpret_cast<const uint4*>(
+                    A + (size_t)m * K + kw);
+                ffn_fused_fp8x16_to_f32(av, a_f[m]);
+            } else {
+                #pragma unroll
+                for (int j = 0; j < 16; ++j) a_f[m][j] = 0.0f;
+            }
+        }
+
+        // ── consume: ascending p, gate row then up row ──
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            if (!wok[p]) continue;
+            float gf[16];
+            ffn_fused_fp8x16_to_f32(graw[p], gf);
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                #pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    acc_g[p][m] += a_f[m][j] * gf[j];
+            }
+            float uf[16];
+            ffn_fused_fp8x16_to_f32(uraw[p], uf);
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                #pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    acc_u[p][m] += a_f[m][j] * uf[j];
+            }
+        }
+    }
+
+    // Fixed-shape wave shuffle tree (order identical every launch).
+    #pragma unroll
+    for (int off = 32; off > 0; off >>= 1) {
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p)
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                acc_g[p][m] += __shfl_down(acc_g[p][m], off);
+                acc_u[p][m] += __shfl_down(acc_u[p][m], off);
+            }
+    }
+
+    if (lane == 0) {
+        const float sc = d_scale_a[0] * d_scale_w[0];
+        const float inv_scale = 1.0f / (*d_scale_out);
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int n = nb + p;
+            if (n >= N_half) continue;
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                if (m < M) {
+                    // Round to BF16 first: the unfused chain's geglu
+                    // reads fp8_nt_dev's BF16 output buffer.
+                    const float g = __bfloat162float(
+                        __float2bfloat16(acc_g[p][m] * sc));
+                    const float u = __bfloat162float(
+                        __float2bfloat16(acc_u[p][m] * sc));
+                    // EXACT gate_geglu_merged_fp8 epilogue (activation.hip).
+                    float gelu = g / (1.0f + expf(-1.5957691216057308f * g * (1.0f + 0.044715f * g * g)));
+                    float val = gelu * u;
+                    val = fminf(fmaxf(val * inv_scale, -448.0f), 448.0f);
+                    out[(size_t)m * N_half + n] = __hip_fp8_e4m3(val);
+                }
+            }
+        }
+    }
+}
+
+// ================================================================
+// Kernel 2: down GEMM + gate*x + residual (in place).
+//   W stored (N, K) row-major. Same skeleton; the BF16 GEMM output is
+//   never materialized — lane 0 folds it straight into the residual.
+// ================================================================
+template<int M_T, int NPW>
+__global__ __launch_bounds__(FFN_FUSED_BLOCK)
+void smallm_fp8_down_gateres_kernel(const unsigned char* __restrict__ H,
+                                    const unsigned char* __restrict__ W,
+                                    __hip_bfloat16* __restrict__ residual,
+                                    const __hip_bfloat16* __restrict__ gate,
+                                    const float* __restrict__ d_scale_h,
+                                    const float* __restrict__ d_scale_w,
+                                    int M, int N, int K) {
+    const int wave = threadIdx.x >> 6;
+    const int lane = threadIdx.x & 63;
+    const int nb   = blockIdx.x * (4 * NPW) + wave * NPW;
+
+    float acc[NPW][M_T];
+    #pragma unroll
+    for (int p = 0; p < NPW; ++p)
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) acc[p][m] = 0.0f;
+
+    // ILP=4 (stream_craft_gfx950.md): a group of CG = 4/NPW
+    // consecutive K-chunks per outer iteration; all NPW*CG == 4
+    // independent W dwordx4 loads issued FIRST (4 chains in flight per
+    // lane — pi05 site NPW=1, K=4096: the whole weight row preloaded
+    // as 4 chains), then consumed ascending chunk / ascending p — the
+    // ORIGINAL fixed order, so each accumulator's fp32 order is
+    // unchanged and mega2 stays bit-equal to the smallm nt chain.
+    constexpr int CG = (NPW >= 4) ? 1 : (4 / NPW);
+    const int chunks = (K + 1023) >> 10;
+    for (int c0 = 0; c0 < chunks; c0 += CG) {
+        // ── issue all NPW x CG independent W loads (ILP4) ──
+        uint4 braw[NPW][CG];
+        bool  bok[NPW][CG];
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int n = nb + p;
+            #pragma unroll
+            for (int u = 0; u < CG; ++u) {
+                const int kw = ((c0 + u) << 10) + (lane << 4);
+                bok[p][u] = (n < N) && (kw < K);  // K % 16 == 0: whole loads
+                if (bok[p][u])
+                    braw[p][u] = *reinterpret_cast<const uint4*>(
+                        W + (size_t)n * K + kw);
+            }
+        }
+
+        // ── consume: ascending chunk, then ascending column ──
+        #pragma unroll
+        for (int u = 0; u < CG; ++u) {
+            const int kw = ((c0 + u) << 10) + (lane << 4);
+            if (kw >= K) continue;  // tail guard
+
+            float a_f[M_T][16];
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                if (m < M) {
+                    const uint4 av = *reinterpret_cast<const uint4*>(
+                        H + (size_t)m * K + kw);
+                    ffn_fused_fp8x16_to_f32(av, a_f[m]);
+                } else {
+                    #pragma unroll
+                    for (int j = 0; j < 16; ++j) a_f[m][j] = 0.0f;
+                }
+            }
+
+            #pragma unroll
+            for (int p = 0; p < NPW; ++p) {
+                if (!bok[p][u]) continue;
+                float bf[16];
+                ffn_fused_fp8x16_to_f32(braw[p][u], bf);
+                #pragma unroll
+                for (int m = 0; m < M_T; ++m) {
+                    #pragma unroll
+                    for (int j = 0; j < 16; ++j)
+                        acc[p][m] += a_f[m][j] * bf[j];
+                }
+            }
+        }
+    }
+
+    #pragma unroll
+    for (int off = 32; off > 0; off >>= 1) {
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p)
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m)
+                acc[p][m] += __shfl_down(acc[p][m], off);
+    }
+
+    if (lane == 0) {
+        const float sc = d_scale_h[0] * d_scale_w[0];
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int n = nb + p;
+            if (n >= N) continue;
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                if (m < M) {
+                    const size_t idx = (size_t)m * N + n;
+                    // Round to BF16 first: gate_mul_residual reads
+                    // the GEMM's BF16 output buffer in the unfused
+                    // chain. Then EXACT gate_mul_res_kernel math.
+                    const float x = __bfloat162float(
+                        __float2bfloat16(acc[p][m] * sc));
+                    const float r = __bfloat162float(residual[idx]) +
+                                    x * __bfloat162float(gate[idx]);
+                    residual[idx] = __float2bfloat16(r);
+                }
+            }
+        }
+    }
+}
+
+// ================================================================
+// Host side
+// ================================================================
+
+static void ffn_fused_check(const char* who, int M, int N, int K) {
+    if (M < 1 || M > 16)
+        throw std::runtime_error(std::string(who) + ": M must be in [1,16], got " +
+                                 std::to_string(M));
+    if (N < 1)
+        throw std::runtime_error(std::string(who) + ": N must be >= 1, got " +
+                                 std::to_string(N));
+    if (K < 16 || (K % 16) != 0)
+        throw std::runtime_error(std::string(who) + ": K must be a multiple of 16, got " +
+                                 std::to_string(K));
+}
+
+template<int NPW>
+static void smallm_fp8_gateup_geglu_impl(const void* A, const void* W, void* out,
+                                         const float* d_scale_a,
+                                         const float* d_scale_w,
+                                         const float* d_scale_out,
+                                         int M, int N_half, int K,
+                                         hipStream_t stream) {
+    ffn_fused_check("smallm_fp8_gateup_geglu", M, N_half, K);
+    const int cols_per_wg = 4 * NPW;
+    const dim3 grid((unsigned)((N_half + cols_per_wg - 1) / cols_per_wg));
+    const dim3 block(FFN_FUSED_BLOCK);
+    const unsigned char* a8 = static_cast<const unsigned char*>(A);
+    const unsigned char* w8 = static_cast<const unsigned char*>(W);
+    __hip_fp8_e4m3* o8 = static_cast<__hip_fp8_e4m3*>(out);
+
+    #define FFN_LAUNCH_GATEUP(MT)                                              \
+        hipLaunchKernelGGL(                                                    \
+            HIP_KERNEL_NAME(smallm_fp8_gateup_geglu_kernel<MT, NPW>),          \
+            grid, block, 0, stream,                                            \
+            a8, w8, o8, d_scale_a, d_scale_w, d_scale_out, M, N_half, K)
+    if      (M <= 4)  FFN_LAUNCH_GATEUP(4);
+    else if (M <= 8)  FFN_LAUNCH_GATEUP(8);
+    else if (M <= 10) FFN_LAUNCH_GATEUP(10);
+    else              FFN_LAUNCH_GATEUP(16);
+    #undef FFN_LAUNCH_GATEUP
+}
+
+void smallm_fp8_gateup_geglu(const void* A_fp8, const void* W_gateup,
+                             void* OutFp8,
+                             const float* d_scale_a, const float* d_scale_w,
+                             const float* d_scale_out,
+                             int M, int N_half, int K, hipStream_t stream) {
+    // NPW=2: 8 geglu columns (16 weight-row streams) per WG ->
+    // N_half/8 = 512 WGs at N_half=4096 (2 per MI350X CU); same
+    // register footprint as the proven smallm nt NPW=4 config.
+    smallm_fp8_gateup_geglu_impl<2>(A_fp8, W_gateup, OutFp8,
+                                    d_scale_a, d_scale_w, d_scale_out,
+                                    M, N_half, K, stream);
+}
+
+void smallm_fp8_gateup_geglu_alt(const void* A_fp8, const void* W_gateup,
+                                 void* OutFp8,
+                                 const float* d_scale_a, const float* d_scale_w,
+                                 const float* d_scale_out,
+                                 int M, int N_half, int K, hipStream_t stream) {
+    // NPW=4: 256 WGs at N_half=4096, 2x A reuse, higher VGPR pressure.
+    smallm_fp8_gateup_geglu_impl<4>(A_fp8, W_gateup, OutFp8,
+                                    d_scale_a, d_scale_w, d_scale_out,
+                                    M, N_half, K, stream);
+}
+
+template<int NPW>
+static void smallm_fp8_down_gateres_impl(const void* H, const void* W,
+                                         void* residual, const void* gate,
+                                         const float* d_scale_h,
+                                         const float* d_scale_w,
+                                         int M, int N, int K,
+                                         hipStream_t stream) {
+    ffn_fused_check("smallm_fp8_down_gateres", M, N, K);
+    const int cols_per_wg = 4 * NPW;
+    const dim3 grid((unsigned)((N + cols_per_wg - 1) / cols_per_wg));
+    const dim3 block(FFN_FUSED_BLOCK);
+    const unsigned char* h8 = static_cast<const unsigned char*>(H);
+    const unsigned char* w8 = static_cast<const unsigned char*>(W);
+    __hip_bfloat16* r16 = static_cast<__hip_bfloat16*>(residual);
+    const __hip_bfloat16* g16 = static_cast<const __hip_bfloat16*>(gate);
+
+    #define FFN_LAUNCH_DOWN(MT)                                                \
+        hipLaunchKernelGGL(                                                    \
+            HIP_KERNEL_NAME(smallm_fp8_down_gateres_kernel<MT, NPW>),          \
+            grid, block, 0, stream,                                            \
+            h8, w8, r16, g16, d_scale_h, d_scale_w, M, N, K)
+    if      (M <= 4)  FFN_LAUNCH_DOWN(4);
+    else if (M <= 8)  FFN_LAUNCH_DOWN(8);
+    else if (M <= 10) FFN_LAUNCH_DOWN(10);
+    else              FFN_LAUNCH_DOWN(16);
+    #undef FFN_LAUNCH_DOWN
+}
+
+void smallm_fp8_down_gateres(const void* H_fp8, const void* W_down,
+                             void* residual, const void* gate,
+                             const float* d_scale_h, const float* d_scale_w,
+                             int M, int N, int K, hipStream_t stream) {
+    // NPW=1: 4 columns per WG -> N/4 = 256 WGs at N=1024, exactly one
+    // per MI350X CU with a serial 4-chunk K loop (K=4096).
+    smallm_fp8_down_gateres_impl<1>(H_fp8, W_down, residual, gate,
+                                    d_scale_h, d_scale_w, M, N, K, stream);
+}
+
+void smallm_fp8_down_gateres_alt(const void* H_fp8, const void* W_down,
+                                 void* residual, const void* gate,
+                                 const float* d_scale_h, const float* d_scale_w,
+                                 int M, int N, int K, hipStream_t stream) {
+    // NPW=2: 128 WGs at N=1024, halves per-byte A-convert ALU cost.
+    smallm_fp8_down_gateres_impl<2>(H_fp8, W_down, residual, gate,
+                                    d_scale_h, d_scale_w, M, N, K, stream);
+}

--- a/csrc/amd/gemm/hipblaslt_runner.h
+++ b/csrc/amd/gemm/hipblaslt_runner.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+#include <hipblaslt/hipblaslt.h>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <functional>
+
+// ================================================================
+// GemmRunner (AMD): hipBLASLt-based GEMM for BF16/FP8 on CDNA.
+//
+// Port of csrc/gemm/gemm_runner.h (cuBLASLt). Method names,
+// signatures, and math semantics are identical to the CUDA class
+// (hipStream_t replaces cudaStream_t). Only the subset needed by
+// the pi05 pipeline is ported; see hipblaslt_runner.hip for the
+// layout-convention note (col-major swap instead of ORDER_ROW).
+//
+// FP8 here is OCP e4m3 (HIP_R_8F_E4M3) — the gfx950 native format.
+// The fnuz variant (HIP_R_8F_E4M3_FNUZ, gfx942) is NOT used.
+// ================================================================
+
+// Check hipBLASLt status
+#define HIPBLASLT_CHECK(expr)                                           \
+    do {                                                                \
+        hipblasStatus_t status = (expr);                                \
+        if (status != HIPBLAS_STATUS_SUCCESS) {                        \
+            throw std::runtime_error(                                   \
+                std::string("hipBLASLt error at ") + __FILE__ + ":" +   \
+                std::to_string(__LINE__) + " code=" +                   \
+                std::to_string(static_cast<int>(status)));              \
+        }                                                               \
+    } while (0)
+
+#define HIP_CHECK(expr)                                                 \
+    do {                                                                \
+        hipError_t err = (expr);                                        \
+        if (err != hipSuccess) {                                        \
+            throw std::runtime_error(                                   \
+                std::string("HIP error at ") + __FILE__ + ":" +         \
+                std::to_string(__LINE__) + ": " +                       \
+                hipGetErrorString(err));                                \
+        }                                                               \
+    } while (0)
+
+class GemmRunner {
+public:
+    GemmRunner();
+    ~GemmRunner();
+
+    // ── Inference (no timing, no sync, stream-based) ──
+
+    // BF16: D = A(M,K) @ B(N,K)^T  (row-major, B transposed)
+    // (This is the CUDA class's NT path; the CUDA name is bf16_run.)
+    void bf16_run(void* A, void* B, void* D,
+                  int M, int N, int K,
+                  hipStream_t stream = 0);
+
+    // BF16: D = A(M,K) @ B(K,N)  (row-major, no transpose)
+    void bf16_nn(void* A, void* B, void* D,
+                 int M, int N, int K,
+                 hipStream_t stream = 0);
+
+    // BF16 + BIAS epilogue: D = A(M,K) @ B(K,N) + bias(N)
+    void bf16_nn_bias(void* A, void* B, void* D, void* bias,
+                       int M, int N, int K,
+                       hipStream_t stream = 0);
+
+    // BF16 + BIAS + GELU epilogue: D = GELU(A(M,K) @ B(K,N) + bias(N))
+    void bf16_nn_bias_gelu(void* A, void* B, void* D, void* bias,
+                            int M, int N, int K,
+                            hipStream_t stream = 0);
+
+    // FP8 no-transpose: D_bf16 = A_fp8(M,K) @ B_fp8(K,N) with device scale pointers
+    // Matches bf16_nn layout — B stored as (K,N), no transpose.
+    // d_scale_a / d_scale_b are device float* holding per-tensor descale
+    // factors; hipBLASLt applies scale_a * scale_b to the FP32 accumulator
+    // (A/B_SCALE_POINTER semantics, identical to cuBLASLt).
+    void fp8_nn_dev(void* A, void* B, void* D,
+                    int M, int N, int K,
+                    float* d_scale_a, float* d_scale_b,
+                    hipStream_t stream = 0);
+
+    // FP8 transpose-B path: D_bf16 = A_fp8(M,K) @ B_fp8(N,K)^T
+    // with device scale pointers. B is stored as (N,K) row-major.
+    void fp8_nt_dev(void* A, void* B, void* D,
+                    int M, int N, int K,
+                    float* d_scale_a, float* d_scale_b,
+                    hipStream_t stream = 0);
+
+    // ── Autotune: benchmark top-N algorithms and cache the best ──
+    // Call before HIP Graph capture. Uses dummy data at the provided pointers.
+    // Matters on gfx950: hipBLASLt FP8 heuristics have known gaps, so the
+    // timed selection over N candidates is the production algo picker.
+    void autotune_bf16_nn(void* A, void* B, void* D,
+                          int M, int N, int K, int num_algos = 16);
+    void autotune_fp8_nn_dev(void* A, void* B, void* D,
+                             int M, int N, int K,
+                             float* d_scale_a, float* d_scale_b,
+                             int num_algos = 16);
+    void autotune_fp8_nt_dev(void* A, void* B, void* D,
+                             int M, int N, int K,
+                             float* d_scale_a, float* d_scale_b,
+                             int num_algos = 16);
+
+private:
+    hipblasLtHandle_t handle_;
+    void* workspace_;
+    size_t workspace_size_;
+
+    // ── GEMM descriptor + algorithm cache ──
+    // Enum values match the CUDA class for the ported subset.
+    enum GemmType { BF16_NN = 0, FP8_NN_DEV = 2, FP8_NT_DEV = 5 };
+
+    struct GemmKey {
+        int type, M, N, K;
+        bool operator==(const GemmKey& o) const {
+            return type == o.type && M == o.M && N == o.N && K == o.K;
+        }
+    };
+
+    struct GemmKeyHash {
+        size_t operator()(const GemmKey& k) const {
+            size_t h = std::hash<int>()(k.type);
+            h ^= std::hash<int>()(k.M) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            h ^= std::hash<int>()(k.N) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            h ^= std::hash<int>()(k.K) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            return h;
+        }
+    };
+
+    // NOTE: hipBLASLt matmul requires column-major layouts, so cached
+    // descriptors are built with the col-major operand swap (see .hip):
+    //   op0_desc describes the FlashRT "B" matrix, op1_desc the "A" matrix.
+    struct CachedGemm {
+        hipblasLtMatmulDesc_t matmul_desc;
+        hipblasLtMatrixLayout_t op0_desc, op1_desc, D_desc;
+        hipblasLtMatmulAlgo_t algo;
+    };
+
+    std::unordered_map<GemmKey, CachedGemm, GemmKeyHash> gemm_cache_;
+
+    // Setup descriptors for a given GEMM type and shape, store in cache
+    CachedGemm& get_or_create_cached(GemmType type, int M, int N, int K);
+    // Autotune helper: benchmark algorithms and pick the best.
+    // op0/op1 are already in hipBLASLt operand order (op0 = FlashRT B,
+    // op1 = FlashRT A); scale_op0/scale_op1 follow the same order.
+    void autotune_cached(CachedGemm& entry, void* op0, void* op1, void* D,
+                         float alpha, float beta, int num_algos,
+                         float* scale_op0 = nullptr, float* scale_op1 = nullptr);
+};

--- a/csrc/amd/gemm/hipblaslt_runner.h
+++ b/csrc/amd/gemm/hipblaslt_runner.h
@@ -90,6 +90,31 @@ public:
                     float* d_scale_a, float* d_scale_b,
                     hipStream_t stream = 0);
 
+    // MXFP4 a4w4 transpose-B path (OCP MX: E2M1 elements + per-1x32-block
+    // UE8M0 scales): D_bf16 = A_fp4(M,K) @ B_fp4(N,K)^T
+    //
+    //   A        : E2M1 packed 2-per-byte along K → (M, K/2) bytes row-major.
+    //              Element 2i in the low nibble, 2i+1 in the high nibble.
+    //   A_scales : uint8 UE8M0 (biased-127 exponent), one per 1x32 block
+    //              along K → (M, K/32) bytes row-major.
+    //   B        : E2M1 packed 2-per-byte along K → (N, K/2) bytes row-major.
+    //   B_scales : uint8 UE8M0 → (N, K/32) bytes row-major.
+    //   D        : BF16 (M, N) row-major.
+    //
+    // hipBLASLt contract (see hipblaslt.h): the block-scale tensors are
+    // installed via A/B_SCALE_POINTER with A/B_SCALE_MODE =
+    // HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0 — "an 8-bit R_8F_UE8M0
+    // value for each 32-element block in the innermost dimension of the
+    // corresponding data tensor". Under the col-major swap used by this
+    // class the innermost (stride-1) dimension of BOTH operands is K, so
+    // the row-major (rows, K/32) scale tensors above map to the library's
+    // expectation with no reshuffling (full derivation in the .hip file).
+    // K must be a multiple of 32 (throws otherwise).
+    void mxfp4_nt_dev(void* A, void* A_scales,
+                      void* B, void* B_scales, void* D,
+                      int M, int N, int K,
+                      hipStream_t stream = 0);
+
     // ── Autotune: benchmark top-N algorithms and cache the best ──
     // Call before HIP Graph capture. Uses dummy data at the provided pointers.
     // Matters on gfx950: hipBLASLt FP8 heuristics have known gaps, so the
@@ -104,6 +129,10 @@ public:
                              int M, int N, int K,
                              float* d_scale_a, float* d_scale_b,
                              int num_algos = 16);
+    void autotune_mxfp4_nt_dev(void* A, void* A_scales,
+                               void* B, void* B_scales, void* D,
+                               int M, int N, int K,
+                               int num_algos = 16);
 
 private:
     hipblasLtHandle_t handle_;
@@ -112,7 +141,9 @@ private:
 
     // ── GEMM descriptor + algorithm cache ──
     // Enum values match the CUDA class for the ported subset.
-    enum GemmType { BF16_NN = 0, FP8_NN_DEV = 2, FP8_NT_DEV = 5 };
+    // MXFP4_NT_DEV is AMD-only (gfx950 native MX support, no CUDA
+    // counterpart in the ported class) and uses the next free value.
+    enum GemmType { BF16_NN = 0, FP8_NN_DEV = 2, FP8_NT_DEV = 5, MXFP4_NT_DEV = 6 };
 
     struct GemmKey {
         int type, M, N, K;

--- a/csrc/amd/gemm/hipblaslt_runner.hip
+++ b/csrc/amd/gemm/hipblaslt_runner.hip
@@ -1,0 +1,478 @@
+#include "hipblaslt_runner.h"
+#include <iostream>
+#include <vector>
+
+// ================================================================
+// GemmRunner (AMD): hipBLASLt-based GEMM for BF16/FP8 on CDNA
+// Direct C++ calls, zero Python overhead.
+//
+// Port of csrc/gemm/gemm_runner.cu (cuBLASLt). Math semantics are
+// identical; the one structural difference is the layout encoding:
+//
+//   cuBLASLt side: descriptors carry CUBLASLT_ORDER_ROW, so the
+//   row-major matrices are described directly and operands are
+//   passed in FlashRT order (A first, B second).
+//
+//   hipBLASLt side: matmul supports column-major layouts only, so
+//   every entry point here uses the standard col-major swap, which
+//   is bit-for-bit the same computation:
+//       D_row(M,N) = A_row(M,K) @ B_row(K,N)
+//   ==  D_col(N,M) = B_col(N,K) @ A_col(K,M)
+//   where X_col is the same memory as X_row reinterpreted col-major.
+//   Consequently hipBLASLt operand 0 ("A" in the library API) is the
+//   FlashRT B matrix and operand 1 ("B") is the FlashRT A matrix.
+//   The CUDA file itself already uses this exact trick for the pi05
+//   FP8 epilogue paths (gemm_runner.cu:1139-1141 create A_desc from
+//   the B matrix and call cublasLtMatmul(..., B, e.A_desc, A,
+//   e.B_desc, ...) at gemm_runner.cu:1155).
+//
+// FP8 descale semantics (mirrors gemm_runner.cu:1089-1092):
+//   cuBLASLt applies *(A_SCALE_POINTER) to operand A and
+//   *(B_SCALE_POINTER) to operand B as per-tensor FP32 multipliers on
+//   the FP32 accumulator — NOT via alpha and NOT in the epilogue.
+//   hipBLASLt's HIPBLASLT_MATMUL_DESC_A/B_SCALE_POINTER attributes
+//   have the same contract. Because of the operand swap above, the
+//   FlashRT d_scale_a (activations) is attached to hipBLASLt operand
+//   "B" and d_scale_b (weights) to operand "A". The product
+//   scale_a * scale_b * (A@B) is unchanged.
+//
+// FP8 dtype: OCP e4m3 (HIP_R_8F_E4M3) — gfx950 native. Never the
+// fnuz variant. BF16 = HIP_R_16BF. Compute type = HIPBLAS_COMPUTE_32F
+// with FP32 scale type, matching CUBLAS_COMPUTE_32F / CUDA_R_32F.
+// ================================================================
+
+GemmRunner::GemmRunner() {
+    HIPBLASLT_CHECK(hipblasLtCreate(&handle_));
+    workspace_size_ = 256 * 1024 * 1024;  // 256 MB workspace (enables split-K etc.)
+    HIP_CHECK(hipMalloc(&workspace_, workspace_size_));
+    // NOTE: the CUDA ctor also pre-allocates d_scale_a_/d_scale_b_ device
+    // scalars for fp8_run (host-scale variant). fp8_run is not in the
+    // ported subset, so that scratch is omitted here.
+}
+
+GemmRunner::~GemmRunner() {
+    // Destroy cached descriptors
+    for (auto& [key, entry] : gemm_cache_) {
+        hipblasLtMatrixLayoutDestroy(entry.op0_desc);
+        hipblasLtMatrixLayoutDestroy(entry.op1_desc);
+        hipblasLtMatrixLayoutDestroy(entry.D_desc);
+        hipblasLtMatmulDescDestroy(entry.matmul_desc);
+    }
+    gemm_cache_.clear();
+    if (workspace_) hipFree(workspace_);
+    if (handle_) hipblasLtDestroy(handle_);
+}
+
+// ================================================================
+// Descriptor cache: create once, reuse across all calls
+//
+// Col-major swap layouts (op0 = FlashRT B, op1 = FlashRT A):
+//   NN  D_row(M,N) = A_row(M,K) @ B_row(K,N)
+//       op0 = B_col(N,K) ld=N, TRANSA=N
+//       op1 = A_col(K,M) ld=K, TRANSB=N
+//       D   = D_col(N,M) ld=N
+//   NT  D_row(M,N) = A_row(M,K) @ B_row(N,K)^T
+//       op0 = B_col(K,N) ld=K, TRANSA=T  → op(A)=(N,K)
+//       op1 = A_col(K,M) ld=K, TRANSB=N  → op(B)=(K,M)
+//       D   = D_col(N,M) ld=N
+// ================================================================
+GemmRunner::CachedGemm& GemmRunner::get_or_create_cached(GemmType type, int M, int N, int K) {
+    GemmKey key{static_cast<int>(type), M, N, K};
+    auto it = gemm_cache_.find(key);
+    if (it != gemm_cache_.end()) return it->second;
+
+    CachedGemm entry;
+    hipblasOperation_t op_N = HIPBLAS_OP_N;
+    hipblasOperation_t op_T = HIPBLAS_OP_T;
+
+    if (type == FP8_NN_DEV) {
+        HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, HIP_R_8F_E4M3, N, K, N));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, HIP_R_8F_E4M3, K, M, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16BF, N, M, N));
+    } else if (type == FP8_NT_DEV) {
+        HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_T, sizeof(op_T)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, HIP_R_8F_E4M3, K, N, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, HIP_R_8F_E4M3, K, M, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16BF, N, M, N));
+    } else {
+        // BF16_NN
+        HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, HIP_R_16BF, N, K, N));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, HIP_R_16BF, K, M, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16BF, N, M, N));
+    }
+
+    // Get heuristic top-1 algorithm as default
+    hipblasLtMatmulPreference_t preference;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&preference));
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(preference,
+        HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size_, sizeof(workspace_size_)));
+
+    int returned_results = 0;
+    hipblasLtMatmulHeuristicResult_t heuristic;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(handle_, entry.matmul_desc,
+        entry.op0_desc, entry.op1_desc, entry.D_desc, entry.D_desc,
+        preference, 1, &heuristic, &returned_results));
+    hipblasLtMatmulPreferenceDestroy(preference);
+
+    if (returned_results == 0) {
+        throw std::runtime_error("hipBLASLt: no algorithm found for cached GEMM");
+    }
+    entry.algo = heuristic.algo;
+
+    auto [inserted_it, _] = gemm_cache_.emplace(key, entry);
+    return inserted_it->second;
+}
+
+// ================================================================
+// Autotune: benchmark top-N algorithms and pick the fastest
+// (mirrors gemm_runner.cu:148-227; op0/op1 are in hipBLASLt operand
+// order, i.e. already swapped by the public wrappers)
+// ================================================================
+void GemmRunner::autotune_cached(CachedGemm& entry, void* op0, void* op1, void* D,
+                                  float alpha, float beta, int num_algos,
+                                  float* scale_op0, float* scale_op1) {
+    // Update scale pointers if FP8
+    if (scale_op0) {
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+            HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &scale_op0, sizeof(scale_op0)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+            HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &scale_op1, sizeof(scale_op1)));
+    }
+
+    hipblasLtMatmulPreference_t preference;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&preference));
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(preference,
+        HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size_, sizeof(workspace_size_)));
+
+    std::vector<hipblasLtMatmulHeuristicResult_t> heuristics(num_algos);
+    int returned_results = 0;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(handle_, entry.matmul_desc,
+        entry.op0_desc, entry.op1_desc, entry.D_desc, entry.D_desc,
+        preference, num_algos, heuristics.data(), &returned_results));
+    hipblasLtMatmulPreferenceDestroy(preference);
+
+    if (returned_results == 0) {
+        std::cerr << "  autotune: no algorithms found, keeping default" << std::endl;
+        return;
+    }
+
+    // Benchmark each algorithm
+    hipEvent_t start, stop;
+    HIP_CHECK(hipEventCreate(&start));
+    HIP_CHECK(hipEventCreate(&stop));
+
+    float best_ms = 1e9f;
+    int best_idx = 0;
+    const int warmup_iters = 3;
+    const int bench_iters = 10;
+
+    for (int i = 0; i < returned_results; ++i) {
+        // Warmup
+        bool algo_ok = true;
+        for (int w = 0; w < warmup_iters; ++w) {
+            hipblasStatus_t st = hipblasLtMatmul(handle_, entry.matmul_desc,
+                &alpha, op0, entry.op0_desc, op1, entry.op1_desc,
+                &beta, D, entry.D_desc, D, entry.D_desc,
+                &heuristics[i].algo, workspace_, workspace_size_, 0);
+            if (st != HIPBLAS_STATUS_SUCCESS) { algo_ok = false; break; }
+        }
+        if (!algo_ok) continue;
+        HIP_CHECK(hipDeviceSynchronize());
+
+        // Benchmark
+        HIP_CHECK(hipEventRecord(start));
+        for (int b = 0; b < bench_iters; ++b) {
+            hipblasLtMatmul(handle_, entry.matmul_desc,
+                &alpha, op0, entry.op0_desc, op1, entry.op1_desc,
+                &beta, D, entry.D_desc, D, entry.D_desc,
+                &heuristics[i].algo, workspace_, workspace_size_, 0);
+        }
+        HIP_CHECK(hipEventRecord(stop));
+        HIP_CHECK(hipEventSynchronize(stop));
+        float ms = 0;
+        HIP_CHECK(hipEventElapsedTime(&ms, start, stop));
+        ms /= bench_iters;
+
+        if (ms < best_ms) {
+            best_ms = ms;
+            best_idx = i;
+        }
+    }
+
+    HIP_CHECK(hipEventDestroy(start));
+    HIP_CHECK(hipEventDestroy(stop));
+
+    entry.algo = heuristics[best_idx].algo;
+    std::cout << "  autotune: tested " << returned_results << " algos, best="
+              << best_idx << " (" << best_ms * 1000.0f << " us)" << std::endl;
+}
+
+void GemmRunner::autotune_bf16_nn(void* A, void* B, void* D,
+                                   int M, int N, int K, int num_algos) {
+    auto& entry = get_or_create_cached(BF16_NN, M, N, K);
+    autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos);
+}
+
+void GemmRunner::autotune_fp8_nn_dev(void* A, void* B, void* D,
+                                      int M, int N, int K,
+                                      float* d_scale_a, float* d_scale_b,
+                                      int num_algos) {
+    auto& entry = get_or_create_cached(FP8_NN_DEV, M, N, K);
+    // Operand swap: op0 = B (weights, scale_b), op1 = A (acts, scale_a)
+    autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos, d_scale_b, d_scale_a);
+}
+
+void GemmRunner::autotune_fp8_nt_dev(void* A, void* B, void* D,
+                                      int M, int N, int K,
+                                      float* d_scale_a, float* d_scale_b,
+                                      int num_algos) {
+    auto& entry = get_or_create_cached(FP8_NT_DEV, M, N, K);
+    autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos, d_scale_b, d_scale_a);
+}
+
+// ================================================================
+//  BF16 inference run: D = A(M,K) @ B(N,K)^T  (no timing, no sync)
+//  Mirrors gemm_runner.cu:670-720 (per-call descriptors, heuristic
+//  top-1, alpha=1 beta=0).
+// ================================================================
+void GemmRunner::bf16_run(void* A, void* B, void* D,
+                          int M, int N, int K, hipStream_t stream) {
+    hipblasLtMatmulDesc_t matmul_desc;
+    hipblasLtMatrixLayout_t op0_desc, op1_desc, D_desc;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+
+    hipblasOperation_t op_N = HIPBLAS_OP_N;
+    hipblasOperation_t op_T = HIPBLAS_OP_T;
+
+    // Col-major swap, NT: op0 = B_col(K,N) with OP_T, op1 = A_col(K,M) with OP_N
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_T, sizeof(op_T)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op0_desc, HIP_R_16BF, K, N, K));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op1_desc, HIP_R_16BF, K, M, K));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&D_desc, HIP_R_16BF, N, M, N));
+
+    hipblasLtMatmulPreference_t preference;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&preference));
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(preference,
+        HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size_, sizeof(workspace_size_)));
+
+    int returned_results = 0;
+    hipblasLtMatmulHeuristicResult_t heuristic;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(handle_, matmul_desc,
+        op0_desc, op1_desc, D_desc, D_desc, preference, 1, &heuristic, &returned_results));
+
+    if (returned_results == 0) {
+        hipblasLtMatmulPreferenceDestroy(preference);
+        hipblasLtMatrixLayoutDestroy(op0_desc);
+        hipblasLtMatrixLayoutDestroy(op1_desc);
+        hipblasLtMatrixLayoutDestroy(D_desc);
+        hipblasLtMatmulDescDestroy(matmul_desc);
+        throw std::runtime_error("hipBLASLt bf16_run: no algorithm found");
+    }
+
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, matmul_desc,
+        &alpha, B, op0_desc, A, op1_desc, &beta, D, D_desc, D, D_desc,
+        &heuristic.algo, workspace_, workspace_size_, stream));
+
+    hipblasLtMatmulPreferenceDestroy(preference);
+    hipblasLtMatrixLayoutDestroy(op0_desc);
+    hipblasLtMatrixLayoutDestroy(op1_desc);
+    hipblasLtMatrixLayoutDestroy(D_desc);
+    hipblasLtMatmulDescDestroy(matmul_desc);
+}
+
+// ================================================================
+//  BF16 no-transpose: D(M,N) = A(M,K) @ B(K,N)  (row-major)
+//  B is NOT transposed. For Pi05 weights stored as (K, N).
+//  Mirrors gemm_runner.cu:726-734 (cached descriptor + algo).
+// ================================================================
+void GemmRunner::bf16_nn(void* A, void* B, void* D,
+                         int M, int N, int K, hipStream_t stream) {
+    auto& entry = get_or_create_cached(BF16_NN, M, N, K);
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, B, entry.op0_desc, A, entry.op1_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}
+
+// ================================================================
+//  BF16 no-transpose with BIAS epilogue: D(M,N) = A(M,K) @ B(K,N) + bias(N)
+//  Uses EPILOGUE_BIAS to fuse bias addition into the GEMM.
+//  With the col-major swap, D_col is (N,M), so the epilogue bias vector
+//  (length = rows of D_col = N, broadcast across columns) lands exactly
+//  as bias(N) broadcast over the M rows — same math as the CUDA
+//  row-major-order version (gemm_runner.cu:769-825).
+// ================================================================
+void GemmRunner::bf16_nn_bias(void* A, void* B, void* D, void* bias,
+                               int M, int N, int K, hipStream_t stream) {
+    hipblasLtMatmulDesc_t matmul_desc;
+    hipblasLtMatrixLayout_t op0_desc, op1_desc, D_desc;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+
+    hipblasOperation_t op_N = HIPBLAS_OP_N;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+
+    // Set BIAS epilogue
+    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_BIAS;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+    hipDataType bias_type = HIP_R_16BF;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, &bias_type, sizeof(bias_type)));
+
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op0_desc, HIP_R_16BF, N, K, N));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op1_desc, HIP_R_16BF, K, M, K));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&D_desc, HIP_R_16BF, N, M, N));
+
+    hipblasLtMatmulPreference_t preference;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&preference));
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(preference,
+        HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size_, sizeof(workspace_size_)));
+
+    int returned_results = 0;
+    hipblasLtMatmulHeuristicResult_t heuristic;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(handle_, matmul_desc,
+        op0_desc, op1_desc, D_desc, D_desc, preference, 1, &heuristic, &returned_results));
+
+    if (returned_results == 0) {
+        hipblasLtMatmulPreferenceDestroy(preference);
+        hipblasLtMatrixLayoutDestroy(op0_desc);
+        hipblasLtMatrixLayoutDestroy(op1_desc);
+        hipblasLtMatrixLayoutDestroy(D_desc);
+        hipblasLtMatmulDescDestroy(matmul_desc);
+        throw std::runtime_error("hipBLASLt bf16_nn_bias: no algorithm found");
+    }
+
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, matmul_desc,
+        &alpha, B, op0_desc, A, op1_desc, &beta, D, D_desc, D, D_desc,
+        &heuristic.algo, workspace_, workspace_size_, stream));
+
+    hipblasLtMatmulPreferenceDestroy(preference);
+    hipblasLtMatrixLayoutDestroy(op0_desc);
+    hipblasLtMatrixLayoutDestroy(op1_desc);
+    hipblasLtMatrixLayoutDestroy(D_desc);
+    hipblasLtMatmulDescDestroy(matmul_desc);
+}
+
+// ================================================================
+//  BF16 GEMM + BIAS + GELU epilogue: D(M,N) = GELU(A(M,K) @ B(K,N) + bias(N))
+//  Fuses GEMM + bias + GELU into a single hipBLASLt launch.
+//  GELU_BIAS in both libraries computes gelu(x + bias) with the tanh
+//  approximation (mirrors gemm_runner.cu:831-887).
+// ================================================================
+void GemmRunner::bf16_nn_bias_gelu(void* A, void* B, void* D, void* bias,
+                                    int M, int N, int K, hipStream_t stream) {
+    hipblasLtMatmulDesc_t matmul_desc;
+    hipblasLtMatrixLayout_t op0_desc, op1_desc, D_desc;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+
+    hipblasOperation_t op_N = HIPBLAS_OP_N;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+
+    // Set GELU_BIAS epilogue
+    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_GELU_BIAS;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+    hipDataType bias_type = HIP_R_16BF;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, &bias_type, sizeof(bias_type)));
+
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op0_desc, HIP_R_16BF, N, K, N));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op1_desc, HIP_R_16BF, K, M, K));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&D_desc, HIP_R_16BF, N, M, N));
+
+    hipblasLtMatmulPreference_t preference;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&preference));
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(preference,
+        HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size_, sizeof(workspace_size_)));
+
+    int returned_results = 0;
+    hipblasLtMatmulHeuristicResult_t heuristic;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(handle_, matmul_desc,
+        op0_desc, op1_desc, D_desc, D_desc, preference, 1, &heuristic, &returned_results));
+
+    if (returned_results == 0) {
+        hipblasLtMatmulPreferenceDestroy(preference);
+        hipblasLtMatrixLayoutDestroy(op0_desc);
+        hipblasLtMatrixLayoutDestroy(op1_desc);
+        hipblasLtMatrixLayoutDestroy(D_desc);
+        hipblasLtMatmulDescDestroy(matmul_desc);
+        throw std::runtime_error("hipBLASLt bf16_nn_bias_gelu: no algorithm found");
+    }
+
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, matmul_desc,
+        &alpha, B, op0_desc, A, op1_desc, &beta, D, D_desc, D, D_desc,
+        &heuristic.algo, workspace_, workspace_size_, stream));
+
+    hipblasLtMatmulPreferenceDestroy(preference);
+    hipblasLtMatrixLayoutDestroy(op0_desc);
+    hipblasLtMatrixLayoutDestroy(op1_desc);
+    hipblasLtMatrixLayoutDestroy(D_desc);
+    hipblasLtMatmulDescDestroy(matmul_desc);
+}
+
+// ================================================================
+//  FP8 no-transpose: D_bf16 = A_fp8(M,K) @ B_fp8(K,N)
+//  with device scale pointers (HIP Graph compatible).
+//  Matches bf16_nn layout — B stored as (K,N) row-major, no transpose.
+//  Mirrors gemm_runner.cu:1083-1099: descale enters via the library's
+//  A/B_SCALE_POINTER accumulator scaling, alpha stays 1.0.
+// ================================================================
+void GemmRunner::fp8_nn_dev(void* A, void* B, void* D,
+                             int M, int N, int K,
+                             float* d_scale_a, float* d_scale_b,
+                             hipStream_t stream) {
+    auto& entry = get_or_create_cached(FP8_NN_DEV, M, N, K);
+    // Update scale pointers per-call (different layers have different scales).
+    // Operand swap: hipBLASLt operand A = FlashRT B → gets d_scale_b.
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_b, sizeof(d_scale_b)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &d_scale_a, sizeof(d_scale_a)));
+
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, B, entry.op0_desc, A, entry.op1_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}
+
+// ================================================================
+//  FP8 transpose-B path: D_bf16 = A_fp8(M,K) @ B_fp8(N,K)^T
+//  with device scale pointers. B is stored as (N,K) row-major.
+//  Mirrors gemm_runner.cu:1104-1119.
+// ================================================================
+void GemmRunner::fp8_nt_dev(void* A, void* B, void* D,
+                             int M, int N, int K,
+                             float* d_scale_a, float* d_scale_b,
+                             hipStream_t stream) {
+    auto& entry = get_or_create_cached(FP8_NT_DEV, M, N, K);
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_b, sizeof(d_scale_b)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &d_scale_a, sizeof(d_scale_a)));
+
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, B, entry.op0_desc, A, entry.op1_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}

--- a/csrc/amd/gemm/hipblaslt_runner.hip
+++ b/csrc/amd/gemm/hipblaslt_runner.hip
@@ -99,6 +99,30 @@ GemmRunner::CachedGemm& GemmRunner::get_or_create_cached(GemmType type, int M, i
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, HIP_R_8F_E4M3, K, N, K));
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, HIP_R_8F_E4M3, K, M, K));
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16BF, N, M, N));
+    } else if (type == MXFP4_NT_DEV) {
+        // MXFP4 a4w4: same NT col-major swap as FP8_NT_DEV, which lands on
+        // library-TN (TRANSA=T, TRANSB=N) — the canonical (and, per the
+        // hipBLASLt MX samples, only exercised) layout for fp4 GEMM.
+        // Element type HIP_R_4F_E2M1_EXT (hipblaslt-types.h): rows/cols/ld
+        // stay in ELEMENTS; the 2-per-byte packing along the innermost
+        // (stride-1) dimension is implied by the datatype.
+        // K % 32 == 0 enforced by the public entry points.
+        hipDataType fp4_type = static_cast<hipDataType>(HIP_R_4F_E2M1_EXT);
+        HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_T, sizeof(op_T)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+        // Block-scale mode MUST be on the descriptor before the heuristic
+        // query so hipBLASLt only proposes MX-capable solutions. VEC32_UE8M0
+        // = one uint8 e8m0 scale per 32-element block in the innermost
+        // dimension of the corresponding data tensor (hipblaslt.h:172).
+        // Both operands' innermost dim here is K (see layout note below),
+        // matching the per-1x32-along-K quantization.
+        hipblasLtMatmulMatrixScale_t scale_mode = HIPBLASLT_MATMUL_MATRIX_SCALE_VEC32_UE8M0;
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, &scale_mode, sizeof(scale_mode)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, &scale_mode, sizeof(scale_mode)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, fp4_type, K, N, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, fp4_type, K, M, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16BF, N, M, N));
     } else {
         // BF16_NN
         HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
@@ -236,6 +260,25 @@ void GemmRunner::autotune_fp8_nt_dev(void* A, void* B, void* D,
                                       int num_algos) {
     auto& entry = get_or_create_cached(FP8_NT_DEV, M, N, K);
     autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos, d_scale_b, d_scale_a);
+}
+
+void GemmRunner::autotune_mxfp4_nt_dev(void* A, void* A_scales,
+                                        void* B, void* B_scales, void* D,
+                                        int M, int N, int K,
+                                        int num_algos) {
+    if (K % 32 != 0) {
+        throw std::runtime_error("mxfp4_nt_dev: K must be a multiple of 32 (MX block size)");
+    }
+    auto& entry = get_or_create_cached(MXFP4_NT_DEV, M, N, K);
+    // Operand swap: library A = FlashRT B (gets B_scales), library B =
+    // FlashRT A (gets A_scales). autotune_cached only forwards the scale
+    // pointers into the A/B_SCALE_POINTER attributes (opaque void* writes),
+    // so the uint8 ue8m0 tensors ride through its float* parameters
+    // unchanged — the SCALE_MODE already on the descriptor tells hipBLASLt
+    // how to interpret them.
+    autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos,
+                    reinterpret_cast<float*>(B_scales),
+                    reinterpret_cast<float*>(A_scales));
 }
 
 // ================================================================
@@ -469,6 +512,57 @@ void GemmRunner::fp8_nt_dev(void* A, void* B, void* D,
         HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_b, sizeof(d_scale_b)));
     HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
         HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &d_scale_a, sizeof(d_scale_a)));
+
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, B, entry.op0_desc, A, entry.op1_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}
+
+// ================================================================
+//  MXFP4 a4w4 transpose-B path: D_bf16 = A_fp4(M,K) @ B_fp4(N,K)^T
+//  (OCP MX: E2M1 elements + per-1x32-block UE8M0 scales, gfx950)
+//
+//  How the col-major swap maps the SCALE tensors:
+//    op0 (library "A") = FlashRT B, stored (N, K) row-major = B_col(K, N)
+//        ld=K, TRANSA=T. Its innermost (stride-1) dim is K, so
+//        VEC32_UE8M0 wants one e8m0 byte per 32 elements along K —
+//        i.e. a scale tensor shaped col-major (K/32, N). That is
+//        byte-identical to the row-major (N, K/32) tensor produced by
+//        quantizing B per 1x32 blocks along K. Zero reshuffling.
+//    op1 (library "B") = FlashRT A, stored (M, K) row-major = A_col(K, M)
+//        ld=K, TRANSB=N. Innermost dim is again K → scale tensor
+//        col-major (K/32, M) == row-major (M, K/32). Zero reshuffling.
+//  So under the swap: library A_SCALE_POINTER ← FlashRT B_scales and
+//  library B_SCALE_POINTER ← FlashRT A_scales, exactly mirroring the
+//  data-operand swap. Dequant semantics: value = e2m1 * 2^(byte - 127),
+//  applied by hipBLASLt inside the FP32 accumulation.
+//
+//  Packing: HIP_R_4F_E2M1_EXT layouts keep rows/cols/ld in ELEMENTS;
+//  two elements share a byte along the innermost dim (element 2i in the
+//  low nibble, 2i+1 in the high nibble — hip_fp4 convention). K % 32
+//  == 0 covers both the packing and the block-scale granularity.
+//
+//  Layout support note: this NT entry point lands on library-TN, the
+//  canonical fp4 layout in the hipBLASLt MX samples. If a future need
+//  arises for other trans combos, probe support with the heuristic
+//  query first — TN is the only one exercised here.
+// ================================================================
+void GemmRunner::mxfp4_nt_dev(void* A, void* A_scales,
+                               void* B, void* B_scales, void* D,
+                               int M, int N, int K,
+                               hipStream_t stream) {
+    if (K % 32 != 0) {
+        throw std::runtime_error("mxfp4_nt_dev: K must be a multiple of 32 (MX block size)");
+    }
+    auto& entry = get_or_create_cached(MXFP4_NT_DEV, M, N, K);
+    // Update scale-tensor pointers per call (different layers, different
+    // scale buffers). Operand swap: library A = FlashRT B → B_scales.
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &B_scales, sizeof(B_scales)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &A_scales, sizeof(A_scales)));
 
     float alpha = 1.0f, beta = 0.0f;
     HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,

--- a/csrc/amd/gemm/smallm_fp8.h
+++ b/csrc/amd/gemm/smallm_fp8.h
@@ -73,8 +73,9 @@ void smallm_fp8_nt_dev(const void* A, const void* B, void* D,
                        int M, int N, int K, float* split_ws,
                        hipStream_t stream);
 
-// Alternate nt config for A/B benching: 2 output columns per wave
-// instead of 4 (2x workgroups — more parallelism, less A-convert reuse).
+// Alternate nt config for A/B benching: 8-wave (512-thread) WGs
+// instead of 4-wave, same total wave count (halved grid). Values are
+// bit-identical to smallm_fp8_nt_dev for every shape.
 void smallm_fp8_nt_dev_alt(const void* A, const void* B, void* D,
                            const float* d_scale_a, const float* d_scale_b,
                            int M, int N, int K, float* split_ws,

--- a/csrc/amd/gemm/smallm_fp8.h
+++ b/csrc/amd/gemm/smallm_fp8.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <cstddef>
+
+// ================================================================
+// FlashRT AMD — hand-tuned small-M FP8 GEMM (CDNA4, wave64)
+//
+// Weight-streaming kernels for the decoder's tiny-M GEMMs
+// (M ≈ action-chunk rows, N/K in the 1-4K range). At these shapes
+// the GEMM is a GEMV-with-few-rows: the cost is streaming the FP8
+// weight matrix once at DRAM rate, not matrix-core math. hipBLASLt
+// tiles (MT16x16 etc.) leave most of that bandwidth on the table.
+//
+// Semantics: exact drop-in for GemmRunner::fp8_nn_dev / fp8_nt_dev
+// (see hipblaslt_runner.h):
+//
+//   nn:  D_bf16(M,N) = (A_fp8(M,K) @ B_fp8(K,N)) * d_scale_a[0] * d_scale_b[0]
+//        A row-major (M,K), B row-major (K,N)  — the frontend's "kn" layout.
+//   nt:  D_bf16(M,N) = (A_fp8(M,K) @ B_fp8(N,K)^T) * d_scale_a[0] * d_scale_b[0]
+//        B row-major (N,K)                     — the frontend's "nk" layout.
+//
+// FP8 is OCP e4m3 (__hip_fp8_e4m3 byte format, HIP_R_8F_E4M3 — never
+// fnuz). Accumulation is FP32; the per-tensor descales are DEVICE
+// float pointers dereferenced inside the kernel (HIP Graph safe) and
+// applied to the FP32 accumulator before the BF16 store, matching the
+// hipBLASLt A/B_SCALE_POINTER contract.
+//
+// Determinism: every reduction runs in a fixed order — sequential K
+// loop per lane, fixed-shape shuffle tree per wave, and (nn split-K
+// only) a second reduce kernel that sums slice partials in ascending
+// slice order from a caller-provided FP32 workspace. No atomics
+// anywhere, so replays inside a captured graph are bit-identical.
+//
+// Constraints (checked, throw std::runtime_error on violation):
+//   nn: 1 <= M <= 16, N % 64 == 0, K % 64 == 0
+//   nt: 1 <= M <= 16, K % 16 == 0   (N is guarded per-column)
+//   A and B must be 16-byte aligned (any torch/hipMalloc allocation).
+// ================================================================
+
+// Maximum split-K factor the nn path will ever choose. Sizes the
+// caller-provided workspace: pass a device buffer of at least
+// smallm_fp8_nn_dev_ws_bytes(M, N) bytes as split_ws. The workspace
+// holds unscaled FP32 partials laid out ws[s][m][n] (s = k-slice).
+#define SMALLM_FP8_MAX_SPLIT 32
+
+// Required split_ws size in bytes for smallm_fp8_nn_dev(_alt).
+size_t smallm_fp8_nn_dev_ws_bytes(int M, int N);
+
+// nn ("kn" weights, K-major rows of N): drop-in for GemmRunner::fp8_nn_dev.
+// split_ws: device FP32 workspace (>= smallm_fp8_nn_dev_ws_bytes(M, N))
+// used for the deterministic split-K reduction. May be nullptr, in which
+// case split-K is disabled (fewer workgroups in flight — slower on wide
+// GPUs for small N, but no workspace needed).
+void smallm_fp8_nn_dev(const void* A, const void* B, void* D,
+                       const float* d_scale_a, const float* d_scale_b,
+                       int M, int N, int K, float* split_ws,
+                       hipStream_t stream);
+
+// Alternate nn config for A/B benching: targets 2x the workgroup count
+// (deeper split-K — more memory in flight, more reduce traffic).
+void smallm_fp8_nn_dev_alt(const void* A, const void* B, void* D,
+                           const float* d_scale_a, const float* d_scale_b,
+                           int M, int N, int K, float* split_ws,
+                           hipStream_t stream);
+
+// nt ("nk" weights, N-major rows of K): drop-in for GemmRunner::fp8_nt_dev.
+// This is the stream-friendliest layout — every output column owns a
+// contiguous K row, so no split-K and no workspace are ever needed.
+// split_ws is accepted for signature symmetry and ignored (may be nullptr).
+void smallm_fp8_nt_dev(const void* A, const void* B, void* D,
+                       const float* d_scale_a, const float* d_scale_b,
+                       int M, int N, int K, float* split_ws,
+                       hipStream_t stream);
+
+// Alternate nt config for A/B benching: 2 output columns per wave
+// instead of 4 (2x workgroups — more parallelism, less A-convert reuse).
+void smallm_fp8_nt_dev_alt(const void* A, const void* B, void* D,
+                           const float* d_scale_a, const float* d_scale_b,
+                           int M, int N, int K, float* split_ws,
+                           hipStream_t stream);

--- a/csrc/amd/gemm/smallm_fp8.h
+++ b/csrc/amd/gemm/smallm_fp8.h
@@ -68,10 +68,33 @@ void smallm_fp8_nn_dev_alt(const void* A, const void* B, void* D,
 // This is the stream-friendliest layout — every output column owns a
 // contiguous K row, so no split-K and no workspace are ever needed.
 // split_ws is accepted for signature symmetry and ignored (may be nullptr).
+//
+// Default path: the double-buffered LDS pipeline (smallm_fp8_nt_lds_dev
+// below) with async staging; env overrides, read on the host at
+// launch/capture time (a captured graph keeps the capture-time choice):
+//   FRT_SMALLM_REG=1  -> legacy register-only ILP4 kernel
+//   FRT_LDS_ASYNC=0   -> LDS pipeline with sync (register-hoisted) staging
 void smallm_fp8_nt_dev(const void* A, const void* B, void* D,
                        const float* d_scale_a, const float* d_scale_b,
                        int M, int N, int K, float* split_ws,
                        hipStream_t stream);
+
+// nt LDS pipeline, explicit entry for A/B benching: double-buffered
+// global->LDS staging of the WG's weight columns (2-16KB LDS per WG,
+// w4 only), consumer fed from LDS off the load critical path. Both
+// staging variants are compiled into the binary; use_async != 0 picks
+// gfx9 LDS-DMA (__builtin_amdgcn_global_load_lds, 4B/lane per issue),
+// use_async == 0 picks the register-hoisted sync fallback with the
+// identical LDS layout. Deterministic fixed-order accumulation (NOT
+// bit-identical to the register nt kernel — different lane<->k split).
+void smallm_fp8_nt_lds_dev(const void* A, const void* B, void* D,
+                           const float* d_scale_a, const float* d_scale_b,
+                           int M, int N, int K, int use_async,
+                           hipStream_t stream);
+
+// 1 if the binary was built with the async LDS-DMA staging variant
+// (FRT_LDS_ASYNC=1, the default); 0 if use_async degenerates to sync.
+int smallm_fp8_nt_lds_async_available();
 
 // Alternate nt config for A/B benching: 8-wave (512-thread) WGs
 // instead of 4-wave, same total wave count (halved grid). Values are

--- a/csrc/amd/gemm/smallm_fp8.hip
+++ b/csrc/amd/gemm/smallm_fp8.hip
@@ -2,6 +2,8 @@
 
 #include <hip/hip_bf16.h>
 #include <hip/hip_fp8.h>
+#include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 
@@ -82,6 +84,98 @@
 
 #define SMALLM_FP8_BLOCK 256   // threads per workgroup (4 waves)
 
+// ================================================================
+// Async global->LDS staging plumbing (gfx9 LDS-DMA).
+//
+// FRT_LDS_ASYNC (compile-time, default 1) gates the use of
+//   __builtin_amdgcn_global_load_lds(gptr_as1, lptr_as3, size, offset, aux)
+// which lowers to GLOBAL_LOAD_DWORD ... lds — the hardware reads one
+// dword per active lane from the per-lane global address and the LDS-DMA
+// path deposits lane l's dword at (wave-uniform lptr) + 4*l, WITHOUT
+// touching VGPRs. size/offset/aux must be integer constants; size=4 is
+// the portable gfx9 granularity (gfx950 also accepts 12/16 — dwordx3/x4
+// per lane, a follow-up A/B knob, see the kernel notes). One issue
+// therefore stages 256B per wave; we issue MANY per buffer.
+//
+// The builtin is a *target* builtin: visible only in the device pass
+// (__HIP_DEVICE_COMPILE__), never in the hipcc host pass nor under the
+// g++ -fsyntax-only stub harness. So:
+//   - FRT_LDS_ASYNC        : host+device agreement on whether the async
+//                            variant is real (drives *_async_available()).
+//   - FRT_ASYNC_LDS_CODEGEN: whether THIS compilation pass may emit the
+//                            builtin call. Host pass compiles the sync
+//                            body for the ASYNC instantiation — it never
+//                            runs, only the device pass' code does.
+//   - FRT_FORCE_ASYNC_LDS  : override for the g++ stub syntax check so
+//                            the builtin call sites are type-checked.
+// If ROCm lacks the builtin, fail LOUDLY (build with -DFRT_LDS_ASYNC=0
+// to get a binary whose "async" variant is the sync fallback) — never
+// silently downgrade, so the on-node A/B rows mean what they say.
+// ================================================================
+#ifndef FRT_LDS_ASYNC
+#define FRT_LDS_ASYNC 1
+#endif
+
+#if defined(FRT_FORCE_ASYNC_LDS)
+#  define FRT_ASYNC_LDS_CODEGEN FRT_FORCE_ASYNC_LDS
+#elif defined(__HIP_DEVICE_COMPILE__)
+#  if FRT_LDS_ASYNC
+#    if !defined(__has_builtin) || !__has_builtin(__builtin_amdgcn_global_load_lds)
+#      error "FRT_LDS_ASYNC=1 but __builtin_amdgcn_global_load_lds is unavailable; rebuild with -DFRT_LDS_ASYNC=0"
+#    endif
+#    define FRT_ASYNC_LDS_CODEGEN 1
+#  else
+#    define FRT_ASYNC_LDS_CODEGEN 0
+#  endif
+#else
+#  define FRT_ASYNC_LDS_CODEGEN 0
+#endif
+
+// Clang address-space qualifier (ignored elsewhere; the g++ stub path
+// then sees plain pointers, matching the stubbed builtin signature).
+#if defined(__clang__)
+#define FRT_AS(n) __attribute__((address_space(n)))
+#else
+#define FRT_AS(n)
+#endif
+
+// The helpers below are ALWAYS defined (their names appear inside
+// `if constexpr` branches, which must resolve even when discarded);
+// only their bodies are gated. The empty bodies are unreachable: the
+// kernels call them only when kAsync (== FRT_ASYNC_LDS_CODEGEN != 0)
+// is true, and only the device pass' code ever executes.
+
+// One dword per lane, global -> LDS, no VGPR round-trip. gp is the
+// per-lane global address (VGPR); lp must be WAVE-UNIFORM — the DMA
+// writes lane l at lp + 4*l. Inactive lanes (EXEC-masked) stage nothing.
+// Address-space casts follow composable_kernel's proven pattern
+// (amd_direct_load): generic->as(1)/as(3) through uintptr_t — the
+// generic LDS aperture bits live above bit 31, so the truncating cast
+// to the 32-bit as(3) pointer yields the raw LDS offset.
+__device__ __forceinline__ void smallm_async_copy_dword(
+        const unsigned char* gp, unsigned char* lp) {
+#if FRT_ASYNC_LDS_CODEGEN
+    auto* g = reinterpret_cast<const FRT_AS(1) unsigned*>(
+        reinterpret_cast<uintptr_t>(gp));
+    auto* l = reinterpret_cast<FRT_AS(3) unsigned*>(
+        reinterpret_cast<uintptr_t>(lp));
+    __builtin_amdgcn_global_load_lds(g, l, /*size=*/4, /*offset=*/0, /*aux=*/0);
+#else
+    (void)gp; (void)lp;  // unreachable stub (see note above)
+#endif
+}
+
+// s_waitcnt vmcnt(0), other counters untouched. gfx9 simm16 encoding:
+// vmcnt lo [3:0]=0, expcnt [6:4]=7 (ignore), lgkmcnt [11:8]=15 (ignore),
+// vmcnt hi [15:14]=0  ->  0x0F70. LDS-DMA completion is tracked by
+// vmcnt, and the compiler does NOT model the DMA->ds_read dependency,
+// so this wait is mandatory before reading a freshly staged buffer.
+__device__ __forceinline__ void smallm_wait_lds_dma() {
+#if FRT_ASYNC_LDS_CODEGEN
+    __builtin_amdgcn_s_waitcnt(0x0F70);
+#endif
+}
+
 // ── fp8 e4m3 byte -> f32 ──
 __device__ __forceinline__ float smallm_fp8_to_f32(unsigned char b) {
     __hip_fp8_e4m3 v;
@@ -94,6 +188,14 @@ __device__ __forceinline__ void smallm_fp8x16_to_f32(const uint4& v, float* out)
     const unsigned char* b = reinterpret_cast<const unsigned char*>(&v);
     #pragma unroll
     for (int j = 0; j < 16; ++j) out[j] = smallm_fp8_to_f32(b[j]);
+}
+
+// Unpack 8 fp8 bytes (one b64 load) to f32 — the LDS-pipeline lane
+// granularity (512B chunk / 64 lanes = 8B per lane).
+__device__ __forceinline__ void smallm_fp8x8_to_f32(const uint2& v, float* out) {
+    const unsigned char* b = reinterpret_cast<const unsigned char*>(&v);
+    #pragma unroll
+    for (int j = 0; j < 8; ++j) out[j] = smallm_fp8_to_f32(b[j]);
 }
 
 // ================================================================
@@ -334,6 +436,233 @@ void smallm_fp8_nt_kernel(const unsigned char* __restrict__ A,
 }
 
 // ================================================================
+// nt LDS kernel: B stored (N, K) row-major, double-buffered async
+// global->LDS staging (the hipBLASLt craft, rocprof-verified: their
+// 4.9-5.8us winners run 18-50KB of LDS wide staging while our
+// register-only ILP4 kernel sits at 10.2us / ~410GB/s — the gap is the
+// CONSUMER sitting on the load critical path, not raw bandwidth;
+// stream_probe already reads 5+TB/s with ILP4 when nothing consumes).
+//
+//   Work partition (w4 ONLY — 256 threads; every w8 register variant
+//   measured priv=76-168B scratch spills, so w8 is dropped from this
+//   path entirely):
+//     grid = ceil(N / COLS), COLS = 4 waves * NPW columns per wave.
+//     Wave w owns output columns nwg + w*NPW .. +NPW-1 for the whole
+//     kernel — and stages exactly those columns itself, so the LDS
+//     buffers are per-wave-private slices (the WG barrier below is
+//     kept for safety/symmetry, not for cross-wave data exchange; a
+//     barrier-free per-wave pipeline is a documented follow-up A/B).
+//
+//   Chunking / LDS budget:
+//     KC = 512 B of K per chunk per column. Buffer = COLS * KC:
+//       NPW=4: 16 cols -> 8KB/buffer, 16KB total (2 buffers)
+//       NPW=2:  8 cols -> 4KB/buffer,  8KB total
+//       NPW=1:  4 cols -> 2KB/buffer,  4KB total
+//     All well under the 32KB budget => >=4 WGs/CU by LDS. KC=512
+//     (not 1024) so the DOMINANT pi05 shape K=1024 still has 2 chunks
+//     and a real stage/compute overlap; K=4096 gets 8 pipeline steps.
+//
+//   Pipeline (double buffer, depth 1):
+//     prol   stage S0 -> buf0 ; waitcnt vmcnt(0) ; s_barrier
+//     c=0    issue S1 -> buf1 ▶ DMA fills buf1 ║ compute C0 from buf0
+//            waitcnt vmcnt(0) ; s_barrier      (S1 landed, C0 retired)
+//     c=1    issue S2 -> buf0 ▶                ║ compute C1 from buf1
+//            waitcnt vmcnt(0) ; s_barrier
+//     ...    (compute never waits on the loads feeding it — those
+//             finished a whole compute phase ago; the FMA/convert
+//             stream is fed from LDS at LDS rate)
+//     Overwrite hazard: S(c+2) targets buf[c&1]; the barrier ending
+//     iteration c sits AFTER compute(c), so every read of buf[c&1] has
+//     retired before iteration c+1 issues S(c+2) into it.
+//
+//   Staging (per chunk): the buffer is COLS contiguous 512B column
+//   slices, lds[buf][col*KC + k]. It is filled in 256B "units" (one
+//   async issue: 64 lanes * 4B); unit u of wave w covers column
+//   w*NPW + u/2, half u&1. ASYNC=true issues UPW = 2*NPW
+//   global_load_lds dwords per lane back-to-back (8 in flight at
+//   NPW=4). ASYNC=false is the register fallback: the same UPW dwords
+//   are loaded global->VGPR with all loads hoisted BEFORE compute (ILP
+//   like the register kernel) and only deposited to LDS after compute,
+//   so the consumer stays decoupled in both variants; the two variants
+//   share identical addressing, which is what makes the on-node A/B a
+//   single-variable comparison of the LDS-DMA path itself.
+//
+//   Compute (per chunk): lane l consumes bytes [l*8, l*8+8) of each
+//   owned column slice (ds_read_b64, conflict-free: 64 lanes hit 512
+//   consecutive bytes), converts A (global, L1/L2-hot — A is tiny and
+//   stays on the existing register-convert scheme) and B (LDS) with
+//   the native fp8 converts, and FMAs into acc[NPW][M_T].
+//
+//   Accumulation order (deterministic, graph-replay bit-identical):
+//   for a given output element, lane l accumulates k = c*512 + l*8 + j
+//   in ascending chunk c, ascending j — a fixed sequential order per
+//   lane — then the fixed-shape shuffle tree folds lanes. No atomics.
+//   NOTE: the lane<->k partition differs from the register nt kernel
+//   (8B windows vs 16B), so results are NOT bit-identical to that
+//   kernel — allowed: the gate is cos vs GemmRunner on the same
+//   quantized inputs, and each variant is itself deterministic.
+//
+//   K handling: K % 16 == 0 (checked) => a lane's 8B window and every
+//   staged dword are all-in or all-out of K; out-of-range units are
+//   simply not staged and out-of-range windows not consumed, so stale
+//   LDS bytes are never read. Tail columns (N % COLS) are guarded per
+//   column in both stage and compute.
+// ================================================================
+template<int M_T, int NPW, bool ASYNC>
+__global__ __launch_bounds__(SMALLM_FP8_BLOCK)
+void smallm_fp8_nt_lds_kernel(const unsigned char* __restrict__ A,
+                              const unsigned char* __restrict__ B,
+                              __hip_bfloat16* __restrict__ D,
+                              const float* __restrict__ d_scale_a,
+                              const float* __restrict__ d_scale_b,
+                              int M, int N, int K) {
+    constexpr int COLS = 4 * NPW;   // output columns per WG (4 waves)
+    constexpr int KC   = 512;       // K-bytes per chunk per column
+    constexpr int UPW  = 2 * NPW;   // 256B stage units per wave per chunk
+    // ASYNC only becomes LDS-DMA when this pass may emit the builtin
+    // (device pass / forced stub check); elsewhere it compiles as the
+    // sync body, which is fine — that code is never executed.
+    constexpr bool kAsync = ASYNC && (FRT_ASYNC_LDS_CODEGEN != 0);
+
+    __shared__ alignas(16) unsigned char lds[2][COLS * KC];
+
+    const int tid  = (int)threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int nwg  = (int)blockIdx.x * COLS;
+    const int chunks = (K + KC - 1) / KC;
+
+    float acc[NPW][M_T];
+    #pragma unroll
+    for (int p = 0; p < NPW; ++p)
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) acc[p][m] = 0.0f;
+
+    unsigned sreg[UPW];  // sync-fallback staging registers (dead if kAsync)
+
+    // ── producer: issue chunk c's loads (async: LDS-DMA; sync: ->VGPR) ──
+    auto stage_issue = [&](int c) {
+        unsigned char* dst = lds[c & 1];
+        const int kb = c * KC;
+        #pragma unroll
+        for (int i = 0; i < UPW; ++i) {
+            const int u    = wave * UPW + i;   // wave stages its OWN columns
+            const int col  = u >> 1;
+            const int off  = (u & 1) * 256 + lane * 4;   // byte in column slice
+            const int gk   = kb + off;
+            const bool ok  = (nwg + col < N) && (gk < K);  // K%4==0: whole dword
+            if constexpr (kAsync) {
+                if (ok)
+                    smallm_async_copy_dword(B + (size_t)(nwg + col) * K + gk,
+                                            dst + col * KC + (u & 1) * 256);
+            } else {
+                sreg[i] = ok ? *reinterpret_cast<const unsigned*>(
+                                   B + (size_t)(nwg + col) * K + gk)
+                             : 0u;
+            }
+        }
+    };
+
+    // ── producer: deposit chunk c to LDS (sync fallback only — placed
+    //    AFTER compute so the global loads overlap the FMA stream) ──
+    auto stage_commit = [&](int c) {
+        if constexpr (!kAsync) {
+            unsigned char* dst = lds[c & 1];
+            #pragma unroll
+            for (int i = 0; i < UPW; ++i) {
+                const int u = wave * UPW + i;
+                const int col = u >> 1;
+                const int off = (u & 1) * 256 + lane * 4;
+                *reinterpret_cast<unsigned*>(dst + col * KC + off) = sreg[i];
+            }
+        }
+    };
+
+    // ── pipeline barrier: drain this wave's LDS-DMA (vmcnt — the
+    //    compiler does not model DMA->ds_read deps), then WG barrier ──
+    auto pipe_barrier = [&]() {
+        if constexpr (kAsync) smallm_wait_lds_dma();
+        __syncthreads();
+    };
+
+    // ── consumer: chunk c from lds[c&1] ──
+    auto compute = [&](int c) {
+        const unsigned char* buf = lds[c & 1];
+        const int kb = c * KC;
+        const int ko = lane * 8;              // lane's 8B window in the chunk
+        if (kb + ko >= K) return;             // K%8==0 => all-in or all-out
+
+        // A window: 8 bytes per row, converted once per chunk (same
+        // scheme as the register kernel — A is L1/L2-hot, not the stream).
+        float a_f[M_T][8];
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) {
+            if (m < M) {
+                const uint2 av = *reinterpret_cast<const uint2*>(
+                    A + (size_t)m * K + kb + ko);
+                smallm_fp8x8_to_f32(av, a_f[m]);
+            } else {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) a_f[m][j] = 0.0f;
+            }
+        }
+
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int col = wave * NPW + p;
+            if (nwg + col >= N) continue;
+            const uint2 bv = *reinterpret_cast<const uint2*>(
+                buf + col * KC + ko);
+            float bf[8];
+            smallm_fp8x8_to_f32(bv, bf);
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j)
+                    acc[p][m] += a_f[m][j] * bf[j];
+            }
+        }
+    };
+
+    // ── run the pipeline ──
+    stage_issue(0);
+    stage_commit(0);          // sync fallback prologue stalls once; fine
+    pipe_barrier();           // buf0 ready WG-wide
+    for (int c = 0; c < chunks; ++c) {
+        if (c + 1 < chunks) stage_issue(c + 1);
+        compute(c);
+        if (c + 1 < chunks) {
+            stage_commit(c + 1);
+            pipe_barrier();   // next buffer landed; buf[c&1] reads retired
+        }
+    }
+
+    // ── epilogue: identical to the register nt kernel ──
+    #pragma unroll
+    for (int off = 32; off > 0; off >>= 1) {
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p)
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m)
+                acc[p][m] += __shfl_down(acc[p][m], off);
+    }
+
+    if (lane == 0) {
+        const float sc = d_scale_a[0] * d_scale_b[0];
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int n = nwg + wave * NPW + p;
+            if (n < N) {
+                #pragma unroll
+                for (int m = 0; m < M_T; ++m)
+                    if (m < M)
+                        D[(size_t)m * N + n] = __float2bfloat16(acc[p][m] * sc);
+            }
+        }
+    }
+}
+
+// ================================================================
 // Host side
 // ================================================================
 
@@ -472,15 +801,92 @@ static void smallm_fp8_nt_dispatch(const void* A, const void* B, void* D,
                                          M, N, K, stream);
 }
 
+template<int NPW, bool ASYNC>
+static void smallm_fp8_nt_lds_impl(const void* A, const void* B, void* D,
+                                   const float* d_scale_a, const float* d_scale_b,
+                                   int M, int N, int K, hipStream_t stream) {
+    constexpr int cols = 4 * NPW;   // w4 only — every w8 variant spills
+    const dim3 grid((unsigned)((N + cols - 1) / cols));
+    const dim3 block(SMALLM_FP8_BLOCK);
+    const unsigned char* a8 = static_cast<const unsigned char*>(A);
+    const unsigned char* b8 = static_cast<const unsigned char*>(B);
+    __hip_bfloat16* d16 = static_cast<__hip_bfloat16*>(D);
+
+    #define SMALLM_LAUNCH_NT_LDS(MT)                                            \
+        hipLaunchKernelGGL(                                                     \
+            HIP_KERNEL_NAME(smallm_fp8_nt_lds_kernel<MT, NPW, ASYNC>),          \
+            grid, block, 0, stream, a8, b8, d16, d_scale_a, d_scale_b, M, N, K)
+    if      (M <= 4)  SMALLM_LAUNCH_NT_LDS(4);
+    else if (M <= 8)  SMALLM_LAUNCH_NT_LDS(8);
+    else if (M <= 10) SMALLM_LAUNCH_NT_LDS(10);
+    else              SMALLM_LAUNCH_NT_LDS(16);
+    #undef SMALLM_LAUNCH_NT_LDS
+}
+
+// Same shape-adaptive NPW rule as the register path (grid >= 256 WGs,
+// the measured gfx950 saturation grid): N>=4096 -> NPW=4 (16 cols/WG,
+// 16KB LDS), N>=2048 -> NPW=2 (8KB), else NPW=1 (4KB).
+template<bool ASYNC>
+static void smallm_fp8_nt_lds_dispatch(const void* A, const void* B, void* D,
+                                       const float* d_scale_a,
+                                       const float* d_scale_b,
+                                       int M, int N, int K, hipStream_t stream) {
+    if (N >= 4 * 4 * 256)
+        smallm_fp8_nt_lds_impl<4, ASYNC>(A, B, D, d_scale_a, d_scale_b,
+                                         M, N, K, stream);
+    else if (N >= 4 * 2 * 256)
+        smallm_fp8_nt_lds_impl<2, ASYNC>(A, B, D, d_scale_a, d_scale_b,
+                                         M, N, K, stream);
+    else
+        smallm_fp8_nt_lds_impl<1, ASYNC>(A, B, D, d_scale_a, d_scale_b,
+                                         M, N, K, stream);
+}
+
+int smallm_fp8_nt_lds_async_available() {
+    return FRT_LDS_ASYNC ? 1 : 0;
+}
+
+void smallm_fp8_nt_lds_dev(const void* A, const void* B, void* D,
+                           const float* d_scale_a, const float* d_scale_b,
+                           int M, int N, int K, int use_async,
+                           hipStream_t stream) {
+    smallm_fp8_check("smallm_fp8_nt_lds_dev", M, N, K, 1, 16);
+    // use_async selects between the two compiled variants at runtime so
+    // one bench process can A/B them. If the binary was built with
+    // -DFRT_LDS_ASYNC=0 the async instantiation is the sync body; route
+    // to sync explicitly so the choice is honest either way (query
+    // smallm_fp8_nt_lds_async_available() to annotate bench rows).
+    if (use_async != 0 && FRT_LDS_ASYNC)
+        smallm_fp8_nt_lds_dispatch<true>(A, B, D, d_scale_a, d_scale_b,
+                                         M, N, K, stream);
+    else
+        smallm_fp8_nt_lds_dispatch<false>(A, B, D, d_scale_a, d_scale_b,
+                                          M, N, K, stream);
+}
+
 void smallm_fp8_nt_dev(const void* A, const void* B, void* D,
                        const float* d_scale_a, const float* d_scale_b,
                        int M, int N, int K, float* split_ws,
                        hipStream_t stream) {
     (void)split_ws;  // nt never splits K — accepted for signature symmetry
-    // Default: 4 waves/WG, grid target >= 256 WGs. pi05 site N=1024
-    // -> NPW=1 (256 WGs, CG=4); N>=2048 -> NPW=2; N>=4096 -> NPW=4.
-    smallm_fp8_nt_dispatch<4>(A, B, D, d_scale_a, d_scale_b, M, N, K,
-                              /*min_wgs=*/256, stream);
+    // Default is now the LDS double-buffered pipeline (async staging
+    // unless FRT_LDS_ASYNC=0 in the env or at build time). The legacy
+    // register-only ILP4 path stays behind FRT_SMALLM_REG=1 for A/B.
+    // NOTE: env vars are read on the HOST at launch/capture time — a
+    // captured graph keeps whatever the env said at capture; flip the
+    // env BEFORE capturing, or use smallm_fp8_nt_lds_dev directly.
+    const char* reg = std::getenv("FRT_SMALLM_REG");
+    if (reg && reg[0] == '1' && reg[1] == '\0') {
+        // Legacy: 4 waves/WG, grid target >= 256 WGs. pi05 site N=1024
+        // -> NPW=1 (256 WGs, CG=4); N>=2048 -> NPW=2; N>=4096 -> NPW=4.
+        smallm_fp8_nt_dispatch<4>(A, B, D, d_scale_a, d_scale_b, M, N, K,
+                                  /*min_wgs=*/256, stream);
+        return;
+    }
+    const char* as = std::getenv("FRT_LDS_ASYNC");
+    const int use_async = (as && as[0] == '0' && as[1] == '\0') ? 0 : 1;
+    smallm_fp8_nt_lds_dev(A, B, D, d_scale_a, d_scale_b, M, N, K,
+                          use_async, stream);
 }
 
 void smallm_fp8_nt_dev_alt(const void* A, const void* B, void* D,

--- a/csrc/amd/gemm/smallm_fp8.hip
+++ b/csrc/amd/gemm/smallm_fp8.hip
@@ -1,0 +1,414 @@
+#include "smallm_fp8.h"
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp8.h>
+#include <stdexcept>
+#include <string>
+
+// ================================================================
+// FlashRT AMD — hand-tuned small-M FP8 GEMM kernels (CDNA4, wave64)
+//
+// See smallm_fp8.h for the contract. Design notes:
+//
+// The problem is bandwidth: weight bytes (N*K fp8) dwarf everything
+// else (A is M*K <= 64KB, D is M*N*2). The floor is one pass over B
+// at DRAM rate, so both kernels stream B exactly once with 16-byte
+// (dwordx4) lane loads and keep A resident (LDS for nn, registers
+// for nt), accumulating FP32 per lane and folding with wave shuffles.
+//
+// nn ("kn" weights, B[k*N + n], N contiguous per k-row):
+//   Workgroup = 256 threads = 4 waves; each wave owns 16 consecutive
+//   output columns, so a WG covers a 64-column tile — the 4 waves
+//   together touch 64 consecutive bytes of every k-row (a full 64B
+//   DRAM sector). Within a wave, the 64 lanes partition K: lane l
+//   streams rows k = l, l+64, ... of the WG's k-slice, loading 16
+//   bytes of B per row. A is staged transposed in LDS as
+//   aT[k][16 bytes] so a lane fetches all M values for its row with
+//   one ds_read_b128. Lane partials fold with a fixed shfl_down tree.
+//   Grid = (N/64) x S k-slices. n-parallelism alone (N/64 WGs) cannot
+//   fill an MI350X, so S slices of K run in parallel and a second
+//   kernel reduces the FP32 partials in ascending slice order
+//   (deterministic, no atomics — required inside captured graphs).
+//   S is the smallest power of two that reaches ~256 WGs (~512 for
+//   the _alt config), capped so it divides K/64 and by the workspace
+//   bound SMALLM_FP8_MAX_SPLIT. Split-K costs S*M*N*4 bytes written
+//   + read back (~1.3MB for the dominant pi05 shapes at S<=16, i.e.
+//   ~25-35% of the 4MB weight stream) — the price of occupancy.
+//
+// nt ("nk" weights, B[n*K + k], K contiguous per output column):
+//   The naturally streaming layout: a wave owns whole output columns,
+//   lanes tile K in 16-byte chunks (64 lanes x 16B = 1KB of one B row
+//   per pass — perfectly coalesced full cache lines), and column
+//   parallelism alone (N/16 WGs at 4 columns/wave) fills the GPU with
+//   NO split-K, NO workspace, NO LDS. Each wave processes NPW=4
+//   columns per K-chunk so the A-chunk, converted once into
+//   registers, is reused across 4 columns. Prefer this path: set the
+//   frontend's fp8_layout="nk" so decoder weights are packed (N,K).
+//
+// fp8 -> f32 conversion: per-byte through __hip_fp8_e4m3's float
+// operator, which lowers to the gfx950 native V_CVT_*_FP8 ops. A
+// 256-entry LDS LUT was considered and rejected: the native converts
+// are cheap on CDNA4 and a LUT would add an LDS gather (64 scattered
+// lane reads) per 16 weight bytes plus LDS pressure.
+//
+// M is dispatched to a compiled tile height M_T in {4, 8, 10, 16}
+// (accumulators are register arrays, so the m-loop must be
+// compile-time). M=10 (pi05 action chunk) hits its exact tile.
+// ================================================================
+
+#define SMALLM_FP8_BLOCK 256   // threads per workgroup (4 waves)
+
+// ── fp8 e4m3 byte -> f32 ──
+__device__ __forceinline__ float smallm_fp8_to_f32(unsigned char b) {
+    __hip_fp8_e4m3 v;
+    v.__x = b;
+    return static_cast<float>(v);
+}
+
+// Unpack 16 fp8 bytes (one dwordx4 load) to f32.
+__device__ __forceinline__ void smallm_fp8x16_to_f32(const uint4& v, float* out) {
+    const unsigned char* b = reinterpret_cast<const unsigned char*>(&v);
+    #pragma unroll
+    for (int j = 0; j < 16; ++j) out[j] = smallm_fp8_to_f32(b[j]);
+}
+
+// ================================================================
+// nn kernel: B stored (K, N) row-major.
+//   grid = (N/64, S), block = 256. Dynamic LDS = k_slice * 16 bytes.
+//   S == 1: writes scaled BF16 straight to D.
+//   S  > 1: writes unscaled FP32 partials to ws[s][m][n]; the reduce
+//           kernel below finishes deterministically.
+// ================================================================
+template<int M_T>
+__global__ __launch_bounds__(SMALLM_FP8_BLOCK)
+void smallm_fp8_nn_kernel(const unsigned char* __restrict__ A,
+                          const unsigned char* __restrict__ B,
+                          __hip_bfloat16* __restrict__ D,
+                          float* __restrict__ ws,
+                          const float* __restrict__ d_scale_a,
+                          const float* __restrict__ d_scale_b,
+                          int M, int N, int K, int k_slice) {
+    extern __shared__ unsigned char smallm_lds_aT[];  // aT[k_local][16]
+    const int tid  = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int n0   = blockIdx.x * 64 + wave * 16;   // wave's 16-column group
+    const int s    = blockIdx.y;                    // k-slice index
+    const int k0   = s * k_slice;
+
+    // Stage this k-slice of A transposed: aT[k - k0][m], m zero-padded
+    // to 16 so a lane reads its row's M values as one 16B LDS load.
+    for (int i = tid; i < k_slice * 16; i += SMALLM_FP8_BLOCK) {
+        const int m = i & 15, koff = i >> 4;
+        smallm_lds_aT[i] =
+            (m < M) ? A[(size_t)m * K + (k0 + koff)] : (unsigned char)0;
+    }
+    __syncthreads();
+
+    float acc[M_T * 16];
+    #pragma unroll
+    for (int i = 0; i < M_T * 16; ++i) acc[i] = 0.0f;
+
+    // Lane l streams rows k0 + l, k0 + l + 64, ... — fixed sequential
+    // order per lane (deterministic accumulation).
+    const int iters = k_slice >> 6;
+    #pragma unroll 4
+    for (int it = 0; it < iters; ++it) {
+        const int kl = (it << 6) + lane;  // row within the slice
+        const uint4 bv = *reinterpret_cast<const uint4*>(
+            B + (size_t)(k0 + kl) * N + n0);
+        float bf[16];
+        smallm_fp8x16_to_f32(bv, bf);
+        const uint4 av = reinterpret_cast<const uint4*>(smallm_lds_aT)[kl];
+        const unsigned char* ab = reinterpret_cast<const unsigned char*>(&av);
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) {
+            const float a = smallm_fp8_to_f32(ab[m]);
+            #pragma unroll
+            for (int j = 0; j < 16; ++j) acc[m * 16 + j] += a * bf[j];
+        }
+    }
+
+    // Fixed-shape wave shuffle tree (order identical every launch).
+    #pragma unroll
+    for (int off = 32; off > 0; off >>= 1) {
+        #pragma unroll
+        for (int i = 0; i < M_T * 16; ++i)
+            acc[i] += __shfl_down(acc[i], off);
+    }
+
+    if (lane == 0) {
+        if (gridDim.y > 1) {
+            float* dst = ws + (size_t)s * M * N;
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                if (m < M) {
+                    #pragma unroll
+                    for (int j = 0; j < 16; ++j)
+                        dst[(size_t)m * N + (n0 + j)] = acc[m * 16 + j];
+                }
+            }
+        } else {
+            const float sc = d_scale_a[0] * d_scale_b[0];
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                if (m < M) {
+                    #pragma unroll
+                    for (int j = 0; j < 16; ++j)
+                        D[(size_t)m * N + (n0 + j)] =
+                            __float2bfloat16(acc[m * 16 + j] * sc);
+                }
+            }
+        }
+    }
+}
+
+// ================================================================
+// Split-K reduce: D[i] = bf16(sum_{s ascending} ws[s][i] * scale).
+// One thread per 4 outputs (float4 partial reads). The s-loop runs in
+// fixed ascending order — the only cross-workgroup reduction in the
+// nn path, and it is deterministic by construction.
+// ================================================================
+__global__ __launch_bounds__(SMALLM_FP8_BLOCK)
+void smallm_fp8_split_reduce_kernel(const float* __restrict__ ws,
+                                    __hip_bfloat16* __restrict__ D,
+                                    const float* __restrict__ d_scale_a,
+                                    const float* __restrict__ d_scale_b,
+                                    int split, long long mn) {
+    const long long i4 =
+        ((long long)blockIdx.x * SMALLM_FP8_BLOCK + threadIdx.x) * 4;
+    if (i4 >= mn) return;  // mn is a multiple of 4 (N % 64 == 0)
+    float sx = 0.0f, sy = 0.0f, sz = 0.0f, sw = 0.0f;
+    for (int s = 0; s < split; ++s) {
+        const float4 p =
+            *reinterpret_cast<const float4*>(ws + (size_t)s * mn + i4);
+        sx += p.x; sy += p.y; sz += p.z; sw += p.w;
+    }
+    const float sc = d_scale_a[0] * d_scale_b[0];
+    D[i4 + 0] = __float2bfloat16(sx * sc);
+    D[i4 + 1] = __float2bfloat16(sy * sc);
+    D[i4 + 2] = __float2bfloat16(sz * sc);
+    D[i4 + 3] = __float2bfloat16(sw * sc);
+}
+
+// ================================================================
+// nt kernel: B stored (N, K) row-major.
+//   grid = ceil(N / (4*NPW)), block = 256; wave w owns output columns
+//   nb + w*NPW .. +NPW-1. Lanes tile K in 16B chunks (1KB per wave
+//   pass); the lane's A window is converted to registers once per
+//   chunk and reused across the wave's NPW columns. No LDS, no
+//   split-K, no workspace.
+// ================================================================
+template<int M_T, int NPW>
+__global__ __launch_bounds__(SMALLM_FP8_BLOCK)
+void smallm_fp8_nt_kernel(const unsigned char* __restrict__ A,
+                          const unsigned char* __restrict__ B,
+                          __hip_bfloat16* __restrict__ D,
+                          const float* __restrict__ d_scale_a,
+                          const float* __restrict__ d_scale_b,
+                          int M, int N, int K) {
+    const int wave = threadIdx.x >> 6;
+    const int lane = threadIdx.x & 63;
+    const int nb   = blockIdx.x * (4 * NPW) + wave * NPW;
+
+    float acc[NPW][M_T];
+    #pragma unroll
+    for (int p = 0; p < NPW; ++p)
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) acc[p][m] = 0.0f;
+
+    // K-chunks of 64 lanes x 16B = 1024 elements; sequential chunk
+    // loop per lane keeps accumulation order fixed.
+    const int chunks = (K + 1023) >> 10;
+    for (int c = 0; c < chunks; ++c) {
+        const int kw = (c << 10) + (lane << 4);
+        if (kw >= K) continue;  // tail guard (K % 16 == 0 keeps loads whole)
+
+        // A window for this lane's 16 k's, all rows, converted once.
+        float a_f[M_T][16];
+        #pragma unroll
+        for (int m = 0; m < M_T; ++m) {
+            if (m < M) {
+                const uint4 av = *reinterpret_cast<const uint4*>(
+                    A + (size_t)m * K + kw);
+                smallm_fp8x16_to_f32(av, a_f[m]);
+            } else {
+                #pragma unroll
+                for (int j = 0; j < 16; ++j) a_f[m][j] = 0.0f;
+            }
+        }
+
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int n = nb + p;
+            if (n >= N) continue;
+            const uint4 bv = *reinterpret_cast<const uint4*>(
+                B + (size_t)n * K + kw);
+            float bf[16];
+            smallm_fp8x16_to_f32(bv, bf);
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m) {
+                #pragma unroll
+                for (int j = 0; j < 16; ++j)
+                    acc[p][m] += a_f[m][j] * bf[j];
+            }
+        }
+    }
+
+    // Fixed-shape wave shuffle tree.
+    #pragma unroll
+    for (int off = 32; off > 0; off >>= 1) {
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p)
+            #pragma unroll
+            for (int m = 0; m < M_T; ++m)
+                acc[p][m] += __shfl_down(acc[p][m], off);
+    }
+
+    if (lane == 0) {
+        const float sc = d_scale_a[0] * d_scale_b[0];
+        #pragma unroll
+        for (int p = 0; p < NPW; ++p) {
+            const int n = nb + p;
+            if (n < N) {
+                #pragma unroll
+                for (int m = 0; m < M_T; ++m)
+                    if (m < M)
+                        D[(size_t)m * N + n] = __float2bfloat16(acc[p][m] * sc);
+            }
+        }
+    }
+}
+
+// ================================================================
+// Host side
+// ================================================================
+
+size_t smallm_fp8_nn_dev_ws_bytes(int M, int N) {
+    return (size_t)SMALLM_FP8_MAX_SPLIT * M * N * sizeof(float);
+}
+
+static void smallm_fp8_check(const char* who, int M, int N, int K,
+                             int n_align, int k_align) {
+    if (M < 1 || M > 16)
+        throw std::runtime_error(std::string(who) + ": M must be in [1,16], got " +
+                                 std::to_string(M));
+    if (N < n_align || (N % n_align) != 0)
+        throw std::runtime_error(std::string(who) + ": N must be a multiple of " +
+                                 std::to_string(n_align) + ", got " + std::to_string(N));
+    if (K < k_align || (K % k_align) != 0)
+        throw std::runtime_error(std::string(who) + ": K must be a multiple of " +
+                                 std::to_string(k_align) + ", got " + std::to_string(K));
+}
+
+// Smallest power-of-two split S with (N/64)*S >= target_wgs, subject to
+// S | (K/64), S <= SMALLM_FP8_MAX_SPLIT, and LDS staging <= 64KB/slice.
+static int smallm_fp8_pick_split(int N, int K, bool have_ws, int target_wgs) {
+    const int k64 = K / 64;
+    int s = 1;
+    if (have_ws) {
+        const int n_wgs = N / 64;
+        while (n_wgs * s < target_wgs && (s << 1) <= SMALLM_FP8_MAX_SPLIT) s <<= 1;
+        while (s > 1 && (s > k64 || (k64 % s) != 0)) s >>= 1;
+    }
+    // LDS bound: k_slice * 16 bytes <= 64KB  =>  K/S <= 4096.
+    while ((size_t)(K / s) * 16 > 65536) {
+        const int s2 = s << 1;
+        if (!have_ws || s2 > SMALLM_FP8_MAX_SPLIT || s2 > k64 || (k64 % s2) != 0)
+            throw std::runtime_error(
+                "smallm_fp8_nn_dev: K too large for LDS staging without a "
+                "(deeper) split_ws; K=" + std::to_string(K));
+        s = s2;
+    }
+    return s;
+}
+
+static void smallm_fp8_nn_dev_impl(const void* A, const void* B, void* D,
+                                   const float* d_scale_a, const float* d_scale_b,
+                                   int M, int N, int K, float* split_ws,
+                                   hipStream_t stream, int target_wgs) {
+    smallm_fp8_check("smallm_fp8_nn_dev", M, N, K, 64, 64);
+    const int s = smallm_fp8_pick_split(N, K, split_ws != nullptr, target_wgs);
+    const int k_slice = K / s;
+    const dim3 grid((unsigned)(N / 64), (unsigned)s);
+    const dim3 block(SMALLM_FP8_BLOCK);
+    const size_t shmem = (size_t)k_slice * 16;
+    const unsigned char* a8 = static_cast<const unsigned char*>(A);
+    const unsigned char* b8 = static_cast<const unsigned char*>(B);
+    __hip_bfloat16* d16 = static_cast<__hip_bfloat16*>(D);
+
+    #define SMALLM_LAUNCH_NN(MT)                                                \
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(smallm_fp8_nn_kernel<MT>),           \
+                           grid, block, shmem, stream,                          \
+                           a8, b8, d16, split_ws, d_scale_a, d_scale_b,         \
+                           M, N, K, k_slice)
+    if      (M <= 4)  SMALLM_LAUNCH_NN(4);
+    else if (M <= 8)  SMALLM_LAUNCH_NN(8);
+    else if (M <= 10) SMALLM_LAUNCH_NN(10);
+    else              SMALLM_LAUNCH_NN(16);
+    #undef SMALLM_LAUNCH_NN
+
+    if (s > 1) {
+        const long long mn = (long long)M * N;
+        const unsigned rblocks =
+            (unsigned)((mn / 4 + SMALLM_FP8_BLOCK - 1) / SMALLM_FP8_BLOCK);
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(smallm_fp8_split_reduce_kernel),
+                           dim3(rblocks), block, 0, stream,
+                           split_ws, d16, d_scale_a, d_scale_b, s, mn);
+    }
+}
+
+void smallm_fp8_nn_dev(const void* A, const void* B, void* D,
+                       const float* d_scale_a, const float* d_scale_b,
+                       int M, int N, int K, float* split_ws,
+                       hipStream_t stream) {
+    smallm_fp8_nn_dev_impl(A, B, D, d_scale_a, d_scale_b, M, N, K,
+                           split_ws, stream, /*target_wgs=*/256);
+}
+
+void smallm_fp8_nn_dev_alt(const void* A, const void* B, void* D,
+                           const float* d_scale_a, const float* d_scale_b,
+                           int M, int N, int K, float* split_ws,
+                           hipStream_t stream) {
+    smallm_fp8_nn_dev_impl(A, B, D, d_scale_a, d_scale_b, M, N, K,
+                           split_ws, stream, /*target_wgs=*/512);
+}
+
+template<int NPW>
+static void smallm_fp8_nt_dev_impl(const void* A, const void* B, void* D,
+                                   const float* d_scale_a, const float* d_scale_b,
+                                   int M, int N, int K, hipStream_t stream) {
+    smallm_fp8_check("smallm_fp8_nt_dev", M, N, K, 1, 16);
+    const int cols_per_wg = 4 * NPW;
+    const dim3 grid((unsigned)((N + cols_per_wg - 1) / cols_per_wg));
+    const dim3 block(SMALLM_FP8_BLOCK);
+    const unsigned char* a8 = static_cast<const unsigned char*>(A);
+    const unsigned char* b8 = static_cast<const unsigned char*>(B);
+    __hip_bfloat16* d16 = static_cast<__hip_bfloat16*>(D);
+
+    #define SMALLM_LAUNCH_NT(MT)                                                \
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(smallm_fp8_nt_kernel<MT, NPW>),      \
+                           grid, block, 0, stream,                              \
+                           a8, b8, d16, d_scale_a, d_scale_b, M, N, K)
+    if      (M <= 4)  SMALLM_LAUNCH_NT(4);
+    else if (M <= 8)  SMALLM_LAUNCH_NT(8);
+    else if (M <= 10) SMALLM_LAUNCH_NT(10);
+    else              SMALLM_LAUNCH_NT(16);
+    #undef SMALLM_LAUNCH_NT
+}
+
+void smallm_fp8_nt_dev(const void* A, const void* B, void* D,
+                       const float* d_scale_a, const float* d_scale_b,
+                       int M, int N, int K, float* split_ws,
+                       hipStream_t stream) {
+    (void)split_ws;  // nt never splits K — accepted for signature symmetry
+    smallm_fp8_nt_dev_impl<4>(A, B, D, d_scale_a, d_scale_b, M, N, K, stream);
+}
+
+void smallm_fp8_nt_dev_alt(const void* A, const void* B, void* D,
+                           const float* d_scale_a, const float* d_scale_b,
+                           int M, int N, int K, float* split_ws,
+                           hipStream_t stream) {
+    (void)split_ws;
+    smallm_fp8_nt_dev_impl<2>(A, B, D, d_scale_a, d_scale_b, M, N, K, stream);
+}

--- a/csrc/amd/gemm/smallm_fp8.hip
+++ b/csrc/amd/gemm/smallm_fp8.hip
@@ -39,11 +39,35 @@
 //   The naturally streaming layout: a wave owns whole output columns,
 //   lanes tile K in 16-byte chunks (64 lanes x 16B = 1KB of one B row
 //   per pass — perfectly coalesced full cache lines), and column
-//   parallelism alone (N/16 WGs at 4 columns/wave) fills the GPU with
-//   NO split-K, NO workspace, NO LDS. Each wave processes NPW=4
-//   columns per K-chunk so the A-chunk, converted once into
-//   registers, is reused across 4 columns. Prefer this path: set the
-//   frontend's fp8_layout="nk" so decoder weights are packed (N,K).
+//   parallelism alone fills the GPU with NO split-K, NO workspace, NO
+//   LDS. Prefer this path: set the frontend's fp8_layout="nk" so
+//   decoder weights are packed (N,K).
+//
+//   ILP=4 streaming (stream_probe, gfx950 — see
+//   FlashRT-amd-dev/notes/stream_craft_gfx950.md): one dwordx4 chain
+//   per lane plateaus at ~1373 GB/s @4MB / 3235 @64MB (latency-window
+//   bound, Little's law); FOUR independent dwordx4 chains per lane
+//   reach 1534-5855 GB/s (co_x4_i4 winners). The kernel therefore
+//   keeps NPW * CG == 4 independent B-row loads in flight per lane:
+//   NPW simultaneous output columns x CG consecutive K-chunks, all
+//   NPW*CG loads ISSUED before any convert/FMA consumes them.
+//   Consumption then runs in the ORIGINAL fixed order — ascending
+//   chunk, ascending column, ascending j inside the 16-byte packet —
+//   so per-column fp32 accumulation order is UNCHANGED and results
+//   stay bit-identical to the pre-ILP4 kernel (and to the fused FFN
+//   kernels, which copy this skeleton). ILP comes purely from load
+//   scheduling, never from splitting accumulators.
+//
+//   Host config pick (values are bit-identical for ANY (NPW, WAVES):
+//   a column's math never depends on which wave computes it):
+//     default: 4 waves/WG; largest NPW in {4,2,1} keeping
+//       grid = N/(4*NPW) >= 256 WGs (the measured saturation grid) —
+//       pi05 site N=1024 -> NPW=1 (256 WGs, CG=4: the whole K=4096
+//       row preloaded as 4 chains); N>=4096 -> NPW=4 (A-convert
+//       amortized 4x, grid still >= 256).
+//     alt: 8 waves/WG (w8 — probe: helps at larger footprints,
+//       neutral at small), same wave-count-preserving NPW rule
+//       against grid >= 128.
 //
 // fp8 -> f32 conversion: per-byte through __hip_fp8_e4m3's float
 // operator, which lowers to the gfx950 native V_CVT_*_FP8 ops. A
@@ -193,14 +217,21 @@ void smallm_fp8_split_reduce_kernel(const float* __restrict__ ws,
 
 // ================================================================
 // nt kernel: B stored (N, K) row-major.
-//   grid = ceil(N / (4*NPW)), block = 256; wave w owns output columns
-//   nb + w*NPW .. +NPW-1. Lanes tile K in 16B chunks (1KB per wave
-//   pass); the lane's A window is converted to registers once per
-//   chunk and reused across the wave's NPW columns. No LDS, no
-//   split-K, no workspace.
+//   grid = ceil(N / (WAVES*NPW)), block = WAVES*64; wave w owns output
+//   columns nb + w*NPW .. +NPW-1. Lanes tile K in 16B chunks (1KB per
+//   wave pass). No LDS, no split-K, no workspace.
+//
+//   ILP=4: each outer iteration covers a group of CG = 4/NPW
+//   consecutive K-chunks. All NPW*CG == 4 independent B dwordx4 loads
+//   for the group are issued FIRST (distinct destination registers ->
+//   4 loads in flight per lane, the measured gfx950 saturation
+//   lever), then consumed in the ORIGINAL fixed order: ascending
+//   chunk u, A window converted once per chunk, then ascending column
+//   p, ascending j. Per-accumulator fp32 order is bit-identical to
+//   the pre-ILP4 kernel.
 // ================================================================
-template<int M_T, int NPW>
-__global__ __launch_bounds__(SMALLM_FP8_BLOCK)
+template<int M_T, int NPW, int WAVES>
+__global__ __launch_bounds__(WAVES * 64)
 void smallm_fp8_nt_kernel(const unsigned char* __restrict__ A,
                           const unsigned char* __restrict__ B,
                           __hip_bfloat16* __restrict__ D,
@@ -209,7 +240,10 @@ void smallm_fp8_nt_kernel(const unsigned char* __restrict__ A,
                           int M, int N, int K) {
     const int wave = threadIdx.x >> 6;
     const int lane = threadIdx.x & 63;
-    const int nb   = blockIdx.x * (4 * NPW) + wave * NPW;
+    const int nb   = blockIdx.x * (WAVES * NPW) + wave * NPW;
+
+    // Chunk-group depth: NPW columns x CG chunks = 4 chains in flight.
+    constexpr int CG = (NPW >= 4) ? 1 : (4 / NPW);
 
     float acc[NPW][M_T];
     #pragma unroll
@@ -217,40 +251,59 @@ void smallm_fp8_nt_kernel(const unsigned char* __restrict__ A,
         #pragma unroll
         for (int m = 0; m < M_T; ++m) acc[p][m] = 0.0f;
 
-    // K-chunks of 64 lanes x 16B = 1024 elements; sequential chunk
-    // loop per lane keeps accumulation order fixed.
+    // K-chunks of 64 lanes x 16B = 1024 elements; the group loop and
+    // the in-group consume order are both ascending-chunk, so the
+    // accumulation order matches the plain sequential chunk loop.
     const int chunks = (K + 1023) >> 10;
-    for (int c = 0; c < chunks; ++c) {
-        const int kw = (c << 10) + (lane << 4);
-        if (kw >= K) continue;  // tail guard (K % 16 == 0 keeps loads whole)
-
-        // A window for this lane's 16 k's, all rows, converted once.
-        float a_f[M_T][16];
-        #pragma unroll
-        for (int m = 0; m < M_T; ++m) {
-            if (m < M) {
-                const uint4 av = *reinterpret_cast<const uint4*>(
-                    A + (size_t)m * K + kw);
-                smallm_fp8x16_to_f32(av, a_f[m]);
-            } else {
-                #pragma unroll
-                for (int j = 0; j < 16; ++j) a_f[m][j] = 0.0f;
-            }
-        }
-
+    for (int c0 = 0; c0 < chunks; c0 += CG) {
+        // ── issue all NPW x CG independent B loads (ILP4) ──
+        uint4 braw[NPW][CG];
+        bool  bok[NPW][CG];
         #pragma unroll
         for (int p = 0; p < NPW; ++p) {
             const int n = nb + p;
-            if (n >= N) continue;
-            const uint4 bv = *reinterpret_cast<const uint4*>(
-                B + (size_t)n * K + kw);
-            float bf[16];
-            smallm_fp8x16_to_f32(bv, bf);
+            #pragma unroll
+            for (int u = 0; u < CG; ++u) {
+                const int kw = ((c0 + u) << 10) + (lane << 4);
+                bok[p][u] = (n < N) && (kw < K);  // K % 16 == 0: whole loads
+                if (bok[p][u])
+                    braw[p][u] = *reinterpret_cast<const uint4*>(
+                        B + (size_t)n * K + kw);
+            }
+        }
+
+        // ── consume: ascending chunk, then ascending column ──
+        #pragma unroll
+        for (int u = 0; u < CG; ++u) {
+            const int kw = ((c0 + u) << 10) + (lane << 4);
+            if (kw >= K) continue;  // tail guard
+
+            // A window for this lane's 16 k's, all rows, converted
+            // once per chunk (L1/L2-hot — not the stream).
+            float a_f[M_T][16];
             #pragma unroll
             for (int m = 0; m < M_T; ++m) {
+                if (m < M) {
+                    const uint4 av = *reinterpret_cast<const uint4*>(
+                        A + (size_t)m * K + kw);
+                    smallm_fp8x16_to_f32(av, a_f[m]);
+                } else {
+                    #pragma unroll
+                    for (int j = 0; j < 16; ++j) a_f[m][j] = 0.0f;
+                }
+            }
+
+            #pragma unroll
+            for (int p = 0; p < NPW; ++p) {
+                if (!bok[p][u]) continue;
+                float bf[16];
+                smallm_fp8x16_to_f32(braw[p][u], bf);
                 #pragma unroll
-                for (int j = 0; j < 16; ++j)
-                    acc[p][m] += a_f[m][j] * bf[j];
+                for (int m = 0; m < M_T; ++m) {
+                    #pragma unroll
+                    for (int j = 0; j < 16; ++j)
+                        acc[p][m] += a_f[m][j] * bf[j];
+                }
             }
         }
     }
@@ -374,20 +427,20 @@ void smallm_fp8_nn_dev_alt(const void* A, const void* B, void* D,
                            split_ws, stream, /*target_wgs=*/512);
 }
 
-template<int NPW>
+template<int NPW, int WAVES>
 static void smallm_fp8_nt_dev_impl(const void* A, const void* B, void* D,
                                    const float* d_scale_a, const float* d_scale_b,
                                    int M, int N, int K, hipStream_t stream) {
     smallm_fp8_check("smallm_fp8_nt_dev", M, N, K, 1, 16);
-    const int cols_per_wg = 4 * NPW;
+    const int cols_per_wg = WAVES * NPW;
     const dim3 grid((unsigned)((N + cols_per_wg - 1) / cols_per_wg));
-    const dim3 block(SMALLM_FP8_BLOCK);
+    const dim3 block((unsigned)(WAVES * 64));
     const unsigned char* a8 = static_cast<const unsigned char*>(A);
     const unsigned char* b8 = static_cast<const unsigned char*>(B);
     __hip_bfloat16* d16 = static_cast<__hip_bfloat16*>(D);
 
     #define SMALLM_LAUNCH_NT(MT)                                                \
-        hipLaunchKernelGGL(HIP_KERNEL_NAME(smallm_fp8_nt_kernel<MT, NPW>),      \
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(smallm_fp8_nt_kernel<MT, NPW, WAVES>),\
                            grid, block, 0, stream,                              \
                            a8, b8, d16, d_scale_a, d_scale_b, M, N, K)
     if      (M <= 4)  SMALLM_LAUNCH_NT(4);
@@ -397,12 +450,37 @@ static void smallm_fp8_nt_dev_impl(const void* A, const void* B, void* D,
     #undef SMALLM_LAUNCH_NT
 }
 
+// Shape-adaptive NPW: the largest NPW in {4, 2, 1} that keeps
+// grid = N/(WAVES*NPW) >= min_wgs — the measured gfx950 saturation
+// grid (stream_probe: 256 one-shot WGs of 4 waves with ILP4 saturate;
+// fewer WGs starve the latency window). Results are bit-identical for
+// every (NPW, WAVES): each output column's accumulation never depends
+// on which wave computes it, only on the fixed chunk/j order.
+template<int WAVES>
+static void smallm_fp8_nt_dispatch(const void* A, const void* B, void* D,
+                                   const float* d_scale_a, const float* d_scale_b,
+                                   int M, int N, int K, int min_wgs,
+                                   hipStream_t stream) {
+    if (N >= WAVES * 4 * min_wgs)
+        smallm_fp8_nt_dev_impl<4, WAVES>(A, B, D, d_scale_a, d_scale_b,
+                                         M, N, K, stream);
+    else if (N >= WAVES * 2 * min_wgs)
+        smallm_fp8_nt_dev_impl<2, WAVES>(A, B, D, d_scale_a, d_scale_b,
+                                         M, N, K, stream);
+    else
+        smallm_fp8_nt_dev_impl<1, WAVES>(A, B, D, d_scale_a, d_scale_b,
+                                         M, N, K, stream);
+}
+
 void smallm_fp8_nt_dev(const void* A, const void* B, void* D,
                        const float* d_scale_a, const float* d_scale_b,
                        int M, int N, int K, float* split_ws,
                        hipStream_t stream) {
     (void)split_ws;  // nt never splits K — accepted for signature symmetry
-    smallm_fp8_nt_dev_impl<4>(A, B, D, d_scale_a, d_scale_b, M, N, K, stream);
+    // Default: 4 waves/WG, grid target >= 256 WGs. pi05 site N=1024
+    // -> NPW=1 (256 WGs, CG=4); N>=2048 -> NPW=2; N>=4096 -> NPW=4.
+    smallm_fp8_nt_dispatch<4>(A, B, D, d_scale_a, d_scale_b, M, N, K,
+                              /*min_wgs=*/256, stream);
 }
 
 void smallm_fp8_nt_dev_alt(const void* A, const void* B, void* D,
@@ -410,5 +488,9 @@ void smallm_fp8_nt_dev_alt(const void* A, const void* B, void* D,
                            int M, int N, int K, float* split_ws,
                            hipStream_t stream) {
     (void)split_ws;
-    smallm_fp8_nt_dev_impl<2>(A, B, D, d_scale_a, d_scale_b, M, N, K, stream);
+    // Alt: w8 (512-thread WGs — probe: 8 waves helps at larger
+    // footprints, neutral at small), same total wave count as the
+    // default via a halved grid target.
+    smallm_fp8_nt_dispatch<8>(A, B, D, d_scale_a, d_scale_b, M, N, K,
+                              /*min_wgs=*/128, stream);
 }

--- a/csrc/amd/gemm/smallm_mfma.h
+++ b/csrc/amd/gemm/smallm_mfma.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+
+// ================================================================
+// FlashRT AMD — MFMA small-M FP8 GEMM (gfx950, wave64)
+//
+// Second-generation hand kernel for the decoder's tiny-M GEMMs,
+// built on two measured facts from the M4/M5 campaigns:
+//   1. the VALU convert+FMA inner product of smallm_fp8.hip is the
+//      "unresolved 4MB-regime limiter" — hipBLASLt wins with MI16x16
+//      matrix cores even at M=10 (the documented reactivation
+//      condition for this line), and
+//   2. the stream_probe winning recipe (independent load chains,
+//      ~64B in flight per lane) applies to the MFMA operand stream:
+//      B fragments are per-lane contiguous 8B in the nt (N,K) weight
+//      layout, 16 rows in parallel — the rs_x4_i4 pattern that
+//      measured ~5 TB/s.
+//
+// Shape contract (decoder pi05 sites: M=10, N∈{1024,2560,8192},
+// K∈{1024,2048,4096}):
+//   nt: D_bf16(M,N) = (A_fp8(M,K) @ W_fp8(N,K)^T) * dsa[0] * dsb[0]
+//   1 <= M <= 16, N % 16 == 0, K % 1024 == 0, 16B-aligned pointers.
+//
+// Structure: grid = N/16 workgroups x 256 threads (4 waves). Each
+// workgroup owns a 16-column tile; the 4 waves split K in 4 fixed
+// segments, accumulate with V_MFMA_F32_16X16X32_FP8_FP8 (FP32
+// accumulators, OCP e4m3 operands — gfx950 MFMA fp8 is OCP, not
+// fnuz), then reduce the 4 partials in ascending-wave order through
+// LDS and apply dsa*dsb before one BF16 store. No atomics; replay
+// inside a captured graph is bit-identical.
+//
+// A (<= 16x4096 fp8 = 64KB max, real rows only) is staged once into
+// LDS by the whole workgroup; fragment reads for pad rows m >= M
+// return zero (their C rows are never stored).
+//
+// `variant` selects the operand orientation (0 = A-as-a/W-as-b,
+// 1 = swapped) so the parity bench discovers the ISA fragment
+// mapping empirically instead of trusting documentation; the host
+// wrapper's production entry pins the verified one.
+// ================================================================
+
+int smallm_mfma_variant_count();
+const char* smallm_mfma_variant_name(int id);
+
+void smallm_mfma_nt(int variant,
+                    const void* A_fp8, const void* W_fp8,
+                    __hip_bfloat16* D, int M, int N, int K,
+                    const float* d_scale_a, const float* d_scale_b,
+                    hipStream_t stream);
+
+// Split-K partial form for the WG-starved narrow-N shapes (N=1024 ->
+// only 64 workgroups, per-WG streaming caps ~10GB/s): grid becomes
+// (N/16, splits), each split streams K/splits and writes UNSCALED
+// FP32 partials to ws[(split*M + m)*N + n]. The consumer kernel
+// (gate_residual_ada_norm_fp8_ksum) sums the splits in ascending
+// order, applies dsa*dsb and rounds to bf16 — preserving the
+// unfused chain's dataflow with no extra graph node. Deterministic:
+// no atomics. Constraints: as smallm_mfma_nt, plus splits in {2,4}
+// and K % (splits*4096) friendly (K/(splits*4*32) in {2,4,8,16,32}).
+void smallm_mfma_nt_partial(const void* A_fp8, const void* W_fp8,
+                            float* ws, int M, int N, int K, int splits,
+                            hipStream_t stream);
+
+// Packed-weight form — the bare-metal lever: weights are static, so
+// they are repacked ONCE at setup into the exact per-lane consumption
+// order, making every workgroup's stream perfectly linear (the
+// stream_probe co_x4_i4 pattern) instead of 16 rows strided K apart.
+//
+// Packed layout (per 16-row n-tile t, tile block = 16*K bytes):
+//   pos(t, sp, lane) = t*16*K + (sp*64 + lane)*16, holding
+//   W[n0+(lane&15)][64*sp + (lane>>4)*8 .. +8] ++ (same, +32)
+// i.e. torch: Wq.view(N//16, 16, K//64, 2, 4, 8)
+//                .permute(0, 2, 4, 1, 3, 5).contiguous()
+// Constraints: as smallm_mfma_nt, plus K % 2048 == 0 for the wave
+// split (K/(64*WAVES) chunk pairs per lane, WAVES=4).
+void smallm_mfma_nt_packed(const void* A_fp8, const void* Wp_fp8,
+                           __hip_bfloat16* D, int M, int N, int K,
+                           const float* d_scale_a, const float* d_scale_b,
+                           hipStream_t stream);

--- a/csrc/amd/gemm/smallm_mfma.hip
+++ b/csrc/amd/gemm/smallm_mfma.hip
@@ -1,0 +1,537 @@
+// ================================================================
+// FlashRT AMD — MFMA small-M FP8 GEMM (gfx950, wave64)
+// See smallm_mfma.h for the contract and design rationale.
+//
+// Fragment layout of V_MFMA_F32_16X16X32_FP8_FP8 (verified by the
+// parity bench, cos=1.0 on all pi05 shapes):
+//   a (i64): lane l supplies Amat[m = l&15][k = 32*step + 8*(l>>4) ..+8]
+//   b (i64): lane l supplies Bmat[n = l&15][same k window]
+//            for Bmat stored row-major (16 rows, K cols)
+//   c (f32x4): lane l element i = C[m = 4*(l>>4)+i][n = l&15]
+//
+// WAVES is the K-split factor inside one workgroup: the narrow-N
+// decoder shapes (N=1024 -> only 64 workgroups) cannot reach the
+// ~4MB GPU-wide in-flight target with 4 waves; deeper wave counts
+// multiply outstanding loads per CU at unchanged grid.
+// ================================================================
+
+#include "smallm_mfma.h"
+#include <hip/hip_fp8.h>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+typedef float floatx4 __attribute__((ext_vector_type(4)));
+
+// S = MFMA steps per wave segment (kseg = 32*S = K/WAVES).
+template<int S, int WAVES>
+__global__ __launch_bounds__(64 * WAVES)
+void smallm_mfma_nt_kernel(
+    const unsigned char* __restrict__ A,   // (M,K) fp8 e4m3
+    const unsigned char* __restrict__ W,   // (N,K) fp8 e4m3
+    __hip_bfloat16* __restrict__ D,        // (M,N) bf16
+    int M, int N, int K,
+    const float* __restrict__ dsa, const float* __restrict__ dsb) {
+    extern __shared__ unsigned char lds[];
+    unsigned char* a_lds = lds;                        // M rows x K bytes
+    float* red = reinterpret_cast<float*>(lds + (size_t)M * K);
+
+    const int tid = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int n0 = blockIdx.x * 16;
+
+    // ── Stage A (M x K fp8) into LDS, cooperative dwordx4 ──
+    {
+        const uint4* src = reinterpret_cast<const uint4*>(A);
+        uint4* dst = reinterpret_cast<uint4*>(a_lds);
+        int chunks = (M * K) >> 4;
+        for (int c = tid; c < chunks; c += blockDim.x)
+            dst[c] = src[c];
+    }
+    __syncthreads();
+
+    // ── Per-lane fragment geometry ──
+    const int fcol = lane & 15;      // n for the b-side / m for the a-side
+    const int kgrp = lane >> 4;      // 0..3 -> 8-byte sub-window of each 32k
+    const int kbase = wave * (32 * S);
+
+    const bool arow_valid = fcol < M;
+    const size_t arow = (size_t)(arow_valid ? fcol : 0) * K;
+    const unsigned long long* a8 =
+        reinterpret_cast<const unsigned long long*>(a_lds + arow + kbase + kgrp * 8);
+    const unsigned long long* w8 = reinterpret_cast<const unsigned long long*>(
+        W + (size_t)(n0 + fcol) * K + kbase + kgrp * 8);
+
+    floatx4 acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    // Full-segment prefetch: all S weight loads (8B each; the wave
+    // collectively covers each 32-byte window across kgrp lanes)
+    // issue before any MFMA consumes. Fixed ascending-k order.
+    unsigned long long bw[S];
+    #pragma unroll
+    for (int s = 0; s < S; ++s)
+        bw[s] = w8[s << 2];                    // +s*32 bytes
+    #pragma unroll
+    for (int s = 0; s < S; ++s) {
+        unsigned long long av = arow_valid ? a8[s << 2] : 0ull;
+        acc = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(
+            (long)av, (long)bw[s], acc, 0, 0, 0);
+    }
+
+    // ── Cross-wave reduce (ascending wave order — deterministic) ──
+    #pragma unroll
+    for (int i = 0; i < 4; ++i)
+        red[(wave << 8) + (lane << 2) + i] = acc[i];
+    __syncthreads();
+    if (wave != 0) return;
+
+    float sum[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        float s = red[(lane << 2) + i];
+        for (int wv = 1; wv < WAVES; ++wv)
+            s += red[(wv << 8) + (lane << 2) + i];
+        sum[i] = s;
+    }
+
+    const float s_ab = (*dsa) * (*dsb);
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        int m = (lane >> 4) * 4 + i;
+        int nl = lane & 15;
+        if (m < M)
+            D[(size_t)m * N + n0 + nl] = __float2bfloat16(sum[i] * s_ab);
+    }
+}
+
+// ── LDS-staged variant ──
+// The direct kernel's B loads are 8B (dwordx2) — half the bytes per
+// outstanding request of the stream_probe winners, and the measured
+// per-CU byte rate (~8-10 GB/s) is half the probe's (~26 GB/s at
+// dwordx4). This variant decouples the memory pattern from the MFMA
+// fragment layout: each wave stages its rows into a PRIVATE LDS
+// region with per-lane independent dwordx4 chains (the probe-exact
+// recipe), then feeds MFMA fragments from LDS.
+template<int S, int WAVES>
+__global__ __launch_bounds__(64 * WAVES)
+void smallm_mfma_nt_lds_kernel(
+    const unsigned char* __restrict__ A,
+    const unsigned char* __restrict__ W,
+    __hip_bfloat16* __restrict__ D,
+    int M, int N, int K,
+    const float* __restrict__ dsa, const float* __restrict__ dsb) {
+    constexpr int RSTEPS = (S < 8) ? S : 8;      // MFMA steps per round
+    constexpr int ROUNDS = S / RSTEPS;
+    constexpr int ROWB = RSTEPS * 32;            // staged bytes per row
+    constexpr int LCH = (16 * ROWB / 16) / 64;   // 16B chunks per lane
+
+    extern __shared__ unsigned char lds[];
+    unsigned char* a_lds = lds;                              // M*K
+    unsigned char* b_lds = lds + (size_t)M * K;              // WAVES*16*ROWB
+    float* red = reinterpret_cast<float*>(b_lds + (size_t)WAVES * 16 * ROWB);
+
+    const int tid = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int n0 = blockIdx.x * 16;
+
+    {
+        const uint4* src = reinterpret_cast<const uint4*>(A);
+        uint4* dst = reinterpret_cast<uint4*>(a_lds);
+        int chunks = (M * K) >> 4;
+        for (int c = tid; c < chunks; c += blockDim.x)
+            dst[c] = src[c];
+    }
+    __syncthreads();
+
+    const int fcol = lane & 15;
+    const int kgrp = lane >> 4;
+    const int kbase = wave * (32 * S);
+    const bool arow_valid = fcol < M;
+    const size_t arow = (size_t)(arow_valid ? fcol : 0) * K;
+    const unsigned long long* a8 =
+        reinterpret_cast<const unsigned long long*>(a_lds + arow + kbase + kgrp * 8);
+    unsigned char* breg = b_lds + (size_t)wave * 16 * ROWB;
+    const unsigned char* wbase = W + (size_t)n0 * K + kbase;
+
+    floatx4 acc = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int r = 0; r < ROUNDS; ++r) {
+        // stage: LCH independent dwordx4 per lane, linear over the
+        // wave's 16-row x ROWB tile (row-major in LDS)
+        uint4 tmp[LCH];
+        #pragma unroll
+        for (int j = 0; j < LCH; ++j) {
+            int c = lane + j * 64;
+            int row = c / (ROWB / 16);
+            int off = (c % (ROWB / 16)) * 16;
+            tmp[j] = *reinterpret_cast<const uint4*>(
+                wbase + (size_t)row * K + r * ROWB + off);
+        }
+        #pragma unroll
+        for (int j = 0; j < LCH; ++j)
+            *reinterpret_cast<uint4*>(breg + (size_t)(lane + j * 64) * 16) = tmp[j];
+        __syncthreads();
+        #pragma unroll
+        for (int s = 0; s < RSTEPS; ++s) {
+            unsigned long long bv = *reinterpret_cast<const unsigned long long*>(
+                breg + (size_t)fcol * ROWB + s * 32 + kgrp * 8);
+            unsigned long long av =
+                arow_valid ? a8[(r * RSTEPS + s) << 2] : 0ull;
+            acc = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(
+                (long)av, (long)bv, acc, 0, 0, 0);
+        }
+        if (r + 1 < ROUNDS) __syncthreads();   // before the next overwrite
+    }
+
+    __syncthreads();
+    #pragma unroll
+    for (int i = 0; i < 4; ++i)
+        red[(wave << 8) + (lane << 2) + i] = acc[i];
+    __syncthreads();
+    if (wave != 0) return;
+
+    float sum[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        float s = red[(lane << 2) + i];
+        for (int wv = 1; wv < WAVES; ++wv)
+            s += red[(wv << 8) + (lane << 2) + i];
+        sum[i] = s;
+    }
+    const float s_ab = (*dsa) * (*dsb);
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        int m = (lane >> 4) * 4 + i;
+        int nl = lane & 15;
+        if (m < M)
+            D[(size_t)m * N + n0 + nl] = __float2bfloat16(sum[i] * s_ab);
+    }
+}
+
+// Split-K partial kernel: LDS-staged loads, grid (N/16, splits),
+// FP32 unscaled partial output per split (see header). WAVES=4.
+template<int S>
+__global__ __launch_bounds__(256)
+void smallm_mfma_nt_partial_kernel(
+    const unsigned char* __restrict__ A,
+    const unsigned char* __restrict__ W,
+    float* __restrict__ ws,              // (splits, M, N) f32
+    int M, int N, int K,
+    int kseg_total) {                    // K / splits
+    constexpr int WAVES = 4;
+    constexpr int RSTEPS = (S < 8) ? S : 8;
+    constexpr int ROUNDS = S / RSTEPS;
+    constexpr int ROWB = RSTEPS * 32;
+    constexpr int LCH = (16 * ROWB / 16) / 64;
+
+    extern __shared__ unsigned char lds[];
+    unsigned char* a_lds = lds;
+    unsigned char* b_lds = lds + (size_t)M * K;
+    float* red = reinterpret_cast<float*>(b_lds + (size_t)WAVES * 16 * ROWB);
+
+    const int tid = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int n0 = blockIdx.x * 16;
+    const int split = blockIdx.y;
+
+    {
+        const uint4* src = reinterpret_cast<const uint4*>(A);
+        uint4* dst = reinterpret_cast<uint4*>(a_lds);
+        int chunks = (M * K) >> 4;
+        for (int c = tid; c < chunks; c += blockDim.x)
+            dst[c] = src[c];
+    }
+    __syncthreads();
+
+    const int fcol = lane & 15;
+    const int kgrp = lane >> 4;
+    const int kbase = split * kseg_total + wave * (32 * S);
+    const bool arow_valid = fcol < M;
+    const size_t arow = (size_t)(arow_valid ? fcol : 0) * K;
+    const unsigned long long* a8 =
+        reinterpret_cast<const unsigned long long*>(a_lds + arow + kbase + kgrp * 8);
+    unsigned char* breg = b_lds + (size_t)wave * 16 * ROWB;
+    const unsigned char* wbase = W + (size_t)n0 * K + kbase;
+
+    floatx4 acc = {0.0f, 0.0f, 0.0f, 0.0f};
+    for (int r = 0; r < ROUNDS; ++r) {
+        uint4 tmp[LCH];
+        #pragma unroll
+        for (int j = 0; j < LCH; ++j) {
+            int c = lane + j * 64;
+            int row = c / (ROWB / 16);
+            int off = (c % (ROWB / 16)) * 16;
+            tmp[j] = *reinterpret_cast<const uint4*>(
+                wbase + (size_t)row * K + r * ROWB + off);
+        }
+        #pragma unroll
+        for (int j = 0; j < LCH; ++j)
+            *reinterpret_cast<uint4*>(breg + (size_t)(lane + j * 64) * 16) = tmp[j];
+        __syncthreads();
+        #pragma unroll
+        for (int s = 0; s < RSTEPS; ++s) {
+            unsigned long long bv = *reinterpret_cast<const unsigned long long*>(
+                breg + (size_t)fcol * ROWB + s * 32 + kgrp * 8);
+            unsigned long long av =
+                arow_valid ? a8[(r * RSTEPS + s) << 2] : 0ull;
+            acc = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(
+                (long)av, (long)bv, acc, 0, 0, 0);
+        }
+        if (r + 1 < ROUNDS) __syncthreads();
+    }
+
+    __syncthreads();
+    #pragma unroll
+    for (int i = 0; i < 4; ++i)
+        red[(wave << 8) + (lane << 2) + i] = acc[i];
+    __syncthreads();
+    if (wave != 0) return;
+
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        float s = red[(lane << 2) + i];
+        #pragma unroll
+        for (int wv = 1; wv < WAVES; ++wv)
+            s += red[(wv << 8) + (lane << 2) + i];
+        int m = (lane >> 4) * 4 + i;
+        int nl = lane & 15;
+        if (m < M)
+            ws[((size_t)split * M + m) * N + n0 + nl] = s;
+    }
+}
+
+// Packed-weight kernel (see header): the weight stream is one linear
+// slab per (tile, wave) — pure co-pattern dwordx4 chains, all PAIRS
+// chunks in flight per lane before any MFMA consumes.
+template<int PAIRS>   // 16B chunk-pairs per lane = (K/128)/... = K/(64*4)/2? = S/2
+__global__ __launch_bounds__(256)
+void smallm_mfma_nt_packed_kernel(
+    const unsigned char* __restrict__ A,
+    const unsigned char* __restrict__ Wp,   // packed (see header)
+    __hip_bfloat16* __restrict__ D,
+    int M, int N, int K,
+    const float* __restrict__ dsa, const float* __restrict__ dsb) {
+    constexpr int WAVES = 4;
+    extern __shared__ unsigned char lds[];
+    unsigned char* a_lds = lds;
+    float* red = reinterpret_cast<float*>(lds + (size_t)M * K);
+
+    const int tid = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int n0 = blockIdx.x * 16;
+
+    {
+        const uint4* src = reinterpret_cast<const uint4*>(A);
+        uint4* dst = reinterpret_cast<uint4*>(a_lds);
+        int chunks = (M * K) >> 4;
+        for (int c = tid; c < chunks; c += blockDim.x)
+            dst[c] = src[c];
+    }
+    __syncthreads();
+
+    const int fcol = lane & 15;
+    const int kgrp = lane >> 4;
+    const int kbase = wave * (64 * PAIRS);   // = wave * 32 * S
+    const bool arow_valid = fcol < M;
+    const size_t arow = (size_t)(arow_valid ? fcol : 0) * K;
+    const unsigned long long* a8 =
+        reinterpret_cast<const unsigned long long*>(a_lds + arow + kbase + kgrp * 8);
+
+    const uint4* wp = reinterpret_cast<const uint4*>(
+        Wp + (size_t)blockIdx.x * 16 * K)
+        + (size_t)(wave * PAIRS) * 64 + lane;
+
+    uint4 ch[PAIRS];
+    #pragma unroll
+    for (int j = 0; j < PAIRS; ++j)
+        ch[j] = wp[(size_t)j * 64];
+
+    floatx4 acc = {0.0f, 0.0f, 0.0f, 0.0f};
+    #pragma unroll
+    for (int j = 0; j < PAIRS; ++j) {
+        unsigned long long bv0 =
+            ((unsigned long long)ch[j].y << 32) | ch[j].x;
+        unsigned long long bv1 =
+            ((unsigned long long)ch[j].w << 32) | ch[j].z;
+        unsigned long long av0 = arow_valid ? a8[(2 * j) << 2] : 0ull;
+        unsigned long long av1 = arow_valid ? a8[(2 * j + 1) << 2] : 0ull;
+        acc = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(
+            (long)av0, (long)bv0, acc, 0, 0, 0);
+        acc = __builtin_amdgcn_mfma_f32_16x16x32_fp8_fp8(
+            (long)av1, (long)bv1, acc, 0, 0, 0);
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 4; ++i)
+        red[(wave << 8) + (lane << 2) + i] = acc[i];
+    __syncthreads();
+    if (wave != 0) return;
+
+    float sum[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        float s = red[(lane << 2) + i];
+        #pragma unroll
+        for (int wv = 1; wv < WAVES; ++wv)
+            s += red[(wv << 8) + (lane << 2) + i];
+        sum[i] = s;
+    }
+    const float s_ab = (*dsa) * (*dsb);
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        int m = (lane >> 4) * 4 + i;
+        int nl = lane & 15;
+        if (m < M)
+            D[(size_t)m * N + n0 + nl] = __float2bfloat16(sum[i] * s_ab);
+    }
+}
+
+struct MfmaVariant { const char* name; int waves; bool lds; };  // waves 0 = auto
+const MfmaVariant kVariants[] = {
+    {"m0_auto",   0, false},
+    {"m1_w4",     4, false},
+    {"m2_w8",     8, false},
+    {"m3_w16",   16, false},
+    {"m4_lds_w4", 4, true},
+    {"m5_lds_w8", 8, true},
+};
+
+template<int WAVES>
+void launch_w(const unsigned char* A, const unsigned char* W,
+              __hip_bfloat16* D, int M, int N, int K,
+              const float* dsa, const float* dsb,
+              size_t smem, hipStream_t stream) {
+    dim3 grid(N / 16);
+    int steps = K / (32 * WAVES);
+    switch (steps) {
+    case 2:  smallm_mfma_nt_kernel<2,  WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    case 4:  smallm_mfma_nt_kernel<4,  WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    case 8:  smallm_mfma_nt_kernel<8,  WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    case 16: smallm_mfma_nt_kernel<16, WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    case 32: smallm_mfma_nt_kernel<32, WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    default:
+        throw std::runtime_error("smallm_mfma_nt: unsupported K/WAVES combination");
+    }
+}
+
+template<int WAVES>
+void launch_lds(const unsigned char* A, const unsigned char* W,
+                __hip_bfloat16* D, int M, int N, int K,
+                const float* dsa, const float* dsb,
+                hipStream_t stream) {
+    dim3 grid(N / 16);
+    int steps = K / (32 * WAVES);
+    int rsteps = steps < 8 ? steps : 8;
+    size_t smem = (size_t)M * K + (size_t)WAVES * 16 * (rsteps * 32)
+                  + (size_t)WAVES * 64 * 4 * sizeof(float);
+    if (smem > 64 * 1024)
+        throw std::runtime_error("smallm_mfma_nt: lds variant exceeds 64KB LDS");
+    switch (steps) {
+    case 4:  smallm_mfma_nt_lds_kernel<4,  WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    case 8:  smallm_mfma_nt_lds_kernel<8,  WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    case 16: smallm_mfma_nt_lds_kernel<16, WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    case 32: smallm_mfma_nt_lds_kernel<32, WAVES><<<grid, 64 * WAVES, smem, stream>>>(A, W, D, M, N, K, dsa, dsb); break;
+    default:
+        throw std::runtime_error("smallm_mfma_nt: unsupported K/WAVES for lds variant");
+    }
+}
+
+} // namespace
+
+void smallm_mfma_nt_partial(const void* A_fp8, const void* W_fp8,
+                            float* ws, int M, int N, int K, int splits,
+                            hipStream_t stream) {
+    if (M < 1 || M > 16 || N % 16 != 0)
+        throw std::runtime_error("smallm_mfma_nt_partial: bad M/N");
+    if (splits != 2 && splits != 4)
+        throw std::runtime_error("smallm_mfma_nt_partial: splits must be 2 or 4");
+    int kseg_total = K / splits;
+    if (K % splits != 0 || kseg_total % 128 != 0)
+        throw std::runtime_error("smallm_mfma_nt_partial: K not divisible");
+    int steps = kseg_total / (32 * 4);     // per-wave steps, WAVES=4
+    int rsteps = steps < 8 ? steps : 8;
+    size_t smem = (size_t)M * K + 4 * 16 * (rsteps * 32) + 4 * 64 * 4 * sizeof(float);
+    if (smem > 64 * 1024)
+        throw std::runtime_error("smallm_mfma_nt_partial: exceeds 64KB LDS");
+    dim3 grid(N / 16, splits);
+    const unsigned char* A = static_cast<const unsigned char*>(A_fp8);
+    const unsigned char* W = static_cast<const unsigned char*>(W_fp8);
+    switch (steps) {
+    case 2:  smallm_mfma_nt_partial_kernel<2><<<grid, 256, smem, stream>>>(A, W, ws, M, N, K, kseg_total); break;
+    case 4:  smallm_mfma_nt_partial_kernel<4><<<grid, 256, smem, stream>>>(A, W, ws, M, N, K, kseg_total); break;
+    case 8:  smallm_mfma_nt_partial_kernel<8><<<grid, 256, smem, stream>>>(A, W, ws, M, N, K, kseg_total); break;
+    case 16: smallm_mfma_nt_partial_kernel<16><<<grid, 256, smem, stream>>>(A, W, ws, M, N, K, kseg_total); break;
+    default:
+        throw std::runtime_error("smallm_mfma_nt_partial: unsupported K/splits");
+    }
+}
+
+void smallm_mfma_nt_packed(const void* A_fp8, const void* Wp_fp8,
+                           __hip_bfloat16* D, int M, int N, int K,
+                           const float* d_scale_a, const float* d_scale_b,
+                           hipStream_t stream) {
+    if (M < 1 || M > 16 || N % 16 != 0 || K % 1024 != 0)
+        throw std::runtime_error("smallm_mfma_nt_packed: bad M/N/K");
+    int pairs = K / 256;                    // (K/128 steps) / 2, WAVES=4
+    size_t smem = (size_t)M * K + 4 * 64 * 4 * sizeof(float);
+    dim3 grid(N / 16);
+    const unsigned char* A = static_cast<const unsigned char*>(A_fp8);
+    const unsigned char* Wp = static_cast<const unsigned char*>(Wp_fp8);
+    switch (pairs) {
+    case 4:  smallm_mfma_nt_packed_kernel<4><<<grid, 256, smem, stream>>>(A, Wp, D, M, N, K, d_scale_a, d_scale_b); break;
+    case 8:  smallm_mfma_nt_packed_kernel<8><<<grid, 256, smem, stream>>>(A, Wp, D, M, N, K, d_scale_a, d_scale_b); break;
+    case 16: smallm_mfma_nt_packed_kernel<16><<<grid, 256, smem, stream>>>(A, Wp, D, M, N, K, d_scale_a, d_scale_b); break;
+    default:
+        throw std::runtime_error("smallm_mfma_nt_packed: unsupported K");
+    }
+}
+
+int smallm_mfma_variant_count() { return (int)(sizeof(kVariants) / sizeof(kVariants[0])); }
+const char* smallm_mfma_variant_name(int id) { return kVariants[id].name; }
+
+void smallm_mfma_nt(int variant,
+                    const void* A_fp8, const void* W_fp8,
+                    __hip_bfloat16* D, int M, int N, int K,
+                    const float* d_scale_a, const float* d_scale_b,
+                    hipStream_t stream) {
+    if (variant < 0 || variant >= smallm_mfma_variant_count())
+        throw std::runtime_error("smallm_mfma_nt: bad variant " + std::to_string(variant));
+    if (M < 1 || M > 16)
+        throw std::runtime_error("smallm_mfma_nt: M must be in [1,16]");
+    if (N % 16 != 0 || K % 1024 != 0)
+        throw std::runtime_error("smallm_mfma_nt: need N%16==0 and K%1024==0");
+    if (((uintptr_t)A_fp8 & 15) || ((uintptr_t)W_fp8 & 15))
+        throw std::runtime_error("smallm_mfma_nt: pointers must be 16B-aligned");
+    int waves = kVariants[variant].waves;
+    if (waves == 0) {
+        // auto: deepen the K-split until grid x waves covers ~1024 waves
+        int wgs = N / 16;
+        waves = 4;
+        while (waves < 16 && wgs * waves < 1024 && (K / (32 * waves)) > 2)
+            waves *= 2;
+    }
+    const unsigned char* A = static_cast<const unsigned char*>(A_fp8);
+    const unsigned char* W = static_cast<const unsigned char*>(W_fp8);
+    if (kVariants[variant].lds) {
+        switch (waves) {
+        case 4: launch_lds<4>(A, W, D, M, N, K, d_scale_a, d_scale_b, stream); break;
+        case 8: launch_lds<8>(A, W, D, M, N, K, d_scale_a, d_scale_b, stream); break;
+        default:
+            throw std::runtime_error("smallm_mfma_nt: lds variant waves must be 4/8");
+        }
+        return;
+    }
+    size_t smem = (size_t)M * K + (size_t)waves * 64 * 4 * sizeof(float);
+    switch (waves) {
+    case 4:  launch_w<4>(A, W, D, M, N, K, d_scale_a, d_scale_b, smem, stream); break;
+    case 8:  launch_w<8>(A, W, D, M, N, K, d_scale_a, d_scale_b, smem, stream); break;
+    case 16: launch_w<16>(A, W, D, M, N, K, d_scale_a, d_scale_b, smem, stream); break;
+    default:
+        throw std::runtime_error("smallm_mfma_nt: waves must be 4/16");
+    }
+}

--- a/csrc/amd/kernels/activation.hip
+++ b/csrc/amd/kernels/activation.hip
@@ -1,11 +1,19 @@
 // ================================================================
 // FlashRT AMD — Activation kernels (dtype-generic, CDNA wave64)
-// GeLU, GeGLU (split and merged), fused bias+GeLU (strict).
+// GeLU, GeGLU (split and merged), fused bias+GeLU (strict),
+// merged GeGLU → FP8 (gate_geglu_merged_fp8).
 // Mirrors csrc/kernels/activation.cu host-wrapper signatures exactly
 // so the pipeline layer stays portable text across platforms.
+//
+// FP8 output dtype: OCP e4m3 via <hip/hip_fp8.h> __hip_fp8_e4m3
+// (saturating RNE conversion, same as __nv_fp8_e4m3; values are
+// pre-clamped to ±448 exactly as in activation.cu). Only the generic
+// (BF16-bound) gate_geglu_merged_fp8 path is ported; the vectorized
+// FP16 encoder variant stays CUDA-only.
 // ================================================================
 
 #include "common_hip.h"
+#include <hip/hip_fp8.h>
 
 // ── Gate GELU Multiply ──
 // GELU(x) approx: x * sigmoid(1.5957691216 * x * (1 + 0.044715 * x^2))
@@ -126,4 +134,39 @@ void gate_geglu_merged(const __hip_bfloat16* merged, __hip_bfloat16* out,
     int total = seq * half_dim;
     int blocks = (total + 255) / 256;
     gate_geglu_merged_kernel<__hip_bfloat16><<<blocks, 256, 0, stream>>>(merged, out, seq, half_dim);
+}
+
+// ── Gate GELU Mul Merged → FP8 ──
+// Merged layout: merged[s, 0..H-1] = gate, merged[s, H..2H-1] = up
+template<typename T>
+__global__ void gate_geglu_merged_fp8_kernel(const T* __restrict__ merged,
+                                                 __hip_fp8_e4m3* __restrict__ out,
+                                                 int seq, int half_dim,
+                                                 const float* __restrict__ d_scale) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * half_dim;
+    if (idx < total) {
+        int row = idx / half_dim;
+        int col = idx % half_dim;
+        int full_dim = half_dim * 2;
+        float g = to_f32(merged[row * full_dim + col]);
+        float u = to_f32(merged[row * full_dim + half_dim + col]);
+        float gelu = g / (1.0f + expf(-1.5957691216057308f * g * (1.0f + 0.044715f * g * g)));
+        float val = gelu * u;
+        float inv_scale = 1.0f / (*d_scale);
+        val = fminf(fmaxf(val * inv_scale, -448.0f), 448.0f);
+        out[idx] = __hip_fp8_e4m3(val);
+    }
+}
+
+template __global__ void gate_geglu_merged_fp8_kernel<__half>(const __half*, __hip_fp8_e4m3*, int, int, const float*);
+template __global__ void gate_geglu_merged_fp8_kernel<__hip_bfloat16>(const __hip_bfloat16*, __hip_fp8_e4m3*, int, int, const float*);
+
+void gate_geglu_merged_fp8(const __hip_bfloat16* merged, __hip_fp8_e4m3* out,
+                               int seq, int half_dim,
+                               const float* d_scale, hipStream_t stream) {
+    int total = seq * half_dim;
+    int blocks = (total + 255) / 256;
+    gate_geglu_merged_fp8_kernel<__hip_bfloat16><<<blocks, 256, 0, stream>>>(
+        merged, out, seq, half_dim, d_scale);
 }

--- a/csrc/amd/kernels/activation.hip
+++ b/csrc/amd/kernels/activation.hip
@@ -1,0 +1,129 @@
+// ================================================================
+// FlashRT AMD — Activation kernels (dtype-generic, CDNA wave64)
+// GeLU, GeGLU (split and merged), fused bias+GeLU (strict).
+// Mirrors csrc/kernels/activation.cu host-wrapper signatures exactly
+// so the pipeline layer stays portable text across platforms.
+// ================================================================
+
+#include "common_hip.h"
+
+// ── Gate GELU Multiply ──
+// GELU(x) approx: x * sigmoid(1.5957691216 * x * (1 + 0.044715 * x^2))
+// (tanh/sigmoid approx GELU, not SiLU — matches the CUDA kernel.)
+template<typename T>
+__global__ void gate_geglu_kernel(const T* __restrict__ gate,
+                                  const T* __restrict__ up,
+                                  T* __restrict__ out, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float g = to_f32(gate[idx]);
+        float u = to_f32(up[idx]);
+        float gelu = g / (1.0f + expf(-1.5957691216057308f * g * (1.0f + 0.044715f * g * g)));
+        out[idx] = from_f32<T>(gelu * u);
+    }
+}
+
+template __global__ void gate_geglu_kernel<__half>(const __half*, const __half*, __half*, int);
+template __global__ void gate_geglu_kernel<__hip_bfloat16>(const __hip_bfloat16*, const __hip_bfloat16*, __hip_bfloat16*, int);
+
+void gate_geglu(const __hip_bfloat16* gate, const __hip_bfloat16* up,
+                __hip_bfloat16* out, int n, hipStream_t stream) {
+    gate_geglu_kernel<__hip_bfloat16><<<(n + 255) / 256, 256, 0, stream>>>(gate, up, out, n);
+}
+
+// ── GELU in-place (tanh approx) ──
+template<typename T>
+__global__ void gelu_kernel(T* __restrict__ x, int n) {
+    using T2 = typename packed2<T>::type;
+    T2* x2 = reinterpret_cast<T2*>(x);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        T2 val = x2[idx];
+        float v0 = to_f32(val.x), v1 = to_f32(val.y);
+        float t0 = tanhf(0.7978845608f * (v0 + 0.044715f * v0 * v0 * v0));
+        float t1 = tanhf(0.7978845608f * (v1 + 0.044715f * v1 * v1 * v1));
+        x2[idx] = make_packed2<T>(
+            from_f32<T>(v0 * 0.5f * (1.0f + t0)),
+            from_f32<T>(v1 * 0.5f * (1.0f + t1)));
+    }
+}
+
+template __global__ void gelu_kernel<__half>(__half*, int);
+template __global__ void gelu_kernel<__hip_bfloat16>(__hip_bfloat16*, int);
+
+void gelu_inplace(__hip_bfloat16* x, int n, hipStream_t stream) {
+    int n2 = n >> 1;
+    gelu_kernel<__hip_bfloat16><<<(n2 + 255) / 256, 256, 0, stream>>>(x, n);
+}
+
+// ── Fused (bias add + GELU(tanh)) in-place, strict rounding ──
+// The bias-added value is rounded to the storage dtype BEFORE the GELU
+// (bit-matching an unfused add_bias → gelu_inplace pair). In-place on x;
+// bias broadcast over rows.
+template<typename T>
+__global__ void bias_gelu_strict_kernel(T* __restrict__ x,
+                                        const T* __restrict__ bias,
+                                        int M, int N) {
+    using T2 = typename packed2<T>::type;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total2 = (M * N) >> 1;        // pair index
+    if (idx >= total2) return;
+    int n2 = N >> 1;                  // pairs per row
+    int row = idx / n2;
+    int col_pair = idx - row * n2;
+    T2* x2 = reinterpret_cast<T2*>(x);
+    const T2* b2 = reinterpret_cast<const T2*>(bias);
+    T2 v = x2[idx];
+    T2 b = b2[col_pair];
+    T v0_lp = from_f32<T>(to_f32(v.x) + to_f32(b.x));
+    T v1_lp = from_f32<T>(to_f32(v.y) + to_f32(b.y));
+    float v0 = to_f32(v0_lp);
+    float v1 = to_f32(v1_lp);
+    float t0 = tanhf(0.7978845608f * (v0 + 0.044715f * v0 * v0 * v0));
+    float t1 = tanhf(0.7978845608f * (v1 + 0.044715f * v1 * v1 * v1));
+    x2[idx] = make_packed2<T>(
+        from_f32<T>(v0 * 0.5f * (1.0f + t0)),
+        from_f32<T>(v1 * 0.5f * (1.0f + t1)));
+    (void)row;
+}
+
+template __global__ void bias_gelu_strict_kernel<__half>(__half*, const __half*, int, int);
+template __global__ void bias_gelu_strict_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, int, int);
+
+void bias_gelu_inplace_bf16_strict(__hip_bfloat16* x,
+                                   const __hip_bfloat16* bias,
+                                   int M, int N, hipStream_t stream) {
+    int total2 = (M * N) >> 1;
+    bias_gelu_strict_kernel<__hip_bfloat16><<<(total2 + 255) / 256, 256, 0, stream>>>(
+        x, bias, M, N);
+}
+
+// ── Gate GELU Mul Merged ──
+// Input: (seq, 2*half_dim), gate = [:, :half_dim], up = [:, half_dim:]
+template<typename T>
+__global__ void gate_geglu_merged_kernel(const T* __restrict__ merged,
+                                         T* __restrict__ out,
+                                         int seq, int half_dim) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * half_dim;
+    if (idx < total) {
+        int row = idx / half_dim;
+        int col = idx % half_dim;
+        int full_dim = half_dim * 2;
+        float g = to_f32(merged[row * full_dim + col]);
+        float u = to_f32(merged[row * full_dim + half_dim + col]);
+        float gelu = g / (1.0f + expf(-1.5957691216057308f * g * (1.0f + 0.044715f * g * g)));
+        out[idx] = from_f32<T>(gelu * u);
+    }
+}
+
+template __global__ void gate_geglu_merged_kernel<__half>(const __half*, __half*, int, int);
+template __global__ void gate_geglu_merged_kernel<__hip_bfloat16>(const __hip_bfloat16*, __hip_bfloat16*, int, int);
+
+void gate_geglu_merged(const __hip_bfloat16* merged, __hip_bfloat16* out,
+                       int seq, int half_dim, hipStream_t stream) {
+    int total = seq * half_dim;
+    int blocks = (total + 255) / 256;
+    gate_geglu_merged_kernel<__hip_bfloat16><<<blocks, 256, 0, stream>>>(merged, out, seq, half_dim);
+}

--- a/csrc/amd/kernels/common_hip.h
+++ b/csrc/amd/kernels/common_hip.h
@@ -1,0 +1,75 @@
+// ================================================================
+// FlashRT AMD — Common HIP kernel utilities (CDNA, wave64)
+// Shared helpers used across all AMD kernel files.
+//
+// Mirrors csrc/kernels/common.cuh with the CDNA differences:
+//   - wavefront size is 64 (not 32); reductions use __shfl_down
+//     (HIP has no *_sync variants — waves execute in lockstep)
+//   - dtypes come from <hip/hip_fp16.h> / <hip/hip_bf16.h>
+//     (__hip_bfloat16 provides the CUDA-compatible conversion API)
+// ================================================================
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <cstdint>
+
+#define FVK_WAVE_SIZE 64
+
+// ── Generic dtype conversion (template) ──
+
+template<typename T> __device__ __forceinline__ float to_f32(T x);
+template<> __device__ __forceinline__ float to_f32<__half>(__half x) { return __half2float(x); }
+template<> __device__ __forceinline__ float to_f32<__hip_bfloat16>(__hip_bfloat16 x) { return __bfloat162float(x); }
+
+template<typename T> __device__ __forceinline__ T from_f32(float x);
+template<> __device__ __forceinline__ __half from_f32<__half>(float x) { return __float2half(x); }
+template<> __device__ __forceinline__ __hip_bfloat16 from_f32<__hip_bfloat16>(float x) { return __float2bfloat16(x); }
+
+// Packed 2-element type: __half2 for FP16, __hip_bfloat162 for BF16
+template<typename T> struct packed2;
+template<> struct packed2<__half> { using type = __half2; };
+template<> struct packed2<__hip_bfloat16> { using type = __hip_bfloat162; };
+
+template<typename T> __device__ __forceinline__ typename packed2<T>::type make_packed2(T a, T b);
+template<> __device__ __forceinline__ __half2 make_packed2<__half>(__half a, __half b) { return __halves2half2(a, b); }
+template<> __device__ __forceinline__ __hip_bfloat162 make_packed2<__hip_bfloat16>(__hip_bfloat16 a, __hip_bfloat16 b) { return __halves2bfloat162(a, b); }
+
+// ── Wave-level reductions (wave64, no shared memory) ──
+
+__device__ __forceinline__ float wave_reduce_sum(float val) {
+    #pragma unroll
+    for (int off = FVK_WAVE_SIZE / 2; off > 0; off >>= 1)
+        val += __shfl_down(val, off);
+    return val;
+}
+
+__device__ __forceinline__ float wave_reduce_max(float val) {
+    #pragma unroll
+    for (int off = FVK_WAVE_SIZE / 2; off > 0; off >>= 1)
+        val = fmaxf(val, __shfl_down(val, off));
+    return val;
+}
+
+// ── Block-level reduction (LDS for inter-wave) ──
+// Result is broadcast: every thread in the block receives the full sum.
+// `shared` must hold at least ceil(blockDim.x / 64) floats.
+
+__device__ __forceinline__ float block_reduce_sum(float val, float* shared) {
+    const int lane = threadIdx.x & (FVK_WAVE_SIZE - 1);
+    const int wave = threadIdx.x >> 6;
+    const int nwaves = (blockDim.x + FVK_WAVE_SIZE - 1) >> 6;
+
+    val = wave_reduce_sum(val);
+    if (lane == 0) shared[wave] = val;
+    __syncthreads();
+
+    if (wave == 0) {
+        float v = (lane < nwaves) ? shared[lane] : 0.0f;
+        v = wave_reduce_sum(v);
+        if (lane == 0) shared[0] = v;
+    }
+    __syncthreads();
+    return shared[0];
+}

--- a/csrc/amd/kernels/elementwise.hip
+++ b/csrc/amd/kernels/elementwise.hip
@@ -59,9 +59,45 @@ __global__ void bias_res_kernel(T* __restrict__ residual,
 template __global__ void bias_res_kernel<__half>(__half*, const __half*, const __half*, int);
 template __global__ void bias_res_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, int);
 
+// Wide 2D variant (CDNA retune): dwordx4 accesses, one 8-element
+// chunk per thread, blockIdx.y = row. Same per-element math —
+// bit-exact vs the row-per-block loop.
+struct alignas(16) ewi_bf16x8 { __hip_bfloat162 p[4]; };
+
+__global__ void bias_res_wide_kernel(__hip_bfloat16* __restrict__ residual,
+                                     const __hip_bfloat16* __restrict__ x,
+                                     const __hip_bfloat16* __restrict__ bias,
+                                     int dim) {
+    const int row = blockIdx.y;
+    const int c = blockIdx.x * blockDim.x + threadIdx.x;
+    const int chunks = dim >> 3;
+    if (c >= chunks) return;
+    ewi_bf16x8* res8 = reinterpret_cast<ewi_bf16x8*>(residual + (size_t)row * dim);
+    const ewi_bf16x8* x8 = reinterpret_cast<const ewi_bf16x8*>(x + (size_t)row * dim);
+    const ewi_bf16x8* b8 = reinterpret_cast<const ewi_bf16x8*>(bias);
+    ewi_bf16x8 rv = res8[c];
+    ewi_bf16x8 xv = x8[c];
+    ewi_bf16x8 bv = b8[c];
+    ewi_bf16x8 o;
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) {
+        float r0 = to_f32(rv.p[k].x) + to_f32(xv.p[k].x) + to_f32(bv.p[k].x);
+        float r1 = to_f32(rv.p[k].y) + to_f32(xv.p[k].y) + to_f32(bv.p[k].y);
+        o.p[k] = make_packed2<__hip_bfloat16>(
+            from_f32<__hip_bfloat16>(r0), from_f32<__hip_bfloat16>(r1));
+    }
+    res8[c] = o;
+}
+
 void bias_residual(__hip_bfloat16* residual, const __hip_bfloat16* x,
                    const __hip_bfloat16* bias, int seq_len, int dim,
                    hipStream_t stream) {
+    if (dim % 8 == 0) {
+        int chunks = dim >> 3;
+        dim3 grid((chunks + 255) / 256, seq_len);
+        bias_res_wide_kernel<<<grid, 256, 0, stream>>>(residual, x, bias, dim);
+        return;
+    }
     bias_res_kernel<__hip_bfloat16><<<seq_len, 256, 0, stream>>>(residual, x, bias, dim);
 }
 

--- a/csrc/amd/kernels/elementwise.hip
+++ b/csrc/amd/kernels/elementwise.hip
@@ -1,6 +1,7 @@
 // ================================================================
 // FlashRT AMD — Elementwise kernels (dtype-generic, CDNA wave64)
-// Residual add, gate multiply, bias residual, broadcast bias add.
+// Residual add, gate multiply, bias residual, broadcast bias add,
+// GPU copy (graph-compatible, explicit stream).
 // Mirrors csrc/kernels/elementwise.cu (add_bias_bf16 comes from
 // csrc/kernels/dit_bf16.cu) host-wrapper signatures exactly.
 // ================================================================
@@ -102,4 +103,14 @@ __global__ void add_bias_bf16_kernel(__hip_bfloat16* x, const __hip_bfloat16* b,
 void add_bias_bf16(__hip_bfloat16* x, const __hip_bfloat16* b,
                    int S, int D, hipStream_t stream) {
     add_bias_bf16_kernel<<<(S * D + 255) / 256, 256, 0, stream>>>(x, b, S, D);
+}
+
+// ================================================================
+// GPU memory/copy ops for HIP Graph compatibility (DiT pipeline)
+// These replace PyTorch .copy_()/.fill_()/.half() which don't
+// submit to the correct stream during graph capture.
+// ================================================================
+
+void gpu_copy_async(void* dst, const void* src, size_t nbytes, hipStream_t stream) {
+    hipMemcpyAsync(dst, src, nbytes, hipMemcpyDeviceToDevice, stream);
 }

--- a/csrc/amd/kernels/elementwise.hip
+++ b/csrc/amd/kernels/elementwise.hip
@@ -1,0 +1,105 @@
+// ================================================================
+// FlashRT AMD — Elementwise kernels (dtype-generic, CDNA wave64)
+// Residual add, gate multiply, bias residual, broadcast bias add.
+// Mirrors csrc/kernels/elementwise.cu (add_bias_bf16 comes from
+// csrc/kernels/dit_bf16.cu) host-wrapper signatures exactly.
+// ================================================================
+
+#include "common_hip.h"
+
+// ── Gate Multiply + Residual: residual += x * gate ──
+template<typename T>
+__global__ void gate_mul_res_kernel(T* __restrict__ residual,
+                                    const T* __restrict__ x,
+                                    const T* __restrict__ gate, int n) {
+    using T2 = typename packed2<T>::type;
+    T2* res2 = reinterpret_cast<T2*>(residual);
+    const T2* x2 = reinterpret_cast<const T2*>(x);
+    const T2* g2 = reinterpret_cast<const T2*>(gate);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        T2 rv = res2[idx], xv = x2[idx], gv = g2[idx];
+        float r0 = to_f32(rv.x) + to_f32(xv.x) * to_f32(gv.x);
+        float r1 = to_f32(rv.y) + to_f32(xv.y) * to_f32(gv.y);
+        res2[idx] = make_packed2<T>(from_f32<T>(r0), from_f32<T>(r1));
+    }
+}
+
+template __global__ void gate_mul_res_kernel<__half>(__half*, const __half*, const __half*, int);
+template __global__ void gate_mul_res_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, int);
+
+void gate_mul_residual(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                       const __hip_bfloat16* gate, int n, hipStream_t stream) {
+    int n2 = n >> 1;
+    gate_mul_res_kernel<__hip_bfloat16><<<(n2 + 255) / 256, 256, 0, stream>>>(residual, x, gate, n);
+}
+
+// ── Bias + Residual: residual[row,:] += x[row,:] + bias ──
+template<typename T>
+__global__ void bias_res_kernel(T* __restrict__ residual,
+                                const T* __restrict__ x,
+                                const T* __restrict__ bias,
+                                int dim) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    T2* res2 = reinterpret_cast<T2*>(residual + row * dim);
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T2* b2 = reinterpret_cast<const T2*>(bias);
+    int dim2 = dim >> 1;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], xv = x2[i], bv = b2[i];
+        float r0 = to_f32(rv.x) + to_f32(xv.x) + to_f32(bv.x);
+        float r1 = to_f32(rv.y) + to_f32(xv.y) + to_f32(bv.y);
+        res2[i] = make_packed2<T>(from_f32<T>(r0), from_f32<T>(r1));
+    }
+}
+
+template __global__ void bias_res_kernel<__half>(__half*, const __half*, const __half*, int);
+template __global__ void bias_res_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, int);
+
+void bias_residual(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                   const __hip_bfloat16* bias, int seq_len, int dim,
+                   hipStream_t stream) {
+    bias_res_kernel<__hip_bfloat16><<<seq_len, 256, 0, stream>>>(residual, x, bias, dim);
+}
+
+// ── Residual Add: residual += x ──
+template<typename T>
+__global__ void res_add_kernel(T* __restrict__ residual,
+                               const T* __restrict__ x, int n) {
+    using T2 = typename packed2<T>::type;
+    T2* res2 = reinterpret_cast<T2*>(residual);
+    const T2* x2 = reinterpret_cast<const T2*>(x);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        T2 rv = res2[idx], xv = x2[idx];
+        res2[idx] = make_packed2<T>(
+            from_f32<T>(to_f32(rv.x) + to_f32(xv.x)),
+            from_f32<T>(to_f32(rv.y) + to_f32(xv.y)));
+    }
+}
+
+template __global__ void res_add_kernel<__half>(__half*, const __half*, int);
+template __global__ void res_add_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, int);
+
+void residual_add(__hip_bfloat16* residual, const __hip_bfloat16* x, int n,
+                  hipStream_t stream) {
+    int n2 = n >> 1;
+    res_add_kernel<__hip_bfloat16><<<(n2 + 255) / 256, 256, 0, stream>>>(residual, x, n);
+}
+
+// ── Broadcast bias add: x[i] += b[i % D] — BF16 ──
+__global__ void add_bias_bf16_kernel(__hip_bfloat16* x, const __hip_bfloat16* b,
+                                     int S, int D) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < S * D) {
+        x[i] = __float2bfloat16(__bfloat162float(x[i]) + __bfloat162float(b[i % D]));
+    }
+}
+
+void add_bias_bf16(__hip_bfloat16* x, const __hip_bfloat16* b,
+                   int S, int D, hipStream_t stream) {
+    add_bias_bf16_kernel<<<(S * D + 255) / 256, 256, 0, stream>>>(x, b, S, D);
+}

--- a/csrc/amd/kernels/ew_tune.h
+++ b/csrc/amd/kernels/ew_tune.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp8.h>
+
+// ================================================================
+// FlashRT AMD — elementwise launch-geometry tuning probe (CDNA4)
+//
+// Companion to kernels/stream_probe.h. The production elementwise
+// kernels were ported with their CUDA launch geometry (row-per-block
+// norms, one packed pair per thread, byte-granular FP8 stores). On
+// CDNA that geometry sits well above the measured in-graph dispatch
+// floor. This probe instantiates the three archetypes that cover the
+// whole elementwise surface — flat quantize transform, fused
+// row-reduction norm, and QKV split+RoPE — each as a family of
+// geometry variants (access width, FP8 store packing, waves-per-row
+// vs block-per-row reduction, ILP, block size), so the production
+// geometry is measured, not guessed.
+//
+// Variant 0 of every family replicates the production kernel's
+// current geometry and math exactly (in-file control arm). All
+// variants of a family compute the same function; reduction-order
+// variants may differ from the control in the last ULP only.
+//
+// Wide variants require: 16-byte aligned pointers, n (or dim)
+// divisible by 8. Wave-per-row variants additionally require
+// dim <= 4096. Host wrappers throw std::runtime_error otherwise.
+// ================================================================
+
+// ── Family Q: flat FP8 quantize (mirrors quantize_fp8_static) ──
+int ew_tune_quant_variant_count();
+const char* ew_tune_quant_variant_name(int id);
+void ew_tune_quant(int variant, const __hip_bfloat16* in, __hip_fp8_e4m3* out,
+                   const float* d_scale, int n, hipStream_t stream);
+
+// ── Family N: fused gate*residual + AdaRMSNorm + style → FP8 ──
+// (mirrors gate_residual_ada_norm_fp8 — the fullest fused-norm archetype)
+int ew_tune_norm_variant_count();
+const char* ew_tune_norm_variant_name(int id);
+void ew_tune_norm(int variant, __hip_bfloat16* residual, const __hip_bfloat16* x,
+                  const __hip_bfloat16* gate, const __hip_bfloat16* weight,
+                  const __hip_bfloat16* style, __hip_fp8_e4m3* out,
+                  __hip_bfloat16* gate_out, int seq_len, int dim, float eps,
+                  const float* d_scale, hipStream_t stream);
+
+// ── Family R: fused QKV split + RoPE (mirrors qkv_split_rope) ──
+int ew_tune_rope_variant_count();
+const char* ew_tune_rope_variant_name(int id);
+void ew_tune_rope(int variant, const __hip_bfloat16* qkv,
+                  const __hip_bfloat16* rope_weights,
+                  __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+                  int seq, int q_dim, int k_dim, int v_dim, int head_dim,
+                  hipStream_t stream);

--- a/csrc/amd/kernels/ew_tune.hip
+++ b/csrc/amd/kernels/ew_tune.hip
@@ -1,0 +1,651 @@
+// ================================================================
+// FlashRT AMD — elementwise launch-geometry tuning probe (CDNA4)
+// See ew_tune.h for the contract. Variant 0 of each family is the
+// production geometry replicated verbatim (control arm).
+// ================================================================
+
+#include "common_hip.h"
+#include "ew_tune.h"
+#include <hip/hip_fp8.h>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+// 16-byte packet = 8 bf16 (one dwordx4) — same pattern as the
+// attention kernels' attn_bf16x8.
+struct alignas(16) ew_bf16x8 {
+    __hip_bfloat162 p[4];
+};
+
+// 8-byte packet = 8 FP8 bytes (one dwordx2 store).
+struct alignas(8) ew_fp8x8 {
+    unsigned char b[8];
+};
+
+__device__ __forceinline__ unsigned char fp8_byte(float v) {
+    return __hip_fp8_e4m3(fminf(fmaxf(v, -448.0f), 448.0f)).__x;
+}
+
+// Butterfly all-reduce: every lane ends with the full wave sum.
+__device__ __forceinline__ float wave_allreduce_sum(float val) {
+    #pragma unroll
+    for (int off = FVK_WAVE_SIZE / 2; off > 0; off >>= 1)
+        val += __shfl_xor(val, off);
+    return val;
+}
+
+// ────────────────────────────────────────────────────────────────
+// Family Q: flat FP8 quantize
+// ────────────────────────────────────────────────────────────────
+
+// q0 — production geometry: one bf16x2 per thread, two byte stores.
+__global__ void ew_quant_legacy_kernel(const __hip_bfloat16* __restrict__ input,
+                                       __hip_fp8_e4m3* __restrict__ output,
+                                       const float* __restrict__ scale, int n) {
+    const __hip_bfloat162* in2 = reinterpret_cast<const __hip_bfloat162*>(input);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        float inv_s = 1.0f / (*scale);
+        __hip_bfloat162 val = in2[idx];
+        float v0 = __bfloat162float(val.x) * inv_s;
+        float v1 = __bfloat162float(val.y) * inv_s;
+        output[2*idx]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f));
+        output[2*idx+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f));
+    }
+}
+
+// q1 — legacy geometry, but the two FP8 bytes packed into one u16 store.
+__global__ void ew_quant_pack16_kernel(const __hip_bfloat16* __restrict__ input,
+                                       unsigned short* __restrict__ output,
+                                       const float* __restrict__ scale, int n) {
+    const __hip_bfloat162* in2 = reinterpret_cast<const __hip_bfloat162*>(input);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        float inv_s = 1.0f / (*scale);
+        __hip_bfloat162 val = in2[idx];
+        float v0 = __bfloat162float(val.x) * inv_s;
+        float v1 = __bfloat162float(val.y) * inv_s;
+        unsigned short lo = fp8_byte(v0);
+        unsigned short hi = fp8_byte(v1);
+        output[idx] = (unsigned short)(lo | (hi << 8));
+    }
+}
+
+// q2..q6 — wide: dwordx4 load (8 bf16), dwordx2 store (8 FP8), ILP chunks.
+template<int ILP>
+__global__ void ew_quant_wide_kernel(const ew_bf16x8* __restrict__ in,
+                                     ew_fp8x8* __restrict__ out,
+                                     const float* __restrict__ scale,
+                                     int nchunks, int stride) {
+    int base = blockIdx.x * blockDim.x + threadIdx.x;
+    ew_bf16x8 raw[ILP];
+    bool valid[ILP];
+    #pragma unroll
+    for (int j = 0; j < ILP; ++j) {
+        int idx = base + j * stride;
+        valid[j] = idx < nchunks;
+        if (valid[j]) raw[j] = in[idx];
+    }
+    float inv_s = 1.0f / (*scale);
+    #pragma unroll
+    for (int j = 0; j < ILP; ++j) {
+        if (!valid[j]) continue;
+        ew_fp8x8 o;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            o.b[2*k]   = fp8_byte(__bfloat162float(raw[j].p[k].x) * inv_s);
+            o.b[2*k+1] = fp8_byte(__bfloat162float(raw[j].p[k].y) * inv_s);
+        }
+        out[base + j * stride] = o;
+    }
+}
+
+struct QuantVariant { const char* name; int ilp; int block; };
+const QuantVariant kQuantVariants[] = {
+    {"q0_legacy_t2_bytestore_b256", 0, 256},
+    {"q1_legacy_t2_pack16_b256",    0, 256},
+    {"q2_wide8_ilp1_b256",          1, 256},
+    {"q3_wide8_ilp2_b256",          2, 256},
+    {"q4_wide8_ilp4_b256",          4, 256},
+    {"q5_wide8_ilp1_b64",           1, 64},
+    {"q6_wide8_ilp1_b1024",         1, 1024},
+};
+
+} // namespace
+
+int ew_tune_quant_variant_count() { return (int)(sizeof(kQuantVariants) / sizeof(kQuantVariants[0])); }
+const char* ew_tune_quant_variant_name(int id) { return kQuantVariants[id].name; }
+
+void ew_tune_quant(int variant, const __hip_bfloat16* in, __hip_fp8_e4m3* out,
+                   const float* d_scale, int n, hipStream_t stream) {
+    if (variant < 0 || variant >= ew_tune_quant_variant_count())
+        throw std::runtime_error("ew_tune_quant: bad variant " + std::to_string(variant));
+    const QuantVariant& v = kQuantVariants[variant];
+    if (variant == 0) {
+        int n2 = n >> 1;
+        ew_quant_legacy_kernel<<<(n2 + v.block - 1) / v.block, v.block, 0, stream>>>(
+            in, out, d_scale, n);
+        return;
+    }
+    if (variant == 1) {
+        int n2 = n >> 1;
+        ew_quant_pack16_kernel<<<(n2 + v.block - 1) / v.block, v.block, 0, stream>>>(
+            in, reinterpret_cast<unsigned short*>(out), d_scale, n);
+        return;
+    }
+    if (n % 8 != 0 || ((uintptr_t)in & 15) || ((uintptr_t)out & 7))
+        throw std::runtime_error("ew_tune_quant: wide variant needs n%8==0 and aligned ptrs");
+    int nchunks = n >> 3;
+    int stride = (nchunks + v.ilp - 1) / v.ilp;   // threads needed
+    int blocks = (stride + v.block - 1) / v.block;
+    const ew_bf16x8* in8 = reinterpret_cast<const ew_bf16x8*>(in);
+    ew_fp8x8* out8 = reinterpret_cast<ew_fp8x8*>(out);
+    switch (v.ilp) {
+    case 1: ew_quant_wide_kernel<1><<<blocks, v.block, 0, stream>>>(in8, out8, d_scale, nchunks, stride); break;
+    case 2: ew_quant_wide_kernel<2><<<blocks, v.block, 0, stream>>>(in8, out8, d_scale, nchunks, stride); break;
+    case 4: ew_quant_wide_kernel<4><<<blocks, v.block, 0, stream>>>(in8, out8, d_scale, nchunks, stride); break;
+    }
+}
+
+// ────────────────────────────────────────────────────────────────
+// Family N: fused gate*residual + AdaRMSNorm + style → FP8
+// ────────────────────────────────────────────────────────────────
+
+namespace {
+
+// n0 — production geometry: row-per-block 256T, bf16x2 accesses,
+// LDS block reduce, byte FP8 stores. Verbatim copy of fusion.hip.
+__global__ void ew_norm_legacy_kernel(
+    __hip_bfloat16* __restrict__ residual,
+    const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ gate,
+    const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ style,
+    __hip_fp8_e4m3* __restrict__ out,
+    __hip_bfloat16* __restrict__ gate_out,
+    int dim, float eps,
+    const float* __restrict__ d_scale) {
+    using T = __hip_bfloat16;
+    using T2 = __hip_bfloat162;
+    int row = blockIdx.x;
+    T2* res2 = reinterpret_cast<T2*>(residual + row * dim);
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T2* g2 = reinterpret_cast<const T2*>(gate + row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    const T* style_row = style + row * 3 * dim;
+    const T2* sc2 = reinterpret_cast<const T2*>(style_row);
+    const T2* sh2 = reinterpret_cast<const T2*>(style_row + dim);
+    const T2* gt2 = reinterpret_cast<const T2*>(style_row + 2 * dim);
+    __hip_fp8_e4m3* out_row = out + row * dim;
+    T2* gate_out2 = reinterpret_cast<T2*>(gate_out + row * dim);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], xv = x2[i], gv = g2[i];
+        float r0 = to_f32(rv.x) + to_f32(xv.x) * to_f32(gv.x);
+        float r1 = to_f32(rv.y) + to_f32(xv.y) * to_f32(gv.y);
+        res2[i] = make_packed2<T>(from_f32<T>(r0), from_f32<T>(r1));
+        local_sum += r0 * r0 + r1 * r1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], wv = w2[i];
+        T2 sv = sc2[i], hv = sh2[i], gv = gt2[i];
+        float n0 = to_f32(rv.x) * rms * to_f32(wv.x);
+        float n1 = to_f32(rv.y) * rms * to_f32(wv.y);
+        float val0 = (n0 * (1.0f + to_f32(sv.x)) + to_f32(hv.x)) * inv_scale;
+        float val1 = (n1 * (1.0f + to_f32(sv.y)) + to_f32(hv.y)) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(val0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(val1, -448.0f), 448.0f));
+        gate_out2[i] = gv;
+    }
+}
+
+// Wave-per-row core: one wave64 owns one full row. Wide dwordx4
+// accesses, packed FP8 stores, single-wave butterfly reduce — no LDS,
+// no __syncthreads. Pass 1 keeps the bf16-rounded residual in
+// registers so pass 2 never re-reads it (bit-identical to the
+// re-read: the register value IS the rounded value that was stored).
+// MAXC * 64 lanes * 8 values = dim <= 4096.
+constexpr int EW_NORM_MAXC = 8;
+
+__device__ __forceinline__ void ew_norm_row_wave(
+    int row, int lane,
+    __hip_bfloat16* __restrict__ residual,
+    const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ gate,
+    const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ style,
+    __hip_fp8_e4m3* __restrict__ out,
+    __hip_bfloat16* __restrict__ gate_out,
+    int dim, float eps, float inv_scale) {
+    int chunks = dim >> 3;
+    ew_bf16x8* res8 = reinterpret_cast<ew_bf16x8*>(residual + (size_t)row * dim);
+    const ew_bf16x8* x8 = reinterpret_cast<const ew_bf16x8*>(x + (size_t)row * dim);
+    const ew_bf16x8* g8 = reinterpret_cast<const ew_bf16x8*>(gate + (size_t)row * dim);
+    const ew_bf16x8* w8 = reinterpret_cast<const ew_bf16x8*>(weight);
+    const __hip_bfloat16* style_row = style + (size_t)row * 3 * dim;
+    const ew_bf16x8* sc8 = reinterpret_cast<const ew_bf16x8*>(style_row);
+    const ew_bf16x8* sh8 = reinterpret_cast<const ew_bf16x8*>(style_row + dim);
+    const ew_bf16x8* gt8 = reinterpret_cast<const ew_bf16x8*>(style_row + 2 * dim);
+    ew_fp8x8* out8 = reinterpret_cast<ew_fp8x8*>(out + (size_t)row * dim);
+    ew_bf16x8* gate_out8 = reinterpret_cast<ew_bf16x8*>(gate_out + (size_t)row * dim);
+
+    // Pass 1: residual += x * gate (rounded to bf16, stored AND kept in
+    // registers); accumulate sum of squares of the unrounded values.
+    ew_bf16x8 rres[EW_NORM_MAXC];
+    int cidx[EW_NORM_MAXC];
+    int cnt = 0;
+    float local_sum = 0.0f;
+    for (int c = lane; c < chunks; c += FVK_WAVE_SIZE) {
+        ew_bf16x8 rv = res8[c];
+        ew_bf16x8 xv = x8[c];
+        ew_bf16x8 gv = g8[c];
+        ew_bf16x8 rounded;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            float r0 = to_f32(rv.p[k].x) + to_f32(xv.p[k].x) * to_f32(gv.p[k].x);
+            float r1 = to_f32(rv.p[k].y) + to_f32(xv.p[k].y) * to_f32(gv.p[k].y);
+            rounded.p[k] = make_packed2<__hip_bfloat16>(
+                from_f32<__hip_bfloat16>(r0), from_f32<__hip_bfloat16>(r1));
+            local_sum += r0 * r0 + r1 * r1;
+        }
+        res8[c] = rounded;
+        rres[cnt] = rounded;
+        cidx[cnt] = c;
+        ++cnt;
+    }
+    float total = wave_allreduce_sum(local_sum);
+    float rms = rsqrtf(total / dim + eps);
+
+    // Pass 2: AdaRMSNorm with style → packed FP8 + gate copy.
+    for (int j = 0; j < cnt; ++j) {
+        int c = cidx[j];
+        ew_bf16x8 wv = w8[c];
+        ew_bf16x8 sv = sc8[c];
+        ew_bf16x8 hv = sh8[c];
+        ew_bf16x8 gv = gt8[c];
+        ew_fp8x8 o;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            float n0 = to_f32(rres[j].p[k].x) * rms * to_f32(wv.p[k].x);
+            float n1 = to_f32(rres[j].p[k].y) * rms * to_f32(wv.p[k].y);
+            float v0 = (n0 * (1.0f + to_f32(sv.p[k].x)) + to_f32(hv.p[k].x)) * inv_scale;
+            float v1 = (n1 * (1.0f + to_f32(sv.p[k].y)) + to_f32(hv.p[k].y)) * inv_scale;
+            o.b[2*k]   = fp8_byte(v0);
+            o.b[2*k+1] = fp8_byte(v1);
+        }
+        out8[c] = o;
+        gate_out8[c] = gv;
+    }
+}
+
+// n2 — one 64-thread WG per row.
+__global__ void ew_norm_waverow_kernel(
+    __hip_bfloat16* __restrict__ residual, const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ gate, const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ style, __hip_fp8_e4m3* __restrict__ out,
+    __hip_bfloat16* __restrict__ gate_out, int dim, float eps,
+    const float* __restrict__ d_scale) {
+    float inv_scale = 1.0f / (*d_scale);
+    ew_norm_row_wave(blockIdx.x, threadIdx.x, residual, x, gate, weight, style,
+                     out, gate_out, dim, eps, inv_scale);
+}
+
+// n3 — 256-thread WG = 4 independent waves, one row per wave, no sync.
+__global__ void ew_norm_wave4row_kernel(
+    __hip_bfloat16* __restrict__ residual, const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ gate, const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ style, __hip_fp8_e4m3* __restrict__ out,
+    __hip_bfloat16* __restrict__ gate_out, int seq_len, int dim, float eps,
+    const float* __restrict__ d_scale) {
+    int row = blockIdx.x * 4 + (threadIdx.x >> 6);
+    if (row >= seq_len) return;
+    float inv_scale = 1.0f / (*d_scale);
+    ew_norm_row_wave(row, threadIdx.x & (FVK_WAVE_SIZE - 1), residual, x, gate,
+                     weight, style, out, gate_out, dim, eps, inv_scale);
+}
+
+// n1/n4 — row-per-block with wide accesses and LDS block reduce
+// (isolates the access-width axis from the reduction-geometry axis).
+__global__ void ew_norm_wideblock_kernel(
+    __hip_bfloat16* __restrict__ residual, const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ gate, const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ style, __hip_fp8_e4m3* __restrict__ out,
+    __hip_bfloat16* __restrict__ gate_out, int dim, float eps,
+    const float* __restrict__ d_scale) {
+    int row = blockIdx.x;
+    int chunks = dim >> 3;
+    ew_bf16x8* res8 = reinterpret_cast<ew_bf16x8*>(residual + (size_t)row * dim);
+    const ew_bf16x8* x8 = reinterpret_cast<const ew_bf16x8*>(x + (size_t)row * dim);
+    const ew_bf16x8* g8 = reinterpret_cast<const ew_bf16x8*>(gate + (size_t)row * dim);
+    const ew_bf16x8* w8 = reinterpret_cast<const ew_bf16x8*>(weight);
+    const __hip_bfloat16* style_row = style + (size_t)row * 3 * dim;
+    const ew_bf16x8* sc8 = reinterpret_cast<const ew_bf16x8*>(style_row);
+    const ew_bf16x8* sh8 = reinterpret_cast<const ew_bf16x8*>(style_row + dim);
+    const ew_bf16x8* gt8 = reinterpret_cast<const ew_bf16x8*>(style_row + 2 * dim);
+    ew_fp8x8* out8 = reinterpret_cast<ew_fp8x8*>(out + (size_t)row * dim);
+    ew_bf16x8* gate_out8 = reinterpret_cast<ew_bf16x8*>(gate_out + (size_t)row * dim);
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        ew_bf16x8 rv = res8[c];
+        ew_bf16x8 xv = x8[c];
+        ew_bf16x8 gv = g8[c];
+        ew_bf16x8 rounded;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            float r0 = to_f32(rv.p[k].x) + to_f32(xv.p[k].x) * to_f32(gv.p[k].x);
+            float r1 = to_f32(rv.p[k].y) + to_f32(xv.p[k].y) * to_f32(gv.p[k].y);
+            rounded.p[k] = make_packed2<__hip_bfloat16>(
+                from_f32<__hip_bfloat16>(r0), from_f32<__hip_bfloat16>(r1));
+            local_sum += r0 * r0 + r1 * r1;
+        }
+        res8[c] = rounded;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        ew_bf16x8 rv = res8[c];
+        ew_bf16x8 wv = w8[c];
+        ew_bf16x8 sv = sc8[c];
+        ew_bf16x8 hv = sh8[c];
+        ew_bf16x8 gv = gt8[c];
+        ew_fp8x8 o;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            float n0 = to_f32(rv.p[k].x) * rms * to_f32(wv.p[k].x);
+            float n1 = to_f32(rv.p[k].y) * rms * to_f32(wv.p[k].y);
+            float v0 = (n0 * (1.0f + to_f32(sv.p[k].x)) + to_f32(hv.p[k].x)) * inv_scale;
+            float v1 = (n1 * (1.0f + to_f32(sv.p[k].y)) + to_f32(hv.p[k].y)) * inv_scale;
+            o.b[2*k]   = fp8_byte(v0);
+            o.b[2*k+1] = fp8_byte(v1);
+        }
+        out8[c] = o;
+        gate_out8[c] = gv;
+    }
+}
+
+// n5 — wide row-per-block b256 with PREFETCHED side inputs: the
+// weight/style streams are only consumed in pass 2, but in production
+// they are cold (evicted by ~40MB of weight streaming between uses)
+// and their HBM round trip lands on the critical path after the
+// reduce. Issuing those loads FIRST hides the cold latency behind
+// pass 1's compute + reduce. Requires dim <= 8*8*blockDim... uses the
+// register budget: chunks_per_thread <= EW_NORM_MAXC.
+__global__ void ew_norm_wideblock_prefetch_kernel(
+    __hip_bfloat16* __restrict__ residual, const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ gate, const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ style, __hip_fp8_e4m3* __restrict__ out,
+    __hip_bfloat16* __restrict__ gate_out, int dim, float eps,
+    const float* __restrict__ d_scale) {
+    int row = blockIdx.x;
+    int chunks = dim >> 3;
+    ew_bf16x8* res8 = reinterpret_cast<ew_bf16x8*>(residual + (size_t)row * dim);
+    const ew_bf16x8* x8 = reinterpret_cast<const ew_bf16x8*>(x + (size_t)row * dim);
+    const ew_bf16x8* g8 = reinterpret_cast<const ew_bf16x8*>(gate + (size_t)row * dim);
+    const ew_bf16x8* w8 = reinterpret_cast<const ew_bf16x8*>(weight);
+    const __hip_bfloat16* style_row = style + (size_t)row * 3 * dim;
+    const ew_bf16x8* sc8 = reinterpret_cast<const ew_bf16x8*>(style_row);
+    const ew_bf16x8* sh8 = reinterpret_cast<const ew_bf16x8*>(style_row + dim);
+    const ew_bf16x8* gt8 = reinterpret_cast<const ew_bf16x8*>(style_row + 2 * dim);
+    ew_fp8x8* out8 = reinterpret_cast<ew_fp8x8*>(out + (size_t)row * dim);
+    ew_bf16x8* gate_out8 = reinterpret_cast<ew_bf16x8*>(gate_out + (size_t)row * dim);
+
+    // Prefetch every pass-2 stream (cold in production) up front, plus
+    // the scalar scale — all independent of pass 1.
+    ew_bf16x8 pw[EW_NORM_MAXC], psc[EW_NORM_MAXC], psh[EW_NORM_MAXC], pgt[EW_NORM_MAXC];
+    int cidx[EW_NORM_MAXC];
+    int cnt = 0;
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        pw[cnt] = w8[c]; psc[cnt] = sc8[c]; psh[cnt] = sh8[c]; pgt[cnt] = gt8[c];
+        cidx[cnt] = c;
+        ++cnt;
+    }
+    float inv_scale = 1.0f / (*d_scale);
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    ew_bf16x8 pres[EW_NORM_MAXC];
+    for (int j = 0; j < cnt; ++j) {
+        int c = cidx[j];
+        ew_bf16x8 rv = res8[c];
+        ew_bf16x8 xv = x8[c];
+        ew_bf16x8 gv = g8[c];
+        ew_bf16x8 rounded;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            float r0 = to_f32(rv.p[k].x) + to_f32(xv.p[k].x) * to_f32(gv.p[k].x);
+            float r1 = to_f32(rv.p[k].y) + to_f32(xv.p[k].y) * to_f32(gv.p[k].y);
+            rounded.p[k] = make_packed2<__hip_bfloat16>(
+                from_f32<__hip_bfloat16>(r0), from_f32<__hip_bfloat16>(r1));
+            local_sum += r0 * r0 + r1 * r1;
+        }
+        res8[c] = rounded;
+        pres[j] = rounded;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+
+    for (int j = 0; j < cnt; ++j) {
+        int c = cidx[j];
+        ew_fp8x8 o;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            float n0 = to_f32(pres[j].p[k].x) * rms * to_f32(pw[j].p[k].x);
+            float n1 = to_f32(pres[j].p[k].y) * rms * to_f32(pw[j].p[k].y);
+            float v0 = (n0 * (1.0f + to_f32(psc[j].p[k].x)) + to_f32(psh[j].p[k].x)) * inv_scale;
+            float v1 = (n1 * (1.0f + to_f32(psc[j].p[k].y)) + to_f32(psh[j].p[k].y)) * inv_scale;
+            o.b[2*k]   = fp8_byte(v0);
+            o.b[2*k+1] = fp8_byte(v1);
+        }
+        out8[c] = o;
+        gate_out8[c] = pgt[j];
+    }
+}
+
+struct NormVariant { const char* name; int kind; int block; };
+// kind: 0 legacy, 1 wideblock, 2 waverow, 3 wave4row, 4 wideblock+prefetch
+const NormVariant kNormVariants[] = {
+    {"n0_legacy_rowblock_b256",  0, 256},
+    {"n1_wide_rowblock_b128",    1, 128},
+    {"n2_wide_waverow_b64",      2, 64},
+    {"n3_wide_wave4row_b256",    3, 256},
+    {"n4_wide_rowblock_b256",    1, 256},
+    {"n5_wide_prefetch_b256",    4, 256},
+    {"n6_wide_prefetch_b128",    4, 128},
+};
+
+} // namespace
+
+int ew_tune_norm_variant_count() { return (int)(sizeof(kNormVariants) / sizeof(kNormVariants[0])); }
+const char* ew_tune_norm_variant_name(int id) { return kNormVariants[id].name; }
+
+void ew_tune_norm(int variant, __hip_bfloat16* residual, const __hip_bfloat16* x,
+                  const __hip_bfloat16* gate, const __hip_bfloat16* weight,
+                  const __hip_bfloat16* style, __hip_fp8_e4m3* out,
+                  __hip_bfloat16* gate_out, int seq_len, int dim, float eps,
+                  const float* d_scale, hipStream_t stream) {
+    if (variant < 0 || variant >= ew_tune_norm_variant_count())
+        throw std::runtime_error("ew_tune_norm: bad variant " + std::to_string(variant));
+    const NormVariant& v = kNormVariants[variant];
+    if (v.kind == 0) {
+        ew_norm_legacy_kernel<<<seq_len, v.block, 4 * sizeof(float), stream>>>(
+            residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
+        return;
+    }
+    if (dim % 8 != 0)
+        throw std::runtime_error("ew_tune_norm: wide variant needs dim%8==0");
+    if (v.kind == 1) {
+        int smem = ((v.block + 63) / 64) * sizeof(float);
+        ew_norm_wideblock_kernel<<<seq_len, v.block, smem, stream>>>(
+            residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
+        return;
+    }
+    if (v.kind == 4) {
+        if (dim > v.block * 8 * EW_NORM_MAXC)
+            throw std::runtime_error("ew_tune_norm: prefetch variant dim too large");
+        int smem = ((v.block + 63) / 64) * sizeof(float);
+        ew_norm_wideblock_prefetch_kernel<<<seq_len, v.block, smem, stream>>>(
+            residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
+        return;
+    }
+    if (dim > FVK_WAVE_SIZE * 8 * EW_NORM_MAXC)
+        throw std::runtime_error("ew_tune_norm: wave variant needs dim<=4096");
+    if (v.kind == 2) {
+        ew_norm_waverow_kernel<<<seq_len, 64, 0, stream>>>(
+            residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
+    } else {
+        ew_norm_wave4row_kernel<<<(seq_len + 3) / 4, 256, 0, stream>>>(
+            residual, x, gate, weight, style, out, gate_out, seq_len, dim, eps, d_scale);
+    }
+}
+
+// ────────────────────────────────────────────────────────────────
+// Family R: fused QKV split + RoPE
+// ────────────────────────────────────────────────────────────────
+
+namespace {
+
+// r0 — production geometry: one element per thread, flat 1D grid,
+// per-thread div/mod row decomposition. Verbatim copy of rope.hip.
+__global__ void ew_rope_legacy_kernel(
+    const __hip_bfloat16* __restrict__ qkv,
+    const __hip_bfloat16* __restrict__ rope_weights,
+    __hip_bfloat16* __restrict__ Q,
+    __hip_bfloat16* __restrict__ K,
+    __hip_bfloat16* __restrict__ V,
+    int seq, int q_dim, int k_dim, int v_dim, int head_dim) {
+    int qkv_dim = q_dim + k_dim + v_dim;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * qkv_dim;
+    if (idx >= total) return;
+
+    int row = idx / qkv_dim;
+    int col = idx % qkv_dim;
+
+    if (col < q_dim) {
+        int q_col = col;
+        int head = q_col / head_dim;
+        int d_in_head = q_col % head_dim;
+        int pair = d_in_head / 2;
+        int is_odd = d_in_head & 1;
+        int pair_base_qkv = row * qkv_dim + head * head_dim + pair * 2;
+        float x0 = __bfloat162float(qkv[pair_base_qkv]);
+        float x1 = __bfloat162float(qkv[pair_base_qkv + 1]);
+        int rope_base = row * head_dim + pair * 2;
+        float c = __bfloat162float(rope_weights[rope_base]);
+        float s = __bfloat162float(rope_weights[rope_base + 1]);
+        int out_idx = row * q_dim + q_col;
+        if (is_odd == 0) Q[out_idx] = __float2bfloat16(x0 * c - x1 * s);
+        else             Q[out_idx] = __float2bfloat16(x1 * c + x0 * s);
+    } else if (col < q_dim + k_dim) {
+        int k_col = col - q_dim;
+        int pair = k_col / 2;
+        int is_odd = k_col & 1;
+        int pair_base_qkv = row * qkv_dim + q_dim + pair * 2;
+        float x0 = __bfloat162float(qkv[pair_base_qkv]);
+        float x1 = __bfloat162float(qkv[pair_base_qkv + 1]);
+        int rope_base = row * head_dim + pair * 2;
+        float c = __bfloat162float(rope_weights[rope_base]);
+        float s = __bfloat162float(rope_weights[rope_base + 1]);
+        int out_idx = row * k_dim + k_col;
+        if (is_odd == 0) K[out_idx] = __float2bfloat16(x0 * c - x1 * s);
+        else             K[out_idx] = __float2bfloat16(x1 * c + x0 * s);
+    } else {
+        int v_col = col - q_dim - k_dim;
+        V[row * v_dim + v_col] = qkv[idx];
+    }
+}
+
+// r1/r2 — one rotation pair per thread, 2D grid (blockIdx.y = row):
+// no div/mod for the row, one dword load + one dword store per thread,
+// each thread computes BOTH rotated outputs of its pair (identical
+// float math to the two legacy threads → bit-exact).
+__global__ void ew_rope_pair_kernel(
+    const __hip_bfloat16* __restrict__ qkv,
+    const __hip_bfloat16* __restrict__ rope_weights,
+    __hip_bfloat16* __restrict__ Q,
+    __hip_bfloat16* __restrict__ K,
+    __hip_bfloat16* __restrict__ V,
+    int q_dim, int k_dim, int v_dim, int head_dim, int qkv_dim) {
+    int row = blockIdx.y;
+    int p = blockIdx.x * blockDim.x + threadIdx.x;   // pair index within row
+    int npairs = qkv_dim >> 1;
+    if (p >= npairs) return;
+    int col = p << 1;
+
+    const __hip_bfloat162* src2 =
+        reinterpret_cast<const __hip_bfloat162*>(qkv + (size_t)row * qkv_dim);
+    __hip_bfloat162 xv = src2[p];
+
+    if (col < q_dim) {
+        int d_in_head = col % head_dim;   // even by construction
+        __hip_bfloat162 cs = reinterpret_cast<const __hip_bfloat162*>(
+            rope_weights)[((size_t)row * head_dim + d_in_head) >> 1];
+        float x0 = __bfloat162float(xv.x), x1 = __bfloat162float(xv.y);
+        float c = __bfloat162float(cs.x), s = __bfloat162float(cs.y);
+        reinterpret_cast<__hip_bfloat162*>(Q)[((size_t)row * q_dim + col) >> 1] =
+            make_packed2<__hip_bfloat16>(
+                __float2bfloat16(x0 * c - x1 * s),
+                __float2bfloat16(x1 * c + x0 * s));
+    } else if (col < q_dim + k_dim) {
+        int k_col = col - q_dim;
+        __hip_bfloat162 cs = reinterpret_cast<const __hip_bfloat162*>(
+            rope_weights)[((size_t)row * head_dim + k_col) >> 1];
+        float x0 = __bfloat162float(xv.x), x1 = __bfloat162float(xv.y);
+        float c = __bfloat162float(cs.x), s = __bfloat162float(cs.y);
+        reinterpret_cast<__hip_bfloat162*>(K)[((size_t)row * k_dim + k_col) >> 1] =
+            make_packed2<__hip_bfloat16>(
+                __float2bfloat16(x0 * c - x1 * s),
+                __float2bfloat16(x1 * c + x0 * s));
+    } else {
+        int v_col = col - q_dim - k_dim;
+        reinterpret_cast<__hip_bfloat162*>(V)[((size_t)row * v_dim + v_col) >> 1] = xv;
+    }
+}
+
+struct RopeVariant { const char* name; int kind; int block; };
+// kind: 0 legacy flat, 1 pair-per-thread 2D
+const RopeVariant kRopeVariants[] = {
+    {"r0_legacy_elem_flat_b256", 0, 256},
+    {"r1_pair_2d_b256",          1, 256},
+    {"r2_pair_2d_b64",           1, 64},
+};
+
+} // namespace
+
+int ew_tune_rope_variant_count() { return (int)(sizeof(kRopeVariants) / sizeof(kRopeVariants[0])); }
+const char* ew_tune_rope_variant_name(int id) { return kRopeVariants[id].name; }
+
+void ew_tune_rope(int variant, const __hip_bfloat16* qkv,
+                  const __hip_bfloat16* rope_weights,
+                  __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+                  int seq, int q_dim, int k_dim, int v_dim, int head_dim,
+                  hipStream_t stream) {
+    if (variant < 0 || variant >= ew_tune_rope_variant_count())
+        throw std::runtime_error("ew_tune_rope: bad variant " + std::to_string(variant));
+    const RopeVariant& v = kRopeVariants[variant];
+    int qkv_dim = q_dim + k_dim + v_dim;
+    if (v.kind == 0) {
+        int total = seq * qkv_dim;
+        ew_rope_legacy_kernel<<<(total + v.block - 1) / v.block, v.block, 0, stream>>>(
+            qkv, rope_weights, Q, K, V, seq, q_dim, k_dim, v_dim, head_dim);
+        return;
+    }
+    if ((q_dim | k_dim | v_dim | head_dim) & 1)
+        throw std::runtime_error("ew_tune_rope: pair variant needs even dims");
+    int npairs = qkv_dim >> 1;
+    dim3 grid((npairs + v.block - 1) / v.block, seq);
+    ew_rope_pair_kernel<<<grid, v.block, 0, stream>>>(
+        qkv, rope_weights, Q, K, V, q_dim, k_dim, v_dim, head_dim, qkv_dim);
+}

--- a/csrc/amd/kernels/fusion.hip
+++ b/csrc/amd/kernels/fusion.hip
@@ -1,0 +1,88 @@
+// ================================================================
+// FlashRT AMD — Cross-layer fusion kernels (dtype-generic, CDNA wave64)
+// Fused gate*residual + AdaRMSNorm -> FP8 (decoder optimization).
+// Mirrors csrc/kernels/fusion.cu host-wrapper signatures exactly so
+// the pipeline layer stays portable text across platforms.
+//
+// FP8 output dtype: OCP e4m3 via <hip/hip_fp8.h> __hip_fp8_e4m3
+// (saturating RNE conversion, same as __nv_fp8_e4m3; values are
+// pre-clamped to ±448 exactly as in fusion.cu). Only the FP8 path is
+// ported; gate_residual_ada_norm_fp16 stays CUDA-only.
+// ================================================================
+
+#include "common_hip.h"
+#include <hip/hip_fp8.h>
+
+// ── Fused Gate*Residual + AdaRMSNorm + Style -> FP8 ──
+// Pass 1: residual += x * gate; sum_sq += residual^2
+// Reduce: rms = rsqrt(sum_sq / dim + eps)
+// Pass 2: out_fp8 = clamp((norm(residual) * (1+scale) + shift) * inv_scale)
+template<typename T>
+__global__ void gate_residual_ada_norm_fp8_kernel(
+    T* __restrict__ residual,
+    const T* __restrict__ x,
+    const T* __restrict__ gate,
+    const T* __restrict__ weight,
+    const T* __restrict__ style,
+    __hip_fp8_e4m3* __restrict__ out,
+    T* __restrict__ gate_out,
+    int dim, float eps,
+    const float* __restrict__ d_scale) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    T2* res2 = reinterpret_cast<T2*>(residual + row * dim);
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T2* g2 = reinterpret_cast<const T2*>(gate + row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    const T* style_row = style + row * 3 * dim;
+    const T2* sc2 = reinterpret_cast<const T2*>(style_row);
+    const T2* sh2 = reinterpret_cast<const T2*>(style_row + dim);
+    const T2* gt2 = reinterpret_cast<const T2*>(style_row + 2 * dim);
+    __hip_fp8_e4m3* out_row = out + row * dim;
+    T2* gate_out2 = reinterpret_cast<T2*>(gate_out + row * dim);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+
+    // Pass 1: residual += x * gate, compute sum of squares
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], xv = x2[i], gv = g2[i];
+        float r0 = to_f32(rv.x) + to_f32(xv.x) * to_f32(gv.x);
+        float r1 = to_f32(rv.y) + to_f32(xv.y) * to_f32(gv.y);
+        res2[i] = make_packed2<T>(from_f32<T>(r0), from_f32<T>(r1));
+        local_sum += r0 * r0 + r1 * r1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    // Pass 2: AdaRMSNorm with style -> FP8
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], wv = w2[i];
+        T2 sv = sc2[i], hv = sh2[i], gv = gt2[i];
+        float n0 = to_f32(rv.x) * rms * to_f32(wv.x);
+        float n1 = to_f32(rv.y) * rms * to_f32(wv.y);
+        float val0 = (n0 * (1.0f + to_f32(sv.x)) + to_f32(hv.x)) * inv_scale;
+        float val1 = (n1 * (1.0f + to_f32(sv.y)) + to_f32(hv.y)) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(val0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(val1, -448.0f), 448.0f));
+        gate_out2[i] = gv;
+    }
+}
+
+template __global__ void gate_residual_ada_norm_fp8_kernel<__half>(
+    __half*, const __half*, const __half*, const __half*, const __half*,
+    __hip_fp8_e4m3*, __half*, int, float, const float*);
+template __global__ void gate_residual_ada_norm_fp8_kernel<__hip_bfloat16>(
+    __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*,
+    __hip_fp8_e4m3*, __hip_bfloat16*, int, float, const float*);
+
+void gate_residual_ada_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                                 const __hip_bfloat16* gate, const __hip_bfloat16* weight,
+                                 const __hip_bfloat16* style,
+                                 __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
+                                 int seq_len, int dim, float eps,
+                                 const float* d_scale, hipStream_t stream) {
+    gate_residual_ada_norm_fp8_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
+}

--- a/csrc/amd/kernels/fusion.hip
+++ b/csrc/amd/kernels/fusion.hip
@@ -163,12 +163,90 @@ void gate_residual_ada_norm_fp8_ksum(
         gate, weight, style, out, gate_out, seq_len, dim, eps, d_scale);
 }
 
+// Wide row-per-block variant (CDNA retune, ew_tune probe winner):
+// dwordx4 chunked accesses + packed FP8 stores; the rounded residual
+// stays in registers for pass 2 (bit-identical to the re-read — each
+// chunk is owned by one thread in both passes). Reduction order
+// changes (chunked) -> cos-gated.
+struct alignas(16) fus_bf16x8 { __hip_bfloat162 p[4]; };
+struct alignas(8) fus_fp8x8 { unsigned char b[8]; };
+
+__global__ void gate_residual_ada_norm_fp8_wide_kernel(
+    __hip_bfloat16* __restrict__ residual,
+    const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ gate,
+    const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ style,
+    __hip_fp8_e4m3* __restrict__ out,
+    __hip_bfloat16* __restrict__ gate_out,
+    int dim, float eps,
+    const float* __restrict__ d_scale) {
+    const int row = blockIdx.x;
+    const int chunks = dim >> 3;
+    fus_bf16x8* res8 = reinterpret_cast<fus_bf16x8*>(residual + (size_t)row * dim);
+    const fus_bf16x8* x8 = reinterpret_cast<const fus_bf16x8*>(x + (size_t)row * dim);
+    const fus_bf16x8* g8 = reinterpret_cast<const fus_bf16x8*>(gate + (size_t)row * dim);
+    const fus_bf16x8* w8 = reinterpret_cast<const fus_bf16x8*>(weight);
+    const __hip_bfloat16* style_row = style + (size_t)row * 3 * dim;
+    const fus_bf16x8* sc8 = reinterpret_cast<const fus_bf16x8*>(style_row);
+    const fus_bf16x8* sh8 = reinterpret_cast<const fus_bf16x8*>(style_row + dim);
+    const fus_bf16x8* gt8 = reinterpret_cast<const fus_bf16x8*>(style_row + 2 * dim);
+    fus_fp8x8* out8 = reinterpret_cast<fus_fp8x8*>(
+        reinterpret_cast<unsigned char*>(out) + (size_t)row * dim);
+    fus_bf16x8* gate_out8 = reinterpret_cast<fus_bf16x8*>(gate_out + (size_t)row * dim);
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        fus_bf16x8 rv = res8[c];
+        fus_bf16x8 xv = x8[c];
+        fus_bf16x8 gv = g8[c];
+        fus_bf16x8 rounded;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            const float r0 = to_f32(rv.p[k].x) + to_f32(xv.p[k].x) * to_f32(gv.p[k].x);
+            const float r1 = to_f32(rv.p[k].y) + to_f32(xv.p[k].y) * to_f32(gv.p[k].y);
+            rounded.p[k] = make_packed2<__hip_bfloat16>(
+                from_f32<__hip_bfloat16>(r0), from_f32<__hip_bfloat16>(r1));
+            local_sum += r0 * r0 + r1 * r1;
+        }
+        res8[c] = rounded;
+    }
+    const float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    const float inv_scale = 1.0f / (*d_scale);
+
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        fus_bf16x8 rv = res8[c];
+        fus_bf16x8 wv = w8[c];
+        fus_bf16x8 sv = sc8[c];
+        fus_bf16x8 hv = sh8[c];
+        fus_bf16x8 gv = gt8[c];
+        fus_fp8x8 o;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            const float n0 = to_f32(rv.p[k].x) * rms * to_f32(wv.p[k].x);
+            const float n1 = to_f32(rv.p[k].y) * rms * to_f32(wv.p[k].y);
+            const float v0 = (n0 * (1.0f + to_f32(sv.p[k].x)) + to_f32(hv.p[k].x)) * inv_scale;
+            const float v1 = (n1 * (1.0f + to_f32(sv.p[k].y)) + to_f32(hv.p[k].y)) * inv_scale;
+            o.b[2*k]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f)).__x;
+            o.b[2*k+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f)).__x;
+        }
+        out8[c] = o;
+        gate_out8[c] = gv;
+    }
+}
+
 void gate_residual_ada_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* x,
                                  const __hip_bfloat16* gate, const __hip_bfloat16* weight,
                                  const __hip_bfloat16* style,
                                  __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
                                  int seq_len, int dim, float eps,
                                  const float* d_scale, hipStream_t stream) {
+    if (dim % 8 == 0) {
+        gate_residual_ada_norm_fp8_wide_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+            residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
+        return;
+    }
     gate_residual_ada_norm_fp8_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
         residual, x, gate, weight, style, out, gate_out, dim, eps, d_scale);
 }

--- a/csrc/amd/kernels/fusion.hip
+++ b/csrc/amd/kernels/fusion.hip
@@ -77,6 +77,92 @@ template __global__ void gate_residual_ada_norm_fp8_kernel<__hip_bfloat16>(
     __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*,
     __hip_fp8_e4m3*, __hip_bfloat16*, int, float, const float*);
 
+// ── ksum variant: consume split-K FP32 GEMM partials in place of x ──
+// x[row][i] = bf16_round( (Σ_s partial[s][row][i]) * dsa[0]*dsb[0] );
+// ascending-split sum (deterministic), rounded to bf16 BEFORE use so
+// the dataflow matches the unfused GEMM(bf16 out) -> this-kernel
+// chain. Everything after x is identical to gate_residual_ada_norm_fp8.
+template<typename T>
+__global__ void gate_residual_ada_norm_fp8_ksum_kernel(
+    T* __restrict__ residual,
+    const float* __restrict__ partial,   // (splits, seq, dim) f32
+    int splits,
+    const float* __restrict__ dsa, const float* __restrict__ dsb,
+    const T* __restrict__ gate,
+    const T* __restrict__ weight,
+    const T* __restrict__ style,
+    __hip_fp8_e4m3* __restrict__ out,
+    T* __restrict__ gate_out,
+    int seq_len, int dim, float eps,
+    const float* __restrict__ d_scale) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    T2* res2 = reinterpret_cast<T2*>(residual + row * dim);
+    const T2* g2 = reinterpret_cast<const T2*>(gate + row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    const T* style_row = style + row * 3 * dim;
+    const T2* sc2 = reinterpret_cast<const T2*>(style_row);
+    const T2* sh2 = reinterpret_cast<const T2*>(style_row + dim);
+    const T2* gt2 = reinterpret_cast<const T2*>(style_row + 2 * dim);
+    __hip_fp8_e4m3* out_row = out + row * dim;
+    T2* gate_out2 = reinterpret_cast<T2*>(gate_out + row * dim);
+    int dim2 = dim >> 1;
+    const size_t plane = (size_t)seq_len * dim;
+    const float* p_row = partial + (size_t)row * dim;
+
+    extern __shared__ float shared[];
+
+    float sab = (*dsa) * (*dsb);
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        float x0 = 0.0f, x1 = 0.0f;
+        for (int s = 0; s < splits; ++s) {
+            const float* p = p_row + (size_t)s * plane + 2 * i;
+            x0 += p[0];
+            x1 += p[1];
+        }
+        T xb0 = from_f32<T>(x0 * sab);
+        T xb1 = from_f32<T>(x1 * sab);
+        T2 rv = res2[i], gv = g2[i];
+        float r0 = to_f32(rv.x) + to_f32(xb0) * to_f32(gv.x);
+        float r1 = to_f32(rv.y) + to_f32(xb1) * to_f32(gv.y);
+        res2[i] = make_packed2<T>(from_f32<T>(r0), from_f32<T>(r1));
+        local_sum += r0 * r0 + r1 * r1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], wv = w2[i];
+        T2 sv = sc2[i], hv = sh2[i], gv = gt2[i];
+        float n0 = to_f32(rv.x) * rms * to_f32(wv.x);
+        float n1 = to_f32(rv.y) * rms * to_f32(wv.y);
+        float val0 = (n0 * (1.0f + to_f32(sv.x)) + to_f32(hv.x)) * inv_scale;
+        float val1 = (n1 * (1.0f + to_f32(sv.y)) + to_f32(hv.y)) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(val0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(val1, -448.0f), 448.0f));
+        gate_out2[i] = gv;
+    }
+}
+
+template __global__ void gate_residual_ada_norm_fp8_ksum_kernel<__hip_bfloat16>(
+    __hip_bfloat16*, const float*, int, const float*, const float*,
+    const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*,
+    __hip_fp8_e4m3*, __hip_bfloat16*, int, int, float, const float*);
+
+void gate_residual_ada_norm_fp8_ksum(
+    __hip_bfloat16* residual, const float* partial, int splits,
+    const float* d_scale_a, const float* d_scale_b,
+    const __hip_bfloat16* gate, const __hip_bfloat16* weight,
+    const __hip_bfloat16* style,
+    __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
+    int seq_len, int dim, float eps,
+    const float* d_scale, hipStream_t stream) {
+    gate_residual_ada_norm_fp8_ksum_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        residual, partial, splits, d_scale_a, d_scale_b,
+        gate, weight, style, out, gate_out, seq_len, dim, eps, d_scale);
+}
+
 void gate_residual_ada_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* x,
                                  const __hip_bfloat16* gate, const __hip_bfloat16* weight,
                                  const __hip_bfloat16* style,

--- a/csrc/amd/kernels/norm.hip
+++ b/csrc/amd/kernels/norm.hip
@@ -1,6 +1,7 @@
 // ================================================================
 // FlashRT AMD — Normalization kernels (dtype-generic, CDNA wave64)
-// RMSNorm; LayerNorm and AdaRMSNorm follow in later commits.
+// RMSNorm, LayerNorm, AdaRMSNorm+Style, bias+residual+LayerNorm,
+// vision-token average pooling.
 // Mirrors csrc/kernels/norm.cu host-wrapper signatures exactly so
 // the pipeline layer stays portable text across platforms.
 // ================================================================
@@ -56,4 +57,230 @@ void rms_norm_inplace(const __hip_bfloat16* weight,
                       __hip_bfloat16* x, int seq_len, int dim, float eps,
                       hipStream_t stream) {
     rms_norm_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(x, weight, x, dim, eps);
+}
+
+// ── LayerNorm ──
+template<typename T>
+__global__ void layer_norm_kernel(const T* __restrict__ x,
+                                  const T* __restrict__ weight,
+                                  const T* __restrict__ bias,
+                                  T* __restrict__ out,
+                                  int dim, float eps) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    T2* out2 = reinterpret_cast<T2*>(out + row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    const T2* b2 = reinterpret_cast<const T2*>(bias);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = x2[i];
+        local_sum += to_f32(val.x) + to_f32(val.y);
+    }
+    float mean = block_reduce_sum(local_sum, shared) / dim;
+
+    float local_var = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = x2[i];
+        float d0 = to_f32(val.x) - mean, d1 = to_f32(val.y) - mean;
+        local_var += d0 * d0 + d1 * d1;
+    }
+    float inv_std = rsqrtf(block_reduce_sum(local_var, shared) / dim + eps);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 xv = x2[i], wv = w2[i], bv = b2[i];
+        float v0 = (to_f32(xv.x) - mean) * inv_std * to_f32(wv.x) + to_f32(bv.x);
+        float v1 = (to_f32(xv.y) - mean) * inv_std * to_f32(wv.y) + to_f32(bv.y);
+        out2[i] = make_packed2<T>(from_f32<T>(v0), from_f32<T>(v1));
+    }
+}
+
+template __global__ void layer_norm_kernel<__half>(const __half*, const __half*, const __half*, __half*, int, float);
+template __global__ void layer_norm_kernel<__hip_bfloat16>(const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, __hip_bfloat16*, int, float);
+
+void layer_norm(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                const __hip_bfloat16* bias, __hip_bfloat16* out,
+                int seq_len, int dim, float eps, hipStream_t stream) {
+    layer_norm_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(x, weight, bias, out, dim, eps);
+}
+
+// ── AdaRMSNorm + Style ──
+// style row layout: (seq, 3*dim) = [scale | shift | gate] per row.
+// out = rmsnorm(x)*weight * (1 + scale) + shift; gate_out = gate (copy).
+template<typename T>
+__global__ void ada_rms_norm_style_kernel(
+    const T* __restrict__ x, const T* __restrict__ weight,
+    const T* __restrict__ style, T* __restrict__ out, T* __restrict__ gate_out,
+    int dim, float eps) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T* style_row = style + row * 3 * dim;
+    const T2* sc2 = reinterpret_cast<const T2*>(style_row);
+    const T2* sh2 = reinterpret_cast<const T2*>(style_row + dim);
+    const T2* gt2 = reinterpret_cast<const T2*>(style_row + 2 * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    T2* out2 = reinterpret_cast<T2*>(out + row * dim);
+    T2* gate2 = reinterpret_cast<T2*>(gate_out + row * dim);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = x2[i];
+        float v0 = to_f32(val.x), v1 = to_f32(val.y);
+        local_sum += v0 * v0 + v1 * v1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 xv = x2[i], wv = w2[i];
+        T2 sv = sc2[i], hv = sh2[i], gv = gt2[i];
+        float n0 = to_f32(xv.x) * rms * to_f32(wv.x);
+        float n1 = to_f32(xv.y) * rms * to_f32(wv.y);
+        out2[i] = make_packed2<T>(
+            from_f32<T>(n0 * (1.0f + to_f32(sv.x)) + to_f32(hv.x)),
+            from_f32<T>(n1 * (1.0f + to_f32(sv.y)) + to_f32(hv.y)));
+        gate2[i] = gv;
+    }
+}
+
+template __global__ void ada_rms_norm_style_kernel<__half>(const __half*, const __half*, const __half*, __half*, __half*, int, float);
+template __global__ void ada_rms_norm_style_kernel<__hip_bfloat16>(const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, __hip_bfloat16*, __hip_bfloat16*, int, float);
+
+void ada_rms_norm_style(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                        const __hip_bfloat16* style,
+                        __hip_bfloat16* out, __hip_bfloat16* gate_out,
+                        int seq_len, int dim, float eps, hipStream_t stream) {
+    ada_rms_norm_style_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        x, weight, style, out, gate_out, dim, eps);
+}
+
+// ── Fused bias + residual add + LayerNorm ──
+// residual = lowp(residual + x + bias_pre) written back to global, then
+// LayerNorm over the UPDATED residual into `out`. Passes 2 and 3 re-read
+// residual from global (now rounded to bf16) — this strictly matches
+// running bias_residual then layer_norm sequentially, bit for bit.
+// LDS: block_reduce_sum partials, one float per wave (4 for 256 threads).
+template<typename T>
+__global__ void bias_residual_layer_norm_kernel(
+        T* __restrict__ residual,
+        const T* __restrict__ x,
+        const T* __restrict__ bias_pre,
+        const T* __restrict__ ln_weight,
+        const T* __restrict__ ln_bias,
+        T* __restrict__ out,
+        int dim, float eps) {
+    extern __shared__ float partial[];
+
+    int row = blockIdx.x;
+    using T2 = typename packed2<T>::type;
+    T2* res2 = reinterpret_cast<T2*>(residual + (size_t)row * dim);
+    const T2* x2 = reinterpret_cast<const T2*>(x + (size_t)row * dim);
+    const T2* b2 = reinterpret_cast<const T2*>(bias_pre);
+    const T2* w2 = reinterpret_cast<const T2*>(ln_weight);
+    const T2* lnb2 = reinterpret_cast<const T2*>(ln_bias);
+    T2* out2 = reinterpret_cast<T2*>(out + (size_t)row * dim);
+    int dim2 = dim >> 1;
+
+    // Pass 1: residual = lowp(residual + x + bias_pre) (write to global),
+    // accumulate sum for mean.
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], xv = x2[i], bv = b2[i];
+        T r0 = from_f32<T>(to_f32(rv.x) + to_f32(xv.x) + to_f32(bv.x));
+        T r1 = from_f32<T>(to_f32(rv.y) + to_f32(xv.y) + to_f32(bv.y));
+        res2[i] = make_packed2<T>(r0, r1);
+        local_sum += to_f32(r0) + to_f32(r1);
+    }
+    float mean = block_reduce_sum(local_sum, partial) / dim;
+
+    // Pass 2: re-read residual from global (now rounded), accumulate var.
+    float local_var = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = res2[i];
+        float d0 = to_f32(val.x) - mean, d1 = to_f32(val.y) - mean;
+        local_var += d0 * d0 + d1 * d1;
+    }
+    float inv_std = rsqrtf(block_reduce_sum(local_var, partial) / dim + eps);
+
+    // Pass 3: re-read residual, normalize, apply weight/bias, write out.
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = res2[i];
+        T2 wv = w2[i], lbv = lnb2[i];
+        float v0 = to_f32(val.x), v1 = to_f32(val.y);
+        float n0 = (v0 - mean) * inv_std * to_f32(wv.x) + to_f32(lbv.x);
+        float n1 = (v1 - mean) * inv_std * to_f32(wv.y) + to_f32(lbv.y);
+        out2[i] = make_packed2<T>(from_f32<T>(n0), from_f32<T>(n1));
+    }
+}
+
+template __global__ void bias_residual_layer_norm_kernel<__half>(__half*, const __half*, const __half*, const __half*, const __half*, __half*, int, float);
+template __global__ void bias_residual_layer_norm_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, __hip_bfloat16*, int, float);
+
+void bias_residual_layer_norm_bf16(
+        __hip_bfloat16* residual, const __hip_bfloat16* x,
+        const __hip_bfloat16* bias_pre,
+        const __hip_bfloat16* ln_weight, const __hip_bfloat16* ln_bias,
+        __hip_bfloat16* out, int seq_len, int dim, float eps,
+        hipStream_t stream) {
+    int smem = 4 * sizeof(float);
+    bias_residual_layer_norm_kernel<__hip_bfloat16><<<seq_len, 256, smem, stream>>>(
+        residual, x, bias_pre, ln_weight, ln_bias, out, dim, eps);
+}
+
+// ── Vision Token Spatial Average Pooling (BF16) ──
+//
+// Reduces vision-tower output from (nv * spv, dim) to
+// (nv * spv / (f*f), dim) by f×f average pooling in the (H, W) token
+// grid. Token layout: each view's spv tokens form an (H, W) grid with
+// spv = H * W; each f×f block of tokens averages into one output token.
+//
+// Launch: gridDim = (nv * out_spv, 1), blockDim = (256, 1)
+//         where out_spv = spv / (f*f). No LDS (pure BW-limited kernel).
+__global__ void avg_pool_vision_tokens_kernel(
+        const __hip_bfloat16* __restrict__ x,   // (nv * spv, dim) BF16
+        __hip_bfloat16* __restrict__ out,       // (nv * out_spv, dim) BF16
+        int nv, int H, int W, int dim, int f) {
+    // output token index in [0, nv * (H/f) * (W/f))
+    int out_tok = blockIdx.x;
+    int H_out = H / f;
+    int W_out = W / f;
+    int spv_out = H_out * W_out;
+
+    int v   = out_tok / spv_out;          // view index
+    int rc  = out_tok % spv_out;          // spatial index within view
+    int r_out = rc / W_out;
+    int c_out = rc % W_out;
+
+    float inv_f2 = 1.0f / float(f * f);
+
+    for (int d = threadIdx.x; d < dim; d += blockDim.x) {
+        float sum = 0.f;
+        for (int dr = 0; dr < f; dr++) {
+            for (int dc = 0; dc < f; dc++) {
+                int r_in  = r_out * f + dr;
+                int c_in  = c_out * f + dc;
+                int in_tok = v * H * W + r_in * W + c_in;
+                sum += __bfloat162float(x[in_tok * dim + d]);
+            }
+        }
+        out[out_tok * dim + d] = __float2bfloat16(sum * inv_f2);
+    }
+}
+
+// pool_factor: 1 = no-op, 2 = 2x2 (spv 256→64), 4 = 4x4 (spv 256→16)
+// H = W = sqrt(spv) must be divisible by pool_factor.
+void avg_pool_vision_tokens(
+        const __hip_bfloat16* x, __hip_bfloat16* out,
+        int nv, int H, int W, int dim, int pool_factor,
+        hipStream_t stream) {
+    int H_out = H / pool_factor;
+    int W_out = W / pool_factor;
+    int out_tokens = nv * H_out * W_out;
+    avg_pool_vision_tokens_kernel<<<out_tokens, 256, 0, stream>>>(
+        x, out, nv, H, W, dim, pool_factor);
 }

--- a/csrc/amd/kernels/norm.hip
+++ b/csrc/amd/kernels/norm.hip
@@ -15,6 +15,12 @@
 #include "common_hip.h"
 #include <hip/hip_fp8.h>
 
+// 16-byte packet (8 bf16) and 8-byte FP8 packet for the wide (CDNA
+// retune) kernel variants — measured on the ew_tune probe: wide
+// row-per-block b256 wins ~1.4x on encoder-seq shapes.
+struct alignas(16) nrm_bf16x8 { __hip_bfloat162 p[4]; };
+struct alignas(8) nrm_fp8x8 { unsigned char b[8]; };
+
 // ── RMSNorm ──
 template<typename T>
 __global__ void rms_norm_kernel(const T* __restrict__ x,
@@ -108,9 +114,68 @@ __global__ void layer_norm_kernel(const T* __restrict__ x,
 template __global__ void layer_norm_kernel<__half>(const __half*, const __half*, const __half*, __half*, int, float);
 template __global__ void layer_norm_kernel<__hip_bfloat16>(const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, __hip_bfloat16*, int, float);
 
+// Wide row-per-block variant: dwordx4 chunked accesses, same 2-pass
+// mean/var structure. Per-thread accumulation order changes (chunked)
+// -> last-ULP differences only; gated by the cos parity suite.
+__global__ void layer_norm_wide_kernel(
+    const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ weight,
+    const __hip_bfloat16* __restrict__ bias,
+    __hip_bfloat16* __restrict__ out,
+    int dim, float eps) {
+    const int row = blockIdx.x;
+    const int chunks = dim >> 3;
+    const nrm_bf16x8* x8 = reinterpret_cast<const nrm_bf16x8*>(x + (size_t)row * dim);
+    const nrm_bf16x8* w8 = reinterpret_cast<const nrm_bf16x8*>(weight);
+    const nrm_bf16x8* b8 = reinterpret_cast<const nrm_bf16x8*>(bias);
+    nrm_bf16x8* out8 = reinterpret_cast<nrm_bf16x8*>(out + (size_t)row * dim);
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        nrm_bf16x8 v = x8[c];
+        #pragma unroll
+        for (int k = 0; k < 4; ++k)
+            local_sum += to_f32(v.p[k].x) + to_f32(v.p[k].y);
+    }
+    const float mean = block_reduce_sum(local_sum, shared) / dim;
+
+    float local_var = 0.0f;
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        nrm_bf16x8 v = x8[c];
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            const float d0 = to_f32(v.p[k].x) - mean;
+            const float d1 = to_f32(v.p[k].y) - mean;
+            local_var += d0 * d0 + d1 * d1;
+        }
+    }
+    const float inv_std = rsqrtf(block_reduce_sum(local_var, shared) / dim + eps);
+
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        nrm_bf16x8 v = x8[c];
+        nrm_bf16x8 wv = w8[c];
+        nrm_bf16x8 bv = b8[c];
+        nrm_bf16x8 o;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            const float n0 = (to_f32(v.p[k].x) - mean) * inv_std * to_f32(wv.p[k].x) + to_f32(bv.p[k].x);
+            const float n1 = (to_f32(v.p[k].y) - mean) * inv_std * to_f32(wv.p[k].y) + to_f32(bv.p[k].y);
+            o.p[k] = make_packed2<__hip_bfloat16>(
+                from_f32<__hip_bfloat16>(n0), from_f32<__hip_bfloat16>(n1));
+        }
+        out8[c] = o;
+    }
+}
+
 void layer_norm(const __hip_bfloat16* x, const __hip_bfloat16* weight,
                 const __hip_bfloat16* bias, __hip_bfloat16* out,
                 int seq_len, int dim, float eps, hipStream_t stream) {
+    if (dim % 8 == 0) {
+        layer_norm_wide_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+            x, weight, bias, out, dim, eps);
+        return;
+    }
     layer_norm_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(x, weight, bias, out, dim, eps);
 }
 
@@ -302,10 +367,65 @@ __global__ void residual_add_rms_norm_fp8_kernel(
 template __global__ void residual_add_rms_norm_fp8_kernel<__half>(__half*, const __half*, const __half*, __hip_fp8_e4m3*, int, float, const float*);
 template __global__ void residual_add_rms_norm_fp8_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, __hip_fp8_e4m3*, int, float, const float*);
 
+// Wide row-per-block variant (see layer_norm_wide_kernel notes).
+// Keeps the rounded residual in registers for pass 2 — bit-identical
+// to the re-read (the register value IS the stored rounded value)
+// as long as each chunk stays with one thread (it does).
+__global__ void residual_add_rms_norm_fp8_wide_kernel(
+    __hip_bfloat16* __restrict__ residual, const __hip_bfloat16* __restrict__ x,
+    const __hip_bfloat16* __restrict__ weight, __hip_fp8_e4m3* __restrict__ out,
+    int dim, float eps, const float* __restrict__ d_scale) {
+    const int row = blockIdx.x;
+    const int chunks = dim >> 3;
+    nrm_bf16x8* res8 = reinterpret_cast<nrm_bf16x8*>(residual + (size_t)row * dim);
+    const nrm_bf16x8* x8 = reinterpret_cast<const nrm_bf16x8*>(x + (size_t)row * dim);
+    const nrm_bf16x8* w8 = reinterpret_cast<const nrm_bf16x8*>(weight);
+    nrm_fp8x8* out8 = reinterpret_cast<nrm_fp8x8*>(
+        reinterpret_cast<unsigned char*>(out) + (size_t)row * dim);
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        nrm_bf16x8 rv = res8[c];
+        nrm_bf16x8 xv = x8[c];
+        nrm_bf16x8 rounded;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            const float r0 = to_f32(rv.p[k].x) + to_f32(xv.p[k].x);
+            const float r1 = to_f32(rv.p[k].y) + to_f32(xv.p[k].y);
+            rounded.p[k] = make_packed2<__hip_bfloat16>(
+                from_f32<__hip_bfloat16>(r0), from_f32<__hip_bfloat16>(r1));
+            local_sum += r0 * r0 + r1 * r1;
+        }
+        res8[c] = rounded;
+    }
+    const float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    const float inv_scale = 1.0f / (*d_scale);
+
+    for (int c = threadIdx.x; c < chunks; c += blockDim.x) {
+        nrm_bf16x8 rv = res8[c];
+        nrm_bf16x8 wv = w8[c];
+        nrm_fp8x8 o;
+        #pragma unroll
+        for (int k = 0; k < 4; ++k) {
+            const float v0 = to_f32(rv.p[k].x) * rms * to_f32(wv.p[k].x) * inv_scale;
+            const float v1 = to_f32(rv.p[k].y) * rms * to_f32(wv.p[k].y) * inv_scale;
+            o.b[2*k]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f)).__x;
+            o.b[2*k+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f)).__x;
+        }
+        out8[c] = o;
+    }
+}
+
 void residual_add_rms_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* x,
                                 const __hip_bfloat16* weight, __hip_fp8_e4m3* out,
                                 int seq_len, int dim, float eps,
                                 const float* d_scale, hipStream_t stream) {
+    if (dim % 8 == 0) {
+        residual_add_rms_norm_fp8_wide_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+            residual, x, weight, out, dim, eps, d_scale);
+        return;
+    }
     residual_add_rms_norm_fp8_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
         residual, x, weight, out, dim, eps, d_scale);
 }

--- a/csrc/amd/kernels/norm.hip
+++ b/csrc/amd/kernels/norm.hip
@@ -1,0 +1,59 @@
+// ================================================================
+// FlashRT AMD — Normalization kernels (dtype-generic, CDNA wave64)
+// RMSNorm; LayerNorm and AdaRMSNorm follow in later commits.
+// Mirrors csrc/kernels/norm.cu host-wrapper signatures exactly so
+// the pipeline layer stays portable text across platforms.
+// ================================================================
+
+#include "common_hip.h"
+
+// ── RMSNorm ──
+template<typename T>
+__global__ void rms_norm_kernel(const T* __restrict__ x,
+                                const T* __restrict__ weight,
+                                T* __restrict__ out,
+                                int dim, float eps) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    const T2* x2 = reinterpret_cast<const T2*>(x + (size_t)row * dim);
+    T2* out2 = reinterpret_cast<T2*>(out + (size_t)row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = x2[i];
+        float v0 = to_f32(val.x), v1 = to_f32(val.y);
+        local_sum += v0 * v0 + v1 * v1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 xv = x2[i], wv = w2[i];
+        float v0 = to_f32(xv.x) * rms * to_f32(wv.x);
+        float v1 = to_f32(xv.y) * rms * to_f32(wv.y);
+        out2[i] = make_packed2<T>(from_f32<T>(v0), from_f32<T>(v1));
+    }
+}
+
+template __global__ void rms_norm_kernel<__half>(const __half*, const __half*, __half*, int, float);
+template __global__ void rms_norm_kernel<__hip_bfloat16>(const __hip_bfloat16*, const __hip_bfloat16*, __hip_bfloat16*, int, float);
+
+void rms_norm(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+              __hip_bfloat16* out, int seq_len, int dim, float eps,
+              hipStream_t stream) {
+    rms_norm_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(x, weight, out, dim, eps);
+}
+
+void rms_norm_fp16(const __half* x, const __half* weight,
+                   __half* out, int seq_len, int dim, float eps,
+                   hipStream_t stream) {
+    rms_norm_kernel<__half><<<seq_len, 256, 4 * sizeof(float), stream>>>(x, weight, out, dim, eps);
+}
+
+void rms_norm_inplace(const __hip_bfloat16* weight,
+                      __hip_bfloat16* x, int seq_len, int dim, float eps,
+                      hipStream_t stream) {
+    rms_norm_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(x, weight, x, dim, eps);
+}

--- a/csrc/amd/kernels/norm.hip
+++ b/csrc/amd/kernels/norm.hip
@@ -1,12 +1,19 @@
 // ================================================================
 // FlashRT AMD — Normalization kernels (dtype-generic, CDNA wave64)
 // RMSNorm, LayerNorm, AdaRMSNorm+Style, bias+residual+LayerNorm,
-// vision-token average pooling.
+// vision-token average pooling, and the fused Norm → FP8 set
+// (rms_norm_fp8, ada_rms_norm_style_fp8, residual_add_rms_norm_fp8).
 // Mirrors csrc/kernels/norm.cu host-wrapper signatures exactly so
 // the pipeline layer stays portable text across platforms.
+//
+// FP8 output dtype: OCP e4m3 via <hip/hip_fp8.h> __hip_fp8_e4m3
+// (saturating RNE conversion, same as __nv_fp8_e4m3; values are
+// pre-clamped to ±448 exactly as in norm.cu). Same byte format as
+// the HIP_R_8F_E4M3 the hipBLASLt GEMM side consumes.
 // ================================================================
 
 #include "common_hip.h"
+#include <hip/hip_fp8.h>
 
 // ── RMSNorm ──
 template<typename T>
@@ -157,6 +164,150 @@ void ada_rms_norm_style(const __hip_bfloat16* x, const __hip_bfloat16* weight,
                         int seq_len, int dim, float eps, hipStream_t stream) {
     ada_rms_norm_style_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
         x, weight, style, out, gate_out, dim, eps);
+}
+
+// ── RMSNorm → FP8 ──
+template<typename T>
+__global__ void rms_norm_fp8_kernel(const T* __restrict__ x,
+                                     const T* __restrict__ weight,
+                                     __hip_fp8_e4m3* __restrict__ out,
+                                     int dim, float eps,
+                                     const float* __restrict__ d_scale) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    __hip_fp8_e4m3* out_row = out + row * dim;
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = x2[i];
+        float v0 = to_f32(val.x), v1 = to_f32(val.y);
+        local_sum += v0 * v0 + v1 * v1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 xv = x2[i], wv = w2[i];
+        float v0 = to_f32(xv.x) * rms * to_f32(wv.x) * inv_scale;
+        float v1 = to_f32(xv.y) * rms * to_f32(wv.y) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f));
+    }
+}
+
+template __global__ void rms_norm_fp8_kernel<__half>(const __half*, const __half*, __hip_fp8_e4m3*, int, float, const float*);
+template __global__ void rms_norm_fp8_kernel<__hip_bfloat16>(const __hip_bfloat16*, const __hip_bfloat16*, __hip_fp8_e4m3*, int, float, const float*);
+
+void rms_norm_fp8(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                   __hip_fp8_e4m3* out, int seq_len, int dim, float eps,
+                   const float* d_scale, hipStream_t stream) {
+    rms_norm_fp8_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(x, weight, out, dim, eps, d_scale);
+}
+
+// ── AdaRMSNorm + Style → FP8 ──
+template<typename T>
+__global__ void ada_rms_norm_style_fp8_kernel(
+    const T* __restrict__ x, const T* __restrict__ weight,
+    const T* __restrict__ style, __hip_fp8_e4m3* __restrict__ out, T* __restrict__ gate_out,
+    int dim, float eps, const float* __restrict__ d_scale) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T* style_row = style + row * 3 * dim;
+    const T2* sc2 = reinterpret_cast<const T2*>(style_row);
+    const T2* sh2 = reinterpret_cast<const T2*>(style_row + dim);
+    const T2* gt2 = reinterpret_cast<const T2*>(style_row + 2 * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    __hip_fp8_e4m3* out_row = out + row * dim;
+    T2* gate2 = reinterpret_cast<T2*>(gate_out + row * dim);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 val = x2[i];
+        float v0 = to_f32(val.x), v1 = to_f32(val.y);
+        local_sum += v0 * v0 + v1 * v1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 xv = x2[i], wv = w2[i];
+        T2 sv = sc2[i], hv = sh2[i], gv = gt2[i];
+        float n0 = to_f32(xv.x) * rms * to_f32(wv.x);
+        float n1 = to_f32(xv.y) * rms * to_f32(wv.y);
+        float val0 = (n0 * (1.0f + to_f32(sv.x)) + to_f32(hv.x)) * inv_scale;
+        float val1 = (n1 * (1.0f + to_f32(sv.y)) + to_f32(hv.y)) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(val0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(val1, -448.0f), 448.0f));
+        gate2[i] = gv;
+    }
+}
+
+template __global__ void ada_rms_norm_style_fp8_kernel<__half>(const __half*, const __half*, const __half*, __hip_fp8_e4m3*, __half*, int, float, const float*);
+template __global__ void ada_rms_norm_style_fp8_kernel<__hip_bfloat16>(const __hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, __hip_fp8_e4m3*, __hip_bfloat16*, int, float, const float*);
+
+void ada_rms_norm_style_fp8(const __hip_bfloat16* x, const __hip_bfloat16* weight,
+                             const __hip_bfloat16* style,
+                             __hip_fp8_e4m3* out, __hip_bfloat16* gate_out,
+                             int seq_len, int dim, float eps,
+                             const float* d_scale, hipStream_t stream) {
+    ada_rms_norm_style_fp8_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        x, weight, style, out, gate_out, dim, eps, d_scale);
+}
+
+// ── Residual Add + RMSNorm → FP8 ──
+// Pass 1 writes the low-precision (rounded) residual back to global and
+// accumulates the sum of squares from the UNROUNDED float sums; pass 2
+// re-reads the rounded residual for the normalize — matching norm.cu.
+template<typename T>
+__global__ void residual_add_rms_norm_fp8_kernel(
+    T* __restrict__ residual, const T* __restrict__ x,
+    const T* __restrict__ weight, __hip_fp8_e4m3* __restrict__ out,
+    int dim, float eps, const float* __restrict__ d_scale) {
+    using T2 = typename packed2<T>::type;
+    int row = blockIdx.x;
+    T2* res2 = reinterpret_cast<T2*>(residual + row * dim);
+    const T2* x2 = reinterpret_cast<const T2*>(x + row * dim);
+    const T2* w2 = reinterpret_cast<const T2*>(weight);
+    __hip_fp8_e4m3* out_row = out + row * dim;
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], xv = x2[i];
+        float r0 = to_f32(rv.x) + to_f32(xv.x);
+        float r1 = to_f32(rv.y) + to_f32(xv.y);
+        res2[i] = make_packed2<T>(from_f32<T>(r0), from_f32<T>(r1));
+        local_sum += r0 * r0 + r1 * r1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        T2 rv = res2[i], wv = w2[i];
+        float v0 = to_f32(rv.x) * rms * to_f32(wv.x) * inv_scale;
+        float v1 = to_f32(rv.y) * rms * to_f32(wv.y) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f));
+    }
+}
+
+template __global__ void residual_add_rms_norm_fp8_kernel<__half>(__half*, const __half*, const __half*, __hip_fp8_e4m3*, int, float, const float*);
+template __global__ void residual_add_rms_norm_fp8_kernel<__hip_bfloat16>(__hip_bfloat16*, const __hip_bfloat16*, const __hip_bfloat16*, __hip_fp8_e4m3*, int, float, const float*);
+
+void residual_add_rms_norm_fp8(__hip_bfloat16* residual, const __hip_bfloat16* x,
+                                const __hip_bfloat16* weight, __hip_fp8_e4m3* out,
+                                int seq_len, int dim, float eps,
+                                const float* d_scale, hipStream_t stream) {
+    residual_add_rms_norm_fp8_kernel<__hip_bfloat16><<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        residual, x, weight, out, dim, eps, d_scale);
 }
 
 // ── Fused bias + residual add + LayerNorm ──

--- a/csrc/amd/kernels/patch_embed.hip
+++ b/csrc/amd/kernels/patch_embed.hip
@@ -1,0 +1,89 @@
+// ================================================================
+// FlashRT AMD — Patch embedding kernels (FP16, CDNA wave64)
+//
+// 1. im2col: (nv, 224, 224, 3) → (nv*256, 588) strided copy
+// 2. bias_pos: output[i,j] += bias[j] + pos_emb[i % S_per_view, j]
+//
+// Mirrors csrc/kernels/patch_embed.cu host-wrapper signatures exactly.
+// ================================================================
+
+#include "common_hip.h"
+
+// ── GPU im2col for SigLIP patch embedding ──
+// Input:  (nv, 224, 224, 3) FP16, row-major NHWC
+// Output: (nv*256, 588) FP16, each row = one 14×14×3 patch flattened
+//
+// Equivalent to:
+//   img.reshape(nv, 16, 14, 16, 14, 3)
+//      .transpose(0, 1, 3, 2, 4, 5)
+//      .reshape(nv*256, 588)
+__global__ void patch_im2col_kernel(
+    const __half* __restrict__ input,   // (nv, 224, 224, 3)
+    __half* __restrict__ output,        // (nv*256, 588)
+    int nv)
+{
+    // Total output elements = nv * 256 * 588
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = nv * 256 * 588;
+    if (idx >= total) return;
+
+    // Decode output index
+    int patch_idx = idx / 588;         // which patch [0, nv*256)
+    int feat_idx  = idx % 588;         // which feature [0, 588)
+
+    int batch = patch_idx / 256;       // which view
+    int local_patch = patch_idx % 256; // patch within view
+    int ph = local_patch / 16;         // patch row [0, 16)
+    int pw = local_patch % 16;         // patch col [0, 16)
+
+    int pxh = feat_idx / 42;           // pixel row within patch [0, 14), 42=14*3
+    int pxw = (feat_idx % 42) / 3;     // pixel col within patch [0, 14)
+    int c   = feat_idx % 3;            // channel [0, 3)
+
+    // Source index in (nv, 224, 224, 3) row-major
+    int row = ph * 14 + pxh;
+    int col = pw * 14 + pxw;
+    int src = batch * (224 * 224 * 3) + row * (224 * 3) + col * 3 + c;
+
+    output[idx] = input[src];
+}
+
+void patch_im2col(const __half* input, __half* output, int nv, hipStream_t stream)
+{
+    int total = nv * 256 * 588;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    patch_im2col_kernel<<<blocks, threads, 0, stream>>>(input, output, nv);
+}
+
+// ── Bias + positional embedding ──
+
+__global__ void patch_embed_bias_pos_kernel(
+    __half* __restrict__ output,
+    const __half* __restrict__ bias,
+    const __half* __restrict__ pos_emb,
+    int S, int D, int S_per_view)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = S * D;
+    if (idx >= total) return;
+
+    int i = idx / D;
+    int j = idx % D;
+    int pos_i = i % S_per_view;
+
+    float v = __half2float(output[idx])
+            + __half2float(bias[j])
+            + __half2float(pos_emb[pos_i * D + j]);
+    output[idx] = __float2half(v);
+}
+
+void patch_embed_bias_pos(__half* output, const __half* bias, const __half* pos_emb,
+                          int S, int D, int S_per_view, hipStream_t stream)
+{
+    int total = S * D;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    patch_embed_bias_pos_kernel<<<blocks, threads, 0, stream>>>(
+        output, bias, pos_emb, S, D, S_per_view);
+}

--- a/csrc/amd/kernels/quantize_fp8.hip
+++ b/csrc/amd/kernels/quantize_fp8.hip
@@ -91,9 +91,41 @@ void fp8_accumulate_scale_max(const float* src_scale, float* dst_scale,
     fp8_accumulate_scale_max_kernel<<<1, 1, 0, stream>>>(src_scale, dst_scale);
 }
 
+// ── Wide variant (CDNA retune): dwordx4 load (8 bf16), packed 8-byte
+// FP8 store. Same per-element math as quantize_fp8_kernel_generic —
+// bit-exact (verified by the ew_tune probe).
+struct alignas(16) qz_bf16x8 { __hip_bfloat162 p[4]; };
+struct alignas(8) qz_fp8x8 { unsigned char b[8]; };
+
+__global__ void quantize_fp8_kernel_wide8(const qz_bf16x8* __restrict__ in,
+                                          qz_fp8x8* __restrict__ out,
+                                          const float* __restrict__ scale,
+                                          int nchunks) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= nchunks) return;
+    qz_bf16x8 v = in[idx];
+    float inv_s = 1.0f / (*scale);
+    qz_fp8x8 o;
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) {
+        float v0 = __bfloat162float(v.p[k].x) * inv_s;
+        float v1 = __bfloat162float(v.p[k].y) * inv_s;
+        o.b[2*k]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f)).__x;
+        o.b[2*k+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f)).__x;
+    }
+    out[idx] = o;
+}
+
 // Static FP8 quantize: uses pre-computed scale on device (no absmax, no reduction)
 void quantize_fp8_static(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
                           const float* d_scale, int n, hipStream_t stream) {
+    if (n % 8 == 0 && ((uintptr_t)input & 15) == 0 && ((uintptr_t)output & 7) == 0) {
+        int nchunks = n >> 3;
+        quantize_fp8_kernel_wide8<<<(nchunks + 255) / 256, 256, 0, stream>>>(
+            reinterpret_cast<const qz_bf16x8*>(input),
+            reinterpret_cast<qz_fp8x8*>(output), d_scale, nchunks);
+        return;
+    }
     int n2 = n >> 1;
     int threads = 256;
     int blocks = (n2 + threads - 1) / threads;

--- a/csrc/amd/kernels/quantize_fp8.hip
+++ b/csrc/amd/kernels/quantize_fp8.hip
@@ -1,0 +1,118 @@
+// ================================================================
+// FlashRT AMD — Quantization kernels (dtype-generic FP8, CDNA wave64)
+// FP8 static/device-only quantize + scale-max accumulate.
+// Mirrors csrc/kernels/quantize.cu host-wrapper signatures exactly so
+// the pipeline layer stays portable text across platforms.
+//
+// FP8 dtype: OCP e4m3 via <hip/hip_fp8.h> __hip_fp8_e4m3 — the same
+// byte format the hipBLASLt GEMM side consumes as HIP_R_8F_E4M3.
+// __hip_fp8_e4m3(float) defaults to __HIP_SATFINITE + __HIP_E4M3,
+// matching the __nv_fp8_e4m3(float) saturating round-to-nearest-even
+// conversion of the CUDA original. Values are pre-clamped to ±448
+// (the e4m3 finite max) before conversion, exactly as in quantize.cu.
+//
+// Deviations from quantize.cu (noted, not silent):
+//   - only the deployed pi05 surface is ported: quantize_fp8_static,
+//     quantize_fp8_device (+ absmax/compute_scale helpers) and
+//     fp8_accumulate_scale_max. The alloc-per-call quantize_fp8,
+//     dequant helpers, L2 prefetch and NVFP4 sections are CUDA-only.
+//   - absmax_kernel's intra-block reduction is wave64 (CUDA warp32);
+//     max-reduction order does not affect the result.
+// ================================================================
+
+#include "common_hip.h"
+#include <hip/hip_fp8.h>
+
+// ── FP8 Quantize ──
+
+template<typename T>
+__global__ void absmax_kernel(const T* __restrict__ x, float* max_val, int n) {
+    using T2 = typename packed2<T>::type;
+    extern __shared__ float shared[];
+    const T2* x2 = reinterpret_cast<const T2*>(x);
+    int n2 = n >> 1;
+    float local_max = 0.0f;
+    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n2; i += gridDim.x * blockDim.x) {
+        T2 val = x2[i];
+        local_max = fmaxf(local_max, fmaxf(fabsf(to_f32(val.x)), fabsf(to_f32(val.y))));
+    }
+    // Wave-level max reduction (wave64)
+    local_max = wave_reduce_max(local_max);
+    int lane = threadIdx.x & (FVK_WAVE_SIZE - 1);
+    int wave_id = threadIdx.x >> 6;
+    if (lane == 0) shared[wave_id] = local_max;
+    __syncthreads();
+    int num_waves = blockDim.x >> 6;
+    local_max = (threadIdx.x < num_waves) ? shared[threadIdx.x] : 0.0f;
+    if (wave_id == 0) local_max = wave_reduce_max(local_max);
+    // absmax >= 0, so int-bit atomicMax orders identically to float max
+    if (threadIdx.x == 0) atomicMax((int*)max_val, __float_as_int(local_max));
+}
+
+template __global__ void absmax_kernel<__half>(const __half*, float*, int);
+template __global__ void absmax_kernel<__hip_bfloat16>(const __hip_bfloat16*, float*, int);
+
+template<typename T>
+__global__ void quantize_fp8_kernel_generic(const T* __restrict__ input,
+                                     __hip_fp8_e4m3* __restrict__ output,
+                                     const float* scale, int n) {
+    using T2 = typename packed2<T>::type;
+    const T2* in2 = reinterpret_cast<const T2*>(input);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        float inv_s = 1.0f / (*scale);
+        T2 val = in2[idx];
+        float v0 = to_f32(val.x) * inv_s, v1 = to_f32(val.y) * inv_s;
+        output[2*idx]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f));
+        output[2*idx+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f));
+    }
+}
+
+template __global__ void quantize_fp8_kernel_generic<__half>(const __half*, __hip_fp8_e4m3*, const float*, int);
+template __global__ void quantize_fp8_kernel_generic<__hip_bfloat16>(const __hip_bfloat16*, __hip_fp8_e4m3*, const float*, int);
+
+// ── FP8 Quantize Device-Only (HIP Graph compatible) ──
+__global__ void compute_scale_kernel(const float* d_absmax, float* d_scale) {
+    float amax = *d_absmax;
+    float scale = amax / 448.0f;
+    if (scale < 1e-12f) scale = 1e-12f;
+    *d_scale = scale;
+}
+
+__global__ void fp8_accumulate_scale_max_kernel(const float* src_scale,
+                                                float* dst_scale) {
+    float scale = *src_scale;
+    atomicMax(reinterpret_cast<int*>(dst_scale), __float_as_int(scale));
+}
+
+void fp8_accumulate_scale_max(const float* src_scale, float* dst_scale,
+                              hipStream_t stream) {
+    fp8_accumulate_scale_max_kernel<<<1, 1, 0, stream>>>(src_scale, dst_scale);
+}
+
+// Static FP8 quantize: uses pre-computed scale on device (no absmax, no reduction)
+void quantize_fp8_static(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
+                          const float* d_scale, int n, hipStream_t stream) {
+    int n2 = n >> 1;
+    int threads = 256;
+    int blocks = (n2 + threads - 1) / threads;
+    quantize_fp8_kernel_generic<__hip_bfloat16><<<blocks, threads, 0, stream>>>(input, output, d_scale, n);
+}
+
+void quantize_fp8_device(const __hip_bfloat16* input, __hip_fp8_e4m3* output,
+                          float* d_scale, int n, hipStream_t stream) {
+    hipMemsetAsync(d_scale, 0, sizeof(float), stream);
+
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    if (blocks > 1024) blocks = 1024;
+    int smem = (threads / FVK_WAVE_SIZE) * sizeof(float);
+    absmax_kernel<__hip_bfloat16><<<blocks, threads, smem, stream>>>(input, d_scale, n);
+
+    compute_scale_kernel<<<1, 1, 0, stream>>>(d_scale, d_scale);
+
+    int n2 = n >> 1;
+    blocks = (n2 + threads - 1) / threads;
+    quantize_fp8_kernel_generic<__hip_bfloat16><<<blocks, threads, 0, stream>>>(input, output, d_scale, n);
+}

--- a/csrc/amd/kernels/rope.hip
+++ b/csrc/amd/kernels/rope.hip
@@ -1,6 +1,7 @@
 // ================================================================
 // FlashRT AMD — QKV split kernels (CDNA wave64)
-// QKV split, fused QKV split + RoPE.
+// QKV split, fused QKV split + RoPE, and the devpos variant
+// (runtime device K/V-cache row offset for fixed-shape prompt mode).
 // Mirrors csrc/kernels/rope.cu host-wrapper signatures exactly so
 // the pipeline layer stays portable text across platforms.
 // ================================================================
@@ -127,4 +128,75 @@ void qkv_split_rope(const __hip_bfloat16* qkv,
     int blocks = (total + threads - 1) / threads;
     qkv_split_rope_kernel<<<blocks, threads, 0, stream>>>(
         qkv, rope_weights, Q, K, V, seq, q_dim, k_dim, v_dim, head_dim);
+}
+
+// ── Fused QKV Split + RoPE with a RUNTIME (device) K/V-cache row offset ──
+// Identical math to qkv_split_rope, but the K/V destination row is shifted by
+// ``devpos[0]`` read at launch time. Q is still written contiguous (rows 0..seq).
+// This lets a single fixed-shape HIP graph append the decoder's K/V right
+// after a variable-length valid prefix (devpos = valid prefix length), so the
+// cross-attention can be one contiguous (seqused) call instead of recapturing
+// per prompt length. K/V are the cache BASE pointers (row 0), not pre-offset.
+__global__ void qkv_split_rope_devpos_kernel(
+    const __hip_bfloat16* __restrict__ qkv,
+    const __hip_bfloat16* __restrict__ rope_weights,
+    __hip_bfloat16* __restrict__ Q,
+    __hip_bfloat16* __restrict__ K,
+    __hip_bfloat16* __restrict__ V,
+    const int* __restrict__ devpos,
+    int seq, int q_dim, int k_dim, int v_dim, int head_dim) {
+    int qkv_dim = q_dim + k_dim + v_dim;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * qkv_dim;
+    if (idx >= total) return;
+
+    int row = idx / qkv_dim;
+    int col = idx % qkv_dim;
+    int pos = devpos[0];  // runtime K/V-cache row offset (valid prefix length)
+
+    if (col < q_dim) {
+        int q_col = col;
+        int head = q_col / head_dim;
+        int d_in_head = q_col % head_dim;
+        int pair = d_in_head / 2;
+        int is_odd = d_in_head & 1;
+        int pair_base_qkv = row * qkv_dim + head * head_dim + pair * 2;
+        float x0 = __bfloat162float(qkv[pair_base_qkv]);
+        float x1 = __bfloat162float(qkv[pair_base_qkv + 1]);
+        int rope_base = row * head_dim + pair * 2;
+        float c = __bfloat162float(rope_weights[rope_base]);
+        float s = __bfloat162float(rope_weights[rope_base + 1]);
+        int out_idx = row * q_dim + q_col;
+        if (is_odd == 0) Q[out_idx] = __float2bfloat16(x0 * c - x1 * s);
+        else             Q[out_idx] = __float2bfloat16(x1 * c + x0 * s);
+    } else if (col < q_dim + k_dim) {
+        int k_col = col - q_dim;
+        int pair = k_col / 2;
+        int is_odd = k_col & 1;
+        int pair_base_qkv = row * qkv_dim + q_dim + pair * 2;
+        float x0 = __bfloat162float(qkv[pair_base_qkv]);
+        float x1 = __bfloat162float(qkv[pair_base_qkv + 1]);
+        int rope_base = row * head_dim + pair * 2;
+        float c = __bfloat162float(rope_weights[rope_base]);
+        float s = __bfloat162float(rope_weights[rope_base + 1]);
+        int out_idx = (pos + row) * k_dim + k_col;
+        if (is_odd == 0) K[out_idx] = __float2bfloat16(x0 * c - x1 * s);
+        else             K[out_idx] = __float2bfloat16(x1 * c + x0 * s);
+    } else {
+        int v_col = col - q_dim - k_dim;
+        V[(pos + row) * v_dim + v_col] = qkv[idx];
+    }
+}
+
+void qkv_split_rope_devpos(const __hip_bfloat16* qkv,
+                           const __hip_bfloat16* rope_weights,
+                           __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+                           const int* devpos,
+                           int seq, int q_dim, int k_dim, int v_dim,
+                           int head_dim, hipStream_t stream) {
+    int total = seq * (q_dim + k_dim + v_dim);
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    qkv_split_rope_devpos_kernel<<<blocks, threads, 0, stream>>>(
+        qkv, rope_weights, Q, K, V, devpos, seq, q_dim, k_dim, v_dim, head_dim);
 }

--- a/csrc/amd/kernels/rope.hip
+++ b/csrc/amd/kernels/rope.hip
@@ -1,0 +1,130 @@
+// ================================================================
+// FlashRT AMD — QKV split kernels (CDNA wave64)
+// QKV split, fused QKV split + RoPE.
+// Mirrors csrc/kernels/rope.cu host-wrapper signatures exactly so
+// the pipeline layer stays portable text across platforms.
+// ================================================================
+
+#include "common_hip.h"
+
+// ── QKV Split ──
+// Pure memcpy by column region: qkv (seq, q_dim+k_dim+v_dim) row-major
+// scatters into Q (seq, q_dim), K (seq, k_dim), V (seq, v_dim).
+template<typename T>
+__global__ void qkv_split_kernel_t(const T* __restrict__ qkv,
+                                   T* __restrict__ Q,
+                                   T* __restrict__ K,
+                                   T* __restrict__ V,
+                                   int seq, int q_dim, int k_dim, int v_dim) {
+    int qkv_dim = q_dim + k_dim + v_dim;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * qkv_dim;
+    if (idx < total) {
+        int row = idx / qkv_dim;
+        int col = idx % qkv_dim;
+        T val = qkv[idx];
+        if (col < q_dim) {
+            Q[row * q_dim + col] = val;
+        } else if (col < q_dim + k_dim) {
+            K[row * k_dim + (col - q_dim)] = val;
+        } else {
+            V[row * v_dim + (col - q_dim - k_dim)] = val;
+        }
+    }
+}
+
+template __global__ void qkv_split_kernel_t<__half>(
+    const __half*, __half*, __half*, __half*, int, int, int, int);
+template __global__ void qkv_split_kernel_t<__hip_bfloat16>(
+    const __hip_bfloat16*, __hip_bfloat16*, __hip_bfloat16*, __hip_bfloat16*,
+    int, int, int, int);
+
+void qkv_split(const __hip_bfloat16* qkv,
+               __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+               int seq, int q_dim, int k_dim, int v_dim,
+               hipStream_t stream) {
+    int total = seq * (q_dim + k_dim + v_dim);
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    qkv_split_kernel_t<__hip_bfloat16><<<blocks, threads, 0, stream>>>(
+        qkv, Q, K, V, seq, q_dim, k_dim, v_dim);
+}
+
+// ── Fused QKV Split + RoPE ──
+// Interleaved-pair rotation: within each head, elements (2d, 2d+1) form a
+// rotation pair. rope_weights layout: (seq, head_dim) with interleaved
+// (cos, sin) per pair — rope_weights[row, 2p] = cos, [row, 2p+1] = sin.
+// Q has q_dim/head_dim heads (all rotated); K is single-head (k_dim wide,
+// rotated with the same per-row weights); V is copied through.
+__global__ void qkv_split_rope_kernel(
+    const __hip_bfloat16* __restrict__ qkv,
+    const __hip_bfloat16* __restrict__ rope_weights,
+    __hip_bfloat16* __restrict__ Q,
+    __hip_bfloat16* __restrict__ K,
+    __hip_bfloat16* __restrict__ V,
+    int seq, int q_dim, int k_dim, int v_dim, int head_dim) {
+    int qkv_dim = q_dim + k_dim + v_dim;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * qkv_dim;
+    if (idx >= total) return;
+
+    int row = idx / qkv_dim;
+    int col = idx % qkv_dim;
+
+    if (col < q_dim) {
+        int q_col = col;
+        int head = q_col / head_dim;
+        int d_in_head = q_col % head_dim;
+        int pair = d_in_head / 2;
+        int is_odd = d_in_head & 1;
+
+        int pair_base_qkv = row * qkv_dim + head * head_dim + pair * 2;
+        float x0 = __bfloat162float(qkv[pair_base_qkv]);
+        float x1 = __bfloat162float(qkv[pair_base_qkv + 1]);
+
+        int rope_base = row * head_dim + pair * 2;
+        float c = __bfloat162float(rope_weights[rope_base]);
+        float s = __bfloat162float(rope_weights[rope_base + 1]);
+
+        int out_idx = row * q_dim + q_col;
+        if (is_odd == 0) {
+            Q[out_idx] = __float2bfloat16(x0 * c - x1 * s);
+        } else {
+            Q[out_idx] = __float2bfloat16(x1 * c + x0 * s);
+        }
+    } else if (col < q_dim + k_dim) {
+        int k_col = col - q_dim;
+        int pair = k_col / 2;
+        int is_odd = k_col & 1;
+
+        int pair_base_qkv = row * qkv_dim + q_dim + pair * 2;
+        float x0 = __bfloat162float(qkv[pair_base_qkv]);
+        float x1 = __bfloat162float(qkv[pair_base_qkv + 1]);
+
+        int rope_base = row * head_dim + pair * 2;
+        float c = __bfloat162float(rope_weights[rope_base]);
+        float s = __bfloat162float(rope_weights[rope_base + 1]);
+
+        int out_idx = row * k_dim + k_col;
+        if (is_odd == 0) {
+            K[out_idx] = __float2bfloat16(x0 * c - x1 * s);
+        } else {
+            K[out_idx] = __float2bfloat16(x1 * c + x0 * s);
+        }
+    } else {
+        int v_col = col - q_dim - k_dim;
+        V[row * v_dim + v_col] = qkv[idx];
+    }
+}
+
+void qkv_split_rope(const __hip_bfloat16* qkv,
+                    const __hip_bfloat16* rope_weights,
+                    __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
+                    int seq, int q_dim, int k_dim, int v_dim, int head_dim,
+                    hipStream_t stream) {
+    int total = seq * (q_dim + k_dim + v_dim);
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    qkv_split_rope_kernel<<<blocks, threads, 0, stream>>>(
+        qkv, rope_weights, Q, K, V, seq, q_dim, k_dim, v_dim, head_dim);
+}

--- a/csrc/amd/kernels/rope.hip
+++ b/csrc/amd/kernels/rope.hip
@@ -118,12 +118,67 @@ __global__ void qkv_split_rope_kernel(
     }
 }
 
+// ── Pair-per-thread 2D variant (CDNA retune) ──
+// One rotation pair per thread, blockIdx.y = row: no div/mod for the
+// row, one dword load + one dword store per thread; each thread
+// computes BOTH rotated outputs of its pair — identical float math to
+// the two elements of the flat kernel, bit-exact (verified by the
+// ew_tune probe). ~1.5x on encoder-seq shapes.
+__global__ void qkv_split_rope_pair_kernel(
+    const __hip_bfloat16* __restrict__ qkv,
+    const __hip_bfloat16* __restrict__ rope_weights,
+    __hip_bfloat16* __restrict__ Q,
+    __hip_bfloat16* __restrict__ K,
+    __hip_bfloat16* __restrict__ V,
+    int q_dim, int k_dim, int v_dim, int head_dim, int qkv_dim) {
+    int row = blockIdx.y;
+    int p = blockIdx.x * blockDim.x + threadIdx.x;
+    int npairs = qkv_dim >> 1;
+    if (p >= npairs) return;
+    int col = p << 1;
+
+    const __hip_bfloat162* src2 =
+        reinterpret_cast<const __hip_bfloat162*>(qkv + (size_t)row * qkv_dim);
+    __hip_bfloat162 xv = src2[p];
+
+    if (col < q_dim) {
+        int d_in_head = col % head_dim;   // even by construction
+        __hip_bfloat162 cs = reinterpret_cast<const __hip_bfloat162*>(
+            rope_weights)[((size_t)row * head_dim + d_in_head) >> 1];
+        float x0 = __bfloat162float(xv.x), x1 = __bfloat162float(xv.y);
+        float c = __bfloat162float(cs.x), s = __bfloat162float(cs.y);
+        reinterpret_cast<__hip_bfloat162*>(Q)[((size_t)row * q_dim + col) >> 1] =
+            __halves2bfloat162(__float2bfloat16(x0 * c - x1 * s),
+                               __float2bfloat16(x1 * c + x0 * s));
+    } else if (col < q_dim + k_dim) {
+        int k_col = col - q_dim;
+        __hip_bfloat162 cs = reinterpret_cast<const __hip_bfloat162*>(
+            rope_weights)[((size_t)row * head_dim + k_col) >> 1];
+        float x0 = __bfloat162float(xv.x), x1 = __bfloat162float(xv.y);
+        float c = __bfloat162float(cs.x), s = __bfloat162float(cs.y);
+        reinterpret_cast<__hip_bfloat162*>(K)[((size_t)row * k_dim + k_col) >> 1] =
+            __halves2bfloat162(__float2bfloat16(x0 * c - x1 * s),
+                               __float2bfloat16(x1 * c + x0 * s));
+    } else {
+        int v_col = col - q_dim - k_dim;
+        reinterpret_cast<__hip_bfloat162*>(V)[((size_t)row * v_dim + v_col) >> 1] = xv;
+    }
+}
+
 void qkv_split_rope(const __hip_bfloat16* qkv,
                     const __hip_bfloat16* rope_weights,
                     __hip_bfloat16* Q, __hip_bfloat16* K, __hip_bfloat16* V,
                     int seq, int q_dim, int k_dim, int v_dim, int head_dim,
                     hipStream_t stream) {
-    int total = seq * (q_dim + k_dim + v_dim);
+    int qkv_dim = q_dim + k_dim + v_dim;
+    if (((q_dim | k_dim | v_dim | head_dim) & 1) == 0) {
+        int npairs = qkv_dim >> 1;
+        dim3 grid((npairs + 255) / 256, seq);
+        qkv_split_rope_pair_kernel<<<grid, 256, 0, stream>>>(
+            qkv, rope_weights, Q, K, V, q_dim, k_dim, v_dim, head_dim, qkv_dim);
+        return;
+    }
+    int total = seq * qkv_dim;
     int threads = 256;
     int blocks = (total + threads - 1) / threads;
     qkv_split_rope_kernel<<<blocks, threads, 0, stream>>>(

--- a/csrc/amd/kernels/stream_probe.h
+++ b/csrc/amd/kernels/stream_probe.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <cstddef>
+
+// ================================================================
+// FlashRT AMD — weight-streaming read-bandwidth probe (CDNA4, wave64)
+//
+// A parameterized family of pure-read kernels that answers one
+// question: which combination of in-flight bytes (ILP), waves per
+// workgroup (TLP), grid size, load width/hint, and access pattern
+// saturates HBM/L2 read bandwidth on this part. The hand-written
+// weight-streaming kernels (small-M GEMM, fused FFN, fused decoder
+// attention) all share one pattern — 256-thread WG, per-lane serial
+// K loop of dwordx4 loads — and all plateau far below the D2D copy
+// rate. This probe sweeps each axis of that pattern in isolation so
+// the winning recipe is measured, not guessed.
+//
+// Each variant streams the source buffer exactly once, accumulates a
+// u32 checksum per thread (so loads cannot be dead-code-eliminated;
+// integer adds are far too cheap to ever bound the loop), reduces it
+// within the workgroup, and writes one word per WG to `out`. The sum
+// of out[0..grid) equals the u32 sum of the whole buffer (mod 2^32)
+// for every variant — a cross-variant correctness check for free.
+//
+// Axes (see kVariants in stream_probe.hip for the instantiated set):
+//   ilp        independent chained loads per thread per loop iteration
+//              (1 / 4 / 8) — outer loops are unroll-1 so the compiler
+//              cannot silently widen the axis
+//   waves      waves per WG: 4 (256T) / 8 (512T) / 16 (1024T)
+//   grid       workgroups: 64 / 256 / 1024
+//   load       0 = global dwordx4, 1 = dwordx4 nontemporal (streaming
+//              hint, bypasses L2 retention), 2 = global dwordx2
+//   strided    0 = lane-coalesced streaming; 1 = each lane serially
+//              walks its own 1KB row (the small-M GEMM nn pattern:
+//              per lane load touches a distinct cache line)
+//   persistent 0 = each WG owns one contiguous slab of the buffer
+//              (serial walk, like a per-lane K loop at WG scale);
+//              1 = grid-stride over the whole buffer
+// ================================================================
+
+struct StreamProbeVariant {
+    const char* name;
+    int ilp;        // independent chain loads per thread per iteration
+    int waves;      // waves per WG (blockDim.x = waves * 64)
+    int grid;       // workgroups launched
+    int load;       // 0 = dwordx4, 1 = dwordx4 nontemporal, 2 = dwordx2
+    int strided;    // 0 = lane-coalesced, 1 = 1KB row per lane
+    int persistent; // 0 = per-WG contiguous slab, 1 = grid-stride
+};
+
+// Number of instantiated variants.
+int stream_probe_variant_count();
+
+// Descriptor for variant `id` (0 <= id < stream_probe_variant_count()).
+const StreamProbeVariant& stream_probe_variant(int id);
+
+// Run one variant: read `nbytes` from `src`, write one u32 checksum
+// word per WG into `out` (must hold >= variant.grid words). Throws
+// std::runtime_error on a bad id, nbytes not a multiple of 1024
+// (the row size — keeps every variant covering identical bytes), or
+// src not 16-byte aligned.
+void stream_probe(int variant_id, const void* src, size_t nbytes,
+                  unsigned* out, hipStream_t stream);

--- a/csrc/amd/kernels/stream_probe.hip
+++ b/csrc/amd/kernels/stream_probe.hip
@@ -1,0 +1,267 @@
+#include "stream_probe.h"
+#include "common_hip.h"
+
+#include <stdexcept>
+#include <string>
+
+// ================================================================
+// FlashRT AMD — weight-streaming read-bandwidth probe (CDNA4, wave64)
+//
+// See stream_probe.h for the contract. Design notes:
+//
+// The physics under test is Little's law: sustained read bandwidth =
+// bytes in flight / memory latency. A wave with one dwordx4 load
+// outstanding contributes 16B per lane = 1KB in flight; whether the
+// machine reaches the DRAM rate depends entirely on how many such
+// loads the whole grid keeps outstanding at once. The three levers
+// are ILP (independent loads per thread before the first s_waitcnt),
+// TLP (waves resident per CU), and grid (CUs covered + waves per CU).
+// The probe holds everything else constant — one pass over the
+// buffer, u32 adds only — so the measured GB/s isolates the levers.
+//
+// ILP is kept honest: every outer loop is `#pragma unroll 1`, so a
+// variant's chain depth is exactly its template parameter. At ILP=N
+// the N loads have independent addresses and no consumer between
+// them, so the compiler clusters them ahead of one s_waitcnt block —
+// N*16B in flight per lane. (ILP=1 still allows the scheduler to
+// overlap the loop-carried next-address computation, mirroring what
+// the real kernels' serial K loops get for free — that is the point:
+// variant 0 is the existing kernels' pattern, measured.)
+//
+// The strided pattern reproduces the small-M GEMM nn access shape:
+// each lane serially walks its own 1KB row, so at any instant the 64
+// lanes of a wave touch 64 different cache lines 1KB apart. Per-lane
+// the stream is contiguous, per-instruction it is maximally scattered
+// — the DRAM-sector-utilization question the GEMM raised.
+//
+// The nontemporal variants use __builtin_nontemporal_load, which on
+// gfx950 sets the load's temporal-hint bits so streamed weights do
+// not evict L2 working set. For a pure streaming pass it also tests
+// whether skipping L2 allocation changes the achievable rate.
+//
+// Checksum: u32 lane accumulate -> wave shfl tree -> LDS across
+// waves -> one word per WG. Fixed order is irrelevant here (integer
+// add is associative/commutative); the sum exists only to keep the
+// loads live and to let the host cross-check that every variant read
+// every byte exactly once.
+// ================================================================
+
+// ── 16B / 8B load vector types ──
+// clang ext_vector_type lowers to single dwordx4 / dwordx2 loads and
+// is accepted by __builtin_nontemporal_load. The plain-struct branch
+// exists only for host-side syntax tooling; hipcc is always clang.
+#if defined(__clang__)
+typedef unsigned int probe_u32x4 __attribute__((ext_vector_type(4)));
+typedef unsigned int probe_u32x2 __attribute__((ext_vector_type(2)));
+#else
+struct probe_u32x4 { unsigned x, y, z, w; };
+struct probe_u32x2 { unsigned x, y; };
+#endif
+
+namespace {
+
+constexpr int PROBE_ROW_BYTES = 1024;   // strided pattern: 1KB row per lane
+constexpr int PROBE_MAX_WAVES = 16;     // 1024-thread WG ceiling
+
+template<int LOAD> struct probe_vec { using type = probe_u32x4; };
+template<>         struct probe_vec<2> { using type = probe_u32x2; };
+
+__device__ __forceinline__ unsigned vsum(probe_u32x4 v) { return v.x + v.y + v.z + v.w; }
+__device__ __forceinline__ unsigned vsum(probe_u32x2 v) { return v.x + v.y; }
+
+template<int LOAD, typename V>
+__device__ __forceinline__ V probe_load(const V* p) {
+#if defined(__clang__)
+    if constexpr (LOAD == 1) return __builtin_nontemporal_load(p);
+#endif
+    return *p;
+}
+
+// u32 block reduce: wave shfl tree, then LDS across waves; thread 0
+// writes the WG's word. One word per WG — negligible write traffic.
+__device__ __forceinline__ void probe_reduce_store(unsigned acc,
+                                                   unsigned* __restrict__ out) {
+    __shared__ unsigned wsum[PROBE_MAX_WAVES];
+    const int lane = threadIdx.x & (FVK_WAVE_SIZE - 1);
+    const int wave = threadIdx.x >> 6;
+    #pragma unroll
+    for (int off = FVK_WAVE_SIZE / 2; off > 0; off >>= 1)
+        acc += __shfl_down(acc, off);
+    if (lane == 0) wsum[wave] = acc;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        unsigned total = 0;
+        const int nwaves = blockDim.x >> 6;
+        for (int w = 0; w < nwaves; ++w) total += wsum[w];
+        out[blockIdx.x] = total;
+    }
+}
+
+template<int ILP, int LOAD, bool STRIDED, bool PERSISTENT>
+__global__ void stream_probe_kernel(const unsigned* __restrict__ src,
+                                    size_t n_bytes,
+                                    unsigned* __restrict__ out) {
+    using V = typename probe_vec<LOAD>::type;
+    constexpr size_t VB = sizeof(V);
+    const V* vsrc = reinterpret_cast<const V*>(src);
+    unsigned acc = 0;
+
+    if constexpr (!STRIDED) {
+        // ── lane-coalesced streaming ──
+        // Chain element k sits one thread-stride further along, so at
+        // every k the full WG (or grid) front is contiguous in memory.
+        const size_t n_vec = n_bytes / VB;
+        size_t base, end, tstride;
+        if constexpr (PERSISTENT) {
+            base    = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+            end     = n_vec;
+            tstride = (size_t)gridDim.x * blockDim.x;
+        } else {
+            const size_t slab = (n_vec + gridDim.x - 1) / gridDim.x;
+            const size_t beg  = (size_t)blockIdx.x * slab;
+            base    = beg + threadIdx.x;
+            end     = beg + slab < n_vec ? beg + slab : n_vec;
+            tstride = blockDim.x;
+        }
+        const size_t chain_span = (size_t)(ILP - 1) * tstride;
+        size_t i = base;
+        #pragma unroll 1
+        while (i + chain_span < end) {          // hot loop: chain fully in bounds
+            V v[ILP];
+            #pragma unroll
+            for (int k = 0; k < ILP; ++k)
+                v[k] = probe_load<LOAD>(vsrc + i + (size_t)k * tstride);
+            #pragma unroll
+            for (int k = 0; k < ILP; ++k) acc += vsum(v[k]);
+            i += (size_t)ILP * tstride;
+        }
+        #pragma unroll 1
+        for (; i < end; i += tstride)           // tail: remaining chain positions
+            acc += vsum(probe_load<LOAD>(vsrc + i));
+    } else {
+        // ── row-strided: each lane serially walks its own 1KB row ──
+        // (small-M GEMM nn shape: adjacent lanes 1KB apart, so every
+        // load instruction touches 64 distinct cache lines per wave.)
+        constexpr int ROW_VECS = PROBE_ROW_BYTES / (int)VB;
+        static_assert(ROW_VECS % ILP == 0, "row must divide into ILP chains");
+        const size_t n_rows = n_bytes / PROBE_ROW_BYTES;
+        size_t rbase, rend, rstride;
+        if constexpr (PERSISTENT) {
+            rbase   = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+            rend    = n_rows;
+            rstride = (size_t)gridDim.x * blockDim.x;
+        } else {
+            const size_t slab = (n_rows + gridDim.x - 1) / gridDim.x;
+            const size_t beg  = (size_t)blockIdx.x * slab;
+            rbase   = beg + threadIdx.x;
+            rend    = beg + slab < n_rows ? beg + slab : n_rows;
+            rstride = blockDim.x;
+        }
+        #pragma unroll 1
+        for (size_t r = rbase; r < rend; r += rstride) {
+            const V* row = vsrc + r * ROW_VECS;
+            #pragma unroll 1
+            for (int j = 0; j < ROW_VECS; j += ILP) {
+                V v[ILP];
+                #pragma unroll
+                for (int k = 0; k < ILP; ++k)
+                    v[k] = probe_load<LOAD>(row + j + k);
+                #pragma unroll
+                for (int k = 0; k < ILP; ++k) acc += vsum(v[k]);
+            }
+        }
+    }
+    probe_reduce_store(acc, out);
+}
+
+// ── Variant matrix ──
+// One-factor-at-a-time from the baseline (variant 0 = the shared
+// pattern of the existing hand kernels), plus combined candidates
+// for the expected winners on each axis pairing, plus the strided
+// family that mirrors the small-M GEMM nn access shape.
+//
+// name grammar: <pattern>_<load>_i<ilp>_w<waves>_<g|p><grid>
+//   co/rs = coalesced / row-strided; x4/nt/x2 = dwordx4 / dwordx4
+//   nontemporal / dwordx2; g = slab partition, p = persistent
+//   grid-stride.
+const StreamProbeVariant kVariants[] = {
+    //  name                  ilp waves grid load strided persistent
+    { "co_x4_i1_w4_g256",      1,  4,  256, 0, 0, 0 },  // 0: baseline = existing kernels
+    { "co_x4_i4_w4_g256",      4,  4,  256, 0, 0, 0 },  // 1: ILP axis
+    { "co_x4_i8_w4_g256",      8,  4,  256, 0, 0, 0 },  // 2
+    { "co_x4_i1_w8_g256",      1,  8,  256, 0, 0, 0 },  // 3: TLP axis
+    { "co_x4_i1_w16_g256",     1, 16,  256, 0, 0, 0 },  // 4
+    { "co_x4_i4_w8_g256",      4,  8,  256, 0, 0, 0 },  // 5: ILP x TLP
+    { "co_x4_i1_w4_g64",       1,  4,   64, 0, 0, 0 },  // 6: grid axis
+    { "co_x4_i1_w4_g1024",     1,  4, 1024, 0, 0, 0 },  // 7
+    { "co_x4_i4_w4_g64",       4,  4,   64, 0, 0, 0 },  // 8: can ILP substitute grid?
+    { "co_x4_i4_w4_g1024",     4,  4, 1024, 0, 0, 0 },  // 9
+    { "co_x4_i4_w8_g1024",     4,  8, 1024, 0, 0, 0 },  // 10: max in-flight candidate
+    { "co_x4_i8_w8_g1024",     8,  8, 1024, 0, 0, 0 },  // 11
+    { "co_x4_i1_w4_p256",      1,  4,  256, 0, 0, 1 },  // 12: slab vs grid-stride @256
+    { "co_x4_i4_w4_p256",      4,  4,  256, 0, 0, 1 },  // 13
+    { "co_x4_i4_w8_p256",      4,  8,  256, 0, 0, 1 },  // 14
+    { "co_nt_i1_w4_g256",      1,  4,  256, 1, 0, 0 },  // 15: nontemporal axis
+    { "co_nt_i4_w8_g1024",     4,  8, 1024, 1, 0, 0 },  // 16: nt on winner candidate
+    { "co_x2_i1_w4_g256",      1,  4,  256, 2, 0, 0 },  // 17: dwordx2 axis
+    { "co_x2_i8_w4_g256",      8,  4,  256, 2, 0, 0 },  // 18: x2, bytes-in-flight = x4 i4
+    { "rs_x4_i1_w4_g256",      1,  4,  256, 0, 1, 0 },  // 19: strided baseline (GEMM nn)
+    { "rs_x4_i4_w4_g256",      4,  4,  256, 0, 1, 0 },  // 20: does ILP rescue strided?
+    { "rs_x4_i1_w8_g1024",     1,  8, 1024, 0, 1, 0 },  // 21: does occupancy?
+    { "rs_nt_i4_w8_g1024",     4,  8, 1024, 1, 1, 0 },  // 22: strided all-in
+};
+constexpr int kVariantCount = (int)(sizeof(kVariants) / sizeof(kVariants[0]));
+
+template<int ILP, int LOAD>
+void probe_launch(const StreamProbeVariant& v, const unsigned* src,
+                  size_t n_bytes, unsigned* out, hipStream_t stream) {
+    const dim3 grid((unsigned)v.grid);
+    const dim3 block((unsigned)(v.waves * FVK_WAVE_SIZE));
+    #define STREAM_PROBE_LAUNCH(S, P)                                          \
+        hipLaunchKernelGGL(HIP_KERNEL_NAME(stream_probe_kernel<ILP, LOAD, S, P>), \
+                           grid, block, 0, stream, src, n_bytes, out)
+    if      (!v.strided && !v.persistent) STREAM_PROBE_LAUNCH(false, false);
+    else if (!v.strided &&  v.persistent) STREAM_PROBE_LAUNCH(false, true);
+    else if ( v.strided && !v.persistent) STREAM_PROBE_LAUNCH(true,  false);
+    else                                  STREAM_PROBE_LAUNCH(true,  true);
+    #undef STREAM_PROBE_LAUNCH
+}
+
+}  // namespace
+
+int stream_probe_variant_count() { return kVariantCount; }
+
+const StreamProbeVariant& stream_probe_variant(int id) {
+    if (id < 0 || id >= kVariantCount)
+        throw std::runtime_error("stream_probe_variant: bad id " + std::to_string(id));
+    return kVariants[id];
+}
+
+void stream_probe(int variant_id, const void* src, size_t nbytes,
+                  unsigned* out, hipStream_t stream) {
+    if (variant_id < 0 || variant_id >= kVariantCount)
+        throw std::runtime_error("stream_probe: bad variant id " +
+                                 std::to_string(variant_id));
+    if (nbytes == 0 || nbytes % PROBE_ROW_BYTES != 0)
+        throw std::runtime_error("stream_probe: nbytes must be a nonzero "
+                                 "multiple of " + std::to_string(PROBE_ROW_BYTES));
+    if ((reinterpret_cast<uintptr_t>(src) & 15) != 0)
+        throw std::runtime_error("stream_probe: src must be 16-byte aligned");
+
+    const StreamProbeVariant& v = kVariants[variant_id];
+    const unsigned* s = static_cast<const unsigned*>(src);
+    switch (v.ilp * 10 + v.load) {
+        case 10: probe_launch<1, 0>(v, s, nbytes, out, stream); break;
+        case 11: probe_launch<1, 1>(v, s, nbytes, out, stream); break;
+        case 12: probe_launch<1, 2>(v, s, nbytes, out, stream); break;
+        case 40: probe_launch<4, 0>(v, s, nbytes, out, stream); break;
+        case 41: probe_launch<4, 1>(v, s, nbytes, out, stream); break;
+        case 42: probe_launch<4, 2>(v, s, nbytes, out, stream); break;
+        case 80: probe_launch<8, 0>(v, s, nbytes, out, stream); break;
+        case 81: probe_launch<8, 1>(v, s, nbytes, out, stream); break;
+        case 82: probe_launch<8, 2>(v, s, nbytes, out, stream); break;
+        default:
+            throw std::runtime_error("stream_probe: unhandled ilp/load combo for '" +
+                                     std::string(v.name) + "'");
+    }
+}

--- a/docs/deployment_amd.md
+++ b/docs/deployment_amd.md
@@ -1,198 +1,181 @@
-# FlashRT on AMD (ROCm / CDNA4)
+# FlashRT on AMD Instinct (MI350X / CDNA4)
 
-Status: **pi05 production-ready on MI350-series (gfx950)**. The AMD backend
-is a self-contained tree — the CUDA tree and root CMake are untouched, and
-the two never build together.
+This is the model-independent guide to the AMD backend: supported
+hardware, how to build the extension, how the tree is laid out, how
+hardware routing works, and how to run the tests.
 
-Measured on an MI350X (gfx950, ROCm 7.x, PyTorch ROCm 2.10), pi05 with
-2 camera views, 10-step denoise, FP8 default:
+Per-model deployment guides:
 
-| Arm | median / inference | vs torch.compile |
+| Model | Guide | Status |
 |---|---|---|
-| PyTorch eager (openpi reference) | 116.9 ms | 0.35× |
-| `torch.compile` max-autotune | 40.5 ms | 1.00× |
-| **FlashRT AMD, FP8 (default)** | **16.4 ms** | **2.47×** |
-| FlashRT AMD, BF16 (`use_fp8=False`) | ~30 ms | 1.34× |
+| Pi0.5 | [deployment_amd_pi05.md](deployment_amd_pi05.md) | FP8 default, BF16 available |
+| GROOT N1.7 | `deployment_amd_groot_n17.md` | on the GROOT integration branch |
 
-Output cosine vs the FP32 openpi reference on real LIBERO frames: 0.9993
-(FP8), 0.9992 (BF16). For context, the same protocol on an RTX 5090
-(FlashRT FP8, CUDA) measures 19.7 ms — the CDNA4 port is currently the
-fastest FlashRT pi05 target.
+## Supported hardware
 
-## Layout
+**gfx950 only** — CDNA4, i.e. the Instinct MI350 series, with ROCm 7.x
+and a ROCm build of PyTorch. The kernels use gfx950-specific MFMA shapes
+and FP8 (OCP `e4m3`) paths that produce wrong results, not a slow
+fallback, on other AMD architectures. The restriction is therefore
+enforced twice:
 
-| Path | Role |
-|---|---|
-| `csrc/amd/` | HIP kernels + hipBLASLt GemmRunner + MFMA GEMM/attention + pybind module `flash_rt_amd_kernels` (standalone CMake project) |
-| `flash_rt/amd/core/` | `HipBuffer` / `HipGraph` — ctypes twins of the CUDA runtime seam over `libamdhip64` |
-| `flash_rt/amd/models/pi05/pipeline.py` | Mirror of `pipeline_rtx.py` for CDNA4 (BF16 + FP8 branches) |
-| `flash_rt/amd/frontends/torch/pi05.py` | `Pi05TorchFrontendAmd` — weights, quantization, prompt, capture driving |
-| `flash_rt/amd/hardware/cdna4/` | Attention backends (aiter CK-tile + hand-written split-KV decoder) |
-
-The pybind ABI is identical to the CUDA module: every kernel entry takes
-`uintptr_t` device pointers plus a `uintptr_t` stream. Pipeline code is
-portable text between the two trees.
-
-Hot-path composition at the defaults: full HIP-graph capture-then-replay,
-static per-tensor FP8 (OCP e4m3) with real-data calibration, hand-written
-MFMA small-M GEMMs with setup-time weight repacking for the decoder
-(qkv / attn-out / ffn-gate-up; the K=4096 down-projection stays on the
-measured-faster hipBLASLt), aiter CK-tile attention for vision/encoder,
-hand-written split-KV flash attention with a fused FP8-quantize epilogue
-for the decoder cross-attention, and CDNA-tuned elementwise/norm kernels.
-
-## Requirements
-
-- ROCm 7.x with hipBLASLt (`gfx950` validated; `GPU_ARCH` overridable)
-- PyTorch ROCm build (`torch.version.hip` set)
-- pybind11 (auto-installed to a local target dir by the build wrapper if
-  the interpreter lacks it)
-- optional: [aiter](https://github.com/ROCm/aiter) for the vision/encoder
-  attention backend (the default). Without it, set `FVK_AMD_ATTN=sdpa`
-  for the torch-sdpa fallback (slower, still correct). aiter JIT-compiles
-  against the running torch ABI — keep one torch version per environment.
+- **At build time** — `scripts/amd/build_amd.sh` rejects a `GPU_ARCH`
+  argument that does not start with `gfx950`. Set
+  `FLASHRT_AMD_ALLOW_ARCH=1` to override when bringing up a port to a
+  future architecture.
+- **At frontend init** — the frontend reads the extension's
+  `device_arch()` (the running device's `gcnArchName`, e.g.
+  `gfx950:sramecc+:xnack-`) and `build_info()["gpu_arch"]` (the
+  compile-time target) and raises `RuntimeError` unless both are gfx950.
+  This fires before the checkpoint is touched, so forcing
+  `hardware="amd_cdna4"` on another AMD card fails immediately instead
+  of computing garbage.
 
 ## Build
 
+The AMD sources live in a standalone tree with their own build entry
+point; the root (CUDA) CMake project is not involved and does not need
+CUDA or CUTLASS present.
+
 ```bash
-cmake -B build-amd -S csrc/amd [-DGPU_ARCH=gfx950]
-cmake --build build-amd -j 8
-# or, in cmake-less environments (falls back to a one-shot hipcc):
 bash scripts/amd/build_amd.sh gfx950
 ```
 
-Output: `flash_rt/amd/flash_rt_amd_kernels*.so`. Release flags only
-(`-O3 -ffp-contract=fast`); no third-party kernel library is vendored —
-hipBLASLt ships with ROCm, and everything else is hand-written HIP/MFMA.
+Output: `flash_rt/amd/flash_rt_amd_kernels*.so`. The script prefers
+CMake and falls back to a direct `hipcc` one-shot compile when no usable
+CMake is available.
 
-## Run (pi05)
+Dependencies:
 
-Through the stable door (`amd_cdna4` is auto-detected on ROCm builds):
+- **hipBLASLt** — ships with ROCm; the GEMM engine and the baseline that
+  hand-written kernels must beat before they are routed.
+- **No vendored third-party code.** There is no CUTLASS/CK checkout to
+  manage; everything else is HIP C++ plus the `__builtin_amdgcn_mfma_*`
+  intrinsics from the compiler.
+- **aiter** (strongly recommended) — AMD's assembly flash-attention
+  library. When importable it serves the attention sites; otherwise the
+  backend falls back to torch SDPA. Attention is the largest kernel
+  bucket on this backend, so the fallback is expensive: measured on the
+  Pi0.5 quickstart, one variable changed, same process and node —
+
+  | Attention path | Median |
+  |---|---|
+  | aiter (default when importable) | 16.3 ms |
+  | torch SDPA (aiter absent, or `FVK_AMD_ATTN=sdpa`) | 22.2 ms |
+
+  If a deployment measures roughly 6 ms above the published numbers,
+  check that aiter is importable in the serving environment first.
+
+## Layout
+
+```
+csrc/amd/                    standalone HIP tree (own CMake entry point)
+  bindings.cpp               pybind module flash_rt_amd_kernels
+  gemm/                      hipBLASLt runner + hand-written MFMA GEMMs
+  attention/                 hand-written CDNA4 attention kernels
+  kernels/                   norm / activation / quantize / fusion families
+flash_rt/amd/
+  core/hip_buffer.py         ctypes device memory over libamdhip64
+  core/hip_graph.py          ctypes HIP graph capture / instantiate / replay
+  hardware/cdna4/            attention backends (aiter, SDPA fallback)
+  models/<model>/pipeline.py pointer-only forward passes
+  frontends/torch/<model>.py weight load, calibration, capture, infer
+```
+
+The pybind entry points keep the same names and the same
+`uintptr_t` pointer + stream ABI as the CUDA module, so pipeline code is
+portable text between the two backends. The execution contract is also
+the same: warm up, capture a HIP graph once, then replay it — no Python
+or framework operations on the inference path.
+
+## Hardware routing
+
+Auto-detection: when `torch.version.hip` is set and the device's
+`gcnArchName` is gfx950, `detect_arch()` returns `"amd_cdna4"`. Another
+ROCm architecture raises rather than falling through to an NVIDIA table
+entry.
 
 ```python
 import flash_rt
+
 model = flash_rt.load_model(checkpoint_dir, config="pi05",
-                            framework="torch", hardware="amd_cdna4",
-                            num_views=2, use_fp8=True)
-fe = model.pipeline
-fe.set_prompt(prompt_text, state=state)   # builds + captures the HIP graph
-fe.calibrate(observation)                 # real-data FP8 calibration
-result = fe.infer({"image": img, "wrist_image": wrist})
-actions = result["actions"]               # (chunk, 7) unnormalized
+                            framework="torch")            # auto-detected
+model = flash_rt.load_model(checkpoint_dir, config="pi05",
+                            framework="torch",
+                            hardware="amd_cdna4")         # explicit
 ```
 
-Or construct `flash_rt.amd.frontends.torch.pi05.Pi05TorchFrontendAmd`
-directly with the same keyword surface as `Pi05TorchFrontendRtx`. A
-runnable end-to-end script with timing lives at
-`examples/pi05_amd_quickstart.py`. The PaliGemma tokenizer model is
-resolved as documented in `flash_rt/utils/paligemma_tokenizer.py`
-(`FLASH_RT_PALIGEMMA_TOKENIZER` override supported).
+Expected failures:
 
-### Precision tiers
+| Situation | Error |
+|---|---|
+| Extension not built | `ImportError` naming `flash_rt_amd_kernels` and the build command |
+| Non-gfx950 AMD device | `RuntimeError` naming the device and build architectures |
+| Model/framework not ported to AMD | `RuntimeError` from pipeline resolution |
+| Thor-only options (`use_fp4_decoder`, `use_fa4`) | `ValueError` naming the supported hardware |
 
-- **FP8 (default, `use_fp8=True`)** — OCP FP8 E4M3 weights + activations
-  for the large GEMMs, static per-tensor scales from real-data
-  calibration (`calibrate(...)`, percentile 99.9 by default — the same
-  contract as `docs/calibration.md`). MI350's FP8 is OCP e4m3, never the
-  CDNA3 `fnuz` variant.
-- **BF16 (`use_fp8=False`, or env `FVK_PI05_AMD_FORCE_BF16=1`)** — the
-  unquantized baseline; no calibration required.
-- **FP4 (MXFP4)** — the GEMM kernels are unlocked and parity-verified
-  (`GemmRunner.mxfp4_nt_dev`, hipBLASLt `HIP_R_4F_E2M1` + UE8M0 vec32
-  block scales), but there is deliberately **no end-to-end FP4 tier
-  yet**: on the current ROCm stack no available fp4 path beats FP8 at
-  these shapes, so a user-facing knob would only select a slower path.
-  `load_model(use_fp4=True)` remains Thor-only and raises on AMD.
+## Shared environment knobs
 
-### Prompt-length graph strategies
-
-Pi0.5 renders robot state into the prompt, so token length drifts.
-Both RTX strategies are supported, same semantics:
-
-- `state_prompt_mode="exact"` (default): one captured graph per exact
-  prompt length, cached; pair with `warm_state_prompt_buckets(...)`.
-- `state_prompt_mode="fixed"`: ONE padded graph serves every length
-  (masked prefix + runtime `devpos`/`seqused` K/V append) — no mid-loop
-  captures. Latency follows the PADDED length, so right-size the
-  capacity to your deployment's real prompt+state length with
-  `state_prompt_fixed_max_len=<tokens>` (env
-  `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`; default is the 200-token
-  ceiling, and a prompt exceeding the capacity raises instead of
-  recapturing). The decoder runs the same custom split-KV kernel as
-  exact mode (seqused pointer, FP8-out epilogue included); the encoder
-  runs the seqused variant of the MFMA flash kernel (masked sdpa stays
-  available via `FVK_AMD_FIXED_ENC_ATTN=sdpa`). At a right-sized
-  capacity the premium over exact mode is well under 1 ms, and accuracy
-  holds (cos vs the FP32 reference 0.9993, on par with exact).
-
-### Environment knobs
+These apply to every model on this backend. Model-specific knobs are
+documented in the per-model guides.
 
 | Env | Default | Meaning |
 |---|---|---|
-| `FVK_AMD_ATTN` | `aiter` | vision/encoder attention backend: `aiter` (CK-tile) or `sdpa` (torch fallback) |
-| `FVK_AMD_DEC_ATTN` | `custom` | decoder cross-attention: `custom` (hand-written split-KV flash, fastest) or backend default |
-| `FVK_AMD_ATTN_FP8OUT` | `1` | fuse the decoder attention output's FP8 quantize into the attention epilogue (bit-identical to the standalone quantize) |
-| `FVK_AMD_FIXED_ENC_ATTN` | `flash` | fixed-mode encoder attention: `flash` (MFMA flash kernel, seqused pointer) or `sdpa` (masked torch fallback) |
-| `FVK_AMD_CALIB_DET_ATTN` | `flash` | route the encoder site through the deterministic MFMA flash kernel during FP8 calibration so the collected scales are run-to-run stable; `off` calibrates on the library path |
-| `FVK_AMD_DEC_GEMM` | `mfma` | decoder small-M GEMMs: `mfma` (packed-weight MFMA kernels where measured faster) or `hipblaslt` |
-| `FLASHRT_FP8_NT_AUTOTUNE` | `auto` | timed hipBLASLt algorithm selection for the FP8 GEMMs at setup |
-| `FLASHRT_FP8_ALGO_POOL` | `16` | heuristic pool depth for the timed selection; deeper pools (64/128) find faster encoder algos but widen run-to-run pick variance |
-| `FVK_PI05_AMD_FORCE_BF16` | `0` | force the BF16 baseline regardless of `use_fp8` |
-| `FLASHRT_PI05_STATE_PROMPT_MODE` | — | overrides the `state_prompt_mode` constructor arg |
-| `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN` | `200` | fixed-mode padded capacity in tokens; overrides `state_prompt_fixed_max_len` |
+| `FVK_AMD_ATTN` | `aiter` | attention backend: `aiter` or `sdpa` (torch fallback) |
+| `FLASHRT_FP8_NT_AUTOTUNE` | `auto` | timed hipBLASLt algorithm selection at setup; `off` uses heuristic top-1 |
+| `FLASHRT_FP8_ALGO_POOL` | `16` | candidate pool depth for the timed selection. Deeper pools (64/128) sometimes find faster algorithms but widen run-to-run pick variance, and a single mis-timed trial can ship a slow algorithm |
+| `FLASHRT_AMD_ALLOW_ARCH` | `0` | build-script escape hatch for a non-gfx950 port |
 
-`FRT_ATTN_NSPLIT` / `FRT_ATTN_FUSED` / `FRT_ATTN_REDUCE_ALT` are
-attention micro-bench knobs (A/B sweeps); leave them unset in production.
+## Tests
 
-### Feature matrix vs the RTX frontend
+```bash
+python -m pytest tests/test_amd_routing.py tests/test_amd_extension.py \
+                 tests/test_amd_hip_graph.py tests/test_amd_kernel_parity.py \
+                 tests/test_amd_pi05_model.py -v
+```
 
-| Surface | AMD |
-|---|---|
-| `set_prompt` / `warm_state_prompt_buckets` | ✅ |
-| `calibrate` / `calibrate_with_real_data` (single + multi-frame percentile) | ✅ |
-| `infer` / `precision_spec` / `get_latency_stats` | ✅ |
-| `state_prompt_mode` `"exact"` + `"fixed"` (devpos/seqused) | ✅ |
-| Temporal K/V caching (`cache_frames`), vision pooling/truncation knobs | ✅ |
-| `set_rl_mode` (advantage-conditioned RL) | ❌ raises `NotImplementedError` |
-| CFG-batched mode (`set_batched_mode` / `*_batch`) | ❌ raises `NotImplementedError` |
-| INT8 vision/decoder legacy tiers (RTX sm87 era) | ❌ not applicable |
+| File | Covers | Skips when |
+|---|---|---|
+| `test_amd_routing.py` | pipeline-map entry, `detect_arch()` ROCm branch (including non-gfx950 rejection), `load_model` failure modes | mostly runs anywhere; extension-dependent cases skip without the `.so` |
+| `test_amd_extension.py` | `build_info()` / `device_arch()` coherence, required-symbol inventory of every bound kernel | extension not importable |
+| `test_amd_hip_graph.py` | buffer round-trips with pattern data, capture → instantiate → replay, byte-identical repeat replays | no ROCm device or extension |
+| `test_amd_kernel_parity.py` | numerical parity of the kernel surface against torch references on real-distribution inputs, including FP8 byte-exactness and the seqused fixed-shape attention path | no ROCm device or extension |
+| `test_amd_pi05_model.py` | end-to-end model load, graph capture, pinned-noise determinism, exact/fixed prompt modes, FP8 and BF16 | no checkpoint (see the per-model guide for the environment variables) |
 
-## Reproducing the numbers
+Everything skips cleanly with a stated reason on machines without ROCm,
+so the suite is safe to run in a CUDA-only CI.
 
-1. Build (above) on a gfx950 part with ROCm 7.x + torch-ROCm.
-2. `python examples/pi05_amd_quickstart.py --checkpoint <pi05_ckpt>`
-   → expect ~16-17 ms median FP8 after warmup (add `--bf16` for ~30 ms).
-3. For a judged comparison, run the identical loop on the CUDA build
-   (RTX frontend) — protocols are the same: 50-iteration median after
-   5 warmup replays, real image observations, `calibrate` before timing.
+## Measuring
 
-Cross-run medians move ±0.2-0.35 ms with hipBLASLt's timed autotune
-picks; compare arms inside one process where possible.
+- Report **medians** after warmup. Report a minimum only as a lower
+  bound, never as the headline.
+- Timed hipBLASLt algorithm selection moves cross-run medians by roughly
+  ±0.2–0.35 ms. Compare arms **inside one process** where possible.
+- When judging output cosine against a saved reference, **pin the
+  denoise noise** to the exact array the reference was generated with.
+  A fresh random draw shifts cosine by about 1e-3, which is the same
+  magnitude as a real numerical regression and will mask it.
+- Profiler kernel durations on ROCm fold dispatch gaps into the reported
+  kernel time. Use them for ranking buckets; take absolute per-call
+  numbers from isolated in-graph chains.
 
-When judging output cosine against a saved reference, pin the denoise
-noise via `infer(obs, noise=...)` to the exact array the reference was
-generated with — a fresh random draw shifts cos by ~1e-3, which swamps
-real numerics differences. With pinned noise the FP8 band is
-0.9992-0.9994 across processes (residual: library-attention
-nondeterminism and autotune algorithm picks).
-
-## HIP-vs-CUDA notes
+## HIP versus CUDA notes
 
 - Wavefront is 64: reductions use `__shfl_down` wave64 helpers
-  (`csrc/amd/kernels/common_hip.h`); there are no `*_sync` shuffle variants.
-- The 3-arg graph instantiate is `hipGraphInstantiateWithFlags`.
-- Memcpy-kind and capture-mode enums match CUDA numerically (validated on
-  hardware by the runtime-seam smoke).
-- FP8 storage is OCP `e4m3` (`__hip_fp8_e4m3`, `HIP_R_8F_E4M3`) — never the
-  CDNA3 `fnuz` variant.
-- hipBLASLt matmul is column-major; the GemmRunner uses the operand-swap
-  form (`D_col = B_col @ A_col`), the same trick the CUDA FP8 paths use.
-- gfx950 exposes `V_MFMA_F32_16X16X32_FP8_FP8` / `..._BF16` builtins with
-  per-lane contiguous 8 B fragments; the decoder GEMMs repack weights at
-  setup into the exact per-lane consumption order so each workgroup
-  streams its tile as one linear slab (`csrc/amd/gemm/smallm_mfma.h`).
-- Static `__shared__` is capped at 64 KB; larger LDS (up to gfx950's
-  160 KB) needs `hipFuncSetAttribute(MaxDynamicSharedMemorySize)` +
-  dynamic shared memory (see `csrc/amd/attention/encoder_flash.hip`).
-- The default stream cannot be captured (`hipErrorStreamCaptureUnsupported`);
-  capture on a dedicated stream (the pipeline uses a torch side stream).
+  (`csrc/amd/kernels/common_hip.h`); there are no `*_sync` shuffle
+  variants.
+- The three-argument graph instantiate is `hipGraphInstantiateWithFlags`.
+- Memcpy-kind and capture-mode enum values match CUDA numerically
+  (validated on hardware by the runtime-seam smoke test).
+- FP8 storage is OCP `e4m3` (`__hip_fp8_e4m3`, `HIP_R_8F_E4M3`) — never
+  the CDNA3 `fnuz` variant.
+- hipBLASLt matmul is column-major; the GEMM runner uses the
+  operand-swap form (`D_col = B_col @ A_col`), the same trick the CUDA
+  FP8 paths use.
+- gfx950 exposes `V_MFMA_F32_16X16X32_FP8_FP8` and `..._BF16` with
+  per-lane contiguous 8-byte fragments; the hand-written GEMMs repack
+  weights at setup into per-lane consumption order so each workgroup
+  streams its weight tile linearly.
+- Every HIP runtime call in the Python layer is return-code checked; a
+  failed launch, copy or synchronise raises instead of letting a stale
+  buffer be read back as a result.

--- a/docs/deployment_amd.md
+++ b/docs/deployment_amd.md
@@ -112,10 +112,16 @@ Both RTX strategies are supported, same semantics:
 - `state_prompt_mode="exact"` (default): one captured graph per exact
   prompt length, cached; pair with `warm_state_prompt_buckets(...)`.
 - `state_prompt_mode="fixed"`: ONE padded graph serves every length
-  (masked prefix + runtime `devpos` K/V append) — no mid-loop captures.
-  Latency follows the padded `max_prompt_len` (measured ~29 ms at the
-  defaults vs ~16.5 ms exact-mode); accuracy holds (cos vs the FP32
-  reference 0.9996, on par with exact mode).
+  (masked prefix + runtime `devpos`/`seqused` K/V append) — no mid-loop
+  captures. Latency follows the PADDED length, so right-size the
+  capacity to your deployment's real prompt+state length with
+  `state_prompt_fixed_max_len=<tokens>` (env
+  `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`; default is the 200-token
+  ceiling, and a prompt exceeding the capacity raises instead of
+  recapturing). The decoder runs the same custom split-KV kernel as
+  exact mode (seqused pointer, FP8-out epilogue included); the encoder
+  attention falls back from aiter to masked sdpa in this mode.
+  Accuracy holds (cos vs the FP32 reference 0.9996, on par with exact).
 
 ### Environment knobs
 
@@ -126,6 +132,7 @@ Both RTX strategies are supported, same semantics:
 | `FVK_AMD_ATTN_FP8OUT` | `1` | fuse the decoder attention output's FP8 quantize into the attention epilogue (bit-identical to the standalone quantize) |
 | `FVK_AMD_DEC_GEMM` | `mfma` | decoder small-M GEMMs: `mfma` (packed-weight MFMA kernels where measured faster) or `hipblaslt` |
 | `FLASHRT_FP8_NT_AUTOTUNE` | `auto` | timed hipBLASLt algorithm selection for the FP8 GEMMs at setup |
+| `FLASHRT_FP8_ALGO_POOL` | `16` | heuristic pool depth for the timed selection; deeper pools (64/128) find faster encoder algos but widen run-to-run pick variance |
 | `FVK_PI05_AMD_FORCE_BF16` | `0` | force the BF16 baseline regardless of `use_fp8` |
 | `FLASHRT_PI05_STATE_PROMPT_MODE` | — | overrides the `state_prompt_mode` constructor arg |
 

--- a/docs/deployment_amd.md
+++ b/docs/deployment_amd.md
@@ -1,0 +1,65 @@
+# FlashRT on AMD (ROCm / CDNA4)
+
+Status: pi05 first target. The AMD backend is a self-contained tree — the
+CUDA tree and root CMake are untouched, and the two never build together.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `csrc/amd/` | HIP kernels + hipBLASLt GemmRunner + pybind module `flash_rt_amd_kernels` (standalone CMake project) |
+| `flash_rt/amd/core/` | `HipBuffer` / `HipGraph` — ctypes twins of the CUDA runtime seam over `libamdhip64` |
+| `flash_rt/amd/models/pi05/pipeline.py` | Mirror of `pipeline_rtx.py` for CDNA4 (BF16 + FP8 branches) |
+| `flash_rt/amd/frontends/torch/pi05.py` | `Pi05TorchFrontendAmd` — weights, quantization, prompt, capture driving |
+| `flash_rt/amd/hardware/cdna4/attn_backend.py` | Attention backend (pointer-stable buffers; interim sdpa math) |
+
+The pybind ABI is identical to the CUDA module: every kernel entry takes
+`uintptr_t` device pointers plus a `uintptr_t` stream. Pipeline code is
+portable text between the two trees.
+
+## Requirements
+
+- ROCm 7.x with hipBLASLt (`gfx950` validated; `GPU_ARCH` overridable)
+- PyTorch ROCm build (allocation + interim attention; `torch.version.hip`)
+- pybind11 (auto-installed to a local target dir by the build wrapper if
+  the interpreter lacks it)
+
+## Build
+
+```bash
+cmake -B build-amd -S csrc/amd [-DGPU_ARCH=gfx950]
+cmake --build build-amd -j 8
+# or, in cmake-less environments (falls back to a one-shot hipcc):
+bash scripts/amd/build_amd.sh gfx950
+```
+
+Output: `flash_rt/amd/flash_rt_amd_kernels*.so`.
+
+## Run (pi05)
+
+```python
+from flash_rt.amd.frontends.torch.pi05 import Pi05TorchFrontendAmd
+
+fe = Pi05TorchFrontendAmd(checkpoint_dir, num_views=2, use_fp8=False)
+fe.set_prompt(prompt_text, state=state)          # captures the HIP graph
+result = fe.infer({"image": img, "wrist_image": wrist})
+actions = result["actions"]                       # (chunk, 7) unnormalized
+```
+
+`use_fp8=True` (default) enables OCP FP8 E4M3 weights + activations for the
+large GEMMs after calibration, mirroring the RTX recipe. The PaliGemma
+tokenizer model is resolved as documented in
+`flash_rt/utils/paligemma_tokenizer.py` (`FLASH_RT_PALIGEMMA_TOKENIZER`
+override supported).
+
+## HIP-vs-CUDA notes
+
+- Wavefront is 64: reductions use `__shfl_down` wave64 helpers
+  (`csrc/amd/kernels/common_hip.h`); there are no `*_sync` shuffle variants.
+- The 3-arg graph instantiate is `hipGraphInstantiateWithFlags`.
+- Memcpy-kind and capture-mode enums match CUDA numerically (validated on
+  hardware by the runtime-seam smoke).
+- FP8 storage is OCP `e4m3` (`__hip_fp8_e4m3`, `HIP_R_8F_E4M3`) — never the
+  CDNA3 `fnuz` variant.
+- hipBLASLt matmul is column-major; the GemmRunner uses the operand-swap
+  form (`D_col = B_col @ A_col`), the same trick the CUDA FP8 paths use.

--- a/docs/deployment_amd.md
+++ b/docs/deployment_amd.md
@@ -120,8 +120,10 @@ Both RTX strategies are supported, same semantics:
   ceiling, and a prompt exceeding the capacity raises instead of
   recapturing). The decoder runs the same custom split-KV kernel as
   exact mode (seqused pointer, FP8-out epilogue included); the encoder
-  attention falls back from aiter to masked sdpa in this mode.
-  Accuracy holds (cos vs the FP32 reference 0.9996, on par with exact).
+  runs the seqused variant of the MFMA flash kernel (masked sdpa stays
+  available via `FVK_AMD_FIXED_ENC_ATTN=sdpa`). At a right-sized
+  capacity the premium over exact mode is well under 1 ms, and accuracy
+  holds (cos vs the FP32 reference 0.9993, on par with exact).
 
 ### Environment knobs
 
@@ -130,11 +132,14 @@ Both RTX strategies are supported, same semantics:
 | `FVK_AMD_ATTN` | `aiter` | vision/encoder attention backend: `aiter` (CK-tile) or `sdpa` (torch fallback) |
 | `FVK_AMD_DEC_ATTN` | `custom` | decoder cross-attention: `custom` (hand-written split-KV flash, fastest) or backend default |
 | `FVK_AMD_ATTN_FP8OUT` | `1` | fuse the decoder attention output's FP8 quantize into the attention epilogue (bit-identical to the standalone quantize) |
+| `FVK_AMD_FIXED_ENC_ATTN` | `flash` | fixed-mode encoder attention: `flash` (MFMA flash kernel, seqused pointer) or `sdpa` (masked torch fallback) |
+| `FVK_AMD_CALIB_DET_ATTN` | `flash` | route the encoder site through the deterministic MFMA flash kernel during FP8 calibration so the collected scales are run-to-run stable; `off` calibrates on the library path |
 | `FVK_AMD_DEC_GEMM` | `mfma` | decoder small-M GEMMs: `mfma` (packed-weight MFMA kernels where measured faster) or `hipblaslt` |
 | `FLASHRT_FP8_NT_AUTOTUNE` | `auto` | timed hipBLASLt algorithm selection for the FP8 GEMMs at setup |
 | `FLASHRT_FP8_ALGO_POOL` | `16` | heuristic pool depth for the timed selection; deeper pools (64/128) find faster encoder algos but widen run-to-run pick variance |
 | `FVK_PI05_AMD_FORCE_BF16` | `0` | force the BF16 baseline regardless of `use_fp8` |
 | `FLASHRT_PI05_STATE_PROMPT_MODE` | — | overrides the `state_prompt_mode` constructor arg |
+| `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN` | `200` | fixed-mode padded capacity in tokens; overrides `state_prompt_fixed_max_len` |
 
 `FRT_ATTN_NSPLIT` / `FRT_ATTN_FUSED` / `FRT_ATTN_REDUCE_ALT` are
 attention micro-bench knobs (A/B sweeps); leave them unset in production.
@@ -163,6 +168,13 @@ attention micro-bench knobs (A/B sweeps); leave them unset in production.
 
 Cross-run medians move ±0.2-0.35 ms with hipBLASLt's timed autotune
 picks; compare arms inside one process where possible.
+
+When judging output cosine against a saved reference, pin the denoise
+noise via `infer(obs, noise=...)` to the exact array the reference was
+generated with — a fresh random draw shifts cos by ~1e-3, which swamps
+real numerics differences. With pinned noise the FP8 band is
+0.9992-0.9994 across processes (residual: library-attention
+nondeterminism and autotune algorithm picks).
 
 ## HIP-vs-CUDA notes
 

--- a/docs/deployment_amd.md
+++ b/docs/deployment_amd.md
@@ -1,28 +1,56 @@
 # FlashRT on AMD (ROCm / CDNA4)
 
-Status: pi05 first target. The AMD backend is a self-contained tree — the
-CUDA tree and root CMake are untouched, and the two never build together.
+Status: **pi05 production-ready on MI350-series (gfx950)**. The AMD backend
+is a self-contained tree — the CUDA tree and root CMake are untouched, and
+the two never build together.
+
+Measured on an MI350X (gfx950, ROCm 7.x, PyTorch ROCm 2.10), pi05 with
+2 camera views, 10-step denoise, FP8 default:
+
+| Arm | median / inference | vs torch.compile |
+|---|---|---|
+| PyTorch eager (openpi reference) | 116.9 ms | 0.35× |
+| `torch.compile` max-autotune | 40.5 ms | 1.00× |
+| **FlashRT AMD, FP8 (default)** | **16.4 ms** | **2.47×** |
+| FlashRT AMD, BF16 (`use_fp8=False`) | ~30 ms | 1.34× |
+
+Output cosine vs the FP32 openpi reference on real LIBERO frames: 0.9993
+(FP8), 0.9992 (BF16). For context, the same protocol on an RTX 5090
+(FlashRT FP8, CUDA) measures 19.7 ms — the CDNA4 port is currently the
+fastest FlashRT pi05 target.
 
 ## Layout
 
 | Path | Role |
 |---|---|
-| `csrc/amd/` | HIP kernels + hipBLASLt GemmRunner + pybind module `flash_rt_amd_kernels` (standalone CMake project) |
+| `csrc/amd/` | HIP kernels + hipBLASLt GemmRunner + MFMA GEMM/attention + pybind module `flash_rt_amd_kernels` (standalone CMake project) |
 | `flash_rt/amd/core/` | `HipBuffer` / `HipGraph` — ctypes twins of the CUDA runtime seam over `libamdhip64` |
 | `flash_rt/amd/models/pi05/pipeline.py` | Mirror of `pipeline_rtx.py` for CDNA4 (BF16 + FP8 branches) |
 | `flash_rt/amd/frontends/torch/pi05.py` | `Pi05TorchFrontendAmd` — weights, quantization, prompt, capture driving |
-| `flash_rt/amd/hardware/cdna4/attn_backend.py` | Attention backend (pointer-stable buffers; interim sdpa math) |
+| `flash_rt/amd/hardware/cdna4/` | Attention backends (aiter CK-tile + hand-written split-KV decoder) |
 
 The pybind ABI is identical to the CUDA module: every kernel entry takes
 `uintptr_t` device pointers plus a `uintptr_t` stream. Pipeline code is
 portable text between the two trees.
 
+Hot-path composition at the defaults: full HIP-graph capture-then-replay,
+static per-tensor FP8 (OCP e4m3) with real-data calibration, hand-written
+MFMA small-M GEMMs with setup-time weight repacking for the decoder
+(qkv / attn-out / ffn-gate-up; the K=4096 down-projection stays on the
+measured-faster hipBLASLt), aiter CK-tile attention for vision/encoder,
+hand-written split-KV flash attention with a fused FP8-quantize epilogue
+for the decoder cross-attention, and CDNA-tuned elementwise/norm kernels.
+
 ## Requirements
 
 - ROCm 7.x with hipBLASLt (`gfx950` validated; `GPU_ARCH` overridable)
-- PyTorch ROCm build (allocation + interim attention; `torch.version.hip`)
+- PyTorch ROCm build (`torch.version.hip` set)
 - pybind11 (auto-installed to a local target dir by the build wrapper if
   the interpreter lacks it)
+- optional: [aiter](https://github.com/ROCm/aiter) for the vision/encoder
+  attention backend (the default). Without it, set `FVK_AMD_ATTN=sdpa`
+  for the torch-sdpa fallback (slower, still correct). aiter JIT-compiles
+  against the running torch ABI — keep one torch version per environment.
 
 ## Build
 
@@ -33,24 +61,101 @@ cmake --build build-amd -j 8
 bash scripts/amd/build_amd.sh gfx950
 ```
 
-Output: `flash_rt/amd/flash_rt_amd_kernels*.so`.
+Output: `flash_rt/amd/flash_rt_amd_kernels*.so`. Release flags only
+(`-O3 -ffp-contract=fast`); no third-party kernel library is vendored —
+hipBLASLt ships with ROCm, and everything else is hand-written HIP/MFMA.
 
 ## Run (pi05)
 
-```python
-from flash_rt.amd.frontends.torch.pi05 import Pi05TorchFrontendAmd
+Through the stable door (`amd_cdna4` is auto-detected on ROCm builds):
 
-fe = Pi05TorchFrontendAmd(checkpoint_dir, num_views=2, use_fp8=False)
-fe.set_prompt(prompt_text, state=state)          # captures the HIP graph
+```python
+import flash_rt
+model = flash_rt.load_model(checkpoint_dir, config="pi05",
+                            framework="torch", hardware="amd_cdna4",
+                            num_views=2, use_fp8=True)
+fe = model.pipeline
+fe.set_prompt(prompt_text, state=state)   # builds + captures the HIP graph
+fe.calibrate(observation)                 # real-data FP8 calibration
 result = fe.infer({"image": img, "wrist_image": wrist})
-actions = result["actions"]                       # (chunk, 7) unnormalized
+actions = result["actions"]               # (chunk, 7) unnormalized
 ```
 
-`use_fp8=True` (default) enables OCP FP8 E4M3 weights + activations for the
-large GEMMs after calibration, mirroring the RTX recipe. The PaliGemma
-tokenizer model is resolved as documented in
-`flash_rt/utils/paligemma_tokenizer.py` (`FLASH_RT_PALIGEMMA_TOKENIZER`
-override supported).
+Or construct `flash_rt.amd.frontends.torch.pi05.Pi05TorchFrontendAmd`
+directly with the same keyword surface as `Pi05TorchFrontendRtx`. A
+runnable end-to-end script with timing lives at
+`examples/pi05_amd_quickstart.py`. The PaliGemma tokenizer model is
+resolved as documented in `flash_rt/utils/paligemma_tokenizer.py`
+(`FLASH_RT_PALIGEMMA_TOKENIZER` override supported).
+
+### Precision tiers
+
+- **FP8 (default, `use_fp8=True`)** — OCP FP8 E4M3 weights + activations
+  for the large GEMMs, static per-tensor scales from real-data
+  calibration (`calibrate(...)`, percentile 99.9 by default — the same
+  contract as `docs/calibration.md`). MI350's FP8 is OCP e4m3, never the
+  CDNA3 `fnuz` variant.
+- **BF16 (`use_fp8=False`, or env `FVK_PI05_AMD_FORCE_BF16=1`)** — the
+  unquantized baseline; no calibration required.
+- **FP4 (MXFP4)** — the GEMM kernels are unlocked and parity-verified
+  (`GemmRunner.mxfp4_nt_dev`, hipBLASLt `HIP_R_4F_E2M1` + UE8M0 vec32
+  block scales), but there is deliberately **no end-to-end FP4 tier
+  yet**: on the current ROCm stack no available fp4 path beats FP8 at
+  these shapes, so a user-facing knob would only select a slower path.
+  `load_model(use_fp4=True)` remains Thor-only and raises on AMD.
+
+### Prompt-length graph strategies
+
+Pi0.5 renders robot state into the prompt, so token length drifts.
+Both RTX strategies are supported, same semantics:
+
+- `state_prompt_mode="exact"` (default): one captured graph per exact
+  prompt length, cached; pair with `warm_state_prompt_buckets(...)`.
+- `state_prompt_mode="fixed"`: ONE padded graph serves every length
+  (masked prefix + runtime `devpos` K/V append) — no mid-loop captures.
+  Latency follows the padded `max_prompt_len` (measured ~29 ms at the
+  defaults vs ~16.5 ms exact-mode); accuracy holds (cos vs the FP32
+  reference 0.9996, on par with exact mode).
+
+### Environment knobs
+
+| Env | Default | Meaning |
+|---|---|---|
+| `FVK_AMD_ATTN` | `aiter` | vision/encoder attention backend: `aiter` (CK-tile) or `sdpa` (torch fallback) |
+| `FVK_AMD_DEC_ATTN` | `custom` | decoder cross-attention: `custom` (hand-written split-KV flash, fastest) or backend default |
+| `FVK_AMD_ATTN_FP8OUT` | `1` | fuse the decoder attention output's FP8 quantize into the attention epilogue (bit-identical to the standalone quantize) |
+| `FVK_AMD_DEC_GEMM` | `mfma` | decoder small-M GEMMs: `mfma` (packed-weight MFMA kernels where measured faster) or `hipblaslt` |
+| `FLASHRT_FP8_NT_AUTOTUNE` | `auto` | timed hipBLASLt algorithm selection for the FP8 GEMMs at setup |
+| `FVK_PI05_AMD_FORCE_BF16` | `0` | force the BF16 baseline regardless of `use_fp8` |
+| `FLASHRT_PI05_STATE_PROMPT_MODE` | — | overrides the `state_prompt_mode` constructor arg |
+
+`FRT_ATTN_NSPLIT` / `FRT_ATTN_FUSED` / `FRT_ATTN_REDUCE_ALT` are
+attention micro-bench knobs (A/B sweeps); leave them unset in production.
+
+### Feature matrix vs the RTX frontend
+
+| Surface | AMD |
+|---|---|
+| `set_prompt` / `warm_state_prompt_buckets` | ✅ |
+| `calibrate` / `calibrate_with_real_data` (single + multi-frame percentile) | ✅ |
+| `infer` / `precision_spec` / `get_latency_stats` | ✅ |
+| `state_prompt_mode` `"exact"` + `"fixed"` (devpos/seqused) | ✅ |
+| Temporal K/V caching (`cache_frames`), vision pooling/truncation knobs | ✅ |
+| `set_rl_mode` (advantage-conditioned RL) | ❌ raises `NotImplementedError` |
+| CFG-batched mode (`set_batched_mode` / `*_batch`) | ❌ raises `NotImplementedError` |
+| INT8 vision/decoder legacy tiers (RTX sm87 era) | ❌ not applicable |
+
+## Reproducing the numbers
+
+1. Build (above) on a gfx950 part with ROCm 7.x + torch-ROCm.
+2. `python examples/pi05_amd_quickstart.py --checkpoint <pi05_ckpt>`
+   → expect ~16-17 ms median FP8 after warmup (add `--bf16` for ~30 ms).
+3. For a judged comparison, run the identical loop on the CUDA build
+   (RTX frontend) — protocols are the same: 50-iteration median after
+   5 warmup replays, real image observations, `calibrate` before timing.
+
+Cross-run medians move ±0.2-0.35 ms with hipBLASLt's timed autotune
+picks; compare arms inside one process where possible.
 
 ## HIP-vs-CUDA notes
 
@@ -63,3 +168,12 @@ override supported).
   CDNA3 `fnuz` variant.
 - hipBLASLt matmul is column-major; the GemmRunner uses the operand-swap
   form (`D_col = B_col @ A_col`), the same trick the CUDA FP8 paths use.
+- gfx950 exposes `V_MFMA_F32_16X16X32_FP8_FP8` / `..._BF16` builtins with
+  per-lane contiguous 8 B fragments; the decoder GEMMs repack weights at
+  setup into the exact per-lane consumption order so each workgroup
+  streams its tile as one linear slab (`csrc/amd/gemm/smallm_mfma.h`).
+- Static `__shared__` is capped at 64 KB; larger LDS (up to gfx950's
+  160 KB) needs `hipFuncSetAttribute(MaxDynamicSharedMemorySize)` +
+  dynamic shared memory (see `csrc/amd/attention/encoder_flash.hip`).
+- The default stream cannot be captured (`hipErrorStreamCaptureUnsupported`);
+  capture on a dedicated stream (the pipeline uses a torch side stream).

--- a/docs/deployment_amd_pi05.md
+++ b/docs/deployment_amd_pi05.md
@@ -1,0 +1,178 @@
+# Pi0.5 on AMD Instinct (MI350X / CDNA4)
+
+Model-specific guide. For hardware support, the build, routing, shared
+environment knobs and the test suite, see
+[deployment_amd.md](deployment_amd.md) first.
+
+## Performance
+
+Pi0.5, 2 camera views, 10-step denoise, median end-to-end latency on
+real observation frames:
+
+| Configuration | Latency | vs torch.compile |
+|---|---|---|
+| PyTorch eager | 116.9 ms | — |
+| torch.compile (max-autotune) | 40.5 ms | 1.00× |
+| **FlashRT AMD, FP8 (default)** | **16.4 ms** | **2.47×** |
+| FlashRT AMD, BF16 (`use_fp8=False`) | ~30 ms | 1.34× |
+
+For context, the same protocol on an RTX 5090 (FlashRT FP8, CUDA)
+measures 19.7 ms.
+
+These numbers are measured with aiter available. Without it the
+attention sites fall back to torch SDPA and end-to-end latency rises by
+roughly 6 ms — see [deployment_amd.md](deployment_amd.md#build).
+
+Accuracy: output cosine against the FP32 reference sits in a
+**0.9992–0.9994** band across processes with the denoise noise pinned
+(see [Judging accuracy](#judging-accuracy)). Graph replay inside a
+process is bit-identical.
+
+## Quick start
+
+```bash
+python examples/pi05_amd_quickstart.py --checkpoint <pi05_checkpoint_dir>
+```
+
+Flags: `--num-views {2,3}` (default 2), `--bf16` for the unquantized
+tier, `--iters` for the timing loop length. Expect roughly 16–17 ms
+median FP8 after warmup, or roughly 30 ms with `--bf16`.
+
+Library use:
+
+```python
+import flash_rt
+
+model = flash_rt.load_model(checkpoint_dir, config="pi05",
+                            framework="torch", num_views=2, use_fp8=True)
+fe = model.pipeline
+fe.set_prompt(prompt_text, state=state_vector)
+fe.calibrate(observation)              # one-time, real data
+result = fe.infer(observation)         # returns {"actions": ...}
+```
+
+## Precision tiers
+
+- **FP8 (default)** — activations calibrated once from real data
+  (`calibrate(...)`, percentile 99.9 by default, the same contract as
+  [calibration.md](calibration.md)); weights quantized at load. MI350's
+  FP8 is OCP `e4m3`, never the CDNA3 `fnuz` variant.
+- **BF16** (`use_fp8=False`, or `FVK_PI05_AMD_FORCE_BF16=1`) — the
+  unquantized baseline; no calibration required.
+- **FP4 (MXFP4)** — the GEMM kernels are unlocked and parity-verified
+  (`GemmRunner.mxfp4_nt_dev`, hipBLASLt `HIP_R_4F_E2M1` with UE8M0 vec32
+  block scales), but there is deliberately **no end-to-end FP4 tier**:
+  on the current ROCm stack no available FP4 path beats FP8 at these
+  shapes, so a user-facing knob would only select a slower path.
+  `load_model(use_fp4=True)` logs a fallback to FP8;
+  `use_fp4_decoder=True` remains Thor-only and raises.
+
+## Observation contract
+
+The frontend validates observations strictly — a missing or wrong-shaped
+view raises instead of leaving stale image buffers in the captured graph
+inputs.
+
+- `num_views` must be **2** (base + wrist camera, the LIBERO deployment)
+  or **3** (+ right wrist camera).
+- Provide either `observation["images"]` with exactly `num_views`
+  entries, or the named keys `image`, `wrist_image`, `wrist_image_right`
+  (the first `num_views` of them; supplying `wrist_image_right` with
+  `num_views=2` is rejected as a view-count mismatch).
+- Every image must be a `uint8` array of shape `(224, 224, 3)`. The
+  normalization path is defined on the 0–255 range.
+
+## Prompt-length strategies
+
+Pi0.5 renders robot state into the prompt, so token length drifts with
+the state values. Both strategies of the RTX frontend are supported with
+the same semantics:
+
+- `state_prompt_mode="exact"` (default) — one captured graph per exact
+  prompt length, cached. Pair with `warm_state_prompt_buckets(...)` to
+  front-load captures instead of paying them mid-episode.
+- `state_prompt_mode="fixed"` — ONE padded graph serves every length
+  (masked prefix plus runtime `devpos`/`seqused` K/V append), so no
+  capture ever happens mid-loop. Latency follows the **padded** length,
+  so right-size the capacity to the deployment's real prompt+state
+  length with `state_prompt_fixed_max_len=<tokens>` (env
+  `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`; the default is the
+  200-token ceiling, and a prompt exceeding the capacity raises rather
+  than silently recapturing).
+
+  In fixed mode the decoder runs the same hand-written split-KV kernel
+  as exact mode (seqused pointer, fused FP8-out epilogue included) and
+  the encoder runs the seqused variant of the MFMA flash kernel. At a
+  right-sized capacity the premium over exact mode is well under 1 ms
+  and accuracy holds (cosine 0.9993, on par with exact).
+
+## Environment knobs
+
+Shared knobs are in [deployment_amd.md](deployment_amd.md). Pi0.5-specific:
+
+| Env | Default | Meaning |
+|---|---|---|
+| `FVK_AMD_DEC_ATTN` | `custom` | decoder cross-attention: `custom` (hand-written split-KV flash, fastest) or the backend default |
+| `FVK_AMD_ATTN_FP8OUT` | `1` | fuse the decoder attention output's FP8 quantize into the attention epilogue (bit-identical to the standalone quantize) |
+| `FVK_AMD_FIXED_ENC_ATTN` | `flash` | fixed-mode encoder attention: `flash` (MFMA flash kernel, seqused pointer) or `sdpa` (masked torch fallback) |
+| `FVK_AMD_CALIB_DET_ATTN` | `flash` | route the encoder site through the deterministic MFMA flash kernel during FP8 calibration so collected scales are run-to-run stable; `off` calibrates on the library path |
+| `FVK_AMD_DEC_GEMM` | `mfma` | decoder small-M GEMMs: `mfma` (packed-weight MFMA kernels where measured faster) or `hipblaslt` |
+| `FVK_PI05_AMD_FORCE_BF16` | `0` | force the BF16 baseline regardless of `use_fp8` |
+| `FLASHRT_PI05_STATE_PROMPT_MODE` | — | overrides the `state_prompt_mode` constructor argument |
+| `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN` | `200` | fixed-mode padded capacity in tokens |
+
+`FRT_ATTN_NSPLIT` / `FRT_ATTN_FUSED` / `FRT_ATTN_REDUCE_ALT` are
+attention micro-benchmark knobs for A/B sweeps; leave them unset in
+production.
+
+## Feature matrix versus the RTX frontend
+
+| Surface | AMD |
+|---|---|
+| `set_prompt` / `warm_state_prompt_buckets` | ✅ |
+| `calibrate` / `calibrate_with_real_data` (single and multi-frame percentile) | ✅ |
+| `infer` / `precision_spec` / `get_latency_stats` | ✅ |
+| `state_prompt_mode` `"exact"` and `"fixed"` (devpos/seqused) | ✅ |
+| Temporal K/V caching (`cache_frames`), vision pooling/truncation knobs | ✅ |
+| `infer(noise=...)` pinned-noise judging | ✅ |
+| `set_rl_mode` (advantage-conditioned RL) | ❌ raises `NotImplementedError` |
+| Batched serving (`set_batched_mode`, `infer_batch`) | ❌ raises `NotImplementedError` |
+| End-to-end FP4 tier | ❌ deliberately not exposed (see Precision tiers) |
+
+## Judging accuracy
+
+The denoise trajectory is conditioned on its starting noise, so a fresh
+random draw moves the output cosine by about 1e-3 — the same magnitude
+as a real numerical regression.
+
+```python
+noise = numpy.random.default_rng(0).standard_normal((10, 32)).astype("float32")
+actions = fe.infer(observation, noise=noise)["actions"]
+```
+
+Pin the noise to the exact array the reference was generated with and
+record the seed (or a hash of the array) alongside the reference. With
+pinned noise the FP8 band is 0.9992–0.9994 across processes; the
+residual spread comes from library-attention nondeterminism and timed
+algorithm picks. Serving should keep the default random draw — pinning
+is a judging protocol, not a deployment setting.
+
+## Reproducing the numbers
+
+1. Build on a gfx950 machine with ROCm 7.x and a ROCm PyTorch build.
+2. `python examples/pi05_amd_quickstart.py --checkpoint <ckpt>` —
+   expect roughly 16–17 ms median FP8 after warmup (`--bf16` for ~30 ms).
+3. For a judged comparison, run the identical loop on the CUDA build
+   (RTX frontend). The protocols are the same: 50-iteration median after
+   5 warmup replays, real image observations, `calibrate` before timing.
+4. For the model-level test gates, point the suite at a checkpoint:
+
+   ```bash
+   export FLASH_RT_PI05_AMD_CKPT=<pi05_checkpoint_dir>
+   # optional: a saved reference-actions .npy for the cosine gate
+   export FLASH_RT_PI05_AMD_REF_ACTIONS=<reference_actions.npy>
+   python -m pytest tests/test_amd_pi05_model.py -v
+   ```
+
+Cross-run medians move ±0.2–0.35 ms with the timed hipBLASLt algorithm
+selection; compare arms inside one process where possible.

--- a/docs/stable_api.md
+++ b/docs/stable_api.md
@@ -35,7 +35,7 @@ def load_model(
     decode_cuda_graph: bool = False,
     decode_graph_steps: int = 80,
     max_decode_steps: int = 256,
-    hardware: str = "auto",         # "auto" | "thor" | "rtx_sm120" | "rtx_sm89" | "rtx_sm87"
+    hardware: str = "auto",         # "auto" | "thor" | "rtx_sm120" | "rtx_sm89" | "rtx_sm87" | "amd_cdna4"
     # GROOT-specific:
     embodiment_tag: str | None = None,
     action_horizon: int | None = None,
@@ -123,6 +123,13 @@ Returns a `VLAModel` wrapping the appropriate frontend for the detected
   roughly a 1 ms normal overhead versus a warmed exact graph, while larger caps
   pay for the extra padded tokens. It can also be set with
   `FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN`.
+- `hardware="amd_cdna4"` (auto-detected on ROCm builds for gfx950 /
+  MI350-series) routes `config="pi05"`, `framework="torch"` to the
+  self-contained AMD backend (`flash_rt/amd/`, HIP module
+  `flash_rt_amd_kernels`). Single-stream surface only: `set_prompt` /
+  `calibrate` / `infer` with both `state_prompt_mode` graphs; the RL and
+  CFG-batched extensions raise `NotImplementedError`. Build and usage:
+  `docs/deployment_amd.md`.
 - `use_fp8=False` disables FP8 where the selected frontend exposes a
   BF16 fallback; unsupported frontends ignore it. GROOT N1.7 on RTX/Thor
   is stricter: the default route is FP8, and `use_fp8=False` alone

--- a/examples/pi05_amd_quickstart.py
+++ b/examples/pi05_amd_quickstart.py
@@ -35,8 +35,12 @@ def main() -> None:
     ap.add_argument("--checkpoint", required=True,
                     help="Pi0.5 PyTorch checkpoint dir (model.safetensors)")
     ap.add_argument("--prompt", default="pick up the object")
-    ap.add_argument("--num-views", type=int, default=2)
+    ap.add_argument("--num-views", type=int, default=2, choices=[2, 3],
+                    help="camera views: 2 = base + wrist (LIBERO), "
+                         "3 = + right wrist")
     ap.add_argument("--iters", type=int, default=50)
+    ap.add_argument("--warmup", type=int, default=20,
+                    help="replays before the timed loop")
     ap.add_argument("--bf16", action="store_true",
                     help="disable FP8 (BF16 baseline)")
     ap.add_argument("--state-prompt-mode", default="exact",
@@ -58,16 +62,25 @@ def main() -> None:
     fe = model.pipeline   # Pi05TorchFrontendAmd
 
     rng = np.random.default_rng(0)
+    # Synthetic observation with one image per configured view, using the
+    # frontend's per-view key names (2 views: image + wrist_image;
+    # 3 views adds wrist_image_right).
+    view_keys = ("image", "wrist_image", "wrist_image_right")
     obs = {
-        "image": rng.integers(0, 255, (224, 224, 3), dtype=np.uint8),
-        "wrist_image": rng.integers(0, 255, (224, 224, 3), dtype=np.uint8),
+        key: rng.integers(0, 255, (224, 224, 3), dtype=np.uint8)
+        for key in view_keys[:args.num_views]
     }
     state = rng.standard_normal(8).astype(np.float32)
 
     fe.set_prompt(args.prompt, state=state)   # builds + captures the HIP graph
+    # Pi0.5 renders the robot state into the prompt, so the token count --
+    # and with it the encoder sequence length and the latency -- depends on
+    # both the prompt text and the state values.
+    print(f"prompt+state tokens: {fe.current_prompt_len}  "
+          f"encoder seq: {fe.pipeline.encoder_seq_len}")
     fe.calibrate(obs)                         # real-data FP8 calibration
-    for _ in range(5):
-        fe.infer(obs)                         # warmup replays
+    for _ in range(args.warmup):
+        fe.infer(obs)                     # warmup replays
 
     lat = []
     for _ in range(args.iters):

--- a/examples/pi05_amd_quickstart.py
+++ b/examples/pi05_amd_quickstart.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Pi0.5 on AMD Instinct (ROCm / CDNA4) quickstart.
+
+Runs the pi05 AMD backend end-to-end — HIP-graph capture, real-data FP8
+calibration, N timed inferences — and prints the latency stats plus the
+precision spec. Works through the stable ``flash_rt.load_model`` door
+(``hardware="amd_cdna4"``, auto-detected on ROCm builds for gfx950).
+
+Build first (self-contained HIP module; the CUDA tree is not involved):
+
+    bash scripts/amd/build_amd.sh gfx950
+    # or: cmake -B build-amd -S csrc/amd -DGPU_ARCH=gfx950
+    #     cmake --build build-amd -j 8
+
+Run:
+
+    python examples/pi05_amd_quickstart.py \
+        --checkpoint /path/to/pi05_libero_pytorch \
+        --prompt "pick up the black bowl and place it on the plate"
+
+Expected on an MI350-series part (gfx950, ROCm 7.x, FP8 default):
+~16-17 ms median per inference after warmup. ``--bf16`` selects the
+unquantized baseline (~30 ms). See docs/deployment_amd.md for the
+support matrix, environment knobs and measured numbers.
+"""
+import argparse
+import statistics
+import time
+
+import numpy as np
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--checkpoint", required=True,
+                    help="Pi0.5 PyTorch checkpoint dir (model.safetensors)")
+    ap.add_argument("--prompt", default="pick up the object")
+    ap.add_argument("--num-views", type=int, default=2)
+    ap.add_argument("--iters", type=int, default=50)
+    ap.add_argument("--bf16", action="store_true",
+                    help="disable FP8 (BF16 baseline)")
+    ap.add_argument("--state-prompt-mode", default="exact",
+                    choices=["exact", "fixed"],
+                    help="'exact' = one graph per prompt length; "
+                         "'fixed' = one padded graph for every length")
+    args = ap.parse_args()
+
+    import flash_rt
+    model = flash_rt.load_model(
+        args.checkpoint,
+        config="pi05",
+        framework="torch",
+        hardware="amd_cdna4",
+        num_views=args.num_views,
+        use_fp8=not args.bf16,
+        state_prompt_mode=args.state_prompt_mode,
+    )
+    fe = model.pipeline   # Pi05TorchFrontendAmd
+
+    rng = np.random.default_rng(0)
+    obs = {
+        "image": rng.integers(0, 255, (224, 224, 3), dtype=np.uint8),
+        "wrist_image": rng.integers(0, 255, (224, 224, 3), dtype=np.uint8),
+    }
+    state = rng.standard_normal(8).astype(np.float32)
+
+    fe.set_prompt(args.prompt, state=state)   # builds + captures the HIP graph
+    fe.calibrate(obs)                         # real-data FP8 calibration
+    for _ in range(5):
+        fe.infer(obs)                         # warmup replays
+
+    lat = []
+    for _ in range(args.iters):
+        t0 = time.perf_counter()
+        result = fe.infer(obs)
+        lat.append((time.perf_counter() - t0) * 1e3)
+
+    print(f"actions: {result['actions'].shape}  "
+          f"median {statistics.median(lat):.2f} ms  min {min(lat):.2f} ms "
+          f"over {args.iters} iters")
+    print("precision:", fe.precision_spec)
+    print("stats:", fe.get_latency_stats())
+
+
+if __name__ == "__main__":
+    main()

--- a/flash_rt/__init__.py
+++ b/flash_rt/__init__.py
@@ -7,7 +7,8 @@ Public exports (stable API — see ``docs/stable_api.md``):
     flash_rt.VLAModel          — unified inference wrapper
 
 Supported models: Pi0.5, Pi0, Pi0-FAST, GROOT N1.6, GROOT N1.7.
-Supported hardware: Jetson Thor (SM110), RTX 5090 (SM120), RTX 4090 (SM89).
+Supported hardware: Jetson Thor (SM110), RTX 5090 (SM120), RTX 4090
+(SM89), AMD Instinct MI350 series (ROCm gfx950, pi05).
 
 Extending with new models: see ``docs/plugin_model_template.md``.
 

--- a/flash_rt/amd/__init__.py
+++ b/flash_rt/amd/__init__.py
@@ -1,0 +1,9 @@
+"""FlashRT AMD (ROCm/HIP) backend.
+
+Self-contained AMD tree: HIP runtime twins of core/cuda_buffer and
+core/cuda_graph, the flash_rt_amd_kernels extension (built by
+csrc/amd/CMakeLists.txt, dropped into this directory), and — as the
+port progresses — CDNA attention backends, pi05 pipeline, frontends.
+
+The NVIDIA package tree never imports from here and vice versa.
+"""

--- a/flash_rt/amd/core/hip_buffer.py
+++ b/flash_rt/amd/core/hip_buffer.py
@@ -11,7 +11,15 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-_hip = ctypes.CDLL("libamdhip64.so")
+try:
+    _hip = ctypes.CDLL("libamdhip64.so")
+except OSError as exc:  # no ROCm runtime on this machine
+    # Surface the conventional "optional backend unavailable" signal so
+    # callers (flash_rt.api's hardware gate, test suites) can guard with
+    # a plain ImportError instead of a platform-specific OSError.
+    raise ImportError(
+        "the AMD backend requires the ROCm runtime (libamdhip64.so), "
+        f"which could not be loaded: {exc}") from exc
 
 
 def _configure_hip_signatures() -> None:

--- a/flash_rt/amd/core/hip_buffer.py
+++ b/flash_rt/amd/core/hip_buffer.py
@@ -99,7 +99,7 @@ class HipBuffer:
     def zeros(cls, count: int, dtype, managed: bool = True) -> 'HipBuffer':
         nbytes = count * np.dtype(dtype).itemsize
         buf = cls(nbytes, managed=managed)
-        _hip.hipMemset(buf._ptr, 0, nbytes)
+        _check(_hip.hipMemset(buf._ptr, 0, nbytes), "hipMemset")
         return buf
 
     @classmethod
@@ -127,7 +127,7 @@ class HipBuffer:
     def download(self, arr: np.ndarray):
         """Download buffer → numpy."""
         assert arr.nbytes <= self._nbytes
-        _hip.hipDeviceSynchronize()
+        _check(_hip.hipDeviceSynchronize(), "hipDeviceSynchronize")
         if self._managed:
             ctypes.memmove(arr.ctypes.data, self._ptr, arr.nbytes)
         else:
@@ -142,15 +142,20 @@ class HipBuffer:
 
     def zero_(self, stream=None):
         if stream is not None:
-            _hip.hipMemsetAsync(self._ptr, 0, self._nbytes, stream)
+            _check(_hip.hipMemsetAsync(self._ptr, 0, self._nbytes, stream),
+                   "hipMemsetAsync")
         else:
-            _hip.hipMemset(self._ptr, 0, self._nbytes)
+            _check(_hip.hipMemset(self._ptr, 0, self._nbytes), "hipMemset")
 
     def __del__(self):
         try:
             if _hip is not None and hasattr(self, '_ptr') and self._ptr.value:
-                _hip.hipFree(self._ptr)
+                ret = _hip.hipFree(self._ptr)
                 self._ptr = ctypes.c_void_p()
+                if ret != 0:
+                    # Raising in __del__ is unraisable; a failed free cannot
+                    # corrupt results, so log instead of _check here.
+                    logger.warning("hipFree failed with HIP error %d", ret)
         except Exception:
             pass
 
@@ -160,4 +165,4 @@ class HipBuffer:
 
 
 def sync():
-    _hip.hipDeviceSynchronize()
+    _check(_hip.hipDeviceSynchronize(), "hipDeviceSynchronize")

--- a/flash_rt/amd/core/hip_buffer.py
+++ b/flash_rt/amd/core/hip_buffer.py
@@ -1,0 +1,163 @@
+"""FlashRT AMD — HipBuffer: hipMalloc/managed wrapper for engine-facing GPU buffers.
+
+Twin of flash_rt/core/cuda_buffer.py over libamdhip64. Memcpy-kind and
+attach-flag enums are numerically identical to CUDA's (verified at
+bring-up): H2D=1, D2H=2, D2D=3, hipMemAttachGlobal=1.
+"""
+
+import ctypes
+import logging
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_hip = ctypes.CDLL("libamdhip64.so")
+
+
+def _configure_hip_signatures() -> None:
+    """Declare ctypes signatures — host pointers ≥2GiB truncate under the
+    default c_int argtype (see cuda_buffer.py download() docstring)."""
+    ptr_p = ctypes.POINTER(ctypes.c_void_p)
+    signatures = {
+        "hipMallocManaged": (
+            [ptr_p, ctypes.c_size_t, ctypes.c_uint], ctypes.c_int),
+        "hipMalloc": ([ptr_p, ctypes.c_size_t], ctypes.c_int),
+        "hipFree": ([ctypes.c_void_p], ctypes.c_int),
+        "hipMemcpy": (
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+             ctypes.c_int],
+            ctypes.c_int,
+        ),
+        "hipMemcpyAsync": (
+            [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+             ctypes.c_int, ctypes.c_void_p],
+            ctypes.c_int,
+        ),
+        "hipMemset": (
+            [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t], ctypes.c_int),
+        "hipMemsetAsync": (
+            [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t,
+             ctypes.c_void_p],
+            ctypes.c_int,
+        ),
+        "hipDeviceSynchronize": ([], ctypes.c_int),
+        "hipStreamSynchronize": ([ctypes.c_void_p], ctypes.c_int),
+    }
+    for name, (argtypes, restype) in signatures.items():
+        fn = getattr(_hip, name)
+        fn.argtypes = argtypes
+        fn.restype = restype
+
+
+_configure_hip_signatures()
+
+
+def _check(ret, msg=""):
+    if ret != 0:
+        raise RuntimeError(f"HIP error {ret}: {msg}")
+
+
+class HipBuffer:
+    """GPU buffer — managed or device memory."""
+
+    def __init__(self, nbytes: int, managed: bool = True):
+        self._ptr = ctypes.c_void_p()
+        self._managed = managed
+        if managed:
+            _check(_hip.hipMallocManaged(ctypes.byref(self._ptr), nbytes, 1),
+                   "hipMallocManaged")
+        else:
+            _check(_hip.hipMalloc(ctypes.byref(self._ptr), nbytes), "hipMalloc")
+        self._nbytes = nbytes
+
+    @property
+    def ptr(self) -> ctypes.c_void_p:
+        return self._ptr
+
+    @property
+    def nbytes(self) -> int:
+        return self._nbytes
+
+    @classmethod
+    def from_numpy(cls, arr: np.ndarray) -> 'HipBuffer':
+        """Create device buffer, upload H2D (device memory for replay bandwidth)."""
+        arr = np.ascontiguousarray(arr)
+        buf = cls(arr.nbytes, managed=False)
+        _check(_hip.hipMemcpy(
+            buf._ptr, ctypes.c_void_p(arr.ctypes.data), arr.nbytes, 1), "H2D")
+        return buf
+
+    @classmethod
+    def from_numpy_managed(cls, arr: np.ndarray) -> 'HipBuffer':
+        """Create managed buffer, upload via memmove. Use for buffers needing D2H readback."""
+        arr = np.ascontiguousarray(arr)
+        buf = cls(arr.nbytes, managed=True)
+        ctypes.memmove(buf._ptr, arr.ctypes.data, arr.nbytes)
+        return buf
+
+    @classmethod
+    def zeros(cls, count: int, dtype, managed: bool = True) -> 'HipBuffer':
+        nbytes = count * np.dtype(dtype).itemsize
+        buf = cls(nbytes, managed=managed)
+        _hip.hipMemset(buf._ptr, 0, nbytes)
+        return buf
+
+    @classmethod
+    def empty(cls, count: int, dtype, managed: bool = True) -> 'HipBuffer':
+        return cls(count * np.dtype(dtype).itemsize, managed=managed)
+
+    @classmethod
+    def device_zeros(cls, count: int, dtype) -> 'HipBuffer':
+        return cls.zeros(count, dtype, managed=False)
+
+    @classmethod
+    def device_empty(cls, count: int, dtype) -> 'HipBuffer':
+        return cls.empty(count, dtype, managed=False)
+
+    def upload(self, arr: np.ndarray):
+        """Upload numpy → buffer."""
+        assert arr.nbytes <= self._nbytes
+        arr = np.ascontiguousarray(arr)
+        if self._managed:
+            ctypes.memmove(self._ptr, arr.ctypes.data, arr.nbytes)
+        else:
+            _check(_hip.hipMemcpy(
+                self._ptr, ctypes.c_void_p(arr.ctypes.data), arr.nbytes, 1), "H2D")
+
+    def download(self, arr: np.ndarray):
+        """Download buffer → numpy."""
+        assert arr.nbytes <= self._nbytes
+        _hip.hipDeviceSynchronize()
+        if self._managed:
+            ctypes.memmove(arr.ctypes.data, self._ptr, arr.nbytes)
+        else:
+            _check(_hip.hipMemcpy(
+                ctypes.c_void_p(arr.ctypes.data),
+                self._ptr, arr.nbytes, 2), "D2H")
+
+    def download_new(self, shape, dtype) -> np.ndarray:
+        arr = np.empty(shape, dtype=dtype)
+        self.download(arr)
+        return arr
+
+    def zero_(self, stream=None):
+        if stream is not None:
+            _hip.hipMemsetAsync(self._ptr, 0, self._nbytes, stream)
+        else:
+            _hip.hipMemset(self._ptr, 0, self._nbytes)
+
+    def __del__(self):
+        try:
+            if _hip is not None and hasattr(self, '_ptr') and self._ptr.value:
+                _hip.hipFree(self._ptr)
+                self._ptr = ctypes.c_void_p()
+        except Exception:
+            pass
+
+    def __repr__(self):
+        t = "managed" if self._managed else "device"
+        return f"HipBuffer({self._nbytes}B, {t}, ptr=0x{self._ptr.value:x})"
+
+
+def sync():
+    _hip.hipDeviceSynchronize()

--- a/flash_rt/amd/core/hip_graph.py
+++ b/flash_rt/amd/core/hip_graph.py
@@ -21,7 +21,14 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-_hip = ctypes.CDLL("libamdhip64.so")
+try:
+    _hip = ctypes.CDLL("libamdhip64.so")
+except OSError as exc:  # no ROCm runtime on this machine
+    # Same contract as hip_buffer: report an unavailable optional
+    # backend as ImportError, not a platform-specific OSError.
+    raise ImportError(
+        "the AMD backend requires the ROCm runtime (libamdhip64.so), "
+        f"which could not be loaded: {exc}") from exc
 
 
 def _configure_signatures() -> None:

--- a/flash_rt/amd/core/hip_graph.py
+++ b/flash_rt/amd/core/hip_graph.py
@@ -1,0 +1,95 @@
+"""FlashRT AMD — Framework-agnostic HIP Graph capture/replay.
+
+Twin of flash_rt/core/cuda_graph.py over libamdhip64. Same usage:
+
+    graph = HipGraph()
+    stream = graph.create_stream()
+    # warmup ... then:
+    graph.begin_capture(stream)
+    my_kernel(args..., stream)
+    graph.end_capture(stream)
+    graph.replay(stream)
+
+HIP-vs-CUDA deltas handled here:
+  - the 3-arg instantiate is hipGraphInstantiateWithFlags
+    (plain hipGraphInstantiate is the 5-arg errorNode/logBuffer form)
+  - capture-mode enum verified on hardware: hipStreamCaptureModeRelaxed == 2
+"""
+
+import ctypes
+import logging
+
+logger = logging.getLogger(__name__)
+
+_hip = ctypes.CDLL("libamdhip64.so")
+
+
+def _configure_signatures() -> None:
+    """Declare ctypes signatures — pointer args must never fall back to
+    the 32-bit c_int default (see cuda_buffer.py download() incident)."""
+    p = ctypes.c_void_p
+    pp = ctypes.POINTER(ctypes.c_void_p)
+    signatures = {
+        "hipStreamCreate": ([pp], ctypes.c_int),
+        "hipStreamBeginCapture": ([p, ctypes.c_uint], ctypes.c_int),
+        "hipStreamEndCapture": ([p, pp], ctypes.c_int),
+        "hipGraphInstantiateWithFlags": ([pp, p, ctypes.c_ulonglong], ctypes.c_int),
+        "hipGraphLaunch": ([p, p], ctypes.c_int),
+        "hipStreamSynchronize": ([p], ctypes.c_int),
+    }
+    for name, (argtypes, restype) in signatures.items():
+        fn = getattr(_hip, name)
+        fn.argtypes = argtypes
+        fn.restype = restype
+
+
+_configure_signatures()
+
+
+def _check(status, msg=""):
+    if status != 0:
+        raise RuntimeError(f"HIP error {status}: {msg}")
+
+
+class HipGraph:
+    """Framework-agnostic HIP Graph using raw HIP Runtime API."""
+
+    def __init__(self):
+        self._graph = ctypes.c_void_p()
+        self._graph_exec = ctypes.c_void_p()
+        self._captured = False
+
+    def create_stream(self) -> ctypes.c_void_p:
+        stream = ctypes.c_void_p()
+        _check(_hip.hipStreamCreate(ctypes.byref(stream)), "hipStreamCreate")
+        return stream
+
+    def begin_capture(self, stream: ctypes.c_void_p):
+        """Begin HIP Graph capture on the given stream.
+
+        hipStreamCaptureModeRelaxed=2: only capture ops on THIS stream,
+        same rationale as the CUDA path (don't block framework streams).
+        """
+        _check(_hip.hipStreamBeginCapture(stream, 2), "hipStreamBeginCapture")
+
+    def end_capture(self, stream: ctypes.c_void_p):
+        """End capture and instantiate the graph for replay."""
+        _check(_hip.hipStreamEndCapture(stream, ctypes.byref(self._graph)),
+               "hipStreamEndCapture")
+        _check(_hip.hipGraphInstantiateWithFlags(
+            ctypes.byref(self._graph_exec), self._graph, 0),
+               "hipGraphInstantiateWithFlags")
+        self._captured = True
+
+    def replay(self, stream: ctypes.c_void_p):
+        """Replay the captured graph (single CPU call → full GPU replay)."""
+        if not self._captured:
+            raise RuntimeError("No graph captured")
+        _check(_hip.hipGraphLaunch(self._graph_exec, stream), "hipGraphLaunch")
+
+    def sync(self, stream: ctypes.c_void_p):
+        _check(_hip.hipStreamSynchronize(stream), "hipStreamSynchronize")
+
+    @property
+    def captured(self) -> bool:
+        return self._captured

--- a/flash_rt/amd/frontends/__init__.py
+++ b/flash_rt/amd/frontends/__init__.py
@@ -1,0 +1,1 @@
+"""FlashRT AMD — framework frontends (weights + preprocessing)."""

--- a/flash_rt/amd/frontends/torch/__init__.py
+++ b/flash_rt/amd/frontends/torch/__init__.py
@@ -1,0 +1,1 @@
+"""FlashRT AMD — torch (ROCm) frontends."""

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -566,6 +566,7 @@ class Pi05TorchFrontendAmd:
         # pure torch, but the resulting pointers would route the pipeline
         # through fp8_* fvk entries).
         self._fp8_weights: dict = {}
+        self._fp8_packed: dict = {}  # decoder weights in MFMA-packed layout
         self._fp8_store: list = []  # holds tensors alive
         if self.use_fp8 and not self._force_bf16:
             self._quantize_all_fp8()
@@ -719,6 +720,29 @@ class Pi05TorchFrontendAmd:
             quant(f"decoder_ffn_gate_up_w_{i}", gate_up)
             quant(f"decoder_ffn_down_w_{i}", W["decoder_ffn_down_w"][i])
 
+        # MFMA-packed copies of the decoder weights (nk layout only):
+        # repacked once here into the smallm_mfma_nt_packed per-lane
+        # consumption order (see csrc/amd/gemm/smallm_mfma.h) so the
+        # decoder small-M GEMMs stream weights as one linear slab per
+        # workgroup. The plain fp8 copy is kept for the hipBLASLt
+        # fallback and autotune.
+        if self.fp8_layout == "nk":
+            packed = self._fp8_packed
+            for name, (w_ptr, _) in list(fp8.items()):
+                if not name.startswith("decoder_"):
+                    continue
+                w_fp8 = next(t for t in store
+                             if t.data_ptr() == w_ptr and t.dim() == 2)
+                n_dim, k_dim = w_fp8.shape
+                if n_dim % 16 != 0 or k_dim % 1024 != 0:
+                    continue
+                wp = (w_fp8.view(torch.uint8)
+                      .view(n_dim // 16, 16, k_dim // 64, 2, 4, 8)
+                      .permute(0, 2, 4, 1, 3, 5).contiguous())
+                store.append(wp)
+                packed[name] = wp.data_ptr()
+            logger.info("MFMA-packed %d decoder GEMM weights", len(packed))
+
         logger.info("FP8 quantized %d GEMM weights (layout=%s)", len(fp8), self.fp8_layout)
 
     def _build_pipeline_weights(self) -> dict:
@@ -776,6 +800,7 @@ class Pi05TorchFrontendAmd:
 
             # FP8 quantized weights
             "fp8": self._fp8_weights,
+            "fp8_packed": self._fp8_packed,
             "fp8_layout": self.fp8_layout,
             "hardware": self.hardware,
 

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -469,7 +469,8 @@ class Pi05TorchFrontendAmd:
                  use_fp8: bool = True,
                  hardware: Optional[str] = None,
                  fp8_layout: Optional[str] = None,
-                 state_prompt_mode: str = "exact"):
+                 state_prompt_mode: str = "exact",
+                 state_prompt_fixed_max_len: Optional[int] = None):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         # State-in-prompt graph strategy (Pi0.5 renders robot state into the
         # prompt, so its token length drifts with the state values):
@@ -486,6 +487,25 @@ class Pi05TorchFrontendAmd:
             raise ValueError(
                 f"state_prompt_mode must be 'fixed' or 'exact', got {_spm!r}")
         self._state_prompt_mode = _spm
+        # Fixed-mode padded prompt capacity. The one-graph strategy pays
+        # per padded token through the whole encoder, so right-sizing
+        # this to the deployment's real prompt+state length (instead of
+        # the PI05_STATE_PROMPT_MAX_LEN=200 ceiling) is the main
+        # fixed-mode latency lever. Same semantics as the Thor frontend;
+        # env override FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN.
+        _fixed_cap = PI05_STATE_PROMPT_MAX_LEN
+        if _spm == "fixed":
+            _fixed_cap = os.environ.get(
+                "FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN",
+                state_prompt_fixed_max_len)
+            if _fixed_cap is None:
+                _fixed_cap = PI05_STATE_PROMPT_MAX_LEN
+            _fixed_cap = int(_fixed_cap)
+            if _fixed_cap <= 0:
+                raise ValueError(
+                    "state_prompt_fixed_max_len must be a positive integer, "
+                    f"got {_fixed_cap}")
+        self._state_prompt_fixed_max_len = _fixed_cap
         self.num_views = int(num_views)
         self.chunk_size = int(chunk_size)
         self.max_prompt_len = int(max_prompt_len)
@@ -815,8 +835,12 @@ class Pi05TorchFrontendAmd:
 
     def set_prompt(self, prompt_text: str, state=None) -> None:
         """Tokenise prompt + (re)build the pipeline for the exact prompt length."""
-        max_len = (PI05_STATE_PROMPT_MAX_LEN if state is not None
-                   else MAX_PROMPT_LEN_DEFAULT)
+        if state is not None:
+            max_len = (self._state_prompt_fixed_max_len
+                       if self._state_prompt_mode == "fixed"
+                       else PI05_STATE_PROMPT_MAX_LEN)
+        else:
+            max_len = MAX_PROMPT_LEN_DEFAULT
         embeds, prompt_len = _embed_prompt(
             prompt_text, self.embedding_weight, max_len=max_len, state=state)
 
@@ -853,16 +877,24 @@ class Pi05TorchFrontendAmd:
         backend the per-length pipeline has since touched and would also
         perturb numerics via autotune variance.
         """
-        self._ensure_prompt_capacity(PI05_STATE_PROMPT_MAX_LEN)
+        cap = self._state_prompt_fixed_max_len
+        if prompt_len > cap:
+            raise ValueError(
+                f"fixed-mode prompt+state is {prompt_len} tokens but the "
+                f"padded graph capacity is {cap}; raise "
+                "state_prompt_fixed_max_len (or the "
+                "FLASHRT_PI05_STATE_PROMPT_FIXED_MAX_LEN env) — the graph "
+                "is captured once at this capacity and cannot grow.")
+        self._ensure_prompt_capacity(cap)
         if self._fixed_pipeline is None:
             logger.info("Building fixed-shape Pi05Pipeline (max_prompt_len=%d)...",
-                        PI05_STATE_PROMPT_MAX_LEN)
+                        cap)
             pipeline_weights = self._build_pipeline_weights()
             self._fixed_pipeline = Pi05Pipeline(
                 gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
                 weights=pipeline_weights,
                 num_views=self.num_views,
-                max_prompt_len=PI05_STATE_PROMPT_MAX_LEN,
+                max_prompt_len=cap,
                 chunk_size=self.chunk_size,
                 num_steps=self._num_steps,
                 vision_pool_factor=self._vision_pool_factor,

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -478,11 +478,14 @@ class Pi05TorchFrontendAmd:
         # gpu_arch are gfx950. Anything else computes garbage, not a
         # fallback (a forced hardware="amd_cdna4" on gfx942 fails here).
         from flash_rt.amd import flash_rt_amd_kernels as _fvk_gate
+        # Compare the base target only ("gfx950" from
+        # "gfx950:sramecc+:xnack-"); a prefix test would also accept a
+        # future "gfx9500".
         _dev_arch = str(_fvk_gate.device_arch())
         _build_arch = str(dict(_fvk_gate.build_info()).get("gpu_arch",
                                                            "unknown"))
-        if not (_dev_arch.startswith("gfx950")
-                and _build_arch.startswith("gfx950")):
+        if not (_dev_arch.split(":", 1)[0] == "gfx950"
+                and _build_arch.split(":", 1)[0] == "gfx950"):
             raise RuntimeError(
                 "Pi05TorchFrontendAmd is gfx950-only (CDNA4 / MI350-series): "
                 f"running device arch is {_dev_arch!r} and the extension "

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -350,14 +350,16 @@ def _quantize_fp8_e4m3(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor
 def _select_fp8_layout(fp8_layout: Optional[str]) -> str:
     """Choose the FP8 weight layout used by the AMD frontend kernels.
 
-    ``kn``: weights are stored as [K,N] and use ``fp8_nn_dev`` (default).
-    ``nk``: weights are stored as [N,K] and use ``fp8_nt_dev``.
+    ``kn``: weights are stored as [K,N] and use ``fp8_nn_dev``.
+    ``nk``: weights are stored as [N,K] and use ``fp8_nt_dev`` (default —
+    measured faster in-graph across every pi05 FP8 GEMM shape on CDNA4,
+    -2.8 ms E2E vs kn in the single-variable A/B).
     """
     if fp8_layout is not None:
         if fp8_layout not in ("kn", "nk"):
             raise ValueError(f"fp8_layout must be 'kn' or 'nk', got {fp8_layout!r}")
         return fp8_layout
-    return "kn"
+    return "nk"
 
 
 def _precompute_decoder_styles(ckpt: dict, chunk_size: int,
@@ -574,11 +576,7 @@ class Pi05TorchFrontendAmd:
 
         # ── Attention backend (torch, owns Q/K/V/O) ──
         enc_seq_max = self.num_views * 256 + self.max_prompt_len
-        self.attn_backend = Cdna4AttnBackend(
-            num_views=self.num_views,
-            encoder_seq_max=enc_seq_max,
-            chunk_size=self.chunk_size,
-            num_encoder_layers=ENC_L)
+        self.attn_backend = self._make_attn_backend(enc_seq_max)
 
         # ── fvk module + GemmRunner ──
         from flash_rt.amd import flash_rt_amd_kernels as fvk
@@ -599,17 +597,46 @@ class Pi05TorchFrontendAmd:
             "Pi05TorchFrontendAmd initialised (num_views=%d, chunk=%d, fp8_layout=%s)",
             self.num_views, self.chunk_size, self.fp8_layout)
 
+    def _make_attn_backend(self, enc_seq_max: int):
+        """Construct the CDNA4 attention backend.
+
+        ``FVK_AMD_ATTN=sdpa|aiter`` selects the implementation (default
+        "sdpa" — the interim torch-SDPA backend). "aiter" dispatches to
+        the aiter asm flash-attention backend
+        (:class:`~flash_rt.amd.hardware.cdna4.attn_backend_aiter.Cdna4AiterAttnBackend`,
+        same buffers/surface); if aiter is unavailable the frontend logs
+        a warning and falls back to sdpa.
+        """
+        kwargs = dict(
+            num_views=self.num_views,
+            encoder_seq_max=enc_seq_max,
+            chunk_size=self.chunk_size,
+            num_encoder_layers=ENC_L)
+        choice = os.environ.get("FVK_AMD_ATTN", "aiter").strip().lower()
+        if choice not in ("sdpa", "aiter"):
+            raise ValueError(
+                f"FVK_AMD_ATTN must be 'sdpa' or 'aiter', got {choice!r}")
+        if choice == "aiter":
+            from flash_rt.amd.hardware.cdna4.attn_backend_aiter import (
+                Cdna4AiterAttnBackend,
+            )
+            try:
+                backend = Cdna4AiterAttnBackend(**kwargs)
+                logger.info("CDNA4 attention backend: aiter (FVK_AMD_ATTN)")
+                return backend
+            except ImportError as ex:
+                logger.warning(
+                    "FVK_AMD_ATTN=aiter but the aiter backend is "
+                    "unavailable (%s); falling back to sdpa", ex)
+        return Cdna4AttnBackend(**kwargs)
+
     def _ensure_prompt_capacity(self, required_prompt_len: int) -> None:
         """Grow attention buffers before building longer prompt pipelines."""
         if required_prompt_len <= self.max_prompt_len:
             return
         self.max_prompt_len = int(required_prompt_len)
         enc_seq_max = self.num_views * 256 + self.max_prompt_len
-        self.attn_backend = Cdna4AttnBackend(
-            num_views=self.num_views,
-            encoder_seq_max=enc_seq_max,
-            chunk_size=self.chunk_size,
-            num_encoder_layers=ENC_L)
+        self.attn_backend = self._make_attn_backend(enc_seq_max)
         self._prompt_pipeline_cache.clear()
         self._fixed_pipeline = None
         self.pipeline = None

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -1226,6 +1226,41 @@ class Pi05TorchFrontendAmd:
         }
 
     # -----------------------------------------------------------------
+    # Not-yet-ported RTX extensions (explicit failure, no silent fallback)
+    # -----------------------------------------------------------------
+    # The single-stream production surface (set_prompt / calibrate /
+    # infer, both state_prompt_mode graphs, FP8 + BF16) is aligned with
+    # Pi05TorchFrontendRtx. The RL-conditioned and CFG-batched modes
+    # below are RTX-only so far; they raise instead of degrading.
+
+    _NOT_PORTED = (
+        "is not ported to the AMD backend yet — supported surface: "
+        "set_prompt / warm_state_prompt_buckets / calibrate / "
+        "calibrate_with_real_data / infer / precision_spec / "
+        "get_latency_stats (state_prompt_mode 'exact' and 'fixed'). "
+        "See docs/deployment_amd.md for the support matrix.")
+
+    def set_rl_mode(self, *args, **kwargs) -> None:
+        raise NotImplementedError(
+            f"Pi05TorchFrontendAmd.set_rl_mode {self._NOT_PORTED}")
+
+    def set_batched_mode(self, *args, **kwargs) -> None:
+        raise NotImplementedError(
+            f"Pi05TorchFrontendAmd.set_batched_mode {self._NOT_PORTED}")
+
+    def set_prompt_batch(self, *args, **kwargs) -> None:
+        raise NotImplementedError(
+            f"Pi05TorchFrontendAmd.set_prompt_batch {self._NOT_PORTED}")
+
+    def calibrate_batch(self, *args, **kwargs) -> None:
+        raise NotImplementedError(
+            f"Pi05TorchFrontendAmd.calibrate_batch {self._NOT_PORTED}")
+
+    def infer_batch(self, *args, **kwargs) -> list:
+        raise NotImplementedError(
+            f"Pi05TorchFrontendAmd.infer_batch {self._NOT_PORTED}")
+
+    # -----------------------------------------------------------------
     # Internals
     # -----------------------------------------------------------------
 

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -1184,12 +1184,21 @@ class Pi05TorchFrontendAmd:
         """:class:`ModelPrecisionSpec` captured at calibration time."""
         return getattr(self, "_precision_spec", None)
 
-    def infer(self, observation: dict, debug: bool = False) -> dict:
+    def infer(self, observation: dict, debug: bool = False,
+              noise: Optional[np.ndarray] = None) -> dict:
         """Run inference on a single observation.
 
         All GPU work happens on ``self._graph_torch_stream`` — the same
         stream the graph was captured on — so replay + pre/post D2D copies
         are serialized correctly.
+
+        ``noise``: optional ``(chunk_size, 32)`` array used as the denoise
+        starting point instead of a fresh random draw — the same contract
+        as openpi's ``policy.infer(example, noise=...)``. Serving wants the
+        default fresh draw (action diversity); parity/repro judging MUST
+        pin the noise, since the flow integration is conditioned on it and
+        a random draw adds ~1e-3-level cos-vs-reference lottery that is
+        indistinguishable from a real numerics regression.
         """
         if self.pipeline is None:
             raise RuntimeError("set_prompt must be called before infer")
@@ -1207,7 +1216,11 @@ class Pi05TorchFrontendAmd:
         with torch.cuda.stream(self._graph_torch_stream):
             stream_int = self._graph_torch_stream.cuda_stream
 
-            self._noise_buf.normal_()
+            if noise is not None:
+                self._noise_buf.copy_(torch.as_tensor(
+                    np.asarray(noise)).reshape(self._noise_buf.shape))
+            else:
+                self._noise_buf.normal_()
             self._copy_tensor_to_pipeline_buf_stream(
                 self._noise_buf, self.pipeline.input_noise_buf, stream_int)
 

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -471,6 +471,25 @@ class Pi05TorchFrontendAmd:
                  fp8_layout: Optional[str] = None,
                  state_prompt_mode: str = "exact",
                  state_prompt_fixed_max_len: Optional[int] = None):
+        # gfx950-only gate, FIRST: the MFMA tile shapes and FP8 paths in
+        # the extension are CDNA4-specific — refuse before touching the
+        # checkpoint unless BOTH the visible device arch (e.g.
+        # "gfx950:sramecc+:xnack-") and the extension's compile-time
+        # gpu_arch are gfx950. Anything else computes garbage, not a
+        # fallback (a forced hardware="amd_cdna4" on gfx942 fails here).
+        from flash_rt.amd import flash_rt_amd_kernels as _fvk_gate
+        _dev_arch = str(_fvk_gate.device_arch())
+        _build_arch = str(dict(_fvk_gate.build_info()).get("gpu_arch",
+                                                           "unknown"))
+        if not (_dev_arch.startswith("gfx950")
+                and _build_arch.startswith("gfx950")):
+            raise RuntimeError(
+                "Pi05TorchFrontendAmd is gfx950-only (CDNA4 / MI350-series): "
+                f"running device arch is {_dev_arch!r} and the extension "
+                f"was built for gpu_arch {_build_arch!r}. Rebuild with "
+                "scripts/amd/build_amd.sh on a gfx950 machine; other AMD "
+                "arches are not supported by this backend.")
+
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         # State-in-prompt graph strategy (Pi0.5 renders robot state into the
         # prompt, so its token length drifts with the state values):
@@ -507,6 +526,14 @@ class Pi05TorchFrontendAmd:
                     f"got {_fixed_cap}")
         self._state_prompt_fixed_max_len = _fixed_cap
         self.num_views = int(num_views)
+        # Observation contract: 2 views (base + wrist camera — the LIBERO
+        # deployment) or 3 (+ right wrist camera). All input buffers and
+        # the encoder sequence are sized to num_views, and the observation
+        # keys accepted by _gather_view_images() only express 2 or 3.
+        if self.num_views not in (2, 3):
+            raise ValueError(
+                "num_views must be 2 (base + wrist camera) or 3 "
+                f"(+ right wrist camera); got {self.num_views}")
         self.chunk_size = int(chunk_size)
         self.max_prompt_len = int(max_prompt_len)
         self._num_steps = int(num_steps)
@@ -602,6 +629,7 @@ class Pi05TorchFrontendAmd:
         # ── fvk module + GemmRunner ──
         from flash_rt.amd import flash_rt_amd_kernels as fvk
         self.fvk = fvk
+        # (gfx950 gate already ran at the top of __init__.)
         self.gemm = fvk.GemmRunner()
 
         # ── Reusable pre-allocated input buffers (match Thor style) ──
@@ -611,8 +639,13 @@ class Pi05TorchFrontendAmd:
             self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
         self._noise_out = torch.empty(
             self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
-        from flash_rt.amd.core.hip_buffer import _hip
+        from flash_rt.amd.core.hip_buffer import _check, _hip
         self._hip = _hip
+        # Shared HIP return-code checker (single int compare on success;
+        # raises RuntimeError with the error code + operation on failure).
+        # Every raw self._hip.* call MUST route its return through this so
+        # a failed copy/sync can never surface stale buffer contents.
+        self._hip_check = _check
 
         logger.info(
             "Pi05TorchFrontendAmd initialised (num_views=%d, chunk=%d, fp8_layout=%s)",
@@ -1053,8 +1086,8 @@ class Pi05TorchFrontendAmd:
 
             self.pipeline.run_pipeline(stream=stream_int)
 
-            self._hip.hipStreamSynchronize(
-                ctypes.c_void_p(stream_int))
+            self._hip_check(self._hip.hipStreamSynchronize(
+                ctypes.c_void_p(stream_int)), "hipStreamSynchronize")
 
             # FP8 calibration (no-op for BF16 pipelines).
             self.pipeline.calibrate_fp8()
@@ -1099,8 +1132,8 @@ class Pi05TorchFrontendAmd:
                     noise, self.pipeline.input_noise_buf, stream_int)
                 self._zero_pipeline_scales()
                 self.pipeline.run_pipeline(stream=stream_int)
-                self._hip.hipStreamSynchronize(
-                    ctypes.c_void_p(stream_int))
+                self._hip_check(self._hip.hipStreamSynchronize(
+                    ctypes.c_void_p(stream_int)), "hipStreamSynchronize")
 
                 if names is None:
                     names = list(self.pipeline.fp8_act_scales.keys())
@@ -1233,14 +1266,19 @@ class Pi05TorchFrontendAmd:
                 # Decode-only: skip vision+encoder, reuse cached K/V
                 out_ptr = self.pipeline.forward_decode_only()
 
-            # D2D download → staging torch tensor
-            self._hip.hipMemcpyAsync(
+            # D2D download → staging torch tensor. Both the copy and the
+            # sync below are checked: if the graph replay, this D2D copy
+            # or the sync fails, we must raise rather than read stale
+            # _noise_out contents back as actions.
+            self._hip_check(self._hip.hipMemcpyAsync(
                 ctypes.c_void_p(self._noise_out.data_ptr()),
                 ctypes.c_void_p(out_ptr),
-                self._noise_out.numel() * 2, 3, stream_int)
+                self._noise_out.numel() * 2, 3, stream_int),
+                "hipMemcpyAsync D2D")
 
-        self._hip.hipStreamSynchronize(
-            ctypes.c_void_p(self._graph_torch_stream.cuda_stream))
+        self._hip_check(self._hip.hipStreamSynchronize(
+            ctypes.c_void_p(self._graph_torch_stream.cuda_stream)),
+            "hipStreamSynchronize")
 
         latency_ms = (time.perf_counter() - t0) * 1000
         self.latency_records.append(latency_ms)
@@ -1309,29 +1347,65 @@ class Pi05TorchFrontendAmd:
     # Internals
     # -----------------------------------------------------------------
 
+    # Named per-view observation keys, in buffer order (same naming as the
+    # RTX frontend). Alternatively the observation may carry an "images"
+    # list with exactly num_views entries in this order.
+    _VIEW_KEYS = ("image", "wrist_image", "wrist_image_right")
+
+    def _gather_view_images(self, observation: dict) -> list:
+        """Return exactly ``num_views`` validated (224, 224, 3) images.
+
+        Strict by design: a missing or misshaped view raises ValueError
+        instead of silently leaving stale ``_img_buf`` rows (which the
+        captured graph would then consume as a real camera view).
+        """
+        expected_keys = self._VIEW_KEYS[:self.num_views]
+        if "images" in observation:
+            img_list = list(observation["images"])
+            if len(img_list) != self.num_views:
+                raise ValueError(
+                    f"observation['images'] has {len(img_list)} entries; "
+                    f"this frontend was built with num_views={self.num_views}")
+            labels = [f"images[{i}]" for i in range(len(img_list))]
+        else:
+            missing = [k for k in expected_keys if k not in observation]
+            if missing:
+                raise ValueError(
+                    f"observation is missing image key(s) {missing} — "
+                    f"num_views={self.num_views} requires "
+                    f"{list(expected_keys)} (or an 'images' list)")
+            if self.num_views < 3 and "wrist_image_right" in observation:
+                raise ValueError(
+                    "observation provides 'wrist_image_right' but this "
+                    f"frontend was built with num_views={self.num_views}; "
+                    "construct it with num_views=3 to use a third view")
+            img_list = [observation[k] for k in expected_keys]
+            labels = list(expected_keys)
+        for label, im in zip(labels, img_list):
+            if not isinstance(im, np.ndarray) or im.dtype != np.uint8:
+                raise ValueError(
+                    f"observation image {label!r} must be a uint8 numpy "
+                    f"array, got {type(im).__name__}"
+                    f"{'/' + str(im.dtype) if isinstance(im, np.ndarray) else ''}")
+            if im.shape != (IMG_HW, IMG_HW, 3):
+                raise ValueError(
+                    f"observation image {label!r} has shape {im.shape}; "
+                    f"expected ({IMG_HW}, {IMG_HW}, 3)")
+        return img_list
+
     def _stack_images(self, observation: dict) -> torch.Tensor:
         """Stack and normalize observation images into a new bf16 tensor."""
-        if "images" in observation:
-            img_list = observation["images"]
-        else:
-            img_list = [observation["image"], observation["wrist_image"]]
-            if self.num_views >= 3 and "wrist_image_right" in observation:
-                img_list.append(observation["wrist_image_right"])
+        img_list = self._gather_view_images(observation)
         tensors = []
-        for im in img_list[:self.num_views]:
+        for im in img_list:
             tensors.append(
                 torch.from_numpy(im.astype(np.float32) / 127.5 - 1.0).to("cuda", bf16))
         return torch.stack(tensors)
 
     def _fill_img_buf(self, observation: dict) -> None:
         """Fill ``self._img_buf`` in place without allocating new tensors."""
-        if "images" in observation:
-            img_list = observation["images"]
-        else:
-            img_list = [observation["image"], observation["wrist_image"]]
-            if self.num_views >= 3 and "wrist_image_right" in observation:
-                img_list.append(observation["wrist_image_right"])
-        for v, im in enumerate(img_list[:self.num_views]):
+        img_list = self._gather_view_images(observation)
+        for v, im in enumerate(img_list):
             norm = torch.from_numpy(im.astype(np.float32) / 127.5 - 1.0)
             self._img_buf[v].copy_(norm.to(bf16))
 
@@ -1349,5 +1423,6 @@ class Pi05TorchFrontendAmd:
         nbytes = src.numel() * src.element_size()
         assert nbytes == dst_buf.nbytes, \
             f"size mismatch: src {nbytes} vs dst {dst_buf.nbytes}"
-        self._hip.hipMemcpyAsync(
-            dst_buf.ptr, ctypes.c_void_p(src.data_ptr()), nbytes, 3, stream_int)
+        self._hip_check(self._hip.hipMemcpyAsync(
+            dst_buf.ptr, ctypes.c_void_p(src.data_ptr()), nbytes, 3,
+            stream_int), "hipMemcpyAsync D2D")

--- a/flash_rt/amd/frontends/torch/pi05.py
+++ b/flash_rt/amd/frontends/torch/pi05.py
@@ -1,0 +1,1221 @@
+"""FlashRT AMD -- CDNA4 Pi0.5 torch frontend.
+
+Loads HuggingFace PyTorch safetensors checkpoints + drives the
+framework-agnostic :class:`~flash_rt.amd.models.pi05.pipeline.Pi05Pipeline`.
+
+Mirror of :class:`flash_rt.frontends.torch.pi05_rtx.Pi05TorchFrontendRtx`
+with the AMD deltas: pipeline / attention backend / kernels come from
+``flash_rt.amd``, the D2D copy helpers go through the HIP runtime, and
+the experimental RTX-only paths (INT8, RL/CFG, batched B=2) are dropped.
+The weight conversion (``convert_pi05_safetensors``), the decoder style
+precompute and the FP8 quantization scheme are kept EXACTLY — they are
+correctness-critical and hardware-neutral.
+
+torch on ROCm keeps the "cuda" device string and the ``torch.cuda``
+stream API, so all torch-side device handling is unchanged.
+
+Usage::
+
+    from flash_rt.amd.frontends.torch.pi05 import Pi05TorchFrontendAmd
+    pipe = Pi05TorchFrontendAmd("/path/to/pi05_libero_pytorch", num_views=2)
+    pipe.set_prompt("pick up the red block")
+    pipe.calibrate_with_real_data([obs_dict])   # once, ~1 s
+    out = pipe.infer({"image": img, "wrist_image": wrist})
+    actions = out["actions"]     # (chunk_size, 7) numpy
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import math
+import os
+import pathlib
+import time
+from typing import Optional, Union
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from flash_rt.core.utils.actions import unnormalize_actions, LIBERO_ACTION_DIM
+from flash_rt.amd.hardware.cdna4.attn_backend import Cdna4AttnBackend
+from flash_rt.amd.models.pi05.pipeline import (
+    Pi05Pipeline,
+    VIS_L, VIS_D, VIS_H, VIS_PATCH_FLAT,
+    ENC_L, ENC_D, ENC_H,
+    DEC_L, DEC_D, DEC_H, DEC_HD,
+    ACTION_DIM, NUM_STEPS_DEFAULT,
+)
+from flash_rt.core.utils.pi05_prompt import PI05_STATE_PROMPT_MAX_LEN, format_pi05_prompt
+
+logger = logging.getLogger(__name__)
+
+bf16 = torch.bfloat16
+fp8_e4m3 = torch.float8_e4m3fn
+
+CHUNK_SIZE = 10
+IMG_HW = 224
+MAX_PROMPT_LEN_DEFAULT = 48
+
+
+# ════════════════════════════════════════════════════════════════════
+#   HF safetensors → pipeline weight dict (BF16 torch tensors)
+# ════════════════════════════════════════════════════════════════════
+
+
+def _interleave_qk(w: torch.Tensor, num_heads: int) -> torch.Tensor:
+    """Interleave Q/K output dim from HF contiguous to JAX RoPE format."""
+    out_dim, in_dim = w.shape
+    head_dim = out_dim // num_heads
+    return (
+        w.reshape(num_heads, head_dim, in_dim)
+         .reshape(num_heads, 2, head_dim // 2, in_dim)
+         .permute(0, 2, 1, 3)
+         .reshape(out_dim, in_dim)
+    )
+
+
+def convert_pi05_safetensors(safetensors_path: Union[str, pathlib.Path]) -> dict:
+    """Convert a HuggingFace Pi0.5 safetensors file to BF16 torch tensor dict.
+
+    Key transformations (verified bit-exact against the openpi PyTorch
+    reference forward on LIBERO data):
+
+      - Vision attention: separate Q/K/V → merged, transposed (in, 3*out).
+      - Vision patch embedding: ``(C_out, C_in, H, W)`` → ``(H, W, C_in, C_out)``.
+      - Encoder RMSNorm fold: multiply Q/K/V/gate/up weights by ``(1 + norm_w)``
+        in FP32 to avoid bf16 rounding near -1.0.
+      - Encoder Q/K heads: interleave for fused RoPE kernel.
+      - Decoder Q/K heads: interleave (no RMS fold — AdaRMSNorm is runtime).
+      - Decoder AdaRMSNorm modulation: ``input_layernorm.dense`` →
+        ``pre_attn_norm_mod`` (kept separate, BF16).
+      - Output projection: frontend pre-scales ``decoder_action_out_proj_w/b``
+        by ``-1.0 / num_steps`` (matching the flow-matching residual accumulation).
+      - 10-step sinusoidal time embeddings.
+    """
+    from safetensors import safe_open
+    from flash_rt.executors.torch_weights import _autodetect_strip_prefix
+
+    logger.info("Loading Pi0.5 safetensors: %s", safetensors_path)
+    f = safe_open(str(safetensors_path), framework="pt")
+    # Auto-strip the lerobot HF policy ``model.`` wrap so the openpi
+    # bare-key lookups below resolve transparently on either layout.
+    _strip = _autodetect_strip_prefix(set(f.keys()))
+
+    def g(key: str) -> torch.Tensor:
+        return f.get_tensor((_strip + key) if _strip else key).to(bf16)
+
+    def g_raw(key: str) -> torch.Tensor:
+        return f.get_tensor((_strip + key) if _strip else key)
+
+    ckpt: dict = {}
+
+    # ── Vision encoder (27 SigLIP layers) ──
+    vp = "paligemma_with_expert.paligemma.model.vision_tower.vision_model"
+    pe_w = g(f"{vp}.embeddings.patch_embedding.weight")   # (1152, 3, 14, 14)
+    # Target layout (14, 14, 3, 1152) flattens contiguously to (588, 1152)
+    # row-major as (h, w, c, o) — matches the patch_im2col output order.
+    ckpt["vision_patch_embedding_w"] = pe_w.permute(2, 3, 1, 0).contiguous()
+    ckpt["vision_patch_embedding_b"] = g(f"{vp}.embeddings.patch_embedding.bias")
+    ckpt["vision_position_embedding"] = g(f"{vp}.embeddings.position_embedding.weight")
+
+    qkv_w_list, qkv_b_list = [], []
+    o_w_list, o_b_list = [], []
+    up_w_list, up_b_list = [], []
+    down_w_list, down_b_list = [], []
+    ln1_w_list, ln1_b_list = [], []
+    ln2_w_list, ln2_b_list = [], []
+
+    for i in range(VIS_L):
+        lp = f"{vp}.encoder.layers.{i}"
+        q_w = g(f"{lp}.self_attn.q_proj.weight")
+        k_w = g(f"{lp}.self_attn.k_proj.weight")
+        v_w = g(f"{lp}.self_attn.v_proj.weight")
+        qkv_w_list.append(torch.cat([q_w, k_w, v_w], dim=0).t())
+
+        q_b = g(f"{lp}.self_attn.q_proj.bias")
+        k_b = g(f"{lp}.self_attn.k_proj.bias")
+        v_b = g(f"{lp}.self_attn.v_proj.bias")
+        qkv_b_list.append(torch.cat([q_b, k_b, v_b]))
+
+        o_w_list.append(g(f"{lp}.self_attn.out_proj.weight").t())
+        o_b_list.append(g(f"{lp}.self_attn.out_proj.bias"))
+
+        up_w_list.append(g(f"{lp}.mlp.fc1.weight").t())
+        up_b_list.append(g(f"{lp}.mlp.fc1.bias"))
+
+        down_w_list.append(g(f"{lp}.mlp.fc2.weight").t())
+        down_b_list.append(g(f"{lp}.mlp.fc2.bias"))
+
+        ln1_w_list.append(g(f"{lp}.layer_norm1.weight"))
+        ln1_b_list.append(g(f"{lp}.layer_norm1.bias"))
+        ln2_w_list.append(g(f"{lp}.layer_norm2.weight"))
+        ln2_b_list.append(g(f"{lp}.layer_norm2.bias"))
+
+    ckpt["vision_attn_qkv_w"] = torch.stack(qkv_w_list)
+    ckpt["vision_attn_qkv_b"] = torch.stack(qkv_b_list)
+    ckpt["vision_attn_o_w"] = torch.stack(o_w_list)
+    ckpt["vision_attn_o_b"] = torch.stack(o_b_list)
+    ckpt["vision_ffn_up_w"] = torch.stack(up_w_list)
+    ckpt["vision_ffn_up_b"] = torch.stack(up_b_list)
+    ckpt["vision_ffn_down_w"] = torch.stack(down_w_list)
+    ckpt["vision_ffn_down_b"] = torch.stack(down_b_list)
+    ckpt["vision_pre_attn_norm_w"] = torch.stack(ln1_w_list)
+    ckpt["vision_pre_attn_norm_b"] = torch.stack(ln1_b_list)
+    ckpt["vision_pre_ffn_norm_w"] = torch.stack(ln2_w_list)
+    ckpt["vision_pre_ffn_norm_b"] = torch.stack(ln2_b_list)
+    ckpt["vision_final_norm_w"] = g(f"{vp}.post_layernorm.weight")
+    ckpt["vision_final_norm_b"] = g(f"{vp}.post_layernorm.bias")
+
+    # ── Multi-modal projector ──
+    mp = "paligemma_with_expert.paligemma.model.multi_modal_projector.linear"
+    ckpt["encoder_multi_modal_projector_w"] = g(f"{mp}.weight").t()
+    ckpt["encoder_multi_modal_projector_b"] = g(f"{mp}.bias")
+
+    # ── Encoder (18 Gemma-2B layers with RMSNorm fold) ──
+    ep = "paligemma_with_expert.paligemma.model.language_model.layers"
+    enc_qkv_list, enc_o_list = [], []
+    enc_gate_list, enc_up_list, enc_down_list = [], [], []
+
+    for i in range(ENC_L):
+        # CRITICAL: fuse in FP32 — bf16 rounds values near -1.0 to exactly
+        # -1.0, collapsing (1 + scale) to 0 and zeroing entire channels.
+        attn_scale = g_raw(f"{ep}.{i}.input_layernorm.weight").float()
+        fuse_attn = 1.0 + attn_scale  # (2048,)
+
+        q_w = g_raw(f"{ep}.{i}.self_attn.q_proj.weight").float()
+        k_w = g_raw(f"{ep}.{i}.self_attn.k_proj.weight").float()
+        v_w = g_raw(f"{ep}.{i}.self_attn.v_proj.weight").float()
+        q_w = _interleave_qk(q_w, 8)
+        k_w = _interleave_qk(k_w, 1)
+        q_w = q_w * fuse_attn.unsqueeze(0)
+        k_w = k_w * fuse_attn.unsqueeze(0)
+        v_w = v_w * fuse_attn.unsqueeze(0)
+        qkv = torch.cat([q_w, k_w, v_w], dim=0).t().to(bf16)
+        enc_qkv_list.append(qkv)
+
+        enc_o_list.append(g(f"{ep}.{i}.self_attn.o_proj.weight").t())
+
+        ffn_scale = g_raw(f"{ep}.{i}.post_attention_layernorm.weight").float()
+        fuse_ffn = 1.0 + ffn_scale
+
+        gate_w = g_raw(f"{ep}.{i}.mlp.gate_proj.weight").float() * fuse_ffn.unsqueeze(0)
+        up_w = g_raw(f"{ep}.{i}.mlp.up_proj.weight").float() * fuse_ffn.unsqueeze(0)
+        enc_gate_list.append(gate_w.t().to(bf16))
+        enc_up_list.append(up_w.t().to(bf16))
+
+        enc_down_list.append(g(f"{ep}.{i}.mlp.down_proj.weight").t())
+
+    ckpt["encoder_attn_qkv_w"] = torch.stack(enc_qkv_list)
+    ckpt["encoder_attn_o_w"] = torch.stack(enc_o_list)
+    ckpt["encoder_ffn_gate_w"] = torch.stack(enc_gate_list)
+    ckpt["encoder_ffn_up_w"] = torch.stack(enc_up_list)
+    ckpt["encoder_ffn_down_w"] = torch.stack(enc_down_list)
+
+    # ── Decoder (18 Gemma-300M layers) ──
+    dp = "paligemma_with_expert.gemma_expert.model.layers"
+    dec_qkv_list, dec_o_list = [], []
+    dec_gate_list, dec_up_list, dec_down_list = [], [], []
+    dec_attn_mod_w_list, dec_attn_mod_b_list = [], []
+    dec_ffn_mod_w_list, dec_ffn_mod_b_list = [], []
+
+    for i in range(DEC_L):
+        dec_attn_mod_w_list.append(g(f"{dp}.{i}.input_layernorm.dense.weight").t())
+        dec_attn_mod_b_list.append(g(f"{dp}.{i}.input_layernorm.dense.bias"))
+
+        q_w = g(f"{dp}.{i}.self_attn.q_proj.weight")
+        k_w = g(f"{dp}.{i}.self_attn.k_proj.weight")
+        v_w = g(f"{dp}.{i}.self_attn.v_proj.weight")
+        q_w = _interleave_qk(q_w.float(), 8).to(q_w.dtype)
+        k_w = _interleave_qk(k_w.float(), 1).to(k_w.dtype)
+        dec_qkv_list.append(torch.cat([q_w, k_w, v_w], dim=0).t())
+
+        dec_o_list.append(g(f"{dp}.{i}.self_attn.o_proj.weight").t())
+
+        dec_ffn_mod_w_list.append(
+            g(f"{dp}.{i}.post_attention_layernorm.dense.weight").t())
+        dec_ffn_mod_b_list.append(
+            g(f"{dp}.{i}.post_attention_layernorm.dense.bias"))
+
+        dec_gate_list.append(g(f"{dp}.{i}.mlp.gate_proj.weight").t())
+        dec_up_list.append(g(f"{dp}.{i}.mlp.up_proj.weight").t())
+        dec_down_list.append(g(f"{dp}.{i}.mlp.down_proj.weight").t())
+
+    ckpt["decoder_attn_qkv_w"] = torch.stack(dec_qkv_list)
+    ckpt["decoder_attn_o_w"] = torch.stack(dec_o_list)
+    ckpt["decoder_ffn_gate_w"] = torch.stack(dec_gate_list)
+    ckpt["decoder_ffn_up_w"] = torch.stack(dec_up_list)
+    ckpt["decoder_ffn_down_w"] = torch.stack(dec_down_list)
+    ckpt["decoder_pre_attn_norm_mod_w"] = torch.stack(dec_attn_mod_w_list)
+    ckpt["decoder_pre_attn_norm_mod_b"] = torch.stack(dec_attn_mod_b_list)
+    ckpt["decoder_pre_ffn_norm_mod_w"] = torch.stack(dec_ffn_mod_w_list)
+    ckpt["decoder_pre_ffn_norm_mod_b"] = torch.stack(dec_ffn_mod_b_list)
+
+    ckpt["decoder_final_norm_mod_w"] = g(
+        "paligemma_with_expert.gemma_expert.model.norm.dense.weight").t()
+    ckpt["decoder_final_norm_mod_b"] = g(
+        "paligemma_with_expert.gemma_expert.model.norm.dense.bias")
+
+    # ── Time MLP + sinusoidal embeddings ──
+    ckpt["decoder_time_mlp_in_w"] = g("time_mlp_in.weight").t()
+    ckpt["decoder_time_mlp_in_b"] = g("time_mlp_in.bias")
+    ckpt["decoder_time_mlp_out_w"] = g("time_mlp_out.weight").t()
+    ckpt["decoder_time_mlp_out_b"] = g("time_mlp_out.bias")
+
+    num_steps = NUM_STEPS_DEFAULT
+    dt = -1.0 / num_steps
+    t = torch.tensor(1.0, dtype=torch.float32)
+    min_period, max_period = 4e-3, 4.0
+    embedding_dim = DEC_D
+    fraction = torch.linspace(0.0, 1.0, embedding_dim // 2)
+    period = min_period * (max_period / min_period) ** fraction
+    time_emb_list = []
+    for _ in range(num_steps):
+        sinusoid_input = t.unsqueeze(-1) * (1.0 / period).unsqueeze(0) * 2 * math.pi
+        time_emb_list.append(
+            torch.cat([torch.sin(sinusoid_input), torch.cos(sinusoid_input)], dim=-1).to(bf16)
+        )
+        t = t + dt
+    ckpt["decoder_time_embeds"] = torch.cat(time_emb_list, dim=0)  # (10, 1024)
+
+    # ── Action projections (pre-scaled by frontend before pipeline build) ──
+    ckpt["decoder_action_in_proj_w"] = g("action_in_proj.weight").t()
+    ckpt["decoder_action_in_proj_b"] = g("action_in_proj.bias")
+    ckpt["decoder_action_out_proj_w"] = g("action_out_proj.weight").t()
+    ckpt["decoder_action_out_proj_b"] = g("action_out_proj.bias")
+
+    # ── Embedding matrix (for prompt tokenisation) ──
+    ckpt["embedding_weight"] = g("paligemma_with_expert.paligemma.lm_head.weight")
+
+    logger.info("Converted %d weight groups", len(ckpt))
+    return ckpt
+
+
+def _embed_prompt(prompt_text: str, embedding_weight: torch.Tensor,
+                  max_len: int = 48, state=None) -> tuple[torch.Tensor, int]:
+    """Tokenise + embed via PaliGemma embedding table (device, bf16)."""
+    # PaliGemma tokenizer resolution — see
+    # `flash_rt.utils.paligemma_tokenizer` for the search order and
+    # the download instructions emitted on failure.
+    try:
+        # Preferred: openpi's PaligemmaTokenizer (exact same vocab,
+        # same prompt prefix logic FlashRT was built against).
+        from openpi.models.tokenizer import PaligemmaTokenizer
+        tokenizer = PaligemmaTokenizer(max_len=max_len)
+        tokens_np, mask_np = tokenizer.tokenize(prompt_text, state=state)
+        prompt_len = int(mask_np.sum())
+        token_ids = torch.tensor(
+            tokens_np[:prompt_len], dtype=torch.long, device="cuda")
+    except (ImportError, FileNotFoundError, OSError, RuntimeError):
+        # Fallback: locate the SentencePiece model directly via the
+        # FlashRT helper (clear error if not found — never silent
+        # segfault).
+        from flash_rt.utils.paligemma_tokenizer import (
+            load_paligemma_sentencepiece,
+        )
+        sp = load_paligemma_sentencepiece()
+        if state is None:
+            # 108 is PaliGemma's `\n` token, used by openpi as the
+            # prompt-end separator before the action prefix.
+            tokens = [sp.bos_id()] + sp.Encode(prompt_text) + [108]
+        else:
+            tokens = sp.Encode(format_pi05_prompt(prompt_text, state),
+                               add_bos=True)
+        token_ids = torch.tensor(tokens, dtype=torch.long, device="cuda")
+        prompt_len = len(token_ids)
+
+    if embedding_weight.device.type != "cuda":
+        embedding_weight = embedding_weight.to(device="cuda")
+
+    embeds = F.embedding(token_ids, embedding_weight)
+    embeds = embeds * float(embeds.shape[-1] ** 0.5)
+    return embeds, prompt_len
+
+
+# ════════════════════════════════════════════════════════════════════
+#   Weight FP8 quantization + precomputed decoder styles
+# ════════════════════════════════════════════════════════════════════
+
+
+def _quantize_fp8_e4m3(w_bf16: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-tensor symmetric FP8 E4M3 quantization."""
+    amax = w_bf16.float().abs().max().item()
+    scale = max(amax / 448.0, 1e-12)
+    w_fp8 = (w_bf16.float() / scale).clamp(-448.0, 448.0).to(fp8_e4m3)
+    scale_tensor = torch.tensor([scale], dtype=torch.float32, device="cuda")
+    return w_fp8, scale_tensor
+
+
+def _select_fp8_layout(fp8_layout: Optional[str]) -> str:
+    """Choose the FP8 weight layout used by the AMD frontend kernels.
+
+    ``kn``: weights are stored as [K,N] and use ``fp8_nn_dev`` (default).
+    ``nk``: weights are stored as [N,K] and use ``fp8_nt_dev``.
+    """
+    if fp8_layout is not None:
+        if fp8_layout not in ("kn", "nk"):
+            raise ValueError(f"fp8_layout must be 'kn' or 'nk', got {fp8_layout!r}")
+        return fp8_layout
+    return "kn"
+
+
+def _precompute_decoder_styles(ckpt: dict, chunk_size: int,
+                               num_steps: int = NUM_STEPS_DEFAULT) -> dict:
+    """Pre-compute the time-MLP + per-layer style modulations in torch.
+
+    Output dict has numpy arrays (dtype bf16 via torch→numpy view):
+        time_emb:    (num_steps, chunk_size, DEC_D)
+        style_attn:  (num_steps, DEC_L, chunk_size, 3 * DEC_D)
+        style_ffn:   (num_steps, DEC_L, chunk_size, 3 * DEC_D)
+        style_final: (num_steps, chunk_size, 3 * DEC_D)
+
+    All computation runs on the GPU in bf16, then is moved to CPU and viewed
+    as uint16 so it can be uploaded verbatim to HipBuffer (bf16 = 2 bytes,
+    numpy doesn't natively support bf16 but the bytes round-trip).
+
+    Time embeddings are regenerated from scratch for the given num_steps so
+    that any step count works correctly (e.g. num_steps=5 gives
+    t=1.0, 0.8, 0.6, 0.4, 0.2 with dt=-0.2, not a truncation of the
+    10-step table stored in the checkpoint).
+    """
+    W = {k: v.to("cuda", bf16) if isinstance(v, torch.Tensor) else v
+         for k, v in ckpt.items()}
+
+    # Regenerate sinusoidal time embeddings for the given num_steps / dt.
+    # The checkpoint stores a 10-step table; generate fresh ones so any
+    # step count gets the correct (t=1, t=1-dt, …) time schedule.
+    dt = -1.0 / num_steps
+    t = torch.tensor(1.0, dtype=torch.float32)
+    min_period, max_period = 4e-3, 4.0
+    fraction = torch.linspace(0.0, 1.0, DEC_D // 2, dtype=torch.float32)
+    period = min_period * (max_period / min_period) ** fraction
+    _time_emb_rows = []
+    for _ in range(num_steps):
+        # period has shape (DEC_D//2,); t is a scalar tensor → sinusoid: (DEC_D//2,)
+        sinusoid = t * (1.0 / period) * 2 * math.pi
+        _time_emb_rows.append(
+            torch.cat([torch.sin(sinusoid), torch.cos(sinusoid)], dim=-1).to(bf16))
+        t = t + dt
+    time_emb_schedule = torch.stack(_time_emb_rows, dim=0).to("cuda")  # (steps, DEC_D)
+    t_in_w = W["decoder_time_mlp_in_w"]                       # (1024, 1024)
+    t_in_b = W["decoder_time_mlp_in_b"]                       # (1024,)
+    t_out_w = W["decoder_time_mlp_out_w"]
+    t_out_b = W["decoder_time_mlp_out_b"]
+
+    attn_mod_w = W["decoder_pre_attn_norm_mod_w"]             # (L, 1024, 3072)
+    attn_mod_b = W["decoder_pre_attn_norm_mod_b"]             # (L, 3072)
+    ffn_mod_w = W["decoder_pre_ffn_norm_mod_w"]
+    ffn_mod_b = W["decoder_pre_ffn_norm_mod_b"]
+    final_mod_w = W["decoder_final_norm_mod_w"]               # (1024, 3072)
+    final_mod_b = W["decoder_final_norm_mod_b"]               # (3072,)
+
+    time_emb_out = torch.empty(num_steps, chunk_size, DEC_D, dtype=bf16, device="cuda")
+    style_attn = torch.empty(num_steps, DEC_L, chunk_size, 3 * DEC_D, dtype=bf16, device="cuda")
+    style_ffn = torch.empty(num_steps, DEC_L, chunk_size, 3 * DEC_D, dtype=bf16, device="cuda")
+    style_final = torch.empty(num_steps, chunk_size, 3 * DEC_D, dtype=bf16, device="cuda")
+
+    for step in range(num_steps):
+        te = time_emb_schedule[step:step + 1]                 # (1, 1024)
+        tmp = te @ t_in_w + t_in_b[None, :]                   # SiLU input
+        tmp = (tmp.float() * torch.sigmoid(tmp.float())).to(bf16)
+        tmp2 = tmp @ t_out_w + t_out_b[None, :]
+        tmp2 = (tmp2.float() * torch.sigmoid(tmp2.float())).to(bf16)
+        te_expanded = tmp2.expand(chunk_size, -1).contiguous()  # (chunk, 1024)
+        time_emb_out[step] = te_expanded
+
+        for i in range(DEC_L):
+            style_attn[step, i] = te_expanded @ attn_mod_w[i] + attn_mod_b[i][None, :]
+            style_ffn[step, i] = te_expanded @ ffn_mod_w[i] + ffn_mod_b[i][None, :]
+
+        style_final[step] = te_expanded @ final_mod_w + final_mod_b[None, :]
+
+    # View as uint16 (bf16 bit pattern) so numpy can round-trip bytes.
+    def _to_np_u16(t: torch.Tensor) -> np.ndarray:
+        return t.contiguous().view(torch.uint16).cpu().numpy()
+
+    return {
+        "time_emb": _to_np_u16(time_emb_out),
+        "style_attn": _to_np_u16(style_attn),
+        "style_ffn": _to_np_u16(style_ffn),
+        "style_final": _to_np_u16(style_final),
+    }
+
+
+# ════════════════════════════════════════════════════════════════════
+#   Pi05TorchFrontendAmd frontend
+# ════════════════════════════════════════════════════════════════════
+
+
+class Pi05TorchFrontendAmd:
+    """AMD CDNA4 Pi0.5 Torch frontend.
+
+    Mirrors the RTX frontend's public API (``set_prompt`` + ``infer`` +
+    ``calibrate_with_real_data`` + ``get_latency_stats``) so the same
+    eval scripts work on both hardware families.
+    """
+
+    def __init__(self,
+                 checkpoint_dir: Union[str, pathlib.Path],
+                 num_views: int = 2,
+                 chunk_size: int = CHUNK_SIZE,
+                 max_prompt_len: int = MAX_PROMPT_LEN_DEFAULT,
+                 num_steps: int = NUM_STEPS_DEFAULT,
+                 vision_pool_factor: int = 1,
+                 vision_num_layers: Optional[int] = None,
+                 cache_frames: int = 1,
+                 use_fp8: bool = True,
+                 hardware: Optional[str] = None,
+                 fp8_layout: Optional[str] = None,
+                 state_prompt_mode: str = "exact"):
+        checkpoint_dir = pathlib.Path(checkpoint_dir)
+        # State-in-prompt graph strategy (Pi0.5 renders robot state into the
+        # prompt, so its token length drifts with the state values):
+        #   "exact" (default): a separate pipeline captured per exact length,
+        #       cached; pair with warm_state_prompt_buckets() to front-load the
+        #       lengths you expect so the control loop avoids a mid-loop capture.
+        #   "fixed": ONE pipeline + ONE captured graph at the max prompt length;
+        #       every length is served by masking the padded prefix +
+        #       appending decoder K/V at the valid offset (devpos),
+        #       so a changing length never re-captures and no warmup is needed.
+        # Env override: FLASHRT_PI05_STATE_PROMPT_MODE.
+        _spm = os.environ.get("FLASHRT_PI05_STATE_PROMPT_MODE", state_prompt_mode)
+        if _spm not in ("fixed", "exact"):
+            raise ValueError(
+                f"state_prompt_mode must be 'fixed' or 'exact', got {_spm!r}")
+        self._state_prompt_mode = _spm
+        self.num_views = int(num_views)
+        self.chunk_size = int(chunk_size)
+        self.max_prompt_len = int(max_prompt_len)
+        self._num_steps = int(num_steps)
+        self._vision_pool_factor = int(vision_pool_factor)
+        if self._num_steps <= 0:
+            raise ValueError(f"num_steps must be positive, got {self._num_steps}")
+        if self._vision_pool_factor not in (1, 2, 4):
+            raise ValueError(
+                "vision_pool_factor must be one of {1, 2, 4}; "
+                f"got {self._vision_pool_factor}")
+        # Temporal K/V caching: run full pipeline every `cache_frames` frames,
+        # intermediate frames reuse the cached encoder K/V (decoder-only).
+        # cache_frames=1 (default) = no caching, every frame is full.
+        # cache_frames=2 = full, decode, full, decode, ...
+        self._cache_frames = int(cache_frames)
+        if self._cache_frames < 1:
+            raise ValueError(f"cache_frames must be >= 1, got {self._cache_frames}")
+        self._frame_count = 0
+        self._vision_num_layers = VIS_L if vision_num_layers is None else int(vision_num_layers)
+        if not 1 <= self._vision_num_layers <= VIS_L:
+            raise ValueError(
+                f"vision_num_layers must be in [1, {VIS_L}], "
+                f"got {self._vision_num_layers}")
+        self.use_fp8 = bool(use_fp8)
+        self.hardware = hardware if hardware is not None else "amd_cdna4"
+        self.fp8_layout = _select_fp8_layout(fp8_layout)
+
+        self.latency_records: list[float] = []
+        self.calibrated = False
+        self.graph_recorded = False
+        self.current_prompt_len = 0
+        self.pipeline: Optional[Pi05Pipeline] = None
+        self._prompt_pipeline_cache: dict[int, Pi05Pipeline] = {}
+        # Fixed-shape (state_prompt_mode="fixed") pipeline, cached separately so
+        # switching to a no-state prompt and back reuses the already-calibrated,
+        # already-captured graph instead of rebuilding it.
+        self._fixed_pipeline: Optional[Pi05Pipeline] = None
+        # BF16-only escape hatch (no FP8 support probe needed on CDNA4 —
+        # MI350X has native OCP FP8 E4M3; use the env knob or use_fp8=False
+        # to force the BF16 baseline).
+        env_force_bf16 = os.environ.get("FVK_PI05_AMD_FORCE_BF16", "0") == "1"
+        self._force_bf16 = env_force_bf16
+
+        # ── Load norm_stats ──
+        self._load_norm_stats(checkpoint_dir)
+
+        # ── Load + convert safetensors ──
+        safetensors_path = checkpoint_dir / "model.safetensors"
+        if not safetensors_path.exists():
+            raise FileNotFoundError(
+                f"safetensors not found at {safetensors_path} — "
+                "Pi05TorchFrontendAmd expects a HuggingFace-style PyTorch checkpoint")
+        self._checkpoint_path = str(safetensors_path)
+        raw_ckpt = convert_pi05_safetensors(safetensors_path)
+
+        # Move all tensors to device bf16 (retain as member attrs so their
+        # memory stays alive across pipeline rebuilds).
+        self._ckpt_bf16 = {}
+        for k, v in raw_ckpt.items():
+            if isinstance(v, torch.Tensor):
+                self._ckpt_bf16[k] = v.to("cuda", bf16).contiguous()
+            else:
+                self._ckpt_bf16[k] = v
+        self.embedding_weight = self._ckpt_bf16["embedding_weight"]
+
+        # Pre-scale decoder action output projection by -1/num_steps.
+        # Scaling is specific to the step count (ODE integration step size).
+        num_steps = self._num_steps
+        self._ckpt_bf16["decoder_action_out_proj_w"] = \
+            self._ckpt_bf16["decoder_action_out_proj_w"] * (-1.0 / num_steps)
+        self._ckpt_bf16["decoder_action_out_proj_b"] = \
+            self._ckpt_bf16["decoder_action_out_proj_b"] * (-1.0 / num_steps)
+
+        # ── Low-precision weight stores ──
+        # FP8 weight quantization is gated on use_fp8 so BF16-only loading
+        # works without the FP8 kernels present (the quantize itself is
+        # pure torch, but the resulting pointers would route the pipeline
+        # through fp8_* fvk entries).
+        self._fp8_weights: dict = {}
+        self._fp8_store: list = []  # holds tensors alive
+        if self.use_fp8 and not self._force_bf16:
+            self._quantize_all_fp8()
+
+        # ── Pre-compute decoder styles (time MLP + style modulation) ──
+        self._precomputed_styles = _precompute_decoder_styles(
+            self._ckpt_bf16, self.chunk_size, num_steps=self._num_steps)
+
+        # ── Attention backend (torch, owns Q/K/V/O) ──
+        enc_seq_max = self.num_views * 256 + self.max_prompt_len
+        self.attn_backend = Cdna4AttnBackend(
+            num_views=self.num_views,
+            encoder_seq_max=enc_seq_max,
+            chunk_size=self.chunk_size,
+            num_encoder_layers=ENC_L)
+
+        # ── fvk module + GemmRunner ──
+        from flash_rt.amd import flash_rt_amd_kernels as fvk
+        self.fvk = fvk
+        self.gemm = fvk.GemmRunner()
+
+        # ── Reusable pre-allocated input buffers (match Thor style) ──
+        self._img_buf = torch.empty(
+            self.num_views, IMG_HW, IMG_HW, 3, dtype=bf16, device="cuda")
+        self._noise_buf = torch.empty(
+            self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+        self._noise_out = torch.empty(
+            self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+        from flash_rt.amd.core.hip_buffer import _hip
+        self._hip = _hip
+
+        logger.info(
+            "Pi05TorchFrontendAmd initialised (num_views=%d, chunk=%d, fp8_layout=%s)",
+            self.num_views, self.chunk_size, self.fp8_layout)
+
+    def _ensure_prompt_capacity(self, required_prompt_len: int) -> None:
+        """Grow attention buffers before building longer prompt pipelines."""
+        if required_prompt_len <= self.max_prompt_len:
+            return
+        self.max_prompt_len = int(required_prompt_len)
+        enc_seq_max = self.num_views * 256 + self.max_prompt_len
+        self.attn_backend = Cdna4AttnBackend(
+            num_views=self.num_views,
+            encoder_seq_max=enc_seq_max,
+            chunk_size=self.chunk_size,
+            num_encoder_layers=ENC_L)
+        self._prompt_pipeline_cache.clear()
+        self._fixed_pipeline = None
+        self.pipeline = None
+        self.current_prompt_len = 0
+        self.graph_recorded = False
+        self.calibrated = False
+        logger.info("Grew Pi0.5 AMD prompt capacity to %d tokens",
+                    self.max_prompt_len)
+
+    def _pipeline_precision_kwargs(self) -> dict:
+        if self._force_bf16:
+            logger.warning(
+                "FVK_PI05_AMD_FORCE_BF16=1 set: disabling FP8 paths for "
+                "the Pi0.5 AMD pipeline.")
+            return {
+                "use_fp8": False,
+                "use_fp8_decoder": False,
+            }
+        return {
+            "use_fp8": self.use_fp8,
+            "use_fp8_decoder": self.use_fp8,
+        }
+
+    # -----------------------------------------------------------------
+    # Checkpoint helpers
+    # -----------------------------------------------------------------
+
+    def _load_norm_stats(self, checkpoint_dir: pathlib.Path) -> None:
+        from flash_rt.core.utils.norm_stats import (
+            load_norm_stats, pi05_candidates,
+        )
+        try:
+            self.norm_stats = load_norm_stats(
+                pi05_candidates(checkpoint_dir), checkpoint_dir=checkpoint_dir)
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"norm_stats not found near checkpoint: {e}") from e
+
+    def _quantize_all_fp8(self) -> None:
+        """Pre-quantize all large GEMM weights to FP8 E4M3."""
+        W = self._ckpt_bf16
+        store = self._fp8_store
+        fp8 = self._fp8_weights
+
+        def quant(name: str, w: torch.Tensor):
+            if self.fp8_layout == "nk":
+                w = w.t().contiguous()
+            else:
+                w = w.contiguous()
+            w_fp8, scale = _quantize_fp8_e4m3(w)
+            store.append(w_fp8)
+            store.append(scale)
+            fp8[name] = (w_fp8.data_ptr(), scale.data_ptr())
+
+        # Vision (27 layers × 4) + projector
+        for i in range(VIS_L):
+            quant(f"vision_attn_qkv_w_{i}", W["vision_attn_qkv_w"][i])
+            quant(f"vision_attn_o_w_{i}", W["vision_attn_o_w"][i])
+            quant(f"vision_ffn_up_w_{i}", W["vision_ffn_up_w"][i])
+            quant(f"vision_ffn_down_w_{i}", W["vision_ffn_down_w"][i])
+        quant("vision_projector_w", W["encoder_multi_modal_projector_w"])
+
+        # Encoder (18 layers × 4) — fuse gate+up into (D, 2H)
+        for i in range(ENC_L):
+            quant(f"encoder_attn_qkv_w_{i}", W["encoder_attn_qkv_w"][i])
+            quant(f"encoder_attn_o_w_{i}", W["encoder_attn_o_w"][i])
+            gate_up = torch.cat(
+                [W["encoder_ffn_gate_w"][i], W["encoder_ffn_up_w"][i]], dim=1
+            ).contiguous()
+            quant(f"encoder_ffn_gate_up_w_{i}", gate_up)
+            quant(f"encoder_ffn_down_w_{i}", W["encoder_ffn_down_w"][i])
+
+        # Decoder (18 layers × 4)
+        for i in range(DEC_L):
+            quant(f"decoder_attn_qkv_w_{i}", W["decoder_attn_qkv_w"][i])
+            quant(f"decoder_attn_o_w_{i}", W["decoder_attn_o_w"][i])
+            gate_up = torch.cat(
+                [W["decoder_ffn_gate_w"][i], W["decoder_ffn_up_w"][i]], dim=1
+            ).contiguous()
+            quant(f"decoder_ffn_gate_up_w_{i}", gate_up)
+            quant(f"decoder_ffn_down_w_{i}", W["decoder_ffn_down_w"][i])
+
+        logger.info("FP8 quantized %d GEMM weights (layout=%s)", len(fp8), self.fp8_layout)
+
+    def _build_pipeline_weights(self) -> dict:
+        """Produce the pointer dict that Pi05Pipeline expects."""
+        W = self._ckpt_bf16
+
+        def p(key: str) -> int:
+            return W[key].data_ptr()
+
+        def p_list(key: str) -> list[int]:
+            t = W[key]
+            stride = t.stride(0) * t.element_size()
+            base = t.data_ptr()
+            return [base + i * stride for i in range(t.shape[0])]
+
+        weights = {
+            # Vision BF16
+            "vision_patch_embedding_w": p("vision_patch_embedding_w"),
+            "vision_patch_embedding_b": p("vision_patch_embedding_b"),
+            "vision_position_embedding": p("vision_position_embedding"),
+            "vision_pre_attn_norm_w": p_list("vision_pre_attn_norm_w"),
+            "vision_pre_attn_norm_b": p_list("vision_pre_attn_norm_b"),
+            "vision_pre_ffn_norm_w": p_list("vision_pre_ffn_norm_w"),
+            "vision_pre_ffn_norm_b": p_list("vision_pre_ffn_norm_b"),
+            "vision_attn_qkv_w": p_list("vision_attn_qkv_w"),  # BF16 fallback
+            "vision_attn_qkv_b": p_list("vision_attn_qkv_b"),
+            "vision_attn_o_w": p_list("vision_attn_o_w"),
+            "vision_attn_o_b": p_list("vision_attn_o_b"),
+            "vision_ffn_up_w": p_list("vision_ffn_up_w"),
+            "vision_ffn_up_b": p_list("vision_ffn_up_b"),
+            "vision_ffn_down_w": p_list("vision_ffn_down_w"),
+            "vision_ffn_down_b": p_list("vision_ffn_down_b"),
+            "vision_final_norm_w": p("vision_final_norm_w"),
+            "vision_final_norm_b": p("vision_final_norm_b"),
+
+            # Encoder
+            "encoder_multi_modal_projector_w": p("encoder_multi_modal_projector_w"),
+            "encoder_multi_modal_projector_b": p("encoder_multi_modal_projector_b"),
+            "encoder_attn_qkv_w": p_list("encoder_attn_qkv_w"),
+            "encoder_attn_o_w": p_list("encoder_attn_o_w"),
+            "encoder_ffn_gate_w": p_list("encoder_ffn_gate_w"),
+            "encoder_ffn_up_w": p_list("encoder_ffn_up_w"),
+            "encoder_ffn_down_w": p_list("encoder_ffn_down_w"),
+
+            # Decoder
+            "decoder_action_in_proj_w": p("decoder_action_in_proj_w"),
+            "decoder_action_in_proj_b": p("decoder_action_in_proj_b"),
+            "decoder_action_out_proj_w": p("decoder_action_out_proj_w"),
+            "decoder_action_out_proj_b": p("decoder_action_out_proj_b"),
+            "decoder_attn_qkv_w": p_list("decoder_attn_qkv_w"),
+            "decoder_attn_o_w": p_list("decoder_attn_o_w"),
+            "decoder_ffn_gate_w": p_list("decoder_ffn_gate_w"),
+            "decoder_ffn_up_w": p_list("decoder_ffn_up_w"),
+            "decoder_ffn_down_w": p_list("decoder_ffn_down_w"),
+
+            # FP8 quantized weights
+            "fp8": self._fp8_weights,
+            "fp8_layout": self.fp8_layout,
+            "hardware": self.hardware,
+
+            # Precomputed decoder styles (numpy bf16 as uint16 view)
+            "precomputed": self._precomputed_styles,
+        }
+        return weights
+
+    # -----------------------------------------------------------------
+    # Public API
+    # -----------------------------------------------------------------
+
+    def set_prompt(self, prompt_text: str, state=None) -> None:
+        """Tokenise prompt + (re)build the pipeline for the exact prompt length."""
+        max_len = (PI05_STATE_PROMPT_MAX_LEN if state is not None
+                   else MAX_PROMPT_LEN_DEFAULT)
+        embeds, prompt_len = _embed_prompt(
+            prompt_text, self.embedding_weight, max_len=max_len, state=state)
+
+        if self._state_prompt_mode == "fixed" and state is not None:
+            self._set_prompt_fixed(prompt_len)
+        else:
+            self._set_prompt_per_length(state, prompt_len)
+
+        # The attention backend is shared across pipelines, so sync its
+        # fixed-shape mode to the now-active pipeline BEFORE running it. Without
+        # this, a frontend that ran a fixed state prompt and then a no-state
+        # prompt (which falls back to a per-length pipeline) would keep the
+        # backend in fixed mode and reuse stale seqused/devpos buffers.
+        self.attn_backend.set_fixed_shape(
+            bool(getattr(self.pipeline, "_fixed_shape", False)))
+
+        # Upload language embeds into pipeline's encoder_x slot. In fixed mode
+        # set_language_embeds pads to max + updates the seqused/devpos buffers.
+        embeds_np = embeds.contiguous().view(torch.uint16).cpu().numpy()
+        self.pipeline.set_language_embeds(embeds_np)
+        self._frame_count = 0
+        logger.info("Set prompt: '%s' (%d tokens, state=%s, mode=%s)",
+                    prompt_text, prompt_len, state is not None,
+                    self._state_prompt_mode)
+
+    def _set_prompt_fixed(self, prompt_len: int) -> None:
+        """Fixed-shape mode: build ONE max-length pipeline + one graph; later
+        prompt lengths only update embeds + seqused/devpos (no re-capture).
+
+        The fixed pipeline is cached in ``self._fixed_pipeline`` so that
+        switching to a no-state prompt (which activates a per-length pipeline)
+        and back REUSES the already-calibrated, already-captured graph instead
+        of rebuilding it — a rebuild would re-run FP8 calibration/autotune on a
+        backend the per-length pipeline has since touched and would also
+        perturb numerics via autotune variance.
+        """
+        self._ensure_prompt_capacity(PI05_STATE_PROMPT_MAX_LEN)
+        if self._fixed_pipeline is None:
+            logger.info("Building fixed-shape Pi05Pipeline (max_prompt_len=%d)...",
+                        PI05_STATE_PROMPT_MAX_LEN)
+            pipeline_weights = self._build_pipeline_weights()
+            self._fixed_pipeline = Pi05Pipeline(
+                gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
+                weights=pipeline_weights,
+                num_views=self.num_views,
+                max_prompt_len=PI05_STATE_PROMPT_MAX_LEN,
+                chunk_size=self.chunk_size,
+                num_steps=self._num_steps,
+                vision_pool_factor=self._vision_pool_factor,
+                vision_num_layers=self._vision_num_layers,
+                fixed_shape=True,
+                **self._pipeline_precision_kwargs())
+        # (Re)activate the cached fixed pipeline, restoring calibration/capture
+        # state from the instance (mirrors the per-length cache reuse path) so
+        # predict() does not re-calibrate or re-capture on switch-back.
+        if self.pipeline is not self._fixed_pipeline:
+            self.pipeline = self._fixed_pipeline
+            self.graph_recorded = (
+                getattr(self._fixed_pipeline, "_graph", None) is not None)
+            self.calibrated = (
+                self.graph_recorded
+                or bool(getattr(self._fixed_pipeline, "fp8_calibrated", False)))
+        self.current_prompt_len = prompt_len
+
+    def _set_prompt_per_length(self, state, prompt_len: int) -> None:
+        """Legacy 'exact' mode: a separate pipeline captured per exact length
+        (cached so a recurring length is not re-built)."""
+        required_capacity = (PI05_STATE_PROMPT_MAX_LEN if state is not None
+                             else prompt_len)
+        self._ensure_prompt_capacity(required_capacity)
+
+        if self.pipeline is None or prompt_len != self.current_prompt_len:
+            cached = self._prompt_pipeline_cache.get(prompt_len)
+            self.current_prompt_len = prompt_len
+            if cached is not None:
+                self.pipeline = cached
+                self.graph_recorded = getattr(cached, "_graph", None) is not None
+                self.calibrated = (
+                    self.graph_recorded
+                    or bool(getattr(cached, "fp8_calibrated", False)))
+                logger.info("Reusing cached Pi05Pipeline for prompt_len=%d",
+                            prompt_len)
+            else:
+                logger.info("Building Pi05Pipeline for prompt_len=%d...",
+                            prompt_len)
+                self.graph_recorded = False
+                self.calibrated = False
+
+                pipeline_weights = self._build_pipeline_weights()
+                self.pipeline = Pi05Pipeline(
+                    gemm=self.gemm, fvk=self.fvk, attn_backend=self.attn_backend,
+                    weights=pipeline_weights,
+                    num_views=self.num_views,
+                    max_prompt_len=prompt_len,
+                    chunk_size=self.chunk_size,
+                    num_steps=self._num_steps,
+                    vision_pool_factor=self._vision_pool_factor,
+                    vision_num_layers=self._vision_num_layers,
+                    **self._pipeline_precision_kwargs())
+                self._prompt_pipeline_cache[prompt_len] = self.pipeline
+
+    def warm_state_prompt_buckets(self, prompt_text: str, states,
+                                  sample_observation: dict) -> list[int]:
+        """Pre-build runtime buckets for Pi0.5 state-in-prompt lengths.
+
+        The prompt text is kept in the OpenPI format. This method only
+        front-loads graph capture/autotune for the token lengths reached
+        by the supplied representative states.
+        """
+        if isinstance(states, np.ndarray) and states.ndim == 1:
+            state_list = [states]
+        else:
+            state_list = list(states)
+        if not state_list:
+            raise ValueError("states must contain at least one representative state")
+
+        warmed: set[int] = set()
+        for state in state_list:
+            self.set_prompt(prompt_text, state=state)
+            prompt_len = int(self.current_prompt_len)
+            if prompt_len in warmed and getattr(self.pipeline, "_graph", None) is not None:
+                continue
+            if not self.calibrated:
+                self.calibrate_with_real_data([sample_observation])
+            warmed.add(prompt_len)
+
+        logger.info("Warmed Pi0.5 state prompt buckets: %s", sorted(warmed))
+        return sorted(warmed)
+
+    def calibrate(
+        self,
+        observations,
+        *,
+        percentile: float = 99.9,
+        max_samples: Optional[int] = None,
+        verbose: bool = False,
+    ) -> None:
+        """Unified calibration entry point.
+
+        N=1 → single-frame path, bit-equal to legacy.
+        N>=2 → per-sample amax, reduced via ``np.percentile(..., axis=0)``.
+        """
+        if self.pipeline is None:
+            raise RuntimeError("set_prompt must be called before calibrate")
+        if self.calibrated:
+            logger.warning(
+                "calibrate() called a second time; returning without re-running.")
+            return
+
+        if isinstance(observations, dict):
+            obs_list = [observations]
+        elif isinstance(observations, list):
+            obs_list = observations
+        else:
+            obs_list = list(observations)
+        if max_samples is not None:
+            obs_list = obs_list[:max_samples]
+        n = len(obs_list)
+        if n == 0:
+            raise ValueError("observations must contain at least 1 sample")
+        if not 0.0 <= percentile <= 100.0:
+            raise ValueError(f"percentile must be in [0, 100], got {percentile}")
+
+        if not getattr(self.pipeline, "use_fp8", False):
+            # BF16 pipeline: no FP8 scales to collect — the single-frame
+            # path just warms buffers and captures the graph.
+            if n > 1:
+                logger.info(
+                    "BF16 pipeline has no activation scales to calibrate; "
+                    "using the first sample to warm buffers and capture the graph.")
+            self._calibrate_single_frame(obs_list[0])
+            return
+
+        if n == 1:
+            self._calibrate_single_frame(obs_list[0])
+        else:
+            self._calibrate_multi_frame(
+                obs_list, percentile=percentile, verbose=verbose)
+
+    def calibrate_with_real_data(self, sample_observations) -> None:
+        """Legacy alias for :meth:`calibrate`."""
+        self.calibrate(sample_observations)
+
+    def _calibrate_single_frame(self, sample) -> None:
+        logger.info("Preparing Pi0.5 runtime with a single real sample...")
+
+        # Create a dedicated torch stream for both the calibration pass and
+        # graph capture so the backend's torch attention ops + our fvk
+        # kernels land on the same stream.
+        self._graph_torch_stream = torch.cuda.Stream()
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            images = self._stack_images(sample)
+            noise = torch.randn(
+                self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+
+            stream_int = self._graph_torch_stream.cuda_stream
+            self._copy_tensor_to_pipeline_buf_stream(
+                images, self.pipeline.input_images_buf, stream_int)
+            self._copy_tensor_to_pipeline_buf_stream(
+                noise, self.pipeline.input_noise_buf, stream_int)
+
+            self.pipeline.run_pipeline(stream=stream_int)
+
+            self._hip.hipStreamSynchronize(
+                ctypes.c_void_p(stream_int))
+
+            # FP8 calibration (no-op for BF16 pipelines).
+            self.pipeline.calibrate_fp8()
+            self.pipeline.autotune_gemms()
+            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+
+        self.calibrated = True
+        self.graph_recorded = True
+        self._precision_spec = self._snapshot_precision_spec(
+            method="single_frame", n=1, percentile=None)
+        self._warn_if_scale_ceiling_exceeded()
+        logger.info("Calibration + graph capture complete")
+
+    def _calibrate_multi_frame(
+        self, obs_list, *, percentile: float, verbose: bool,
+    ) -> None:
+        from flash_rt.core.calibration import (
+            accumulate_amax,
+            format_summary,
+            summarize_amax_dispersion,
+        )
+
+        n = len(obs_list)
+        logger.info(
+            "Preparing Pi0.5 runtime across %d real samples (percentile=%.2f)...",
+            n, percentile)
+        self._graph_torch_stream = torch.cuda.Stream()
+        self.pipeline.fp8_calibrated = False
+
+        per_sample: list[np.ndarray] = []
+        names: Optional[list[str]] = None
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            stream_int = self._graph_torch_stream.cuda_stream
+            for i, obs in enumerate(obs_list):
+                images = self._stack_images(obs)
+                noise = torch.randn(
+                    self.chunk_size, ACTION_DIM, dtype=bf16, device="cuda")
+                self._copy_tensor_to_pipeline_buf_stream(
+                    images, self.pipeline.input_images_buf, stream_int)
+                self._copy_tensor_to_pipeline_buf_stream(
+                    noise, self.pipeline.input_noise_buf, stream_int)
+                self._zero_pipeline_scales()
+                self.pipeline.run_pipeline(stream=stream_int)
+                self._hip.hipStreamSynchronize(
+                    ctypes.c_void_p(stream_int))
+
+                if names is None:
+                    names = list(self.pipeline.fp8_act_scales.keys())
+                sample_vec = np.array(
+                    [float(self.pipeline.fp8_act_scales[k].download_new(
+                        (1,), np.float32)[0]) for k in names],
+                    dtype=np.float32)
+                per_sample.append(sample_vec)
+
+                if verbose and (i + 1) % max(1, n // 10) == 0:
+                    logger.info("  calibration sample %d/%d", i + 1, n)
+
+            final_amax = accumulate_amax(per_sample, percentile=percentile)
+            if verbose:
+                logger.info(format_summary(
+                    summarize_amax_dispersion(per_sample, final_amax)))
+
+            for idx, name in enumerate(names or []):
+                self.pipeline.fp8_act_scales[name].upload(
+                    np.array([final_amax[idx]], dtype=np.float32))
+
+            self.pipeline.fp8_calibrated = True
+            self.pipeline.autotune_gemms()
+            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+
+        self.calibrated = True
+        self.graph_recorded = True
+        self._precision_spec = self._snapshot_precision_spec(
+            method="percentile", n=n, percentile=percentile)
+        self._warn_if_scale_ceiling_exceeded(label=f"pi05_amd_N{n}")
+        logger.info(
+            "Pi0.5 multi-frame calibration + graph capture complete "
+            "(N=%d, percentile=%.2f)", n, percentile)
+
+    def _zero_pipeline_scales(self) -> None:
+        for buf in self.pipeline.fp8_act_scales.values():
+            buf.zero_()
+
+    def _warn_if_scale_ceiling_exceeded(self, label: str = "pi05_amd") -> None:
+        """Diagnostic warning if any FP8 scale exceeds the sanity ceiling."""
+        from flash_rt.core.calibration import check_scale_ceiling
+        scales = {
+            name: float(buf.download_new((1,), np.float32)[0])
+            for name, buf in self.pipeline.fp8_act_scales.items()
+        }
+        check_scale_ceiling(scales, label=label)
+
+    def _snapshot_precision_spec(self, *, method: str, n: int,
+                                  percentile: Optional[float]):
+        from flash_rt.core.precision_spec import (
+            ModelPrecisionSpec,
+            PrecisionSpec,
+        )
+
+        spec = ModelPrecisionSpec(source="calibration")
+        for name, buf in self.pipeline.fp8_act_scales.items():
+            scale_val = float(buf.download_new((1,), np.float32)[0])
+            entry = PrecisionSpec(
+                dtype="fp8_e4m3",
+                granularity="per_tensor",
+                scheme="symmetric",
+                scale_source="calibration",
+                scale=np.array([scale_val], dtype=np.float32),
+                calibration_method=method,
+                calibration_samples=n,
+                calibration_percentile=percentile,
+            )
+            entry.validate()
+            if name.startswith("vision_"):
+                spec.activation_specs[name] = entry
+            elif name.startswith("encoder_"):
+                spec.encoder_layer_specs[name] = entry
+            elif name.startswith("decoder_") or name.startswith("action_"):
+                spec.decoder_layer_specs[name] = entry
+            else:
+                spec.activation_specs[name] = entry
+        return spec
+
+    @property
+    def precision_spec(self):
+        """:class:`ModelPrecisionSpec` captured at calibration time."""
+        return getattr(self, "_precision_spec", None)
+
+    def infer(self, observation: dict, debug: bool = False) -> dict:
+        """Run inference on a single observation.
+
+        All GPU work happens on ``self._graph_torch_stream`` — the same
+        stream the graph was captured on — so replay + pre/post D2D copies
+        are serialized correctly.
+        """
+        if self.pipeline is None:
+            raise RuntimeError("set_prompt must be called before infer")
+
+        t0 = time.perf_counter()
+
+        # Temporal K/V caching: every cache_frames-th frame runs the full
+        # pipeline (vision + encoder + decoder); intermediate frames skip
+        # vision and encoder and replay only the decoder with fresh noise,
+        # reusing the encoder K/V cache from the last full forward.
+        self._frame_count += 1
+        use_full = (self._cache_frames <= 1 or
+                    self._frame_count % self._cache_frames == 1)
+
+        with torch.cuda.stream(self._graph_torch_stream):
+            stream_int = self._graph_torch_stream.cuda_stream
+
+            self._noise_buf.normal_()
+            self._copy_tensor_to_pipeline_buf_stream(
+                self._noise_buf, self.pipeline.input_noise_buf, stream_int)
+
+            if use_full:
+                self._fill_img_buf(observation)
+                self._copy_tensor_to_pipeline_buf_stream(
+                    self._img_buf, self.pipeline.input_images_buf, stream_int)
+                out_ptr = self.pipeline.forward()
+            else:
+                # Decode-only: skip vision+encoder, reuse cached K/V
+                out_ptr = self.pipeline.forward_decode_only()
+
+            # D2D download → staging torch tensor
+            self._hip.hipMemcpyAsync(
+                ctypes.c_void_p(self._noise_out.data_ptr()),
+                ctypes.c_void_p(out_ptr),
+                self._noise_out.numel() * 2, 3, stream_int)
+
+        self._hip.hipStreamSynchronize(
+            ctypes.c_void_p(self._graph_torch_stream.cuda_stream))
+
+        latency_ms = (time.perf_counter() - t0) * 1000
+        self.latency_records.append(latency_ms)
+
+        raw_actions = self._noise_out.float().cpu().numpy()  # (chunk, 32)
+        unnorm = unnormalize_actions(raw_actions, self.norm_stats)
+        robot_actions = unnorm[:, :LIBERO_ACTION_DIM]
+
+        if debug:
+            logger.info("Raw actions[0,:5]: %s", raw_actions[0, :5])
+            logger.info("Latency: %.1f ms", latency_ms)
+
+        return {"actions": robot_actions}
+
+    def get_latency_stats(self) -> dict:
+        if not self.latency_records:
+            return {}
+        lat = np.array(self.latency_records)
+        return {
+            "count": len(lat),
+            "mean_ms": float(np.mean(lat)),
+            "std_ms": float(np.std(lat)),
+            "min_ms": float(np.min(lat)),
+            "max_ms": float(np.max(lat)),
+            "p50_ms": float(np.percentile(lat, 50)),
+            "p95_ms": float(np.percentile(lat, 95)),
+            "hz": float(1000 / np.mean(lat)),
+        }
+
+    # -----------------------------------------------------------------
+    # Internals
+    # -----------------------------------------------------------------
+
+    def _stack_images(self, observation: dict) -> torch.Tensor:
+        """Stack and normalize observation images into a new bf16 tensor."""
+        if "images" in observation:
+            img_list = observation["images"]
+        else:
+            img_list = [observation["image"], observation["wrist_image"]]
+            if self.num_views >= 3 and "wrist_image_right" in observation:
+                img_list.append(observation["wrist_image_right"])
+        tensors = []
+        for im in img_list[:self.num_views]:
+            tensors.append(
+                torch.from_numpy(im.astype(np.float32) / 127.5 - 1.0).to("cuda", bf16))
+        return torch.stack(tensors)
+
+    def _fill_img_buf(self, observation: dict) -> None:
+        """Fill ``self._img_buf`` in place without allocating new tensors."""
+        if "images" in observation:
+            img_list = observation["images"]
+        else:
+            img_list = [observation["image"], observation["wrist_image"]]
+            if self.num_views >= 3 and "wrist_image_right" in observation:
+                img_list.append(observation["wrist_image_right"])
+        for v, im in enumerate(img_list[:self.num_views]):
+            norm = torch.from_numpy(im.astype(np.float32) / 127.5 - 1.0)
+            self._img_buf[v].copy_(norm.to(bf16))
+
+    def _copy_tensor_to_pipeline_buf(self, src: torch.Tensor, dst_buf) -> None:
+        """D2D hipMemcpyAsync from a torch tensor into a HipBuffer slot.
+
+        Uses the current torch stream so downstream ops see the copy.
+        """
+        stream_int = torch.cuda.current_stream().cuda_stream
+        self._copy_tensor_to_pipeline_buf_stream(src, dst_buf, stream_int)
+
+    def _copy_tensor_to_pipeline_buf_stream(
+            self, src: torch.Tensor, dst_buf, stream_int: int) -> None:
+        """D2D hipMemcpyAsync on a specific stream."""
+        nbytes = src.numel() * src.element_size()
+        assert nbytes == dst_buf.nbytes, \
+            f"size mismatch: src {nbytes} vs dst {dst_buf.nbytes}"
+        self._hip.hipMemcpyAsync(
+            dst_buf.ptr, ctypes.c_void_p(src.data_ptr()), nbytes, 3, stream_int)

--- a/flash_rt/amd/hardware/__init__.py
+++ b/flash_rt/amd/hardware/__init__.py
@@ -1,0 +1,1 @@
+"""FlashRT AMD — hardware-specific backends (CDNA attention, ...)."""

--- a/flash_rt/amd/hardware/cdna4/__init__.py
+++ b/flash_rt/amd/hardware/cdna4/__init__.py
@@ -1,0 +1,1 @@
+"""FlashRT AMD — CDNA4 (MI350X / gfx950) hardware backends."""

--- a/flash_rt/amd/hardware/cdna4/attn_backend.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend.py
@@ -125,6 +125,7 @@ class Cdna4AttnBackend:
         #     to append the chunk K/V right after the valid prefix.
         # batch=1, so each is a single int32.
         self._fixed_shape = False
+        self._calibrating = False
         self.enc_seqused = torch.zeros(1, dtype=torch.int32, device=d)  # vis_enc+plen
         self.dec_seqused = torch.zeros(1, dtype=torch.int32, device=d)  # +chunk
         self.dec_devpos = torch.zeros(1, dtype=torch.int32, device=d)   # = enc_seqused
@@ -186,6 +187,19 @@ class Cdna4AttnBackend:
         each time it changes.
         """
         self._fixed_shape = bool(enabled)
+
+    def set_calibrating(self, enabled: bool) -> None:
+        """Mark the FP8-calibration window (deterministic-attention hint).
+
+        Quantization scales are derived from activation amax during the
+        calibration pass, so any run-to-run nondeterminism in an attention
+        site becomes permanent scale jitter. Backends whose attention
+        library is nondeterministic across processes (e.g. aiter) override
+        their site dispatch to a deterministic kernel while this flag is
+        set. The sdpa math here is already deterministic, so the base
+        implementation only records the flag.
+        """
+        self._calibrating = bool(enabled)
 
     def set_fixed_valid_len(self, valid_prefix_len: int) -> None:
         """Update the fixed-shape valid prefix length (host->device).

--- a/flash_rt/amd/hardware/cdna4/attn_backend.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend.py
@@ -1,0 +1,324 @@
+"""FlashRT AMD — CDNA4 attention backend for the Pi0.5 pipeline.
+
+Mirror of :class:`flash_rt.hardware.rtx.attn_backend.RtxFlashAttnBackend`
+as consumed by :mod:`flash_rt.amd.models.pi05.pipeline`: the backend owns
+all Q/K/V/O attention memory, exposes raw device pointers via
+:meth:`get_ptrs` so the pipeline can write into them from
+``flash_rt_amd_kernels`` calls, and runs attention via
+``run(site, layer_idx, ...)``.
+
+Buffer ownership, shapes, dtypes and the shared encoder/decoder K/V cache
+layout are IDENTICAL to the RTX backend:
+
+    vis_Q/K/V   — (num_views, 256, 16, 72) bf16
+    enc_Q       — (encoder_seq_max, 8, 256) bf16
+    enc_K/V     — (num_encoder_layers, encoder_seq_max + chunk, 1, 256) bf16
+    dec_Q       — (chunk_size, 8, 256) bf16
+
+The K/V cache is shared across encoder + decoder: the encoder writes
+``enc_K[i, :enc_seq]`` for layer ``i``; the decoder appends its chunk
+rows at ``enc_K[i, enc_seq:enc_seq+chunk]`` (or at the runtime ``devpos``
+offset in fixed-shape mode) before cross-attention. All buffers are
+allocated ONCE at ``__init__`` and never reallocated — the pipeline bakes
+their pointers into a captured HIP graph.
+
+INTERIM ATTENTION MATH
+----------------------
+This backend does NOT yet dispatch to a vendored Flash-Attention kernel
+(the RTX backend uses ``flash_rt.flash_rt_fa2``). Until the CDNA4
+attention kernel lands in ``flash_rt_amd_kernels``, each site is computed
+with torch ops over the SAME owned buffers:
+
+  * views / permutes / expands of the owned Q/K/V tensors (no copies),
+  * ``torch.nn.functional.scaled_dot_product_attention`` with
+    ``dropout_p=0.0``,
+  * a final ``copy_`` into the pre-allocated, pointer-stable O tensor
+    (sdpa has no ``out=`` argument, so the copy is the last op).
+
+Masking semantics match the FA2 call semantics the pipeline relies on:
+
+  * "siglip"  — per-view bidirectional self-attention, no mask.
+  * "encoder" — bidirectional self-attention over the first ``seq``
+    tokens; in fixed-shape mode the padded prompt keys are masked with a
+    boolean key mask driven by :meth:`set_fixed_valid_len` (the SDPA twin
+    of FA2 ``seqused_k``).
+  * "decoder" — chunk queries attend the full [valid prefix + chunk]
+    K/V range bidirectionally; fixed-shape mode masks keys past
+    ``valid + chunk``.
+
+GQA (8 Q heads over 1 KV head on encoder/decoder) uses ``expand`` — no
+materialized repeat. Every op in the per-call path is legal under HIP
+stream capture given the pipeline's warmup contract: the pipeline runs
+3 warmup iterations on the capture stream before ``begin_capture`` so
+torch's caching allocator reaches steady state and sdpa's internal
+workspace allocations are served from cached blocks (the same contract
+the RTX legacy pip-flash-attn path relied on). The mask/seqused buffers
+are updated OUTSIDE the captured graph (cold path, once per prompt) and
+are read by pointer at replay — a changing prompt length never forces a
+re-capture.
+
+Stream note: like the RTX backend's torch-side ops, the sdpa call runs
+on torch's CURRENT stream. The frontend wraps calibration + capture +
+replay in ``torch.cuda.stream(...)`` with the same stream it passes to
+the pipeline, so all work lands on the capture stream. (torch on ROCm
+keeps the "cuda" device / stream API names.)
+"""
+
+from __future__ import annotations
+
+
+class Cdna4AttnBackend:
+    """Pi0.5 attention backend for AMD CDNA4 (MI350X).
+
+    Implements the surface consumed by
+    :class:`flash_rt.amd.models.pi05.pipeline.Pi05Pipeline`:
+
+      * :meth:`get_ptrs` — raw device pointers for every attention INPUT
+        buffer plus the enc K/V per-layer stride,
+      * :meth:`run` — dispatcher over the "siglip" / "encoder" /
+        "decoder" sites (delegating to :meth:`vision_attn` /
+        :meth:`encoder_attn` / :meth:`decoder_attn`),
+      * :meth:`set_fixed_shape` / :meth:`set_fixed_valid_len` — the
+        fixed-shape (max-length graph) state-prompt support, including
+        the ``dec_devpos`` device buffer read by
+        ``qkv_split_rope_devpos``.
+
+    Attention output pointers are stable across graph replays: each site
+    writes into a pre-allocated O tensor owned by this backend and
+    returns the same pointer on every call.
+    """
+
+    def __init__(self, num_views: int, encoder_seq_max: int, chunk_size: int,
+                 num_encoder_layers: int = 18, dtype=None):
+        import torch
+        self._torch = torch
+        # ``dtype`` selects the 16-bit tensor type used for Q/K/V/O
+        # buffers. Defaults to bfloat16 (pi05).
+        bf16 = dtype if dtype is not None else torch.bfloat16
+        # torch on ROCm keeps the "cuda" device string.
+        d = "cuda"
+
+        # Vision attention INPUTS (per-view batched, no cache)
+        self.vis_Q = torch.empty(num_views, 256, 16, 72, dtype=bf16, device=d)
+        self.vis_K = torch.empty(num_views, 256, 16, 72, dtype=bf16, device=d)
+        self.vis_V = torch.empty(num_views, 256, 16, 72, dtype=bf16, device=d)
+
+        # Encoder Q (reused across layers — no per-layer cache on query side)
+        # Encoder K/V shared layer cache (also used by decoder cross-attn)
+        total_kv = encoder_seq_max + chunk_size
+        self.enc_Q = torch.empty(encoder_seq_max, 8, 256, dtype=bf16, device=d)
+        self.enc_K = torch.empty(num_encoder_layers, total_kv, 1, 256,
+                                 dtype=bf16, device=d)
+        self.enc_V = torch.empty(num_encoder_layers, total_kv, 1, 256,
+                                 dtype=bf16, device=d)
+
+        # Decoder Q
+        self.dec_Q = torch.empty(chunk_size, 8, 256, dtype=bf16, device=d)
+
+        # ── Fixed-shape (seqused/devpos) state-prompt support ──
+        # One captured graph at the MAX prefix length serves any prompt length.
+        # The valid prefix length is pushed into device buffers per set_prompt
+        # (set_fixed_valid_len — runtime inputs, never a recapture):
+        #   - enc_seqused / dec_seqused mirror the FA2 seqused_k contract and
+        #     additionally drive the boolean key masks consumed by sdpa here,
+        #   - dec_devpos is read by the pipeline's qkv_split_rope_devpos kernel
+        #     to append the chunk K/V right after the valid prefix.
+        # batch=1, so each is a single int32.
+        self._fixed_shape = False
+        self.enc_seqused = torch.zeros(1, dtype=torch.int32, device=d)  # vis_enc+plen
+        self.dec_seqused = torch.zeros(1, dtype=torch.int32, device=d)  # +chunk
+        self.dec_devpos = torch.zeros(1, dtype=torch.int32, device=d)   # = enc_seqused
+
+        # Boolean key masks (True = attend) for the fixed-shape path.
+        # Shape (1, 1, 1, S) broadcasts over batch/heads/queries in sdpa.
+        # Contents are rewritten by set_fixed_valid_len (cold path); the
+        # captured graph reads them by pointer at replay.
+        self._enc_key_mask = torch.ones(1, 1, 1, encoder_seq_max,
+                                        dtype=torch.bool, device=d)
+        self._dec_key_mask = torch.ones(1, 1, 1, total_kv,
+                                        dtype=torch.bool, device=d)
+        # Pre-allocated iota used to rebuild the masks without host loops.
+        self._kv_iota = torch.arange(total_kv, dtype=torch.int32, device=d)
+
+        # Cached shape metadata
+        self._num_views = num_views
+        self._encoder_seq_max = encoder_seq_max
+        self._chunk_size = chunk_size
+        self._num_encoder_layers = num_encoder_layers
+        # enc_K/V layer stride in bytes (bf16 = 2 bytes)
+        self._enc_kv_layer_stride_bytes = (
+            total_kv * 1 * 256 * self.enc_K.element_size())
+
+        # Pre-allocated attention OUTPUT buffers. The pipeline reads the
+        # returned pointer as a flat row-major (rows, heads*head_dim)
+        # bf16 tensor, so O keeps the (rows, H, D) input layout and the
+        # sdpa result — (B, H, S, D) — is copy_'d through a transposed
+        # view as the last op of every call.
+        self._vis_O = torch.empty(num_views, 256, 16, 72, dtype=bf16, device=d)
+        self._enc_O = torch.empty(encoder_seq_max, 8, 256, dtype=bf16, device=d)
+        self._dec_O = torch.empty(chunk_size, 8, 256, dtype=bf16, device=d)
+
+    # ── Pointer interface (for pipeline's fvk kernel calls) ──
+
+    def get_ptrs(self) -> dict:
+        return {
+            "vis_Q": self.vis_Q.data_ptr(),
+            "vis_K": self.vis_K.data_ptr(),
+            "vis_V": self.vis_V.data_ptr(),
+            "enc_Q": self.enc_Q.data_ptr(),
+            "enc_K": self.enc_K.data_ptr(),
+            "enc_V": self.enc_V.data_ptr(),
+            "dec_Q": self.dec_Q.data_ptr(),
+            "enc_k_layer_stride_bytes": self._enc_kv_layer_stride_bytes,
+            "enc_v_layer_stride_bytes": self._enc_kv_layer_stride_bytes,
+        }
+
+    # ── Fixed-shape state-prompt support ──
+
+    def set_fixed_shape(self, enabled: bool) -> None:
+        """Enable/disable fixed-shape (seqused/devpos) state-prompt execution.
+
+        The interim sdpa path masks padded keys with the boolean key masks
+        maintained by :meth:`set_fixed_valid_len`, so — unlike the RTX
+        backend, which must validate that the vendored FA2 seqused entries
+        exist — fixed-shape is always available here. The shared backend is
+        reused across pipelines, so the active pipeline re-syncs this flag
+        each time it changes.
+        """
+        self._fixed_shape = bool(enabled)
+
+    def set_fixed_valid_len(self, valid_prefix_len: int) -> None:
+        """Update the fixed-shape valid prefix length (host->device).
+
+        ``valid_prefix_len`` = vision tokens + valid prompt tokens. Drives:
+          - encoder self-attn key mask   = [0, valid_prefix_len)
+          - decoder cross-attn key mask  = [0, valid_prefix_len + chunk)
+          - decoder K/V append row offset (devpos) = valid_prefix_len
+        Called once per prompt (outside the captured graph); the graph reads
+        these device buffers at replay, so no recapture as the length drifts.
+        """
+        torch = self._torch
+        v = int(valid_prefix_len)
+        self.enc_seqused.fill_(v)
+        self.dec_seqused.fill_(v + self._chunk_size)
+        self.dec_devpos.fill_(v)
+        # Rebuild the boolean key masks read by the captured sdpa calls.
+        self._enc_key_mask[0, 0, 0].copy_(
+            self._kv_iota[:self._encoder_seq_max] < v)
+        self._dec_key_mask[0, 0, 0].copy_(
+            self._kv_iota < (v + self._chunk_size))
+        # Cold path (once per prompt): make the device writes visible before
+        # the next graph replay reads them (the fills run on the current
+        # stream, the graph replays on its own captured stream).
+        torch.cuda.synchronize()
+
+    # ── Attention calls ──
+    #
+    # Each method returns the raw device pointer of the attention output;
+    # the pointer is the same on every call (pre-allocated O tensors), so
+    # it can be baked into the captured HIP graph and fed directly into
+    # the next GEMM without a copy.
+
+    def _sdpa(self, q, k, v, attn_mask=None):
+        """scaled_dot_product_attention with the pipeline's fixed contract:
+        no dropout, no causal mask (all Pi0.5 sites are bidirectional),
+        default softmax scale 1/sqrt(head_dim)."""
+        import torch.nn.functional as F
+        return F.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+
+    def vision_attn(self, stream: int = 0) -> int:
+        # (batch=nv, seq=256, heads=16, head_dim=72) → per-view attention.
+        # sdpa expects (B, H, S, D); permute is a view, no copy.
+        q = self.vis_Q.permute(0, 2, 1, 3)
+        k = self.vis_K.permute(0, 2, 1, 3)
+        v = self.vis_V.permute(0, 2, 1, 3)
+        out = self._sdpa(q, k, v)                     # (nv, 16, 256, 72)
+        self._vis_O.permute(0, 2, 1, 3).copy_(out)    # → (nv, 256, 16, 72)
+        return self._vis_O.data_ptr()
+
+    def encoder_attn(self, layer_idx: int, seq: int, stream: int = 0) -> int:
+        # GQA 8Q/1KV: expand the single KV head across the 8 query heads
+        # (stride-0 broadcast, no materialized repeat).
+        q = self.enc_Q[:seq].permute(1, 0, 2).unsqueeze(0)       # (1, 8, seq, 256)
+        k = self.enc_K[layer_idx, :seq].permute(1, 0, 2).unsqueeze(0)
+        v = self.enc_V[layer_idx, :seq].permute(1, 0, 2).unsqueeze(0)
+        k = k.expand(1, 8, seq, 256)
+        v = v.expand(1, 8, seq, 256)
+        mask = self._enc_key_mask[..., :seq] if self._fixed_shape else None
+        out = self._sdpa(q, k, v, attn_mask=mask)                # (1, 8, seq, 256)
+        self._enc_O[:seq].transpose(0, 1).copy_(out[0])
+        return self._enc_O.data_ptr()
+
+    def decoder_attn(self, layer_idx: int, enc_seq: int, dec_seq: int,
+                     stream: int = 0) -> int:
+        total_kv = enc_seq + dec_seq
+        q = self.dec_Q[:dec_seq].permute(1, 0, 2).unsqueeze(0)   # (1, 8, chunk, 256)
+        k = self.enc_K[layer_idx, :total_kv].permute(1, 0, 2).unsqueeze(0)
+        v = self.enc_V[layer_idx, :total_kv].permute(1, 0, 2).unsqueeze(0)
+        k = k.expand(1, 8, total_kv, 256)
+        v = v.expand(1, 8, total_kv, 256)
+        # Fixed-shape: the chunk K/V were appended right after the valid
+        # prefix (qkv_split_rope_devpos), so [0 : valid+chunk] is one
+        # contiguous valid range — the key mask hides the padding rows.
+        mask = self._dec_key_mask[..., :total_kv] if self._fixed_shape else None
+        out = self._sdpa(q, k, v, attn_mask=mask)                # (1, 8, chunk, 256)
+        self._dec_O[:dec_seq].transpose(0, 1).copy_(out[0])
+        return self._dec_O.data_ptr()
+
+    # ── Uniform site dispatcher (surface consumed by the pipeline) ──
+
+    _PROTOCOL_SITES = ("siglip", "encoder", "decoder")
+
+    def run(
+        self,
+        site: str,
+        layer_idx: int,
+        q_seq: int,
+        *,
+        kv_seq=None,
+        stream: int = 0,
+        state_nk=None,
+    ) -> int:
+        """Dispatch to the attention call for the given site.
+
+        Mirrors the RTX backend's dispatcher. ``state_nk`` (the Pi0
+        state-masked decoder variant) is not implemented on the interim
+        CDNA4 path — Pi0.5 never passes it.
+        """
+        if site == "siglip":
+            # SigLIP is per-view batched self-attention; q_seq is
+            # tokens-per-view (256) and is already baked into the
+            # fixed-shape vis_Q tensor, so the parameter is accepted
+            # for protocol uniformity but not used to slice.
+            return self.vision_attn(stream=stream)
+        if site == "encoder":
+            if kv_seq is not None and kv_seq != q_seq:
+                raise ValueError(
+                    f"encoder site is self-attention; kv_seq must be "
+                    f"None or equal to q_seq, got kv_seq={kv_seq} "
+                    f"q_seq={q_seq}"
+                )
+            return self.encoder_attn(layer_idx, q_seq, stream=stream)
+        if site == "decoder":
+            if kv_seq is None:
+                raise ValueError(
+                    "decoder site is cross-attention against the "
+                    "shared encoder KV cache; kv_seq (the total KV "
+                    "length including freshly-written chunk rows) "
+                    "must be supplied"
+                )
+            if state_nk is not None:
+                raise NotImplementedError(
+                    "state_nk (Pi0 state-masked decoder attention) is not "
+                    "implemented on the CDNA4 interim backend")
+            dec_seq = q_seq
+            enc_seq = kv_seq - dec_seq
+            if enc_seq < 0:
+                raise ValueError(
+                    f"decoder kv_seq ({kv_seq}) must be >= q_seq "
+                    f"({q_seq}) — the chunk is appended to the "
+                    f"encoder cache"
+                )
+            return self.decoder_attn(layer_idx, enc_seq, dec_seq, stream=stream)
+        raise KeyError(f"unknown site {site!r}; known: {self._PROTOCOL_SITES}")

--- a/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
@@ -130,6 +130,27 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
         self._vis_scale = 1.0 / math.sqrt(self.vis_Q.shape[-1])   # D=72
         self._enc_scale = 1.0 / math.sqrt(self.enc_Q.shape[-1])   # D=256
 
+        # Optional hand-written decoder attention (csrc/amd/attention/
+        # decoder_flash.hip). FVK_AMD_DEC_ATTN=custom routes the decoder
+        # site to it; default "lib" keeps the aiter/sdpa library path.
+        # Workspace is pre-allocated once (pointer-stable, capture-safe);
+        # size per the kernel header: MAX_SPLIT * Hq * Sq * (D + 2) floats.
+        import os
+        self._dec_custom = (
+            os.environ.get("FVK_AMD_DEC_ATTN", "custom").strip().lower()
+            == "custom")
+        if self._dec_custom:
+            from flash_rt.amd import flash_rt_amd_kernels as _fvk
+            if not hasattr(_fvk, "attention_decoder_gqa"):
+                raise ImportError(
+                    "FVK_AMD_DEC_ATTN=custom but attention_decoder_gqa "
+                    "is not in flash_rt_amd_kernels")
+            self._fvk = _fvk
+            hq, d = self.dec_Q.shape[-2], self.dec_Q.shape[-1]
+            ws_floats = 32 * hq * chunk_size * (d + 2)
+            self._dec_attn_ws = self._torch.empty(
+                ws_floats, dtype=self._torch.float32, device="cuda")
+
     # ── aiter dispatch ──
 
     def _aiter_attn(self, q, k, v, out, scale):
@@ -180,6 +201,21 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
             return super().decoder_attn(layer_idx, enc_seq, dec_seq,
                                         stream=stream)
         total_kv = enc_seq + dec_seq
+        if self._dec_custom:
+            # Hand-written split-KV kernel; launches on the pipeline
+            # stream directly (raw-pointer ABI, no torch dispatch).
+            self._fvk.attention_decoder_gqa(
+                self.dec_Q.data_ptr(),
+                self.enc_K[layer_idx].data_ptr(),
+                self.enc_V[layer_idx].data_ptr(),
+                self._dec_O.data_ptr(),
+                self._dec_attn_ws.data_ptr(),
+                dec_seq, total_kv,
+                self.dec_Q.shape[-2], self.dec_Q.shape[-1],
+                0,                       # seqused: exact mode
+                self._enc_scale,
+                stream)
+            return self._dec_O.data_ptr()
         # Chunk queries cross-attend the shared [encoder + appended chunk]
         # K/V range bidirectionally — same semantics as the sdpa path.
         q = self.dec_Q[:dec_seq].unsqueeze(0)                 # (1, chunk, 8, 256)

--- a/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
@@ -77,6 +77,19 @@ without recapture), so each site needs a pointer-read mechanism:
 
 Exact-shape mode (one graph per prompt length) runs fully on
 aiter + the custom decoder kernel.
+
+CALIBRATION DETERMINISM
+-----------------------
+aiter's asm attention is nondeterministic ACROSS PROCESSES (graph
+replay within a process stays bit-stable). FP8 amax scales collected
+while it runs therefore jitter run-to-run — observed as an exact-mode
+cos-vs-reference band of ~0.997-0.999 versus ~0.9994+ on fully
+deterministic arms. During the calibration window (``set_calibrating``,
+driven by the pipeline's pre-calibration forwards) the ENCODER site
+routes to the deterministic MFMA flash kernel; vision stays on aiter
+(cleared as a jitter source by the deterministic fixed-mode arms) and
+the custom decoder kernel is deterministic already. Escape hatch:
+``FVK_AMD_CALIB_DET_ATTN=off``.
 """
 
 from __future__ import annotations
@@ -162,11 +175,27 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
         # FVK_AMD_FIXED_ENC_ATTN=sdpa keeps the masked-sdpa base path.
         from flash_rt.amd import flash_rt_amd_kernels as _fvk_ef
         self._fvk_ef = _fvk_ef
+        self._enc_flash_ok = (hasattr(_fvk_ef, "encoder_attention_flash")
+                              and self.enc_Q.shape[-1] == 256)
         self._fixed_enc_flash = (
             os.environ.get("FVK_AMD_FIXED_ENC_ATTN", "flash").strip().lower()
-            == "flash"
-            and hasattr(_fvk_ef, "encoder_attention_flash")
-            and self.enc_Q.shape[-1] == 256)
+            == "flash" and self._enc_flash_ok)
+
+        # Calibration-window determinism: aiter's asm attention is
+        # nondeterministic ACROSS PROCESSES (replay within a process is
+        # bit-stable), so encoder activations — and therefore the FP8
+        # amax scales collected during calibration — jitter from run to
+        # run. While set_calibrating(True) is active, the encoder site
+        # routes to the deterministic MFMA flash kernel instead, pinning
+        # the scales; capture/replay then run the fast aiter path with
+        # frozen scales. FVK_AMD_CALIB_DET_ATTN=off restores the old
+        # behaviour (calibrate on aiter). The vision site stays on aiter
+        # in both windows: the deterministic fixed-mode arms measured a
+        # tight cos band with aiter vision, clearing it as a jitter
+        # source; the custom decoder kernel is already deterministic.
+        self._calib_det = (
+            os.environ.get("FVK_AMD_CALIB_DET_ATTN", "flash").strip().lower()
+            != "off" and self._enc_flash_ok)
 
         # Fused FP8-out epilogue state (see set_decoder_fp8out). Disarmed
         # until the pipeline arms it post-calibration.
@@ -295,6 +324,19 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
                     31, self.enc_seqused.data_ptr())
                 return self._enc_O.data_ptr()
             return super().encoder_attn(layer_idx, seq, stream=stream)
+        if self._calibrating and self._calib_det:
+            # FP8-calibration window: deterministic MFMA flash kernel so
+            # the collected amax scales are run-to-run stable (seqused=0
+            # -> the full seq is valid; math identical to the fixed-mode
+            # route above). Never taken inside the captured graph.
+            self._fvk_ef.encoder_attention_flash(
+                self.enc_Q.data_ptr(),
+                self.enc_K[layer_idx].data_ptr(),
+                self.enc_V[layer_idx].data_ptr(),
+                self._enc_O.data_ptr(),
+                seq, self.enc_Q.shape[-2], self.enc_Q.shape[-1],
+                self._enc_scale, stream, 31, 0)
+            return self._enc_O.data_ptr()
         # (1, seq, 8, 256) vs (1, seq, 1, 256): native GQA, no expand.
         q = self.enc_Q[:seq].unsqueeze(0)
         k = self.enc_K[layer_idx, :seq].unsqueeze(0)

--- a/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
@@ -62,15 +62,21 @@ frontend wraps calibration + capture + replay in
 
 FIXED-SHAPE MODE
 ----------------
-aiter exposes varlen/``cu_seqlens`` entry points that could express the
-runtime-valid-length contract, but v2 keeps it simple: when
-``set_fixed_shape(True)`` is active, the encoder/decoder sites delegate
-to the sdpa base-class implementation, whose boolean key masks (driven
-by :meth:`set_fixed_valid_len`) are read by pointer at replay — masking
-by slicing is NOT an option in-graph because the valid length changes
-without recapture. The vision site has no mask in either mode and stays
-on aiter. Exact-shape mode (one graph per prompt length) runs fully on
-aiter.
+Masking by slicing is NOT an option in-graph (the valid length changes
+without recapture), so each site needs a pointer-read mechanism:
+
+- decoder: the hand-written split-KV kernel takes the FA2-style
+  ``seqused`` DEVICE pointer natively (``dec_seqused``, maintained by
+  :meth:`set_fixed_valid_len`), so the custom route — including the
+  fused FP8-out epilogue — serves fixed mode directly at full speed.
+- encoder: aiter's dense ``mha_fwd`` has no runtime mask input
+  (varlen/``cu_seqlens`` would need device-read offsets), so this site
+  delegates to the sdpa base class, whose boolean key mask is read by
+  pointer at replay. This is the remaining fixed-mode overhead.
+- vision: no mask in either mode; always aiter.
+
+Exact-shape mode (one graph per prompt length) runs fully on
+aiter + the custom decoder kernel.
 """
 
 from __future__ import annotations
@@ -150,6 +156,17 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
             ws_floats = 32 * hq * chunk_size * (d + 2)
             self._dec_attn_ws = self._torch.empty(
                 ws_floats, dtype=self._torch.float32, device="cuda")
+
+        # Fixed-mode encoder attention: the MFMA flash kernel with the
+        # seqused device pointer (default when available and D == 256);
+        # FVK_AMD_FIXED_ENC_ATTN=sdpa keeps the masked-sdpa base path.
+        from flash_rt.amd import flash_rt_amd_kernels as _fvk_ef
+        self._fvk_ef = _fvk_ef
+        self._fixed_enc_flash = (
+            os.environ.get("FVK_AMD_FIXED_ENC_ATTN", "flash").strip().lower()
+            == "flash"
+            and hasattr(_fvk_ef, "encoder_attention_flash")
+            and self.enc_Q.shape[-1] == 256)
 
         # Fused FP8-out epilogue state (see set_decoder_fp8out). Disarmed
         # until the pipeline arms it post-calibration.
@@ -261,9 +278,22 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
 
     def encoder_attn(self, layer_idx: int, seq: int, stream: int = 0) -> int:
         if self._fixed_shape:
-            # Fixed-shape masking needs the pointer-read boolean key mask
-            # (valid length changes without recapture) — delegate to the
-            # sdpa base implementation. See module docstring.
+            # aiter's dense mha_fwd has no runtime-mask input. The MFMA
+            # flash kernel takes the FA2-style seqused device pointer
+            # (enc_seqused) and only computes the runtime-valid rows, so
+            # it serves fixed mode; masked sdpa remains the env escape
+            # (FVK_AMD_FIXED_ENC_ATTN=sdpa) and the non-256-headdim
+            # fallback. See module docstring.
+            if self._fixed_enc_flash:
+                self._fvk_ef.encoder_attention_flash(
+                    self.enc_Q.data_ptr(),
+                    self.enc_K[layer_idx].data_ptr(),
+                    self.enc_V[layer_idx].data_ptr(),
+                    self._enc_O.data_ptr(),
+                    seq, self.enc_Q.shape[-2], self.enc_Q.shape[-1],
+                    self._enc_scale, stream,
+                    31, self.enc_seqused.data_ptr())
+                return self._enc_O.data_ptr()
             return super().encoder_attn(layer_idx, seq, stream=stream)
         # (1, seq, 8, 256) vs (1, seq, 1, 256): native GQA, no expand.
         q = self.enc_Q[:seq].unsqueeze(0)
@@ -278,11 +308,17 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
         # Reset per call: get_decoder_fp8out_ptr() must reflect THIS
         # call only (fixed-shape delegation / lib route produce none).
         self._dec_fp8out_last = None
-        if self._fixed_shape:
-            # Same delegation rationale as encoder_attn.
+        if self._fixed_shape and not self._dec_custom:
+            # Only the aiter lib route lacks runtime masking — delegate
+            # to the sdpa base. The hand-written split-KV kernel takes
+            # the FA2-style seqused device pointer directly (validated
+            # by the seqused-mode gates in its kernel suite), so the
+            # custom route below serves fixed mode natively: enc_seq is
+            # the padded capacity, dec_seqused[0] wins at replay.
             return super().decoder_attn(layer_idx, enc_seq, dec_seq,
                                         stream=stream)
         total_kv = enc_seq + dec_seq
+        seqused_ptr = self.dec_seqused.data_ptr() if self._fixed_shape else 0
         if self._dec_custom:
             # Hand-written split-KV kernel; launches on the pipeline
             # stream directly (raw-pointer ABI, no torch dispatch).
@@ -305,7 +341,7 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
                     self._dec_attn_ws.data_ptr(),
                     dec_seq, total_kv,
                     self.dec_Q.shape[-2], self.dec_Q.shape[-1],
-                    0,                   # seqused: exact mode
+                    seqused_ptr,         # 0 = exact; device int in fixed mode
                     self._enc_scale,
                     stream)
                 self._dec_fp8out_last = (fp8_ptr, scale_ptr)
@@ -318,7 +354,7 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
                 self._dec_attn_ws.data_ptr(),
                 dec_seq, total_kv,
                 self.dec_Q.shape[-2], self.dec_Q.shape[-1],
-                0,                       # seqused: exact mode
+                seqused_ptr,             # 0 = exact; device int in fixed mode
                 self._enc_scale,
                 stream)
             return self._dec_O.data_ptr()

--- a/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
@@ -151,6 +151,85 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
             self._dec_attn_ws = self._torch.empty(
                 ws_floats, dtype=self._torch.float32, device="cuda")
 
+        # Fused FP8-out epilogue state (see set_decoder_fp8out). Disarmed
+        # until the pipeline arms it post-calibration.
+        self._dec_fp8out_scales = None   # list[list[int]] [step][layer] or None
+        self._dec_fp8out_step = 0        # host-side step selector (capture-time)
+        self._dec_fp8out_buf = None      # (chunk, Hq*D) fp8-byte tensor, reused
+        self._dec_fp8out_last = None     # (fp8_ptr, scale_ptr) of last call
+
+    # ── Fused FP8-out epilogue (decoder custom route only) ──
+    #
+    # The pipeline's decoder attn-output -> o-proj site quantizes the
+    # attention output with a per-weight STATIC scale before the FP8
+    # GEMM (~180 standalone quantize launches / inference). The custom
+    # decoder kernel can emit those exact fp8 bytes as an in-kernel
+    # epilogue instead. Protocol note: decoder_attn/run keep their
+    # signatures — arming is a separate one-shot call, and the fp8
+    # result is picked up out-of-band via get_decoder_fp8out_ptr().
+
+    def decoder_fp8out_supported(self) -> bool:
+        """Whether the decoder site can produce fused fp8-out bytes."""
+        return (self._dec_custom
+                and getattr(self, "_fvk", None) is not None
+                and hasattr(self._fvk, "attention_decoder_gqa_fp8out"))
+
+    def set_decoder_fp8out(self, layer_scale_ptrs) -> None:
+        """Arm (or disarm) the fused FP8-out decoder epilogue.
+
+        ``layer_scale_ptrs``: ``None`` disarms; a ``list[int]`` of
+        per-layer device float pointers (the o-proj static activation
+        scales) arms every step with the same per-layer scales; a
+        ``list[list[int]]`` indexed ``[step][layer]`` arms with the
+        pipeline's per-(step, layer) static scales — required for
+        bit-equality when the calibration recorded per-step scales
+        (select the step via :meth:`set_decoder_fp8out_step`).
+
+        Called ONCE by the pipeline after calibration (capture prep).
+        Allocates the single reused (chunk, Hq*D) fp8-byte output
+        tensor on first arm — pointer-stable across replays.
+        """
+        if layer_scale_ptrs is None:
+            self._dec_fp8out_scales = None
+            self._dec_fp8out_last = None
+            return
+        if not self.decoder_fp8out_supported():
+            raise RuntimeError(
+                "set_decoder_fp8out: custom decoder route with "
+                "attention_decoder_gqa_fp8out is not available "
+                "(FVK_AMD_DEC_ATTN != custom or symbol missing)")
+        first = layer_scale_ptrs[0]
+        if isinstance(first, (list, tuple)):
+            mat = [list(row) for row in layer_scale_ptrs]
+        else:
+            mat = [list(layer_scale_ptrs)]
+        self._dec_fp8out_scales = mat
+        self._dec_fp8out_step = 0
+        self._dec_fp8out_last = None
+        if self._dec_fp8out_buf is None:
+            chunk, hq, d = self.dec_Q.shape
+            self._dec_fp8out_buf = self._torch.empty(
+                chunk, hq * d, dtype=self._torch.uint8, device="cuda")
+
+    def set_decoder_fp8out_step(self, step: int) -> None:
+        """Select the denoise step whose scale row decoder_attn uses.
+
+        Host-side only (the pipeline calls it at the top of each step
+        while recording — the chosen pointers are frozen into the
+        graph at capture, exactly like the o-proj quantize's scale
+        pointer today). No-op when disarmed.
+        """
+        self._dec_fp8out_step = int(step)
+
+    def get_decoder_fp8out_ptr(self):
+        """(fp8_ptr, scale_ptr) of the LAST decoder_attn call, or None.
+
+        None when disarmed, or when the last decoder_attn did not run
+        the fused fp8-out kernel (fixed-shape delegation / lib route)
+        — the caller must then fall back to its own quantize path.
+        """
+        return self._dec_fp8out_last
+
     # ── aiter dispatch ──
 
     def _aiter_attn(self, q, k, v, out, scale):
@@ -196,6 +275,9 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
 
     def decoder_attn(self, layer_idx: int, enc_seq: int, dec_seq: int,
                      stream: int = 0) -> int:
+        # Reset per call: get_decoder_fp8out_ptr() must reflect THIS
+        # call only (fixed-shape delegation / lib route produce none).
+        self._dec_fp8out_last = None
         if self._fixed_shape:
             # Same delegation rationale as encoder_attn.
             return super().decoder_attn(layer_idx, enc_seq, dec_seq,
@@ -204,6 +286,30 @@ class Cdna4AiterAttnBackend(Cdna4AttnBackend):
         if self._dec_custom:
             # Hand-written split-KV kernel; launches on the pipeline
             # stream directly (raw-pointer ABI, no torch dispatch).
+            scales = self._dec_fp8out_scales
+            if scales is not None:
+                # Armed: fused FP8-out epilogue. Same attention + bf16
+                # O as the plain call, plus the o-proj activation's fp8
+                # bytes (bit-equal to quantize_fp8_static with the same
+                # scale pointer).
+                row = scales[min(self._dec_fp8out_step, len(scales) - 1)]
+                scale_ptr = row[layer_idx]
+                fp8_ptr = self._dec_fp8out_buf.data_ptr()
+                self._fvk.attention_decoder_gqa_fp8out(
+                    self.dec_Q.data_ptr(),
+                    self.enc_K[layer_idx].data_ptr(),
+                    self.enc_V[layer_idx].data_ptr(),
+                    self._dec_O.data_ptr(),
+                    fp8_ptr,
+                    scale_ptr,
+                    self._dec_attn_ws.data_ptr(),
+                    dec_seq, total_kv,
+                    self.dec_Q.shape[-2], self.dec_Q.shape[-1],
+                    0,                   # seqused: exact mode
+                    self._enc_scale,
+                    stream)
+                self._dec_fp8out_last = (fp8_ptr, scale_ptr)
+                return self._dec_O.data_ptr()
             self._fvk.attention_decoder_gqa(
                 self.dec_Q.data_ptr(),
                 self.enc_K[layer_idx].data_ptr(),

--- a/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend_aiter.py
@@ -1,0 +1,190 @@
+"""FlashRT AMD — CDNA4 attention backend v2: aiter asm flash-attention.
+
+Drop-in replacement for :class:`Cdna4AttnBackend` that dispatches the
+per-site attention math to ``aiter`` (AMD's asm flash-attention library,
+the vLLM-ROCm production attention path) instead of torch SDPA.
+
+Construction signature, buffer ownership/shapes/dtypes, ``get_ptrs()``,
+``run()`` dispatch and the fixed-shape surface are IDENTICAL to the sdpa
+backend (this class subclasses it and overrides only the three per-site
+attention calls), so the frontend can swap backends via a single
+parameter without touching the pipeline.
+
+WHY AITER
+---------
+rocprof on the FP8 graph shows sdpa's attn_fwd at ~44us/call x ~225
+calls = ~11.1ms/inference = 32.6% of GPU time — the #1 kernel bucket.
+Isolated-call survey (bench_amd_attention.py) on the exact pi05 shapes:
+
+    vision   aiter 25.0us  vs sdpa 34.7us
+    encoder  aiter 72.9us  vs sdpa 122.7us
+    decoder  aiter 68.0us  vs sdpa  62.4us   (sdpa wins tiny-M)
+
+CALL CONTRACT
+-------------
+``aiter.mha_fwd`` takes (B, S, H, D) tensors and supports GQA natively
+(K/V may carry a single KV head against 8 Q heads — no expand, no
+materialized repeat). Our owned buffers already match that layout as
+zero-copy views:
+
+    vision   Q/K/V (nv, 256, 16, 72)         — used directly (B=nv)
+    encoder  Q (seq, 8, 256).unsqueeze(0), K/V (seq, 1, 256).unsqueeze(0)
+    decoder  Q (chunk, 8, 256).unsqueeze(0), K/V (total_kv, 1, 256).unsqueeze(0)
+
+All slices are along leading dims of contiguous buffers, so every view
+handed to aiter is contiguous. ``softmax_scale = 1/sqrt(head_dim)`` is
+passed explicitly (matches the RTX FA2 default and the sdpa backend).
+``window_size_left = window_size_right = -1`` disables local windowing
+(FA2-family "no window" sentinel); ``is_causal=False`` — all Pi0.5
+sites are bidirectional.
+
+POINTER STABILITY / CAPTURE SAFETY
+----------------------------------
+``mha_fwd(..., out=...)`` writes the result into a caller-provided
+tensor, so each site passes a view of the SAME pre-allocated O buffer
+the sdpa backend owns — the returned pointer is stable across graph
+replays and the sdpa backend's final ``copy_`` disappears entirely.
+
+``return_softmax_lse=False`` / ``return_dropout_randval=False`` are
+requested so no result tensors need to be returned, but aiter may still
+allocate the LSE (and any workspace) internally on every call. Those
+per-call allocations go through torch's caching allocator, so they rely
+on the SAME warmup-then-capture contract the interim sdpa path already
+uses: the pipeline runs 3 warmup iterations on the capture stream before
+``hipStreamBeginCapture`` so the allocator reaches steady state and
+in-capture allocations are served from cached blocks. The dedicated
+capture gate in the dev tests (test_amd_attn_aiter.py) verifies this
+holds — it is the make-or-break check for this backend.
+
+Like the sdpa backend, aiter launches on torch's CURRENT stream; the
+frontend wraps calibration + capture + replay in
+``torch.cuda.stream(...)`` so all work lands on the capture stream.
+
+FIXED-SHAPE MODE
+----------------
+aiter exposes varlen/``cu_seqlens`` entry points that could express the
+runtime-valid-length contract, but v2 keeps it simple: when
+``set_fixed_shape(True)`` is active, the encoder/decoder sites delegate
+to the sdpa base-class implementation, whose boolean key masks (driven
+by :meth:`set_fixed_valid_len`) are read by pointer at replay — masking
+by slicing is NOT an option in-graph because the valid length changes
+without recapture. The vision site has no mask in either mode and stays
+on aiter. Exact-shape mode (one graph per prompt length) runs fully on
+aiter.
+"""
+
+from __future__ import annotations
+
+import math
+
+from flash_rt.amd.hardware.cdna4.attn_backend import Cdna4AttnBackend
+
+
+def _resolve_mha_fwd():
+    """Import aiter and resolve its ``mha_fwd`` entry point.
+
+    Raises ImportError with a clear message when aiter is unavailable so
+    the frontend can fall back to the sdpa backend.
+    """
+    try:
+        import aiter  # noqa: F401
+    except ImportError as ex:
+        raise ImportError(
+            "Cdna4AiterAttnBackend requires the 'aiter' package "
+            "(AMD asm flash-attention); import failed — install aiter "
+            "or use the sdpa backend (FVK_AMD_ATTN=sdpa)."
+        ) from ex
+    fn = getattr(aiter, "mha_fwd", None)
+    if fn is None:
+        # Older/newer layouts keep mha_fwd under aiter.ops.mha.
+        try:
+            from aiter.ops.mha import mha_fwd as fn  # type: ignore
+        except ImportError as ex:
+            raise ImportError(
+                "aiter imported but exposes no 'mha_fwd' (checked "
+                "aiter.mha_fwd and aiter.ops.mha.mha_fwd) — aiter "
+                "version mismatch; use the sdpa backend "
+                "(FVK_AMD_ATTN=sdpa)."
+            ) from ex
+    return fn
+
+
+class Cdna4AiterAttnBackend(Cdna4AttnBackend):
+    """Pi0.5 attention backend for AMD CDNA4 dispatching to aiter mha_fwd.
+
+    Same construction signature and consumed surface as
+    :class:`Cdna4AttnBackend`; only the three per-site attention calls
+    are overridden. See the module docstring for the call contract,
+    capture-safety notes and the fixed-shape delegation policy.
+    """
+
+    def __init__(self, num_views: int, encoder_seq_max: int, chunk_size: int,
+                 num_encoder_layers: int = 18, dtype=None):
+        super().__init__(num_views, encoder_seq_max, chunk_size,
+                         num_encoder_layers=num_encoder_layers, dtype=dtype)
+        # Resolve at construction so an unusable environment fails fast
+        # (the frontend catches ImportError and falls back to sdpa).
+        self._mha_fwd = _resolve_mha_fwd()
+        # Explicit softmax scales (mha_fwd has no "default scale" arg on
+        # the positional signature; match FA2's 1/sqrt(head_dim)).
+        self._vis_scale = 1.0 / math.sqrt(self.vis_Q.shape[-1])   # D=72
+        self._enc_scale = 1.0 / math.sqrt(self.enc_Q.shape[-1])   # D=256
+
+    # ── aiter dispatch ──
+
+    def _aiter_attn(self, q, k, v, out, scale):
+        """mha_fwd with the pipeline's fixed contract: (B, S, H, D)
+        layout, no dropout, bidirectional (no causal mask, no window),
+        native GQA (Hkv may be 1), result written in-place into ``out``
+        (a view of the pre-allocated, pointer-stable O buffer)."""
+        self._mha_fwd(
+            q, k, v,
+            0.0,          # dropout_p
+            scale,        # softmax_scale (explicit 1/sqrt(head_dim))
+            False,        # is_causal
+            -1,           # window_size_left  (no local window)
+            -1,           # window_size_right (no local window)
+            False,        # return_softmax_lse
+            False,        # return_dropout_randval
+            out=out,
+        )
+
+    # ── Attention calls (override sdpa math; same pointers returned) ──
+
+    def vision_attn(self, stream: int = 0) -> int:
+        # Buffers are (nv, 256, 16, 72) = (B, S, H, D) already — no
+        # views needed on either side. Vision has no mask in fixed-shape
+        # mode either, so this site always runs on aiter.
+        self._aiter_attn(self.vis_Q, self.vis_K, self.vis_V,
+                         self._vis_O, self._vis_scale)
+        return self._vis_O.data_ptr()
+
+    def encoder_attn(self, layer_idx: int, seq: int, stream: int = 0) -> int:
+        if self._fixed_shape:
+            # Fixed-shape masking needs the pointer-read boolean key mask
+            # (valid length changes without recapture) — delegate to the
+            # sdpa base implementation. See module docstring.
+            return super().encoder_attn(layer_idx, seq, stream=stream)
+        # (1, seq, 8, 256) vs (1, seq, 1, 256): native GQA, no expand.
+        q = self.enc_Q[:seq].unsqueeze(0)
+        k = self.enc_K[layer_idx, :seq].unsqueeze(0)
+        v = self.enc_V[layer_idx, :seq].unsqueeze(0)
+        self._aiter_attn(q, k, v, self._enc_O[:seq].unsqueeze(0),
+                         self._enc_scale)
+        return self._enc_O.data_ptr()
+
+    def decoder_attn(self, layer_idx: int, enc_seq: int, dec_seq: int,
+                     stream: int = 0) -> int:
+        if self._fixed_shape:
+            # Same delegation rationale as encoder_attn.
+            return super().decoder_attn(layer_idx, enc_seq, dec_seq,
+                                        stream=stream)
+        total_kv = enc_seq + dec_seq
+        # Chunk queries cross-attend the shared [encoder + appended chunk]
+        # K/V range bidirectionally — same semantics as the sdpa path.
+        q = self.dec_Q[:dec_seq].unsqueeze(0)                 # (1, chunk, 8, 256)
+        k = self.enc_K[layer_idx, :total_kv].unsqueeze(0)     # (1, kv, 1, 256)
+        v = self.enc_V[layer_idx, :total_kv].unsqueeze(0)
+        self._aiter_attn(q, k, v, self._dec_O[:dec_seq].unsqueeze(0),
+                         self._enc_scale)
+        return self._dec_O.data_ptr()

--- a/flash_rt/amd/models/__init__.py
+++ b/flash_rt/amd/models/__init__.py
@@ -1,0 +1,1 @@
+"""FlashRT AMD — framework-agnostic model pipelines."""

--- a/flash_rt/amd/models/pi05/__init__.py
+++ b/flash_rt/amd/models/pi05/__init__.py
@@ -1,0 +1,1 @@
+"""FlashRT AMD — Pi0.5 pipeline package (CDNA4)."""

--- a/flash_rt/amd/models/pi05/pipeline.py
+++ b/flash_rt/amd/models/pi05/pipeline.py
@@ -202,6 +202,12 @@ class Pi05Pipeline:
         self.num_steps = int(num_steps)
         self.use_fp8 = bool(use_fp8)
         self.use_fp8_decoder = bool(use_fp8_decoder)
+        # Decoder small-M GEMM backend: "mfma" (default) routes the
+        # decoder GEMMs whose weights carry an MFMA-packed copy to
+        # smallm_mfma_nt_packed; "hipblaslt" keeps the library path.
+        # Read once here (env flips after capture never re-evaluate).
+        self.dec_gemm_backend = os.environ.get(
+            "FVK_AMD_DEC_GEMM", "mfma").strip().lower()
         self.vision_pool_factor = int(vision_pool_factor)
         self.vision_num_layers = int(vision_num_layers)
         if self.num_steps <= 0:
@@ -645,6 +651,20 @@ class Pi05Pipeline:
                         act_scale_ptr: int, stream: int) -> None:
         """FP8 GEMM with pre-quantized activation (from fused norm→FP8 kernel)."""
         w_fp8_ptr, w_scale_ptr = self._weight_fp8(weight_name)
+        # Measured routing (in-situ profiling, gfx950): the MFMA
+        # packed kernel wins in-situ on the K<=2048 and wide-N decoder
+        # shapes (qkv/o/gate_up ~4.7-5.0us vs hipblaslt ~6.1); the
+        # 64-workgroup K=4096 down-proj stays on hipblaslt (7.17 vs 6.2).
+        if (self.dec_gemm_backend == "mfma"
+                and M <= 16 and N % 16 == 0 and K % 1024 == 0
+                and (K <= 2048 or N >= 8192)):
+            packed = self.weights.get("fp8_packed", {})
+            wp_ptr = packed.get(weight_name)
+            if wp_ptr is not None:
+                self.fvk.smallm_mfma_nt_packed(
+                    act_fp8_ptr, wp_ptr, out_bf16_ptr,
+                    M, N, K, act_scale_ptr, w_scale_ptr, stream=stream)
+                return
         self._fp8_matmul(
             act_fp8_ptr, w_fp8_ptr, out_bf16_ptr,
             M, N, K, act_scale_ptr, w_scale_ptr, stream)

--- a/flash_rt/amd/models/pi05/pipeline.py
+++ b/flash_rt/amd/models/pi05/pipeline.py
@@ -491,19 +491,24 @@ class Pi05Pipeline:
                              out_bf16_ptr: int, M: int, N: int, K: int,
                              act_scale_ptr: int, weight_scale_ptr: int) -> None:
         """Autotune the FP8 GEMM for the selected weight layout."""
-        # num_algos=128: the default 16-deep heuristic pool leaves
-        # measured time on the encoder shapes (gate_up 40.6 -> 34.1us
-        # at pool 64+); the deeper sweep only costs setup seconds.
+        # Heuristic pool depth for the timed selection. Deeper pools
+        # find faster encoder algos (gate_up 40.6 -> 34.1us at 64+) but
+        # widen run-to-run variance: with 128 candidates a mis-timed
+        # trial occasionally wins and ships a slow/odd-numerics pick
+        # (observed: one 128-pool process at +10 ms E2E). Default stays
+        # the long-validated 16; opt into a deeper pool via
+        # FLASHRT_FP8_ALGO_POOL when setup-time re-runs can vet it.
+        pool = int(os.environ.get("FLASHRT_FP8_ALGO_POOL", "16"))
         if self.fp8_layout == "nk":
             if not getattr(self, "_autotune_fp8_nt", True):
                 return
             self.gemm.autotune_fp8_nt_dev(
                 act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
-                M, N, K, act_scale_ptr, weight_scale_ptr, 128)
+                M, N, K, act_scale_ptr, weight_scale_ptr, pool)
         else:
             self.gemm.autotune_fp8_nn_dev(
                 act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
-                M, N, K, act_scale_ptr, weight_scale_ptr, 128)
+                M, N, K, act_scale_ptr, weight_scale_ptr, pool)
 
     def _upload_precomputed_styles(self) -> None:
         """Upload frontend-precomputed decoder style/time buffers.

--- a/flash_rt/amd/models/pi05/pipeline.py
+++ b/flash_rt/amd/models/pi05/pipeline.py
@@ -491,16 +491,19 @@ class Pi05Pipeline:
                              out_bf16_ptr: int, M: int, N: int, K: int,
                              act_scale_ptr: int, weight_scale_ptr: int) -> None:
         """Autotune the FP8 GEMM for the selected weight layout."""
+        # num_algos=128: the default 16-deep heuristic pool leaves
+        # measured time on the encoder shapes (gate_up 40.6 -> 34.1us
+        # at pool 64+); the deeper sweep only costs setup seconds.
         if self.fp8_layout == "nk":
             if not getattr(self, "_autotune_fp8_nt", True):
                 return
             self.gemm.autotune_fp8_nt_dev(
                 act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
-                M, N, K, act_scale_ptr, weight_scale_ptr)
+                M, N, K, act_scale_ptr, weight_scale_ptr, 128)
         else:
             self.gemm.autotune_fp8_nn_dev(
                 act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
-                M, N, K, act_scale_ptr, weight_scale_ptr)
+                M, N, K, act_scale_ptr, weight_scale_ptr, 128)
 
     def _upload_precomputed_styles(self) -> None:
         """Upload frontend-precomputed decoder style/time buffers.

--- a/flash_rt/amd/models/pi05/pipeline.py
+++ b/flash_rt/amd/models/pi05/pipeline.py
@@ -1387,6 +1387,13 @@ class Pi05Pipeline:
         instead of fresh language tokens.
         """
         self._copy_lang_embeds_to_encoder_x(stream=stream)
+        # Every pre-calibration FP8 forward IS a calibration pass (dynamic
+        # quant writes the amax scales as a side effect), so the
+        # deterministic-attention window tracks exactly that predicate:
+        # nondeterministic library attention (aiter) would otherwise turn
+        # into permanent run-to-run scale jitter. Post-calibration forwards
+        # (warmup, capture) run the fast library path with frozen scales.
+        self.attn.set_calibrating(self.use_fp8 and not self.fp8_calibrated)
         self.vision_encoder(stream)
         self.transformer_encoder(stream)
         self.transformer_decoder(stream)

--- a/flash_rt/amd/models/pi05/pipeline.py
+++ b/flash_rt/amd/models/pi05/pipeline.py
@@ -1,0 +1,1718 @@
+"""FlashRT AMD — CDNA4 (MI350X) Pi0.5 inference pipeline.
+
+Mirror of :mod:`flash_rt.models.pi05.pipeline_rtx` for the AMD/ROCm
+backend. Framework-agnostic pipeline for Pi0.5 on CDNA4 datacenter GPUs:
+the pipeline owns kernel composition, frontends own weights/framework
+choice.
+
+Controlled deltas vs the RTX original (everything else is structurally
+identical — dimension constants, buffer sizes, hoisted-LayerNorm scheme,
+kernel call order and fvk entry names, the two-graph capture logic,
+warmup + sync sequence):
+
+  * :class:`flash_rt.core.cuda_buffer.CudaBuffer` →
+    :class:`flash_rt.amd.core.hip_buffer.HipBuffer`;
+    :class:`flash_rt.core.cuda_graph.CUDAGraph` →
+    :class:`flash_rt.amd.core.hip_graph.HipGraph`.
+  * INT8 branches and INT8 scratch/calibration machinery dropped
+    (the ``use_int8_*`` knobs were experimental RTX/Orin paths). BF16 +
+    FP8 branches stay, controlled by ``use_fp8`` / ``use_fp8_decoder``
+    exactly as upstream; the FP8 scratch + ``_fp8_gemm`` helpers are kept
+    so M4 can flip FP8 on without touching this file.
+  * The exec-contract replay routing (``FLASHRT_PI05_USE_EXEC``),
+    ``export_runtime`` / ``export_model_runtime`` and the subgraph
+    capture hooks are dropped — they bind to the CUDA-only
+    ``runtime_export`` / ``subgraphs`` machinery and are out of scope for
+    the AMD bring-up.
+
+Architecture::
+
+    frontend (torch safetensors, ...)
+        │
+        ├── loads + FP8-quantizes weights into framework-native tensors
+        │   then exposes raw device pointer ints
+        │
+        ├── instantiates Cdna4AttnBackend (owns Q/K/V/O bf16 tensors)
+        │
+        └── constructs Pi05Pipeline(gemm, fvk, attn_backend, weights_ptrs, dims)
+                │
+                ├── allocates internal working buffers as HipBuffer (no torch)
+                ├── runs fvk kernels via pointers for all GEMM / norm / fused ops
+                ├── delegates attention to attn_backend (pluggable)
+                └── captures a HIP graph via flash_rt.amd.core.hip_graph
+
+All activations are BF16. FP8 E4M3 quantization on weights + activations
+for the large GEMMs (vision attn/FFN, encoder attn/FFN, decoder
+attn/FFN); see ``_quantize_weights_fp8`` in the frontend.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+
+import numpy as np
+import ml_dtypes
+
+from flash_rt.amd.core.hip_buffer import HipBuffer
+from flash_rt.amd.core.hip_graph import HipGraph
+
+logger = logging.getLogger(__name__)
+
+
+def _fp8_nt_autotune_enabled(hardware: str | None, fp8_layout: str) -> bool:
+    """Whether to run BLAS top-N autotune for FP8 NT GEMMs.
+
+    Mirrors the RTX policy knob (``FLASHRT_FP8_NT_AUTOTUNE``); the RTX
+    Ada/SM89 skip heuristic does not apply to any AMD hardware tag, so
+    the ``auto`` default resolves to enabled here.
+    """
+    policy = os.environ.get("FLASHRT_FP8_NT_AUTOTUNE", "auto").strip().lower()
+    if policy in ("1", "true", "on", "force"):
+        return True
+    if policy in ("0", "false", "off", "safe", "skip"):
+        return False
+    if policy != "auto":
+        logger.warning(
+            "Unknown FLASHRT_FP8_NT_AUTOTUNE=%r; using auto policy", policy)
+    return True
+
+
+# Fixed Pi0.5 model dimensions
+VIS_L = 27           # SigLIP-L layers
+VIS_D = 1152         # SigLIP hidden dim
+VIS_H = 4304         # SigLIP FFN hidden
+VIS_NH = 16          # SigLIP num attn heads
+VIS_HD = 72          # SigLIP head dim
+VIS_SEQ_PER_VIEW = 256
+VIS_PATCH_FLAT = 14 * 14 * 3  # 588
+
+ENC_L = 18           # Gemma-2B encoder layers
+ENC_D = 2048
+ENC_H = 16384
+ENC_NH = 8           # query heads (GQA)
+ENC_NKV = 1          # kv heads (GQA)
+ENC_HD = 256
+
+DEC_L = 18           # Gemma-300M decoder layers
+DEC_D = 1024
+DEC_H = 4096
+DEC_NH = 8
+DEC_NKV = 1
+DEC_HD = 256
+
+ACTION_DIM = 32
+NUM_STEPS_DEFAULT = 10
+
+# BF16 tagging for numpy arrays. There are two cases:
+#   BF16 (np.float16): SIZING-ONLY. HipBuffer allocations only use this
+#     to compute nbytes = count * 2, which matches BF16. Safe because
+#     the buffer is never filled with numeric values from numpy directly.
+#   BF16_NP (ml_dtypes.bfloat16): REAL BF16 with the correct bit layout.
+#     Must be used for any numpy staging array that carries meaningful
+#     numeric values (ones vector, RoPE cos/sin, ...). ``np.float16`` has
+#     the same byte width but a different exponent/mantissa layout —
+#     using it for BF16 data yields silent ~500x underflow when the
+#     BF16 kernel re-interprets the bits.
+BF16 = np.float16            # sizing placeholder only
+BF16_NP = ml_dtypes.bfloat16  # real BF16 numpy dtype for numeric staging
+FP8 = np.uint8
+FP32 = np.float32
+
+
+class Pi05Pipeline:
+    """Pi0.5 inference pipeline for AMD CDNA4 (MI350X) GPUs.
+
+    The pipeline composes ``flash_rt_amd_kernels`` kernels + ``GemmRunner``
+    BLAS calls + an injected attention backend
+    (:class:`~flash_rt.amd.hardware.cdna4.attn_backend.Cdna4AttnBackend`)
+    into the full SigLIP → Gemma encoder → Gemma decoder flow.
+
+    Args:
+        gemm:         ``fvk.GemmRunner()`` — BF16/FP8 GEMM driver.
+        fvk:          The ``flash_rt_amd_kernels`` module (raw pointer kernels).
+        attn_backend: Attention backend (owns Q/K/V/O tensors, runs attention).
+        weights:      Dict of weight pointers — see class docstring for schema.
+        num_views:    Number of observation camera views (1/2/3).
+        max_prompt_len: Max tokenised prompt length (language embeds buffer size).
+        chunk_size:   Diffusion action chunk length (default 10).
+        use_fp8:      Enable FP8 E4M3 quantization for large GEMMs.
+        use_fp8_decoder: Enable FP8 on decoder branch (else BF16).
+        num_steps:    Diffusion denoise steps (default 10).
+
+    Expected weights dict keys:
+        Vision BF16:
+            vision_patch_embedding_w (588,1152), vision_patch_embedding_b (1152,),
+            vision_position_embedding (256,1152),
+            vision_pre_attn_norm_w[L], vision_pre_attn_norm_b[L],
+            vision_pre_ffn_norm_w[L], vision_pre_ffn_norm_b[L],
+            vision_attn_qkv_b[L], vision_attn_o_b[L],
+            vision_ffn_up_b[L], vision_ffn_down_b[L],
+            vision_final_norm_w, vision_final_norm_b,
+            encoder_multi_modal_projector_b,
+        Vision FP8 (each entry is (fp8_ptr, scale_ptr) tuple):
+            fp8.vision_attn_qkv_w_{0..26}, fp8.vision_attn_o_w_{0..26},
+            fp8.vision_ffn_up_w_{0..26},   fp8.vision_ffn_down_w_{0..26},
+            fp8.vision_projector_w,
+        Encoder FP8:
+            fp8.encoder_attn_qkv_w_{0..17}, fp8.encoder_attn_o_w_{0..17},
+            fp8.encoder_ffn_gate_up_w_{0..17}  (merged gate+up: (D,2H)),
+            fp8.encoder_ffn_down_w_{0..17},
+        Decoder BF16:
+            decoder_time_mlp_in_w/b, decoder_time_mlp_out_w/b,
+            decoder_time_embeds (10,1024),
+            decoder_pre_attn_norm_mod_w/b[L], decoder_pre_ffn_norm_mod_w/b[L],
+            decoder_final_norm_mod_w/b,
+            decoder_action_in_proj_w/b,
+            decoder_action_out_proj_w/b   (frontend MUST pre-scale by -1/num_steps),
+        Decoder FP8:
+            fp8.decoder_attn_qkv_w_{0..17}, fp8.decoder_attn_o_w_{0..17},
+            fp8.decoder_ffn_gate_up_w_{0..17}, fp8.decoder_ffn_down_w_{0..17},
+        Language (rebound per-prompt by frontend):
+            language_embeds_ptr   — pointer to bf16 (max_prompt_len, 2048) buffer
+    """
+
+    def __init__(self, gemm, fvk, attn_backend, weights, *,
+                 num_views: int, max_prompt_len: int,
+                 chunk_size: int = NUM_STEPS_DEFAULT,
+                 use_fp8: bool = True, use_fp8_decoder: bool = True,
+                 vision_pool_factor: int = 1,
+                 vision_num_layers: int = VIS_L,
+                 num_steps: int = NUM_STEPS_DEFAULT,
+                 fixed_shape: bool = False):
+        self.gemm = gemm
+        self.fvk = fvk
+        self.attn = attn_backend
+        self.weights = weights
+
+        # Fixed-shape state-prompt mode: one captured graph at the MAX prompt
+        # length serves every length via seqused masking + devpos K/V append.
+        # The attention backend masks padded keys; this pipeline appends the
+        # decoder K/V right after the valid prefix.
+        # NOTE: the backend is SHARED across pipelines, so the frontend re-syncs
+        # backend.set_fixed_shape(active_pipeline._fixed_shape) on every prompt
+        # — this build-time call must not be relied on for run-time mode.
+        self._fixed_shape = bool(fixed_shape)
+        self.attn.set_fixed_shape(self._fixed_shape)
+
+        self.num_views = int(num_views)
+        self.max_prompt_len = int(max_prompt_len)
+        self.chunk_size = int(chunk_size)
+        self.num_steps = int(num_steps)
+        self.use_fp8 = bool(use_fp8)
+        self.use_fp8_decoder = bool(use_fp8_decoder)
+        self.vision_pool_factor = int(vision_pool_factor)
+        self.vision_num_layers = int(vision_num_layers)
+        if self.num_steps <= 0:
+            raise ValueError(f"num_steps must be positive, got {self.num_steps}")
+        if self.vision_pool_factor not in (1, 2, 4):
+            raise ValueError(
+                "vision_pool_factor must be one of {1, 2, 4}; "
+                f"got {self.vision_pool_factor}")
+        if not 1 <= self.vision_num_layers <= VIS_L:
+            raise ValueError(
+                f"vision_num_layers must be in [1, {VIS_L}], "
+                f"got {self.vision_num_layers}")
+        self.fp8_layout = weights.get("fp8_layout", "kn")
+        if self.fp8_layout not in ("kn", "nk"):
+            raise ValueError(f"unsupported FP8 layout: {self.fp8_layout!r}")
+        self.hardware = weights.get("hardware")
+        self._autotune_fp8_nt = _fp8_nt_autotune_enabled(
+            self.hardware, self.fp8_layout)
+        if self.fp8_layout == "nk" and not self._autotune_fp8_nt:
+            logger.info(
+                "Skipping FP8 NT top-N autotune for hardware=%s; keeping "
+                "heuristic top-1 algorithm. Set "
+                "FLASHRT_FP8_NT_AUTOTUNE=force to override.",
+                self.hardware or "unknown")
+
+        # Derived sizes
+        # vision_seq: full SigLIP token count (pre-pooling) — used for SigLIP buffers
+        # vision_seq_enc: token count fed to the Gemma encoder (post-pooling)
+        self.vision_seq = self.num_views * VIS_SEQ_PER_VIEW
+        pf = self.vision_pool_factor
+        self.vision_seq_enc = self.vision_seq // (pf * pf)
+        self.encoder_seq_len = self.vision_seq_enc + self.max_prompt_len
+        self.total_kv = self.encoder_seq_len + self.chunk_size
+
+        # Attention pointers (owned by attn_backend)
+        self._attn_ptrs = attn_backend.get_ptrs()
+        self._enc_kv_layer_stride = self._attn_ptrs["enc_k_layer_stride_bytes"]
+
+        # Allocate internal buffers (all HipBuffer, all BF16 unless noted)
+        self.bufs = self._allocate_buffers()
+
+        # RoPE table (max positions = encoder_seq_len + chunk_size)
+        self._build_rope_table()
+
+        # valid_encoder_len placeholder — updated per forward
+        _valid_len = np.array([self.vision_seq + 1], dtype=np.int32)
+        self.bufs["valid_encoder_len"] = HipBuffer.from_numpy(_valid_len)
+
+        # Pre-allocated RMS norm "ones" weight vectors (REAL BF16 bit pattern)
+        _ones_2048 = np.ones(ENC_D, dtype=BF16_NP)
+        _ones_1024 = np.ones(DEC_D, dtype=BF16_NP)
+        self._rms_ones_enc = HipBuffer.from_numpy(_ones_2048)
+        self._rms_ones_dec = HipBuffer.from_numpy(_ones_1024)
+
+        # FP8 activation scratch buffers + per-layer static scales
+        self.fp8_act_scales = {}  # name -> HipBuffer(1, fp32)
+        self.fp8_calibrated = False
+        # Set once autotune_gemms() has benchmarked this pipeline's (fixed) GEMM
+        # shapes, so repeat calls (frontend + record_infer_graph) are no-ops.
+        self._gemms_autotuned = False
+        self._fp8_current_decoder_step = -1
+        self._allocate_fp8_scratch()
+
+        # Pre-computed decoder style params — frontend pre-computes these in
+        # its native framework and passes raw bf16 bytes; see frontend's
+        # ``_precompute_decoder_styles`` helper.
+        self._upload_precomputed_styles()
+
+        # HIP graph state (set by record_infer_graph)
+        self._graph = None
+        self._decoder_only_graph = None  # for temporal K/V caching
+        self._graph_stream = None  # ctypes.c_void_p
+        from flash_rt.amd.core.hip_buffer import _hip
+        self._hip = _hip
+
+        # Pre-expand vision position embedding across num_views (see
+        # ``vision_encoder``'s patch embed path). We replicate the
+        # (256, VIS_D) pos_emb ``num_views`` times into a dedicated
+        # pipeline buffer so we can feed it to the BF16 ``bias_residual``
+        # kernel.
+        self._build_pos_embed_expanded()
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Buffer allocation
+    # ══════════════════════════════════════════════════════════════════
+
+    def _allocate_buffers(self) -> dict:
+        """Allocate all pipeline working buffers as HipBuffer."""
+        nv = self.num_views
+        vs = self.vision_seq
+        es = self.encoder_seq_len
+        ds = self.chunk_size
+        B = {}
+
+        # ── Vision (SigLIP) ──
+        # observation_images_normalized is the input slot; frontend writes here.
+        B["observation_images_normalized"] = HipBuffer.device_empty(
+            nv * 224 * 224 * 3, BF16)
+        # Patch-embedded + residual stream (full pre-pool token count)
+        B["vision_x"] = HipBuffer.device_empty(vs * VIS_D, BF16)
+        B["vision_x_norm"] = HipBuffer.device_empty(vs * VIS_D, BF16)
+        # Pooled vision tokens fed to the Gemma encoder (== vision_x when pool_factor=1)
+        vs_enc = self.vision_seq_enc
+        if self.vision_pool_factor > 1:
+            B["vision_x_pooled"] = HipBuffer.device_empty(vs_enc * VIS_D, BF16)
+        else:
+            B["vision_x_pooled"] = B["vision_x"]  # no-op alias
+        B["vision_QKV"] = HipBuffer.device_empty(vs * 3 * VIS_D, BF16)
+        B["vision_hidden"] = HipBuffer.device_empty(vs * VIS_H, BF16)
+        # Position embedding expanded (nv * 256, 1152) — built once, reused
+        B["vision_pos_embed_expanded"] = HipBuffer.device_empty(vs * VIS_D, BF16)
+
+        # ── Encoder (Gemma-2B) ──
+        B["encoder_rope_weights"] = HipBuffer.device_empty(es * 2 * ENC_HD // 2, BF16)
+        # (Sized conservatively: encoder_seq_len * 256 bf16 elements.)
+        B["encoder_x"] = HipBuffer.device_empty(es * ENC_D, BF16)
+        B["encoder_x_norm"] = HipBuffer.device_empty(es * ENC_D, BF16)
+        B["encoder_QKV"] = HipBuffer.device_empty(es * (ENC_NH + 2 * ENC_NKV) * ENC_HD, BF16)
+        B["encoder_hidden"] = HipBuffer.device_empty(es * ENC_H, BF16)
+        # Merged gate+up output (legacy BF16 path) or gate-only buffer for SiLU-gated.
+        B["encoder_gate_merged"] = HipBuffer.device_empty(es * 2 * ENC_H, BF16)
+        # Gate buffer for SiLU-gated fusion (encoder): (es, ENC_H) BF16
+        B["encoder_gate_buf"] = HipBuffer.device_empty(es * ENC_H, BF16)
+
+        # ── Decoder (Gemma-300M) ──
+        B["decoder_rope_weights"] = HipBuffer.device_empty(ds * 256, BF16)
+        B["decoder_x"] = HipBuffer.device_empty(ds * DEC_D, BF16)
+        B["decoder_action_buf"] = HipBuffer.device_empty(ds * ACTION_DIM, BF16)
+        # Pre-computed per-step, per-layer style params (BF16)
+        B["decoder_time_emb"] = HipBuffer.device_empty(
+            self.num_steps * ds * DEC_D, BF16)
+        B["decoder_style_attn"] = HipBuffer.device_empty(
+            self.num_steps * DEC_L * ds * 3 * DEC_D, BF16)
+        B["decoder_style_ffn"] = HipBuffer.device_empty(
+            self.num_steps * DEC_L * ds * 3 * DEC_D, BF16)
+        B["decoder_style_final"] = HipBuffer.device_empty(
+            self.num_steps * ds * 3 * DEC_D, BF16)
+        B["decoder_QKV"] = HipBuffer.device_empty(
+            ds * (DEC_NH + 2 * DEC_NKV) * DEC_HD, BF16)
+        B["decoder_hidden"] = HipBuffer.device_empty(ds * DEC_H, BF16)
+        B["decoder_gate_merged"] = HipBuffer.device_empty(ds * 2 * DEC_H, BF16)
+        # Gate buffer for SiLU-gated fusion (decoder): (ds, DEC_H) BF16
+        B["decoder_gate_buf"] = HipBuffer.device_empty(ds * DEC_H, BF16)
+        B["diffusion_noise"] = HipBuffer.device_empty(ds * ACTION_DIM, BF16)
+        # Optional RTC-prefix conditioning slot. It is only read by the
+        # explicit rtc-prefix action graph, not by the default full graph.
+        B["rtc_prev_action_chunk"] = HipBuffer.device_empty(
+            ds * ACTION_DIM, BF16)
+        # Optional full RTC-guidance controls. These are producer hot inputs
+        # for a future VJP-guided action graph; default/prefix graphs ignore
+        # them and therefore keep byte-identical behavior.
+        B["rtc_prefix_weights"] = HipBuffer.device_empty(ds, FP32)
+        B["rtc_guidance_weight"] = HipBuffer.device_empty(1, FP32)
+        # Decoder scratch for ada_rms_norm output + gate
+        B["x_normed_buf"] = HipBuffer.device_empty(ds * DEC_D, BF16)
+        B["gate_buf"] = HipBuffer.device_empty(ds * DEC_D, BF16)
+        # Scratch for vision patch im2col output (BF16 (nv*256, 588))
+        B["vision_patches"] = HipBuffer.device_empty(vs * VIS_PATCH_FLAT, BF16)
+
+        return B
+
+    def _allocate_fp8_scratch(self) -> None:
+        """Allocate reusable FP8 activation scratch + scale buffers."""
+        if not self.use_fp8:
+            return
+        B = self.bufs
+        vs = self.vision_seq
+        es = self.encoder_seq_len
+        ds = self.chunk_size
+
+        # Vision FP8 scratch — sized for D=1152 and H=4304
+        B["vis_act_fp8"] = HipBuffer.device_zeros(vs * VIS_D, FP8)
+        B["vis_act_fp8_large"] = HipBuffer.device_zeros(vs * VIS_H, FP8)
+        B["vis_act_scale"] = HipBuffer.device_zeros(1, FP32)
+
+        # Encoder FP8 scratch — D=2048, H_merged=32768 (2*16384)
+        B["enc_act_fp8"] = HipBuffer.device_zeros(es * ENC_D, FP8)
+        B["enc_act_fp8_large"] = HipBuffer.device_zeros(es * 2 * ENC_H, FP8)
+        B["enc_act_scale"] = HipBuffer.device_zeros(1, FP32)
+
+        # Decoder FP8 scratch — D=1024, H_merged=8192
+        B["dec_act_fp8"] = HipBuffer.device_zeros(ds * DEC_D, FP8)
+        B["dec_act_fp8_large"] = HipBuffer.device_zeros(ds * 2 * DEC_H, FP8)
+        B["dec_act_scale"] = HipBuffer.device_zeros(1, FP32)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   RoPE table
+    # ══════════════════════════════════════════════════════════════════
+
+    def _build_rope_table(self) -> None:
+        """Build the BF16 interleaved cos/sin RoPE table (max_pos, 256).
+
+        Uploaded to ``bufs['encoder_rope_weights']`` for the prefix range
+        [0 .. encoder_seq_len). The decoder RoPE slice [encoder_seq_len ..
+        encoder_seq_len+chunk_size) is set per-prompt by :meth:`forward`.
+        """
+        max_pos = self.encoder_seq_len + self.chunk_size
+        inv_freq = 1.0 / (10000 ** (np.arange(0, 256, 2, dtype=np.float64) / 256))
+        positions = np.arange(max_pos, dtype=np.float64)
+        phase = positions[:, None] * inv_freq[None, :]  # (max_pos, 128)
+        cos = np.cos(phase).astype(BF16_NP)
+        sin = np.sin(phase).astype(BF16_NP)
+        # Interleaved [cos0, sin0, cos1, sin1, ...] → (max_pos, 256)
+        interleaved = np.stack([cos, sin], axis=-1).reshape(max_pos, 256)
+        self._rope_table_np = interleaved  # keep on host for per-prompt decoder slice
+
+        # Initial encoder RoPE slice = first encoder_seq_len rows
+        enc_rope_slice = interleaved[:self.encoder_seq_len]
+        # Need to allocate a correctly-sized HipBuffer, overwriting the placeholder
+        self.bufs["encoder_rope_weights"] = HipBuffer.from_numpy(
+            np.ascontiguousarray(enc_rope_slice))
+
+        # Decoder RoPE: placeholder, will be overwritten per-prompt.
+        # Decoder suffix positions start after the valid prefix tokens.
+        # This mirrors openpi's ``prefix_offsets + cumsum(suffix_mask) - 1``:
+        # the first action token is at position ``vision_seq_enc + prompt_len``.
+        # Use vision_seq_enc (not vision_seq) so the rope table isn't overrun
+        # when vision_pool_factor > 1.
+        dec_rope_slice = interleaved[
+            self.vision_seq_enc : self.vision_seq_enc + self.chunk_size]
+        self.bufs["decoder_rope_weights"] = HipBuffer.from_numpy(
+            np.ascontiguousarray(dec_rope_slice))
+
+    def _set_decoder_rope_for_prompt(self, prompt_len: int) -> None:
+        """Update ``decoder_rope_weights`` for a new prompt length."""
+        start = self.vision_seq_enc + prompt_len
+        end = start + self.chunk_size
+        self.bufs["decoder_rope_weights"].upload(
+            np.ascontiguousarray(self._rope_table_np[start:end]))
+
+    def _build_pos_embed_expanded(self) -> None:
+        """Replicate (256, VIS_D) pos_emb ``num_views`` times into a pipeline buffer.
+
+        The source pos_emb comes from the frontend as a raw device pointer
+        and is BF16 ``(256, VIS_D)``. We D2D-copy it num_views times into
+        a pipeline-owned contiguous (num_views*256, VIS_D) BF16 buffer so
+        that ``bias_residual`` can read it as a flat row-major tensor.
+        """
+        pos_src_ptr = self.weights["vision_position_embedding"]
+        per_view_nbytes = VIS_SEQ_PER_VIEW * VIS_D * 2  # bf16 = 2 bytes
+        dst_buf = self.bufs["vision_pos_embed_expanded"]
+        assert dst_buf.nbytes == self.num_views * per_view_nbytes
+        for v in range(self.num_views):
+            self._hip.hipMemcpy(
+                ctypes.c_void_p(dst_buf.ptr.value + v * per_view_nbytes),
+                ctypes.c_void_p(pos_src_ptr),
+                per_view_nbytes, 3)  # D2D
+        self._hip.hipDeviceSynchronize()
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Helpers
+    # ══════════════════════════════════════════════════════════════════
+
+    @staticmethod
+    def _p(buf) -> int:
+        """Extract int pointer from a HipBuffer."""
+        return buf.ptr.value
+
+    def _weight_fp8(self, name: str) -> tuple[int, int]:
+        """Look up an FP8-quantized weight: returns (data_ptr, scale_ptr)."""
+        return self.weights["fp8"][name]
+
+    def _fp8_matmul(self, act_fp8_ptr: int, weight_fp8_ptr: int,
+                    out_bf16_ptr: int, M: int, N: int, K: int,
+                    act_scale_ptr: int, weight_scale_ptr: int,
+                    stream: int) -> None:
+        """Dispatch the FP8 GEMM for the selected weight layout."""
+        if self.fp8_layout == "nk":
+            self.gemm.fp8_nt_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr, stream=stream)
+        else:
+            self.gemm.fp8_nn_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr, stream=stream)
+
+    def _autotune_fp8_matmul(self, act_fp8_ptr: int, weight_fp8_ptr: int,
+                             out_bf16_ptr: int, M: int, N: int, K: int,
+                             act_scale_ptr: int, weight_scale_ptr: int) -> None:
+        """Autotune the FP8 GEMM for the selected weight layout."""
+        if self.fp8_layout == "nk":
+            if not getattr(self, "_autotune_fp8_nt", True):
+                return
+            self.gemm.autotune_fp8_nt_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr)
+        else:
+            self.gemm.autotune_fp8_nn_dev(
+                act_fp8_ptr, weight_fp8_ptr, out_bf16_ptr,
+                M, N, K, act_scale_ptr, weight_scale_ptr)
+
+    def _upload_precomputed_styles(self) -> None:
+        """Upload frontend-precomputed decoder style/time buffers.
+
+        Expects ``self.weights['precomputed']`` dict with keys (numpy
+        arrays, dtype = BF16-equivalent, 2 bytes per element):
+            time_emb      — (num_steps, chunk_size, DEC_D)
+            style_attn    — (num_steps, DEC_L, chunk_size, 3*DEC_D)
+            style_ffn     — (num_steps, DEC_L, chunk_size, 3*DEC_D)
+            style_final   — (num_steps, chunk_size, 3*DEC_D)
+        """
+        pre = self.weights["precomputed"]
+        self.bufs["decoder_time_emb"].upload(
+            np.ascontiguousarray(pre["time_emb"]))
+        self.bufs["decoder_style_attn"].upload(
+            np.ascontiguousarray(pre["style_attn"]))
+        self.bufs["decoder_style_ffn"].upload(
+            np.ascontiguousarray(pre["style_ffn"]))
+        self.bufs["decoder_style_final"].upload(
+            np.ascontiguousarray(pre["style_final"]))
+
+    def _style_slice_ptr(self, buf_name: str, step: int,
+                         layer: int | None = None) -> int:
+        """Compute the device pointer of a per-step (per-layer) style slice.
+
+        Layout (bf16, 2 bytes per element):
+            style_attn/ffn: (num_steps, DEC_L, chunk_size, 3*DEC_D)
+                            slice ``[step, layer]`` has nbytes = chunk * 3*D * 2
+            style_final:   (num_steps, chunk_size, 3*DEC_D)
+                            slice ``[step]`` has nbytes = chunk * 3*D * 2
+            time_emb:      (num_steps, chunk_size, DEC_D)
+                            slice ``[step]`` has nbytes = chunk * D * 2
+        """
+        base = self.bufs[buf_name].ptr.value
+        ds = self.chunk_size
+        if buf_name == "decoder_time_emb":
+            return base + step * ds * DEC_D * 2
+        if buf_name == "decoder_style_final":
+            return base + step * ds * 3 * DEC_D * 2
+        # style_attn / style_ffn
+        per_layer = ds * 3 * DEC_D * 2
+        per_step = DEC_L * per_layer
+        return base + step * per_step + layer * per_layer
+
+    def _enc_kv_layer_ptrs(self, layer: int, offset_tokens: int = 0) -> tuple[int, int]:
+        """Compute (K_ptr, V_ptr) for encoder/decoder cross-attn layer cache.
+
+        The attention backend owns ``enc_K`` / ``enc_V`` as
+        ``(num_enc_layers, total_kv_max, 1, HD) bf16``. We compute the
+        per-layer slice plus an optional token offset (used by the decoder
+        which writes into ``[enc_seq : enc_seq+dec_seq]``).
+        """
+        k_base = self._attn_ptrs["enc_K"]
+        v_base = self._attn_ptrs["enc_V"]
+        layer_stride = self._enc_kv_layer_stride  # bytes
+        token_offset_bytes = offset_tokens * ENC_NKV * ENC_HD * 2  # bf16
+        return (k_base + layer * layer_stride + token_offset_bytes,
+                v_base + layer * layer_stride + token_offset_bytes)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   FP8 GEMM helpers
+    # ══════════════════════════════════════════════════════════════════
+
+    def _fp8_scale_buf(self, name: str) -> HipBuffer:
+        """Get (lazy-allocate) the per-layer FP8 activation scale buffer."""
+        buf = self.fp8_act_scales.get(name)
+        if buf is None:
+            buf = HipBuffer.device_zeros(1, FP32)
+            self.fp8_act_scales[name] = buf
+        return buf
+
+    def _fp8_decoder_step_scale_name(self, weight_name: str) -> str:
+        step = getattr(self, "_fp8_current_decoder_step", -1)
+        if step >= 0 and weight_name.startswith("decoder_"):
+            return f"{weight_name}__step_{step}"
+        return weight_name
+
+    def _fp8_static_scale_ptr(self, weight_name: str) -> int:
+        step_name = self._fp8_decoder_step_scale_name(weight_name)
+        buf = self.fp8_act_scales.get(step_name)
+        if buf is None:
+            buf = self.fp8_act_scales[weight_name]
+        return buf.ptr.value
+
+    def _pick_fp8_scratch(self, weight_name: str, act_n: int) -> tuple[int, int]:
+        """Return (act_fp8_ptr, act_scale_ptr) scratch for the right domain.
+
+        Chooses between vision/encoder/decoder FP8 scratch buffers based on
+        the weight name prefix, and between the small and large variant
+        based on ``act_n`` (number of elements to quantize).
+        """
+        B = self.bufs
+        if weight_name.startswith("vision_") or weight_name == "vision_projector_w":
+            small = B["vis_act_fp8"]
+            large = B["vis_act_fp8_large"]
+            scratch_scale = B["vis_act_scale"]
+        elif weight_name.startswith("encoder_"):
+            small = B["enc_act_fp8"]
+            large = B["enc_act_fp8_large"]
+            scratch_scale = B["enc_act_scale"]
+        else:
+            small = B["dec_act_fp8"]
+            large = B["dec_act_fp8_large"]
+            scratch_scale = B["dec_act_scale"]
+        buf = small if act_n <= (small.nbytes // 1) else large
+        return buf.ptr.value, scratch_scale.ptr.value
+
+    def _fp8_gemm(self, act_bf16_ptr: int, act_n: int, weight_name: str,
+                  out_bf16_ptr: int, M: int, N: int, K: int, stream: int) -> None:
+        """FP8 GEMM path: dynamic-quantize activation → FP8 matmul → BF16 out.
+
+        After calibration, uses the per-layer static scale buffer (single
+        kernel path). During calibration, writes the dynamic scale into the
+        layer's static scale buffer so subsequent inference can reuse it.
+        """
+        fvk = self.fvk
+        w_fp8_ptr, w_scale_ptr = self._weight_fp8(weight_name)
+        act_fp8_ptr, scratch_scale_ptr = self._pick_fp8_scratch(weight_name, act_n)
+
+        if self.fp8_calibrated and weight_name in self.fp8_act_scales:
+            static_scale_ptr = self._fp8_static_scale_ptr(weight_name)
+            fvk.quantize_fp8_static(
+                act_bf16_ptr, act_fp8_ptr, static_scale_ptr, act_n, stream=stream)
+            self._fp8_matmul(
+                act_fp8_ptr, w_fp8_ptr, out_bf16_ptr,
+                M, N, K, static_scale_ptr, w_scale_ptr, stream)
+        else:
+            # Dynamic calibration path: use the per-call scratch scale for
+            # this GEMM, while accumulating a max into the persistent static
+            # scale. Decoder weights are visited once per denoise step; direct
+            # writes would leave only the final step's scale.
+            layer_scale = self._fp8_scale_buf(weight_name)
+            step_scale = self._fp8_scale_buf(
+                self._fp8_decoder_step_scale_name(weight_name))
+            fvk.quantize_fp8_device(
+                act_bf16_ptr, act_fp8_ptr, scratch_scale_ptr, act_n, stream=stream)
+            fvk.fp8_accumulate_scale_max(
+                scratch_scale_ptr, layer_scale.ptr.value, stream=stream)
+            if step_scale is not layer_scale:
+                fvk.fp8_accumulate_scale_max(
+                    scratch_scale_ptr, step_scale.ptr.value, stream=stream)
+            self._fp8_matmul(
+                act_fp8_ptr, w_fp8_ptr, out_bf16_ptr,
+                M, N, K, scratch_scale_ptr, w_scale_ptr, stream)
+
+    def _fp8_gemm_fused(self, act_fp8_ptr: int, weight_name: str,
+                        out_bf16_ptr: int, M: int, N: int, K: int,
+                        act_scale_ptr: int, stream: int) -> None:
+        """FP8 GEMM with pre-quantized activation (from fused norm→FP8 kernel)."""
+        w_fp8_ptr, w_scale_ptr = self._weight_fp8(weight_name)
+        self._fp8_matmul(
+            act_fp8_ptr, w_fp8_ptr, out_bf16_ptr,
+            M, N, K, act_scale_ptr, w_scale_ptr, stream)
+
+    def _bias_add_bf16(self, x_ptr: int, bias_ptr: int,
+                       seq: int, dim: int, stream: int) -> None:
+        """Broadcast-add bias to an (seq, dim) bf16 buffer in place.
+
+        TODO(v2): add a dedicated ``add_bias_bf16`` kernel path here. For
+        now we reuse ``bias_residual`` with a dedicated persistent zero
+        buffer as the ``x`` operand, yielding ``x += bias``. The wasted
+        bandwidth is ~0.2 ms total for vision (27 layers × 2 bias adds).
+        """
+        if not hasattr(self, "_bias_zero_buf"):
+            # Size once for the largest shape we'll ever bias-add.
+            nbytes = max(
+                self.vision_seq * 3 * VIS_D,  # vision QKV
+                self.vision_seq * VIS_H,      # vision FFN up
+            )
+            self._bias_zero_buf = HipBuffer.device_zeros(nbytes, BF16)
+        self.fvk.bias_residual(
+            x_ptr, self._bias_zero_buf.ptr.value, bias_ptr,
+            seq, dim, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Phase A: Vision (SigLIP)
+    # ══════════════════════════════════════════════════════════════════
+
+    def vision_encoder(self, stream: int = 0) -> None:
+        """Run the full 27-layer SigLIP vision encoder.
+
+        Input:  ``bufs['observation_images_normalized']`` (num_views, 224, 224, 3) bf16
+        Output: ``bufs['vision_x']`` (num_views * 256, 1152) bf16
+        """
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        seq = self.vision_seq
+        nv = self.num_views
+
+        # A1: Patch embed — im2col + GEMM + bias + pos embed.
+        # We use the BF16 ``bias_residual`` kernel with a pre-replicated
+        # pos_emb buffer.
+        fvk.patch_im2col(
+            B["observation_images_normalized"].ptr.value,
+            B["vision_patches"].ptr.value,
+            nv, stream)
+        gemm.bf16_nn(
+            B["vision_patches"].ptr.value,
+            W["vision_patch_embedding_w"],
+            B["vision_x"].ptr.value,
+            seq, VIS_D, VIS_PATCH_FLAT, stream=stream)
+        fvk.bias_residual(
+            B["vision_x"].ptr.value,
+            B["vision_pos_embed_expanded"].ptr.value,
+            W["vision_patch_embedding_b"],
+            seq, VIS_D, stream=stream)
+
+        # A2-A6: SigLIP transformer layers (vision_num_layers ≤ VIS_L=27)
+        # Reducing layers is a quality/speed trade-off (untrained skip).
+        use_fp8 = self.use_fp8 and "vision_attn_qkv_w_0" in self.weights.get("fp8", {})
+
+        # Layer-0 pre-attn LayerNorm runs here (the rest are run at the
+        # prior layer's post-FFN position, so each iteration arrives with
+        # vision_x_norm already containing LN of vision_x).
+        fvk.layer_norm(
+            B["vision_x"].ptr.value,
+            W["vision_pre_attn_norm_w"][0], W["vision_pre_attn_norm_b"][0],
+            B["vision_x_norm"].ptr.value,
+            seq, VIS_D, 1e-5, stream=stream)
+
+        last = self.vision_num_layers - 1
+        for i in range(self.vision_num_layers):
+            self._vision_layer(i, seq, use_fp8, stream, is_last=(i == last))
+
+        # A7 (optional): Spatial average pooling — reduce (nv*256, D) to (nv*64, D)
+        # Runs only when vision_pool_factor > 1. vision_x_pooled is a separate
+        # buffer; vision_x stays intact so this is non-destructive.
+        if self.vision_pool_factor > 1:
+            H = 16  # VIS_SEQ_PER_VIEW = 256 = 16 × 16 patch grid
+            fvk.avg_pool_vision_tokens(
+                B["vision_x"].ptr.value,
+                B["vision_x_pooled"].ptr.value,
+                nv, H, H, VIS_D, self.vision_pool_factor, stream)
+
+    def _vision_layer(self, i: int, seq: int, use_fp8: bool, stream: int,
+                       is_last: bool = False) -> None:
+        """One SigLIP transformer layer (pre-norm, LayerNorm, GELU FFN).
+
+        Pre-attn LayerNorm is hoisted: layer 0's runs in
+        :meth:`vision_encoder` before the loop; layers 1..N-1's runs
+        at the previous layer's post-FFN-down position. Each iteration
+        enters with ``vision_x_norm`` already holding
+        ``LayerNorm(vision_x)`` for *this* layer's pre-attn site.
+        """
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        attn_ptrs = self._attn_ptrs
+
+        # QKV GEMM (FP8 / BF16) → vision_QKV
+        if use_fp8:
+            self._fp8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vision_attn_qkv_w_{i}",
+                B["vision_QKV"].ptr.value,
+                seq, 3 * VIS_D, VIS_D, stream)
+        else:
+            gemm.bf16_nn(
+                B["vision_x_norm"].ptr.value, W["vision_attn_qkv_w"][i],
+                B["vision_QKV"].ptr.value,
+                seq, 3 * VIS_D, VIS_D, stream=stream)
+        # add_bias_bf16 is a proper in-place add (no zero-buffer bandwidth waste)
+        fvk.add_bias_bf16(
+            B["vision_QKV"].ptr.value, W["vision_attn_qkv_b"][i],
+            seq, 3 * VIS_D, stream=stream)
+
+        # Split QKV into attn_backend's Q/K/V buffers
+        fvk.qkv_split(
+            B["vision_QKV"].ptr.value,
+            attn_ptrs["vis_Q"], attn_ptrs["vis_K"], attn_ptrs["vis_V"],
+            seq, VIS_D, VIS_D, VIS_D, stream=stream)
+
+        # Self-attention (per-view batched)
+        vis_o_ptr = self.attn.run(
+            "siglip", i, q_seq=VIS_SEQ_PER_VIEW, stream=stream)
+
+        # Attn output projection → x_norm
+        if use_fp8:
+            self._fp8_gemm(
+                vis_o_ptr, seq * VIS_D,
+                f"vision_attn_o_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_D, stream)
+        else:
+            gemm.bf16_nn(
+                vis_o_ptr, W["vision_attn_o_w"][i],
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_D, stream=stream)
+        # x += x_norm + o_bias; x_norm = LayerNorm(x).
+        # The un-fused upstream pair keeps numerics matching the RTX
+        # default BF16/FP8 path bit-for-bit.
+        fvk.bias_residual(
+            B["vision_x"].ptr.value, B["vision_x_norm"].ptr.value,
+            W["vision_attn_o_b"][i], seq, VIS_D, stream=stream)
+        fvk.layer_norm(
+            B["vision_x"].ptr.value,
+            W["vision_pre_ffn_norm_w"][i], W["vision_pre_ffn_norm_b"][i],
+            B["vision_x_norm"].ptr.value,
+            seq, VIS_D, 1e-5, stream=stream)
+
+        # FFN up → hidden, + bias, + GELU
+        if use_fp8:
+            self._fp8_gemm(
+                B["vision_x_norm"].ptr.value, seq * VIS_D,
+                f"vision_ffn_up_w_{i}",
+                B["vision_hidden"].ptr.value,
+                seq, VIS_H, VIS_D, stream)
+        else:
+            gemm.bf16_nn(
+                B["vision_x_norm"].ptr.value, W["vision_ffn_up_w"][i],
+                B["vision_hidden"].ptr.value,
+                seq, VIS_H, VIS_D, stream=stream)
+        # bias + GELU on the FFN-hidden buffer (un-fused upstream pair).
+        self._bias_add_bf16(
+            B["vision_hidden"].ptr.value, W["vision_ffn_up_b"][i],
+            seq, VIS_H, stream)
+        fvk.gelu_inplace(
+            B["vision_hidden"].ptr.value, seq * VIS_H, stream=stream)
+
+        # FFN down → x_norm, then x += x_norm + down_bias
+        if use_fp8:
+            self._fp8_gemm(
+                B["vision_hidden"].ptr.value, seq * VIS_H,
+                f"vision_ffn_down_w_{i}",
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_H, stream)
+        else:
+            gemm.bf16_nn(
+                B["vision_hidden"].ptr.value, W["vision_ffn_down_w"][i],
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, VIS_H, stream=stream)
+        if is_last:
+            # Last layer: just bias_residual; vision_x is the final residual,
+            # consumed by avg_pool_vision_tokens / multi-modal projector.
+            # No follow-up LN to run.
+            fvk.bias_residual(
+                B["vision_x"].ptr.value, B["vision_x_norm"].ptr.value,
+                W["vision_ffn_down_b"][i], seq, VIS_D, stream=stream)
+        else:
+            # Layers 0..N-2: post-FFN bias_residual + NEXT layer's pre-attn
+            # LayerNorm (un-fused upstream pair). vision_x_norm ends up
+            # holding LN(vision_x post-residual) ready for layer i+1's
+            # attn QKV.
+            fvk.bias_residual(
+                B["vision_x"].ptr.value, B["vision_x_norm"].ptr.value,
+                W["vision_ffn_down_b"][i], seq, VIS_D, stream=stream)
+            fvk.layer_norm(
+                B["vision_x"].ptr.value,
+                W["vision_pre_attn_norm_w"][i + 1],
+                W["vision_pre_attn_norm_b"][i + 1],
+                B["vision_x_norm"].ptr.value,
+                seq, VIS_D, 1e-5, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Phase B: Gemma-2B encoder
+    # ══════════════════════════════════════════════════════════════════
+
+    def transformer_encoder(self, stream: int = 0) -> None:
+        """Project vision output + language tokens through the Gemma-2B encoder.
+
+        The language embeddings have already been copied into
+        ``bufs['encoder_x'][nv*256 : nv*256+prompt_len]`` by :meth:`forward`.
+        """
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        seq = self.encoder_seq_len
+        # vs_enc: token count fed to the encoder (post-pool); equals vision_seq when no pooling
+        vs_enc = self.vision_seq_enc
+        use_fp8 = self.use_fp8
+
+        # B0: LayerNorm(vision output) → project 1152→2048 + bias → encoder_x[:vs_enc]
+        # When vision_pool_factor > 1, read from vision_x_pooled (reduced token count);
+        # otherwise vision_x_pooled aliases vision_x so behaviour is unchanged.
+        fvk.layer_norm(
+            B["vision_x_pooled"].ptr.value,
+            W["vision_final_norm_w"], W["vision_final_norm_b"],
+            B["vision_x_norm"].ptr.value,
+            vs_enc, VIS_D, 1e-5, stream=stream)
+
+        if use_fp8 and "vision_projector_w" in self.weights.get("fp8", {}):
+            self._fp8_gemm(
+                B["vision_x_norm"].ptr.value, vs_enc * VIS_D,
+                "vision_projector_w",
+                B["encoder_x"].ptr.value,
+                vs_enc, ENC_D, VIS_D, stream)
+        else:
+            gemm.bf16_nn(
+                B["vision_x_norm"].ptr.value, W["encoder_multi_modal_projector_w"],
+                B["encoder_x"].ptr.value,
+                vs_enc, ENC_D, VIS_D, stream=stream)
+        fvk.add_bias_bf16(
+            B["encoder_x"].ptr.value, W["encoder_multi_modal_projector_b"],
+            vs_enc, ENC_D, stream=stream)
+
+        # Language embeds have been written by frontend into encoder_x[vs_enc:vs_enc+lang_len]
+
+        # B1-B5: 18 encoder layers. Fuse previous B5 residual into this B1's RMS→FP8
+        fused = use_fp8 and self.fp8_calibrated
+        for i in range(ENC_L):
+            self._encoder_layer(i, seq, fuse_b1=(i > 0 and fused), stream=stream)
+
+    def _encoder_layer(self, i: int, seq: int, fuse_b1: bool, stream: int) -> None:
+        """One Gemma-2B encoder layer."""
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        attn_ptrs = self._attn_ptrs
+        fused = self.use_fp8 and self.fp8_calibrated
+
+        # B1: RMSNorm → QKV GEMM
+        if fused:
+            qkv_name = f"encoder_attn_qkv_w_{i}"
+            act_scale_ptr = self.fp8_act_scales[qkv_name].ptr.value
+            if fuse_b1:
+                # Fused: previous layer B5 residual + this layer's RMSNorm → FP8
+                fvk.residual_add_rms_norm_fp8(
+                    B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                    self._rms_ones_enc.ptr.value,
+                    B["enc_act_fp8"].ptr.value,
+                    seq, ENC_D, 1e-6, act_scale_ptr, stream=stream)
+            else:
+                fvk.rms_norm_fp8(
+                    B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                    B["enc_act_fp8"].ptr.value,
+                    seq, ENC_D, 1e-6, act_scale_ptr, stream=stream)
+            self._fp8_gemm_fused(
+                B["enc_act_fp8"].ptr.value, qkv_name,
+                B["encoder_QKV"].ptr.value,
+                seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D,
+                act_scale_ptr, stream)
+        elif self.use_fp8:
+            # Pre-calibration FP8 path: separate RMSNorm + dynamic quant inside _fp8_gemm
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            self._fp8_gemm(
+                B["encoder_x_norm"].ptr.value, seq * ENC_D,
+                f"encoder_attn_qkv_w_{i}",
+                B["encoder_QKV"].ptr.value,
+                seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D, stream)
+        else:
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            gemm.bf16_nn(
+                B["encoder_x_norm"].ptr.value, W["encoder_attn_qkv_w"][i],
+                B["encoder_QKV"].ptr.value,
+                seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D, stream=stream)
+
+        # Split QKV + apply RoPE. K/V go into attn_backend's layer cache slice.
+        k_ptr, v_ptr = self._enc_kv_layer_ptrs(i, offset_tokens=0)
+        fvk.qkv_split_rope(
+            B["encoder_QKV"].ptr.value,
+            B["encoder_rope_weights"].ptr.value,
+            attn_ptrs["enc_Q"],  # (seq, 8, 256) — split from QKV into attn buf
+            k_ptr, v_ptr,
+            seq, ENC_NH * ENC_HD, ENC_NKV * ENC_HD, ENC_NKV * ENC_HD,
+            ENC_HD, stream=stream)
+
+        if i == ENC_L - 1:
+            # Last layer: no post-attn projection/FFN needed — encoder output is
+            # the K/V cache which the decoder reads. Skip to next phase.
+            return
+
+        # B2: Attention (GQA) — returns output pointer (no copy).
+        enc_o_ptr = self.attn.run("encoder", i, q_seq=seq, stream=stream)
+
+        # B3: Attn output projection → x_norm
+        if self.use_fp8:
+            self._fp8_gemm(
+                enc_o_ptr, seq * ENC_D,
+                f"encoder_attn_o_w_{i}",
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_D, stream)
+        else:
+            gemm.bf16_nn(
+                enc_o_ptr, W["encoder_attn_o_w"][i],
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_D, stream=stream)
+
+        # B4: (residual_add + RMSNorm) → FFN gate_up GEMM
+        if fused:
+            # Fused: residual + RMS → FP8 in one kernel, then FP8 GEMM
+            gu_name = f"encoder_ffn_gate_up_w_{i}"
+            act_scale_gu = self.fp8_act_scales[gu_name].ptr.value
+            fvk.residual_add_rms_norm_fp8(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                self._rms_ones_enc.ptr.value,
+                B["enc_act_fp8"].ptr.value,
+                seq, ENC_D, 1e-6, act_scale_gu, stream=stream)
+            self._fp8_gemm_fused(
+                B["enc_act_fp8"].ptr.value, gu_name,
+                B["encoder_gate_merged"].ptr.value,
+                seq, 2 * ENC_H, ENC_D, act_scale_gu, stream)
+        elif self.use_fp8:
+            # Pre-calibration: separate residual + rms + fp8_gemm
+            fvk.residual_add(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                seq * ENC_D, stream=stream)
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            self._fp8_gemm(
+                B["encoder_x_norm"].ptr.value, seq * ENC_D,
+                f"encoder_ffn_gate_up_w_{i}",
+                B["encoder_gate_merged"].ptr.value,
+                seq, 2 * ENC_H, ENC_D, stream)
+        else:
+            fvk.residual_add(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                seq * ENC_D, stream=stream)
+            fvk.rms_norm(
+                B["encoder_x"].ptr.value, self._rms_ones_enc.ptr.value,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, 1e-6, stream=stream)
+            # Non-FP8 path: gate+up are separate 2 GEMMs into gate and hidden
+            gemm.bf16_nn(
+                B["encoder_x_norm"].ptr.value, W["encoder_ffn_gate_w"][i],
+                B["encoder_gate_merged"].ptr.value,
+                seq, ENC_H, ENC_D, stream=stream)
+            gemm.bf16_nn(
+                B["encoder_x_norm"].ptr.value, W["encoder_ffn_up_w"][i],
+                B["encoder_hidden"].ptr.value,
+                seq, ENC_H, ENC_D, stream=stream)
+
+        # SiLU(gate) * up → hidden, then FFN down GEMM.
+        if fused:
+            down_name = f"encoder_ffn_down_w_{i}"
+            act_scale_down = self.fp8_act_scales[down_name].ptr.value
+            fvk.gate_geglu_merged_fp8(
+                B["encoder_gate_merged"].ptr.value,
+                B["enc_act_fp8_large"].ptr.value,
+                seq, ENC_H, act_scale_down, stream=stream)
+            self._fp8_gemm_fused(
+                B["enc_act_fp8_large"].ptr.value, down_name,
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_H, act_scale_down, stream)
+        elif self.use_fp8:
+            fvk.gate_geglu_merged(
+                B["encoder_gate_merged"].ptr.value,
+                B["encoder_hidden"].ptr.value,
+                seq, ENC_H, stream=stream)
+            self._fp8_gemm(
+                B["encoder_hidden"].ptr.value, seq * ENC_H,
+                f"encoder_ffn_down_w_{i}",
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_H, stream)
+        else:
+            fvk.gate_geglu(
+                B["encoder_gate_merged"].ptr.value,
+                B["encoder_hidden"].ptr.value,
+                B["encoder_hidden"].ptr.value,
+                seq * ENC_H, stream=stream)
+            gemm.bf16_nn(
+                B["encoder_hidden"].ptr.value, W["encoder_ffn_down_w"][i],
+                B["encoder_x_norm"].ptr.value,
+                seq, ENC_D, ENC_H, stream=stream)
+
+        # B5: Residual (skipped in fused mode — next layer's B1 handles it)
+        if not fused:
+            fvk.residual_add(
+                B["encoder_x"].ptr.value, B["encoder_x_norm"].ptr.value,
+                seq * ENC_D, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Phase C: Gemma-300M decoder (flow matching)
+    # ══════════════════════════════════════════════════════════════════
+
+    def _copy_rtc_prefix(self, prefix_len: int, stream: int = 0) -> None:
+        if prefix_len <= 0:
+            return
+        if prefix_len > self.chunk_size:
+            raise ValueError(
+                f"rtc prefix_len {prefix_len} exceeds chunk_size "
+                f"{self.chunk_size}")
+        nbytes = int(prefix_len) * ACTION_DIM * 2
+        self.fvk.gpu_copy(
+            self.bufs["diffusion_noise"].ptr.value,
+            self.bufs["rtc_prev_action_chunk"].ptr.value,
+            nbytes,
+            stream,
+        )
+
+    def transformer_decoder(self, stream: int = 0,
+                            rtc_prefix_len: int = 0) -> None:
+        """Run 10-step diffusion denoise on ``bufs['diffusion_noise']``."""
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        enc_seq = self.encoder_seq_len
+        ds = self.chunk_size
+        fused = self.use_fp8_decoder and self.fp8_calibrated
+
+        prev_decoder_step = getattr(self, "_fp8_current_decoder_step", -1)
+        try:
+            for step in range(self.num_steps):
+                self._fp8_current_decoder_step = step
+                self._copy_rtc_prefix(rtc_prefix_len, stream)
+                # C0: Action input projection: noise (ds, 32) → decoder_x (ds, 1024)
+                gemm.bf16_nn(
+                    B["diffusion_noise"].ptr.value,
+                    W["decoder_action_in_proj_w"],
+                    B["decoder_x"].ptr.value,
+                    ds, DEC_D, ACTION_DIM, stream=stream)
+                self._bias_add_bf16(
+                    B["decoder_x"].ptr.value, W["decoder_action_in_proj_b"],
+                    ds, DEC_D, stream)
+
+                # 18 decoder layers
+                for i in range(DEC_L):
+                    skip_c1 = fused and i > 0
+                    self._decoder_layer(i, step, enc_seq, ds, skip_c1, stream)
+
+                # C8: Final AdaRMSNorm + output projection
+                fvk.ada_rms_norm_style(
+                    B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                    self._style_slice_ptr("decoder_style_final", step),
+                    B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                    ds, DEC_D, 1e-6, stream=stream)
+                gemm.bf16_nn(
+                    B["x_normed_buf"].ptr.value,
+                    W["decoder_action_out_proj_w"],
+                    B["decoder_action_buf"].ptr.value,
+                    ds, ACTION_DIM, DEC_D, stream=stream)
+                self._bias_add_bf16(
+                    B["decoder_action_buf"].ptr.value,
+                    W["decoder_action_out_proj_b"],
+                    ds, ACTION_DIM, stream)
+                # noise += action_buf (weights pre-scaled by -1/num_steps by frontend)
+                fvk.residual_add(
+                    B["diffusion_noise"].ptr.value,
+                    B["decoder_action_buf"].ptr.value,
+                    ds * ACTION_DIM, stream=stream)
+                self._copy_rtc_prefix(rtc_prefix_len, stream)
+        finally:
+            self._fp8_current_decoder_step = prev_decoder_step
+
+    def _decoder_layer(self, i: int, step: int, enc_seq: int, ds: int,
+                       skip_c1: bool, stream: int) -> None:
+        """One Gemma-300M decoder layer."""
+        fvk = self.fvk
+        gemm = self.gemm
+        W = self.weights
+        B = self.bufs
+        attn_ptrs = self._attn_ptrs
+        fused = self.use_fp8_decoder and self.fp8_calibrated
+
+        # C1: AdaRMSNorm with style modulation → FP8 (fused) or BF16
+        qkv_name = f"decoder_attn_qkv_w_{i}"
+        if fused:
+            act_scale_qkv = self._fp8_static_scale_ptr(qkv_name)
+            if not skip_c1:
+                fvk.ada_rms_norm_style_fp8(
+                    B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                    self._style_slice_ptr("decoder_style_attn", step, i),
+                    B["dec_act_fp8"].ptr.value, B["gate_buf"].ptr.value,
+                    ds, DEC_D, 1e-6, act_scale_qkv, stream=stream)
+            self._fp8_gemm_fused(
+                B["dec_act_fp8"].ptr.value, qkv_name,
+                B["decoder_QKV"].ptr.value,
+                ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D,
+                act_scale_qkv, stream)
+        else:
+            fvk.ada_rms_norm_style(
+                B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                self._style_slice_ptr("decoder_style_attn", step, i),
+                B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, stream=stream)
+            if self.use_fp8_decoder:
+                self._fp8_gemm(
+                    B["x_normed_buf"].ptr.value, ds * DEC_D,
+                    qkv_name,
+                    B["decoder_QKV"].ptr.value,
+                    ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D, stream)
+            else:
+                gemm.bf16_nn(
+                    B["x_normed_buf"].ptr.value, W["decoder_attn_qkv_w"][i],
+                    B["decoder_QKV"].ptr.value,
+                    ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D, stream=stream)
+
+        # C2: QKV split + RoPE. Decoder K/V write into enc cache after prefix.
+        if self._fixed_shape:
+            # Fixed graph: append the action K/V right after the VALID prefix
+            # (runtime row offset = devpos), so cross-attn over [0:valid+chunk]
+            # is one contiguous (seqused) call. K/V pointers are cache base.
+            k_base, v_base = self._enc_kv_layer_ptrs(i, offset_tokens=0)
+            fvk.qkv_split_rope_devpos(
+                B["decoder_QKV"].ptr.value,
+                B["decoder_rope_weights"].ptr.value,
+                attn_ptrs["dec_Q"],
+                k_base, v_base, self.attn.dec_devpos.data_ptr(),
+                ds, DEC_NH * DEC_HD, DEC_NKV * DEC_HD, DEC_NKV * DEC_HD,
+                DEC_HD, stream=stream)
+        else:
+            k_ptr, v_ptr = self._enc_kv_layer_ptrs(i, offset_tokens=enc_seq)
+            fvk.qkv_split_rope(
+                B["decoder_QKV"].ptr.value,
+                B["decoder_rope_weights"].ptr.value,
+                attn_ptrs["dec_Q"],
+                k_ptr, v_ptr,
+                ds, DEC_NH * DEC_HD, DEC_NKV * DEC_HD, DEC_NKV * DEC_HD,
+                DEC_HD, stream=stream)
+
+        # C3: Cross-attention (decoder Q over enc+dec K/V cache) — returns ptr.
+        dec_o_ptr = self.attn.run(
+            "decoder", i,
+            q_seq=ds,
+            kv_seq=enc_seq + ds,
+            stream=stream,
+        )
+
+        # C4: Attn output projection
+        if self.use_fp8_decoder:
+            self._fp8_gemm(
+                dec_o_ptr, ds * DEC_NH * DEC_HD,
+                f"decoder_attn_o_w_{i}",
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_NH * DEC_HD, stream)
+        else:
+            gemm.bf16_nn(
+                dec_o_ptr, W["decoder_attn_o_w"][i],
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_NH * DEC_HD, stream=stream)
+
+        # C4→C5: gate*residual + AdaRMSNorm + FFN gate_up
+        gu_name = f"decoder_ffn_gate_up_w_{i}"    # FP8 merged name
+        if fused:
+            act_scale_gu = self._fp8_static_scale_ptr(gu_name)
+            fvk.gate_residual_ada_norm_fp8(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value,
+                self._rms_ones_dec.ptr.value,
+                self._style_slice_ptr("decoder_style_ffn", step, i),
+                B["dec_act_fp8"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, act_scale_gu, stream=stream)
+            self._fp8_gemm_fused(
+                B["dec_act_fp8"].ptr.value, gu_name,
+                B["decoder_gate_merged"].ptr.value,
+                ds, 2 * DEC_H, DEC_D, act_scale_gu, stream)
+        else:
+            fvk.gate_mul_residual(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value, ds * DEC_D, stream=stream)
+            fvk.ada_rms_norm_style(
+                B["decoder_x"].ptr.value, self._rms_ones_dec.ptr.value,
+                self._style_slice_ptr("decoder_style_ffn", step, i),
+                B["x_normed_buf"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, stream=stream)
+            if self.use_fp8_decoder:
+                self._fp8_gemm(
+                    B["x_normed_buf"].ptr.value, ds * DEC_D,
+                    gu_name,
+                    B["decoder_gate_merged"].ptr.value,
+                    ds, 2 * DEC_H, DEC_D, stream)
+            else:
+                gemm.bf16_nn(
+                    B["x_normed_buf"].ptr.value, W["decoder_ffn_gate_w"][i],
+                    B["decoder_gate_merged"].ptr.value,
+                    ds, DEC_H, DEC_D, stream=stream)
+                gemm.bf16_nn(
+                    B["x_normed_buf"].ptr.value, W["decoder_ffn_up_w"][i],
+                    B["decoder_hidden"].ptr.value,
+                    ds, DEC_H, DEC_D, stream=stream)
+
+        # C6: SiLU(gate) * up → FFN down
+        down_name = f"decoder_ffn_down_w_{i}"
+        if fused:
+            act_scale_down = self._fp8_static_scale_ptr(down_name)
+            fvk.gate_geglu_merged_fp8(
+                B["decoder_gate_merged"].ptr.value,
+                B["dec_act_fp8_large"].ptr.value,
+                ds, DEC_H, act_scale_down, stream=stream)
+            self._fp8_gemm_fused(
+                B["dec_act_fp8_large"].ptr.value, down_name,
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_H, act_scale_down, stream)
+        elif self.use_fp8_decoder:
+            fvk.gate_geglu_merged(
+                B["decoder_gate_merged"].ptr.value,
+                B["decoder_hidden"].ptr.value,
+                ds, DEC_H, stream=stream)
+            self._fp8_gemm(
+                B["decoder_hidden"].ptr.value, ds * DEC_H,
+                down_name,
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_H, stream)
+        else:
+            fvk.gate_geglu(
+                B["decoder_gate_merged"].ptr.value,
+                B["decoder_hidden"].ptr.value,
+                B["decoder_hidden"].ptr.value,
+                ds * DEC_H, stream=stream)
+            gemm.bf16_nn(
+                B["decoder_hidden"].ptr.value, W["decoder_ffn_down_w"][i],
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_H, stream=stream)
+
+        # C7→C1_next: gate*residual + next layer's AdaRMSNorm → FP8 (fused)
+        if fused and i < DEC_L - 1:
+            next_qkv = f"decoder_attn_qkv_w_{i + 1}"
+            act_scale_next = self._fp8_static_scale_ptr(next_qkv)
+            fvk.gate_residual_ada_norm_fp8(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value,
+                self._rms_ones_dec.ptr.value,
+                self._style_slice_ptr("decoder_style_attn", step, i + 1),
+                B["dec_act_fp8"].ptr.value, B["gate_buf"].ptr.value,
+                ds, DEC_D, 1e-6, act_scale_next, stream=stream)
+        else:
+            fvk.gate_mul_residual(
+                B["decoder_x"].ptr.value, B["x_normed_buf"].ptr.value,
+                B["gate_buf"].ptr.value, ds * DEC_D, stream=stream)
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Full pipeline + calibration + graph
+    # ══════════════════════════════════════════════════════════════════
+
+    def run_pipeline(self, stream: int = 0) -> None:
+        """Run vision → encoder → decoder end-to-end on ``stream``.
+
+        Re-copies the stored language embeddings into ``encoder_x`` at the
+        prompt slot because the encoder layers overwrite that region in
+        place (residual stream). Without this, the second call on the
+        same pipeline would feed the encoder its own previous output
+        instead of fresh language tokens.
+        """
+        self._copy_lang_embeds_to_encoder_x(stream=stream)
+        self.vision_encoder(stream)
+        self.transformer_encoder(stream)
+        self.transformer_decoder(stream)
+
+    def calibrate_fp8(self) -> None:
+        """Run one forward pass with dynamic quantization to collect FP8 scales.
+
+        Dynamic quant writes scales directly into each layer's persistent
+        scale buffer (via ``_fp8_gemm``), so flipping ``fp8_calibrated =
+        True`` afterwards enables the static-scale fused kernels with zero
+        further work.
+        """
+        if not self.use_fp8 or self.fp8_calibrated:
+            return
+
+        if len(self.fp8_act_scales) > 0:
+            self.fp8_calibrated = True
+            logger.info("FP8 reuse-from-forward: %d scales already populated",
+                        len(self.fp8_act_scales))
+            return
+
+        # Dynamic calibration pass (writes scales into fp8_act_scales as a
+        # side effect of _fp8_gemm's non-calibrated code path).
+        self.fp8_calibrated = False
+        self.run_pipeline(stream=0)
+        self._hip.hipDeviceSynchronize()
+        self.fp8_calibrated = True
+        logger.info("FP8 calibrated: %d activation scales collected",
+                    len(self.fp8_act_scales))
+
+    def autotune_gemms(self) -> None:
+        """Benchmark GEMM algorithms for each shape and cache the best.
+
+        Call after ``calibrate_fp8()`` and before ``record_infer_graph()``.
+        Idempotent: a pipeline's GEMM shapes are fixed, so once tuned, repeat
+        calls return immediately (the frontend tunes before capture and
+        record_infer_graph tunes again — without this guard that ran twice).
+        """
+        if self._gemms_autotuned:
+            return
+        B = self.bufs
+        W = self.weights
+        gemm = self.gemm
+        vs = self.vision_seq
+        seq = self.encoder_seq_len
+        ds = self.chunk_size
+
+        logger.info("Autotuning GEMM algorithms...")
+
+        # Vision patch embedding (BF16)
+        gemm.autotune_bf16_nn(
+            B["vision_patches"].ptr.value,
+            W["vision_patch_embedding_w"],
+            B["vision_x"].ptr.value,
+            vs, VIS_D, VIS_PATCH_FLAT)
+
+        # Vision BF16 attention + FFN shapes (when FP8 is disabled).
+        # Autotuning picks the best algorithm for each shape; all 27
+        # layers share these 5 shapes so one autotune run covers the
+        # entire SigLIP stack. Output buffers must be large enough for
+        # each shape's output.
+        if not self.use_fp8:
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in [
+                (vs, 3 * VIS_D, VIS_D, "vision_x_norm", "vision_QKV",
+                 W["vision_attn_qkv_w"][0]),
+                (vs, VIS_D,     VIS_D, "vision_x_norm", "vision_x_norm",
+                 W["vision_attn_o_w"][0]),
+                (vs, VIS_H,     VIS_D, "vision_x_norm", "vision_hidden",
+                 W["vision_ffn_up_w"][0]),
+                (vs, VIS_D,     VIS_H, "vision_hidden",  "vision_x_norm",
+                 W["vision_ffn_down_w"][0]),
+                (self.vision_seq_enc, ENC_D, VIS_D, "vision_x_norm", "encoder_x",
+                 W["encoder_multi_modal_projector_w"]),
+            ]:
+                gemm.autotune_bf16_nn(
+                    B[act_key].ptr.value, weight_ptr,
+                    B[out_key].ptr.value,
+                    M_val, N_val, K_val)
+
+        # Vision FP8 shapes
+        if self.use_fp8 and self.fp8_calibrated and "vision_attn_qkv_w_0" in self.weights.get("fp8", {}):
+            for name_prefix, M_val, N_val, K_val, out_key in [
+                ("vision_attn_qkv_w_0", vs, 3 * VIS_D, VIS_D, "vision_QKV"),
+                ("vision_attn_o_w_0",   vs, VIS_D,     VIS_D, "vision_x_norm"),
+                ("vision_ffn_up_w_0",   vs, VIS_H,     VIS_D, "vision_hidden"),
+                ("vision_ffn_down_w_0", vs, VIS_D,     VIS_H, "vision_x_norm"),
+                ("vision_projector_w",  vs, ENC_D,     VIS_D, "encoder_x"),
+            ]:
+                w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
+                act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
+                act_buf_ptr, _ = self._pick_fp8_scratch(name_prefix, M_val * K_val)
+                self._autotune_fp8_matmul(
+                    act_buf_ptr, w_fp8_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+
+        # Encoder FP8 shapes
+        if self.use_fp8 and self.fp8_calibrated:
+            for name_prefix, M_val, N_val, K_val, out_key in [
+                ("encoder_attn_qkv_w_0",    seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D, "encoder_QKV"),
+                ("encoder_attn_o_w_0",      seq, ENC_D,      ENC_D, "encoder_x_norm"),
+                ("encoder_ffn_gate_up_w_0", seq, 2 * ENC_H,  ENC_D, "encoder_gate_merged"),
+                ("encoder_ffn_down_w_0",    seq, ENC_D,      ENC_H, "encoder_x_norm"),
+            ]:
+                w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
+                act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
+                act_buf_ptr, _ = self._pick_fp8_scratch(name_prefix, M_val * K_val)
+                self._autotune_fp8_matmul(
+                    act_buf_ptr, w_fp8_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+        # Plain encoder GEMMs fall back to BF16 when FP8 does not own the
+        # encoder matmuls.
+        elif not self.use_fp8:
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in [
+                (seq, (ENC_NH + 2 * ENC_NKV) * ENC_HD, ENC_D,
+                 "encoder_x_norm", "encoder_QKV",
+                 W["encoder_attn_qkv_w"][0]),
+                (seq, ENC_D, ENC_D,
+                 "encoder_x_norm", "encoder_x_norm",
+                 W["encoder_attn_o_w"][0]),
+                (seq, ENC_H, ENC_D,
+                 "encoder_x_norm", "encoder_gate_merged",
+                 W["encoder_ffn_gate_w"][0]),
+                (seq, ENC_H, ENC_D,
+                 "encoder_x_norm", "encoder_hidden",
+                 W["encoder_ffn_up_w"][0]),
+                (seq, ENC_D, ENC_H,
+                 "encoder_hidden", "encoder_x_norm",
+                 W["encoder_ffn_down_w"][0]),
+            ]:
+                gemm.autotune_bf16_nn(
+                    B[act_key].ptr.value, weight_ptr,
+                    B[out_key].ptr.value,
+                    M_val, N_val, K_val)
+
+        # Decoder FP8 shapes
+        if self.use_fp8 and self.use_fp8_decoder and self.fp8_calibrated:
+            for name_prefix, M_val, N_val, K_val, out_key in [
+                ("decoder_attn_qkv_w_0",    ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D, "decoder_QKV"),
+                ("decoder_attn_o_w_0",      ds, DEC_D,     DEC_NH * DEC_HD, "x_normed_buf"),
+                ("decoder_ffn_gate_up_w_0", ds, 2 * DEC_H, DEC_D, "decoder_gate_merged"),
+                ("decoder_ffn_down_w_0",    ds, DEC_D,     DEC_H, "x_normed_buf"),
+            ]:
+                w_fp8_ptr, w_scale_ptr = self._weight_fp8(name_prefix)
+                act_scale_ptr = self.fp8_act_scales[name_prefix].ptr.value
+                act_buf_ptr, _ = self._pick_fp8_scratch(name_prefix, M_val * K_val)
+                self._autotune_fp8_matmul(
+                    act_buf_ptr, w_fp8_ptr, B[out_key].ptr.value,
+                    M_val, N_val, K_val, act_scale_ptr, w_scale_ptr)
+        # Plain decoder GEMMs fall back to BF16 when FP8 does not own the
+        # decoder matmuls.
+        elif not self.use_fp8_decoder:
+            # BF16 decoder shapes dominate baseline runtime. Tune them
+            # explicitly before graph capture instead of relying on the
+            # heuristic top-1 selected at first use.
+            decoder_shapes = [
+                (ds, DEC_D, ACTION_DIM,
+                 "diffusion_noise", "decoder_x",
+                 W["decoder_action_in_proj_w"]),
+                (ds, (DEC_NH + 2 * DEC_NKV) * DEC_HD, DEC_D,
+                 "x_normed_buf", "decoder_QKV",
+                 W["decoder_attn_qkv_w"][0]),
+                (ds, DEC_D, DEC_NH * DEC_HD,
+                 "decoder_QKV", "x_normed_buf",
+                 W["decoder_attn_o_w"][0]),
+                (ds, DEC_H, DEC_D,
+                 "x_normed_buf", "decoder_gate_merged",
+                 W["decoder_ffn_gate_w"][0]),
+                (ds, DEC_H, DEC_D,
+                 "x_normed_buf", "decoder_hidden",
+                 W["decoder_ffn_up_w"][0]),
+                (ds, DEC_D, DEC_H,
+                 "decoder_hidden", "x_normed_buf",
+                 W["decoder_ffn_down_w"][0]),
+                (ds, ACTION_DIM, DEC_D,
+                 "x_normed_buf", "decoder_action_buf",
+                 W["decoder_action_out_proj_w"]),
+            ]
+            for M_val, N_val, K_val, act_key, out_key, weight_ptr in decoder_shapes:
+                gemm.autotune_bf16_nn(
+                    B[act_key].ptr.value, weight_ptr,
+                    B[out_key].ptr.value,
+                    M_val, N_val, K_val)
+
+        self._hip.hipDeviceSynchronize()
+        self._gemms_autotuned = True
+        logger.info("Autotune complete")
+
+    def record_infer_graph(self, external_stream_int: int | None = None) -> None:
+        """Capture the full pipeline as a HIP Graph.
+
+        Because the attention backend may run framework-specific kernels
+        (torch sdpa on the interim CDNA4 backend), HIP graph capture must
+        use a stream that the backend's framework treats as "current" —
+        otherwise the backend's kernels will launch on the framework's
+        default stream, creating a cross-stream dependency that
+        ``hipStreamBeginCapture`` refuses to record.
+
+        Frontends that use a framework-aware attention backend should pass
+        ``external_stream_int`` (the raw ``hipStream_t`` int handle of a
+        framework-owned stream) and wrap the call in their framework's
+        "current stream" context. For example, the torch frontend does::
+
+            torch_stream = torch.cuda.Stream()
+            with torch.cuda.stream(torch_stream):
+                pipeline.record_infer_graph(
+                    external_stream_int=torch_stream.cuda_stream)
+
+        If ``external_stream_int`` is ``None``, a raw HIP stream is created
+        and used directly (this works only with pure-C attention backends).
+        """
+        if self.use_fp8 and not self.fp8_calibrated:
+            self.calibrate_fp8()
+        self.autotune_gemms()
+
+        self._graph = HipGraph()
+        if external_stream_int is None:
+            stream = self._graph.create_stream()
+            stream_int = stream.value or 0
+            stream_handle = stream
+        else:
+            stream_int = int(external_stream_int)
+            stream_handle = ctypes.c_void_p(stream_int)
+        self._graph_stream = stream_handle
+
+        # Warmup on the capture stream to stabilize allocations
+        for _ in range(3):
+            self.run_pipeline(stream=stream_int)
+        self._hip.hipStreamSynchronize(stream_handle)
+
+        # Capture full pipeline
+        self._graph.begin_capture(stream_handle)
+        self.run_pipeline(stream=stream_int)
+        self._graph.end_capture(stream_handle)
+        self._hip.hipStreamSynchronize(stream_handle)
+        logger.info("HIP Graph captured for Pi05Pipeline")
+
+        # Also capture a decoder-only graph for temporal K/V caching.
+        # This graph skips vision_encoder + transformer_encoder and runs only
+        # transformer_decoder, reusing the K/V cache from the last full forward.
+        # The language embeds and encoder K/V buffers are left intact.
+        self._decoder_only_graph = HipGraph()
+        for _ in range(3):
+            self.transformer_decoder(stream=stream_int)
+        self._hip.hipStreamSynchronize(stream_handle)
+        self._decoder_only_graph.begin_capture(stream_handle)
+        self.transformer_decoder(stream=stream_int)
+        self._decoder_only_graph.end_capture(stream_handle)
+        self._hip.hipStreamSynchronize(stream_handle)
+        logger.info("HIP Graph captured for Pi05Pipeline (decoder-only)")
+
+    # ══════════════════════════════════════════════════════════════════
+    #   Public API
+    # ══════════════════════════════════════════════════════════════════
+
+    # ── Input buffer handles (frontend writes to these) ──
+
+    @property
+    def input_images_buf(self) -> HipBuffer:
+        """Pipeline input: observation images (num_views, 224, 224, 3) bf16."""
+        return self.bufs["observation_images_normalized"]
+
+    @property
+    def input_noise_buf(self) -> HipBuffer:
+        """Pipeline input/output: diffusion noise (chunk_size, 32) bf16.
+
+        Frontend writes initial noise here before :meth:`forward`; reads
+        final actions from here after.
+        """
+        return self.bufs["diffusion_noise"]
+
+    @property
+    def input_rtc_prev_action_chunk_buf(self) -> HipBuffer:
+        """Optional RTC-prefix input: previous raw action chunk (chunk, 32)."""
+        return self.bufs["rtc_prev_action_chunk"]
+
+    @property
+    def input_rtc_prefix_weights_buf(self) -> HipBuffer:
+        """Optional RTC VJP input: per-action prefix weights (chunk,)."""
+        return self.bufs["rtc_prefix_weights"]
+
+    @property
+    def input_rtc_guidance_weight_buf(self) -> HipBuffer:
+        """Optional RTC VJP input: scalar maximum guidance weight."""
+        return self.bufs["rtc_guidance_weight"]
+
+    @property
+    def input_encoder_x_buf(self) -> HipBuffer:
+        """Pipeline input: encoder_x, with language embeds at [vs:vs+len]."""
+        return self.bufs["encoder_x"]
+
+    def set_language_embeds(self, lang_embeds_np) -> None:
+        """Store language embeddings for this prompt.
+
+        The embeds are kept as a persistent device-side copy and are
+        re-copied into ``encoder_x[vs:vs+prompt_len]`` at the start of
+        every :meth:`forward` call, because the encoder layers overwrite
+        that slot in-place during each pass (transformer residual stream).
+
+        ``lang_embeds_np`` is a numpy array of shape ``(prompt_len, ENC_D)``
+        with 2-byte (bf16) elements.
+        """
+        prompt_len = lang_embeds_np.shape[0]
+        assert prompt_len <= self.max_prompt_len, \
+            f"prompt_len {prompt_len} exceeds max_prompt_len {self.max_prompt_len}"
+        assert lang_embeds_np.shape[1] == ENC_D
+
+        if self._fixed_shape and prompt_len < self.max_prompt_len:
+            # Pad to max with zeros so the in-graph embeds copy is a fixed
+            # MAX-row copy; the padded prompt rows are masked (seqused) in
+            # attention, so they never affect the valid output.
+            padded = np.zeros((self.max_prompt_len, ENC_D),
+                              dtype=lang_embeds_np.dtype)
+            padded[:prompt_len] = lang_embeds_np
+            lang_embeds_np = padded
+
+        # Store a persistent device copy of the (prompt_len, ENC_D) embeds.
+        # HIP Graph capture bakes the source pointer used by
+        # _copy_lang_embeds_to_encoder_x(), so same-shape prompt updates must
+        # upload into the existing buffer instead of replacing it.
+        arr = np.ascontiguousarray(lang_embeds_np)
+        if (hasattr(self, "_lang_embeds_buf")
+                and self._lang_embeds_buf.nbytes == arr.nbytes):
+            self._lang_embeds_buf.upload(arr)
+        else:
+            self._lang_embeds_buf = HipBuffer.from_numpy(arr)
+        self._current_prompt_len = prompt_len
+
+        # Update decoder RoPE slice for this prompt length
+        self._set_decoder_rope_for_prompt(prompt_len)
+
+        # Fixed-shape: update the valid prefix length read by the attention
+        # key masks + the devpos K/V append offset. Runtime device buffers;
+        # no recapture.
+        if self._fixed_shape:
+            self.attn.set_fixed_valid_len(self.vision_seq_enc + prompt_len)
+
+        # Initial copy into encoder_x (so the FIRST calibration pass sees
+        # the correct lang embeds without needing a prior forward() call).
+        self._copy_lang_embeds_to_encoder_x()
+
+    def _copy_lang_embeds_to_encoder_x(self, stream: int = 0) -> None:
+        """D2D copy stored lang embeds into encoder_x[vs:vs+prompt_len]."""
+        if not hasattr(self, "_lang_embeds_buf"):
+            return  # set_language_embeds not called yet (first build)
+        start_byte = self.vision_seq_enc * ENC_D * 2  # language embeds follow pooled vision tokens
+        dst_ptr = self.bufs["encoder_x"].ptr.value + start_byte
+        self._hip.hipMemcpyAsync(
+            ctypes.c_void_p(dst_ptr),
+            self._lang_embeds_buf.ptr,
+            self._lang_embeds_buf.nbytes, 3, stream)  # D2D
+
+    def forward(self) -> int:
+        """Replay the captured graph (or fall back to ``run_pipeline``).
+
+        The frontend must have already written the inputs:
+            - ``input_images_buf``       (observation images)
+            - ``input_noise_buf``        (initial diffusion noise)
+            - language embeds via :meth:`set_language_embeds` (once per prompt)
+
+        After this returns, ``input_noise_buf`` contains the final actions.
+        Returns the device pointer of that buffer for the frontend to read.
+        """
+        if self._graph is not None:
+            self._graph.replay(self._graph_stream)
+            self._hip.hipStreamSynchronize(self._graph_stream)
+        else:
+            self.run_pipeline(stream=0)
+            self._hip.hipDeviceSynchronize()
+        return self.bufs["diffusion_noise"].ptr.value
+
+    def forward_decode_only(self) -> int:
+        """Replay the decoder-only graph for temporal K/V caching.
+
+        Skips vision_encoder + transformer_encoder and runs only
+        transformer_decoder, reusing the encoder K/V cache from the last
+        full :meth:`forward` call. The frontend must write fresh noise into
+        ``input_noise_buf`` before calling this.
+
+        Returns the device pointer of ``diffusion_noise`` (final actions).
+        """
+        if hasattr(self, "_decoder_only_graph") and self._decoder_only_graph is not None:
+            self._decoder_only_graph.replay(self._graph_stream)
+            self._hip.hipStreamSynchronize(self._graph_stream)
+        else:
+            self.transformer_decoder(stream=0)
+            self._hip.hipDeviceSynchronize()
+        return self.bufs["diffusion_noise"].ptr.value

--- a/flash_rt/amd/models/pi05/pipeline.py
+++ b/flash_rt/amd/models/pi05/pipeline.py
@@ -259,6 +259,9 @@ class Pi05Pipeline:
         # FP8 activation scratch buffers + per-layer static scales
         self.fp8_act_scales = {}  # name -> HipBuffer(1, fp32)
         self.fp8_calibrated = False
+        # Fused decoder attn->FP8 epilogue: armed once post-calibration by
+        # _arm_decoder_attn_fp8out() (see there for the env gate).
+        self._dec_attn_fp8out_armed = False
         # Set once autotune_gemms() has benchmarked this pipeline's (fixed) GEMM
         # shapes, so repeat calls (frontend + record_infer_graph) are no-ops.
         self._gemms_autotuned = False
@@ -1099,6 +1102,12 @@ class Pi05Pipeline:
         try:
             for step in range(self.num_steps):
                 self._fp8_current_decoder_step = step
+                if self._dec_attn_fp8out_armed:
+                    # Host-side scale-row selector: the fp8out epilogue must
+                    # use the SAME per-(step, layer) o-proj static scale ptr
+                    # the quantize path uses; frozen into the graph at
+                    # capture like every other per-launch pointer.
+                    self.attn.set_decoder_fp8out_step(step)
                 self._copy_rtc_prefix(rtc_prefix_len, stream)
                 # C0: Action input projection: noise (ds, 32) → decoder_x (ds, 1024)
                 gemm.bf16_nn(
@@ -1213,11 +1222,32 @@ class Pi05Pipeline:
             stream=stream,
         )
 
-        # C4: Attn output projection
-        if self.use_fp8_decoder:
+        # C4: Attn output projection.
+        # When the fused decoder attn->FP8 epilogue is armed (see
+        # _arm_decoder_attn_fp8out), the attention kernel already emitted
+        # the o-proj activation's fp8 bytes with the SAME static scale
+        # pointer _fp8_gemm would use — consume them directly and skip the
+        # standalone quantize launch (~180/inference). Bit-equal numerics.
+        o_name = f"decoder_attn_o_w_{i}"
+        fp8out = None
+        if fused and self._dec_attn_fp8out_armed:
+            get_fp8out = getattr(self.attn, "get_decoder_fp8out_ptr", None)
+            fp8out = get_fp8out() if get_fp8out is not None else None
+        if fp8out is not None:
+            fp8_ptr, act_scale_ptr = fp8out
+            # The epilogue and the quantize path must share one scale
+            # pointer, or the fp8 bytes would differ from today's path.
+            assert act_scale_ptr == self._fp8_static_scale_ptr(o_name), (
+                f"decoder fp8out scale ptr mismatch at layer {i} step "
+                f"{self._fp8_current_decoder_step}")
+            self._fp8_gemm_fused(
+                fp8_ptr, o_name,
+                B["x_normed_buf"].ptr.value,
+                ds, DEC_D, DEC_NH * DEC_HD, act_scale_ptr, stream)
+        elif self.use_fp8_decoder:
             self._fp8_gemm(
                 dec_o_ptr, ds * DEC_NH * DEC_HD,
-                f"decoder_attn_o_w_{i}",
+                o_name,
                 B["x_normed_buf"].ptr.value,
                 ds, DEC_D, DEC_NH * DEC_HD, stream)
         else:
@@ -1358,6 +1388,62 @@ class Pi05Pipeline:
         self.fp8_calibrated = True
         logger.info("FP8 calibrated: %d activation scales collected",
                     len(self.fp8_act_scales))
+
+    def _arm_decoder_attn_fp8out(self) -> None:
+        """Arm the fused decoder attention -> FP8 epilogue (capture prep).
+
+        Post-calibration, the decoder attn-output -> o-proj site quantizes
+        the attention output with the layer's (per-step) STATIC scale
+        before the FP8 GEMM. The custom decoder attention kernel can emit
+        those exact fp8 bytes as an in-kernel epilogue instead
+        (attention_decoder_gqa_fp8out), removing ~180 standalone
+        quantize_fp8_static launches per inference with bit-equal numerics
+        (same scale pointers, same conversion math).
+
+        Called once from :meth:`record_infer_graph` after
+        ``calibrate_fp8()`` — the point where the static scales are final.
+        Arms the backend with the per-(step, layer) o-proj static-scale
+        device pointers; :meth:`transformer_decoder` selects the step row
+        (host-side) so each captured attention launch freezes the same
+        scale pointer the o-proj quantize would use.
+
+        Env gate: ``FVK_AMD_ATTN_FP8OUT=0`` disables arming entirely, in
+        which case pipeline behavior is IDENTICAL to the pre-fusion path
+        (split attention + standalone quantize). Default is ON
+        post-calibration.
+        """
+        if self._dec_attn_fp8out_armed:
+            return
+        if not (self.use_fp8 and self.use_fp8_decoder and self.fp8_calibrated):
+            return
+        if os.environ.get("FVK_AMD_ATTN_FP8OUT", "1").strip().lower() in (
+                "0", "off", "false"):
+            logger.info("Decoder attn FP8-out epilogue disabled "
+                        "(FVK_AMD_ATTN_FP8OUT=0)")
+            return
+        supported = getattr(self.attn, "decoder_fp8out_supported", None)
+        if supported is None or not supported():
+            return
+        scale_ptrs = []
+        for step in range(self.num_steps):
+            row = []
+            for i in range(DEC_L):
+                name = f"decoder_attn_o_w_{i}"
+                buf = (self.fp8_act_scales.get(f"{name}__step_{step}")
+                       or self.fp8_act_scales.get(name))
+                if buf is None:
+                    logger.warning(
+                        "Decoder attn FP8-out: scale for %s missing — "
+                        "leaving epilogue disarmed", name)
+                    return
+                row.append(buf.ptr.value)
+            scale_ptrs.append(row)
+        self.attn.set_decoder_fp8out(scale_ptrs)
+        self._dec_attn_fp8out_armed = True
+        logger.info(
+            "Decoder attn FP8-out epilogue armed: %d steps x %d layers "
+            "(standalone o-proj quantize launches eliminated)",
+            self.num_steps, DEC_L)
 
     def autotune_gemms(self) -> None:
         """Benchmark GEMM algorithms for each shape and cache the best.
@@ -1542,6 +1628,10 @@ class Pi05Pipeline:
         if self.use_fp8 and not self.fp8_calibrated:
             self.calibrate_fp8()
         self.autotune_gemms()
+        # Scales are final now — arm the fused decoder attn->FP8 epilogue
+        # so warmup and capture both take the fused route (see helper for
+        # the FVK_AMD_ATTN_FP8OUT env gate).
+        self._arm_decoder_attn_fp8out()
 
         self._graph = HipGraph()
         if external_stream_int is None:

--- a/flash_rt/amd/models/pi05/pipeline.py
+++ b/flash_rt/amd/models/pi05/pipeline.py
@@ -283,8 +283,11 @@ class Pi05Pipeline:
         self._graph = None
         self._decoder_only_graph = None  # for temporal K/V caching
         self._graph_stream = None  # ctypes.c_void_p
-        from flash_rt.amd.core.hip_buffer import _hip
+        from flash_rt.amd.core.hip_buffer import _check, _hip
         self._hip = _hip
+        # Shared HIP return-code checker: every raw self._hip.* call must
+        # route its return through this (raises RuntimeError on failure).
+        self._hip_check = _check
 
         # Pre-expand vision position embedding across num_views (see
         # ``vision_encoder``'s patch embed path). We replicate the
@@ -454,11 +457,12 @@ class Pi05Pipeline:
         dst_buf = self.bufs["vision_pos_embed_expanded"]
         assert dst_buf.nbytes == self.num_views * per_view_nbytes
         for v in range(self.num_views):
-            self._hip.hipMemcpy(
+            self._hip_check(self._hip.hipMemcpy(
                 ctypes.c_void_p(dst_buf.ptr.value + v * per_view_nbytes),
                 ctypes.c_void_p(pos_src_ptr),
-                per_view_nbytes, 3)  # D2D
-        self._hip.hipDeviceSynchronize()
+                per_view_nbytes, 3), "hipMemcpy D2D")
+        self._hip_check(self._hip.hipDeviceSynchronize(),
+                        "hipDeviceSynchronize")
 
     # ══════════════════════════════════════════════════════════════════
     #   Helpers
@@ -1419,7 +1423,8 @@ class Pi05Pipeline:
         # side effect of _fp8_gemm's non-calibrated code path).
         self.fp8_calibrated = False
         self.run_pipeline(stream=0)
-        self._hip.hipDeviceSynchronize()
+        self._hip_check(self._hip.hipDeviceSynchronize(),
+                        "hipDeviceSynchronize")
         self.fp8_calibrated = True
         logger.info("FP8 calibrated: %d activation scales collected",
                     len(self.fp8_act_scales))
@@ -1633,7 +1638,8 @@ class Pi05Pipeline:
                     B[out_key].ptr.value,
                     M_val, N_val, K_val)
 
-        self._hip.hipDeviceSynchronize()
+        self._hip_check(self._hip.hipDeviceSynchronize(),
+                        "hipDeviceSynchronize")
         self._gemms_autotuned = True
         logger.info("Autotune complete")
 
@@ -1681,13 +1687,15 @@ class Pi05Pipeline:
         # Warmup on the capture stream to stabilize allocations
         for _ in range(3):
             self.run_pipeline(stream=stream_int)
-        self._hip.hipStreamSynchronize(stream_handle)
+        self._hip_check(self._hip.hipStreamSynchronize(stream_handle),
+                        "hipStreamSynchronize")
 
         # Capture full pipeline
         self._graph.begin_capture(stream_handle)
         self.run_pipeline(stream=stream_int)
         self._graph.end_capture(stream_handle)
-        self._hip.hipStreamSynchronize(stream_handle)
+        self._hip_check(self._hip.hipStreamSynchronize(stream_handle),
+                        "hipStreamSynchronize")
         logger.info("HIP Graph captured for Pi05Pipeline")
 
         # Also capture a decoder-only graph for temporal K/V caching.
@@ -1697,11 +1705,13 @@ class Pi05Pipeline:
         self._decoder_only_graph = HipGraph()
         for _ in range(3):
             self.transformer_decoder(stream=stream_int)
-        self._hip.hipStreamSynchronize(stream_handle)
+        self._hip_check(self._hip.hipStreamSynchronize(stream_handle),
+                        "hipStreamSynchronize")
         self._decoder_only_graph.begin_capture(stream_handle)
         self.transformer_decoder(stream=stream_int)
         self._decoder_only_graph.end_capture(stream_handle)
-        self._hip.hipStreamSynchronize(stream_handle)
+        self._hip_check(self._hip.hipStreamSynchronize(stream_handle),
+                        "hipStreamSynchronize")
         logger.info("HIP Graph captured for Pi05Pipeline (decoder-only)")
 
     # ══════════════════════════════════════════════════════════════════
@@ -1800,10 +1810,10 @@ class Pi05Pipeline:
             return  # set_language_embeds not called yet (first build)
         start_byte = self.vision_seq_enc * ENC_D * 2  # language embeds follow pooled vision tokens
         dst_ptr = self.bufs["encoder_x"].ptr.value + start_byte
-        self._hip.hipMemcpyAsync(
+        self._hip_check(self._hip.hipMemcpyAsync(
             ctypes.c_void_p(dst_ptr),
             self._lang_embeds_buf.ptr,
-            self._lang_embeds_buf.nbytes, 3, stream)  # D2D
+            self._lang_embeds_buf.nbytes, 3, stream), "hipMemcpyAsync D2D")
 
     def forward(self) -> int:
         """Replay the captured graph (or fall back to ``run_pipeline``).
@@ -1816,12 +1826,17 @@ class Pi05Pipeline:
         After this returns, ``input_noise_buf`` contains the final actions.
         Returns the device pointer of that buffer for the frontend to read.
         """
+        # replay() checks the hipGraphLaunch return; the sync below is
+        # checked too so a failed replay can never let the caller read a
+        # stale diffusion_noise buffer as real actions.
         if self._graph is not None:
             self._graph.replay(self._graph_stream)
-            self._hip.hipStreamSynchronize(self._graph_stream)
+            self._hip_check(self._hip.hipStreamSynchronize(self._graph_stream),
+                            "hipStreamSynchronize")
         else:
             self.run_pipeline(stream=0)
-            self._hip.hipDeviceSynchronize()
+            self._hip_check(self._hip.hipDeviceSynchronize(),
+                            "hipDeviceSynchronize")
         return self.bufs["diffusion_noise"].ptr.value
 
     def forward_decode_only(self) -> int:
@@ -1836,8 +1851,10 @@ class Pi05Pipeline:
         """
         if hasattr(self, "_decoder_only_graph") and self._decoder_only_graph is not None:
             self._decoder_only_graph.replay(self._graph_stream)
-            self._hip.hipStreamSynchronize(self._graph_stream)
+            self._hip_check(self._hip.hipStreamSynchronize(self._graph_stream),
+                            "hipStreamSynchronize")
         else:
             self.transformer_decoder(stream=0)
-            self._hip.hipDeviceSynchronize()
+            self._hip_check(self._hip.hipDeviceSynchronize(),
+                            "hipDeviceSynchronize")
         return self.bufs["diffusion_noise"].ptr.value

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -675,15 +675,29 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             "Qwen36MoeTextFrontend\n"
             "See docs/qwen36_moe_usage.md.")
 
+    from flash_rt.hardware import detect_arch, resolve_pipeline_class
+    arch = detect_arch() if hardware == "auto" else hardware
+
     # Refuse before the frontend import: a frontend that imports the
     # extension at module scope would otherwise fail as a bare
     # ModuleNotFoundError, which reads as a broken install rather than as
-    # a build the user still has to run.
-    from flash_rt import _extensions
-    _extensions.require(config=config)
-
-    from flash_rt.hardware import detect_arch, resolve_pipeline_class
-    arch = detect_arch() if hardware == "auto" else hardware
+    # a build the user still has to run. The AMD backend has its own
+    # self-contained module (the CUDA extensions are neither needed nor
+    # expected on a ROCm box).
+    if arch == "amd_cdna4":
+        try:
+            import flash_rt.amd.flash_rt_amd_kernels  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "flash_rt.amd.flash_rt_amd_kernels is not built (the "
+                "AMD/ROCm backend's core kernels). Build it with:\n"
+                "    bash scripts/amd/build_amd.sh gfx950\n"
+                "or: cmake -B build-amd -S csrc/amd -DGPU_ARCH=gfx950 && "
+                "cmake --build build-amd -j\n"
+                "See docs/deployment_amd.md.") from exc
+    else:
+        from flash_rt import _extensions
+        _extensions.require(config=config)
 
     if recalibrate:
         from flash_rt.core.quant.calibrator import clear_calibration

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -37,6 +37,7 @@ def detect_arch() -> str:
         ``"rtx_sm120"`` — RTX 5090 / DGX Spark GB10 Blackwell, SM120/SM121
         ``"rtx_sm89"``  — RTX 4090 / Ada, SM89 (cc 8.9)
         ``"rtx_sm87"``  — Jetson Orin via RTX consumer backend, SM87 (cc 8.7)
+        ``"amd_cdna4"`` — AMD Instinct MI350 series, ROCm (gfx950)
 
     Raises RuntimeError if CUDA is unavailable or the card has an
     unsupported SM level. Deliberately strict: silently falling back to
@@ -49,8 +50,17 @@ def detect_arch() -> str:
             "FlashRT requires PyTorch for GPU detection") from e
     if not torch.cuda.is_available():
         raise RuntimeError(
-            "FlashRT requires a CUDA-capable GPU "
+            "FlashRT requires a CUDA- or ROCm-capable GPU "
             "(torch.cuda.is_available()==False)")
+    if getattr(torch.version, "hip", None):
+        # ROCm build: route by the gfx architecture name, not the CUDA
+        # cc tuple (which ROCm fills with unrelated values).
+        gcn = torch.cuda.get_device_properties(0).gcnArchName
+        if gcn.split(":")[0] == "gfx950":
+            return "amd_cdna4"
+        raise RuntimeError(
+            f"FlashRT: unsupported ROCm GPU arch {gcn!r}. "
+            "Supported: gfx950 (MI350 series / CDNA4).")
     major, minor = torch.cuda.get_device_capability()
     if (major, minor) == (11, 0):
         return "thor"
@@ -79,6 +89,8 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
         ("flash_rt.frontends.torch.pi05_rtx", "Pi05TorchFrontendRtx"),
     ("pi05", "torch", "rtx_sm87"):
         ("flash_rt.frontends.torch.pi05_rtx", "Pi05TorchFrontendRtx"),
+    ("pi05", "torch", "amd_cdna4"):
+        ("flash_rt.amd.frontends.torch.pi05", "Pi05TorchFrontendAmd"),
     ("pi05", "torch", "rtx_sm89"):
         ("flash_rt.frontends.torch.pi05_rtx", "Pi05TorchFrontendRtx"),
     ("pi05", "jax", "thor"):

--- a/scripts/amd/build_amd.sh
+++ b/scripts/amd/build_amd.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build flash_rt_amd_kernels in a ROCm environment (GPU visible or not).
+#   bash scripts/amd/build_amd.sh [gfx950]
+#
+# Prefers CMake; falls back to a direct hipcc one-shot when no usable
+# cmake is present. Output: flash_rt/amd/flash_rt_amd_kernels*.so
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GPU_ARCH="${1:-gfx950}"
+PYTHON_BIN="${PYTHON:-python3}"
+JOBS="${SLURM_CPUS_PER_TASK:-8}"
+ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
+export PATH=${ROCM_PATH}/bin:${PATH}
+
+# pybind11 headers: use the interpreter's copy, else a one-time --target
+# install into FLASHRT_AMD_PYDEPS (never into a read-only/shared venv).
+if ! "${PYTHON_BIN}" -m pybind11 --includes >/dev/null 2>&1; then
+  PYDEPS="${FLASHRT_AMD_PYDEPS:-${ROOT}/.pydeps}"
+  if [[ ! -d "${PYDEPS}/pybind11" ]]; then
+    "${PYTHON_BIN}" -m pip install --target "${PYDEPS}" pybind11
+  fi
+  export PYTHONPATH="${PYDEPS}${PYTHONPATH:+:${PYTHONPATH}}"
+fi
+PYBIND_INCLUDES="$("${PYTHON_BIN}" -m pybind11 --includes)"
+EXT_SUFFIX="$("${PYTHON_BIN}" -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX") or ".so")')"
+
+mkdir -p "${ROOT}/flash_rt/amd"
+OUT="${ROOT}/flash_rt/amd/flash_rt_amd_kernels${EXT_SUFFIX}"
+
+if command -v cmake >/dev/null 2>&1 \
+   && cmake -B "${ROOT}/build-amd" -S "${ROOT}/csrc/amd" \
+        -DGPU_ARCH="${GPU_ARCH}" -DPython_EXECUTABLE="${PYTHON_BIN}" 2>&1; then
+  cmake --build "${ROOT}/build-amd" -j "${JOBS}"
+  echo "built via cmake: $(ls "${ROOT}"/flash_rt/amd/flash_rt_amd_kernels*.so)"
+else
+  echo "cmake unavailable or failed — falling back to direct hipcc"
+  hipcc -O3 -std=c++17 -fPIC -shared \
+    --offload-arch="${GPU_ARCH}" \
+    -ffp-contract=fast \
+    -DFLASHRT_AMD_GPU_ARCH="\"${GPU_ARCH}\"" \
+    ${PYBIND_INCLUDES} \
+    -I"${ROOT}/csrc/amd" \
+    -x hip "${ROOT}/csrc/amd/bindings.cpp" \
+    "${ROOT}/csrc/amd/kernels/norm.hip" \
+    -o "${OUT}"
+  echo "built via hipcc: ${OUT}"
+fi
+
+"${PYTHON_BIN}" - <<PY
+import sys; sys.path.insert(0, "${ROOT}")
+from flash_rt.amd import flash_rt_amd_kernels as k
+print("import ok:", dict(k.build_info()))
+PY

--- a/scripts/amd/build_amd.sh
+++ b/scripts/amd/build_amd.sh
@@ -42,7 +42,9 @@ else
     ${PYBIND_INCLUDES} \
     -I"${ROOT}/csrc/amd" \
     -x hip "${ROOT}/csrc/amd/bindings.cpp" \
-    "${ROOT}/csrc/amd/kernels/norm.hip" \
+    "${ROOT}/csrc/amd/kernels/"*.hip \
+    "${ROOT}/csrc/amd/gemm/"*.hip \
+    -L"${ROCM_PATH}/lib" -lhipblaslt \
     -o "${OUT}"
   echo "built via hipcc: ${OUT}"
 fi

--- a/scripts/amd/build_amd.sh
+++ b/scripts/amd/build_amd.sh
@@ -8,6 +8,18 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 GPU_ARCH="${1:-gfx950}"
+
+# This backend is gfx950-only (CDNA4 / MI350-series): the kernels use
+# gfx950 MFMA shapes and the runtime refuses to load on other arches, so
+# building for anything else produces a module that can never pass the
+# frontend's device gate. Set FLASHRT_AMD_ALLOW_ARCH=1 to bypass this
+# check when bringing up a port to a future arch.
+if [[ ! "${GPU_ARCH}" =~ ^gfx950 && "${FLASHRT_AMD_ALLOW_ARCH:-0}" != "1" ]]; then
+  echo "error: GPU_ARCH='${GPU_ARCH}' is not gfx950 — this backend is gfx950-only." >&2
+  echo "       Pass gfx950, or set FLASHRT_AMD_ALLOW_ARCH=1 to override for a port." >&2
+  exit 1
+fi
+
 PYTHON_BIN="${PYTHON:-python3}"
 JOBS="${SLURM_CPUS_PER_TASK:-8}"
 ROCM_PATH="${ROCM_PATH:-/opt/rocm}"

--- a/scripts/amd/build_amd.sh
+++ b/scripts/amd/build_amd.sh
@@ -43,6 +43,7 @@ else
     -I"${ROOT}/csrc/amd" \
     -x hip "${ROOT}/csrc/amd/bindings.cpp" \
     "${ROOT}/csrc/amd/kernels/"*.hip \
+    "${ROOT}/csrc/amd/attention/"*.hip \
     "${ROOT}/csrc/amd/gemm/"*.hip \
     -L"${ROCM_PATH}/lib" -lhipblaslt \
     -o "${OUT}"

--- a/scripts/amd/build_amd.sh
+++ b/scripts/amd/build_amd.sh
@@ -14,7 +14,10 @@ GPU_ARCH="${1:-gfx950}"
 # building for anything else produces a module that can never pass the
 # frontend's device gate. Set FLASHRT_AMD_ALLOW_ARCH=1 to bypass this
 # check when bringing up a port to a future arch.
-if [[ ! "${GPU_ARCH}" =~ ^gfx950 && "${FLASHRT_AMD_ALLOW_ARCH:-0}" != "1" ]]; then
+# Compare the base target only ("gfx950" from "gfx950:xnack-"); a
+# prefix match would also accept a future "gfx9500".
+GPU_ARCH_BASE="${GPU_ARCH%%:*}"
+if [[ "${GPU_ARCH_BASE}" != "gfx950" && "${FLASHRT_AMD_ALLOW_ARCH:-0}" != "1" ]]; then
   echo "error: GPU_ARCH='${GPU_ARCH}' is not gfx950 — this backend is gfx950-only." >&2
   echo "       Pass gfx950, or set FLASHRT_AMD_ALLOW_ARCH=1 to override for a port." >&2
   exit 1

--- a/tests/test_amd_arch_gate.py
+++ b/tests/test_amd_arch_gate.py
@@ -1,0 +1,94 @@
+"""The gfx950 gates must reject look-alike architectures.
+
+The AMD backend is gfx950-only: its MFMA tile shapes and FP8 paths
+compute wrong results — not a slow fallback — on other AMD targets. Two
+gates enforce that, and both used to compare with a prefix test, which
+would also accept a hypothetical ``gfx9500``. These tests pin the exact
+base-target comparison at both gates.
+
+The runtime gate is exercised through its comparison rule rather than by
+constructing a frontend (that needs a device, a built extension and a
+checkpoint); the build gate is exercised by running the script.
+"""
+import pathlib
+import re
+import subprocess
+
+import pytest
+
+_REPO = pathlib.Path(__file__).resolve().parents[1]
+_BUILD = _REPO / "scripts" / "amd" / "build_amd.sh"
+
+# (device_arch, build_arch, must_be_accepted)
+_ARCH_CASES = [
+    ("gfx950", "gfx950", True),
+    ("gfx950:sramecc+:xnack-", "gfx950", True),      # feature suffix is fine
+    ("gfx950", "gfx950:xnack-", True),
+    ("gfx9500", "gfx950", False),                    # prefix trap
+    ("gfx950", "gfx9500", False),                    # prefix trap, build side
+    ("gfx942", "gfx950", False),                     # CDNA3
+    ("gfx90a", "gfx950", False),
+    ("none", "gfx950", False),                       # device probe failed
+    ("gfx950", "unknown", False),                    # build stamp missing
+]
+
+
+def _accepted(device_arch: str, build_arch: str) -> bool:
+    """The frontends' gate rule, kept in one place for the test.
+
+    Mirrors ``flash_rt/amd/frontends/torch/pi05.py`` (and the GROOT
+    frontend on its branch): compare only the base target, so a feature
+    suffix passes and a longer look-alike name does not.
+    """
+    return (device_arch.split(":", 1)[0] == "gfx950"
+            and build_arch.split(":", 1)[0] == "gfx950")
+
+
+@pytest.mark.parametrize("device_arch,build_arch,accepted", _ARCH_CASES)
+def test_gate_rule_accepts_only_gfx950(device_arch, build_arch, accepted):
+    assert _accepted(device_arch, build_arch) is accepted
+
+
+@pytest.mark.parametrize("source", [
+    "flash_rt/amd/frontends/torch/pi05.py",
+    "flash_rt/amd/frontends/torch/groot_n17.py",
+])
+def test_frontend_gate_uses_base_target_comparison(source):
+    """Guard against a regression back to ``startswith("gfx950")``.
+
+    A prefix test silently admits ``gfx9500``; the frontends must split
+    the feature suffix off and compare the base target exactly.
+    """
+    path = _REPO / source
+    if not path.exists():
+        pytest.skip(f"{source} is not present on this branch")
+    text = path.read_text()
+    if "device_arch()" not in text:
+        pytest.skip(f"{source} does not carry an architecture gate")
+    assert 'split(":", 1)[0] == "gfx950"' in text, (
+        f"{source} must compare the base architecture target exactly")
+    assert not re.search(r'startswith\(\s*["\']gfx950["\']\s*\)', text), (
+        f"{source} still uses a prefix test, which accepts gfx9500")
+
+
+@pytest.mark.skipif(not _BUILD.exists(), reason="build script not present")
+@pytest.mark.parametrize("arch", ["gfx9500", "gfx942", "gfx90a", "sm_120"])
+def test_build_script_rejects_non_gfx950(arch):
+    """The build script must refuse a non-gfx950 target.
+
+    Building for another architecture yields a module that can never pass
+    the runtime gate, so failing at build time is the cheaper error.
+    """
+    proc = subprocess.run(["bash", str(_BUILD), arch],
+                          capture_output=True, text=True, timeout=120)
+    assert proc.returncode != 0, (
+        f"build script accepted GPU_ARCH={arch}")
+    assert "gfx950" in (proc.stderr + proc.stdout), (
+        "the rejection message should name the supported architecture")
+
+
+@pytest.mark.skipif(not _BUILD.exists(), reason="build script not present")
+def test_build_script_override_is_documented():
+    """The escape hatch for a future port must stay discoverable."""
+    text = _BUILD.read_text()
+    assert "FLASHRT_AMD_ALLOW_ARCH" in text

--- a/tests/test_amd_extension.py
+++ b/tests/test_amd_extension.py
@@ -1,0 +1,200 @@
+"""AMD extension (flash_rt_amd_kernels) — import surface + required symbols.
+
+Sync-fail-fast net for the compiled AMD module: the pi05 pipeline layer
+resolves these bindings lazily by name at run time, so a symbol dropped by
+a bindings.cpp / .inc edit (or by a partial build) would otherwise only
+surface as an AttributeError mid-graph-capture on an MI350X box. This file
+makes the whole bound surface a single loud collect-time-cheap assertion.
+
+The expected-name lists are written out explicitly (not derived from the
+module) and mirror, one to one:
+
+    csrc/amd/bindings.cpp                 (kernels, probes, memory ops)
+    csrc/amd/gemm/bindings_gemm.inc       (FvkContext + GemmRunner)
+    csrc/amd/gemm/bindings_smallm.inc     (hand-tuned small-M FP8 GEMM)
+    csrc/amd/gemm/bindings_ffn_fused.inc  (fused decoder-FFN pair)
+
+If a name is deliberately removed from the bindings, remove it here in the
+same commit — that is the point.
+
+Skip conditions: every test skips unless ``flash_rt.amd.flash_rt_amd_kernels``
+imports (the .so is built and libamdhip64 is loadable). Importing the module
+does NOT require a GPU; the on-ROCm coherence assertions additionally gate
+on a visible gfx device.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _import_ext():
+    """Import the compiled AMD module or skip with the reason."""
+    try:
+        return importlib.import_module("flash_rt.amd.flash_rt_amd_kernels")
+    except ImportError as exc:  # pragma: no cover - build/env dependent
+        pytest.skip(f"flash_rt_amd_kernels not importable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# build_info() / device_arch()
+# ---------------------------------------------------------------------------
+
+
+def test_build_info_reports_hip_platform():
+    """build_info is the first thing a bring-up session inspects; its
+    platform tag is the proof the AMD module (not a CUDA build) was
+    imported."""
+    m = _import_ext()
+    info = m.build_info()
+    assert info["platform"] == "hip"
+    # hipRuntimeGetVersion result; an int by binding contract. May be 0 if
+    # the runtime query failed, so only the type is asserted here.
+    assert isinstance(info["hip_runtime_version"], int)
+
+
+def test_build_info_gpu_arch_is_gfx950_when_stamped():
+    """FLASHRT_AMD_GPU_ARCH is stamped by csrc/amd/CMakeLists.txt at build
+    time; when present it must be the CDNA4 target this backend supports.
+    (Absent key = older build without the stamp; tolerated.)"""
+    m = _import_ext()
+    info = m.build_info()
+    if "gpu_arch" not in info:
+        pytest.skip("build lacks the FLASHRT_AMD_GPU_ARCH stamp")
+    assert str(info["gpu_arch"]).startswith("gfx950"), (
+        f"AMD module built for {info['gpu_arch']!r}, expected gfx950*")
+
+
+def test_device_arch_coherent_with_build():
+    """device_arch() queries the live device. On a gfx950 box it must agree
+    with the build target; with no visible device it answers the documented
+    sentinels instead of raising."""
+    m = _import_ext()
+    arch = m.device_arch()
+    assert isinstance(arch, str)
+    if arch in ("none", "unknown"):
+        pytest.skip(f"no usable HIP device (device_arch()={arch!r})")
+    assert arch.split(":")[0] == "gfx950", (
+        f"extension is gfx950-only but the visible device is {arch!r}")
+
+
+# ---------------------------------------------------------------------------
+# Required symbol surface
+# ---------------------------------------------------------------------------
+
+# csrc/amd/bindings.cpp — the pi05 kernel surface + probes.
+_REQUIRED_FUNCS = [
+    # introspection
+    "build_info", "device_arch",
+    # norm
+    "rms_norm", "rms_norm_fp16", "rms_norm_inplace", "layer_norm",
+    "ada_rms_norm_style",
+    # fused norm -> fp8
+    "rms_norm_fp8", "ada_rms_norm_style_fp8", "residual_add_rms_norm_fp8",
+    "bias_residual_layer_norm_bf16",
+    # vision helpers
+    "avg_pool_vision_tokens", "patch_im2col", "patch_embed_bias_pos",
+    # activation
+    "gate_geglu", "gelu_inplace", "bias_gelu_bf16_strict",
+    "gate_geglu_merged", "gate_geglu_merged_fp8",
+    # elementwise
+    "gate_mul_residual", "bias_residual", "residual_add", "add_bias_bf16",
+    # qkv split / rope
+    "qkv_split", "qkv_split_rope", "qkv_split_rope_devpos",
+    # attention
+    "attention_decoder_gqa", "attention_decoder_gqa_fp8out",
+    "encoder_attention_flash", "attn_partial_probe",
+    # fusion
+    "gate_residual_ada_norm_fp8", "gate_residual_ada_norm_fp8_ksum",
+    # quantize
+    "quantize_fp8_static", "quantize_fp8_device", "fp8_accumulate_scale_max",
+    # memory ops + probes
+    "gpu_copy", "stream_probe", "stream_probe_variants",
+    "ew_tune_quant", "ew_tune_norm", "ew_tune_rope", "ew_tune_variants",
+    # MFMA small-M FP8 GEMM (csrc/amd/gemm/smallm_mfma.h surface)
+    "smallm_mfma_nt", "smallm_mfma_nt_partial", "smallm_mfma_nt_packed",
+    "smallm_mfma_variants",
+]
+
+# csrc/amd/gemm/bindings_smallm.inc — weight-streaming small-M FP8 GEMM.
+_REQUIRED_FUNCS += [
+    "smallm_fp8_nn_ws_bytes",
+    "smallm_fp8_nn_dev", "smallm_fp8_nn_dev_alt",
+    "smallm_fp8_nt_dev", "smallm_fp8_nt_lds_dev",
+    "smallm_fp8_nt_lds_async_available", "smallm_fp8_nt_dev_alt",
+]
+
+# csrc/amd/gemm/bindings_ffn_fused.inc — fused decoder-FFN pair.
+_REQUIRED_FUNCS += [
+    "smallm_fp8_gateup_geglu", "smallm_fp8_gateup_geglu_alt",
+    "smallm_fp8_down_gateres", "smallm_fp8_down_gateres_alt",
+]
+
+# csrc/amd/gemm/bindings_gemm.inc — classes.
+_REQUIRED_CLASSES = ["FvkContext", "GemmRunner"]
+
+# GemmRunner methods the pi05 pipeline dispatches on by name.
+_REQUIRED_GEMM_METHODS = [
+    "bf16_run", "bf16_nn", "bf16_nn_bias", "bf16_nn_bias_gelu",
+    "fp8_nn_dev", "fp8_nt_dev", "mxfp4_nt_dev",
+    "autotune_bf16_nn", "autotune_fp8_nn_dev", "autotune_fp8_nt_dev",
+    "autotune_mxfp4_nt_dev",
+]
+
+
+def test_all_required_symbols_present():
+    """One shot, full inventory: report EVERY missing name, not the first."""
+    m = _import_ext()
+    missing = [n for n in _REQUIRED_FUNCS + _REQUIRED_CLASSES
+               if not hasattr(m, n)]
+    assert not missing, (
+        "flash_rt_amd_kernels is missing bound symbols "
+        f"(bindings.cpp / .inc drift or partial build): {missing}")
+
+
+def test_required_symbols_are_callable_or_types():
+    m = _import_ext()
+    for name in _REQUIRED_FUNCS:
+        if hasattr(m, name):  # missing ones already reported above
+            assert callable(getattr(m, name)), f"{name} bound but not callable"
+    for name in _REQUIRED_CLASSES:
+        if hasattr(m, name):
+            assert isinstance(getattr(m, name), type), f"{name} is not a class"
+
+
+def test_gemm_runner_method_surface():
+    """The pipeline calls these methods on a GemmRunner instance; a method
+    dropped from bindings_gemm.inc must fail here, not at capture time."""
+    m = _import_ext()
+    runner_cls = getattr(m, "GemmRunner", None)
+    if runner_cls is None:
+        pytest.skip("GemmRunner missing (reported by the inventory test)")
+    missing = [n for n in _REQUIRED_GEMM_METHODS if not hasattr(runner_cls, n)]
+    assert not missing, f"GemmRunner missing methods: {missing}"
+
+
+def test_fvk_context_exposes_handle_ptr():
+    """FvkContext.handle_ptr hands the hipBLASLt handle address to raw-ABI
+    call sites; it is a readonly property on the class."""
+    m = _import_ext()
+    ctx_cls = getattr(m, "FvkContext", None)
+    if ctx_cls is None:
+        pytest.skip("FvkContext missing (reported by the inventory test)")
+    assert hasattr(ctx_cls, "handle_ptr")
+
+
+def test_variant_enumerators_answer():
+    """The *_variants() enumerators are pure host-side introspection (no
+    kernel launch, no device memory): they must answer on any box that can
+    import the module, and their answers feed the tuning probes."""
+    m = _import_ext()
+    v = m.stream_probe_variants()
+    assert len(v) > 0 and all("name" in d for d in v)
+    fams = m.ew_tune_variants()
+    assert set(fams.keys()) == {"quant", "norm", "rope"}
+    assert all(len(fams[k]) > 0 for k in fams)
+    assert len(m.smallm_mfma_variants()) > 0
+    # smallm split-K workspace sizing is also pure host arithmetic.
+    assert m.smallm_fp8_nn_ws_bytes(10, 2048) > 0

--- a/tests/test_amd_hip_graph.py
+++ b/tests/test_amd_hip_graph.py
@@ -1,0 +1,244 @@
+"""AMD HIP runtime layer — HipBuffer roundtrips + HipGraph capture/replay.
+
+The AMD backend drives the GPU through two thin ctypes layers
+(flash_rt/amd/core/hip_buffer.py, hip_graph.py) instead of torch: a wrong
+ctypes signature (the historical c_int pointer-truncation incident), a
+broken memcpy-kind constant, or a capture-mode drift would corrupt every
+tensor the pipeline moves, so this file gates the raw layer directly:
+
+  * upload/download roundtrips are byte-exact on PATTERN data — never
+    zeros, which memset bugs and DRAM compression both fake out — for
+    both managed and device memory, and for buffers > 2 GiB-safe sizes;
+  * HipGraph capture → instantiate → replay of a real two-kernel chain
+    (rms_norm_fp16 x2 from the built extension) runs, and N replays are
+    BIT-IDENTICAL (downloaded bytes compared exactly) — the pi05 E2E
+    latency story is 100% graph replay, so replay determinism is the
+    foundation everything above stands on;
+  * a replay observes live input-buffer contents (upload → replay →
+    output moves and tracks a host reference), proving the graph
+    captured pointers, not values.
+
+Skip conditions: needs the built extension AND a visible gfx950 device
+(probed via the extension's device_arch(), no torch dependency). On
+NVIDIA/no-ROCm CI everything skips at the first fixture with a reason;
+imports of the ctypes layers happen inside fixtures because the module
+import itself dlopens libamdhip64.so.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+
+def _rocm_device_or_skip():
+    """Return the extension module, skipping unless a HIP device answers."""
+    try:
+        ext = importlib.import_module("flash_rt.amd.flash_rt_amd_kernels")
+    except ImportError as exc:
+        pytest.skip(f"flash_rt_amd_kernels not importable: {exc}")
+    arch = ext.device_arch()
+    if arch in ("none", "unknown"):
+        pytest.skip(f"no usable HIP device (device_arch()={arch!r})")
+    return ext
+
+
+@pytest.fixture(scope="module")
+def ext():
+    return _rocm_device_or_skip()
+
+
+@pytest.fixture(scope="module")
+def hip_core(ext):
+    """The ctypes layers — imported lazily (module import dlopens HIP)."""
+    from flash_rt.amd.core import hip_buffer, hip_graph
+    return hip_buffer, hip_graph
+
+
+def _pattern_bytes(n: int) -> np.ndarray:
+    """Deterministic non-constant byte pattern. Zeros are forbidden here:
+    a memset-zero buffer hides both stuck-at-zero copy bugs and DRAM
+    compression effects (see the bench-buffer discipline)."""
+    return ((np.arange(n, dtype=np.int64) * 37 + 11) % 251).astype(np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# HipBuffer roundtrips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("managed", [True, False],
+                         ids=["managed", "device"])
+def test_hipbuffer_upload_download_roundtrip(hip_core, managed):
+    hip_buffer, _ = hip_core
+    src = _pattern_bytes(1 << 20)  # 1 MiB, non-trivial but fast
+    buf = hip_buffer.HipBuffer(src.nbytes, managed=managed)
+    buf.upload(src)
+    out = np.zeros_like(src)
+    buf.download(out)
+    assert np.array_equal(out, src), "byte roundtrip corrupted data"
+
+
+def test_hipbuffer_from_numpy_roundtrip(hip_core):
+    """from_numpy (device mem, H2D memcpy) and from_numpy_managed (memmove)
+    must both reproduce float payloads exactly."""
+    hip_buffer, _ = hip_core
+    rng = np.random.RandomState(0)
+    src = rng.randn(4096).astype(np.float32)
+
+    dev = hip_buffer.HipBuffer.from_numpy(src)
+    got_dev = dev.download_new(src.shape, src.dtype)
+    assert np.array_equal(got_dev, src)
+
+    man = hip_buffer.HipBuffer.from_numpy_managed(src)
+    got_man = man.download_new(src.shape, src.dtype)
+    assert np.array_equal(got_man, src)
+
+
+def test_hipbuffer_zero_(hip_core):
+    """zero_ must clear a previously pattern-filled buffer (checked against
+    the pattern so a no-op memset cannot pass)."""
+    hip_buffer, _ = hip_core
+    src = _pattern_bytes(65536)
+    buf = hip_buffer.HipBuffer.from_numpy(src)
+    buf.zero_()
+    out = np.empty_like(src)
+    buf.download(out)
+    assert not np.array_equal(out, src)
+    assert np.all(out == 0)
+
+
+# ---------------------------------------------------------------------------
+# HipGraph capture / replay
+# ---------------------------------------------------------------------------
+
+_SEQ, _DIM = 8, 256   # rms_norm_fp16 needs dim even (packed-pair kernel)
+_EPS = 1e-6
+
+
+def _rms_ref_fp16(x: np.ndarray, w: np.ndarray) -> np.ndarray:
+    """Host reference for rms_norm_fp16 (fp32 math, fp16 store — same
+    structure as the kernel; reduction order may differ by last-ULP)."""
+    xf = x.astype(np.float32)
+    rms = 1.0 / np.sqrt((xf * xf).mean(axis=-1, keepdims=True) + _EPS)
+    return (xf * rms * w.astype(np.float32)).astype(np.float16)
+
+
+@pytest.fixture()
+def graph_setup(ext, hip_core):
+    """Buffers + captured two-kernel graph: x --rms(w1)--> y --rms(w2)--> z."""
+    hip_buffer, hip_graph = hip_core
+    rng = np.random.RandomState(42)
+    x = rng.randn(_SEQ, _DIM).astype(np.float16)
+    w1 = (1.0 + 0.1 * rng.randn(_DIM)).astype(np.float16)
+    w2 = (1.0 + 0.1 * rng.randn(_DIM)).astype(np.float16)
+
+    x_buf = hip_buffer.HipBuffer.from_numpy(x)
+    w1_buf = hip_buffer.HipBuffer.from_numpy(w1)
+    w2_buf = hip_buffer.HipBuffer.from_numpy(w2)
+    y_buf = hip_buffer.HipBuffer.device_zeros(_SEQ * _DIM, np.float16)
+    z_buf = hip_buffer.HipBuffer.device_zeros(_SEQ * _DIM, np.float16)
+
+    graph = hip_graph.HipGraph()
+    stream = graph.create_stream()
+    s = stream.value
+
+    def chain():
+        # named-variable ptrs (buffers held by the closure — no temp GC)
+        ext.rms_norm_fp16(x_buf.ptr.value, w1_buf.ptr.value, y_buf.ptr.value,
+                          _SEQ, _DIM, _EPS, s)
+        ext.rms_norm_fp16(y_buf.ptr.value, w2_buf.ptr.value, z_buf.ptr.value,
+                          _SEQ, _DIM, _EPS, s)
+
+    # Warmup outside capture (module loading / first-launch work must not
+    # land inside the graph), then capture on the SAME stream — the
+    # capture-stream discipline is the historical trap this pins.
+    chain()
+    graph.sync(stream)
+    graph.begin_capture(stream)
+    chain()
+    graph.end_capture(stream)
+
+    return {
+        "graph": graph, "stream": stream,
+        "x": x, "w1": w1, "w2": w2,
+        "x_buf": x_buf, "w1_buf": w1_buf, "w2_buf": w2_buf,
+        "y_buf": y_buf, "z_buf": z_buf,
+    }
+
+
+def test_graph_capture_and_replay_matches_reference(graph_setup):
+    g = graph_setup
+    graph, stream = g["graph"], g["stream"]
+    assert graph.captured
+
+    graph.replay(stream)
+    graph.sync(stream)
+    z = g["z_buf"].download_new((_SEQ, _DIM), np.float16)
+
+    ref = _rms_ref_fp16(_rms_ref_fp16(g["x"], g["w1"]), g["w2"])
+    # Tolerance: only the fp32 reduction order differs between kernel and
+    # host reference; through two chained norms that is a few fp16 ULPs.
+    # 1e-2 absolute on unit-scale data catches any real math/indexing bug
+    # (a wrong weight or a shifted row is O(1) wrong) without flaking.
+    assert np.isfinite(z).all()
+    np.testing.assert_allclose(z.astype(np.float32), ref.astype(np.float32),
+                               atol=1e-2)
+
+
+def test_graph_replays_are_bit_identical(graph_setup):
+    """N replays with frozen inputs must produce byte-for-byte identical
+    output. The pi05 serving loop IS graph replay; nondeterminism here
+    (an atomic reduction, an uninitialized workspace read) would poison
+    every parity number measured above this layer."""
+    g = graph_setup
+    graph, stream = g["graph"], g["stream"]
+
+    downloads = []
+    for _ in range(5):
+        graph.replay(stream)
+        graph.sync(stream)
+        z = g["z_buf"].download_new((_SEQ, _DIM), np.float16)
+        downloads.append(z.tobytes())
+    assert all(d == downloads[0] for d in downloads[1:]), (
+        "graph replay is not bit-stable across replays")
+
+
+def test_graph_replay_reads_live_input_buffers(graph_setup):
+    """The captured graph must be parameterized by buffer ADDRESSES: new
+    data uploaded into the input buffer must flow through the next replay
+    (this is exactly how the pipeline feeds fresh images/noise into the
+    captured pi05 graph)."""
+    g = graph_setup
+    graph, stream = g["graph"], g["stream"]
+
+    graph.replay(stream)
+    graph.sync(stream)
+    z_before = g["z_buf"].download_new((_SEQ, _DIM), np.float16)
+
+    rng = np.random.RandomState(7)
+    x_new = rng.randn(_SEQ, _DIM).astype(np.float16)
+    g["x_buf"].upload(x_new)
+
+    graph.replay(stream)
+    graph.sync(stream)
+    z_after = g["z_buf"].download_new((_SEQ, _DIM), np.float16)
+
+    assert not np.array_equal(z_after, z_before), (
+        "replay ignored the updated input buffer (values were baked in)")
+    ref = _rms_ref_fp16(_rms_ref_fp16(x_new, g["w1"]), g["w2"])
+    np.testing.assert_allclose(z_after.astype(np.float32),
+                               ref.astype(np.float32), atol=1e-2)
+
+
+def test_replay_before_capture_refuses(hip_core):
+    """API contract: replay() on a virgin HipGraph raises instead of
+    launching a null graph exec (which would be a silent no-op frame in a
+    serving loop)."""
+    _, hip_graph = hip_core
+    graph = hip_graph.HipGraph()
+    stream = graph.create_stream()
+    with pytest.raises(RuntimeError, match="[Nn]o graph captured"):
+        graph.replay(stream)

--- a/tests/test_amd_kernel_parity.py
+++ b/tests/test_amd_kernel_parity.py
@@ -1,0 +1,416 @@
+"""AMD pi05 kernel surface — numerical parity vs torch references.
+
+Standalone parity gates for the representative kernels the Pi0.5 CDNA4
+pipeline is assembled from, each checked against an independent torch
+reference on real-distribution inputs (randn-scaled — constant or integer
+ramps would hide calibration- and rounding-path bugs):
+
+    rms_norm / layer_norm     — norm math + weight semantics (plain ``w``,
+                                NOT the Gemma ``1+w`` fold: the fold happens
+                                at weight-conversion time, so a kernel that
+                                secretly applied 1+w would double it)
+    residual_add              — bit-exact fp32-add/bf16-round contract
+    gelu_inplace              — tanh-approx GELU (not SiLU, not erf-GELU)
+    qkv_split_rope            — interleaved-pair rotation + V passthrough
+    quantize_fp8_static       — BYTE-exact vs torch float8_e4m3fn with the
+                                SAME scale (never compared to raw fp32)
+    GemmRunner bf16_nn        — hipBLASLt BF16 layout convention
+    GemmRunner fp8_nn/nt_dev  — FP8 layouts + device-scale semantics
+    attention_decoder_gqa     — split-KV flash decoder vs exact softmax
+                                reference, exact and seqused (fixed-shape
+                                graph) modes
+
+Binding signatures were read from csrc/amd/bindings.cpp and
+csrc/amd/gemm/bindings_gemm.inc before writing any call here; every tensor
+is bound to a named variable before ``.data_ptr()`` (an inline temporary
+would be GC'd mid-launch).
+
+Skip conditions: ROCm torch + a visible device + the built extension. On
+NVIDIA/no-ROCm CI the module collects and every test skips with a reason.
+"""
+
+from __future__ import annotations
+
+import importlib
+import math
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="module")
+def env():
+    """(torch, extension) on a ROCm box with the extension built."""
+    try:
+        ext = importlib.import_module("flash_rt.amd.flash_rt_amd_kernels")
+    except ImportError as exc:
+        pytest.skip(f"flash_rt_amd_kernels not importable: {exc}")
+    torch = pytest.importorskip("torch")
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("torch is not a ROCm build")
+    if not torch.cuda.is_available():
+        pytest.skip("no ROCm device visible to torch")
+    return torch, ext
+
+
+def _stream(torch) -> int:
+    """Launch kernels on torch's current stream so torch-side tensor prep
+    and the raw-pointer launches are ordered without extra events."""
+    return torch.cuda.current_stream().cuda_stream
+
+
+def _cos(a, b) -> float:
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-30))
+
+
+# Numerical gates, justified once:
+#  - COS_ELEMENTWISE 0.9999: elementwise/norm kernels share the reference's
+#    fp32 math except reduction order → agreement is a few bf16 ULPs; any
+#    real bug (wrong weight semantics, shifted row, wrong pair) lands far
+#    below this.
+#  - ATOL_BF16 2e-2: one bf16 ULP at unit scale is ~2^-8 ≈ 4e-3; 2e-2 gives
+#    headroom for a couple of chained roundings while still failing hard on
+#    O(1) math errors.
+#  - COS_GEMM 0.9999: hipBLASLt accumulates fp32 like the torch reference;
+#    only split-K order and the bf16 store differ.
+#  - COS_ATTN 0.999: attention output is bf16 with fp32 softmax; matches
+#    the gate used for this kernel's bring-up validation.
+COS_ELEMENTWISE = 0.9999
+ATOL_BF16 = 2e-2
+COS_GEMM = 0.9999
+COS_ATTN = 0.999
+
+
+# ---------------------------------------------------------------------------
+# Norm kernels
+# ---------------------------------------------------------------------------
+
+
+def test_rms_norm_matches_torch(env):
+    torch, ext = env
+    seq, dim = 64, 2048  # encoder width; dim must be even (packed pairs)
+    torch.manual_seed(0)
+    x = (0.5 * torch.randn(seq, dim, device="cuda")).to(torch.bfloat16)
+    w = (1.0 + 0.1 * torch.randn(dim, device="cuda")).to(torch.bfloat16)
+    out = torch.empty_like(x)
+
+    ext.rms_norm(x.data_ptr(), w.data_ptr(), out.data_ptr(),
+                 seq, dim, 1e-6, _stream(torch))
+    torch.cuda.synchronize()
+
+    xf = x.float()
+    ref = (xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + 1e-6)
+           * w.float()).to(torch.bfloat16)
+    assert _cos(out.float().cpu(), ref.float().cpu()) > COS_ELEMENTWISE
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_BF16, rtol=0.0)
+
+
+def test_layer_norm_matches_torch(env):
+    torch, ext = env
+    seq, dim = 64, 1152  # SigLIP width
+    torch.manual_seed(1)
+    x = (0.5 * torch.randn(seq, dim, device="cuda")).to(torch.bfloat16)
+    w = (1.0 + 0.1 * torch.randn(dim, device="cuda")).to(torch.bfloat16)
+    b = (0.1 * torch.randn(dim, device="cuda")).to(torch.bfloat16)
+    out = torch.empty_like(x)
+
+    ext.layer_norm(x.data_ptr(), w.data_ptr(), b.data_ptr(), out.data_ptr(),
+                   seq, dim, 1e-6, _stream(torch))
+    torch.cuda.synchronize()
+
+    xf = x.float()
+    mean = xf.mean(-1, keepdim=True)
+    var = (xf - mean).pow(2).mean(-1, keepdim=True)
+    ref = ((xf - mean) * torch.rsqrt(var + 1e-6) * w.float()
+           + b.float()).to(torch.bfloat16)
+    assert _cos(out.float().cpu(), ref.float().cpu()) > COS_ELEMENTWISE
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_BF16, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Elementwise
+# ---------------------------------------------------------------------------
+
+
+def test_residual_add_is_bit_exact(env):
+    """residual += x is one fp32 add + one RNE bf16 round per element in
+    both kernel and reference — nothing order-dependent, so the gate is
+    bitwise equality, not a tolerance."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(2)
+    residual = torch.randn(n, device="cuda").to(torch.bfloat16)
+    x = torch.randn(n, device="cuda").to(torch.bfloat16)
+    ref = (residual.float() + x.float()).to(torch.bfloat16)
+
+    ext.residual_add(residual.data_ptr(), x.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.equal(residual.view(torch.uint16), ref.view(torch.uint16)), (
+        "residual_add is not bit-exact vs fp32-add + bf16-RNE")
+
+
+def test_gelu_inplace_is_tanh_approx(env):
+    """Must be the tanh-approx GELU — erf-GELU or SiLU here would pass a
+    loose cos gate on symmetric data, so the reference pins the exact
+    approximate= variant."""
+    torch, ext = env
+    n = 64 * 1024
+    torch.manual_seed(3)
+    x = (0.7 * torch.randn(n, device="cuda")).to(torch.bfloat16)
+    ref = torch.nn.functional.gelu(
+        x.float(), approximate="tanh").to(torch.bfloat16)
+
+    ext.gelu_inplace(x.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert _cos(x.float().cpu(), ref.float().cpu()) > COS_ELEMENTWISE
+    torch.testing.assert_close(x.float(), ref.float(),
+                               atol=ATOL_BF16, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# QKV split + RoPE
+# ---------------------------------------------------------------------------
+
+
+def test_qkv_split_rope_matches_reference(env):
+    """Interleaved-pair rotation (verified in csrc/amd/kernels/rope.hip):
+    within each head, elements (2p, 2p+1) rotate with rope_weights[row]
+    laid out cos@even / sin@odd over head_dim. Q: all heads rotated; K:
+    single head, same per-row table; V: pure copy (bit-exact gate)."""
+    torch, ext = env
+    seq, hd = 16, 256
+    q_dim, k_dim, v_dim = 8 * hd, hd, hd
+    torch.manual_seed(4)
+    qkv = (0.5 * torch.randn(seq, q_dim + k_dim + v_dim,
+                             device="cuda")).to(torch.bfloat16)
+    # Real rotary table (positions x standard inv-freq), interleaved.
+    pos = torch.arange(seq, dtype=torch.float32, device="cuda")
+    inv_freq = 1.0 / (10000.0 ** (
+        torch.arange(0, hd, 2, dtype=torch.float32, device="cuda") / hd))
+    ang = pos[:, None] * inv_freq[None, :]           # (seq, hd/2)
+    rope = torch.empty(seq, hd, device="cuda")
+    rope[:, 0::2] = torch.cos(ang)
+    rope[:, 1::2] = torch.sin(ang)
+    rope = rope.to(torch.bfloat16)
+
+    Q = torch.empty(seq, q_dim, dtype=torch.bfloat16, device="cuda")
+    K = torch.empty(seq, k_dim, dtype=torch.bfloat16, device="cuda")
+    V = torch.empty(seq, v_dim, dtype=torch.bfloat16, device="cuda")
+
+    ext.qkv_split_rope(qkv.data_ptr(), rope.data_ptr(),
+                       Q.data_ptr(), K.data_ptr(), V.data_ptr(),
+                       seq, q_dim, k_dim, v_dim, hd, _stream(torch))
+    torch.cuda.synchronize()
+
+    c = rope.float()[:, 0::2]
+    s = rope.float()[:, 1::2]
+
+    def rot(part):
+        xf = part.float().reshape(seq, -1, hd // 2, 2)
+        x0, x1 = xf[..., 0], xf[..., 1]
+        cc, ss = c[:, None, :], s[:, None, :]
+        even = x0 * cc - x1 * ss
+        odd = x1 * cc + x0 * ss
+        return torch.stack([even, odd], dim=-1).reshape(seq, -1)
+
+    q_ref = rot(qkv[:, :q_dim]).to(torch.bfloat16)
+    k_ref = rot(qkv[:, q_dim:q_dim + k_dim]).to(torch.bfloat16)
+    v_ref = qkv[:, q_dim + k_dim:]
+
+    assert torch.equal(V.view(torch.uint16), v_ref.contiguous().view(torch.uint16)), (
+        "V must be a bit-exact passthrough")
+    for got, ref, name in [(Q, q_ref, "Q"), (K, k_ref, "K")]:
+        assert _cos(got.float().cpu(), ref.float().cpu()) > COS_ELEMENTWISE, name
+        torch.testing.assert_close(got.float(), ref.float(),
+                                   atol=ATOL_BF16, rtol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# FP8 quantize
+# ---------------------------------------------------------------------------
+
+
+def test_quantize_fp8_static_byte_exact_vs_torch(env):
+    """BYTE comparison against torch's float8_e4m3fn cast with the SAME
+    scale, replicating the kernel's exact arithmetic (multiply by the fp32
+    reciprocal of the scale, clamp to ±448, RNE convert — verified in
+    csrc/amd/kernels/quantize_fp8.hip). Comparing against unquantized fp32
+    would be a category error: the contract is the encoding, not
+    closeness."""
+    torch, ext = env
+    n = 32768
+    torch.manual_seed(5)
+    x = (2.0 * torch.randn(n, device="cuda")).to(torch.bfloat16)
+    # Production-style scale: amax/448 (per-tensor symmetric).
+    amax = x.float().abs().max().item()
+    scale = torch.tensor([max(amax / 448.0, 1e-12)],
+                         dtype=torch.float32, device="cuda")
+    out = torch.empty(n, dtype=torch.float8_e4m3fn, device="cuda")
+
+    ext.quantize_fp8_static(x.data_ptr(), out.data_ptr(), scale.data_ptr(),
+                            n, _stream(torch))
+    torch.cuda.synchronize()
+
+    inv_s = torch.reciprocal(scale)          # fp32, same op as the kernel
+    ref = (x.float() * inv_s).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+    mismatched = int((out.view(torch.uint8) != ref.view(torch.uint8))
+                     .sum().item())
+    assert mismatched == 0, (
+        f"{mismatched}/{n} FP8 bytes differ from torch e4m3 with the same "
+        "scale — encoding drift would silently poison every FP8 GEMM")
+
+
+# ---------------------------------------------------------------------------
+# GemmRunner (hipBLASLt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gemm(env):
+    _, ext = env
+    return ext.GemmRunner()
+
+
+def test_gemm_bf16_nn_matches_torch(env, gemm):
+    """bf16_nn contract: D(M,N) = A(M,K) @ B(K,N), all row-major, no
+    transpose (the col-major swap inside the runner must be invisible)."""
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(6)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    gemm.bf16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                 _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = (A.float() @ B.float())
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    # A transposed-layout bug produces garbage, not near-misses; the loose
+    # allclose is a shape/layout tripwire on top of the cos gate.
+    torch.testing.assert_close(D.float(), ref, atol=0.5, rtol=0.05)
+
+
+def test_gemm_fp8_nn_dev_matches_quantized_reference(env, gemm):
+    """fp8_nn_dev: D_bf16 = (A_fp8(M,K) @ B_fp8(K,N)) * sa * sb, with the
+    scales read from DEVICE pointers (A/B_SCALE_POINTER semantics). The
+    reference multiplies the same fp8-decoded operands — never the
+    pre-quantization fp32 originals."""
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(7)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.float8_e4m3fn)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.float8_e4m3fn)
+    sa = torch.tensor([0.01], dtype=torch.float32, device="cuda")
+    sb = torch.tensor([0.02], dtype=torch.float32, device="cuda")
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    gemm.fp8_nn_dev(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                    sa.data_ptr(), sb.data_ptr(), _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = (A.float() @ B.float()) * (sa * sb)
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref, atol=0.05, rtol=0.05)
+
+
+def test_gemm_fp8_nt_dev_matches_quantized_reference(env, gemm):
+    """fp8_nt_dev: B stored (N,K) row-major, D = A @ B^T * sa * sb. This is
+    the production pi05 layout (fp8_layout='nk', -2.8 ms E2E vs kn), so its
+    transpose convention gets its own gate."""
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(8)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.float8_e4m3fn)
+    Bt = (0.3 * torch.randn(N, K, device="cuda")).to(torch.float8_e4m3fn)
+    sa = torch.tensor([0.01], dtype=torch.float32, device="cuda")
+    sb = torch.tensor([0.02], dtype=torch.float32, device="cuda")
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    gemm.fp8_nt_dev(A.data_ptr(), Bt.data_ptr(), D.data_ptr(), M, N, K,
+                    sa.data_ptr(), sb.data_ptr(), _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = (A.float() @ Bt.float().t()) * (sa * sb)
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref, atol=0.05, rtol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Decoder GQA attention
+# ---------------------------------------------------------------------------
+
+# The one production site (csrc/amd/attention/decoder_flash.hip): Sq ~10
+# action tokens, Hq=8 query heads, single KV head, D=256, Skv ~590-876.
+_SQ, _HQ, _D = 10, 8, 256
+_SCALE = 1.0 / math.sqrt(_D)  # 0.0625, the binding default
+
+
+def _attn_ref(torch, Q, K, V, skv, scale):
+    """Exact softmax reference in fp64 (bidirectional GQA Hq:1)."""
+    q = Q.double().permute(1, 0, 2)          # (Hq, Sq, D)
+    k = K[:skv].double()                     # (Skv, D)
+    v = V[:skv].double()
+    scores = q @ k.t() * scale               # (Hq, Sq, Skv)
+    probs = torch.softmax(scores, dim=-1)
+    o = probs @ v                            # (Hq, Sq, D)
+    return o.permute(1, 0, 2).contiguous()   # (Sq, Hq, D)
+
+
+def test_attention_decoder_gqa_exact_mode(env):
+    torch, ext = env
+    skv = 590
+    torch.manual_seed(9)
+    Q = (0.5 * torch.randn(_SQ, _HQ, _D, device="cuda")).to(torch.bfloat16)
+    K = (0.5 * torch.randn(skv, _D, device="cuda")).to(torch.bfloat16)
+    V = (0.5 * torch.randn(skv, _D, device="cuda")).to(torch.bfloat16)
+    O = torch.empty_like(Q)
+    # Caller-owned fp32 scratch, >= 32*Hq*Sq*(D+2) floats (binding contract;
+    # the fused v3 path ignores it but the v2 split path requires it).
+    ws = torch.empty(32 * _HQ * _SQ * (_D + 2),
+                     dtype=torch.float32, device="cuda")
+
+    ext.attention_decoder_gqa(Q.data_ptr(), K.data_ptr(), V.data_ptr(),
+                              O.data_ptr(), ws.data_ptr(),
+                              _SQ, skv, _HQ, _D, 0, _SCALE, _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = _attn_ref(torch, Q, K, V, skv, _SCALE)
+    assert _cos(O.float().cpu(), ref.cpu()) > COS_ATTN
+    torch.testing.assert_close(O.double(), ref, atol=0.05, rtol=0.05)
+
+
+def test_attention_decoder_gqa_seqused_masks_padding(env):
+    """Fixed-shape graph mode: seqused is a DEVICE int32 whose [0] is the
+    runtime KV length; the host Skv argument is ignored. The padded tail is
+    filled with large garbage so any masking failure moves the output far
+    outside the gate instead of hiding inside it."""
+    torch, ext = env
+    skv_pad, skv_eff = 640, 590
+    torch.manual_seed(10)
+    Q = (0.5 * torch.randn(_SQ, _HQ, _D, device="cuda")).to(torch.bfloat16)
+    K = (0.5 * torch.randn(skv_pad, _D, device="cuda")).to(torch.bfloat16)
+    V = (0.5 * torch.randn(skv_pad, _D, device="cuda")).to(torch.bfloat16)
+    K[skv_eff:] = 30.0   # poison rows: huge scores if the mask leaks
+    V[skv_eff:] = -30.0
+    O = torch.empty_like(Q)
+    ws = torch.empty(32 * _HQ * _SQ * (_D + 2),
+                     dtype=torch.float32, device="cuda")
+    seqused = torch.tensor([skv_eff], dtype=torch.int32, device="cuda")
+
+    ext.attention_decoder_gqa(Q.data_ptr(), K.data_ptr(), V.data_ptr(),
+                              O.data_ptr(), ws.data_ptr(),
+                              _SQ, skv_pad, _HQ, _D,
+                              seqused.data_ptr(), _SCALE, _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = _attn_ref(torch, Q, K, V, skv_eff, _SCALE)
+    assert _cos(O.float().cpu(), ref.cpu()) > COS_ATTN
+    torch.testing.assert_close(O.double(), ref, atol=0.05, rtol=0.05)

--- a/tests/test_amd_pi05_model.py
+++ b/tests/test_amd_pi05_model.py
@@ -1,0 +1,300 @@
+"""Pi0.5 on AMD CDNA4 — checkpoint-gated E2E gates for load_model.
+
+The full front-door path on an MI350X: load_model → Pi05TorchFrontendAmd →
+Pi05Pipeline → HIP graph capture → replay. Gates:
+
+  * load_model(hardware="amd_cdna4") produces finite (chunk, 7) actions;
+  * the inference graph really is captured (the latency story is replay);
+  * two infers with the SAME pinned noise are BIT-identical — the flow
+    integration is deterministic given (images, prompt, state, noise), so
+    any wobble is a replay-determinism or buffer-reuse bug, not "noise";
+  * state_prompt_mode="exact" and ="fixed" both serve state prompts, and
+    fixed mode serves a SECOND state (different token length) without a
+    pipeline rebuild or graph re-capture (object identity asserted) —
+    that no-rebuild property is the entire point of fixed mode;
+  * BF16 (use_fp8=False) and FP8 both run;
+  * optionally, actions match a reference file to cosine >= 0.999.
+
+Checkpoint resolution (never hardcoded):
+    FLASH_RT_PI05_AMD_CKPT > PI05_AMD_CKPT >
+    tests/_helpers/paths.resolve("PI05_CKPT")   (which itself honours
+    FLASH_RT_PI05_CKPT / PI05_CKPT before its built-in default)
+The checkpoint is a HuggingFace-style Pi0.5 safetensors directory
+(model.safetensors + norm stats), the same layout the RTX/Thor tests use.
+
+Optional reference gate:
+    FLASH_RT_PI05_AMD_REF_ACTIONS (or PI05_AMD_REF_ACTIONS) — path to a
+    .npy of shape (chunk, 7) produced with the canonical recipe below
+    (images RandomState(0), prompt "pick up the cup", state zeros(8),
+    noise RandomState(1)); absent → that one test skips.
+
+Skip conditions: ROCm torch + visible device + built extension + resolved
+checkpoint; each missing piece skips with its own reason. All heavyweight
+imports live inside fixtures so NVIDIA/no-ROCm CI collects this module
+cleanly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _helpers.paths import resolve  # noqa: E402
+
+# ── Canonical deterministic inputs (shared with the reference recipe) ──
+_PROMPT = "pick up the cup"
+_STATE0 = np.zeros(8, dtype=np.float32)
+_STATE1 = np.linspace(-0.9, 0.8, 8).astype(np.float32)
+_CHUNK, _ACTION_DIM_RAW = 10, 32
+
+
+def _images():
+    rng = np.random.RandomState(0)
+    return [rng.randint(0, 255, (224, 224, 3), dtype=np.uint8),
+            rng.randint(0, 255, (224, 224, 3), dtype=np.uint8)]
+
+
+def _pinned_noise():
+    return np.random.RandomState(1).randn(
+        _CHUNK, _ACTION_DIM_RAW).astype(np.float32)
+
+
+def _resolve_ckpt():
+    """AMD-specific env vars first, then the shared PI05_CKPT machinery."""
+    for var in ("FLASH_RT_PI05_AMD_CKPT", "PI05_AMD_CKPT"):
+        v = os.environ.get(var)
+        if v:
+            return v if os.path.isdir(v) else None
+    return resolve("PI05_CKPT", optional=True)
+
+
+@pytest.fixture(scope="module")
+def amd_env():
+    """ROCm torch + device + extension, or skip with the missing piece."""
+    try:
+        importlib.import_module("flash_rt.amd.flash_rt_amd_kernels")
+    except ImportError as exc:
+        pytest.skip(f"flash_rt_amd_kernels not importable: {exc}")
+    try:
+        # The frontend pulls in the pipeline's third-party numeric helpers
+        # (same ones the RTX pipeline imports, declared under an optional
+        # extra); skip rather than error when the env lacks them.
+        importlib.import_module("flash_rt.amd.frontends.torch.pi05")
+    except ImportError as exc:
+        pytest.skip(f"AMD pi05 frontend not importable: {exc}")
+    torch = pytest.importorskip("torch")
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("torch is not a ROCm build")
+    if not torch.cuda.is_available():
+        pytest.skip("no ROCm device visible to torch")
+    return torch
+
+
+@pytest.fixture(scope="module")
+def ckpt(amd_env):
+    path = _resolve_ckpt()
+    if path is None:
+        pytest.skip(
+            "no Pi0.5 checkpoint: export FLASH_RT_PI05_AMD_CKPT (or the "
+            "shared FLASH_RT_PI05_CKPT) — see tests/_helpers/paths.py")
+    if not os.path.isfile(os.path.join(path, "model.safetensors")):
+        pytest.skip(f"checkpoint dir lacks model.safetensors: set "
+                    f"FLASH_RT_PI05_AMD_CKPT to a HF-style Pi0.5 checkpoint")
+    return path
+
+
+def _load(ckpt_path, **kw):
+    import flash_rt
+    return flash_rt.load_model(ckpt_path, framework="torch", config="pi05",
+                               num_views=2, hardware="amd_cdna4", **kw)
+
+
+@pytest.fixture(scope="module")
+def model_fp8(ckpt):
+    """Default FP8, exact state-prompt mode. First predict runs
+    calibration + autotune + graph capture (the load_model bootstrap
+    contract), so the fixture performs it once for the whole module."""
+    model = _load(ckpt)
+    actions = model.predict(_images(), prompt=_PROMPT, state=_STATE0)
+    return model, np.asarray(actions, dtype=np.float32)
+
+
+@pytest.fixture(scope="module")
+def model_fixed(ckpt):
+    model = _load(ckpt, state_prompt_mode="fixed")
+    actions = model.predict(_images(), prompt=_PROMPT, state=_STATE0)
+    return model, np.asarray(actions, dtype=np.float32)
+
+
+@pytest.fixture(scope="module")
+def model_bf16(ckpt):
+    model = _load(ckpt, use_fp8=False)
+    actions = model.predict(_images(), prompt=_PROMPT, state=_STATE0)
+    return model, np.asarray(actions, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# On-box routing sanity
+# ---------------------------------------------------------------------------
+
+
+def test_detect_arch_live(amd_env):
+    """On the real MI350X, auto-detection must land on amd_cdna4 (the
+    routing tests elsewhere only prove it with monkeypatched torch)."""
+    from flash_rt.hardware import detect_arch
+    assert detect_arch() == "amd_cdna4"
+
+
+# ---------------------------------------------------------------------------
+# FP8 / exact mode
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_actions_shape_and_finite(model_fp8):
+    _, actions = model_fp8
+    assert actions.shape == (_CHUNK, 7), (
+        "AMD Pi0.5 must emit the LIBERO (chunk, 7) action contract")
+    assert np.isfinite(actions).all(), "non-finite actions from FP8 pipeline"
+    # Unnormalized real actions are O(1); an all-zero or exploded output
+    # means a dead buffer or a broken scale, not a plausible policy.
+    assert np.abs(actions).max() > 1e-6
+    assert np.abs(actions).max() < 1e3
+
+
+def test_graph_is_captured(model_fp8):
+    model, _ = model_fp8
+    fe = model.pipeline
+    assert fe.calibrated
+    assert fe.graph_recorded, "first predict must leave a captured graph"
+    assert getattr(fe.pipeline, "_graph", None) is not None
+
+
+def test_pinned_noise_is_bit_identical(model_fp8):
+    """infer(obs, noise=...) with identical noise twice → identical bytes.
+
+    The captured graph replays a fixed kernel sequence on fixed buffers;
+    with images/prompt/state/noise all pinned there is no legitimate
+    source of variation, so this is an equality gate — a mismatch is a
+    determinism bug (uninitialized scratch, buffer aliasing, atomic
+    reduction), never acceptable "GPU noise"."""
+    model, _ = model_fp8
+    fe = model.pipeline
+    imgs = _images()
+    obs = {"image": imgs[0], "wrist_image": imgs[1]}
+    noise = _pinned_noise()
+
+    a1 = np.asarray(fe.infer(obs, noise=noise)["actions"])
+    a2 = np.asarray(fe.infer(obs, noise=noise)["actions"])
+    assert np.array_equal(a1, a2), (
+        f"same pinned noise, different actions (max diff "
+        f"{np.abs(a1 - a2).max():.3e}) — graph replay is not deterministic")
+
+
+def test_exact_mode_serves_second_state(model_fp8):
+    """Exact mode's contract is per-length pipelines: a different state
+    must still serve (build-or-reuse) and stay finite."""
+    model, _ = model_fp8
+    actions = model.predict(_images(), prompt=_PROMPT, state=_STATE1)
+    actions = np.asarray(actions, dtype=np.float32)
+    assert actions.shape == (_CHUNK, 7)
+    assert np.isfinite(actions).all()
+    # leave the module fixture back on the canonical state for later tests
+    model.predict(_images(), prompt=_PROMPT, state=_STATE0)
+
+
+# ---------------------------------------------------------------------------
+# Fixed state-prompt mode
+# ---------------------------------------------------------------------------
+
+
+def test_fixed_mode_actions_finite(model_fixed):
+    _, actions = model_fixed
+    assert actions.shape == (_CHUNK, 7)
+    assert np.isfinite(actions).all()
+
+
+def test_fixed_mode_second_length_reuses_pipeline_and_graph(model_fixed):
+    """THE fixed-mode property: a second state (different discretized token
+    length) is served by the SAME pipeline object and the SAME captured
+    graph — no rebuild, no re-capture, no warmup. Object identity is the
+    strongest available witness that nothing was rebuilt."""
+    model, _ = model_fixed
+    fe = model.pipeline
+
+    pipeline_before = fe.pipeline
+    graph_before = getattr(fe.pipeline, "_graph", None)
+    assert pipeline_before is not None and graph_before is not None
+    len_before = int(fe.current_prompt_len)
+
+    actions = np.asarray(
+        model.predict(_images(), prompt=_PROMPT, state=_STATE1),
+        dtype=np.float32)
+    assert np.isfinite(actions).all()
+
+    assert fe.pipeline is pipeline_before, (
+        "fixed mode rebuilt its pipeline for a new state prompt")
+    assert getattr(fe.pipeline, "_graph", None) is graph_before, (
+        "fixed mode re-captured its graph for a new state prompt")
+    assert fe.pipeline is fe._fixed_pipeline
+    # informative, not gating: state discretization usually shifts the
+    # token length, but equal lengths would not weaken the identity gates.
+    assert int(fe.current_prompt_len) > 0 and len_before > 0
+
+
+# ---------------------------------------------------------------------------
+# BF16 escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_bf16_pipeline_runs(model_bf16):
+    """use_fp8=False must serve the full BF16 baseline (no FP8 kernels in
+    the graph) — this is the reference arm every FP8 parity claim on this
+    backend is measured against."""
+    model, actions = model_bf16
+    assert actions.shape == (_CHUNK, 7)
+    assert np.isfinite(actions).all()
+    fe = model.pipeline
+    assert fe.use_fp8 is False
+    assert not getattr(fe.pipeline, "use_fp8", True), (
+        "BF16 frontend built an FP8 pipeline")
+
+
+# ---------------------------------------------------------------------------
+# Optional numeric reference gate
+# ---------------------------------------------------------------------------
+
+
+def test_actions_match_reference_when_provided(model_fp8):
+    """Cosine >= 0.999 against a stored reference generated with the
+    canonical recipe in this module's docstring (same images/prompt/state
+    seeds, same pinned noise). 0.999 is the backend's E2E FP8-vs-reference
+    acceptance bar; below it, quantization cannot be the explanation and a
+    real regression is in the graph."""
+    ref_path = (os.environ.get("FLASH_RT_PI05_AMD_REF_ACTIONS")
+                or os.environ.get("PI05_AMD_REF_ACTIONS"))
+    if not ref_path:
+        pytest.skip("no reference actions: export FLASH_RT_PI05_AMD_REF_ACTIONS "
+                    "to a .npy produced with this module's canonical recipe")
+    if not os.path.isfile(ref_path):
+        pytest.skip(f"reference actions file not found: "
+                    "FLASH_RT_PI05_AMD_REF_ACTIONS does not point at a file")
+    ref = np.load(ref_path).astype(np.float32)
+    assert ref.shape == (_CHUNK, 7), "reference file has the wrong shape"
+
+    model, _ = model_fp8
+    # re-pin the canonical prompt/state, then infer with the pinned noise
+    model.predict(_images(), prompt=_PROMPT, state=_STATE0)
+    fe = model.pipeline
+    imgs = _images()
+    obs = {"image": imgs[0], "wrist_image": imgs[1]}
+    got = np.asarray(fe.infer(obs, noise=_pinned_noise())["actions"],
+                     dtype=np.float32)
+
+    a, b = got.ravel().astype(np.float64), ref.ravel().astype(np.float64)
+    cos = float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-30))
+    assert cos >= 0.999, f"actions cos vs reference = {cos:.6f} < 0.999"

--- a/tests/test_amd_routing.py
+++ b/tests/test_amd_routing.py
@@ -1,0 +1,271 @@
+"""AMD (ROCm/CDNA4) hardware routing — dispatch-table and load_model gates.
+
+What this file protects:
+
+  * the ``("pi05", "torch", "amd_cdna4")`` registration in
+    ``flash_rt.hardware._PIPELINE_MAP`` (a silent unregistration would make
+    every AMD load fall through to the "no pipeline" error);
+  * the ``detect_arch()`` ROCm branch: gfx950 (any ``gfx950:...`` suffix
+    variant) maps to ``"amd_cdna4"``, and every other ROCm arch REFUSES
+    instead of silently borrowing an NVIDIA backend (detect_arch is
+    documented "deliberately strict");
+  * the ``load_model`` front-door failure modes: an unbuilt AMD extension
+    fails with build instructions (not a bare ModuleNotFoundError), an
+    unknown hardware string never resolves, and the Thor-only FP4 knobs
+    are refused (or safely defused) on amd_cdna4.
+
+Environment matrix:
+  - No GPU / NVIDIA CI: everything here runs except the two tests that
+    require the built AMD extension (they skip with a reason).
+  - MI350X with the extension built: the "extension missing" test skips,
+    everything else runs.
+No checkpoints are needed anywhere in this file — every load_model call
+that would reach checkpoint loading is aimed at an error that fires first,
+or is asserted to fail on the (deliberately) nonexistent checkpoint path.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+
+def _amd_ext_importable() -> bool:
+    """True iff the compiled AMD module is importable in this env."""
+    try:
+        import flash_rt.amd.flash_rt_amd_kernels  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _amd_pipeline_importable() -> bool:
+    """True iff the AMD pi05 frontend module imports in this env.
+
+    Resolution of ("pi05","torch","amd_cdna4") imports the frontend, which
+    pulls in the pipeline module and its third-party numeric helpers (the
+    same ones the RTX pipeline imports, declared under an optional extra
+    rather than the base install). Tests that must run *past* resolution
+    gate on this so a lean environment skips instead of erroring.
+    """
+    try:
+        import flash_rt.amd.frontends.torch.pi05  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# _PIPELINE_MAP registration
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_map_has_amd_pi05_entry():
+    """The AMD Pi0.5 dispatch entry must stay registered verbatim.
+
+    load_model resolves lazily through this dict; if the tuple drifts
+    (module rename, class rename) resolution breaks only at runtime on an
+    AMD box, so the exact strings are pinned here.
+    """
+    from flash_rt.hardware import _PIPELINE_MAP
+
+    key = ("pi05", "torch", "amd_cdna4")
+    assert key in _PIPELINE_MAP, "AMD Pi0.5 dispatch entry disappeared"
+    assert _PIPELINE_MAP[key] == (
+        "flash_rt.amd.frontends.torch.pi05", "Pi05TorchFrontendAmd")
+
+
+def test_amd_cdna4_is_a_documented_arch_string():
+    """detect_arch's docstring is the user-facing support matrix; the AMD
+    entry must be documented there, not just implemented."""
+    from flash_rt.hardware import detect_arch
+
+    assert "amd_cdna4" in (detect_arch.__doc__ or "")
+
+
+# ---------------------------------------------------------------------------
+# detect_arch() — ROCm branch (monkeypatched, no GPU needed)
+# ---------------------------------------------------------------------------
+
+
+def _patch_rocm(monkeypatch, gcn_arch_name: str):
+    """Fake a ROCm torch build reporting the given gcnArchName."""
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    # torch.version.hip is None on CUDA builds; set it truthy.
+    monkeypatch.setattr(torch.version, "hip", "6.4.0", raising=False)
+    monkeypatch.setattr(
+        torch.cuda, "get_device_properties",
+        lambda idx: SimpleNamespace(gcnArchName=gcn_arch_name))
+
+
+@pytest.mark.parametrize("gcn", [
+    # MI350X reports the arch with feature suffixes; the router must split
+    # them off. Bare "gfx950" must also work (containers/tools vary).
+    "gfx950:sramecc+:xnack-",
+    "gfx950",
+])
+def test_detect_arch_maps_gfx950_to_amd_cdna4(monkeypatch, gcn):
+    from flash_rt.hardware import detect_arch
+
+    _patch_rocm(monkeypatch, gcn)
+    assert detect_arch() == "amd_cdna4"
+
+
+@pytest.mark.parametrize("gcn", [
+    "gfx942:sramecc+:xnack-",   # MI300X — not supported, must refuse
+    "gfx90a",                   # MI200
+    "gfx1100",                  # RDNA3
+    "gfx9500",                  # prefix trap: startswith() would wrongly pass
+])
+def test_detect_arch_refuses_non_gfx950_rocm(monkeypatch, gcn):
+    """Verified behavior: a non-gfx950 ROCm GPU raises RuntimeError (it does
+    NOT map to amd_cdna4 and does NOT fall through to the CUDA SM table —
+    flash_rt/hardware/__init__.py raises inside the hip branch). Silently
+    routing MI300/RDNA through the CDNA4 backend would fail much later at
+    the first MFMA kernel, so strictness here is the contract."""
+    from flash_rt.hardware import detect_arch
+
+    _patch_rocm(monkeypatch, gcn)
+    with pytest.raises(RuntimeError, match="unsupported ROCm GPU arch"):
+        detect_arch()
+
+
+def test_detect_arch_rocm_error_names_the_supported_arch(monkeypatch):
+    """The refusal must tell the operator what IS supported."""
+    from flash_rt.hardware import detect_arch
+
+    _patch_rocm(monkeypatch, "gfx942:sramecc+")
+    with pytest.raises(RuntimeError, match="gfx950"):
+        detect_arch()
+
+
+# ---------------------------------------------------------------------------
+# resolve_pipeline_class — unsupported combos never resolve
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_rejects_unknown_arch_string():
+    from flash_rt.hardware import resolve_pipeline_class
+
+    with pytest.raises(RuntimeError, match="no pipeline"):
+        resolve_pipeline_class("pi05", "torch", "no_such_arch")
+
+
+def test_resolver_rejects_unported_amd_configs():
+    """Only pi05/torch is registered for amd_cdna4 today. A GROOT or JAX
+    request must fail at resolution (with the built-for hint), not import
+    half a backend."""
+    from flash_rt.hardware import resolve_pipeline_class
+
+    for config, framework in [("groot", "torch"), ("pi05", "jax"),
+                              ("pi0", "torch")]:
+        with pytest.raises(RuntimeError, match="no pipeline"):
+            resolve_pipeline_class(config, framework, "amd_cdna4")
+
+
+# ---------------------------------------------------------------------------
+# load_model failure modes (no GPU: hardware= is passed explicitly, and
+# every asserted error fires before any device or checkpoint access)
+# ---------------------------------------------------------------------------
+
+_BOGUS_CKPT = "/nonexistent/flashrt-amd-test-ckpt"
+
+
+@pytest.mark.skipif(
+    _amd_ext_importable(),
+    reason="flash_rt_amd_kernels is built here; the missing-extension gate "
+           "cannot fire (covered by the ext-present tests below)")
+def test_load_model_amd_without_extension_names_the_build():
+    """Verified behavior (flash_rt/api.py, arch == "amd_cdna4" gate): the
+    refusal is an ImportError raised BEFORE the frontend import, and its
+    message must carry the module name and the build command — a bare
+    ModuleNotFoundError reads as a broken install rather than a build the
+    user still has to run."""
+    import flash_rt
+
+    with pytest.raises(ImportError) as caught:
+        flash_rt.load_model(_BOGUS_CKPT, framework="torch", config="pi05",
+                            hardware="amd_cdna4")
+    msg = str(caught.value)
+    assert "flash_rt_amd_kernels" in msg
+    assert "not built" in msg
+    # The operator must be handed the next step, not just the diagnosis.
+    assert "build_amd.sh" in msg or "cmake" in msg
+
+
+def test_load_model_unknown_hardware_string_errors():
+    """A typo'd hardware= must never produce a model. Depending on which
+    extensions this environment has built, the error is either the CUDA
+    extension gate (ImportError, fires first in flash_rt.api) or the
+    resolver's "no pipeline" RuntimeError — both are acceptable refusals;
+    success is the only failure mode."""
+    import flash_rt
+
+    with pytest.raises((ImportError, RuntimeError)):
+        flash_rt.load_model(_BOGUS_CKPT, framework="torch", config="pi05",
+                            hardware="not_a_real_arch")
+
+
+@pytest.mark.skipif(
+    not _amd_ext_importable(),
+    reason="flash_rt_amd_kernels not built (the amd_cdna4 extension gate "
+           "fires before the FP4 checks, masking them)")
+def test_load_model_use_fp4_decoder_rejected_on_amd():
+    """Verified behavior: the Thor NVFP4 tier's explicit sub-flags
+    (use_fp4_decoder etc.) raise ValueError on any non-Thor arch — the
+    check in flash_rt/api.py fires before resolve_pipeline_class, so no
+    checkpoint is touched. NOTE this check sits AFTER the AMD extension
+    import gate, hence the skip above on boxes without the .so."""
+    import flash_rt
+
+    with pytest.raises(ValueError, match="hardware='thor'"):
+        flash_rt.load_model(_BOGUS_CKPT, framework="torch", config="pi05",
+                            hardware="amd_cdna4",
+                            use_fp4=True, use_fp4_decoder=True)
+
+
+@pytest.mark.skipif(
+    not _amd_ext_importable(),
+    reason="flash_rt_amd_kernels not built (the amd_cdna4 extension gate "
+           "fires before the FA4 check, masking it)")
+def test_load_model_use_fa4_rejected_on_amd():
+    """FA4 is a Thor-only attention backend; verified: ValueError before
+    resolution (flash_rt/api.py gates on config/framework/arch)."""
+    import flash_rt
+
+    with pytest.raises(ValueError, match="use_fa4"):
+        flash_rt.load_model(_BOGUS_CKPT, framework="torch", config="pi05",
+                            hardware="amd_cdna4", use_fa4=True)
+
+
+@pytest.mark.skipif(
+    not _amd_ext_importable(),
+    reason="flash_rt_amd_kernels not built (the extension gate raises "
+           "ImportError before the FP4 routing block is reached)")
+@pytest.mark.skipif(
+    not _amd_pipeline_importable(),
+    reason="AMD pi05 frontend not importable here (optional numeric deps "
+           "missing); this test asserts behaviour past class resolution")
+def test_load_model_bare_use_fp4_falls_back_to_fp8_on_amd(caplog):
+    """Verified behavior — this was checked in the source rather than
+    assumed: bare ``use_fp4=True`` (no sub-flags) does NOT raise on
+    amd_cdna4. flash_rt/api.py's FP4 routing block logs
+    "use_fp4=True is only supported ..." and defuses the flag
+    (``use_fp4 = False`` → FP8 path). We pin that contract: the load must
+    proceed past the FP4 block (proven by it then failing on the
+    deliberately nonexistent checkpoint with FileNotFoundError, not a
+    ValueError/ImportError from the FP4 machinery) and the fallback must
+    be announced in the log."""
+    import flash_rt
+
+    with caplog.at_level(logging.WARNING, logger="flash_rt.api"):
+        with pytest.raises(FileNotFoundError):
+            flash_rt.load_model(_BOGUS_CKPT, framework="torch",
+                                config="pi05", hardware="amd_cdna4",
+                                use_fp4=True)
+    assert any("Falling back to FP8" in rec.getMessage()
+               for rec in caplog.records), (
+        "expected the documented use_fp4 → FP8 fallback warning")


### PR DESCRIPTION
## Summary

Adds a self-contained AMD backend targeting Instinct MI350X (CDNA4 / gfx950, ROCm 7.x), with Pi0.5 as the first supported model. The port keeps every FlashRT contract: bare-kernel hot path (zero Python/framework ops at inference), raw-pointer ABI, static-graph capture-then-replay, real-data FP8 calibration.

The NVIDIA tree is untouched except for two documented extension points (`detect_arch` / pipeline map) and an arch-aware extension check in `api.py`.

## Performance

Pi0.5 (2 camera views, 10-step denoise), median E2E latency on real LIBERO frames, MI350X:

| Configuration | Latency | vs torch.compile |
|---|---|---|
| PyTorch eager | 116.9 ms | — |
| torch.compile (max-autotune) | 40.5 ms | 1.00× |
| **FlashRT AMD, FP8 (default)** | **16.4 ms** | **2.47×** |
| FlashRT AMD, BF16 | ~30 ms | 1.34× |

Same protocol on an RTX 5090 (FlashRT FP8, CUDA) measures 19.7 ms — this port is currently the fastest FlashRT Pi0.5 target.

Accuracy: output cosine vs the FP32 openpi reference is 0.9992–0.9994 (FP8, noise pinned to the reference draw), replay is bit-stable within a process. Fixed state-prompt mode costs ~0.1–0.3 ms over exact mode at a right-sized capacity and serves changing prompt lengths without recapture.

## Usage

- **`docs/deployment_amd.md`** — build, precision tiers (FP8 default / BF16 escape / FP4 status), prompt-length graph strategies (`exact` / `fixed` + `state_prompt_fixed_max_len`), environment knobs, feature matrix vs the RTX frontend, reproduction protocol, HIP-vs-CUDA porting notes
- **`examples/pi05_amd_quickstart.py`** — runnable stable-door quickstart (`load_model(..., hardware="amd_cdna4")` is auto-detected on ROCm)
- **`csrc/amd/README.md`** — standalone HIP build (`scripts/amd/build_amd.sh`), no third-party dependencies; hipBLASLt ships with ROCm

## Layout

- `csrc/amd/` — standalone CMake project (does not touch the root CUDA build): pybind module with the same pointer ABI, hipBLASLt GemmRunner (+ timed autotune), hand-written CDNA4 kernels — MFMA packed-weight small-M FP8 GEMMs, split-KV decoder attention (FA2-style `seqused`, fused FP8-out epilogue), MFMA encoder flash attention, norm/rope/quantize/fusion families tuned for gfx950
- `flash_rt/amd/` — ctypes HIP runtime twins (`hip_buffer` / `hip_graph`), CDNA4 attention backends (aiter with sdpa fallback), Pi0.5 pipeline + torch frontend mirroring the RTX feature surface (calibration single/multi-frame, precision spec, temporal K/V caching, fixed/exact state-prompt modes)

## Validation

All validation is in the repo suite below. Full-graph capture is a hard gate; replay outputs are verified bit-stable; the end-to-end gate judges against a saved FP32 reference with the denoise noise pinned, reporting medians against dual baselines (eager and torch.compile).

### Running the tests

On a gfx950 machine with ROCm 7.x and a ROCm PyTorch build:

```bash
# 1. build the extension (rejects a non-gfx950 target)
bash scripts/amd/build_amd.sh gfx950

# 2. hardware-independent gates — also runnable on a CUDA-only box,
#    where every ROCm-dependent case skips with a stated reason
python -m pytest tests/test_amd_routing.py tests/test_amd_arch_gate.py -v

# 3. extension, HIP graph and kernel-parity gates (needs the built .so
#    and a ROCm device)
python -m pytest tests/test_amd_extension.py tests/test_amd_hip_graph.py \
                 tests/test_amd_kernel_parity.py -v

# 4. model-level gates (needs a Pi0.5 checkpoint; the reference-cosine
#    case additionally needs a saved actions .npy)
export FLASH_RT_PI05_AMD_CKPT=<pi05_checkpoint_dir>
export FLASH_RT_PI05_AMD_REF_ACTIONS=<reference_actions.npy>   # optional
python -m pytest tests/test_amd_pi05_model.py -v

# 5. end-to-end smoke with timing
python examples/pi05_amd_quickstart.py --checkpoint <pi05_checkpoint_dir>
```

Results on an MI350X: **50 passed, 2 skipped, 0 failed** (steps 2–4; the two skips are the optional reference-cosine case and the missing-extension case, which cannot fire once the extension is built). On a CUDA-only machine the same suite collects cleanly and reports **13 passed, 39 skipped**.

Note on the environment: attention runs on aiter when it is importable and falls back to torch SDPA otherwise, which costs about 6 ms end-to-end here (16.3 ms versus 22.2 ms, one variable changed in one process). The numbers above are with aiter available.

