### PR TITLE
GROOT N1.7 on AMD MI350X (CDNA4) — 16.0 ms full-frame, 4.24× over eager

### DIFF
--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -63,6 +63,9 @@ set(FLASHRT_AMD_SOURCES
   kernels/patch_embed.hip
   kernels/fusion.hip
   kernels/quantize_fp8.hip
+  kernels/elementwise_fp16.hip
+  kernels/norm_fp16.hip
+  kernels/adaln_layer_norm.hip
   kernels/stream_probe.hip
   kernels/ew_tune.hip
   attention/decoder_flash.hip

--- a/csrc/amd/CMakeLists.txt
+++ b/csrc/amd/CMakeLists.txt
@@ -74,6 +74,7 @@ set(FLASHRT_AMD_SOURCES
   gemm/hipblaslt_runner.hip
   gemm/smallm_fp8.hip
   gemm/smallm_mfma.hip
+  gemm/smallm_mfma_bf16.hip
   gemm/decoder_ffn_fused.hip
 )
 set_source_files_properties(${FLASHRT_AMD_SOURCES} PROPERTIES LANGUAGE HIP)

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -27,6 +27,7 @@
 #include "gemm/decoder_ffn_fused.h"
 #include "kernels/stream_probe.h"
 #include "kernels/ew_tune.h"
+#include "kernels/fp16_ops.h"
 
 namespace py = pybind11;
 
@@ -690,4 +691,8 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
 
     // ── GEMM: fused decoder-FFN pair (gate|up+geglu, down+gate*res) ──
 #include "gemm/bindings_ffn_fused.inc"
+
+    // ── FP16 backbone port: elementwise/norm/rope/quantize + AdaLN
+    //    (see kernels/{elementwise_fp16,norm_fp16,adaln_layer_norm}.hip) ──
+#include "kernels/bindings_fp16_port.inc"
 }

--- a/csrc/amd/bindings.cpp
+++ b/csrc/amd/bindings.cpp
@@ -24,6 +24,7 @@
 #include "gemm/hipblaslt_runner.h"
 #include "gemm/smallm_fp8.h"
 #include "gemm/smallm_mfma.h"
+#include "gemm/smallm_mfma_bf16.h"
 #include "gemm/decoder_ffn_fused.h"
 #include "kernels/stream_probe.h"
 #include "kernels/ew_tune.h"
@@ -688,6 +689,9 @@ PYBIND11_MODULE(flash_rt_amd_kernels, m) {
             v.append(smallm_mfma_variant_name(i));
         return v;
     });
+
+    // ── MFMA small-M BF16 packed GEMM (see gemm/smallm_mfma_bf16.h) ──
+#include "gemm/bindings_smallm_bf16.inc"
 
     // ── GEMM: fused decoder-FFN pair (gate|up+geglu, down+gate*res) ──
 #include "gemm/bindings_ffn_fused.inc"

--- a/csrc/amd/gemm/bindings_gemm.inc
+++ b/csrc/amd/gemm/bindings_gemm.inc
@@ -22,7 +22,8 @@
 //
 // Notes vs the CUDA bindings:
 //   - Only the ported subset is exposed: FvkContext, bf16_run,
-//     bf16_nn, bf16_nn_bias, bf16_nn_bias_gelu, fp8_nn_dev,
+//     bf16_nn, bf16_nn_res, bf16_nn_bias, bf16_nn_bias_gelu,
+//     bf16_nn_bias_res, fp8_nn_dev,
 //     fp8_nt_dev, autotune_bf16_nn, autotune_fp8_nn_dev,
 //     autotune_fp8_nt_dev.
 //   - AMD-only additions (no CUDA counterpart): mxfp4_nt_dev and
@@ -59,6 +60,12 @@
             self.bf16_nn(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, to_stream(stream));
         }, py::arg("A"), py::arg("B"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        .def("bf16_nn_res", [](GemmRunner& self,
+                                uintptr_t A, uintptr_t B, uintptr_t D,
+                                int M, int N, int K, uintptr_t stream) {
+            self.bf16_nn_res(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
         .def("bf16_nn_bias", [](GemmRunner& self,
                                  uintptr_t A, uintptr_t B, uintptr_t D, uintptr_t bias,
                                  int M, int N, int K, uintptr_t stream) {
@@ -71,6 +78,13 @@
                                       int M, int N, int K, uintptr_t stream) {
             self.bf16_nn_bias_gelu(to_ptr(A), to_ptr(B), to_ptr(D), to_ptr(bias),
                                     M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"), py::arg("bias"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        .def("bf16_nn_bias_res", [](GemmRunner& self,
+                                     uintptr_t A, uintptr_t B, uintptr_t D, uintptr_t bias,
+                                     int M, int N, int K, uintptr_t stream) {
+            self.bf16_nn_bias_res(to_ptr(A), to_ptr(B), to_ptr(D), to_ptr(bias),
+                                   M, N, K, to_stream(stream));
         }, py::arg("A"), py::arg("B"), py::arg("D"), py::arg("bias"),
            py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
         .def("fp8_nn_dev", [](GemmRunner& self,

--- a/csrc/amd/gemm/bindings_gemm.inc
+++ b/csrc/amd/gemm/bindings_gemm.inc
@@ -142,6 +142,11 @@
         }, py::arg("A"), py::arg("B"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"),
            py::arg("act_descale"), py::arg("w_descale"), py::arg("stream") = 0)
+        // Lazy autotune: timed selection on first use of each shape
+        // (pre-capture eager calls only; see hipblaslt_runner.h note)
+        .def("enable_lazy_autotune", [](GemmRunner& self, int num_algos) {
+            self.enable_lazy_autotune(num_algos);
+        }, py::arg("num_algos") = 16)
         // Autotune
         .def("autotune_bf16_nn", [](GemmRunner& self,
                                      uintptr_t A, uintptr_t B, uintptr_t D,

--- a/csrc/amd/gemm/bindings_gemm.inc
+++ b/csrc/amd/gemm/bindings_gemm.inc
@@ -107,6 +107,41 @@
         }, py::arg("A"), py::arg("A_scales"),
            py::arg("B"), py::arg("B_scales"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        // ── GROOT N1.7 surface: FP16 GEMM + FP8 epilogue variants ──
+        // (same names/args as the CUDA bindings)
+        .def("fp16_nn", [](GemmRunner& self,
+                            uintptr_t A, uintptr_t B, uintptr_t D,
+                            int M, int N, int K, uintptr_t stream) {
+            self.fp16_nn(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("stream") = 0)
+        .def("fp8_nn_bias", [](GemmRunner& self,
+                                uintptr_t A, uintptr_t B, uintptr_t D, uintptr_t bias,
+                                int M, int N, int K, float alpha, uintptr_t stream) {
+            self.fp8_nn_bias(to_ptr(A), to_ptr(B), to_ptr(D), to_ptr(bias),
+                              M, N, K, alpha, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"), py::arg("bias"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("alpha"),
+           py::arg("stream") = 0)
+        .def("fp8_nn_gelu_bias", [](GemmRunner& self,
+                                     uintptr_t A, uintptr_t B, uintptr_t D, uintptr_t bias,
+                                     int M, int N, int K, float alpha, uintptr_t stream) {
+            self.fp8_nn_gelu_bias(to_ptr(A), to_ptr(B), to_ptr(D), to_ptr(bias),
+                                   M, N, K, alpha, to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"), py::arg("bias"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("alpha"),
+           py::arg("stream") = 0)
+        .def("fp8_descale_fp16", [](GemmRunner& self,
+                                     uintptr_t A, uintptr_t B, uintptr_t D,
+                                     int M, int N, int K,
+                                     uintptr_t act_descale, uintptr_t w_descale,
+                                     uintptr_t stream) {
+            self.fp8_descale_fp16(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                                   typed_ptr<float>(act_descale),
+                                   typed_ptr<float>(w_descale), to_stream(stream));
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("act_descale"), py::arg("w_descale"), py::arg("stream") = 0)
         // Autotune
         .def("autotune_bf16_nn", [](GemmRunner& self,
                                      uintptr_t A, uintptr_t B, uintptr_t D,
@@ -146,4 +181,21 @@
         }, py::arg("A"), py::arg("A_scales"),
            py::arg("B"), py::arg("B_scales"), py::arg("D"),
            py::arg("M"), py::arg("N"), py::arg("K"), py::arg("num_algos") = 16)
+        .def("autotune_fp16_nn", [](GemmRunner& self,
+                                     uintptr_t A, uintptr_t B, uintptr_t D,
+                                     int M, int N, int K, int num_algos) {
+            self.autotune_fp16_nn(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K, num_algos);
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"), py::arg("num_algos") = 16)
+        .def("autotune_fp8_descale_fp16", [](GemmRunner& self,
+                                              uintptr_t A, uintptr_t B, uintptr_t D,
+                                              int M, int N, int K,
+                                              uintptr_t act_descale, uintptr_t w_descale,
+                                              int num_algos) {
+            self.autotune_fp8_descale_fp16(to_ptr(A), to_ptr(B), to_ptr(D), M, N, K,
+                                            typed_ptr<float>(act_descale),
+                                            typed_ptr<float>(w_descale), num_algos);
+        }, py::arg("A"), py::arg("B"), py::arg("D"),
+           py::arg("M"), py::arg("N"), py::arg("K"),
+           py::arg("act_descale"), py::arg("w_descale"), py::arg("num_algos") = 16)
     ;

--- a/csrc/amd/gemm/bindings_smallm_bf16.inc
+++ b/csrc/amd/gemm/bindings_smallm_bf16.inc
@@ -1,0 +1,50 @@
+// ================================================================
+// FlashRT AMD — MFMA small-M BF16 packed GEMM bindings fragment
+//
+// #included INSIDE the PYBIND11_MODULE body of csrc/amd/bindings.cpp,
+// after the FP8 MFMA block. Reuses the pointer helpers defined there
+// (to_ptr / typed_ptr / to_stream). Raw-pointer ABI.
+//
+// Semantics: see gemm/smallm_mfma_bf16.h. Wp is the PREPACKED weight
+// (torch one-liner in the header); bias is a bf16 vector of length N.
+// The three entries pin the epilogue; `variant` selects the launch
+// geometry (0 = auto, see header) so the bench can drive every
+// configuration through one calling convention.
+// ================================================================
+
+    m.def("smallm_mfma_bf16_nn_bias", [](uintptr_t A, uintptr_t Wp, uintptr_t bias,
+                                         uintptr_t D, int M, int N, int K,
+                                         int variant, uintptr_t stream) {
+        smallm_mfma_bf16_nn_packed(variant, 0, to_ptr(A), to_ptr(Wp), to_ptr(bias),
+                                   typed_ptr<__hip_bfloat16>(D), M, N, K,
+                                   to_stream(stream));
+    }, py::arg("A"), py::arg("Wp"), py::arg("bias"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("variant") = 0, py::arg("stream") = 0);
+
+    m.def("smallm_mfma_bf16_nn_bias_gelu", [](uintptr_t A, uintptr_t Wp, uintptr_t bias,
+                                              uintptr_t D, int M, int N, int K,
+                                              int variant, uintptr_t stream) {
+        smallm_mfma_bf16_nn_packed(variant, 1, to_ptr(A), to_ptr(Wp), to_ptr(bias),
+                                   typed_ptr<__hip_bfloat16>(D), M, N, K,
+                                   to_stream(stream));
+    }, py::arg("A"), py::arg("Wp"), py::arg("bias"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("variant") = 0, py::arg("stream") = 0);
+
+    m.def("smallm_mfma_bf16_nn_bias_res", [](uintptr_t A, uintptr_t Wp, uintptr_t bias,
+                                             uintptr_t D, int M, int N, int K,
+                                             int variant, uintptr_t stream) {
+        smallm_mfma_bf16_nn_packed(variant, 2, to_ptr(A), to_ptr(Wp), to_ptr(bias),
+                                   typed_ptr<__hip_bfloat16>(D), M, N, K,
+                                   to_stream(stream));
+    }, py::arg("A"), py::arg("Wp"), py::arg("bias"), py::arg("D"),
+       py::arg("M"), py::arg("N"), py::arg("K"),
+       py::arg("variant") = 0, py::arg("stream") = 0);
+
+    m.def("smallm_mfma_bf16_variants", []() {
+        py::list v;
+        for (int i = 0; i < smallm_mfma_bf16_variant_count(); ++i)
+            v.append(smallm_mfma_bf16_variant_name(i));
+        return v;
+    });

--- a/csrc/amd/gemm/hipblaslt_runner.h
+++ b/csrc/amd/gemm/hipblaslt_runner.h
@@ -171,10 +171,21 @@ public:
                                    float* act_descale, float* w_descale,
                                    int num_algos = 16);
 
+    // ── Lazy autotune: timed algorithm selection on the FIRST call of
+    // each cached (type, M, N, K), using that call's real pointers.
+    // First calls happen during eager setup/warmup (pre-capture), so
+    // the device-wide sync inside the timed selection is safe; a shape
+    // first seen INSIDE a graph capture would fail loudly (sync is
+    // illegal in capture) — warm every shape before capturing.
+    // Off by default: the pi05 pipeline manages autotune explicitly.
+    void enable_lazy_autotune(int num_algos = 16);
+
 private:
     hipblasLtHandle_t handle_;
     void* workspace_;
     size_t workspace_size_;
+    bool lazy_autotune_ = false;
+    int lazy_pool_ = 16;
 
     // ── GEMM descriptor + algorithm cache ──
     // Enum values match the CUDA class for the ported subset.
@@ -210,6 +221,7 @@ private:
         hipblasLtMatmulDesc_t matmul_desc;
         hipblasLtMatrixLayout_t op0_desc, op1_desc, D_desc;
         hipblasLtMatmulAlgo_t algo;
+        bool tuned = false;   // timed selection ran (explicit or lazy)
     };
 
     std::unordered_map<GemmKey, CachedGemm, GemmKeyHash> gemm_cache_;

--- a/csrc/amd/gemm/hipblaslt_runner.h
+++ b/csrc/amd/gemm/hipblaslt_runner.h
@@ -63,6 +63,20 @@ public:
                  int M, int N, int K,
                  hipStream_t stream = 0);
 
+    // BF16 with residual: D += A(M,K) @ B(K,N)  (row-major, no transpose)
+    // Fuses residual add into GEMM accumulator (FP32) via beta=1.0,
+    // avoiding the BF16 round-trip of a separate matmul + residual_add.
+    // Mirrors the CUDA class exactly (gemm_runner.h:85). Own cache slot
+    // (BF16_NN_RES) so lazy autotune times it with beta=1; NOTE the
+    // timed selection loop then repeatedly accumulates A@B into D — D
+    // holds garbage right after a lazy tune, which is fine for
+    // warmup/scratch passes (all first-shape calls happen pre-capture
+    // during warmup whose outputs are discarded) but means a lazy-tuned
+    // first call must not be trusted for numerics.
+    void bf16_nn_res(void* A, void* B, void* D,
+                     int M, int N, int K,
+                     hipStream_t stream = 0);
+
     // BF16 + BIAS epilogue: D = A(M,K) @ B(K,N) + bias(N)
     void bf16_nn_bias(void* A, void* B, void* D, void* bias,
                        int M, int N, int K,
@@ -72,6 +86,15 @@ public:
     void bf16_nn_bias_gelu(void* A, void* B, void* D, void* bias,
                             int M, int N, int K,
                             hipStream_t stream = 0);
+
+    // BF16 + BIAS + residual: D += A(M,K) @ B(K,N) + bias(N)
+    // hipBLASLt EPILOGUE_BIAS combined with beta=1.0 (bias and residual
+    // both land on the FP32 accumulator before the single bf16 round).
+    // Mirrors the CUDA class exactly (gemm_runner.h:100): per-call
+    // descriptors + heuristic top-1, same style as bf16_nn_bias above.
+    void bf16_nn_bias_res(void* A, void* B, void* D, void* bias,
+                           int M, int N, int K,
+                           hipStream_t stream = 0);
 
     // FP8 no-transpose: D_bf16 = A_fp8(M,K) @ B_fp8(K,N) with device scale pointers
     // Matches bf16_nn layout — B stored as (K,N), no transpose.
@@ -189,12 +212,16 @@ private:
 
     // ── GEMM descriptor + algorithm cache ──
     // Enum values match the CUDA class for the ported subset.
+    // BF16_NN_RES = 1 matches the CUDA enum (same descriptors as
+    // BF16_NN — only beta differs — but its own slot so lazy autotune
+    // times the beta=1 form separately).
     // MXFP4_NT_DEV is AMD-only (gfx950 native MX support, no CUDA
     // counterpart in the ported class) and uses the next free value.
     // FP16_NN = 4 matches the CUDA class; the CUDA fp8-with-fp16-out
     // cached type (FP8_NN_DEV_FP16) is 6 there, but 6 was already taken
     // by the AMD-only MXFP4_NT_DEV, so it takes the next free value 7.
-    enum GemmType { BF16_NN = 0, FP8_NN_DEV = 2, FP16_NN = 4,
+    enum GemmType { BF16_NN = 0, BF16_NN_RES = 1, FP8_NN_DEV = 2,
+                    FP16_NN = 4,
                     FP8_NT_DEV = 5, MXFP4_NT_DEV = 6, FP8_NN_DEV_FP16 = 7 };
 
     struct GemmKey {

--- a/csrc/amd/gemm/hipblaslt_runner.h
+++ b/csrc/amd/gemm/hipblaslt_runner.h
@@ -115,6 +115,37 @@ public:
                       int M, int N, int K,
                       hipStream_t stream = 0);
 
+    // ── GROOT N1.7 surface: FP16 GEMM + FP8 epilogue variants ──
+    // Signatures mirror the CUDA class exactly (gemm_runner.h) so the
+    // pipeline text stays portable.
+
+    // FP16: D = A(M,K) @ B(K,N)  (row-major, no transpose, fp16 in/out)
+    void fp16_nn(void* A, void* B, void* D,
+                 int M, int N, int K,
+                 hipStream_t stream = 0);
+
+    // FP8 with host alpha + BIAS epilogue: D_fp16 = alpha * A_fp8 @ B_fp8 + bias_fp16
+    // Unlike sm_120 cuBLASLt (which rejects fp8 fused-bias epilogues,
+    // code=15), hipBLASLt supports the fused form on gfx950 — verified
+    // by the standalone gate before any pipeline use.
+    void fp8_nn_bias(void* A, void* B, void* D, void* bias,
+                     int M, int N, int K, float alpha,
+                     hipStream_t stream = 0);
+
+    // FP8 with host alpha + GELU + BIAS epilogue:
+    // D_fp16 = GELU(alpha * A_fp8 @ B_fp8 + bias_fp16)
+    void fp8_nn_gelu_bias(void* A, void* B, void* D, void* bias,
+                          int M, int N, int K, float alpha,
+                          hipStream_t stream = 0);
+
+    // FP8 with device descale pointers → FP16 output.
+    // Same scale semantics as fp8_nn_dev (per-tensor FP32 multipliers on
+    // the FP32 accumulator); only the output dtype differs.
+    void fp8_descale_fp16(void* A, void* B, void* D,
+                          int M, int N, int K,
+                          float* act_descale, float* w_descale,
+                          hipStream_t stream = 0);
+
     // ── Autotune: benchmark top-N algorithms and cache the best ──
     // Call before HIP Graph capture. Uses dummy data at the provided pointers.
     // Matters on gfx950: hipBLASLt FP8 heuristics have known gaps, so the
@@ -133,6 +164,12 @@ public:
                                void* B, void* B_scales, void* D,
                                int M, int N, int K,
                                int num_algos = 16);
+    void autotune_fp16_nn(void* A, void* B, void* D,
+                          int M, int N, int K, int num_algos = 16);
+    void autotune_fp8_descale_fp16(void* A, void* B, void* D,
+                                   int M, int N, int K,
+                                   float* act_descale, float* w_descale,
+                                   int num_algos = 16);
 
 private:
     hipblasLtHandle_t handle_;
@@ -143,7 +180,11 @@ private:
     // Enum values match the CUDA class for the ported subset.
     // MXFP4_NT_DEV is AMD-only (gfx950 native MX support, no CUDA
     // counterpart in the ported class) and uses the next free value.
-    enum GemmType { BF16_NN = 0, FP8_NN_DEV = 2, FP8_NT_DEV = 5, MXFP4_NT_DEV = 6 };
+    // FP16_NN = 4 matches the CUDA class; the CUDA fp8-with-fp16-out
+    // cached type (FP8_NN_DEV_FP16) is 6 there, but 6 was already taken
+    // by the AMD-only MXFP4_NT_DEV, so it takes the next free value 7.
+    enum GemmType { BF16_NN = 0, FP8_NN_DEV = 2, FP16_NN = 4,
+                    FP8_NT_DEV = 5, MXFP4_NT_DEV = 6, FP8_NN_DEV_FP16 = 7 };
 
     struct GemmKey {
         int type, M, N, K;

--- a/csrc/amd/gemm/hipblaslt_runner.hip
+++ b/csrc/amd/gemm/hipblaslt_runner.hip
@@ -140,7 +140,9 @@ GemmRunner::CachedGemm& GemmRunner::get_or_create_cached(GemmType type, int M, i
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, HIP_R_8F_E4M3, K, M, K));
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16F, N, M, N));
     } else {
-        // BF16_NN
+        // BF16_NN or BF16_NN_RES (identical descriptors — only the
+        // runtime beta differs; separate cache slots keep the tuned
+        // algos independent)
         HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
         HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
         HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
@@ -370,6 +372,29 @@ void GemmRunner::bf16_nn(void* A, void* B, void* D,
 }
 
 // ================================================================
+//  BF16 no-transpose with fused residual: D(M,N) += A(M,K) @ B(K,N)
+//  beta=1.0 accumulates the matmul into D on the FP32 accumulator,
+//  avoiding the BF16 round-trip of separate matmul + residual_add.
+//  Mirrors gemm_runner.cu:755-763 (cached BF16_NN_RES descriptor).
+//  Lazy autotune runs with beta=1.0 so the timed pick reflects the
+//  production epilogue; NOTE the timed loop's repeated D += A@B
+//  accumulates garbage into D — acceptable because first-shape calls
+//  happen only during pre-capture warmup whose outputs are discarded
+//  (see the header note).
+// ================================================================
+void GemmRunner::bf16_nn_res(void* A, void* B, void* D,
+                             int M, int N, int K, hipStream_t stream) {
+    auto& entry = get_or_create_cached(BF16_NN_RES, M, N, K);
+    if (lazy_autotune_ && !entry.tuned)
+        autotune_cached(entry, B, A, D, 1.0f, 1.0f, lazy_pool_);
+    float alpha = 1.0f, beta = 1.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, B, entry.op0_desc, A, entry.op1_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}
+
+// ================================================================
 //  BF16 no-transpose with BIAS epilogue: D(M,N) = A(M,K) @ B(K,N) + bias(N)
 //  Uses EPILOGUE_BIAS to fuse bias addition into the GEMM.
 //  With the col-major swap, D_col is (N,M), so the epilogue bias vector
@@ -480,6 +505,67 @@ void GemmRunner::bf16_nn_bias_gelu(void* A, void* B, void* D, void* bias,
     }
 
     float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, matmul_desc,
+        &alpha, B, op0_desc, A, op1_desc, &beta, D, D_desc, D, D_desc,
+        &heuristic.algo, workspace_, workspace_size_, stream));
+
+    hipblasLtMatmulPreferenceDestroy(preference);
+    hipblasLtMatrixLayoutDestroy(op0_desc);
+    hipblasLtMatrixLayoutDestroy(op1_desc);
+    hipblasLtMatrixLayoutDestroy(D_desc);
+    hipblasLtMatmulDescDestroy(matmul_desc);
+}
+
+// ================================================================
+//  BF16 GEMM + BIAS + residual: D(M,N) += A(M,K) @ B(K,N) + bias(N)
+//  EPILOGUE_BIAS combined with beta=1.0 — bias and the residual read
+//  of D both land on the FP32 accumulator before the single bf16
+//  round. Mirrors gemm_runner.cu:893-949 (per-call descriptors +
+//  heuristic top-1, same style as bf16_nn_bias above).
+// ================================================================
+void GemmRunner::bf16_nn_bias_res(void* A, void* B, void* D, void* bias,
+                                   int M, int N, int K, hipStream_t stream) {
+    hipblasLtMatmulDesc_t matmul_desc;
+    hipblasLtMatrixLayout_t op0_desc, op1_desc, D_desc;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+
+    hipblasOperation_t op_N = HIPBLAS_OP_N;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+
+    // Set BIAS epilogue with beta=1 for residual
+    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_BIAS;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+    hipDataType bias_type = HIP_R_16BF;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, &bias_type, sizeof(bias_type)));
+
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op0_desc, HIP_R_16BF, N, K, N));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op1_desc, HIP_R_16BF, K, M, K));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&D_desc, HIP_R_16BF, N, M, N));
+
+    hipblasLtMatmulPreference_t preference;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&preference));
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(preference,
+        HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size_, sizeof(workspace_size_)));
+
+    int returned_results = 0;
+    hipblasLtMatmulHeuristicResult_t heuristic;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(handle_, matmul_desc,
+        op0_desc, op1_desc, D_desc, D_desc, preference, 1, &heuristic, &returned_results));
+
+    if (returned_results == 0) {
+        hipblasLtMatmulPreferenceDestroy(preference);
+        hipblasLtMatrixLayoutDestroy(op0_desc);
+        hipblasLtMatrixLayoutDestroy(op1_desc);
+        hipblasLtMatrixLayoutDestroy(D_desc);
+        hipblasLtMatmulDescDestroy(matmul_desc);
+        throw std::runtime_error("hipBLASLt bf16_nn_bias_res: no algorithm found");
+    }
+
+    float alpha = 1.0f, beta = 1.0f;
     HIPBLASLT_CHECK(hipblasLtMatmul(handle_, matmul_desc,
         &alpha, B, op0_desc, A, op1_desc, &beta, D, D_desc, D, D_desc,
         &heuristic.algo, workspace_, workspace_size_, stream));

--- a/csrc/amd/gemm/hipblaslt_runner.hip
+++ b/csrc/amd/gemm/hipblaslt_runner.hip
@@ -251,6 +251,7 @@ void GemmRunner::autotune_cached(CachedGemm& entry, void* op0, void* op1, void* 
     HIP_CHECK(hipEventDestroy(stop));
 
     entry.algo = heuristics[best_idx].algo;
+    entry.tuned = true;
     std::cout << "  autotune: tested " << returned_results << " algos, best="
               << best_idx << " (" << best_ms * 1000.0f << " us)" << std::endl;
 }
@@ -359,6 +360,8 @@ void GemmRunner::bf16_run(void* A, void* B, void* D,
 void GemmRunner::bf16_nn(void* A, void* B, void* D,
                          int M, int N, int K, hipStream_t stream) {
     auto& entry = get_or_create_cached(BF16_NN, M, N, K);
+    if (lazy_autotune_ && !entry.tuned)
+        autotune_cached(entry, B, A, D, 1.0f, 0.0f, lazy_pool_);
     float alpha = 1.0f, beta = 0.0f;
     HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
         &alpha, B, entry.op0_desc, A, entry.op1_desc,
@@ -500,6 +503,9 @@ void GemmRunner::fp8_nn_dev(void* A, void* B, void* D,
                              float* d_scale_a, float* d_scale_b,
                              hipStream_t stream) {
     auto& entry = get_or_create_cached(FP8_NN_DEV, M, N, K);
+    if (lazy_autotune_ && !entry.tuned)
+        autotune_cached(entry, B, A, D, 1.0f, 0.0f, lazy_pool_,
+                        d_scale_b, d_scale_a);
     // Update scale pointers per-call (different layers have different scales).
     // Operand swap: hipBLASLt operand A = FlashRT B → gets d_scale_b.
     HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
@@ -524,6 +530,9 @@ void GemmRunner::fp8_nt_dev(void* A, void* B, void* D,
                              float* d_scale_a, float* d_scale_b,
                              hipStream_t stream) {
     auto& entry = get_or_create_cached(FP8_NT_DEV, M, N, K);
+    if (lazy_autotune_ && !entry.tuned)
+        autotune_cached(entry, B, A, D, 1.0f, 0.0f, lazy_pool_,
+                        d_scale_b, d_scale_a);
     HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
         HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_b, sizeof(d_scale_b)));
     HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
@@ -595,6 +604,8 @@ void GemmRunner::mxfp4_nt_dev(void* A, void* A_scales,
 void GemmRunner::fp16_nn(void* A, void* B, void* D,
                          int M, int N, int K, hipStream_t stream) {
     auto& entry = get_or_create_cached(FP16_NN, M, N, K);
+    if (lazy_autotune_ && !entry.tuned)
+        autotune_cached(entry, B, A, D, 1.0f, 0.0f, lazy_pool_);
     float alpha = 1.0f, beta = 0.0f;
     HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
         &alpha, B, entry.op0_desc, A, entry.op1_desc,
@@ -607,6 +618,9 @@ void GemmRunner::fp8_descale_fp16(void* A, void* B, void* D,
                                   float* act_descale, float* w_descale,
                                   hipStream_t stream) {
     auto& entry = get_or_create_cached(FP8_NN_DEV_FP16, M, N, K);
+    if (lazy_autotune_ && !entry.tuned)
+        autotune_cached(entry, B, A, D, 1.0f, 0.0f, lazy_pool_,
+                        w_descale, act_descale);
     // Operand swap: hipBLASLt operand A = FlashRT B (weights) → w_descale.
     HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
         HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &w_descale, sizeof(w_descale)));
@@ -706,4 +720,10 @@ void GemmRunner::autotune_fp8_descale_fp16(void* A, void* B, void* D,
                                            int num_algos) {
     auto& entry = get_or_create_cached(FP8_NN_DEV_FP16, M, N, K);
     autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos, w_descale, act_descale);
+}
+
+
+void GemmRunner::enable_lazy_autotune(int num_algos) {
+    lazy_autotune_ = true;
+    lazy_pool_ = num_algos;
 }

--- a/csrc/amd/gemm/hipblaslt_runner.hip
+++ b/csrc/amd/gemm/hipblaslt_runner.hip
@@ -123,6 +123,22 @@ GemmRunner::CachedGemm& GemmRunner::get_or_create_cached(GemmType type, int M, i
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, fp4_type, K, N, K));
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, fp4_type, K, M, K));
         HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16BF, N, M, N));
+    } else if (type == FP16_NN) {
+        // FP16 in/out, same NN col-major swap as BF16_NN.
+        HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, HIP_R_16F, N, K, N));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, HIP_R_16F, K, M, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16F, N, M, N));
+    } else if (type == FP8_NN_DEV_FP16) {
+        // FP8 inputs with device descale, FP16 output (fp8_descale_fp16).
+        HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op0_desc, HIP_R_8F_E4M3, N, K, N));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.op1_desc, HIP_R_8F_E4M3, K, M, K));
+        HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&entry.D_desc, HIP_R_16F, N, M, N));
     } else {
         // BF16_NN
         HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&entry.matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
@@ -569,4 +585,125 @@ void GemmRunner::mxfp4_nt_dev(void* A, void* A_scales,
         &alpha, B, entry.op0_desc, A, entry.op1_desc,
         &beta, D, entry.D_desc, D, entry.D_desc,
         &entry.algo, workspace_, workspace_size_, stream));
+}
+
+// ================================================================
+// GROOT N1.7 surface: FP16 GEMM + FP8 epilogue variants
+// (signature-identical to the CUDA class; see header note)
+// ================================================================
+
+void GemmRunner::fp16_nn(void* A, void* B, void* D,
+                         int M, int N, int K, hipStream_t stream) {
+    auto& entry = get_or_create_cached(FP16_NN, M, N, K);
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, B, entry.op0_desc, A, entry.op1_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}
+
+void GemmRunner::fp8_descale_fp16(void* A, void* B, void* D,
+                                  int M, int N, int K,
+                                  float* act_descale, float* w_descale,
+                                  hipStream_t stream) {
+    auto& entry = get_or_create_cached(FP8_NN_DEV_FP16, M, N, K);
+    // Operand swap: hipBLASLt operand A = FlashRT B (weights) → w_descale.
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &w_descale, sizeof(w_descale)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(entry.matmul_desc,
+        HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &act_descale, sizeof(act_descale)));
+
+    float alpha = 1.0f, beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle_, entry.matmul_desc,
+        &alpha, B, entry.op0_desc, A, entry.op1_desc,
+        &beta, D, entry.D_desc, D, entry.D_desc,
+        &entry.algo, workspace_, workspace_size_, stream));
+}
+
+// Shared body for the two fp8 host-alpha epilogue entry points.
+// Per-call descriptors (bias pointer + alpha are baked per call, same
+// style as bf16_nn_bias above); D/bias are FP16.
+static void fp8_epilogue_nn(hipblasLtHandle_t handle,
+                            void* workspace, size_t workspace_size,
+                            void* A, void* B, void* D, void* bias,
+                            int M, int N, int K, float alpha,
+                            hipblasLtEpilogue_t epilogue_kind,
+                            const char* what, hipStream_t stream) {
+    hipblasLtMatmulDesc_t matmul_desc;
+    hipblasLtMatrixLayout_t op0_desc, op1_desc, D_desc;
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescCreate(&matmul_desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+    hipblasOperation_t op_N = HIPBLAS_OP_N;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSA, &op_N, sizeof(op_N)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_TRANSB, &op_N, sizeof(op_N)));
+
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue_kind, sizeof(epilogue_kind)));
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_POINTER, &bias, sizeof(bias)));
+    hipDataType bias_type = HIP_R_16F;
+    HIPBLASLT_CHECK(hipblasLtMatmulDescSetAttribute(matmul_desc, HIPBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, &bias_type, sizeof(bias_type)));
+
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op0_desc, HIP_R_8F_E4M3, N, K, N));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&op1_desc, HIP_R_8F_E4M3, K, M, K));
+    HIPBLASLT_CHECK(hipblasLtMatrixLayoutCreate(&D_desc, HIP_R_16F, N, M, N));
+
+    hipblasLtMatmulPreference_t preference;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceCreate(&preference));
+    size_t ws = workspace_size;
+    HIPBLASLT_CHECK(hipblasLtMatmulPreferenceSetAttribute(preference,
+        HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &ws, sizeof(ws)));
+
+    int returned_results = 0;
+    hipblasLtMatmulHeuristicResult_t heuristic;
+    HIPBLASLT_CHECK(hipblasLtMatmulAlgoGetHeuristic(handle, matmul_desc,
+        op0_desc, op1_desc, D_desc, D_desc, preference, 1, &heuristic, &returned_results));
+
+    if (returned_results == 0) {
+        hipblasLtMatmulPreferenceDestroy(preference);
+        hipblasLtMatrixLayoutDestroy(op0_desc);
+        hipblasLtMatrixLayoutDestroy(op1_desc);
+        hipblasLtMatrixLayoutDestroy(D_desc);
+        hipblasLtMatmulDescDestroy(matmul_desc);
+        throw std::runtime_error(std::string("hipBLASLt ") + what + ": no algorithm found");
+    }
+
+    float beta = 0.0f;
+    HIPBLASLT_CHECK(hipblasLtMatmul(handle, matmul_desc,
+        &alpha, B, op0_desc, A, op1_desc, &beta, D, D_desc, D, D_desc,
+        &heuristic.algo, workspace, workspace_size, stream));
+
+    hipblasLtMatmulPreferenceDestroy(preference);
+    hipblasLtMatrixLayoutDestroy(op0_desc);
+    hipblasLtMatrixLayoutDestroy(op1_desc);
+    hipblasLtMatrixLayoutDestroy(D_desc);
+    hipblasLtMatmulDescDestroy(matmul_desc);
+}
+
+void GemmRunner::fp8_nn_bias(void* A, void* B, void* D, void* bias,
+                             int M, int N, int K, float alpha,
+                             hipStream_t stream) {
+    fp8_epilogue_nn(handle_, workspace_, workspace_size_, A, B, D, bias,
+                    M, N, K, alpha, HIPBLASLT_EPILOGUE_BIAS,
+                    "fp8_nn_bias", stream);
+}
+
+void GemmRunner::fp8_nn_gelu_bias(void* A, void* B, void* D, void* bias,
+                                  int M, int N, int K, float alpha,
+                                  hipStream_t stream) {
+    fp8_epilogue_nn(handle_, workspace_, workspace_size_, A, B, D, bias,
+                    M, N, K, alpha, HIPBLASLT_EPILOGUE_GELU_BIAS,
+                    "fp8_nn_gelu_bias", stream);
+}
+
+void GemmRunner::autotune_fp16_nn(void* A, void* B, void* D,
+                                  int M, int N, int K, int num_algos) {
+    auto& entry = get_or_create_cached(FP16_NN, M, N, K);
+    autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos);
+}
+
+void GemmRunner::autotune_fp8_descale_fp16(void* A, void* B, void* D,
+                                           int M, int N, int K,
+                                           float* act_descale, float* w_descale,
+                                           int num_algos) {
+    auto& entry = get_or_create_cached(FP8_NN_DEV_FP16, M, N, K);
+    autotune_cached(entry, B, A, D, 1.0f, 0.0f, num_algos, w_descale, act_descale);
 }

--- a/csrc/amd/gemm/smallm_mfma_bf16.h
+++ b/csrc/amd/gemm/smallm_mfma_bf16.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bf16.h>
+
+// ================================================================
+// FlashRT AMD — MFMA small-M BF16 packed-weight GEMM (gfx950, wave64)
+//
+// BF16 sibling of the FP8 packed kernel (smallm_mfma.h): a weight-
+// streaming GEMM for the M<=48 "NN" projection sites where the whole
+// call is bounded by reading the (K,N) bf16 weight once. Target sites
+// are the GROOT N1.7 DiT projections at M=41:
+//   (41, 1536, 1536)  q/k/v/o        -> epilogue bias (o: bias_res)
+//   (41, 6144, 1536)  ffn up         -> epilogue bias_gelu
+//   (41, 1536, 6144)  ffn down       -> epilogue bias_res
+//
+// Math (all epilogues, fp32 accumulate, bf16 store):
+//   acc(M,N)  = A_bf16(M,K) @ W_bf16(K,N) + bias(N)     [fp32]
+//   bias      : D = bf16(acc)
+//   bias_gelu : D = bf16(gelu_tanh(acc))     (tanh-approx GELU, the
+//               hipBLASLt GELU_BIAS / activation.hip semantics)
+//   bias_res  : D = bf16(float(D) + acc)     (accumulate into D)
+//
+// Fragment layout of V_MFMA_F32_16X16X32_BF16 (same mapping the
+// encoder flash kernel uses, verified by its parity gate):
+//   a (shortx8): lane l supplies Amat[m = l&15][k = 32*step + 8*(l>>4) ..+8]
+//   b (shortx8): lane l supplies Bmat[n = l&15][same k window]
+//   c (floatx4): lane l element i = C[m = 4*(l>>4)+i][n = l&15]
+//
+// Packed weight layout — weights are static, so they are repacked
+// ONCE at setup into exact per-lane consumption order: for each
+// 16-column n-tile the stream is a linear slab of 16-byte chunks,
+// chunk index (step*64 + lane) inside the tile, chunk contents
+//   W[32*step + 8*(lane>>4) .. +8][n_tile*16 + (lane&15)]
+// so a wave reading "chunk = base + s*64 + lane" walks DRAM linearly
+// (the stream_probe co-pattern; every lane an independent dwordx4
+// chain). From the (K, N) row-major bf16 weight, in torch:
+//
+//   Wp = W.view(K//32, 4, 8, N//16, 16).permute(3, 0, 1, 4, 2).contiguous()
+//
+// (dims after permute: (N/16 tile, K/32 step, k-group, n-lane, k-elem);
+// flattened 16B-chunk index = tile*(2*K) + step*64 + lane, with
+// lane = (k-group << 4) | n-lane.)
+//
+// Structure: grid.x = N/16 column tiles, WAVES waves per workgroup
+// split K into WAVES fixed segments (S = K/(32*WAVES) MFMA steps
+// each), consumed in rounds of 6 steps with the next round's weight
+// chunks prefetched behind the current round's MFMAs (6 independent
+// dwordx4 in flight per lane = the gfx950 streaming recipe). Partials
+// are reduced across waves through LDS in ascending wave order — no
+// atomics, graph replay is bit-identical.
+//
+// M > 16 needs ceil(M/16) m-tiles; two placements are provided:
+//   fused : one workgroup owns all m-tiles (MTPW accumulators per
+//           lane share each weight fragment — DRAM traffic stays 1x).
+//           Best when grid.x alone gives enough workgroups (wide N).
+//   split : grid.y = ceil(M/16), one m-tile per workgroup. Triples
+//           the workgroup count for the WG-starved narrow-N shapes
+//           (N=1536 -> 96 column tiles); the 2nd/3rd readers of each
+//           weight line ride the LLC.
+// The A operand (<= 48 rows) is NOT staged in LDS: per-fragment 16B
+// global reads hit the LLC (A is KBs vs MBs of weight) and staging
+// 41xK bf16 rows would blow the LDS at K=6144.
+//
+// `variant`: 0 = auto (heuristic below), 1 = w4_fused, 2 = w8_fused,
+// 3 = w4_split, 4 = w8_split. Auto picks w4_fused when N/16 >= 192
+// and M > 16, else the deepest valid split form. The parity/bench
+// gate drives all variants; production pins the measured winner.
+//
+// Constraints: 1 <= M <= 48, N % 16 == 0, and K/(32*waves) must land
+// in {6, 12, 24, 48} for the selected wave depth (waves 4: K in
+// {768, 1536, 3072, 6144}; waves 8: K in {1536, 3072, 6144, 12288}).
+// A, Wp, D 16-byte aligned; bias is a dense bf16 vector of length N.
+// ================================================================
+
+int smallm_mfma_bf16_variant_count();
+const char* smallm_mfma_bf16_variant_name(int id);
+
+// epilogue: 0 = bias, 1 = bias + tanh-GELU, 2 = bias + residual (D +=)
+void smallm_mfma_bf16_nn_packed(int variant, int epilogue,
+                                const void* A_bf16, const void* Wp_bf16,
+                                const void* bias_bf16, __hip_bfloat16* D,
+                                int M, int N, int K, hipStream_t stream);

--- a/csrc/amd/gemm/smallm_mfma_bf16.hip
+++ b/csrc/amd/gemm/smallm_mfma_bf16.hip
@@ -1,0 +1,271 @@
+// ================================================================
+// FlashRT AMD — MFMA small-M BF16 packed-weight GEMM (gfx950, wave64)
+// See smallm_mfma_bf16.h for the contract, pack layout and rationale.
+//
+// Load ordering inside a round (perf-critical, mirrors the FP8 packed
+// kernel's full-in-flight discipline):
+//   1. this round's A fragments   (LLC-resident, cheap)
+//   2. NEXT round's weight chunks (the DRAM stream — 6 independent
+//      dwordx4 per lane, issued before any wait)
+//   3. MFMA chain consuming this round's (already landed) weights
+// vmcnt retires in issue order, so the MFMA wait covers (1) and the
+// PREVIOUS round's weights while leaving (2) outstanding — the weight
+// stream never drains across round boundaries.
+// ================================================================
+
+#include "smallm_mfma_bf16.h"
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+typedef float floatx4 __attribute__((ext_vector_type(4)));
+typedef short shortx8 __attribute__((ext_vector_type(8)));
+
+// Steps consumed per round; every supported S is a multiple.
+constexpr int BF16_RSTEPS = 6;
+// Reduction scratch stride per (wave, tile): 64 lanes x 4 floats,
+// +8 pad so the row stride is not 0 mod 128B.
+constexpr int RED_STRIDE = 64 * 4 + 8;
+
+__device__ __forceinline__ float gelu_tanh_f32(float g) {
+    // sigmoid form of the tanh approximation:
+    //   0.5*g*(1+tanh(0.79788456*(g+0.044715 g^3)))
+    // == g * sigmoid(1.59576912 * g * (1 + 0.044715 g^2))
+    // (same constants as kernels/activation.hip / hipBLASLt GELU_BIAS)
+    return g / (1.0f + __expf(-1.5957691216057308f * g
+                              * (1.0f + 0.044715f * g * g)));
+}
+
+// S     = MFMA k-steps per wave segment (kseg = 32*S = K/WAVES)
+// WAVES = waves per workgroup (K-split factor inside the WG)
+// MTPW  = m-tiles owned by this workgroup (1 = split grid.y, 3 = fused)
+// EPI   = 0 bias, 1 bias+gelu, 2 bias+residual-accumulate
+template<int S, int WAVES, int MTPW, int EPI>
+__global__ __launch_bounds__(64 * WAVES)
+void smallm_bf16_nn_packed_kernel(
+    const __hip_bfloat16* __restrict__ A,     // (M,K) bf16 row-major
+    const shortx8* __restrict__ Wp,           // packed 16B chunks (header)
+    const __hip_bfloat16* __restrict__ bias,  // (N)
+    __hip_bfloat16* __restrict__ D,           // (M,N) bf16
+    int M, int N, int K) {
+    constexpr int ROUNDS = S / BF16_RSTEPS;
+    __shared__ float red[WAVES * MTPW * RED_STRIDE];
+
+    const int tid  = threadIdx.x;
+    const int wave = tid >> 6;
+    const int lane = tid & 63;
+    const int n0   = blockIdx.x * 16;
+    const int gt0  = blockIdx.y * MTPW;   // first global m-tile
+
+    const int fcol = lane & 15;           // n for b / m for a / n for c
+    const int kgrp = lane >> 4;           // 8-elem sub-window of each 32k
+    const int kbase = wave * (32 * S);
+
+    // A row pointers per m-tile; pad rows (m >= M) clamp to the last
+    // real row — their C rows are never stored, only their own
+    // accumulators see the duplicate values.
+    const __hip_bfloat16* arow[MTPW];
+    #pragma unroll
+    for (int t = 0; t < MTPW; ++t) {
+        int m = 16 * (gt0 + t) + fcol;
+        if (m >= M) m = M - 1;
+        arow[t] = A + (size_t)m * K + kbase + kgrp * 8;
+    }
+
+    // Packed stream: 2*K chunks per n-tile, chunk = step*64 + lane
+    // inside the tile, this wave starting at step wave*S.
+    const shortx8* wp = Wp + (size_t)blockIdx.x * 2 * K
+                           + (size_t)(wave * S) * 64 + lane;
+
+    floatx4 acc[MTPW];
+    #pragma unroll
+    for (int t = 0; t < MTPW; ++t)
+        acc[t] = (floatx4){0.0f, 0.0f, 0.0f, 0.0f};
+
+    shortx8 bw[2][BF16_RSTEPS];
+    #pragma unroll
+    for (int s = 0; s < BF16_RSTEPS; ++s)
+        bw[0][s] = wp[(size_t)s * 64];
+
+    for (int r = 0; r < ROUNDS; ++r) {
+        const int cur = r & 1;
+        // (1) this round's a-fragments
+        shortx8 af[MTPW][BF16_RSTEPS];
+        #pragma unroll
+        for (int s = 0; s < BF16_RSTEPS; ++s) {
+            #pragma unroll
+            for (int t = 0; t < MTPW; ++t)
+                af[t][s] = *reinterpret_cast<const shortx8*>(
+                    arow[t] + (r * BF16_RSTEPS + s) * 32);
+        }
+        // (2) next round's weight chunks stay in flight through (3)
+        if (r + 1 < ROUNDS) {
+            #pragma unroll
+            for (int s = 0; s < BF16_RSTEPS; ++s)
+                bw[cur ^ 1][s] = wp[(size_t)((r + 1) * BF16_RSTEPS + s) * 64];
+        }
+        // (3) consume: each weight fragment feeds all MTPW accumulators
+        #pragma unroll
+        for (int s = 0; s < BF16_RSTEPS; ++s) {
+            #pragma unroll
+            for (int t = 0; t < MTPW; ++t)
+                acc[t] = __builtin_amdgcn_mfma_f32_16x16x32_bf16(
+                    af[t][s], bw[cur][s], acc[t], 0, 0, 0);
+        }
+    }
+
+    // ── Cross-wave reduce (ascending wave order — deterministic) ──
+    #pragma unroll
+    for (int t = 0; t < MTPW; ++t) {
+        float* rp = &red[(wave * MTPW + t) * RED_STRIDE + lane * 4];
+        #pragma unroll
+        for (int i = 0; i < 4; ++i) rp[i] = acc[t][i];
+    }
+    __syncthreads();
+    if (wave >= MTPW) return;   // wave t finishes tile t
+
+    const int t = wave;
+    float sum[4];
+    #pragma unroll
+    for (int i = 0; i < 4; ++i)
+        sum[i] = red[t * RED_STRIDE + lane * 4 + i];
+    #pragma unroll
+    for (int wv = 1; wv < WAVES; ++wv) {
+        #pragma unroll
+        for (int i = 0; i < 4; ++i)
+            sum[i] += red[(wv * MTPW + t) * RED_STRIDE + lane * 4 + i];
+    }
+
+    const int nl = n0 + fcol;
+    const float bv = __bfloat162float(bias[nl]);
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int m = 16 * (gt0 + t) + 4 * kgrp + i;
+        if (m >= M) continue;
+        float v = sum[i] + bv;
+        if (EPI == 1) v = gelu_tanh_f32(v);
+        __hip_bfloat16* dp = D + (size_t)m * N + nl;
+        if (EPI == 2) v += __bfloat162float(*dp);
+        *dp = __float2bfloat16(v);
+    }
+}
+
+// ── Dispatch ──
+
+struct Bf16Variant { const char* name; int waves; bool fused; };
+const Bf16Variant kBf16Variants[] = {
+    {"auto",     0, false},
+    {"w4_fused", 4, true},
+    {"w8_fused", 8, true},
+    {"w4_split", 4, false},
+    {"w8_split", 8, false},
+};
+
+template<int S, int WAVES, int MTPW>
+void launch_epi(int epi, dim3 grid,
+                const __hip_bfloat16* A, const shortx8* Wp,
+                const __hip_bfloat16* bias, __hip_bfloat16* D,
+                int M, int N, int K, hipStream_t stream) {
+    const dim3 block(64 * WAVES);
+    switch (epi) {
+    case 0: smallm_bf16_nn_packed_kernel<S, WAVES, MTPW, 0>
+                <<<grid, block, 0, stream>>>(A, Wp, bias, D, M, N, K); break;
+    case 1: smallm_bf16_nn_packed_kernel<S, WAVES, MTPW, 1>
+                <<<grid, block, 0, stream>>>(A, Wp, bias, D, M, N, K); break;
+    case 2: smallm_bf16_nn_packed_kernel<S, WAVES, MTPW, 2>
+                <<<grid, block, 0, stream>>>(A, Wp, bias, D, M, N, K); break;
+    default:
+        throw std::runtime_error("smallm_mfma_bf16: epilogue must be 0/1/2");
+    }
+}
+
+template<int WAVES, int MTPW>
+void launch_steps(int steps, int epi, dim3 grid,
+                  const __hip_bfloat16* A, const shortx8* Wp,
+                  const __hip_bfloat16* bias, __hip_bfloat16* D,
+                  int M, int N, int K, hipStream_t stream) {
+    switch (steps) {
+    case 6:  launch_epi<6,  WAVES, MTPW>(epi, grid, A, Wp, bias, D, M, N, K, stream); break;
+    case 12: launch_epi<12, WAVES, MTPW>(epi, grid, A, Wp, bias, D, M, N, K, stream); break;
+    case 24: launch_epi<24, WAVES, MTPW>(epi, grid, A, Wp, bias, D, M, N, K, stream); break;
+    case 48: launch_epi<48, WAVES, MTPW>(epi, grid, A, Wp, bias, D, M, N, K, stream); break;
+    default:
+        throw std::runtime_error(
+            "smallm_mfma_bf16: K/(32*waves) must be 6/12/24/48, got K="
+            + std::to_string(K) + " waves=" + std::to_string(WAVES));
+    }
+}
+
+bool steps_valid(int K, int waves) {
+    if (K % (32 * waves) != 0) return false;
+    int s = K / (32 * waves);
+    return s == 6 || s == 12 || s == 24 || s == 48;
+}
+
+} // namespace
+
+int smallm_mfma_bf16_variant_count() {
+    return (int)(sizeof(kBf16Variants) / sizeof(kBf16Variants[0]));
+}
+
+const char* smallm_mfma_bf16_variant_name(int id) {
+    return kBf16Variants[id].name;
+}
+
+void smallm_mfma_bf16_nn_packed(int variant, int epilogue,
+                                const void* A_bf16, const void* Wp_bf16,
+                                const void* bias_bf16, __hip_bfloat16* D,
+                                int M, int N, int K, hipStream_t stream) {
+    if (variant < 0 || variant >= smallm_mfma_bf16_variant_count())
+        throw std::runtime_error("smallm_mfma_bf16: bad variant "
+                                 + std::to_string(variant));
+    if (M < 1 || M > 48)
+        throw std::runtime_error("smallm_mfma_bf16: M must be in [1,48]");
+    if (N % 16 != 0)
+        throw std::runtime_error("smallm_mfma_bf16: need N % 16 == 0");
+    if (((uintptr_t)A_bf16 & 15) || ((uintptr_t)Wp_bf16 & 15) || ((uintptr_t)D & 15))
+        throw std::runtime_error("smallm_mfma_bf16: A/Wp/D must be 16B-aligned");
+    if (bias_bf16 == nullptr)
+        throw std::runtime_error("smallm_mfma_bf16: bias is required");
+
+    const int mt = (M + 15) / 16;
+    int waves = kBf16Variants[variant].waves;
+    bool fused = kBf16Variants[variant].fused;
+    if (waves == 0) {
+        // auto: wide N has workgroups to spare — keep the weight
+        // stream 1x with fused m-tiles at 4 waves; narrow N is
+        // WG-starved — split m-tiles across grid.y and go as deep as
+        // the K geometry allows.
+        if (N / 16 >= 192 && mt > 1 && steps_valid(K, 4)) {
+            waves = 4; fused = true;
+        } else if (steps_valid(K, 8)) {
+            waves = 8; fused = false;
+        } else {
+            waves = 4; fused = false;
+        }
+    }
+    if (!steps_valid(K, waves))
+        throw std::runtime_error(
+            "smallm_mfma_bf16: unsupported K for waves="
+            + std::to_string(waves) + " (K=" + std::to_string(K) + ")");
+
+    const int steps = K / (32 * waves);
+    const dim3 grid(N / 16, fused ? 1 : mt);
+    const __hip_bfloat16* A = static_cast<const __hip_bfloat16*>(A_bf16);
+    const shortx8* Wp = static_cast<const shortx8*>(Wp_bf16);
+    const __hip_bfloat16* bias = static_cast<const __hip_bfloat16*>(bias_bf16);
+
+    if (fused) {
+        if (waves == 4)
+            launch_steps<4, 3>(steps, epilogue, grid, A, Wp, bias, D, M, N, K, stream);
+        else
+            launch_steps<8, 3>(steps, epilogue, grid, A, Wp, bias, D, M, N, K, stream);
+    } else {
+        if (waves == 4)
+            launch_steps<4, 1>(steps, epilogue, grid, A, Wp, bias, D, M, N, K, stream);
+        else
+            launch_steps<8, 1>(steps, epilogue, grid, A, Wp, bias, D, M, N, K, stream);
+    }
+}

--- a/csrc/amd/kernels/adaln_layer_norm.hip
+++ b/csrc/amd/kernels/adaln_layer_norm.hip
@@ -1,0 +1,237 @@
+// ================================================================
+// FlashRT AMD — LayerNorm-style AdaLN kernels, BF16 + FP8 out
+// (CDNA wave64). Additive port of:
+//   layer_norm_no_affine_bf16, ada_layer_norm_bf16
+//     (csrc/kernels/dit_bf16.cu)
+//   ada_layer_norm_fp8 (csrc/quantize/ada_layer_norm_fp8.cu)
+//   bias_gelu_quantize_fp8_static_bf16
+//     (csrc/quantize/bias_gelu_quantize_fp8.cu)
+//
+// NOTE: distinct from the RMS-style ada_rms_norm_style in norm.hip —
+// this family is LayerNorm math (mean/variance, no weight), with
+// out = LN(x) * (1 + scale) + shift where scale/shift are (dim,)
+// vectors broadcast over rows.
+//
+// ada_layer_norm_fp8 rounds the modulated value through bf16 in
+// registers BEFORE the fp8 conversion, matching the CUDA kernel's
+// bit-exact equivalence with the 2-launch (ada_layer_norm_bf16 →
+// quantize_fp8_static) chain.
+//
+// Reductions use the tree's wave64 block_reduce_sum (common_hip.h);
+// summation order differs from the CUDA warp32 originals — last-ULP
+// differences only, gated by the cos parity suite.
+//
+// FP8 output dtype: OCP e4m3 via __hip_fp8_e4m3 (never fnuz);
+// values pre-clamped to ±448 exactly as in the CUDA originals.
+// ================================================================
+
+#include "common_hip.h"
+#include <hip/hip_fp8.h>
+
+namespace {  // internal kernels
+
+constexpr float kFp8Max = 448.0f;
+
+// ── LayerNorm (no affine) — BF16, row per block ──
+__global__ void aln_layer_norm_no_affine_bf16_kernel(
+        const __hip_bfloat16* __restrict__ x,
+        __hip_bfloat16* __restrict__ out,
+        int dim, float eps) {
+    int row = blockIdx.x;
+    const __hip_bfloat162* x2 = reinterpret_cast<const __hip_bfloat162*>(x + (size_t)row * dim);
+    __hip_bfloat162* out2 = reinterpret_cast<__hip_bfloat162*>(out + (size_t)row * dim);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 val = x2[i];
+        local_sum += __bfloat162float(val.x) + __bfloat162float(val.y);
+    }
+    float mean = block_reduce_sum(local_sum, shared) / dim;
+
+    float local_var = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 v = x2[i];
+        float d0 = __bfloat162float(v.x) - mean, d1 = __bfloat162float(v.y) - mean;
+        local_var += d0 * d0 + d1 * d1;
+    }
+    float inv_std = rsqrtf(block_reduce_sum(local_var, shared) / dim + eps);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 xv = x2[i];
+        float v0 = (__bfloat162float(xv.x) - mean) * inv_std;
+        float v1 = (__bfloat162float(xv.y) - mean) * inv_std;
+        out2[i] = __halves2bfloat162(__float2bfloat16(v0), __float2bfloat16(v1));
+    }
+}
+
+// ── AdaLayerNorm — BF16: out = LN(x, no_affine) * (1 + scale) + shift ──
+// scale/shift: (dim,) broadcast over rows.
+__global__ void aln_ada_layer_norm_bf16_kernel(
+        const __hip_bfloat16* __restrict__ x,
+        const __hip_bfloat16* __restrict__ scale,
+        const __hip_bfloat16* __restrict__ shift,
+        __hip_bfloat16* __restrict__ out,
+        int dim, float eps) {
+    int row = blockIdx.x;
+    const __hip_bfloat162* x2 = reinterpret_cast<const __hip_bfloat162*>(x + (size_t)row * dim);
+    const __hip_bfloat162* sc2 = reinterpret_cast<const __hip_bfloat162*>(scale);
+    const __hip_bfloat162* sh2 = reinterpret_cast<const __hip_bfloat162*>(shift);
+    __hip_bfloat162* out2 = reinterpret_cast<__hip_bfloat162*>(out + (size_t)row * dim);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 val = x2[i];
+        local_sum += __bfloat162float(val.x) + __bfloat162float(val.y);
+    }
+    float mean = block_reduce_sum(local_sum, shared) / dim;
+
+    float local_var = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 v = x2[i];
+        float d0 = __bfloat162float(v.x) - mean, d1 = __bfloat162float(v.y) - mean;
+        local_var += d0 * d0 + d1 * d1;
+    }
+    float inv_std = rsqrtf(block_reduce_sum(local_var, shared) / dim + eps);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 xv = x2[i], sv = sc2[i], hv = sh2[i];
+        float n0 = (__bfloat162float(xv.x) - mean) * inv_std;
+        float n1 = (__bfloat162float(xv.y) - mean) * inv_std;
+        float v0 = n0 * (1.0f + __bfloat162float(sv.x)) + __bfloat162float(hv.x);
+        float v1 = n1 * (1.0f + __bfloat162float(sv.y)) + __bfloat162float(hv.y);
+        out2[i] = __halves2bfloat162(__float2bfloat16(v0), __float2bfloat16(v1));
+    }
+}
+
+// ── AdaLayerNorm → static FP8 — BF16 input ──
+// Register-level round-through bf16 BEFORE fp8 conversion (see header).
+__global__ void aln_ada_layer_norm_fp8_kernel(
+        const __hip_bfloat16* __restrict__ x,
+        const __hip_bfloat16* __restrict__ scale,
+        const __hip_bfloat16* __restrict__ shift,
+        __hip_fp8_e4m3* __restrict__ out,
+        const float* __restrict__ act_scale_ptr,
+        int dim, float eps) {
+    const int row = blockIdx.x;
+    const __hip_bfloat162* x2 =
+        reinterpret_cast<const __hip_bfloat162*>(x + (size_t)row * dim);
+    const __hip_bfloat162* sc2 = reinterpret_cast<const __hip_bfloat162*>(scale);
+    const __hip_bfloat162* sh2 = reinterpret_cast<const __hip_bfloat162*>(shift);
+    __hip_fp8_e4m3* out_row = out + (size_t)row * dim;
+    const int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 v = x2[i];
+        local_sum += __bfloat162float(v.x) + __bfloat162float(v.y);
+    }
+    const float mean = block_reduce_sum(local_sum, shared) / static_cast<float>(dim);
+
+    float local_var = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 v = x2[i];
+        const float d0 = __bfloat162float(v.x) - mean;
+        const float d1 = __bfloat162float(v.y) - mean;
+        local_var += d0 * d0 + d1 * d1;
+    }
+    const float inv_std =
+        rsqrtf(block_reduce_sum(local_var, shared) / static_cast<float>(dim) + eps);
+
+    const float inv_a = 1.0f / *act_scale_ptr;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __hip_bfloat162 xv = x2[i], sv = sc2[i], hv = sh2[i];
+        const float n0 = (__bfloat162float(xv.x) - mean) * inv_std;
+        const float n1 = (__bfloat162float(xv.y) - mean) * inv_std;
+        const float v0_f32 = n0 * (1.0f + __bfloat162float(sv.x))
+                              + __bfloat162float(hv.x);
+        const float v1_f32 = n1 * (1.0f + __bfloat162float(sv.y))
+                              + __bfloat162float(hv.y);
+        // Round through bf16 in registers (no memory write).
+        const float v0 = __bfloat162float(__float2bfloat16(v0_f32));
+        const float v1 = __bfloat162float(__float2bfloat16(v1_f32));
+        float q0 = fminf(fmaxf(v0 * inv_a, -kFp8Max), kFp8Max);
+        float q1 = fminf(fmaxf(v1 * inv_a, -kFp8Max), kFp8Max);
+        out_row[2 * i]     = __hip_fp8_e4m3(q0);
+        out_row[2 * i + 1] = __hip_fp8_e4m3(q1);
+    }
+}
+
+// ── Fused bias + GELU(tanh) + static FP8 quantize — BF16 input ──
+__device__ __forceinline__ float aln_gelu_tanh(float x) {
+    // 0.7978845608f = sqrt(2/pi) — matches gelu_kernel in activation.cu
+    return 0.5f * x * (1.0f + tanhf(
+        0.7978845608f * (x + 0.044715f * x * x * x)));
+}
+
+__global__ void aln_bias_gelu_quantize_fp8_static_bf16_kernel(
+        const __hip_bfloat16* __restrict__ in,
+        const __hip_bfloat16* __restrict__ bias,   // may be nullptr
+        __hip_fp8_e4m3* __restrict__ out,
+        const float* __restrict__ act_scale_ptr,
+        long long total,                           // M * N
+        int N,
+        int has_bias) {
+    const long long idx =
+        (long long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total) return;
+
+    float v = __bfloat162float(in[idx]);
+    if (has_bias) {
+        int n = (int)(idx % N);
+        v += __bfloat162float(bias[n]);
+    }
+    float g = aln_gelu_tanh(v);
+    float inv_s = 1.0f / *act_scale_ptr;
+    float q = g * inv_s;
+    q = fminf(fmaxf(q, -kFp8Max), kFp8Max);
+    out[idx] = __hip_fp8_e4m3(q);
+}
+
+}  // namespace
+
+// ── Host launchers (CUDA-signature mirrors) ──
+
+void layer_norm_no_affine_bf16(const __hip_bfloat16* x, __hip_bfloat16* out,
+                               int seq_len, int dim, float eps,
+                               hipStream_t stream) {
+    aln_layer_norm_no_affine_bf16_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        x, out, dim, eps);
+}
+
+void ada_layer_norm_bf16(const __hip_bfloat16* x,
+                         const __hip_bfloat16* scale, const __hip_bfloat16* shift,
+                         __hip_bfloat16* out, int seq_len, int dim, float eps,
+                         hipStream_t stream) {
+    aln_ada_layer_norm_bf16_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        x, scale, shift, out, dim, eps);
+}
+
+void ada_layer_norm_fp8(const __hip_bfloat16* x,
+                        const __hip_bfloat16* scale, const __hip_bfloat16* shift,
+                        __hip_fp8_e4m3* out, const float* act_scale,
+                        int seq_len, int dim, float eps,
+                        hipStream_t stream) {
+    if (seq_len <= 0 || dim <= 0) return;
+    // dim must be even for bf162 vectorization (always true for our shapes).
+    aln_ada_layer_norm_fp8_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        x, scale, shift, out, act_scale, dim, eps);
+}
+
+void bias_gelu_quantize_fp8_static_bf16(const __hip_bfloat16* in,
+                                        const __hip_bfloat16* bias,  // may be nullptr
+                                        __hip_fp8_e4m3* out,
+                                        const float* act_scale,
+                                        long long M, int N,
+                                        hipStream_t stream) {
+    const long long total = M * (long long)N;
+    const int block_sz = 256;
+    const unsigned grid = (unsigned)((total + block_sz - 1) / block_sz);
+    const int has_bias = (bias != nullptr) ? 1 : 0;
+    aln_bias_gelu_quantize_fp8_static_bf16_kernel<<<grid, block_sz, 0, stream>>>(
+        in, bias, out, act_scale, total, N, has_bias);
+}

--- a/csrc/amd/kernels/bindings_fp16_port.inc
+++ b/csrc/amd/kernels/bindings_fp16_port.inc
@@ -1,0 +1,259 @@
+// ================================================================
+// FlashRT AMD — bindings for the FP16 backbone kernel port
+// (included inside PYBIND11_MODULE in ../bindings.cpp; additive).
+// Python-visible names and py::arg names mirror csrc/bindings.cpp
+// for the same symbols EXACTLY, so the pipeline layer stays
+// portable text across platforms. Launchers are declared in
+// kernels/fp16_ops.h.
+// ================================================================
+
+// ── FP16 elementwise / activation ──
+m.def("add_bias_fp16", [](uintptr_t x, uintptr_t b, int S, int D, uintptr_t stream) {
+    add_bias_fp16(typed_ptr<__half>(x), typed_ptr<__half>(b),
+                  S, D, to_stream(stream));
+}, py::arg("x"), py::arg("b"), py::arg("S"), py::arg("D"), py::arg("stream") = 0);
+
+m.def("gelu_inplace_fp16", [](uintptr_t x, int n, uintptr_t stream) {
+    gelu_inplace_fp16(typed_ptr<__half>(x), n, to_stream(stream));
+}, py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("silu_inplace_fp16", [](uintptr_t x, int n, uintptr_t stream) {
+    silu_inplace_fp16(typed_ptr<__half>(x), n, to_stream(stream));
+}, py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("relu_inplace_bf16", [](uintptr_t x, int n, uintptr_t stream) {
+    relu_inplace_bf16(typed_ptr<__hip_bfloat16>(x), n, to_stream(stream));
+}, py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("mul_fp16", [](uintptr_t a, uintptr_t b, uintptr_t out,
+                     int n, uintptr_t stream) {
+    mul_fp16(typed_ptr<__half>(a), typed_ptr<__half>(b),
+             typed_ptr<__half>(out), n, to_stream(stream));
+}, py::arg("a"), py::arg("b"), py::arg("out"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("residual_add_fp16", [](uintptr_t residual, uintptr_t x, int n, uintptr_t stream) {
+    residual_add_fp16(typed_ptr<__half>(residual), typed_ptr<__half>(x),
+                      n, to_stream(stream));
+}, py::arg("residual"), py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("gpu_fill_neginf_fp16", [](uintptr_t dst, int n, uintptr_t stream) {
+    gpu_fill_neginf_fp16(typed_ptr<__half>(dst), n, to_stream(stream));
+}, py::arg("dst"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("gpu_strided_copy_fp16", [](uintptr_t src, uintptr_t dst,
+                                  int rows, int dst_cols, int src_stride, int col_offset,
+                                  uintptr_t stream) {
+    gpu_strided_copy_fp16(typed_ptr<__half>(src), typed_ptr<__half>(dst),
+                          rows, dst_cols, src_stride, col_offset, to_stream(stream));
+}, py::arg("src"), py::arg("dst"),
+   py::arg("rows"), py::arg("dst_cols"), py::arg("src_stride"), py::arg("col_offset"),
+   py::arg("stream") = 0);
+
+m.def("gpu_repeat_interleave_heads", [](uintptr_t src, uintptr_t dst,
+                                        int S, int NH_src, int HD, int repeat, uintptr_t stream) {
+    gpu_repeat_interleave_heads(typed_ptr<__half>(src), typed_ptr<__half>(dst),
+                                S, NH_src, HD, repeat, to_stream(stream));
+}, py::arg("src"), py::arg("dst"),
+   py::arg("S"), py::arg("NH_src"), py::arg("HD"), py::arg("repeat"),
+   py::arg("stream") = 0);
+
+m.def("cast_fp16_to_bf16", [](uintptr_t in, uintptr_t out, int n, uintptr_t stream) {
+    cast_fp16_to_bf16(typed_ptr<__half>(in), typed_ptr<__hip_bfloat16>(out),
+                      n, to_stream(stream));
+}, py::arg("in"), py::arg("out"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("cast_bf16_to_fp16", [](uintptr_t in, uintptr_t out, int n, uintptr_t stream) {
+    cast_bf16_to_fp16(typed_ptr<__hip_bfloat16>(in), typed_ptr<__half>(out),
+                      n, to_stream(stream));
+}, py::arg("in"), py::arg("out"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("concat2_bf16", [](uintptr_t a, uintptr_t b, uintptr_t out,
+                         int rows, int cols_a, int cols_b,
+                         uintptr_t stream) {
+    concat2_bf16(typed_ptr<__hip_bfloat16>(a), typed_ptr<__hip_bfloat16>(b),
+                 typed_ptr<__hip_bfloat16>(out),
+                 rows, cols_a, cols_b, to_stream(stream));
+}, py::arg("a"), py::arg("b"), py::arg("out"),
+   py::arg("rows"), py::arg("cols_a"), py::arg("cols_b"),
+   py::arg("stream") = 0);
+
+// ── FP16 quantize / FP8 fusion ──
+m.def("quantize_fp8_static_fp16", [](uintptr_t input, uintptr_t output,
+                                     uintptr_t d_scale, int n, uintptr_t stream) {
+    quantize_fp8_static_fp16(typed_ptr<__half>(input),
+                             typed_ptr<__hip_fp8_e4m3>(output),
+                             reinterpret_cast<const float*>(d_scale), n, to_stream(stream));
+}, py::arg("input"), py::arg("output"), py::arg("d_scale"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("silu_mul_split_fp8_fp16", [](uintptr_t gate, uintptr_t up, uintptr_t out,
+                                    int n, uintptr_t d_scale, uintptr_t stream) {
+    silu_mul_split_fp8_fp16(typed_ptr<__half>(gate), typed_ptr<__half>(up),
+                            typed_ptr<__hip_fp8_e4m3>(out), n,
+                            reinterpret_cast<const float*>(d_scale), to_stream(stream));
+}, py::arg("gate"), py::arg("up"), py::arg("out"),
+   py::arg("n"), py::arg("d_scale"), py::arg("stream") = 0);
+
+// ── FP16 norm / RoPE / norm→FP8 ──
+m.def("layer_norm_fp16", [](uintptr_t x, uintptr_t weight, uintptr_t bias,
+                            uintptr_t out, int seq_len, int dim, float eps, uintptr_t stream) {
+    layer_norm_fp16(typed_ptr<__half>(x), typed_ptr<__half>(weight),
+                    typed_ptr<__half>(bias), typed_ptr<__half>(out),
+                    seq_len, dim, eps, to_stream(stream));
+}, py::arg("x"), py::arg("weight"), py::arg("bias"), py::arg("out"),
+   py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+m.def("rope_rotate_half_fp16", [](uintptr_t x, uintptr_t cos_table, uintptr_t sin_table,
+                                  int S, int NH, int HD, uintptr_t stream) {
+    rope_rotate_half_fp16(typed_ptr<__half>(x),
+                          typed_ptr<__half>(cos_table),
+                          typed_ptr<__half>(sin_table),
+                          S, NH, HD, to_stream(stream));
+}, py::arg("x"), py::arg("cos_table"), py::arg("sin_table"),
+   py::arg("S"), py::arg("NH"), py::arg("HD"), py::arg("stream") = 0);
+
+m.def("rms_norm_fp8_fp16", [](uintptr_t x, uintptr_t weight, uintptr_t out,
+                              int seq_len, int dim, float eps,
+                              uintptr_t d_scale, uintptr_t stream) {
+    rms_norm_fp8_fp16(typed_ptr<__half>(x), typed_ptr<__half>(weight),
+                      typed_ptr<__hip_fp8_e4m3>(out), seq_len, dim, eps,
+                      reinterpret_cast<const float*>(d_scale), to_stream(stream));
+}, py::arg("x"), py::arg("weight"), py::arg("out"),
+   py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+   py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+m.def("residual_add_rms_norm_fp8_fp16", [](uintptr_t residual, uintptr_t x,
+                                           uintptr_t weight, uintptr_t out,
+                                           int seq_len, int dim, float eps,
+                                           uintptr_t d_scale, uintptr_t stream) {
+    residual_add_rms_norm_fp8_fp16(typed_ptr<__half>(residual),
+                                   typed_ptr<__half>(x),
+                                   typed_ptr<__half>(weight),
+                                   typed_ptr<__hip_fp8_e4m3>(out), seq_len, dim, eps,
+                                   reinterpret_cast<const float*>(d_scale), to_stream(stream));
+}, py::arg("residual"), py::arg("x"), py::arg("weight"), py::arg("out"),
+   py::arg("seq_len"), py::arg("dim"), py::arg("eps") = 1e-6f,
+   py::arg("d_scale") = 0, py::arg("stream") = 0);
+
+// ── Vectorized fp16 backbone entries (int status returns; -1 when the
+//    dim%8 / n%16 / 16-byte-alignment preconditions do not hold) ──
+m.def("rms_norm_fp16_vec", [](uintptr_t x, uintptr_t w, uintptr_t out,
+                              int rows, int dim, float eps,
+                              uintptr_t stream) -> int {
+    return rms_norm_fp16_vec(typed_ptr<__half>(x), typed_ptr<__half>(w),
+                             typed_ptr<__half>(out),
+                             rows, dim, eps, to_stream(stream));
+}, py::arg("x"), py::arg("w"), py::arg("out"), py::arg("rows"),
+   py::arg("dim"), py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+m.def("layer_norm_fp16_vec", [](uintptr_t x, uintptr_t w, uintptr_t b,
+                                uintptr_t out, int rows, int dim,
+                                float eps, uintptr_t stream) -> int {
+    return layer_norm_fp16_vec(typed_ptr<__half>(x), typed_ptr<__half>(w),
+                               typed_ptr<__half>(b), typed_ptr<__half>(out),
+                               rows, dim, eps, to_stream(stream));
+}, py::arg("x"), py::arg("w"), py::arg("b"), py::arg("out"),
+   py::arg("rows"), py::arg("dim"), py::arg("eps") = 1e-6f,
+   py::arg("stream") = 0);
+
+m.def("layer_norm_fp8_static_fp16_vec",
+      [](uintptr_t x, uintptr_t w, uintptr_t b, uintptr_t out,
+         uintptr_t d_scale, int rows, int dim, float eps,
+         uintptr_t stream) -> int {
+    return layer_norm_fp8_static_fp16_vec(
+        typed_ptr<__half>(x), typed_ptr<__half>(w), typed_ptr<__half>(b),
+        typed_ptr<__hip_fp8_e4m3>(out),
+        reinterpret_cast<const float*>(d_scale),
+        rows, dim, eps, to_stream(stream));
+}, py::arg("x"), py::arg("w"), py::arg("b"), py::arg("out"),
+   py::arg("d_scale"), py::arg("rows"), py::arg("dim"),
+   py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+m.def("rope_rotate_half_fp16_vec", [](uintptr_t x, uintptr_t cos_table,
+                                      uintptr_t sin_table, int S, int NH,
+                                      int HD, uintptr_t stream) -> int {
+    return rope_rotate_half_fp16_vec(
+        typed_ptr<__half>(x),
+        typed_ptr<__half>(cos_table),
+        typed_ptr<__half>(sin_table),
+        S, NH, HD, to_stream(stream));
+}, py::arg("x"), py::arg("cos_table"), py::arg("sin_table"),
+   py::arg("S"), py::arg("NH"), py::arg("HD"), py::arg("stream") = 0);
+
+m.def("quantize_fp8_static_fp16_vec", [](uintptr_t in, uintptr_t out,
+                                         uintptr_t d_scale, int n,
+                                         uintptr_t stream) -> int {
+    return quantize_fp8_static_fp16_vec(
+        typed_ptr<__half>(in),
+        typed_ptr<__hip_fp8_e4m3>(out),
+        reinterpret_cast<const float*>(d_scale), n, to_stream(stream));
+}, py::arg("in"), py::arg("out"), py::arg("d_scale"), py::arg("n"),
+   py::arg("stream") = 0);
+
+m.def("residual_add_fp16_vec", [](uintptr_t residual, uintptr_t x, int n,
+                                  uintptr_t stream) -> int {
+    return residual_add_fp16_vec(typed_ptr<__half>(residual),
+                                 typed_ptr<__half>(x),
+                                 n, to_stream(stream));
+}, py::arg("residual"), py::arg("x"), py::arg("n"), py::arg("stream") = 0);
+
+m.def("gpu_repeat_interleave_heads_vec", [](uintptr_t src, uintptr_t dst,
+                                            int S, int NH_src, int HD,
+                                            int repeat,
+                                            uintptr_t stream) -> int {
+    return gpu_repeat_interleave_heads_vec(
+        typed_ptr<__half>(src), typed_ptr<__half>(dst),
+        S, NH_src, HD, repeat, to_stream(stream));
+}, py::arg("src"), py::arg("dst"), py::arg("S"), py::arg("NH_src"),
+   py::arg("HD"), py::arg("repeat"), py::arg("stream") = 0);
+
+// ── LayerNorm-style AdaLN (BF16 + FP8 out) ──
+m.def("layer_norm_no_affine_bf16",
+      [](uintptr_t x, uintptr_t out, int seq_len, int dim, float eps,
+         uintptr_t stream) {
+    layer_norm_no_affine_bf16(typed_ptr<__hip_bfloat16>(x),
+                              typed_ptr<__hip_bfloat16>(out),
+                              seq_len, dim, eps, to_stream(stream));
+}, py::arg("x"), py::arg("out"), py::arg("seq_len"), py::arg("dim"),
+   py::arg("eps") = 1e-5f, py::arg("stream") = 0);
+
+m.def("ada_layer_norm_bf16",
+      [](uintptr_t x, uintptr_t scale, uintptr_t shift, uintptr_t out,
+         int seq_len, int dim, float eps, uintptr_t stream) {
+    ada_layer_norm_bf16(typed_ptr<__hip_bfloat16>(x),
+                        typed_ptr<__hip_bfloat16>(scale),
+                        typed_ptr<__hip_bfloat16>(shift),
+                        typed_ptr<__hip_bfloat16>(out),
+                        seq_len, dim, eps, to_stream(stream));
+}, py::arg("x"), py::arg("scale"), py::arg("shift"), py::arg("out"),
+   py::arg("seq_len"), py::arg("dim"),
+   py::arg("eps") = 1e-5f, py::arg("stream") = 0);
+
+m.def("ada_layer_norm_fp8",
+      [](uintptr_t x_bf16, uintptr_t scale_bf16, uintptr_t shift_bf16,
+         uintptr_t out_fp8, uintptr_t act_scale,
+         int seq_len, int dim, float eps, uintptr_t stream) {
+    ada_layer_norm_fp8(typed_ptr<__hip_bfloat16>(x_bf16),
+                       typed_ptr<__hip_bfloat16>(scale_bf16),
+                       typed_ptr<__hip_bfloat16>(shift_bf16),
+                       typed_ptr<__hip_fp8_e4m3>(out_fp8),
+                       reinterpret_cast<const float*>(act_scale),
+                       seq_len, dim, eps, to_stream(stream));
+}, py::arg("x_bf16"), py::arg("scale_bf16"), py::arg("shift_bf16"),
+   py::arg("out_fp8"), py::arg("act_scale"),
+   py::arg("seq_len"), py::arg("dim"),
+   py::arg("eps") = 1e-6f, py::arg("stream") = 0);
+
+m.def("bias_gelu_quantize_fp8_static_bf16",
+      [](uintptr_t in_bf16, uintptr_t bias_bf16, uintptr_t out_fp8,
+         uintptr_t act_scale, long long M, int N, uintptr_t stream) {
+    bias_gelu_quantize_fp8_static_bf16(
+        typed_ptr<__hip_bfloat16>(in_bf16),
+        bias_bf16 ? typed_ptr<__hip_bfloat16>(bias_bf16) : nullptr,
+        typed_ptr<__hip_fp8_e4m3>(out_fp8),
+        reinterpret_cast<const float*>(act_scale),
+        M, N, to_stream(stream));
+},
+   py::arg("in_bf16"), py::arg("bias_bf16"),
+   py::arg("out_fp8"), py::arg("act_scale"),
+   py::arg("M"), py::arg("N"),
+   py::arg("stream") = 0);

--- a/csrc/amd/kernels/elementwise_fp16.hip
+++ b/csrc/amd/kernels/elementwise_fp16.hip
@@ -1,0 +1,366 @@
+// ================================================================
+// FlashRT AMD — FP16 elementwise / activation / quantize kernels
+// (CDNA wave64). Additive port of the CUDA FP16 backbone surface:
+//   add_bias_fp16, gelu_inplace_fp16, silu_inplace_fp16, mul_fp16,
+//   residual_add_fp16 (+_vec), gpu_strided_copy_fp16,
+//   gpu_repeat_interleave_heads (+_vec), gpu_fill_neginf_fp16,
+//   relu_inplace_bf16, cast_bf16_to_fp16 / cast_fp16_to_bf16,
+//   concat2_bf16, quantize_fp8_static_fp16 (+_vec),
+//   silu_mul_split_fp8_fp16
+// Mirrors csrc/kernels/{decoder_fused.cu, activation.cu,
+// elementwise.cu, dit_bf16.cu, quantize.cu, vec_fp16_backbone.cu}
+// host-wrapper signatures and per-element math exactly (fp32
+// intermediates, same clamps/constants).
+//
+// The *_vec entries keep the CUDA precondition contract (return -1
+// when dim%8 / n%16 / 16-byte alignment does not hold, 0 on success)
+// but dispatch to the same-math scalar kernels: element-independent
+// ops (residual add, quantize, repeat-interleave) are bit-identical
+// either way; wide-load retunes come later against profiles.
+//
+// FP8 output dtype: OCP e4m3 via <hip/hip_fp8.h> __hip_fp8_e4m3
+// (saturating RNE conversion, same as __nv_fp8_e4m3; values are
+// pre-clamped to ±448 exactly as in the CUDA originals). Never fnuz.
+//
+// Existing kernel files are untouched (additive-only discipline).
+// ================================================================
+
+#include "common_hip.h"
+#include <hip/hip_fp8.h>
+#include <algorithm>
+#include <cstdint>
+
+namespace {  // internal kernels — avoid any symbol overlap with the
+             // template instantiations in activation.hip/elementwise.hip
+
+// ── Simple bias add: x[i] += b[i % D] (pi05 bias_k) ──
+__global__ void ew16_add_bias_fp16_kernel(__half* x, const __half* b, int S, int D) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < S * D) x[i] = __float2half(__half2float(x[i]) + __half2float(b[i % D]));
+}
+
+// ── GELU in-place (tanh approx), packed __half2 ──
+__global__ void ew16_gelu_fp16_kernel(__half* __restrict__ x, int n) {
+    __half2* x2 = reinterpret_cast<__half2*>(x);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        __half2 val = x2[idx];
+        float v0 = __half2float(val.x), v1 = __half2float(val.y);
+        float t0 = tanhf(0.7978845608f * (v0 + 0.044715f * v0 * v0 * v0));
+        float t1 = tanhf(0.7978845608f * (v1 + 0.044715f * v1 * v1 * v1));
+        x2[idx] = __halves2half2(
+            __float2half(v0 * 0.5f * (1.0f + t0)),
+            __float2half(v1 * 0.5f * (1.0f + t1)));
+    }
+}
+
+// ── SiLU in-place, packed __half2 ──
+__global__ void ew16_silu_fp16_kernel(__half* __restrict__ x, int n) {
+    __half2* x2 = reinterpret_cast<__half2*>(x);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        __half2 val = x2[idx];
+        float v0 = __half2float(val.x), v1 = __half2float(val.y);
+        float s0 = v0 / (1.0f + expf(-v0));
+        float s1 = v1 / (1.0f + expf(-v1));
+        x2[idx] = __halves2half2(__float2half(s0), __float2half(s1));
+    }
+}
+
+// ── ReLU in-place, packed __hip_bfloat162 ──
+__global__ void ew16_relu_bf16_kernel(__hip_bfloat16* __restrict__ x, int n) {
+    __hip_bfloat162* x2 = reinterpret_cast<__hip_bfloat162*>(x);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        __hip_bfloat162 val = x2[idx];
+        float v0 = fmaxf(__bfloat162float(val.x), 0.0f);
+        float v1 = fmaxf(__bfloat162float(val.y), 0.0f);
+        x2[idx] = __halves2bfloat162(__float2bfloat16(v0), __float2bfloat16(v1));
+    }
+}
+
+// ── Elementwise multiply, 8 halves/thread (float4 loads) + scalar tail.
+// Same math as mul_fp16_kernel in activation.cu: half-precision __hmul2
+// on the vector path, fp32 multiply on the tail.
+__global__ void ew16_mul_fp16_kernel(const __half* __restrict__ a,
+                                     const __half* __restrict__ b,
+                                     __half* __restrict__ out, int n) {
+    int i = (blockIdx.x * blockDim.x + threadIdx.x) * 8;
+    if (i + 8 > n) {
+        for (int k = 0; k < 8 && i + k < n; ++k) {
+            float av = __half2float(a[i + k]);
+            float bv = __half2float(b[i + k]);
+            out[i + k] = __float2half(av * bv);
+        }
+        return;
+    }
+    const float4* a4 = reinterpret_cast<const float4*>(a + i);
+    const float4* b4 = reinterpret_cast<const float4*>(b + i);
+    float4 av = *a4, bv = *b4;
+    __half2 ah[4], bh[4], oh[4];
+    ah[0] = *reinterpret_cast<__half2*>(&av.x);
+    ah[1] = *reinterpret_cast<__half2*>(&av.y);
+    ah[2] = *reinterpret_cast<__half2*>(&av.z);
+    ah[3] = *reinterpret_cast<__half2*>(&av.w);
+    bh[0] = *reinterpret_cast<__half2*>(&bv.x);
+    bh[1] = *reinterpret_cast<__half2*>(&bv.y);
+    bh[2] = *reinterpret_cast<__half2*>(&bv.z);
+    bh[3] = *reinterpret_cast<__half2*>(&bv.w);
+    #pragma unroll
+    for (int k = 0; k < 4; ++k) oh[k] = __hmul2(ah[k], bh[k]);
+    float4 ov;
+    ov.x = *reinterpret_cast<float*>(&oh[0]);
+    ov.y = *reinterpret_cast<float*>(&oh[1]);
+    ov.z = *reinterpret_cast<float*>(&oh[2]);
+    ov.w = *reinterpret_cast<float*>(&oh[3]);
+    *reinterpret_cast<float4*>(out + i) = ov;
+}
+
+// ── Residual add: residual += x, packed __half2, fp32 add ──
+__global__ void ew16_res_add_fp16_kernel(__half* __restrict__ residual,
+                                         const __half* __restrict__ x, int n) {
+    __half2* res2 = reinterpret_cast<__half2*>(residual);
+    const __half2* x2 = reinterpret_cast<const __half2*>(x);
+    int n2 = n >> 1;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n2) {
+        __half2 rv = res2[idx], xv = x2[idx];
+        res2[idx] = __halves2half2(
+            __float2half(__half2float(rv.x) + __half2float(xv.x)),
+            __float2half(__half2float(rv.y) + __half2float(xv.y)));
+    }
+}
+
+// ── Fill FP16 buffer with large negative (softmax masking) ──
+__global__ void ew16_fill_neginf_fp16_kernel(__half* data, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) data[idx] = __float2half(-1e30f);
+}
+
+// ── Strided copy: src[rows, src_stride] cols [col_offset, col_offset+dst_cols)
+//    → dst[rows, dst_cols] ──
+__global__ void ew16_strided_copy_fp16_kernel(const __half* src, __half* dst,
+                                              int rows, int dst_cols,
+                                              int src_stride, int col_offset) {
+    int r = blockIdx.x;
+    int c = threadIdx.x;
+    for (int cc = c; cc < dst_cols; cc += blockDim.x) {
+        dst[r * dst_cols + cc] = src[r * src_stride + col_offset + cc];
+    }
+}
+
+// ── GQA repeat interleave: src [S, NH_src*HD] → dst [S, NH_src*repeat*HD] ──
+__global__ void ew16_repeat_interleave_heads_kernel(
+        const __half* src, __half* dst,
+        int S, int NH_src, int HD, int repeat) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int NH_dst = NH_src * repeat;
+    int total = S * NH_dst * HD;
+    if (idx >= total) return;
+
+    int d = idx % HD;
+    int remainder = idx / HD;
+    int h_dst = remainder % NH_dst;
+    int s = remainder / NH_dst;
+
+    int h_src = h_dst / repeat;
+    dst[s * NH_dst * HD + h_dst * HD + d] = src[s * NH_src * HD + h_src * HD + d];
+}
+
+// ── Cast fp16 ↔ bf16 (DiT input/output boundary) ──
+__global__ void ew16_cast_fp16_to_bf16_kernel(const __half* in, __hip_bfloat16* out, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = __float2bfloat16(__half2float(in[i]));
+}
+
+__global__ void ew16_cast_bf16_to_fp16_kernel(const __hip_bfloat16* in, __half* out, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) out[i] = __float2half(__bfloat162float(in[i]));
+}
+
+// ── Row-wise concat: out[r,:] = [a[r,:cols_a] | b[r,:cols_b]] ──
+__global__ void ew16_concat2_bf16_kernel(
+        const __hip_bfloat16* __restrict__ a,
+        const __hip_bfloat16* __restrict__ b,
+        __hip_bfloat16* __restrict__ out,
+        int rows, int cols_a, int cols_b) {
+    int r = blockIdx.x;
+    int c = threadIdx.x;
+    if (r >= rows) return;
+    const int cols = cols_a + cols_b;
+    for (int cc = c; cc < cols; cc += blockDim.x) {
+        if (cc < cols_a) {
+            out[r * cols + cc] = a[r * cols_a + cc];
+        } else {
+            const int bc = cc - cols_a;
+            out[r * cols + cc] = b[r * cols_b + bc];
+        }
+    }
+}
+
+// ── Static FP8 quantize, FP16 input, 4 elem/thread (pi05 quant_fp8_static_k).
+// n is assumed to be a multiple of 4 (production shapes are); inv_scale
+// guards against a zero device scale exactly like quantize.cu.
+__global__ void ew16_quantize_fp8_fp16_kernel(const __half* in,
+                                              __hip_fp8_e4m3* out,
+                                              const float* descale_ptr, int n) {
+    int i = (blockIdx.x * blockDim.x + threadIdx.x) * 4;
+    if (i >= n) return;
+    float inv_scale = 1.0f / fmaxf(*descale_ptr, 1e-12f);
+    const __half2* in2 = reinterpret_cast<const __half2*>(in);
+    __half2 vA = in2[i/2], vB = in2[i/2+1];
+    float fv[4] = {__half2float(vA.x), __half2float(vA.y),
+                   __half2float(vB.x), __half2float(vB.y)};
+    unsigned char pk[4];
+    #pragma unroll
+    for (int j = 0; j < 4; j++) {
+        pk[j] = __hip_fp8_e4m3(fminf(fmaxf(fv[j] * inv_scale, -448.f), 448.f)).__x;
+    }
+    uint32_t w;
+    __builtin_memcpy(&w, pk, 4);
+    *reinterpret_cast<uint32_t*>(reinterpret_cast<unsigned char*>(out) + i) = w;
+}
+
+// ── Split SiLU × Up → FP8 (separate gate/up buffers, pi05 silu_mul_split_fp8_k).
+// Note: no 1e-12 guard on the scale here — matches activation.cu exactly.
+__global__ void ew16_silu_mul_split_fp8_fp16_kernel(
+        const __half* __restrict__ gate,
+        const __half* __restrict__ up,
+        __hip_fp8_e4m3* __restrict__ out,
+        int n, const float* __restrict__ d_scale) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    float inv_scale = 1.0f / (*d_scale);
+    float g = __half2float(gate[idx]);
+    float u = __half2float(up[idx]);
+    float silu_g = g / (1.0f + expf(-g));
+    float val = silu_g * u * inv_scale;
+    out[idx] = __hip_fp8_e4m3(fminf(fmaxf(val, -448.0f), 448.0f));
+}
+
+}  // namespace
+
+// ── Host launchers (CUDA-signature mirrors) ──
+
+void add_bias_fp16(__half* x, const __half* b, int S, int D, hipStream_t stream) {
+    ew16_add_bias_fp16_kernel<<<(S*D + 255)/256, 256, 0, stream>>>(x, b, S, D);
+}
+
+void gelu_inplace_fp16(__half* x, int n, hipStream_t stream) {
+    int n2 = n >> 1;
+    ew16_gelu_fp16_kernel<<<(n2 + 255) / 256, 256, 0, stream>>>(x, n);
+}
+
+void silu_inplace_fp16(__half* x, int n, hipStream_t stream) {
+    int n2 = n >> 1;
+    ew16_silu_fp16_kernel<<<(n2 + 255) / 256, 256, 0, stream>>>(x, n);
+}
+
+void relu_inplace_bf16(__hip_bfloat16* x, int n, hipStream_t stream) {
+    int n2 = n >> 1;
+    ew16_relu_bf16_kernel<<<(n2 + 255) / 256, 256, 0, stream>>>(x, n);
+}
+
+void mul_fp16(const __half* a, const __half* b, __half* out, int n, hipStream_t stream) {
+    int per_block = 256 * 8;
+    int blocks = (n + per_block - 1) / per_block;
+    ew16_mul_fp16_kernel<<<blocks, 256, 0, stream>>>(a, b, out, n);
+}
+
+void residual_add_fp16(__half* residual, const __half* x, int n,
+                       hipStream_t stream) {
+    int n2 = n >> 1;
+    ew16_res_add_fp16_kernel<<<(n2 + 255) / 256, 256, 0, stream>>>(residual, x, n);
+}
+
+void gpu_fill_neginf_fp16(__half* dst, int n, hipStream_t stream) {
+    ew16_fill_neginf_fp16_kernel<<<(n + 255) / 256, 256, 0, stream>>>(dst, n);
+}
+
+void gpu_strided_copy_fp16(const __half* src, __half* dst,
+                           int rows, int dst_cols, int src_stride, int col_offset,
+                           hipStream_t stream) {
+    ew16_strided_copy_fp16_kernel<<<rows, std::min(256, dst_cols), 0, stream>>>(
+        src, dst, rows, dst_cols, src_stride, col_offset);
+}
+
+void gpu_repeat_interleave_heads(const __half* src, __half* dst,
+                                 int S, int NH_src, int HD, int repeat,
+                                 hipStream_t stream) {
+    int NH_dst = NH_src * repeat;
+    int total = S * NH_dst * HD;
+    ew16_repeat_interleave_heads_kernel<<<(total + 255) / 256, 256, 0, stream>>>(
+        src, dst, S, NH_src, HD, repeat);
+}
+
+void cast_fp16_to_bf16(const __half* in, __hip_bfloat16* out, int n,
+                       hipStream_t stream) {
+    ew16_cast_fp16_to_bf16_kernel<<<(n + 255) / 256, 256, 0, stream>>>(in, out, n);
+}
+
+void cast_bf16_to_fp16(const __hip_bfloat16* in, __half* out, int n,
+                       hipStream_t stream) {
+    ew16_cast_bf16_to_fp16_kernel<<<(n + 255) / 256, 256, 0, stream>>>(in, out, n);
+}
+
+void concat2_bf16(const __hip_bfloat16* a, const __hip_bfloat16* b,
+                  __hip_bfloat16* out,
+                  int rows, int cols_a, int cols_b,
+                  hipStream_t stream) {
+    const int cols = cols_a + cols_b;
+    ew16_concat2_bf16_kernel<<<rows, std::min(256, cols), 0, stream>>>(
+        a, b, out, rows, cols_a, cols_b);
+}
+
+void quantize_fp8_static_fp16(const __half* input, __hip_fp8_e4m3* output,
+                              const float* d_scale, int n, hipStream_t stream) {
+    // 4 elem/thread, matching production quant_fp8_static_k
+    int threads = 256;
+    int blocks = (n / 4 + threads - 1) / threads;
+    ew16_quantize_fp8_fp16_kernel<<<blocks, threads, 0, stream>>>(input, output, d_scale, n);
+}
+
+void silu_mul_split_fp8_fp16(const __half* gate, const __half* up,
+                             __hip_fp8_e4m3* out, int n,
+                             const float* d_scale, hipStream_t stream) {
+    ew16_silu_mul_split_fp8_fp16_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        gate, up, out, n, d_scale);
+}
+
+// ── *_vec entries: CUDA precondition contract, same-math dispatch ──
+// (element-independent → bit-identical to the CUDA vec kernels)
+
+int residual_add_fp16_vec(__half* residual, const __half* x, int n,
+                          hipStream_t stream) {
+    if (n % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(residual) & 15) ||
+        (reinterpret_cast<uintptr_t>(x) & 15)) return -1;
+    residual_add_fp16(residual, x, n, stream);
+    const hipError_t e = hipGetLastError();
+    return (e == hipSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int quantize_fp8_static_fp16_vec(const __half* in, __hip_fp8_e4m3* out,
+                                 const float* descale_ptr, int n,
+                                 hipStream_t stream) {
+    if (n % 16 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(in) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
+    quantize_fp8_static_fp16(in, out, descale_ptr, n, stream);
+    const hipError_t e = hipGetLastError();
+    return (e == hipSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int gpu_repeat_interleave_heads_vec(const __half* src, __half* dst,
+                                    int S, int NH_src, int HD, int repeat,
+                                    hipStream_t stream) {
+    if (HD % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(src) & 15) ||
+        (reinterpret_cast<uintptr_t>(dst) & 15)) return -1;
+    gpu_repeat_interleave_heads(src, dst, S, NH_src, HD, repeat, stream);
+    const hipError_t e = hipGetLastError();
+    return (e == hipSuccess) ? 0 : -static_cast<int>(e);
+}

--- a/csrc/amd/kernels/fp16_ops.h
+++ b/csrc/amd/kernels/fp16_ops.h
@@ -1,0 +1,92 @@
+// ================================================================
+// FlashRT AMD — declarations for the FP16 backbone kernel port
+// (kernels/elementwise_fp16.hip, kernels/norm_fp16.hip,
+//  kernels/adaln_layer_norm.hip). Additive surface; the existing
+// kernel files and their declarations in bindings.cpp are untouched.
+// ================================================================
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp8.h>
+
+// ── kernels/elementwise_fp16.hip ──
+void add_bias_fp16(__half* x, const __half* b, int S, int D, hipStream_t stream);
+void gelu_inplace_fp16(__half* x, int n, hipStream_t stream);
+void silu_inplace_fp16(__half* x, int n, hipStream_t stream);
+void relu_inplace_bf16(__hip_bfloat16* x, int n, hipStream_t stream);
+void mul_fp16(const __half* a, const __half* b, __half* out, int n, hipStream_t stream);
+void residual_add_fp16(__half* residual, const __half* x, int n, hipStream_t stream);
+void gpu_fill_neginf_fp16(__half* dst, int n, hipStream_t stream);
+void gpu_strided_copy_fp16(const __half* src, __half* dst,
+                           int rows, int dst_cols, int src_stride, int col_offset,
+                           hipStream_t stream);
+void gpu_repeat_interleave_heads(const __half* src, __half* dst,
+                                 int S, int NH_src, int HD, int repeat,
+                                 hipStream_t stream);
+void cast_fp16_to_bf16(const __half* in, __hip_bfloat16* out, int n, hipStream_t stream);
+void cast_bf16_to_fp16(const __hip_bfloat16* in, __half* out, int n, hipStream_t stream);
+void concat2_bf16(const __hip_bfloat16* a, const __hip_bfloat16* b,
+                  __hip_bfloat16* out, int rows, int cols_a, int cols_b,
+                  hipStream_t stream);
+void quantize_fp8_static_fp16(const __half* input, __hip_fp8_e4m3* output,
+                              const float* d_scale, int n, hipStream_t stream);
+void silu_mul_split_fp8_fp16(const __half* gate, const __half* up,
+                             __hip_fp8_e4m3* out, int n,
+                             const float* d_scale, hipStream_t stream);
+int residual_add_fp16_vec(__half* residual, const __half* x, int n,
+                          hipStream_t stream);
+int quantize_fp8_static_fp16_vec(const __half* in, __hip_fp8_e4m3* out,
+                                 const float* descale_ptr, int n,
+                                 hipStream_t stream);
+int gpu_repeat_interleave_heads_vec(const __half* src, __half* dst,
+                                    int S, int NH_src, int HD, int repeat,
+                                    hipStream_t stream);
+
+// ── kernels/norm_fp16.hip ──
+void layer_norm_fp16(const __half* x, const __half* weight,
+                     const __half* bias, __half* out,
+                     int seq_len, int dim, float eps, hipStream_t stream);
+void rope_rotate_half_fp16(__half* x, const __half* cos_table,
+                           const __half* sin_table,
+                           int S, int NH, int HD, hipStream_t stream);
+void rms_norm_fp8_fp16(const __half* x, const __half* weight,
+                       __hip_fp8_e4m3* out, int seq_len, int dim, float eps,
+                       const float* d_scale, hipStream_t stream);
+void residual_add_rms_norm_fp8_fp16(__half* residual, const __half* x,
+                                    const __half* weight, __hip_fp8_e4m3* out,
+                                    int seq_len, int dim, float eps,
+                                    const float* d_scale, hipStream_t stream);
+int rms_norm_fp16_vec(const __half* x, const __half* w, __half* out,
+                      int rows, int dim, float eps, hipStream_t stream);
+int layer_norm_fp16_vec(const __half* x, const __half* w, const __half* b,
+                        __half* out, int rows, int dim, float eps,
+                        hipStream_t stream);
+int layer_norm_fp8_static_fp16_vec(const __half* x, const __half* w,
+                                   const __half* b, __hip_fp8_e4m3* out,
+                                   const float* d_scale, int rows, int dim,
+                                   float eps, hipStream_t stream);
+int rope_rotate_half_fp16_vec(__half* x, const __half* cos_t,
+                              const __half* sin_t, int S, int NH, int HD,
+                              hipStream_t stream);
+
+// ── kernels/adaln_layer_norm.hip ──
+void layer_norm_no_affine_bf16(const __hip_bfloat16* x, __hip_bfloat16* out,
+                               int seq_len, int dim, float eps,
+                               hipStream_t stream);
+void ada_layer_norm_bf16(const __hip_bfloat16* x,
+                         const __hip_bfloat16* scale, const __hip_bfloat16* shift,
+                         __hip_bfloat16* out, int seq_len, int dim, float eps,
+                         hipStream_t stream);
+void ada_layer_norm_fp8(const __hip_bfloat16* x,
+                        const __hip_bfloat16* scale, const __hip_bfloat16* shift,
+                        __hip_fp8_e4m3* out, const float* act_scale,
+                        int seq_len, int dim, float eps,
+                        hipStream_t stream);
+void bias_gelu_quantize_fp8_static_bf16(const __hip_bfloat16* in,
+                                        const __hip_bfloat16* bias,  // may be nullptr
+                                        __hip_fp8_e4m3* out,
+                                        const float* act_scale,
+                                        long long M, int N,
+                                        hipStream_t stream);

--- a/csrc/amd/kernels/norm_fp16.hip
+++ b/csrc/amd/kernels/norm_fp16.hip
@@ -1,0 +1,304 @@
+// ================================================================
+// FlashRT AMD — FP16 norm / RoPE / norm→FP8 kernels (CDNA wave64).
+// Additive port of the CUDA FP16 backbone surface:
+//   layer_norm_fp16 (+_vec), rms_norm_fp16_vec,
+//   rope_rotate_half_fp16 (+_vec),
+//   rms_norm_fp8_fp16, residual_add_rms_norm_fp8_fp16,
+//   layer_norm_fp8_static_fp16_vec
+// Mirrors csrc/kernels/norm.cu, csrc/kernels/rope_qwen3.cu and
+// csrc/kernels/vec_fp16_backbone.cu host-wrapper signatures and
+// per-element math exactly (fp32 intermediates, clamp ±448, and the
+// fp16 round-through before quantize in layer_norm_fp8_static_*).
+//
+// Reductions use the tree's wave64 block_reduce_sum (common_hip.h);
+// per-thread accumulation order therefore differs from the CUDA
+// warp32 originals — last-ULP differences only, gated by the cos
+// parity suite (same policy as layer_norm_wide_kernel in norm.hip).
+//
+// The *_vec entries keep the CUDA precondition contract (return -1
+// when dim%8 / alignment does not hold, 0 on success) but dispatch
+// to the same-math row-per-block kernels; wide-load retunes come
+// later against profiles. rms_norm_fp16_vec binds to the existing
+// rms_norm_fp16 (kernels/norm.hip) — same math, not duplicated.
+//
+// FP8 output dtype: OCP e4m3 via __hip_fp8_e4m3 (never fnuz).
+// ================================================================
+
+#include "common_hip.h"
+#include <hip/hip_fp8.h>
+#include <cstdint>
+
+// Existing launcher from kernels/norm.hip (host-side call only).
+void rms_norm_fp16(const __half* x, const __half* weight,
+                   __half* out, int seq_len, int dim, float eps,
+                   hipStream_t stream);
+
+namespace {  // internal kernels
+
+// ── LayerNorm (gamma/beta), FP16, row per block, packed __half2 ──
+__global__ void nrm16_layer_norm_fp16_kernel(const __half* __restrict__ x,
+                                             const __half* __restrict__ weight,
+                                             const __half* __restrict__ bias,
+                                             __half* __restrict__ out,
+                                             int dim, float eps) {
+    int row = blockIdx.x;
+    const __half2* x2 = reinterpret_cast<const __half2*>(x + (size_t)row * dim);
+    __half2* out2 = reinterpret_cast<__half2*>(out + (size_t)row * dim);
+    const __half2* w2 = reinterpret_cast<const __half2*>(weight);
+    const __half2* b2 = reinterpret_cast<const __half2*>(bias);
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 val = x2[i];
+        local_sum += __half2float(val.x) + __half2float(val.y);
+    }
+    float mean = block_reduce_sum(local_sum, shared) / dim;
+
+    float local_var = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 val = x2[i];
+        float d0 = __half2float(val.x) - mean, d1 = __half2float(val.y) - mean;
+        local_var += d0 * d0 + d1 * d1;
+    }
+    float inv_std = rsqrtf(block_reduce_sum(local_var, shared) / dim + eps);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 xv = x2[i], wv = w2[i], bv = b2[i];
+        float v0 = (__half2float(xv.x) - mean) * inv_std * __half2float(wv.x) + __half2float(bv.x);
+        float v1 = (__half2float(xv.y) - mean) * inv_std * __half2float(wv.y) + __half2float(bv.y);
+        out2[i] = __halves2half2(__float2half(v0), __float2half(v1));
+    }
+}
+
+// ── LayerNorm (gamma/beta) → static FP8, FP16 input.
+// Norm output is rounded through fp16 BEFORE the fp8 quantize, keeping
+// this identical to the two-step (fp16 LayerNorm, then static quantize)
+// chain — exactly like layer_norm_fp8_static_fp16_vec_kernel in
+// vec_fp16_backbone.cu (which also guards the scale with 1e-12).
+__global__ void nrm16_layer_norm_fp8_static_fp16_kernel(
+        const __half* __restrict__ x, const __half* __restrict__ weight,
+        const __half* __restrict__ bias, __hip_fp8_e4m3* __restrict__ out,
+        const float* __restrict__ descale_ptr, int dim, float eps) {
+    int row = blockIdx.x;
+    const __half2* x2 = reinterpret_cast<const __half2*>(x + (size_t)row * dim);
+    const __half2* w2 = reinterpret_cast<const __half2*>(weight);
+    const __half2* b2 = reinterpret_cast<const __half2*>(bias);
+    __hip_fp8_e4m3* out_row = out + (size_t)row * dim;
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 val = x2[i];
+        local_sum += __half2float(val.x) + __half2float(val.y);
+    }
+    float mean = block_reduce_sum(local_sum, shared) / dim;
+
+    float local_var = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 val = x2[i];
+        float d0 = __half2float(val.x) - mean, d1 = __half2float(val.y) - mean;
+        local_var += d0 * d0 + d1 * d1;
+    }
+    float inv_std = rsqrtf(block_reduce_sum(local_var, shared) / dim + eps);
+    const float inv_scale = 1.0f / fmaxf(*descale_ptr, 1e-12f);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 xv = x2[i], wv = w2[i], bv = b2[i];
+        // fp16 round-through of the norm output (see header comment).
+        const float v0 = __half2float(__float2half(
+            (__half2float(xv.x) - mean) * inv_std * __half2float(wv.x) + __half2float(bv.x)));
+        const float v1 = __half2float(__float2half(
+            (__half2float(xv.y) - mean) * inv_std * __half2float(wv.y) + __half2float(bv.y)));
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(v0 * inv_scale, -448.f), 448.f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(v1 * inv_scale, -448.f), 448.f));
+    }
+}
+
+// ── Split-half RoPE (rotate_half, Qwen3/LLaMA format), in-place.
+// x: [S, NH*HD]; cos/sin tables: [S, HD] (first HD/2 entries used per
+// position, broadcast over heads). Each thread owns one (d, d+HD/2) pair.
+__global__ void nrm16_rope_rotate_half_fp16_kernel(
+        __half* __restrict__ x,
+        const __half* __restrict__ cos_t,
+        const __half* __restrict__ sin_t,
+        int S, int NH, int HD) {
+    int half_hd = HD / 2;
+    int total_pairs = S * NH * half_hd;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= total_pairs) return;
+
+    int d = idx % half_hd;
+    int remainder = idx / half_hd;
+    int h = remainder % NH;
+    int s = remainder / NH;
+
+    int rope_idx = s * HD + d;
+    float c = __half2float(cos_t[rope_idx]);
+    float si = __half2float(sin_t[rope_idx]);
+
+    int base = s * NH * HD + h * HD;
+    float x_lo = __half2float(x[base + d]);
+    float x_hi = __half2float(x[base + d + half_hd]);
+
+    x[base + d]           = __float2half(x_lo * c - x_hi * si);
+    x[base + d + half_hd] = __float2half(x_hi * c + x_lo * si);
+}
+
+// ── RMSNorm → FP8, FP16 input (static device scale) ──
+__global__ void nrm16_rms_norm_fp8_fp16_kernel(
+        const __half* __restrict__ x,
+        const __half* __restrict__ weight,
+        __hip_fp8_e4m3* __restrict__ out,
+        int dim, float eps, const float* __restrict__ d_scale) {
+    int row = blockIdx.x;
+    const __half2* x2 = reinterpret_cast<const __half2*>(x + (size_t)row * dim);
+    const __half2* w2 = reinterpret_cast<const __half2*>(weight);
+    __hip_fp8_e4m3* out_row = out + (size_t)row * dim;
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 val = x2[i];
+        float v0 = __half2float(val.x), v1 = __half2float(val.y);
+        local_sum += v0 * v0 + v1 * v1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 xv = x2[i], wv = w2[i];
+        float v0 = __half2float(xv.x) * rms * __half2float(wv.x) * inv_scale;
+        float v1 = __half2float(xv.y) * rms * __half2float(wv.y) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f));
+    }
+}
+
+// ── Residual add + RMSNorm → FP8, FP16 (pass 1 writes the rounded
+// residual back; sum-of-squares from the UNROUNDED float sums; pass 2
+// re-reads the rounded residual — matching norm.cu exactly).
+__global__ void nrm16_residual_add_rms_norm_fp8_fp16_kernel(
+        __half* __restrict__ residual, const __half* __restrict__ x,
+        const __half* __restrict__ weight, __hip_fp8_e4m3* __restrict__ out,
+        int dim, float eps, const float* __restrict__ d_scale) {
+    int row = blockIdx.x;
+    __half2* res2 = reinterpret_cast<__half2*>(residual + (size_t)row * dim);
+    const __half2* x2 = reinterpret_cast<const __half2*>(x + (size_t)row * dim);
+    const __half2* w2 = reinterpret_cast<const __half2*>(weight);
+    __hip_fp8_e4m3* out_row = out + (size_t)row * dim;
+    int dim2 = dim >> 1;
+
+    extern __shared__ float shared[];
+    float local_sum = 0.0f;
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 rv = res2[i], xv = x2[i];
+        float r0 = __half2float(rv.x) + __half2float(xv.x);
+        float r1 = __half2float(rv.y) + __half2float(xv.y);
+        res2[i] = __halves2half2(__float2half(r0), __float2half(r1));
+        local_sum += r0 * r0 + r1 * r1;
+    }
+    float rms = rsqrtf(block_reduce_sum(local_sum, shared) / dim + eps);
+    float inv_scale = 1.0f / (*d_scale);
+
+    for (int i = threadIdx.x; i < dim2; i += blockDim.x) {
+        __half2 rv = res2[i], wv = w2[i];
+        float v0 = __half2float(rv.x) * rms * __half2float(wv.x) * inv_scale;
+        float v1 = __half2float(rv.y) * rms * __half2float(wv.y) * inv_scale;
+        out_row[2*i]   = __hip_fp8_e4m3(fminf(fmaxf(v0, -448.0f), 448.0f));
+        out_row[2*i+1] = __hip_fp8_e4m3(fminf(fmaxf(v1, -448.0f), 448.0f));
+    }
+}
+
+}  // namespace
+
+// ── Host launchers (CUDA-signature mirrors) ──
+
+void layer_norm_fp16(const __half* x, const __half* weight,
+                     const __half* bias, __half* out,
+                     int seq_len, int dim, float eps, hipStream_t stream) {
+    nrm16_layer_norm_fp16_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        x, weight, bias, out, dim, eps);
+}
+
+void rope_rotate_half_fp16(__half* x, const __half* cos_table,
+                           const __half* sin_table,
+                           int S, int NH, int HD, hipStream_t stream) {
+    int total_pairs = S * NH * (HD / 2);
+    int threads = 256;
+    int blocks = (total_pairs + threads - 1) / threads;
+    nrm16_rope_rotate_half_fp16_kernel<<<blocks, threads, 0, stream>>>(
+        x, cos_table, sin_table, S, NH, HD);
+}
+
+void rms_norm_fp8_fp16(const __half* x, const __half* weight,
+                       __hip_fp8_e4m3* out, int seq_len, int dim, float eps,
+                       const float* d_scale, hipStream_t stream) {
+    nrm16_rms_norm_fp8_fp16_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        x, weight, out, dim, eps, d_scale);
+}
+
+void residual_add_rms_norm_fp8_fp16(__half* residual, const __half* x,
+                                    const __half* weight, __hip_fp8_e4m3* out,
+                                    int seq_len, int dim, float eps,
+                                    const float* d_scale, hipStream_t stream) {
+    nrm16_residual_add_rms_norm_fp8_fp16_kernel<<<seq_len, 256, 4 * sizeof(float), stream>>>(
+        residual, x, weight, out, dim, eps, d_scale);
+}
+
+// ── *_vec entries: CUDA precondition contract, same-math dispatch ──
+
+int rms_norm_fp16_vec(const __half* x, const __half* w, __half* out,
+                      int rows, int dim, float eps, hipStream_t stream) {
+    if (dim % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(w) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
+    rms_norm_fp16(x, w, out, rows, dim, eps, stream);
+    const hipError_t e = hipGetLastError();
+    return (e == hipSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int layer_norm_fp16_vec(const __half* x, const __half* w, const __half* b,
+                        __half* out, int rows, int dim, float eps,
+                        hipStream_t stream) {
+    if (dim % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(w) & 15) ||
+        (reinterpret_cast<uintptr_t>(b) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 15)) return -1;
+    layer_norm_fp16(x, w, b, out, rows, dim, eps, stream);
+    const hipError_t e = hipGetLastError();
+    return (e == hipSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int layer_norm_fp8_static_fp16_vec(const __half* x, const __half* w,
+                                   const __half* b, __hip_fp8_e4m3* out,
+                                   const float* d_scale, int rows, int dim,
+                                   float eps, hipStream_t stream) {
+    if (dim % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(w) & 15) ||
+        (reinterpret_cast<uintptr_t>(b) & 15) ||
+        (reinterpret_cast<uintptr_t>(out) & 7)) return -1;
+    nrm16_layer_norm_fp8_static_fp16_kernel<<<rows, 256, 4 * sizeof(float), stream>>>(
+        x, w, b, out, d_scale, dim, eps);
+    const hipError_t e = hipGetLastError();
+    return (e == hipSuccess) ? 0 : -static_cast<int>(e);
+}
+
+int rope_rotate_half_fp16_vec(__half* x, const __half* cos_t,
+                              const __half* sin_t, int S, int NH, int HD,
+                              hipStream_t stream) {
+    const int half_hd = HD / 2;
+    if (half_hd % 8 != 0) return -1;
+    if ((reinterpret_cast<uintptr_t>(x) & 15) ||
+        (reinterpret_cast<uintptr_t>(cos_t) & 15) ||
+        (reinterpret_cast<uintptr_t>(sin_t) & 15)) return -1;
+    rope_rotate_half_fp16(x, cos_t, sin_t, S, NH, HD, stream);
+    const hipError_t e = hipGetLastError();
+    return (e == hipSuccess) ? 0 : -static_cast<int>(e);
+}

--- a/docs/deployment_amd.md
+++ b/docs/deployment_amd.md
@@ -9,7 +9,7 @@ Per-model deployment guides:
 | Model | Guide | Status |
 |---|---|---|
 | Pi0.5 | [deployment_amd_pi05.md](deployment_amd_pi05.md) | FP8 default, BF16 available |
-| GROOT N1.7 | `deployment_amd_groot_n17.md` | on the GROOT integration branch |
+| GROOT N1.7 | [deployment_amd_groot_n17.md](deployment_amd_groot_n17.md) | FP8 backbone + bf16 DiT |
 
 ## Supported hardware
 
@@ -141,6 +141,8 @@ python -m pytest tests/test_amd_routing.py tests/test_amd_extension.py \
 | `test_amd_hip_graph.py` | buffer round-trips with pattern data, capture → instantiate → replay, byte-identical repeat replays | no ROCm device or extension |
 | `test_amd_kernel_parity.py` | numerical parity of the kernel surface against torch references on real-distribution inputs, including FP8 byte-exactness and the seqused fixed-shape attention path | no ROCm device or extension |
 | `test_amd_pi05_model.py` | end-to-end model load, graph capture, pinned-noise determinism, exact/fixed prompt modes, FP8 and BF16 | no checkpoint (see the per-model guide for the environment variables) |
+| `test_amd_groot_routing.py` | GROOT N1.7 pipeline-map entry, precision-tier contracts, attention-backend site/layer validation | extension-dependent cases skip without the `.so` |
+| `test_amd_groot_model.py` | GROOT N1.7 end-to-end: kernel backbone, finite actions, pinned-noise determinism, optional reference cosine | no checkpoint |
 
 Everything skips cleanly with a stated reason on machines without ROCm,
 so the suite is safe to run in a CUDA-only CI.

--- a/docs/deployment_amd_groot_n17.md
+++ b/docs/deployment_amd_groot_n17.md
@@ -1,0 +1,159 @@
+# GROOT N1.7 on AMD Instinct (MI350X / CDNA4)
+
+Model-specific guide. For hardware support, the build, routing, shared
+environment knobs and the test suite, see
+[deployment_amd.md](deployment_amd.md) first.
+
+## Performance
+
+GROOT N1.7 (3.1 B: Qwen3-VL ViT + truncated Cosmos-Reason2 LLM + VL
+adapter + 32-layer DiT action head), 2 camera views, 4-step flow
+matching, action horizon 40. Median **full-frame** end-to-end latency —
+a fresh observation through the backbone graph plus the action chain,
+i.e. what a serving loop pays per frame:
+
+| Configuration | Latency | vs eager |
+|---|---|---|
+| PyTorch eager (official policy) | 67.9 ms | 1.00× |
+| torch.compile (max-autotune) | 77.9 ms | 0.87× |
+| **FlashRT AMD, FP8 backbone + bf16 DiT** | **16.0 ms** | **4.24×** |
+
+`torch.compile` is slower than eager for this model on this stack; the
+judged baseline is therefore eager.
+
+Scope note: the frame cost splits into roughly 7 ms of backbone graph
+replay and 9 ms of action chain (the 4 denoise steps over the 32-layer
+DiT). Deployments that reuse backbone features across frames pay only
+the action chain.
+
+Accuracy: combined denormalized-action cosine against the reference is
+**0.9995** with the initial noise pinned (per-modality: end-effector and
+joint targets above 0.999; the 1-D gripper signal is near-constant over
+a trajectory so its cosine is naturally lower and is not a useful gate).
+
+## Usage
+
+```python
+import flash_rt
+
+model = flash_rt.load_model(checkpoint_dir, config="groot_n17",
+                            framework="torch", num_views=2)
+fe = model.pipeline
+
+# aux is the official processor's output bundle for the observation
+# (input_ids, visual/text embeds, rope tables, pixel features, grid_thw).
+fe.set_prompt(aux=aux, prompt=instruction_text)
+
+state_normed = fe.normalize_state(state_dict)
+out = fe.infer(state_normed, aux=aux)          # fresh observation
+actions = fe.denormalize_action(out, state_dict=state_dict)
+```
+
+Omitting `aux` from `infer` reuses the backbone features computed at
+`set_prompt` and runs the action chain only.
+
+## Precision
+
+The production tier is an **FP8 backbone with a bf16 DiT action head**,
+mirroring the validated RTX tier:
+
+- ViT, DeepStack mergers, the truncated LLM and the VL self-attention
+  adapter run FP8 GEMMs with per-tensor activation scales.
+- The DiT action head, the state/action encoders and the decoder stay
+  bf16; they are never quantized.
+- Activation scales are calibrated once and cached to disk. A warm
+  `set_prompt` loads the cache and runs kernels only; a cold cache runs
+  a one-time reference pass purely to extract activation maxima.
+
+There is no BF16-only tier: `use_fp8=False` without `use_fp16=True` is
+rejected rather than silently ignored, and the non-quantized full-FP16
+reference tier is not ported to CDNA4 (`use_fp16=True` raises
+`NotImplementedError`).
+
+## Attention
+
+One backend serves all five attention sites — ViT self-attention, the
+causal LLM self-attention, the VL adapter, and the DiT self- and
+cross-attention. On the measured GROOT geometries aiter beats torch SDPA
+at every site (1.19×–1.83×), including head_dim 48 and the GQA causal
+site, so aiter is the default and `FVK_AMD_ATTN=sdpa` is the fallback.
+
+The LLM K/V slots hold the model's native 8 KV heads: aiter performs
+GQA internally, so the head-expansion step the CUDA path needs is not
+run here.
+
+## Fusion and kernel routing
+
+Two AMD-specific paths carry most of the speedup over a direct port.
+Both are controlled by environment knobs so either can be A/B'd against
+the decomposed form in one process.
+
+**Fused GEMM epilogues** (`FVK_AMD_FUSED_EPILOGUE`, default on) —
+hipBLASLt on gfx950 supports fused FP8 bias and bias+GELU epilogues that
+the CUDA SM120 path cannot use, so the backbone runs
+`fp8_nn_bias`/`fp8_nn_gelu_bias` instead of a descale GEMM followed by
+separate bias and activation kernels. The DiT and the frontend's own
+graph closures likewise use `bf16_nn_bias`, `bf16_nn_bias_gelu` and
+`bf16_nn_bias_res` (residual accumulation in the epilogue), and the
+norm→quantize chains collapse into the fused norm kernels. Together this
+removes on the order of a thousand kernel launches per frame.
+
+Numerics note: a fused epilogue adds the bias on the FP32 accumulator
+before the output rounding, where the decomposed form adds it after.
+The difference is last-ULP and is judged by the end-to-end cosine gate,
+not by bit equality.
+
+**Packed-weight MFMA GEMMs** (`FVK_AMD_DIT_GEMM`, default `smallm`) —
+the DiT projections are a small-M, weight-bandwidth-bound shape
+(M = 41 action+state tokens). A hand-written MFMA kernel with weights
+pre-packed at setup into per-lane consumption order beats the autotuned
+hipBLASLt kernel by 1.41× on that shape (951 GB/s versus 673 GB/s
+effective weight bandwidth) and is routed for the Q/K/V/O projections
+only. The FFN shapes measured slower than the library and deliberately
+stay on hipBLASLt — routing is by measured shape list, not blanket
+substitution. Set `FVK_AMD_DIT_GEMM=hipblaslt` to disable the routing;
+the packing costs roughly 430 MB of additional weight storage.
+
+## Environment knobs
+
+Shared knobs are in [deployment_amd.md](deployment_amd.md). GROOT-specific:
+
+| Env | Default | Meaning |
+|---|---|---|
+| `FVK_AMD_FUSED_EPILOGUE` | `1` | fused GEMM epilogues and fused norm→quantize chains; `0` selects the decomposed form (also switches the DiT driver back to the hardware-independent forward) |
+| `FVK_AMD_DIT_GEMM` | `smallm` | DiT projection GEMMs: `smallm` (packed-weight MFMA on the measured-faster shape) or `hipblaslt` |
+
+Both are read at setup and graph-build time, never on the inference
+path; changing them after the graphs are built has no effect.
+
+## Tests
+
+```bash
+export FLASH_RT_GROOT_N17_AMD_CKPT=<groot_n17_checkpoint_dir>
+python -m pytest tests/test_amd_groot_routing.py \
+                 tests/test_amd_groot_model.py -v
+```
+
+`test_amd_groot_routing.py` covers the pipeline-map entry, the
+`load_model` precision-tier contracts and the attention backend's site
+and layer-index validation. `test_amd_groot_model.py` covers the
+end-to-end path: frontend construction, `set_prompt` through the FP8
+kernel backbone, finite actions of the expected shape, bit-identical
+results for a pinned initial noise, and — when a reference fixture is
+provided — a cosine gate against it. Both skip with a stated reason
+without ROCm, the extension, or the checkpoint.
+
+## Reproducing the numbers
+
+1. Build on a gfx950 machine (see the general guide) with aiter
+   importable — without it attention falls back to torch SDPA and every
+   number here shifts.
+2. Run a full-frame loop: `set_prompt` once, then `infer(state, aux=aux,
+   initial_noise=pinned)` in a timed loop after warmup, reporting the
+   median.
+3. Judge accuracy on the same call with the initial noise pinned to the
+   array the reference was generated with, comparing denormalized
+   actions per modality.
+4. To attribute a change, flip one knob at a time in a single process:
+   `FVK_AMD_FUSED_EPILOGUE=0/1` for the fusion tier and
+   `FVK_AMD_DIT_GEMM=hipblaslt/smallm` for the projection routing.

--- a/docs/deployment_amd_groot_n17.md
+++ b/docs/deployment_amd_groot_n17.md
@@ -54,8 +54,12 @@ Omitting `aux` from `infer` reuses the backbone features computed at
 
 ## Precision
 
-The production tier is an **FP8 backbone with a bf16 DiT action head**,
-mirroring the validated RTX tier:
+The tier here is an **FP8 backbone with an unquantized bf16 DiT action
+head**. Note this is deliberately *less* quantized than the Thor and RTX
+FP8 frontends, which additionally run the DiT FFN and fused
+self-attention QKV in FP8 (`_DIT_USE_FP8 = True`); that DiT calibration
+path is not ported to CDNA4 yet, so it remains available headroom rather
+than a shipped capability.
 
 - ViT, DeepStack mergers, the truncated LLM and the VL self-attention
   adapter run FP8 GEMMs with per-tensor activation scales.

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -2,9 +2,13 @@
 
 Production tier mirror of :class:`GrootN17TorchFrontendRtxFP8`: the whole
 VLM backbone (ViT / DeepStack / LLM / VL self-attn) runs through the AMD
-FP8 kernel surface via the decomposed descale form in
-:mod:`flash_rt.amd.models.groot_n17.pipeline`, and the DiT action head
-stays bf16 (``_DIT_USE_FP8 = False``) driven by the hardware-independent
+FP8 kernel surface via :mod:`flash_rt.amd.models.groot_n17.pipeline`
+(FUSED-EPILOGUE tier by default — bias / bias+GELU in the hipBLASLt FP8
+epilogue with host alphas; ``FVK_AMD_FUSED_EPILOGUE=0`` falls back to the
+decomposed descale form), and the DiT action head stays bf16
+(``_DIT_USE_FP8 = False``). The same env picks the DiT driver: fused on →
+the AMD-local ``dit_forward`` (``bf16_nn_bias`` / ``bf16_nn_bias_gelu``);
+off → the hardware-independent
 :func:`flash_rt.models.groot_n17.pipeline_thor.dit_forward` with the AMD
 kernel module passed in — every binding name the bf16 DiT path touches
 (``bf16_nn`` / ``add_bias_bf16`` / ``ada_layer_norm_bf16`` /
@@ -55,6 +59,8 @@ The FP8 / FP4 DiT quantization tiers of the base are NOT ported;
 
 from __future__ import annotations
 
+import os
+
 import torch
 
 from flash_rt.frontends.torch.groot_n17_thor import GrootN17TorchFrontendThor
@@ -62,6 +68,21 @@ from flash_rt.frontends.torch.groot_n17_rtx_fp8 import _GrootN17FP8BackboneMixin
 
 _FP16 = torch.float16
 _U8 = torch.uint8
+
+
+def _fused_epilogue_enabled() -> bool:
+    """FVK_AMD_FUSED_EPILOGUE gate (default ON) for BOTH fusions.
+
+    When on: the FP8 backbone forwards run with ``fused_epilogue=True``
+    (bias / bias+GELU in the hipBLASLt FP8 epilogue, host alphas) and the
+    DiT runs the AMD-local fused ``dit_forward`` (``bf16_nn_bias`` /
+    ``bf16_nn_bias_gelu``). One env flips both for the A/B against the
+    decomposed form. Read at setup time (set_prompt / graph build), never
+    on the hot path — flipping the env after graphs are built has no
+    effect on the built graphs.
+    """
+    return os.environ.get("FVK_AMD_FUSED_EPILOGUE", "1").strip().lower() \
+        not in ("0", "off", "false", "no")
 
 
 def _patch_hf_offline_model_info() -> None:
@@ -318,6 +339,17 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         """
         from flash_rt.models.groot_n17 import pipeline_thor
 
+        # FVK_AMD_FUSED_EPILOGUE flips BOTH fusions (backbone + DiT) for
+        # the A/B: on → the AMD-local dit_forward (bf16_nn_bias /
+        # bf16_nn_bias_gelu fused epilogues); off → the byte-identical
+        # decomposed pipeline_thor.dit_forward. Only dit_forward is
+        # AMD-local; embodiment_* stages keep coming from pipeline_thor.
+        if _fused_epilogue_enabled():
+            from flash_rt.amd.models.groot_n17 import pipeline as _amd_pipeline
+            dit_forward = _amd_pipeline.dit_forward
+        else:
+            dit_forward = pipeline_thor.dit_forward
+
         if getattr(self, "_DIT_USE_FP8", False) or \
                 getattr(self, "_DIT_QUANT", "fp8") == "fp4":
             raise NotImplementedError(
@@ -434,7 +466,7 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
 
         def _step_fwd(step, s):
             _ae_fwd(step, s)
-            pipeline_thor.dit_forward(
+            dit_forward(
                 gemm=self._gemm, fvk=K, bufs=bp, weights=step_weights[step],
                 dims=dims, attn=self._dit_attn, stream=s)
             _post_fwd(step, s)
@@ -517,6 +549,38 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
             """Device act-scale scalar tensors → list of int ptrs."""
             return [t.data_ptr() for t in dev_list]
 
+        # ── FUSED-EPILOGUE tier (FVK_AMD_FUSED_EPILOGUE, default on) ──
+        # Host alphas for the fused fp8_nn_bias / fp8_nn_gelu_bias calls.
+        # _bake_calibration (already run via _ensure_act_scales) composes
+        # them as python floats: alpha = act_scale × w_scale per site per
+        # layer. Key names parallel the scales_dev dicts. The llm stage is
+        # biasless (Qwen3) and always stays on descale GEMMs.
+        fused = _fused_epilogue_enabled()
+        if fused:
+            vit_alphas = {
+                "act_qkv": [float(a) for a in self._vit_alpha_q],
+                "act_o":   [float(a) for a in self._vit_alpha_o],
+                "act_fc1": [float(a) for a in self._vit_alpha_fc1],
+                "act_fc2": [float(a) for a in self._vit_alpha_fc2],
+            }
+            ds_alphas = {
+                "act_fc1": [float(a) for a in self._dsm_alpha_fc1],
+                "act_fc2": [float(a) for a in self._dsm_alpha_fc2],
+            }
+            # vlsa Q/K/V have separate weight scales → per-layer 3-tuples.
+            vlsa_alphas = {
+                "act_qkv": [
+                    (float(q), float(k), float(v))
+                    for q, k, v in zip(self._vlsa_alpha_q,
+                                       self._vlsa_alpha_k,
+                                       self._vlsa_alpha_v)],
+                "act_o":   [float(a) for a in self._vlsa_alpha_o],
+                "act_fc1": [float(a) for a in self._vlsa_alpha_fc1],
+                "act_fc2": [float(a) for a in self._vlsa_alpha_fc2],
+            }
+        else:
+            vit_alphas = ds_alphas = vlsa_alphas = None
+
         # One backend for the whole model: backbone sites now, DiT sites
         # at first infer (reused by _build_dit_attn when Sa matches).
         n_text, n_image = self._dit_kv_split()
@@ -595,7 +659,8 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
             scales_dev=vit_scales,
             dims={"S": Sv, "D": 1024, "NH": 16, "HD": 64,
                   "ff_inner": 4096, "Sper_view": Sv // nv},
-            attn=attn, deepstack_taps=tap_layers, deepstack_capture=dcap)
+            attn=attn, deepstack_taps=tap_layers, deepstack_capture=dcap,
+            fused_epilogue=fused, alphas=vit_alphas)
 
         # ═══ DeepStack (3 mergers) ═══
         Nout = Sv // 4
@@ -622,7 +687,8 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
                    "Dmid": 4096, "Dout": 2048}
         P.deepstack_merge_forward(
             gemm=gemm, fvk=fvkm, bufs=ds_bufs,
-            weights=dsw, scales_dev=ds_scales, dims=ds_dims)
+            weights=dsw, scales_dev=ds_scales, dims=ds_dims,
+            fused_epilogue=fused, alphas=ds_alphas)
 
         # DeepStack inject buffers (S, D) — zero except visual positions.
         mask = self._visual_pos_masks
@@ -742,7 +808,8 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
                      "ff_inner": 8192}
         P.vl_self_attn_forward(
             gemm=gemm, fvk=fvkm, bufs=vlsa_bufs,
-            weights=vsw, scales_dev=vlsa_scales, dims=vlsa_dims, attn=attn)
+            weights=vsw, scales_dev=vlsa_scales, dims=vlsa_dims, attn=attn,
+            fused_epilogue=fused, alphas=vlsa_alphas)
         torch.cuda.synchronize()
 
         vit_dims = {"S": Sv, "D": 1024, "NH": 16, "HD": 64,
@@ -755,10 +822,11 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
                 gemm=gemm, fvk=fvkm, bufs=vit_bufs, weights=vw,
                 scales_dev=vit_scales, dims=vit_dims, attn=attn,
                 deepstack_taps=tap_layers, deepstack_capture=dcap,
-                stream=stream)
+                stream=stream, fused_epilogue=fused, alphas=vit_alphas)
             P.deepstack_merge_forward(
                 gemm=gemm, fvk=fvkm, bufs=ds_bufs, weights=dsw,
-                scales_dev=ds_scales, dims=ds_dims, stream=stream)
+                scales_dev=ds_scales, dims=ds_dims, stream=stream,
+                fused_epilogue=fused, alphas=ds_alphas)
             for j in range(3):
                 injb[j].zero_()
                 injb[j].index_copy_(0, vis_idx, ds_out[j])
@@ -772,7 +840,7 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
             P.vl_self_attn_forward(
                 gemm=gemm, fvk=fvkm, bufs=vlsa_bufs, weights=vsw,
                 scales_dev=vlsa_scales, dims=vlsa_dims, attn=attn,
-                stream=stream)
+                stream=stream, fused_epilogue=fused, alphas=vlsa_alphas)
             return vlsa_h
 
         self._kbb_forward = _kbb_forward

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -297,6 +297,7 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         mg = self._mlp_gemm
         S = self.Se
         nt, ni = self._ck_nt, self._ck_ni
+        fused = _fused_epilogue_enabled()
         K.cast_fp16_to_bf16(
             self._ck_bb_src.data_ptr(), self._ck_bb.data_ptr(),
             S * 2048, int(s))
@@ -315,12 +316,23 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
             k_b = self._dit_k_b[li]
             v_w = self._dit_v_w[li]
             v_b = self._dit_v_b[li]
-            mg.bf16_nn(src.data_ptr(), k_w.data_ptr(), k_dst.data_ptr(),
-                       N, 1536, 2048, int(s))
-            K.add_bias_bf16(k_dst.data_ptr(), k_b.data_ptr(), N, 1536, int(s))
-            mg.bf16_nn(src.data_ptr(), v_w.data_ptr(), v_dst.data_ptr(),
-                       N, 1536, 2048, int(s))
-            K.add_bias_bf16(v_dst.data_ptr(), v_b.data_ptr(), N, 1536, int(s))
+            if fused:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (cross K/V).
+                mg.bf16_nn_bias(src.data_ptr(), k_w.data_ptr(),
+                                k_dst.data_ptr(), k_b.data_ptr(),
+                                N, 1536, 2048, int(s))
+                mg.bf16_nn_bias(src.data_ptr(), v_w.data_ptr(),
+                                v_dst.data_ptr(), v_b.data_ptr(),
+                                N, 1536, 2048, int(s))
+            else:
+                mg.bf16_nn(src.data_ptr(), k_w.data_ptr(), k_dst.data_ptr(),
+                           N, 1536, 2048, int(s))
+                K.add_bias_bf16(k_dst.data_ptr(), k_b.data_ptr(), N, 1536,
+                                int(s))
+                mg.bf16_nn(src.data_ptr(), v_w.data_ptr(), v_dst.data_ptr(),
+                           N, 1536, 2048, int(s))
+                K.add_bias_bf16(v_dst.data_ptr(), v_b.data_ptr(), N, 1536,
+                                int(s))
 
     # ────────────────────────────────────────────────────────────────
     # Fully-kernelized DiT graph (bf16, single combined graph)
@@ -344,7 +356,8 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         # bf16_nn_bias_gelu fused epilogues); off → the byte-identical
         # decomposed pipeline_thor.dit_forward. Only dit_forward is
         # AMD-local; embodiment_* stages keep coming from pipeline_thor.
-        if _fused_epilogue_enabled():
+        fused_ep = _fused_epilogue_enabled()
+        if fused_ep:
             from flash_rt.amd.models.groot_n17 import pipeline as _amd_pipeline
             dit_forward = _amd_pipeline.dit_forward
         else:
@@ -398,40 +411,75 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         step_weights = [_dit_weights(s) for s in range(num_inference_timesteps)]
 
         def _state_fwd(s):
-            mg.bf16_nn(self._k_state_in.data_ptr(), w["st_l1"].data_ptr(),
-                       self._k_st_h1.data_ptr(), 1, 1024, 132, s)
-            K.add_bias_bf16(self._k_st_h1.data_ptr(), w["st_l1b"].data_ptr(),
-                            1, 1024, s)
+            if fused_ep:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (state l1).
+                mg.bf16_nn_bias(self._k_state_in.data_ptr(),
+                                w["st_l1"].data_ptr(),
+                                self._k_st_h1.data_ptr(),
+                                w["st_l1b"].data_ptr(), 1, 1024, 132, s)
+            else:
+                mg.bf16_nn(self._k_state_in.data_ptr(), w["st_l1"].data_ptr(),
+                           self._k_st_h1.data_ptr(), 1, 1024, 132, s)
+                K.add_bias_bf16(self._k_st_h1.data_ptr(),
+                                w["st_l1b"].data_ptr(), 1, 1024, s)
             K.relu_inplace_bf16(self._k_st_h1.data_ptr(), 1024, s)
-            mg.bf16_nn(self._k_st_h1.data_ptr(), w["st_l2"].data_ptr(),
-                       self._k_state_feat.data_ptr(), 1, 1536, 1024, s)
-            K.add_bias_bf16(self._k_state_feat.data_ptr(),
-                            w["st_l2b"].data_ptr(), 1, 1536, s)
+            if fused_ep:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (state l2).
+                mg.bf16_nn_bias(self._k_st_h1.data_ptr(),
+                                w["st_l2"].data_ptr(),
+                                self._k_state_feat.data_ptr(),
+                                w["st_l2b"].data_ptr(), 1, 1536, 1024, s)
+            else:
+                mg.bf16_nn(self._k_st_h1.data_ptr(), w["st_l2"].data_ptr(),
+                           self._k_state_feat.data_ptr(), 1, 1536, 1024, s)
+                K.add_bias_bf16(self._k_state_feat.data_ptr(),
+                                w["st_l2b"].data_ptr(), 1, 1536, s)
 
         def _ae_fwd(step, s):
             # action_encode: W1 (no act) → cat[a_emb, tau] → W2 → SiLU → W3,
             # add pos, then fill dit_h ([0]=state, [1:]=action features).
             T = action_horizon
-            mg.bf16_nn(self._k_actions.data_ptr(), w["ae_W1"].data_ptr(),
-                       self._k_ae_aemb.data_ptr(), T, 1536, 132, s)
-            K.add_bias_bf16(self._k_ae_aemb.data_ptr(), w["ae_b1"].data_ptr(),
-                            T, 1536, s)
+            if fused_ep:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (ae W1).
+                mg.bf16_nn_bias(self._k_actions.data_ptr(),
+                                w["ae_W1"].data_ptr(),
+                                self._k_ae_aemb.data_ptr(),
+                                w["ae_b1"].data_ptr(), T, 1536, 132, s)
+            else:
+                mg.bf16_nn(self._k_actions.data_ptr(), w["ae_W1"].data_ptr(),
+                           self._k_ae_aemb.data_ptr(), T, 1536, 132, s)
+                K.add_bias_bf16(self._k_ae_aemb.data_ptr(),
+                                w["ae_b1"].data_ptr(), T, 1536, s)
             K.concat2_bf16(self._k_ae_aemb.data_ptr(),
                            self._k_tau[step].data_ptr(),
                            self._k_ae_concat.data_ptr(), T, 1536, 1536, s)
-            mg.bf16_nn(self._k_ae_concat.data_ptr(), w["ae_W2"].data_ptr(),
-                       self._k_ae_i2.data_ptr(), T, 1536, 3072, s)
-            K.add_bias_bf16(self._k_ae_i2.data_ptr(), w["ae_b2"].data_ptr(),
-                            T, 1536, s)
+            if fused_ep:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (ae W2).
+                mg.bf16_nn_bias(self._k_ae_concat.data_ptr(),
+                                w["ae_W2"].data_ptr(),
+                                self._k_ae_i2.data_ptr(),
+                                w["ae_b2"].data_ptr(), T, 1536, 3072, s)
+            else:
+                mg.bf16_nn(self._k_ae_concat.data_ptr(), w["ae_W2"].data_ptr(),
+                           self._k_ae_i2.data_ptr(), T, 1536, 3072, s)
+                K.add_bias_bf16(self._k_ae_i2.data_ptr(),
+                                w["ae_b2"].data_ptr(), T, 1536, s)
             K.cast_bf16_to_fp16(self._k_ae_i2.data_ptr(),
                                 self._k_ae_i2f.data_ptr(), T * 1536, s)
             K.silu_inplace_fp16(self._k_ae_i2f.data_ptr(), T * 1536, s)
             K.cast_fp16_to_bf16(self._k_ae_i2f.data_ptr(),
                                 self._k_ae_i2.data_ptr(), T * 1536, s)
-            mg.bf16_nn(self._k_ae_i2.data_ptr(), w["ae_W3"].data_ptr(),
-                       self._k_ae_out.data_ptr(), T, 1536, 1536, s)
-            K.add_bias_bf16(self._k_ae_out.data_ptr(), w["ae_b3"].data_ptr(),
-                            T, 1536, s)
+            if fused_ep:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (ae W3).
+                mg.bf16_nn_bias(self._k_ae_i2.data_ptr(),
+                                w["ae_W3"].data_ptr(),
+                                self._k_ae_out.data_ptr(),
+                                w["ae_b3"].data_ptr(), T, 1536, 1536, s)
+            else:
+                mg.bf16_nn(self._k_ae_i2.data_ptr(), w["ae_W3"].data_ptr(),
+                           self._k_ae_out.data_ptr(), T, 1536, 1536, s)
+                K.add_bias_bf16(self._k_ae_out.data_ptr(),
+                                w["ae_b3"].data_ptr(), T, 1536, s)
             K.residual_add(self._k_ae_out.data_ptr(), self._k_pos.data_ptr(),
                            T * 1536, s)
             K.gpu_copy(dit_h, self._k_state_feat.data_ptr(), 1536 * 2, s)
@@ -444,19 +492,36 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
             K.ada_layer_norm_bf16(dit_h, self._k_oproj_scale[step].data_ptr(),
                                   self._k_oproj_shift[step].data_ptr(),
                                   self._k_hmod.data_ptr(), Sa, 1536, 1e-5, s)
-            mg.bf16_nn(self._k_hmod.data_ptr(), w["po2"].data_ptr(),
-                       self._k_hout.data_ptr(), Sa, 1024, 1536, s)
-            K.add_bias_bf16(self._k_hout.data_ptr(), w["po2b"].data_ptr(),
-                            Sa, 1024, s)
-            mg.bf16_nn(hout_dec, w["dec_l1"].data_ptr(),
-                       self._k_dec_h.data_ptr(), T, 1024, 1024, s)
-            K.add_bias_bf16(self._k_dec_h.data_ptr(), w["dec_l1b"].data_ptr(),
-                            T, 1024, s)
+            if fused_ep:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (po2).
+                mg.bf16_nn_bias(self._k_hmod.data_ptr(), w["po2"].data_ptr(),
+                                self._k_hout.data_ptr(),
+                                w["po2b"].data_ptr(), Sa, 1024, 1536, s)
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (dec l1).
+                mg.bf16_nn_bias(hout_dec, w["dec_l1"].data_ptr(),
+                                self._k_dec_h.data_ptr(),
+                                w["dec_l1b"].data_ptr(), T, 1024, 1024, s)
+            else:
+                mg.bf16_nn(self._k_hmod.data_ptr(), w["po2"].data_ptr(),
+                           self._k_hout.data_ptr(), Sa, 1024, 1536, s)
+                K.add_bias_bf16(self._k_hout.data_ptr(), w["po2b"].data_ptr(),
+                                Sa, 1024, s)
+                mg.bf16_nn(hout_dec, w["dec_l1"].data_ptr(),
+                           self._k_dec_h.data_ptr(), T, 1024, 1024, s)
+                K.add_bias_bf16(self._k_dec_h.data_ptr(),
+                                w["dec_l1b"].data_ptr(), T, 1024, s)
             K.relu_inplace_bf16(self._k_dec_h.data_ptr(), T * 1024, s)
-            mg.bf16_nn(self._k_dec_h.data_ptr(), w["dec_l2"].data_ptr(),
-                       self._k_vel.data_ptr(), T, 132, 1024, s)
-            K.add_bias_bf16(self._k_vel.data_ptr(), w["dec_l2b"].data_ptr(),
-                            T, 132, s)
+            if fused_ep:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (dec l2).
+                mg.bf16_nn_bias(self._k_dec_h.data_ptr(),
+                                w["dec_l2"].data_ptr(),
+                                self._k_vel.data_ptr(),
+                                w["dec_l2b"].data_ptr(), T, 132, 1024, s)
+            else:
+                mg.bf16_nn(self._k_dec_h.data_ptr(), w["dec_l2"].data_ptr(),
+                           self._k_vel.data_ptr(), T, 132, 1024, s)
+                K.add_bias_bf16(self._k_vel.data_ptr(),
+                                w["dec_l2b"].data_ptr(), T, 132, s)
             # Euler update: actions += dt * velocity, in place on the
             # persistent buffers. The AMD module has no euler_step
             # binding; an in-place torch add is capture-safe (fixed

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -140,6 +140,18 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         self._fvk = fvk
         self._gemm = fvk.GemmRunner()
         self._mlp_gemm = fvk.GemmRunner()
+        # Timed hipBLASLt algorithm selection on the first eager call of
+        # each GEMM shape (all first calls happen pre-capture: shadow
+        # calibration / set_prompt backbone / graph warmup). gfx950
+        # heuristics have known gaps; pi05 measured meaningful wins from
+        # timed picks. FLASHRT_FP8_NT_AUTOTUNE=off disables;
+        # FLASHRT_FP8_ALGO_POOL sets the candidate pool (default 16 —
+        # deeper pools widen run-to-run pick variance).
+        import os as _os
+        if _os.environ.get("FLASHRT_FP8_NT_AUTOTUNE", "auto").lower() != "off":
+            pool = int(_os.environ.get("FLASHRT_FP8_ALGO_POOL", "16"))
+            self._gemm.enable_lazy_autotune(pool)
+            self._mlp_gemm.enable_lazy_autotune(pool)
 
     # ────────────────────────────────────────────────────────────────
     # Attention backend (single instance, all 5 sites)

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -338,6 +338,54 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
     # Fully-kernelized DiT graph (bf16, single combined graph)
     # ────────────────────────────────────────────────────────────────
 
+    def _pack_smallm_dit_weights(self) -> None:
+        """MFMA-pack the DiT (41, 1536, 1536) projection weights ONCE at
+        graph-build time (never per frame) for the gfx950 small-M packed
+        bf16 kernel (csrc/amd/gemm/smallm_mfma_bf16.h).
+
+        Measured routing (standalone gate vs autotuned hipBLASLt): the
+        packed kernel wins ONLY on the square D→D shape — bias 1.41x,
+        bias_res 1.12x — and loses on ff1/ff2, so only the projection
+        weights feeding those sites get packed copies: Q (all 32
+        layers), K/V (the 16 self blocks — the cross blocks' K/V
+        weights are the (2048, 1536) cross-KV projections, a different
+        shape consumed by ``_setup_cross_kv_kernel``), O (all 32).
+
+        Packed copies land in ``self._dit_smallm_packed`` keyed
+        ``{q,k,v,o}_w_{li}`` (pointer ints, matching the pipeline
+        ``weights`` lists); the tensors are kept alive in
+        ``self._dit_smallm_store``. Originals are KEPT — they serve the
+        FVK_AMD_DIT_GEMM=hipblaslt fallback and the cross-KV consumer —
+        at ~432 MB extra VRAM for the 96 packed copies.
+        FVK_AMD_DIT_GEMM=hipblaslt (read once here, setup time) skips
+        the packing entirely; the AMD ``dit_forward`` reads the same
+        env for routing.
+        """
+        if getattr(self, "_dit_smallm_packed", None) is not None:
+            return
+        self._dit_smallm_packed: dict = {}
+        self._dit_smallm_store: list = []
+        # FVK_AMD_DIT_GEMM: "smallm" (default) = pack + route the D→D
+        # projections to the MFMA packed kernel; "hipblaslt" = library path.
+        if os.environ.get("FVK_AMD_DIT_GEMM", "smallm").strip().lower() \
+                != "smallm":
+            return
+        with torch.no_grad():
+            for li in range(32):
+                sites = [("q_w", self._dit_q_w), ("o_w", self._dit_o_w)]
+                if li % 2 == 1:  # self blocks only (K/V)
+                    sites += [("k_w", self._dit_k_w),
+                              ("v_w", self._dit_v_w)]
+                for key, wl in sites:
+                    W = wl[li]  # (K, N) row-major bf16, both 1536
+                    Kd, Nd = W.shape
+                    # Per-lane consumption order — the documented
+                    # one-liner from smallm_mfma_bf16.h.
+                    wp = (W.view(Kd // 32, 4, 8, Nd // 16, 16)
+                           .permute(3, 0, 1, 4, 2).contiguous())
+                    self._dit_smallm_store.append(wp)
+                    self._dit_smallm_packed[f"{key}_{li}"] = wp.data_ptr()
+
     def _capture_kernel_dit_graphs(self, num_inference_timesteps: int = 4,
                                    action_horizon: int = 40) -> None:
         """Capture the per-frame action-head chain as ONE HIP graph.
@@ -377,6 +425,10 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
             self._allocate_infer_buffers(action_horizon)
         self._prepare_kernel_dit(num_inference_timesteps)
         self._allocate_kernel_dit_buffers(action_horizon)
+        if fused_ep:
+            # Setup-time MFMA packing for the smallm D→D projection
+            # routing in the AMD dit_forward (FVK_AMD_DIT_GEMM).
+            self._pack_smallm_dit_weights()
 
         K = self._fvk
         mg = self._mlp_gemm
@@ -406,6 +458,12 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
                               ("ff_down_w", "_dit_ff_down_w"),
                               ("ff_down_b", "_dit_ff_down_b")):
                 d[key] = [t.data_ptr() for t in getattr(self, attr)]
+            if fused_ep:
+                # MFMA-packed q/k/v/o copies for the smallm routing in
+                # the AMD dit_forward (same dict for every step —
+                # weights are step-invariant). Empty dict when
+                # FVK_AMD_DIT_GEMM=hipblaslt skipped the packing.
+                d["smallm_packed"] = self._dit_smallm_packed
             return d
 
         step_weights = [_dit_weights(s) for s in range(num_inference_timesteps)]

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -143,6 +143,27 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         embodiment_tag: str = "oxe_droid_relative_eef_relative_joint",
         device: str = "cuda:0",
     ):
+        # gfx950-only gate, FIRST: the MFMA tile shapes and FP8 paths in
+        # the extension are CDNA4-specific — refuse before touching the
+        # checkpoint unless BOTH the visible device arch (e.g.
+        # "gfx950:sramecc+:xnack-") and the extension's compile-time
+        # gpu_arch are gfx950. Anything else computes garbage, not a
+        # fallback (a forced hardware="amd_cdna4" on gfx942 fails here).
+        # This runs ahead of super().__init__, which loads weights.
+        from flash_rt.amd import flash_rt_amd_kernels as _fvk_gate
+        _dev_arch = str(_fvk_gate.device_arch())
+        _build_arch = str(dict(_fvk_gate.build_info()).get("gpu_arch",
+                                                           "unknown"))
+        if not (_dev_arch.startswith("gfx950")
+                and _build_arch.startswith("gfx950")):
+            raise RuntimeError(
+                "GrootN17TorchFrontendAmd is gfx950-only (CDNA4 / "
+                f"MI350-series): running device arch is {_dev_arch!r} and "
+                f"the extension was built for gpu_arch {_build_arch!r}. "
+                "Rebuild with scripts/amd/build_amd.sh on a gfx950 "
+                "machine; other AMD arches are not supported by this "
+                "backend.")
+
         # The strided-FMHA side-load is a CUDA-only .so (Thor ViT path);
         # the AMD ViT attention runs through the CDNA4 backend instead.
         super().__init__(
@@ -158,6 +179,7 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         # import in the base is guarded by ``hasattr(self, "_fvk")`` /
         # ``hasattr(self, "_gemm")`` / ``hasattr(self, "_mlp_gemm")``.
         from flash_rt.amd import flash_rt_amd_kernels as fvk
+        # (gfx950 gate already ran at the top of __init__.)
         self._fvk = fvk
         self._gemm = fvk.GemmRunner()
         self._mlp_gemm = fvk.GemmRunner()

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -1,6 +1,6 @@
 """FlashRT AMD -- GROOT N1.7 FP8 torch frontend for CDNA4 (MI350X, gfx950).
 
-Production tier mirror of :class:`GrootN17TorchFrontendRtxFP8`: the whole
+FP8 kernel backbone with an unquantized bf16 action head. The whole
 VLM backbone (ViT / DeepStack / LLM / VL self-attn) runs through the AMD
 FP8 kernel surface via :mod:`flash_rt.amd.models.groot_n17.pipeline`
 (FUSED-EPILOGUE tier by default — bias / bias+GELU in the hipBLASLt FP8
@@ -59,6 +59,7 @@ The FP8 / FP4 DiT quantization tiers of the base are NOT ported;
 
 from __future__ import annotations
 
+import contextlib
 import os
 
 import torch
@@ -85,49 +86,55 @@ def _fused_epilogue_enabled() -> bool:
         not in ("0", "off", "false", "no")
 
 
-def _patch_hf_offline_model_info() -> None:
-    """Tolerate huggingface_hub offline mode in transformers 4.57.3.
+@contextlib.contextmanager
+def _offline_tolerant_model_info():
+    """Scope a workaround for a transformers offline-mode bug.
 
-    Tokenizer loading in transformers 4.57.3 calls
+    Tokenizer loading in transformers 4.57.x calls
     ``huggingface_hub.model_info`` without catching
     ``OfflineModeIsEnabled``, so ``HF_HUB_OFFLINE=1`` breaks
-    ``AutoProcessor.from_pretrained`` even when every file is local.
-    The caller only reads ``.tags``, so degrade to a ``tags=None`` stub
-    when offline. This frontend triggers processor loading through the
-    inherited ``denormalize_action`` → ``_hf_processor`` path, hence the
-    patch lives here. Idempotent (guarded by a marker attribute).
+    ``AutoProcessor.from_pretrained`` even when every file is already in
+    the local cache. The caller only reads ``.tags``, so within this
+    context an offline lookup degrades to a ``tags=None`` stub.
+
+    The substitution is installed for the duration of one processor load
+    and restored in ``finally`` — it never outlives the call, so other
+    code in the process keeps the real ``model_info`` (and keeps seeing
+    genuine offline errors). Any exception other than
+    ``OfflineModeIsEnabled`` still propagates.
     """
     try:
         import huggingface_hub as hh
         from huggingface_hub.errors import OfflineModeIsEnabled
     except ImportError:
+        yield
         return
-    if getattr(hh.model_info, "_flashrt_offline_tolerant", False):
-        return
-    orig_model_info = hh.model_info
 
-    def _tolerant_model_info(*args, **kwargs):
+    original = hh.model_info
+
+    def _tolerant(*args, **kwargs):
         try:
-            return orig_model_info(*args, **kwargs)
+            return original(*args, **kwargs)
         except OfflineModeIsEnabled:
             class _Stub:
                 tags = None
             return _Stub()
 
-    _tolerant_model_info._flashrt_offline_tolerant = True
-    hh.model_info = _tolerant_model_info
-
-
-_patch_hf_offline_model_info()
+    hh.model_info = _tolerant
+    try:
+        yield
+    finally:
+        hh.model_info = original
 
 
 class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
                                GrootN17TorchFrontendThor):
     """N1.7 CDNA4 frontend: FP8 kernel backbone + bf16 DiT action head."""
 
-    # The DiT stays bf16 on AMD — the production tier is FP8 backbone +
-    # bf16 DiT, mirroring GrootN17TorchFrontendRtxFP8's dtype split. The
-    # FP8-FFN/QKV DiT calibration path of the Thor base is not ported.
+    # The DiT runs unquantized bf16 on AMD. NOTE this is a weaker tier
+    # than the Thor/RTX FP8 frontends, which inherit _DIT_USE_FP8 = True
+    # and quantize the DiT FFN and fused self-attention QKV as well; that
+    # calibration path is not ported to CDNA4 yet.
     _DIT_USE_FP8 = False
 
     # Default DiT token count (1 state + 40 action tokens) used to size
@@ -151,11 +158,14 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         # fallback (a forced hardware="amd_cdna4" on gfx942 fails here).
         # This runs ahead of super().__init__, which loads weights.
         from flash_rt.amd import flash_rt_amd_kernels as _fvk_gate
+        # Compare the base target only ("gfx950" from
+        # "gfx950:sramecc+:xnack-"); a prefix test would also accept a
+        # future "gfx9500".
         _dev_arch = str(_fvk_gate.device_arch())
         _build_arch = str(dict(_fvk_gate.build_info()).get("gpu_arch",
                                                            "unknown"))
-        if not (_dev_arch.startswith("gfx950")
-                and _build_arch.startswith("gfx950")):
+        if not (_dev_arch.split(":", 1)[0] == "gfx950"
+                and _build_arch.split(":", 1)[0] == "gfx950"):
             raise RuntimeError(
                 "GrootN17TorchFrontendAmd is gfx950-only (CDNA4 / "
                 f"MI350-series): running device arch is {_dev_arch!r} and "
@@ -199,6 +209,20 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
     # ────────────────────────────────────────────────────────────────
     # Attention backend (single instance, all 5 sites)
     # ────────────────────────────────────────────────────────────────
+
+    def _hf_processor(self):
+        """Build the HF processor with the offline lookup scoped.
+
+        Identical to the base implementation apart from the surrounding
+        context manager, which contains the transformers offline-mode
+        workaround to this one call (see
+        :func:`_offline_tolerant_model_info`) instead of mutating
+        ``huggingface_hub`` for the whole process.
+        """
+        if hasattr(self, "_hf_proc_cached"):
+            return self._hf_proc_cached
+        with _offline_tolerant_model_info():
+            return super()._hf_processor()
 
     def _dit_kv_split(self) -> tuple:
         """(num_text_tokens, num_image_tokens) from the prompt's mask."""

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -1,0 +1,770 @@
+"""FlashRT AMD -- GROOT N1.7 FP8 torch frontend for CDNA4 (MI350X, gfx950).
+
+Production tier mirror of :class:`GrootN17TorchFrontendRtxFP8`: the whole
+VLM backbone (ViT / DeepStack / LLM / VL self-attn) runs through the AMD
+FP8 kernel surface via the decomposed descale form in
+:mod:`flash_rt.amd.models.groot_n17.pipeline`, and the DiT action head
+stays bf16 (``_DIT_USE_FP8 = False``) driven by the hardware-independent
+:func:`flash_rt.models.groot_n17.pipeline_thor.dit_forward` with the AMD
+kernel module passed in — every binding name the bf16 DiT path touches
+(``bf16_nn`` / ``add_bias_bf16`` / ``ada_layer_norm_bf16`` /
+``layer_norm_no_affine_bf16`` / ``gelu_inplace`` / ``residual_add`` /
+``concat2_bf16`` / ``relu_inplace_bf16`` / ``silu_inplace_fp16`` /
+``cast_*`` / ``gpu_copy``) exists in ``flash_rt_amd_kernels``.
+
+Reuse strategy: subclass ``_GrootN17FP8BackboneMixin`` +
+``GrootN17TorchFrontendThor``. The Thor base resolves its kernel module
+and GEMM runners lazily behind ``hasattr(self, "_fvk"/"_gemm")`` guards,
+so this class seeds them with the AMD module at construction and the
+~1900 validated base lines (weight loading via WEIGHT_SPEC, aux
+contract, calibration bake/save/cache, diffusion modulator precompute,
+graph replay ``infer``) run unmodified. torch on ROCm keeps the "cuda"
+device string, ``torch.cuda.Stream`` and ``torch.cuda.CUDAGraph``
+(hipGraph underneath), so the base's graph machinery is used as-is.
+
+AMD-specific overrides:
+
+  * ``_run_kernel_backbone_fp8`` — AMD pipeline stages + the CDNA4
+    attention backend. The llm stage's Q/K/V GEMMs write straight into
+    the backend slots (Q 16 heads, K/V the NATIVE 8 KV heads — aiter
+    handles GQA internally), so the RTX K/V staging buffers and the
+    ``gpu_repeat_interleave_heads`` expand step are dropped.
+  * ``_build_dit_attn`` — one :class:`Cdna4GrootN17AttnBackend` serves
+    all five sites; the backbone-time instance is reused for the DiT
+    when the action-token count matches.
+  * ``_setup_cross_kv_kernel`` / ``_cross_kv_fwd`` — the per-frame
+    cross-KV refresh writes directly into the backend's per-block K/V
+    slots (exact-size prefix views of the padded slots). The gather of
+    text/image backbone rows uses ``torch.index_select`` with a
+    preallocated ``out=`` (the AMD kernel module has no
+    ``embedding_lookup_bf16`` binding); with fixed shapes and no
+    allocation it is graph-capture-safe.
+  * ``_capture_kernel_dit_graphs`` — same fully-kernelized single-graph
+    chain as Thor with two deltas: the Euler update runs as an in-place
+    ``torch.add_`` on the persistent action buffer (no
+    ``euler_step_bf16_out`` binding on AMD), and — per the aiter
+    capture-safety contract — the warmup iterations run ON the capture
+    stream (inside its ``torch.cuda.stream`` context) so aiter's
+    workspace allocations reach caching-allocator steady state before
+    stream capture begins and every torch-side call lands on the same
+    stream the raw-int kernels use.
+
+The FP8 / FP4 DiT quantization tiers of the base are NOT ported;
+``_capture_kernel_dit_graphs`` rejects them explicitly.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from flash_rt.frontends.torch.groot_n17_thor import GrootN17TorchFrontendThor
+from flash_rt.frontends.torch.groot_n17_rtx_fp8 import _GrootN17FP8BackboneMixin
+
+_FP16 = torch.float16
+_U8 = torch.uint8
+
+
+def _patch_hf_offline_model_info() -> None:
+    """Tolerate huggingface_hub offline mode in transformers 4.57.3.
+
+    Tokenizer loading in transformers 4.57.3 calls
+    ``huggingface_hub.model_info`` without catching
+    ``OfflineModeIsEnabled``, so ``HF_HUB_OFFLINE=1`` breaks
+    ``AutoProcessor.from_pretrained`` even when every file is local.
+    The caller only reads ``.tags``, so degrade to a ``tags=None`` stub
+    when offline. This frontend triggers processor loading through the
+    inherited ``denormalize_action`` → ``_hf_processor`` path, hence the
+    patch lives here. Idempotent (guarded by a marker attribute).
+    """
+    try:
+        import huggingface_hub as hh
+        from huggingface_hub.errors import OfflineModeIsEnabled
+    except ImportError:
+        return
+    if getattr(hh.model_info, "_flashrt_offline_tolerant", False):
+        return
+    orig_model_info = hh.model_info
+
+    def _tolerant_model_info(*args, **kwargs):
+        try:
+            return orig_model_info(*args, **kwargs)
+        except OfflineModeIsEnabled:
+            class _Stub:
+                tags = None
+            return _Stub()
+
+    _tolerant_model_info._flashrt_offline_tolerant = True
+    hh.model_info = _tolerant_model_info
+
+
+_patch_hf_offline_model_info()
+
+
+class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
+                               GrootN17TorchFrontendThor):
+    """N1.7 CDNA4 frontend: FP8 kernel backbone + bf16 DiT action head."""
+
+    # The DiT stays bf16 on AMD — the production tier is FP8 backbone +
+    # bf16 DiT, mirroring GrootN17TorchFrontendRtxFP8's dtype split. The
+    # FP8-FFN/QKV DiT calibration path of the Thor base is not ported.
+    _DIT_USE_FP8 = False
+
+    # Default DiT token count (1 state + 40 action tokens) used to size
+    # the shared attention backend at backbone-build time; a differing
+    # action_horizon at infer time rebuilds a matching backend.
+    _DEFAULT_SA = 41
+
+    def __init__(
+        self,
+        checkpoint_path: str,
+        *,
+        num_views: int = 2,
+        embodiment_tag: str = "oxe_droid_relative_eef_relative_joint",
+        device: str = "cuda:0",
+    ):
+        # The strided-FMHA side-load is a CUDA-only .so (Thor ViT path);
+        # the AMD ViT attention runs through the CDNA4 backend instead.
+        super().__init__(
+            checkpoint_path,
+            num_views=num_views,
+            embodiment_tag=embodiment_tag,
+            device=device,
+            load_strided_fmha=False,
+        )
+        # Seed the kernel-module / GEMM-runner handles with the AMD
+        # surface BEFORE any base method runs its lazy
+        # ``import flash_rt.flash_rt_kernels`` fallback — every such
+        # import in the base is guarded by ``hasattr(self, "_fvk")`` /
+        # ``hasattr(self, "_gemm")`` / ``hasattr(self, "_mlp_gemm")``.
+        from flash_rt.amd import flash_rt_amd_kernels as fvk
+        self._fvk = fvk
+        self._gemm = fvk.GemmRunner()
+        self._mlp_gemm = fvk.GemmRunner()
+
+    # ────────────────────────────────────────────────────────────────
+    # Attention backend (single instance, all 5 sites)
+    # ────────────────────────────────────────────────────────────────
+
+    def _dit_kv_split(self) -> tuple:
+        """(num_text_tokens, num_image_tokens) from the prompt's mask."""
+        mask = self._visual_pos_masks
+        n_text = int((~mask).sum().item())
+        n_image = int(mask.sum().item())
+        return n_text, n_image
+
+    def _build_dit_attn(self, Sa: int) -> None:
+        """Bind the CDNA4 backend for the DiT sites.
+
+        Reuses the backbone-time backend when its DiT token capacity
+        matches ``Sa``; otherwise constructs a fresh full backend with
+        the same backbone geometry. When the eager torch path has
+        already produced exact-size cross K/V tensors
+        (``_precompute_dit_cross_kv``), their contents are copied into
+        the backend's padded per-block slots; once
+        ``_setup_cross_kv_kernel`` rebinds ``_dit_cross_K/V`` to slot
+        prefix views, source and destination alias and the copy is
+        skipped.
+        """
+        from flash_rt.amd.hardware.cdna4.attn_backend_groot_n17 import (
+            Cdna4GrootN17AttnBackend,
+        )
+
+        Sa = int(Sa)
+        n_text, n_image = self._dit_kv_split()
+        kv_max = max(n_text, n_image)
+
+        attn = getattr(self, "_kbb_attn", None)
+        if attn is None or int(getattr(self, "_kbb_attn_sa", -1)) != Sa:
+            attn = Cdna4GrootN17AttnBackend(
+                num_vit_views=int(getattr(self, "_num_vit_views",
+                                          self.num_views)),
+                vit_seq=int(self._S_vit),
+                llm_seq=int(self.Se),
+                vl_self_attn_seq=int(self.Se),
+                sa=Sa,
+                dit_kv_seq=kv_max,
+                device=self.device,
+            )
+        if hasattr(self, "_dit_cross_K"):
+            for j, (k_src, v_src) in enumerate(
+                    zip(self._dit_cross_K, self._dit_cross_V)):
+                rows = int(k_src.shape[0])
+                k_dst = attn.dit_cross_K[j].view(kv_max, -1)[:rows]
+                v_dst = attn.dit_cross_V[j].view(kv_max, -1)[:rows]
+                if k_dst.data_ptr() != k_src.data_ptr():
+                    k_dst.copy_(k_src)
+                if v_dst.data_ptr() != v_src.data_ptr():
+                    v_dst.copy_(v_src)
+        self._dit_attn = attn
+
+    # ────────────────────────────────────────────────────────────────
+    # Kernelized DiT cross-KV (writes straight into backend slots)
+    # ────────────────────────────────────────────────────────────────
+
+    def _setup_cross_kv_kernel(self) -> None:
+        """Persistent cross-KV buffers over the CDNA4 backend slots.
+
+        Mirrors the Thor base with one structural delta: the per-block
+        K/V destinations are exact-size prefix views of the backend's
+        padded ``dit_cross_K/V[j]`` slots (row-major ``(kv, NH*HD)``
+        prefix of ``(kv_max, NH, HD)``), so the projection GEMMs land
+        their output exactly where ``attn.run("dit_cross", ...)`` reads.
+        """
+        if hasattr(self, "_ck_text_idx"):
+            return
+        if not hasattr(self, "_dit_attn"):
+            raise RuntimeError(
+                "_setup_cross_kv_kernel requires the DiT attention backend; "
+                "call _build_dit_attn first")
+        dev = self.device
+        S = self.Se
+        mask = self._visual_pos_masks
+        self._ck_text_idx = torch.where(~mask)[0].to(torch.int64).contiguous()
+        self._ck_image_idx = torch.where(mask)[0].to(torch.int64).contiguous()
+        nt = int(self._ck_text_idx.numel())
+        ni = int(self._ck_image_idx.numel())
+        self._ck_nt, self._ck_ni = nt, ni
+        bf = torch.bfloat16
+        # Per-frame backbone input (fp16, copied in before replay) + bf16 cast
+        self._ck_bb_src = torch.empty(S, 2048, dtype=torch.float16, device=dev)
+        self._ck_bb = torch.empty(S, 2048, dtype=bf, device=dev)
+        self._ck_text_src = torch.empty(nt, 2048, dtype=bf, device=dev)
+        self._ck_image_src = torch.empty(ni, 2048, dtype=bf, device=dev)
+
+        # Cross K/V destinations = exact-size prefix views of the backend
+        # slots. Block j maps to full-layer index li = 2j; text-target
+        # blocks (li % 4 == 0) are the even j.
+        attn = self._dit_attn
+        kv_max = int(attn.dit_cross_K[0].shape[0])
+        D = 1536
+        self._dit_cross_K = [
+            attn.dit_cross_K[j].view(kv_max, D)[: (nt if j % 2 == 0 else ni)]
+            for j in range(16)]
+        self._dit_cross_V = [
+            attn.dit_cross_V[j].view(kv_max, D)[: (nt if j % 2 == 0 else ni)]
+            for j in range(16)]
+
+        # Seed from the current backbone (eager) so a non-graph consumer
+        # sees valid K/V immediately.
+        self._ck_bb_src.copy_(self._backbone_features.reshape(S, 2048).half())
+        self._cross_kv_fwd(0)
+
+    def _cross_kv_fwd(self, s: int) -> None:
+        """Cross-KV forward over the persistent buffers (graph-safe).
+
+        Reads ``_ck_bb_src`` (current backbone, fp16), writes the
+        backend-slot K/V prefixes. The text/image row gather runs as
+        ``torch.index_select`` with preallocated ``out=`` buffers — the
+        AMD kernel module has no ``embedding_lookup_bf16`` binding. The
+        torch calls land on torch's current stream; callers keep it
+        consistent with the raw ``s`` int (stream 0 eagerly, or the
+        capture stream via its ``torch.cuda.stream`` context).
+        """
+        K = self._fvk
+        mg = self._mlp_gemm
+        S = self.Se
+        nt, ni = self._ck_nt, self._ck_ni
+        K.cast_fp16_to_bf16(
+            self._ck_bb_src.data_ptr(), self._ck_bb.data_ptr(),
+            S * 2048, int(s))
+        torch.index_select(
+            self._ck_bb, 0, self._ck_text_idx, out=self._ck_text_src)
+        torch.index_select(
+            self._ck_bb, 0, self._ck_image_idx, out=self._ck_image_src)
+        for j in range(16):
+            li = 2 * j
+            text = (li % 4 == 0)
+            N = nt if text else ni
+            src = self._ck_text_src if text else self._ck_image_src
+            k_dst = self._dit_cross_K[j]
+            v_dst = self._dit_cross_V[j]
+            k_w = self._dit_k_w[li]
+            k_b = self._dit_k_b[li]
+            v_w = self._dit_v_w[li]
+            v_b = self._dit_v_b[li]
+            mg.bf16_nn(src.data_ptr(), k_w.data_ptr(), k_dst.data_ptr(),
+                       N, 1536, 2048, int(s))
+            K.add_bias_bf16(k_dst.data_ptr(), k_b.data_ptr(), N, 1536, int(s))
+            mg.bf16_nn(src.data_ptr(), v_w.data_ptr(), v_dst.data_ptr(),
+                       N, 1536, 2048, int(s))
+            K.add_bias_bf16(v_dst.data_ptr(), v_b.data_ptr(), N, 1536, int(s))
+
+    # ────────────────────────────────────────────────────────────────
+    # Fully-kernelized DiT graph (bf16, single combined graph)
+    # ────────────────────────────────────────────────────────────────
+
+    def _capture_kernel_dit_graphs(self, num_inference_timesteps: int = 4,
+                                   action_horizon: int = 40) -> None:
+        """Capture the per-frame action-head chain as ONE HIP graph.
+
+        AMD adaptation of the Thor base method: same buffer set, same
+        per-step closures, same combined cross-KV + state-encode +
+        4-step-DiT graph, with three deltas (see module docstring):
+        bf16-only DiT (no FP8/FP4 splice), a torch in-place Euler add,
+        and warmup ON the capture stream per the aiter capture-safety
+        contract.
+        """
+        from flash_rt.models.groot_n17 import pipeline_thor
+
+        if getattr(self, "_DIT_USE_FP8", False) or \
+                getattr(self, "_DIT_QUANT", "fp8") == "fp4":
+            raise NotImplementedError(
+                "the AMD CDNA4 N1.7 frontend runs the DiT bf16; the FP8/FP4 "
+                "DiT quantization tiers are not ported")
+
+        Sa = action_horizon + 1
+        if not hasattr(self, "_dit_attn"):
+            self._build_dit_attn(Sa)
+        self._setup_cross_kv_kernel()
+        if not hasattr(self, "_infer_bufs"):
+            self._allocate_infer_buffers(action_horizon)
+        self._prepare_kernel_dit(num_inference_timesteps)
+        self._allocate_kernel_dit_buffers(action_horizon)
+
+        K = self._fvk
+        mg = self._mlp_gemm
+        w = self._kw
+        bufs = self._infer_bufs
+        dit_h = bufs["dit_h"].data_ptr()
+        Skv_text = int(self._dit_cross_K[0].shape[0])
+        Skv_image = int(self._dit_cross_K[1].shape[0])
+        dims = {"Sa": Sa, "D": 1536, "FF": 6144,
+                "Skv_text": Skv_text, "Skv_image": Skv_image}
+        bp = {"h": dit_h, "xn": bufs["dit_xn"].data_ptr(),
+              "o_proj_out": bufs["dit_o_proj_out"].data_ptr(),
+              "ff_proj_out": bufs["dit_ff_proj_out"].data_ptr()}
+        dt = 1.0 / num_inference_timesteps
+        # decode reads the action rows (1..Sa) of the (Sa, 1024) output_proj
+        hout_dec = self._k_hout.data_ptr() + 1024 * 2  # skip state row
+
+        def _dit_weights(step):
+            d = {"scale_msa": [t.data_ptr() for t in self._step_scales[step]],
+                 "shift_msa": [t.data_ptr() for t in self._step_shifts[step]]}
+            for key, attr in (("q_w", "_dit_q_w"), ("q_b", "_dit_q_b"),
+                              ("k_w", "_dit_k_w"), ("k_b", "_dit_k_b"),
+                              ("v_w", "_dit_v_w"), ("v_b", "_dit_v_b"),
+                              ("o_w", "_dit_o_w"), ("o_b", "_dit_o_b"),
+                              ("ff_proj_w", "_dit_ff_proj_w"),
+                              ("ff_proj_b", "_dit_ff_proj_b"),
+                              ("ff_down_w", "_dit_ff_down_w"),
+                              ("ff_down_b", "_dit_ff_down_b")):
+                d[key] = [t.data_ptr() for t in getattr(self, attr)]
+            return d
+
+        step_weights = [_dit_weights(s) for s in range(num_inference_timesteps)]
+
+        def _state_fwd(s):
+            mg.bf16_nn(self._k_state_in.data_ptr(), w["st_l1"].data_ptr(),
+                       self._k_st_h1.data_ptr(), 1, 1024, 132, s)
+            K.add_bias_bf16(self._k_st_h1.data_ptr(), w["st_l1b"].data_ptr(),
+                            1, 1024, s)
+            K.relu_inplace_bf16(self._k_st_h1.data_ptr(), 1024, s)
+            mg.bf16_nn(self._k_st_h1.data_ptr(), w["st_l2"].data_ptr(),
+                       self._k_state_feat.data_ptr(), 1, 1536, 1024, s)
+            K.add_bias_bf16(self._k_state_feat.data_ptr(),
+                            w["st_l2b"].data_ptr(), 1, 1536, s)
+
+        def _ae_fwd(step, s):
+            # action_encode: W1 (no act) → cat[a_emb, tau] → W2 → SiLU → W3,
+            # add pos, then fill dit_h ([0]=state, [1:]=action features).
+            T = action_horizon
+            mg.bf16_nn(self._k_actions.data_ptr(), w["ae_W1"].data_ptr(),
+                       self._k_ae_aemb.data_ptr(), T, 1536, 132, s)
+            K.add_bias_bf16(self._k_ae_aemb.data_ptr(), w["ae_b1"].data_ptr(),
+                            T, 1536, s)
+            K.concat2_bf16(self._k_ae_aemb.data_ptr(),
+                           self._k_tau[step].data_ptr(),
+                           self._k_ae_concat.data_ptr(), T, 1536, 1536, s)
+            mg.bf16_nn(self._k_ae_concat.data_ptr(), w["ae_W2"].data_ptr(),
+                       self._k_ae_i2.data_ptr(), T, 1536, 3072, s)
+            K.add_bias_bf16(self._k_ae_i2.data_ptr(), w["ae_b2"].data_ptr(),
+                            T, 1536, s)
+            K.cast_bf16_to_fp16(self._k_ae_i2.data_ptr(),
+                                self._k_ae_i2f.data_ptr(), T * 1536, s)
+            K.silu_inplace_fp16(self._k_ae_i2f.data_ptr(), T * 1536, s)
+            K.cast_fp16_to_bf16(self._k_ae_i2f.data_ptr(),
+                                self._k_ae_i2.data_ptr(), T * 1536, s)
+            mg.bf16_nn(self._k_ae_i2.data_ptr(), w["ae_W3"].data_ptr(),
+                       self._k_ae_out.data_ptr(), T, 1536, 1536, s)
+            K.add_bias_bf16(self._k_ae_out.data_ptr(), w["ae_b3"].data_ptr(),
+                            T, 1536, s)
+            K.residual_add(self._k_ae_out.data_ptr(), self._k_pos.data_ptr(),
+                           T * 1536, s)
+            K.gpu_copy(dit_h, self._k_state_feat.data_ptr(), 1536 * 2, s)
+            K.gpu_copy(dit_h + 1536 * 2, self._k_ae_out.data_ptr(),
+                       T * 1536 * 2, s)
+
+        def _post_fwd(step, s):
+            # output projection (AdaLN → proj_out_2) + action_decode + Euler.
+            T = action_horizon
+            K.ada_layer_norm_bf16(dit_h, self._k_oproj_scale[step].data_ptr(),
+                                  self._k_oproj_shift[step].data_ptr(),
+                                  self._k_hmod.data_ptr(), Sa, 1536, 1e-5, s)
+            mg.bf16_nn(self._k_hmod.data_ptr(), w["po2"].data_ptr(),
+                       self._k_hout.data_ptr(), Sa, 1024, 1536, s)
+            K.add_bias_bf16(self._k_hout.data_ptr(), w["po2b"].data_ptr(),
+                            Sa, 1024, s)
+            mg.bf16_nn(hout_dec, w["dec_l1"].data_ptr(),
+                       self._k_dec_h.data_ptr(), T, 1024, 1024, s)
+            K.add_bias_bf16(self._k_dec_h.data_ptr(), w["dec_l1b"].data_ptr(),
+                            T, 1024, s)
+            K.relu_inplace_bf16(self._k_dec_h.data_ptr(), T * 1024, s)
+            mg.bf16_nn(self._k_dec_h.data_ptr(), w["dec_l2"].data_ptr(),
+                       self._k_vel.data_ptr(), T, 132, 1024, s)
+            K.add_bias_bf16(self._k_vel.data_ptr(), w["dec_l2b"].data_ptr(),
+                            T, 132, s)
+            # Euler update: actions += dt * velocity, in place on the
+            # persistent buffers. The AMD module has no euler_step
+            # binding; an in-place torch add is capture-safe (fixed
+            # shapes, no allocation) and lands on the capture stream via
+            # the surrounding torch.cuda.stream context.
+            self._k_actions.add_(self._k_vel, alpha=dt)
+
+        def _step_fwd(step, s):
+            _ae_fwd(step, s)
+            pipeline_thor.dit_forward(
+                gemm=self._gemm, fvk=K, bufs=bp, weights=step_weights[step],
+                dims=dims, attn=self._dit_attn, stream=s)
+            _post_fwd(step, s)
+
+        self._kdit_fwd = (_state_fwd, _step_fwd)
+        self._k_nsteps = num_inference_timesteps
+
+        def _dit_all(s):
+            self._cross_kv_fwd(s)
+            _state_fwd(s)
+            for step in range(num_inference_timesteps):
+                _step_fwd(step, s)
+
+        # aiter capture-safety contract (see the CDNA4 backend docstring):
+        # aiter may allocate LSE/workspace through torch's caching
+        # allocator per call, so the warmup iterations must run ON the
+        # capture stream (allocator steady state per stream) and every
+        # torch-side call must land on that same stream. The warmup also
+        # primes the hipBLASLt GemmRunner algo caches for every captured
+        # GEMM shape.
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            s_int = stream.cuda_stream
+            for _ in range(3):
+                _dit_all(s_int)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(stream):
+            graph.capture_begin()
+            _dit_all(stream.cuda_stream)
+            graph.capture_end()
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize()
+        self._k_dit_graph = graph
+
+    # ────────────────────────────────────────────────────────────────
+    # FP8 kernel backbone (AMD pipeline, native-GQA llm slots)
+    # ────────────────────────────────────────────────────────────────
+
+    def _run_kernel_backbone_fp8(self, aux: dict) -> "torch.Tensor":
+        """ViT → DeepStack → LLM → vlln → VL-self-attn on AMD FP8 kernels.
+
+        Mirror of the RTX mixin method retargeted at
+        :mod:`flash_rt.amd.models.groot_n17.pipeline` and the CDNA4
+        attention backend. The llm stage's Q/K/V descale GEMMs write
+        straight into the backend slots (Q 16 heads, K/V the native
+        8 KV heads); no K/V staging buffers and no K_exp/V_exp scratch
+        are allocated — aiter consumes the 8 KV heads natively.
+        """
+        from flash_rt.amd.models.groot_n17 import pipeline as P
+        from flash_rt.amd.hardware.cdna4.attn_backend_groot_n17 import (
+            Cdna4GrootN17AttnBackend,
+        )
+
+        fvkm, gemm = self._fvk, self._gemm
+        dev = self.device
+        Sv, nv, Se = self._S_vit, self._num_vit_views, self.Se
+
+        keep: list = []
+        self._kbb_keep = keep
+
+        def K(t):
+            keep.append(t)
+            return t
+
+        def buf(*shape):
+            return K(torch.empty(*shape, dtype=_FP16, device=dev))
+
+        def buf8(*shape):
+            return K(torch.empty(*shape, dtype=_U8, device=dev))
+
+        def wsc(val):
+            """Upload a host weight scale to a device fp32 scalar; keep ref."""
+            t = K(torch.tensor([float(val)], dtype=torch.float32, device=dev))
+            return t.data_ptr()
+
+        def adv(dev_list):
+            """Device act-scale scalar tensors → list of int ptrs."""
+            return [t.data_ptr() for t in dev_list]
+
+        # One backend for the whole model: backbone sites now, DiT sites
+        # at first infer (reused by _build_dit_attn when Sa matches).
+        n_text, n_image = self._dit_kv_split()
+        sa = int(self._DEFAULT_SA)
+        attn = Cdna4GrootN17AttnBackend(
+            num_vit_views=nv, vit_seq=Sv, llm_seq=Se, vl_self_attn_seq=Se,
+            sa=sa, dit_kv_seq=max(n_text, n_image), device=dev)
+        self._kbb_attn = attn
+        self._kbb_attn_sa = sa
+
+        # ═══ ViT (24L) ═══
+        vit_h = buf(Sv, 1024)
+        vit_h.copy_(aux["pixel_features"].to(dev).half().reshape(Sv, 1024))
+        vit_bufs = {"h": vit_h.data_ptr(), "xn": buf(Sv, 1024).data_ptr(),
+                    "xn_fp8": buf8(Sv, 1024).data_ptr(),
+                    "o_proj_out": buf(Sv, 1024).data_ptr(),
+                    "fc1_out": buf(Sv, 4096).data_ptr(),
+                    "fc1_fp8": buf8(Sv, 4096).data_ptr()}
+        vw = {k: [] for k in (
+            "norm1_w", "norm1_b", "norm2_w", "norm2_b", "q_w", "q_b",
+            "k_w", "k_b", "v_w", "v_b", "o_w", "o_b", "fc1_w", "fc1_b",
+            "fc2_w", "fc2_b", "q_ws", "k_ws", "v_ws", "o_ws",
+            "fc1_ws", "fc2_ws")}
+        vw["cos"] = self._vit_cos.data_ptr()
+        vw["sin"] = self._vit_sin.data_ptr()
+        for li in range(24):
+            qkv = self._vit_qkv_w[li]               # fp8 (1024, 3072) [K, 3N]
+            b = self._vit_qkv_b[li]                 # (3072,)
+            q = K(qkv[:, :1024].contiguous())
+            kk = K(qkv[:, 1024:2048].contiguous())
+            v = K(qkv[:, 2048:].contiguous())
+            qb = K(b[:1024].contiguous())
+            kb = K(b[1024:2048].contiguous())
+            vb = K(b[2048:].contiguous())
+            qkv_ws = wsc(self._vit_alpha[li * 4 + 0])
+            vw["norm1_w"].append(self._vit_ln1_w[li].data_ptr())
+            vw["norm1_b"].append(self._vit_ln1_b[li].data_ptr())
+            vw["norm2_w"].append(self._vit_ln2_w[li].data_ptr())
+            vw["norm2_b"].append(self._vit_ln2_b[li].data_ptr())
+            vw["q_w"].append(q.data_ptr()); vw["q_b"].append(qb.data_ptr())
+            vw["k_w"].append(kk.data_ptr()); vw["k_b"].append(kb.data_ptr())
+            vw["v_w"].append(v.data_ptr()); vw["v_b"].append(vb.data_ptr())
+            vw["q_ws"].append(qkv_ws)
+            vw["k_ws"].append(qkv_ws)
+            vw["v_ws"].append(qkv_ws)
+            vw["o_w"].append(self._vit_o_w[li].data_ptr())
+            vw["o_b"].append(self._vit_o_b[li].data_ptr())
+            vw["o_ws"].append(wsc(self._vit_alpha[li * 4 + 1]))
+            vw["fc1_w"].append(self._vit_fc1_w[li].data_ptr())
+            vw["fc1_b"].append(self._vit_fc1_b[li].data_ptr())
+            vw["fc1_ws"].append(wsc(self._vit_alpha[li * 4 + 2]))
+            vw["fc2_w"].append(self._vit_fc2_w[li].data_ptr())
+            vw["fc2_b"].append(self._vit_fc2_b[li].data_ptr())
+            vw["fc2_ws"].append(wsc(self._vit_alpha[li * 4 + 3]))
+        vit_scales = {
+            "act_qkv": adv(self._vit_act_qkv_dev),
+            "act_o": adv(self._vit_act_o_dev),
+            "act_fc1": adv(self._vit_act_fc1_dev),
+            "act_fc2": adv(self._vit_act_fc2_dev)}
+
+        tap_layers = (5, 11, 17)
+        tap_bufs = {l: buf(Sv, 1024) for l in tap_layers}
+        scell = [0]
+        self._kbb_scell = scell
+
+        def mk_cb(l):
+            def cb(h_ptr):
+                fvkm.gpu_copy(
+                    tap_bufs[l].data_ptr(), int(h_ptr), Sv * 1024 * 2,
+                    scell[0])
+            return cb
+        dcap = [mk_cb(l) for l in tap_layers]
+
+        P.qwen3vl_vit_forward(
+            gemm=gemm, fvk=fvkm, bufs=vit_bufs, weights=vw,
+            scales_dev=vit_scales,
+            dims={"S": Sv, "D": 1024, "NH": 16, "HD": 64,
+                  "ff_inner": 4096, "Sper_view": Sv // nv},
+            attn=attn, deepstack_taps=tap_layers, deepstack_capture=dcap)
+
+        # ═══ DeepStack (3 mergers) ═══
+        Nout = Sv // 4
+        ds_out = [buf(Nout, 2048) for _ in range(3)]
+        dsw = {k: [] for k in ("norm_w", "norm_b", "fc1_w", "fc1_b",
+                               "fc2_w", "fc2_b", "fc1_ws", "fc2_ws")}
+        for j in range(3):
+            dsw["norm_w"].append(getattr(self, f"_dsm{j}_norm_w").data_ptr())
+            dsw["norm_b"].append(getattr(self, f"_dsm{j}_norm_b").data_ptr())
+            dsw["fc1_w"].append(getattr(self, f"_dsm{j}_fc1_w").data_ptr())
+            dsw["fc1_b"].append(getattr(self, f"_dsm{j}_fc1_b").data_ptr())
+            dsw["fc1_ws"].append(wsc(self._dsm_alpha[j * 2 + 0]))
+            dsw["fc2_w"].append(getattr(self, f"_dsm{j}_fc2_w").data_ptr())
+            dsw["fc2_b"].append(getattr(self, f"_dsm{j}_fc2_b").data_ptr())
+            dsw["fc2_ws"].append(wsc(self._dsm_alpha[j * 2 + 1]))
+        ds_scales = {"act_fc1": adv(self._dsm_act_fc1_dev),
+                     "act_fc2": adv(self._dsm_act_fc2_dev)}
+        ds_bufs = {"in": [tap_bufs[l].data_ptr() for l in tap_layers],
+                   "ln_out": buf(Nout, 4096).data_ptr(),
+                   "fp8_scratch": buf8(Nout, 4096).data_ptr(),
+                   "fc1_out": buf(Nout, 4096).data_ptr(),
+                   "out": [t.data_ptr() for t in ds_out]}
+        ds_dims = {"Nin": Sv, "Din": 1024, "Nout": Nout,
+                   "Dmid": 4096, "Dout": 2048}
+        P.deepstack_merge_forward(
+            gemm=gemm, fvk=fvkm, bufs=ds_bufs,
+            weights=dsw, scales_dev=ds_scales, dims=ds_dims)
+
+        # DeepStack inject buffers (S, D) — zero except visual positions.
+        mask = self._visual_pos_masks
+        vis_idx = K(mask.reshape(-1).nonzero(as_tuple=True)[0].to(torch.long))
+        inject = [0] * 16
+        injb = []
+        for j in range(3):
+            ib = buf(Se, 2048)
+            ib.zero_()
+            ib.index_copy_(0, vis_idx, ds_out[j])
+            inject[j] = ib.data_ptr()
+            injb.append(ib)
+
+        # ═══ LLM (16L, causal, native GQA) ═══
+        llm_h = buf(Se, 2048)
+        llm_h.copy_(aux["llm_input_embeds"].to(dev).half().reshape(Se, 2048))
+        lw = {k: [] for k in (
+            "in_ln_w", "post_ln_w", "q_norm_w", "k_norm_w", "q_w", "k_w",
+            "v_w", "o_w", "gate_w", "up_w", "down_w",
+            "q_ws", "k_ws", "v_ws", "o_ws", "gate_ws", "up_ws", "down_ws")}
+        lw["cos"] = self._mrope_cos.data_ptr()
+        lw["sin"] = self._mrope_sin.data_ptr()
+        lw["deepstack_inject"] = inject
+        for li in range(16):
+            qkv = self._llm_qkv_w[li]    # fp8 (2048, 4096) [K, NHQ·HD+2·NHKV·HD]
+            q = K(qkv[:, :2048].contiguous())
+            kk = K(qkv[:, 2048:3072].contiguous())
+            v = K(qkv[:, 3072:4096].contiguous())
+            qkv_ws = wsc(self._llm_alpha[li * 5 + 0])
+            lw["in_ln_w"].append(self._llm_input_ln_w[li].data_ptr())
+            lw["post_ln_w"].append(self._llm_post_ln_w[li].data_ptr())
+            lw["q_norm_w"].append(self._llm_q_norm_w[li].data_ptr())
+            lw["k_norm_w"].append(self._llm_k_norm_w[li].data_ptr())
+            lw["q_w"].append(q.data_ptr())
+            lw["k_w"].append(kk.data_ptr())
+            lw["v_w"].append(v.data_ptr())
+            lw["q_ws"].append(qkv_ws)
+            lw["k_ws"].append(qkv_ws)
+            lw["v_ws"].append(qkv_ws)
+            lw["o_w"].append(self._llm_o_w[li].data_ptr())
+            lw["o_ws"].append(wsc(self._llm_alpha[li * 5 + 1]))
+            lw["gate_w"].append(self._llm_gate_w[li].data_ptr())
+            lw["gate_ws"].append(wsc(self._llm_alpha[li * 5 + 2]))
+            lw["up_w"].append(self._llm_up_w[li].data_ptr())
+            lw["up_ws"].append(wsc(self._llm_alpha[li * 5 + 3]))
+            lw["down_w"].append(self._llm_down_w[li].data_ptr())
+            lw["down_ws"].append(wsc(self._llm_alpha[li * 5 + 4]))
+        llm_scales = {
+            "act_qkv": adv(self._llm_act_qkv_dev),
+            "act_o": adv(self._llm_act_o_dev),
+            "act_gateup": adv(self._llm_act_gateup_dev),
+            "act_down": adv(self._llm_act_down_dev)}
+        # AMD delta vs the RTX mixin: the Q/K/V descale GEMMs land in the
+        # backend slots (Q 16 heads, K/V native 8 heads) and aiter runs
+        # GQA internally, so the RTX Q/K/V staging buffers and the
+        # K_exp/V_exp expand scratch are not allocated at all.
+        llm_bufs = {
+            "h": llm_h.data_ptr(), "xn": buf(Se, 2048).data_ptr(),
+            "xn_fp8": buf8(Se, 2048).data_ptr(),
+            "o_proj_out": buf(Se, 2048).data_ptr(),
+            "gate_out": buf(Se, 6144).data_ptr(),
+            "up_out": buf(Se, 6144).data_ptr(),
+            "gu_fp8": buf8(Se, 6144).data_ptr()}
+        llm_dims = {"S": Se, "D": 2048, "NHQ": 16, "NHKV": 8,
+                    "HD": 128, "FF": 6144}
+        P.qwen3vl_llm_forward(
+            gemm=gemm, fvk=fvkm, bufs=llm_bufs, weights=lw,
+            scales_dev=llm_scales, dims=llm_dims, attn=attn)
+
+        # ═══ vlln + VL self-attn (4L) ═══
+        vlsa_h = buf(Se, 2048)
+        vlln_bufs = {"x": llm_h.data_ptr(), "out": vlsa_h.data_ptr()}
+        vlln_weights = {"vlln_w": self._vlln_w.data_ptr(),
+                        "vlln_b": self._vlln_b.data_ptr()}
+        P.vlln_forward(
+            gemm=gemm, fvk=fvkm, bufs=vlln_bufs, weights=vlln_weights,
+            dims={"S": Se, "D": 2048})
+        vsw = {k: [] for k in (
+            "norm1_w", "norm1_b", "norm3_w", "norm3_b", "q_w", "q_b",
+            "k_w", "k_b", "v_w", "v_b", "o_w", "o_b", "fc1_w", "fc1_b",
+            "fc2_w", "fc2_b", "q_ws", "k_ws", "v_ws", "o_ws",
+            "fc1_ws", "fc2_ws")}
+        for li in range(4):
+            vsw["norm1_w"].append(self._vlsa_norm1_w[li].data_ptr())
+            vsw["norm1_b"].append(self._vlsa_norm1_b[li].data_ptr())
+            vsw["norm3_w"].append(self._vlsa_norm3_w[li].data_ptr())
+            vsw["norm3_b"].append(self._vlsa_norm3_b[li].data_ptr())
+            vsw["q_w"].append(self._vlsa_q_w[li].data_ptr())
+            vsw["q_b"].append(self._vlsa_q_b[li].data_ptr())
+            vsw["q_ws"].append(wsc(self._vlsa_alpha[li * 6 + 0]))
+            vsw["k_w"].append(self._vlsa_k_w[li].data_ptr())
+            vsw["k_b"].append(self._vlsa_k_b[li].data_ptr())
+            vsw["k_ws"].append(wsc(self._vlsa_alpha[li * 6 + 1]))
+            vsw["v_w"].append(self._vlsa_v_w[li].data_ptr())
+            vsw["v_b"].append(self._vlsa_v_b[li].data_ptr())
+            vsw["v_ws"].append(wsc(self._vlsa_alpha[li * 6 + 2]))
+            vsw["o_w"].append(self._vlsa_o_w[li].data_ptr())
+            vsw["o_b"].append(self._vlsa_o_b[li].data_ptr())
+            vsw["o_ws"].append(wsc(self._vlsa_alpha[li * 6 + 3]))
+            vsw["fc1_w"].append(self._vlsa_fc1_w[li].data_ptr())
+            vsw["fc1_b"].append(self._vlsa_fc1_b[li].data_ptr())
+            vsw["fc1_ws"].append(wsc(self._vlsa_alpha[li * 6 + 4]))
+            vsw["fc2_w"].append(self._vlsa_fc2_w[li].data_ptr())
+            vsw["fc2_b"].append(self._vlsa_fc2_b[li].data_ptr())
+            vsw["fc2_ws"].append(wsc(self._vlsa_alpha[li * 6 + 5]))
+        vlsa_scales = {
+            "act_qkv": adv(self._vlsa_act_qkv_dev),
+            "act_o": adv(self._vlsa_act_o_dev),
+            "act_fc1": adv(self._vlsa_act_fc1_dev),
+            "act_fc2": adv(self._vlsa_act_fc2_dev)}
+        vlsa_bufs = {"h": vlsa_h.data_ptr(), "xn": buf(Se, 2048).data_ptr(),
+                     "xn_fp8": buf8(Se, 2048).data_ptr(),
+                     "o_proj_out": buf(Se, 2048).data_ptr(),
+                     "fc1_out": buf(Se, 8192).data_ptr(),
+                     "fc1_fp8": buf8(Se, 8192).data_ptr()}
+        vlsa_dims = {"T": Se, "D": 2048, "NH": 32, "HD": 64,
+                     "ff_inner": 8192}
+        P.vl_self_attn_forward(
+            gemm=gemm, fvk=fvkm, bufs=vlsa_bufs,
+            weights=vsw, scales_dev=vlsa_scales, dims=vlsa_dims, attn=attn)
+        torch.cuda.synchronize()
+
+        vit_dims = {"S": Sv, "D": 1024, "NH": 16, "HD": 64,
+                    "ff_inner": 4096, "Sper_view": Sv // nv}
+        vlln_dims = {"S": Se, "D": 2048}
+
+        def _kbb_forward(stream=0):
+            scell[0] = stream
+            P.qwen3vl_vit_forward(
+                gemm=gemm, fvk=fvkm, bufs=vit_bufs, weights=vw,
+                scales_dev=vit_scales, dims=vit_dims, attn=attn,
+                deepstack_taps=tap_layers, deepstack_capture=dcap,
+                stream=stream)
+            P.deepstack_merge_forward(
+                gemm=gemm, fvk=fvkm, bufs=ds_bufs, weights=dsw,
+                scales_dev=ds_scales, dims=ds_dims, stream=stream)
+            for j in range(3):
+                injb[j].zero_()
+                injb[j].index_copy_(0, vis_idx, ds_out[j])
+            P.qwen3vl_llm_forward(
+                gemm=gemm, fvk=fvkm, bufs=llm_bufs, weights=lw,
+                scales_dev=llm_scales, dims=llm_dims, attn=attn,
+                stream=stream)
+            P.vlln_forward(
+                gemm=gemm, fvk=fvkm, bufs=vlln_bufs,
+                weights=vlln_weights, dims=vlln_dims, stream=stream)
+            P.vl_self_attn_forward(
+                gemm=gemm, fvk=fvkm, bufs=vlsa_bufs, weights=vsw,
+                scales_dev=vlsa_scales, dims=vlsa_dims, attn=attn,
+                stream=stream)
+            return vlsa_h
+
+        self._kbb_forward = _kbb_forward
+        self._kbb_vit_h = vit_h
+        self._kbb_llm_h = llm_h
+        self._kbb_vlsa_h = vlsa_h
+        return vlsa_h.unsqueeze(0)

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -59,7 +59,6 @@ The FP8 / FP4 DiT quantization tiers of the base are NOT ported;
 
 from __future__ import annotations
 
-import contextlib
 import os
 
 import torch
@@ -84,47 +83,6 @@ def _fused_epilogue_enabled() -> bool:
     """
     return os.environ.get("FVK_AMD_FUSED_EPILOGUE", "1").strip().lower() \
         not in ("0", "off", "false", "no")
-
-
-@contextlib.contextmanager
-def _offline_tolerant_model_info():
-    """Scope a workaround for a transformers offline-mode bug.
-
-    Tokenizer loading in transformers 4.57.x calls
-    ``huggingface_hub.model_info`` without catching
-    ``OfflineModeIsEnabled``, so ``HF_HUB_OFFLINE=1`` breaks
-    ``AutoProcessor.from_pretrained`` even when every file is already in
-    the local cache. The caller only reads ``.tags``, so within this
-    context an offline lookup degrades to a ``tags=None`` stub.
-
-    The substitution is installed for the duration of one processor load
-    and restored in ``finally`` — it never outlives the call, so other
-    code in the process keeps the real ``model_info`` (and keeps seeing
-    genuine offline errors). Any exception other than
-    ``OfflineModeIsEnabled`` still propagates.
-    """
-    try:
-        import huggingface_hub as hh
-        from huggingface_hub.errors import OfflineModeIsEnabled
-    except ImportError:
-        yield
-        return
-
-    original = hh.model_info
-
-    def _tolerant(*args, **kwargs):
-        try:
-            return original(*args, **kwargs)
-        except OfflineModeIsEnabled:
-            class _Stub:
-                tags = None
-            return _Stub()
-
-    hh.model_info = _tolerant
-    try:
-        yield
-    finally:
-        hh.model_info = original
 
 
 class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
@@ -210,19 +168,51 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
     # Attention backend (single instance, all 5 sites)
     # ────────────────────────────────────────────────────────────────
 
-    def _hf_processor(self):
-        """Build the HF processor with the offline lookup scoped.
+    def set_hf_processor(self, processor) -> None:
+        """Supply the HF processor instead of letting it be loaded.
 
-        Identical to the base implementation apart from the surrounding
-        context manager, which contains the transformers offline-mode
-        workaround to this one call (see
-        :func:`_offline_tolerant_model_info`) instead of mutating
-        ``huggingface_hub`` for the whole process.
+        ``denormalize_action`` needs the processor for the
+        relative-to-absolute action decode. It is normally built on
+        demand from the checkpoint, which reaches the Hub for the
+        tokenizer's metadata. Callers that must avoid that lookup —
+        offline deployments, or environments hitting the transformers
+        4.57.x bug described in :meth:`_hf_processor` — can build the
+        processor themselves and inject it here before inference.
+        """
+        self._hf_proc_cached = processor
+
+    def _hf_processor(self):
+        """Build the HF processor, with an actionable offline error.
+
+        Loading the processor resolves its tokenizer by Hub repository
+        id, and transformers 4.57.x looks that repository's metadata up
+        through ``huggingface_hub.model_info`` without catching
+        ``OfflineModeIsEnabled``. With ``HF_HUB_OFFLINE=1`` the load then
+        fails even when every file is already cached locally.
+
+        The library does not work around this: the only interception
+        point is ``huggingface_hub``'s module-level function, and
+        swapping that out — even temporarily — mutates state shared with
+        every other thread in the process. Instead the failure is
+        reported with the two remedies that do not.
         """
         if hasattr(self, "_hf_proc_cached"):
             return self._hf_proc_cached
-        with _offline_tolerant_model_info():
+        try:
             return super()._hf_processor()
+        except Exception as exc:
+            if type(exc).__name__ != "OfflineModeIsEnabled":
+                raise
+            raise RuntimeError(
+                "loading the GROOT processor requires a Hub metadata "
+                "lookup that offline mode blocks. This is a transformers "
+                "4.57.x issue (the tokenizer loader calls "
+                "huggingface_hub.model_info without handling offline "
+                "mode), not a missing file. Either allow that one "
+                "lookup by clearing HF_HUB_OFFLINE for the load, or "
+                "build the processor in your own setup code and pass it "
+                "to set_hf_processor() before inference."
+            ) from exc
 
     def _dit_kv_split(self) -> tuple:
         """(num_text_tokens, num_image_tokens) from the prompt's mask."""

--- a/flash_rt/amd/frontends/torch/groot_n17.py
+++ b/flash_rt/amd/frontends/torch/groot_n17.py
@@ -619,7 +619,10 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
         # _bake_calibration (already run via _ensure_act_scales) composes
         # them as python floats: alpha = act_scale × w_scale per site per
         # layer. Key names parallel the scales_dev dicts. The llm stage is
-        # biasless (Qwen3) and always stays on descale GEMMs.
+        # biasless (Qwen3) and always stays on descale GEMMs; its
+        # fused_epilogue flag fuses the norm/residual+quantize chains
+        # instead (rms_norm_fp8_fp16 / residual_add_rms_norm_fp8_fp16 —
+        # no alphas needed).
         fused = _fused_epilogue_enabled()
         if fused:
             vit_alphas = {
@@ -821,7 +824,8 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
                     "HD": 128, "FF": 6144}
         P.qwen3vl_llm_forward(
             gemm=gemm, fvk=fvkm, bufs=llm_bufs, weights=lw,
-            scales_dev=llm_scales, dims=llm_dims, attn=attn)
+            scales_dev=llm_scales, dims=llm_dims, attn=attn,
+            fused_epilogue=fused)
 
         # ═══ vlln + VL self-attn (4L) ═══
         vlsa_h = buf(Se, 2048)
@@ -898,7 +902,7 @@ class GrootN17TorchFrontendAmd(_GrootN17FP8BackboneMixin,
             P.qwen3vl_llm_forward(
                 gemm=gemm, fvk=fvkm, bufs=llm_bufs, weights=lw,
                 scales_dev=llm_scales, dims=llm_dims, attn=attn,
-                stream=stream)
+                stream=stream, fused_epilogue=fused)
             P.vlln_forward(
                 gemm=gemm, fvk=fvkm, bufs=vlln_bufs,
                 weights=vlln_weights, dims=vlln_dims, stream=stream)

--- a/flash_rt/amd/hardware/cdna4/attn_backend_groot_n17.py
+++ b/flash_rt/amd/hardware/cdna4/attn_backend_groot_n17.py
@@ -1,0 +1,297 @@
+"""FlashRT AMD — CDNA4 attention backend for GROOT N1.7 (all 5 sites).
+
+One backend serves the whole model on AMD:
+
+  * ``vit``          multi-view batched ViT self-attention (16h x 64d)
+  * ``llm``          truncated-LLM causal self-attention (16q/8kv x 128d)
+  * ``vl_self_attn`` VL adapter self-attention (32h x 64d)
+  * ``dit_self``     DiT action self-attention (32h x 48d, Sa tokens)
+  * ``dit_cross``    DiT cross-attention (32h x 48d Q, per-block K/V)
+
+Protocol mirrors the RTX pair (``RtxGrootN17BackboneAttn`` +
+``RtxFlashAttnBackendGrootN17``): pre-allocated layer-shared Q/K/V/O
+slots, ``get_slot_ptrs(site, layer)`` for the pipeline's raw-pointer
+writes, ``run(site, layer, q_seq, kv_seq=..., stream=...)`` returning a
+stable O pointer.
+
+DISPATCH
+--------
+Every site runs on aiter ``mha_fwd`` (CK-tile asm flash attention).
+The isolated-shape survey on the exact N1.7 geometries measured aiter
+faster than torch sdpa at every site in both dtypes (1.19-1.83x, the
+GQA-causal llm site largest) with clean parity, and confirmed head_dim
+48 and native-GQA causal support. ``FVK_AMD_ATTN=sdpa`` is the escape
+hatch (torch sdpa fallback, GQA expanded on the fly).
+
+AMD-native GQA: unlike the RTX backend — whose cuBLAS-decomposed llm
+kernel needs K/V pre-expanded to 16 heads by the forward — the llm K/V
+slots here keep the model's 8 KV heads and aiter consumes them
+natively, halving llm K/V slot traffic. The AMD pipeline forward must
+therefore SKIP the ``gpu_repeat_interleave_heads`` step.
+
+Capture safety follows the pi05 aiter backend's contract: aiter may
+allocate LSE/workspace through torch's caching allocator per call, so
+the pipeline must run warmup iterations on the capture stream before
+``hipStreamBeginCapture`` (allocator steady state), and all calls land
+on torch's current stream.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+# Fixed N1.7 attention geometry.
+_VIT_NH, _VIT_HD = 16, 64
+_LLM_NHQ, _LLM_NHKV, _LLM_HD = 16, 8, 128
+_VLSA_NH, _VLSA_HD = 32, 64
+_DIT_NH, _DIT_HD = 32, 48
+
+
+def _resolve_mha_fwd():
+    try:
+        import aiter  # noqa: F401
+    except ImportError as ex:
+        raise ImportError(
+            "Cdna4GrootN17AttnBackend requires the 'aiter' package "
+            "(AMD asm flash attention); import failed — install aiter "
+            "or use the sdpa fallback (FVK_AMD_ATTN=sdpa).") from ex
+    fn = getattr(aiter, "mha_fwd", None)
+    if fn is None:
+        try:
+            from aiter.ops.mha import mha_fwd as fn  # type: ignore
+        except ImportError as ex:
+            raise ImportError(
+                "aiter imported but exposes no 'mha_fwd' — version "
+                "mismatch; use FVK_AMD_ATTN=sdpa.") from ex
+    return fn
+
+
+class Cdna4GrootN17AttnBackend:
+    """aiter-backed attention slots for GROOT N1.7 on AMD CDNA4."""
+
+    SITES = ("vit", "llm", "vl_self_attn", "dit_self", "dit_cross")
+
+    def __init__(
+        self,
+        *,
+        num_vit_views: int,
+        vit_seq: int,
+        llm_seq: int,
+        vl_self_attn_seq: int,
+        sa: int,
+        dit_kv_seq: int,
+        num_dit_cross_blocks: int = 16,
+        device: str = "cuda",
+        backbone_dtype=None,
+        dit_dtype=None,
+    ):
+        import torch
+
+        self._torch = torch
+        self._device = device
+        bdt = backbone_dtype if backbone_dtype is not None else torch.float16
+        ddt = dit_dtype if dit_dtype is not None else torch.bfloat16
+
+        self._nv = int(num_vit_views)
+        self._vit_seq = int(vit_seq)
+        self._llm_seq = int(llm_seq)
+        self._vlsa_seq = int(vl_self_attn_seq)
+        self._sa = int(sa)
+        self._dit_kv_seq = int(dit_kv_seq)
+        self._num_dit_cross_blocks = int(num_dit_cross_blocks)
+        if self._vit_seq % self._nv != 0:
+            raise ValueError(
+                f"vit_seq={self._vit_seq} not divisible by "
+                f"num_vit_views={self._nv}")
+        self._vit_per = self._vit_seq // self._nv
+        if self._sa <= 0 or self._dit_kv_seq <= 0:
+            raise ValueError("sa and dit_kv_seq must be positive")
+
+        def slot(S, NH, HD, dt):
+            return torch.empty(S, NH, HD, dtype=dt, device=device)
+
+        # Backbone slots (layer-shared).
+        self.vit_Q = slot(self._vit_seq, _VIT_NH, _VIT_HD, bdt)
+        self.vit_K = slot(self._vit_seq, _VIT_NH, _VIT_HD, bdt)
+        self.vit_V = slot(self._vit_seq, _VIT_NH, _VIT_HD, bdt)
+        self.vit_O = slot(self._vit_seq, _VIT_NH, _VIT_HD, bdt)
+
+        # llm K/V keep the native 8 KV heads (see module docstring).
+        self.llm_Q = slot(self._llm_seq, _LLM_NHQ, _LLM_HD, bdt)
+        self.llm_K = slot(self._llm_seq, _LLM_NHKV, _LLM_HD, bdt)
+        self.llm_V = slot(self._llm_seq, _LLM_NHKV, _LLM_HD, bdt)
+        self.llm_O = slot(self._llm_seq, _LLM_NHQ, _LLM_HD, bdt)
+
+        self.vlsa_Q = slot(self._vlsa_seq, _VLSA_NH, _VLSA_HD, bdt)
+        self.vlsa_K = slot(self._vlsa_seq, _VLSA_NH, _VLSA_HD, bdt)
+        self.vlsa_V = slot(self._vlsa_seq, _VLSA_NH, _VLSA_HD, bdt)
+        self.vlsa_O = slot(self._vlsa_seq, _VLSA_NH, _VLSA_HD, bdt)
+
+        # DiT slots. Cross K/V are per-block (precomputed once per prompt
+        # and read by all denoise steps), self K/V layer-shared.
+        self.dit_self_Q = slot(self._sa, _DIT_NH, _DIT_HD, ddt)
+        self.dit_self_K = torch.empty_like(self.dit_self_Q)
+        self.dit_self_V = torch.empty_like(self.dit_self_Q)
+        self.dit_self_O = torch.empty_like(self.dit_self_Q)
+
+        self.dit_cross_Q = slot(self._sa, _DIT_NH, _DIT_HD, ddt)
+        self.dit_cross_O = torch.empty_like(self.dit_cross_Q)
+        self.dit_cross_K = [
+            slot(self._dit_kv_seq, _DIT_NH, _DIT_HD, ddt)
+            for _ in range(self._num_dit_cross_blocks)]
+        self.dit_cross_V = [
+            slot(self._dit_kv_seq, _DIT_NH, _DIT_HD, ddt)
+            for _ in range(self._num_dit_cross_blocks)]
+
+        self._use_sdpa = (
+            os.environ.get("FVK_AMD_ATTN", "aiter").strip().lower() == "sdpa")
+        self._mha_fwd = None if self._use_sdpa else _resolve_mha_fwd()
+
+    # ── Protocol surface ──
+
+    def sites(self) -> tuple:
+        return self.SITES
+
+    def get_ptrs(self) -> dict:
+        return {
+            "vit_Q": self.vit_Q.data_ptr(), "vit_K": self.vit_K.data_ptr(),
+            "vit_V": self.vit_V.data_ptr(), "vit_O": self.vit_O.data_ptr(),
+            "llm_Q": self.llm_Q.data_ptr(), "llm_K": self.llm_K.data_ptr(),
+            "llm_V": self.llm_V.data_ptr(), "llm_O": self.llm_O.data_ptr(),
+            "vlsa_Q": self.vlsa_Q.data_ptr(), "vlsa_K": self.vlsa_K.data_ptr(),
+            "vlsa_V": self.vlsa_V.data_ptr(), "vlsa_O": self.vlsa_O.data_ptr(),
+            "dit_self_Q": self.dit_self_Q.data_ptr(),
+            "dit_self_K": self.dit_self_K.data_ptr(),
+            "dit_self_V": self.dit_self_V.data_ptr(),
+            "dit_self_O": self.dit_self_O.data_ptr(),
+            "dit_cross_Q": self.dit_cross_Q.data_ptr(),
+            "dit_cross_O": self.dit_cross_O.data_ptr(),
+            "dit_cross_K": [t.data_ptr() for t in self.dit_cross_K],
+            "dit_cross_V": [t.data_ptr() for t in self.dit_cross_V],
+        }
+
+    def get_slot_ptrs(self, site: str, layer_idx: int = 0) -> dict:
+        if site == "vit":
+            return {"Q": self.vit_Q.data_ptr(), "K": self.vit_K.data_ptr(),
+                    "V": self.vit_V.data_ptr(), "O": self.vit_O.data_ptr()}
+        if site == "llm":
+            return {"Q": self.llm_Q.data_ptr(), "K": self.llm_K.data_ptr(),
+                    "V": self.llm_V.data_ptr(), "O": self.llm_O.data_ptr()}
+        if site == "vl_self_attn":
+            return {"Q": self.vlsa_Q.data_ptr(), "K": self.vlsa_K.data_ptr(),
+                    "V": self.vlsa_V.data_ptr(), "O": self.vlsa_O.data_ptr()}
+        if site == "dit_self":
+            self._check_layer(site, layer_idx, 16)
+            return {"Q": self.dit_self_Q.data_ptr(),
+                    "K": self.dit_self_K.data_ptr(),
+                    "V": self.dit_self_V.data_ptr(),
+                    "O": self.dit_self_O.data_ptr()}
+        if site == "dit_cross":
+            self._check_layer(site, layer_idx, self._num_dit_cross_blocks)
+            return {"Q": self.dit_cross_Q.data_ptr(),
+                    "K": self.dit_cross_K[layer_idx].data_ptr(),
+                    "V": self.dit_cross_V[layer_idx].data_ptr(),
+                    "O": self.dit_cross_O.data_ptr()}
+        raise KeyError(f"unknown site {site!r}; known: {self.SITES}")
+
+    def run(self, site: str, layer_idx: int, q_seq: int,
+            *, kv_seq=None, stream: int = 0) -> int:
+        if kv_seq is None:
+            kv_seq = q_seq
+
+        if site == "vit":
+            if int(q_seq) != self._vit_per or int(kv_seq) != self._vit_per:
+                raise ValueError(
+                    f"vit q_seq/kv_seq must equal per-view len {self._vit_per}")
+            nv, per = self._nv, self._vit_per
+            q = self.vit_Q.view(nv, per, _VIT_NH, _VIT_HD)
+            k = self.vit_K.view(nv, per, _VIT_NH, _VIT_HD)
+            v = self.vit_V.view(nv, per, _VIT_NH, _VIT_HD)
+            o = self.vit_O.view(nv, per, _VIT_NH, _VIT_HD)
+            return self._attn(q, k, v, o, _VIT_HD, causal=False)
+
+        if site == "llm":
+            S = int(q_seq)
+            self._check_seq("llm", S, self._llm_seq)
+            if int(kv_seq) != S:
+                raise ValueError("llm is self-attention; kv_seq must equal q_seq")
+            q = self.llm_Q[:S].unsqueeze(0)
+            k = self.llm_K[:S].unsqueeze(0)   # 8 KV heads, native GQA
+            v = self.llm_V[:S].unsqueeze(0)
+            o = self.llm_O[:S].unsqueeze(0)
+            return self._attn(q, k, v, o, _LLM_HD, causal=True)
+
+        if site == "vl_self_attn":
+            S = int(q_seq)
+            self._check_seq("vl_self_attn", S, self._vlsa_seq)
+            q = self.vlsa_Q[:S].unsqueeze(0)
+            k = self.vlsa_K[:S].unsqueeze(0)
+            v = self.vlsa_V[:S].unsqueeze(0)
+            o = self.vlsa_O[:S].unsqueeze(0)
+            return self._attn(q, k, v, o, _VLSA_HD, causal=False)
+
+        if site == "dit_self":
+            self._check_layer(site, layer_idx, 16)
+            self._check_seq("dit_self q_seq", q_seq, self._sa)
+            if int(kv_seq) != int(q_seq):
+                raise ValueError(
+                    "dit_self is self-attention; kv_seq must equal q_seq")
+            q = self.dit_self_Q[:q_seq].unsqueeze(0)
+            k = self.dit_self_K[:q_seq].unsqueeze(0)
+            v = self.dit_self_V[:q_seq].unsqueeze(0)
+            o = self.dit_self_O[:q_seq].unsqueeze(0)
+            return self._attn(q, k, v, o, _DIT_HD, causal=False)
+
+        if site == "dit_cross":
+            self._check_layer(site, layer_idx, self._num_dit_cross_blocks)
+            self._check_seq("dit_cross q_seq", q_seq, self._sa)
+            self._check_seq("dit_cross kv_seq", kv_seq, self._dit_kv_seq)
+            q = self.dit_cross_Q[:q_seq].unsqueeze(0)
+            k = self.dit_cross_K[layer_idx][:kv_seq].unsqueeze(0)
+            v = self.dit_cross_V[layer_idx][:kv_seq].unsqueeze(0)
+            o = self.dit_cross_O[:q_seq].unsqueeze(0)
+            return self._attn(q, k, v, o, _DIT_HD, causal=False)
+
+        raise KeyError(f"unknown site {site!r}; known: {self.SITES}")
+
+    # ── Dispatch ──
+
+    def _attn(self, q, k, v, o, hd, *, causal: bool) -> int:
+        scale = 1.0 / math.sqrt(hd)
+        if self._mha_fwd is not None:
+            self._mha_fwd(
+                q, k, v,
+                0.0,        # dropout_p
+                scale,      # softmax_scale
+                causal,
+                -1, -1,     # no local window
+                False,      # return_softmax_lse
+                False,      # return_dropout_randval
+                out=o,
+            )
+            return o.data_ptr()
+        # sdpa fallback: (B, S, H, D) -> (B, H, S, D), GQA expanded.
+        torch = self._torch
+        qt = q.transpose(1, 2)
+        kt = k.transpose(1, 2)
+        vt = v.transpose(1, 2)
+        if kt.shape[1] != qt.shape[1]:
+            rep = qt.shape[1] // kt.shape[1]
+            kt = kt.repeat_interleave(rep, dim=1)
+            vt = vt.repeat_interleave(rep, dim=1)
+        res = torch.nn.functional.scaled_dot_product_attention(
+            qt, kt, vt, is_causal=causal, scale=scale)
+        o.copy_(res.transpose(1, 2))
+        return o.data_ptr()
+
+    @staticmethod
+    def _check_layer(site: str, layer_idx: int, num_layers: int) -> None:
+        if not (0 <= int(layer_idx) < int(num_layers)):
+            raise IndexError(
+                f"{site} layer_idx={layer_idx} out of range [0, {num_layers})")
+
+    @staticmethod
+    def _check_seq(name: str, seq: int, limit: int) -> None:
+        if not (1 <= int(seq) <= int(limit)):
+            raise ValueError(f"{name}={seq} out of range [1, {limit}]")

--- a/flash_rt/amd/models/groot_n17/__init__.py
+++ b/flash_rt/amd/models/groot_n17/__init__.py
@@ -1,0 +1,1 @@
+"""FlashRT AMD — GR00T N1.7 backbone pipeline package (CDNA4 / MI350X)."""

--- a/flash_rt/amd/models/groot_n17/pipeline.py
+++ b/flash_rt/amd/models/groot_n17/pipeline.py
@@ -26,7 +26,19 @@ the ``alphas`` dict (key names parallel to ``scales_dev``; required when
 ``fused_epilogue=True``). Numerics: the fused epilogue adds the bias on
 the FP32 accumulator BEFORE the fp16 round, whereas the decomposed form
 adds it AFTER rounding — slightly different, judged by the E2E gate, not
-bit-parity. The llm stage is biasless (Qwen3) and keeps descale GEMMs.
+bit-parity. The llm stage is biasless (Qwen3) and keeps descale GEMMs;
+its ``fused_epilogue`` flag instead fuses the norm/residual elementwise
+chains (see its docstring).
+
+The fused tier additionally collapses the norm→quantize front-ends into
+single kernels (same FVK_AMD_FUSED_EPILOGUE gate): every
+``layer_norm_fp16 → quantize_fp8_static_fp16`` pair whose fp16 normed
+output feeds ONLY the quantize runs as ``layer_norm_fp8_static_fp16_vec``
+(bit-matching — fp16 round-through before the quantize; falls back to
+the pair when the vec preconditions return rc != 0), and the llm's
+RMSNorm chains run as ``rms_norm_fp8_fp16`` /
+``residual_add_rms_norm_fp8_fp16`` (last-ULP deltas, see the llm
+docstring).
 
 Attention stays FP16 (the descale GEMM emits FP16 Q/K/V) and delegates
 to :class:`flash_rt.amd.hardware.cdna4.attn_backend_groot_n17.Cdna4GrootN17AttnBackend`.
@@ -146,13 +158,31 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
         a_fc1 = int(scales_dev["act_fc1"][li])
         a_fc2 = int(scales_dev["act_fc2"][li])
 
-        # ── Pre-attn LayerNorm ──
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
-            xn_ptr, S, D, 1e-6, int(stream))
+        # ── Pre-attn LayerNorm (+ quantize for Q/K/V) ──
+        if fused_epilogue:
+            # AMD FUSED: LayerNorm + static FP8 quantize in ONE kernel.
+            # The kernel rounds the norm output through fp16 BEFORE the
+            # fp8 quantize, bit-matching the decomposed pair; the normed
+            # fp16 buffer (xn) is consumed only by the quantize here, so
+            # its write is dropped entirely. rc != 0 (dim%8 / alignment)
+            # falls back to the decomposed pair.
+            rc = fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                xn_fp8_ptr, a_qkv, S, D, 1e-6, int(stream))
+            if rc != 0:
+                fvk.layer_norm_fp16(
+                    h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                    xn_ptr, S, D, 1e-6, int(stream))
+                fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv,
+                                             S * D, int(stream))
+        else:
+            fvk.layer_norm_fp16(
+                h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                xn_ptr, S, D, 1e-6, int(stream))
+            # ── Quantize xn once for Q/K/V ──
+            fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
 
-        # ── Quantize xn once for Q/K/V; 3 split FP8 GEMMs + bias ──
-        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
+        # ── 3 split FP8 GEMMs + bias ──
         if fused_epilogue:
             # FUSED: bias in the hipBLASLt epilogue, host alpha = act·w scale.
             al_qkv = float(alphas["act_qkv"][li])
@@ -193,13 +223,24 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
             fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), S, D, int(stream))
         fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
 
-        # ── Pre-FF LayerNorm ──
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
-            xn_ptr, S, D, 1e-6, int(stream))
-
-        # ── FF: D → FF (GELU) → D ──
-        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, S * D, int(stream))
+        # ── Pre-FF LayerNorm (+ quantize) then FF: D → FF (GELU) → D ──
+        if fused_epilogue:
+            # AMD FUSED: LayerNorm + static FP8 quantize in ONE kernel
+            # (bit-matching; xn write dropped; rc != 0 falls back).
+            rc = fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
+                xn_fp8_ptr, a_fc1, S, D, 1e-6, int(stream))
+            if rc != 0:
+                fvk.layer_norm_fp16(
+                    h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
+                    xn_ptr, S, D, 1e-6, int(stream))
+                fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1,
+                                             S * D, int(stream))
+        else:
+            fvk.layer_norm_fp16(
+                h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
+                xn_ptr, S, D, 1e-6, int(stream))
+            fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, S * D, int(stream))
         if fused_epilogue:
             # FUSED: fc1 bias+GELU in epilogue; fc2 bias in epilogue.
             gemm.fp8_nn_gelu_bias(xn_fp8_ptr, int(weights["fc1_w"][li]),
@@ -271,11 +312,25 @@ def deepstack_merge_forward(gemm, fvk, bufs, weights, dims,
         a_fc1 = int(scales_dev["act_fc1"][j])
         a_fc2 = int(scales_dev["act_fc2"][j])
 
-        fvk.layer_norm_fp16(
-            in_ptr, int(weights["norm_w"][j]), int(weights["norm_b"][j]),
-            ln_out, Nout, Dmid, 1e-6, int(stream))
-
-        fvk.quantize_fp8_static_fp16(ln_out, fp8_scratch, a_fc1, Nout * Dmid, int(stream))
+        if fused_epilogue:
+            # AMD FUSED: LayerNorm + static FP8 quantize in ONE kernel.
+            # Bit-matches the decomposed pair (fp16 round-through before
+            # the quantize); ln_out is consumed only by the quantize, so
+            # its write is dropped. rc != 0 falls back to the pair.
+            rc = fvk.layer_norm_fp8_static_fp16_vec(
+                in_ptr, int(weights["norm_w"][j]), int(weights["norm_b"][j]),
+                fp8_scratch, a_fc1, Nout, Dmid, 1e-6, int(stream))
+            if rc != 0:
+                fvk.layer_norm_fp16(
+                    in_ptr, int(weights["norm_w"][j]), int(weights["norm_b"][j]),
+                    ln_out, Nout, Dmid, 1e-6, int(stream))
+                fvk.quantize_fp8_static_fp16(ln_out, fp8_scratch, a_fc1,
+                                             Nout * Dmid, int(stream))
+        else:
+            fvk.layer_norm_fp16(
+                in_ptr, int(weights["norm_w"][j]), int(weights["norm_b"][j]),
+                ln_out, Nout, Dmid, 1e-6, int(stream))
+            fvk.quantize_fp8_static_fp16(ln_out, fp8_scratch, a_fc1, Nout * Dmid, int(stream))
         if fused_epilogue:
             # FUSED: fc1 bias+GELU in epilogue; fc2 bias in epilogue.
             gemm.fp8_nn_gelu_bias(fp8_scratch, int(weights["fc1_w"][j]), fc1_out,
@@ -305,7 +360,8 @@ def deepstack_merge_forward(gemm, fvk, bufs, weights, dims,
 
 def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
                         scales_dev, *, attn, stream: int = 0,
-                        layers_subset=None) -> None:
+                        layers_subset=None,
+                        fused_epilogue: bool = False) -> None:
     """16 truncated Qwen3-VL LLM decoder layers, FP8 GEMMs via decomposed descale.
 
     Per layer: RMSNorm → quantize → 3 split FP8 Q/K/V descale GEMMs (no bias) →
@@ -331,6 +387,25 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
                 cos, sin; deepstack_inject (list[16], 0 = none)
     scales_dev: act_qkv, act_o, act_gateup, act_down
     dims:       S, D, NHQ, NHKV, HD, FF
+
+    fused_epilogue: the llm stage is biasless (Qwen3) so the GEMMs always
+        stay on descale form — here the flag instead fuses the elementwise
+        chains around them (same FVK_AMD_FUSED_EPILOGUE gate as the other
+        forwards; no ``alphas`` needed):
+          * pre-attn  ``rms_norm_fp16 + quantize`` → ``rms_norm_fp8_fp16``
+          * o-proj    ``residual_add_fp16 + rms_norm_fp16 + quantize`` →
+            ``residual_add_rms_norm_fp8_fp16`` (h updated in place exactly
+            as the decomposed chain: the fp16-rounded residual is written
+            back before the norm output is quantized)
+        NUMERICS (last-ULP class, judged by the E2E gate like the GEMM
+        epilogues): the fused kernels quantize the fp32 normed value
+        directly (no fp16 round-through of xn) and use 1/scale without the
+        quantize kernel's 1e-12 guard; the residual variant additionally
+        accumulates the sum-of-squares from the UNROUNDED fp32 residual
+        sums (the decomposed rms_norm re-reads the fp16-rounded residual).
+        The per-head q/k norms and the FFN-tail residual (which crosses
+        the layer boundary into the next layer's pre-attn norm and may be
+        followed by a DeepStack inject) are NOT substituted.
     """
     S    = int(dims["S"])
     D    = int(dims["D"])
@@ -366,9 +441,18 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
         a_dn  = int(scales_dev["act_down"][li])
 
         # ── Pre-attn RMSNorm + quantize ──
-        fvk.rms_norm_fp16(h_ptr, int(weights["in_ln_w"][li]), xn_ptr,
-                          S, D, 1e-6, int(stream))
-        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
+        if fused_epilogue:
+            # AMD FUSED: RMSNorm + static FP8 quantize in ONE kernel; xn
+            # is consumed only by the quantize here, so its write is
+            # dropped. Numeric deltas vs the decomposed pair (no fp16
+            # round-through, no 1e-12 scale guard) are last-ULP — see the
+            # docstring; judged by the E2E gate.
+            fvk.rms_norm_fp8_fp16(h_ptr, int(weights["in_ln_w"][li]),
+                                  xn_fp8_ptr, S, D, 1e-6, a_qkv, int(stream))
+        else:
+            fvk.rms_norm_fp16(h_ptr, int(weights["in_ln_w"][li]), xn_ptr,
+                              S, D, 1e-6, int(stream))
+            fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
 
         # ── 3 split FP8 descale GEMMs (no bias — Qwen3 QKV) ──
         gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
@@ -399,12 +483,23 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
                                      S * NHQ * HD, int(stream))
         gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_out_ptr,
                               S, D, NHQ * HD, a_o, int(weights["o_ws"][li]), int(stream))
-        fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
 
-        # ── Pre-FFN RMSNorm + quantize ──
-        fvk.rms_norm_fp16(h_ptr, int(weights["post_ln_w"][li]), xn_ptr,
-                          S, D, 1e-6, int(stream))
-        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_gu, S * D, int(stream))
+        # ── o-proj residual + Pre-FFN RMSNorm + quantize ──
+        if fused_epilogue:
+            # AMD FUSED: residual += o_proj, RMSNorm(residual), FP8
+            # quantize in ONE kernel. Same op sequence as the decomposed
+            # chain: h is updated in place (fp16-rounded residual written
+            # back) and o_out is not read again. Numeric deltas (unrounded
+            # sum-of-squares, no fp16 round-through, no 1e-12 guard) are
+            # last-ULP — see the docstring; judged by the E2E gate.
+            fvk.residual_add_rms_norm_fp8_fp16(
+                h_ptr, o_out_ptr, int(weights["post_ln_w"][li]), xn_fp8_ptr,
+                S, D, 1e-6, a_gu, int(stream))
+        else:
+            fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
+            fvk.rms_norm_fp16(h_ptr, int(weights["post_ln_w"][li]), xn_ptr,
+                              S, D, 1e-6, int(stream))
+            fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_gu, S * D, int(stream))
 
         # ── gate / up FP8 GEMMs → fp16 ──
         gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["gate_w"][li]), gate_ptr,
@@ -487,10 +582,24 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
         a_fc2 = int(scales_dev["act_fc2"][li])
 
         # ── Pre-attn LayerNorm + quantize ──
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
-            xn_ptr, T, D, 1e-5, int(stream))
-        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, T * D, int(stream))
+        if fused_epilogue:
+            # AMD FUSED: LayerNorm + static FP8 quantize in ONE kernel
+            # (bit-matching fp16 round-through; xn consumed only by the
+            # quantize, its write dropped; rc != 0 falls back).
+            rc = fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                xn_fp8_ptr, a_qkv, T, D, 1e-5, int(stream))
+            if rc != 0:
+                fvk.layer_norm_fp16(
+                    h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                    xn_ptr, T, D, 1e-5, int(stream))
+                fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv,
+                                             T * D, int(stream))
+        else:
+            fvk.layer_norm_fp16(
+                h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+                xn_ptr, T, D, 1e-5, int(stream))
+            fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, T * D, int(stream))
 
         # ── Q / K / V FP8 GEMMs + bias (separate weight scales) ──
         if fused_epilogue:
@@ -533,10 +642,23 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
         fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
 
         # ── Pre-FF LayerNorm + FF (GELU) ──
-        fvk.layer_norm_fp16(
-            h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
-            xn_ptr, T, D, 1e-5, int(stream))
-        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, T * D, int(stream))
+        if fused_epilogue:
+            # AMD FUSED: LayerNorm + static FP8 quantize in ONE kernel
+            # (bit-matching; xn write dropped; rc != 0 falls back).
+            rc = fvk.layer_norm_fp8_static_fp16_vec(
+                h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+                xn_fp8_ptr, a_fc1, T, D, 1e-5, int(stream))
+            if rc != 0:
+                fvk.layer_norm_fp16(
+                    h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+                    xn_ptr, T, D, 1e-5, int(stream))
+                fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1,
+                                             T * D, int(stream))
+        else:
+            fvk.layer_norm_fp16(
+                h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+                xn_ptr, T, D, 1e-5, int(stream))
+            fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, T * D, int(stream))
         if fused_epilogue:
             # FUSED: fc1 bias+GELU in epilogue; fc2 bias in epilogue.
             gemm.fp8_nn_gelu_bias(xn_fp8_ptr, int(weights["fc1_w"][li]),
@@ -571,17 +693,27 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
     """AMD copy of :func:`flash_rt.models.groot_n17.pipeline_thor.dit_forward`
     with the bf16 GEMM+bias pairs fused into hipBLASLt epilogues.
 
-    Same signature, same buffers, same order. The ONLY change: every
-    ``gemm.bf16_nn`` followed by ``fvk.add_bias_bf16`` on the SAME output
-    becomes one ``gemm.bf16_nn_bias`` (and ``bf16_nn_bias_gelu`` where the
-    pair is followed by ``gelu_inplace`` on that output) — 6 sites per
-    bf16 layer: Q, K, V (self), O, FFN up (+GELU), FFN down. Each is
-    marked ``# AMD FUSED``. NUMERICS: the epilogue adds bias on the FP32
-    accumulator BEFORE the bf16 round (the decomposed pair adds it after)
-    — judged by the E2E gate, not bit-parity. The FP8/FP4 branches are
-    kept byte-identical for fidelity (dead on AMD: ``_DIT_USE_FP8=False``
-    and no fp4 weights are supplied). See the pipeline_thor docstring for
-    the full per-layer contract.
+    Same signature, same buffers, same order. Two changes vs the Thor
+    source, both marked ``# AMD FUSED``:
+
+      * every ``gemm.bf16_nn`` followed by ``fvk.add_bias_bf16`` on the
+        SAME output becomes one ``gemm.bf16_nn_bias`` (and
+        ``bf16_nn_bias_gelu`` where the pair is followed by
+        ``gelu_inplace`` on that output) — Q, K, V (self), FFN up (+GELU);
+      * where that biased GEMM's output is then only ``residual_add``-ed
+        into ``h`` (O proj, FFN down), the pair collapses further into
+        ``gemm.bf16_nn_bias_res`` writing straight into ``h`` (hipBLASLt
+        beta=1 residual accumulate; the ``o_proj_out`` intermediate write
+        and the res_add launch are dropped).
+
+    NUMERICS: the epilogue adds bias — and, for the ``_res`` sites, the
+    residual — on the FP32 accumulator BEFORE the bf16 round (the
+    decomposed forms round first) — judged by the E2E gate, not
+    bit-parity. The FP8/FP4 branch bodies are kept byte-identical for
+    fidelity (dead on AMD: ``_DIT_USE_FP8=False`` and no fp4 weights are
+    supplied); their shared trailing FFN ``residual_add`` remains as a
+    separate launch reachable only from those branches. See the
+    pipeline_thor docstring for the full per-layer contract.
     """
     Sa = int(dims["Sa"])
     D = int(dims["D"])
@@ -783,11 +915,16 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
                 attn.run("dit_cross", j_attn, q_seq=Sa, kv_seq=kv_seq,
                          stream=int(stream))
 
-        # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (O proj).
-        gemm.bf16_nn_bias(O_ptr, int(weights["o_w"][li]),
-                          o_out_ptr, int(weights["o_b"][li]),
-                          Sa, D, D, int(stream))
-        fvk.residual_add(h_ptr, o_out_ptr, Sa * D, int(stream))
+        # AMD FUSED: bf16_nn_bias + residual_add → bf16_nn_bias_res writing
+        # straight into h (beta=1 residual on the FP32 accumulator; the
+        # o_proj_out intermediate write and the res_add launch are both
+        # dropped — o_proj_out was consumed only by the res_add here).
+        # NUMERICS: the residual is added BEFORE the single bf16 round
+        # (decomposed rounds the GEMM output first) — same class as the
+        # bias epilogues, judged by the E2E gate.
+        gemm.bf16_nn_bias_res(O_ptr, int(weights["o_w"][li]),
+                              h_ptr, int(weights["o_b"][li]),
+                              Sa, D, D, int(stream))
 
         # ── Pre-FF LayerNorm (no affine — DiT default) ───────────────
         fvk.layer_norm_no_affine_bf16(
@@ -865,8 +1002,15 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             gemm.bf16_nn_bias_gelu(xn_ptr, int(weights["ff_proj_w"][li]),
                                    ff_out_ptr, int(weights["ff_proj_b"][li]),
                                    Sa, FF, D, int(stream))
-            # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (FFN down).
-            gemm.bf16_nn_bias(ff_out_ptr, int(weights["ff_down_w"][li]),
-                              o_out_ptr, int(weights["ff_down_b"][li]),
-                              Sa, D, FF, int(stream))
+            # AMD FUSED: bf16_nn_bias + residual_add → bf16_nn_bias_res
+            # writing straight into h (FFN down; o_proj_out intermediate
+            # and the res_add launch dropped, residual added on the FP32
+            # accumulator — judged by the E2E gate).
+            gemm.bf16_nn_bias_res(ff_out_ptr, int(weights["ff_down_w"][li]),
+                                  h_ptr, int(weights["ff_down_b"][li]),
+                                  Sa, D, FF, int(stream))
+            continue
+        # FP8 FFN branches (dead on AMD, kept for fidelity): the down
+        # projection still lands in o_out_ptr, so the residual runs as
+        # the original separate launch.
         fvk.residual_add(h_ptr, o_out_ptr, Sa * D, int(stream))

--- a/flash_rt/amd/models/groot_n17/pipeline.py
+++ b/flash_rt/amd/models/groot_n17/pipeline.py
@@ -12,9 +12,21 @@ numerics-identical to the RTX production path:
     fvk.gelu_inplace_fp16(out, ...)                           # separate activation
 
 hipBLASLt does support fused fp8 bias/gelu epilogues (``fp8_nn_bias`` /
-``fp8_nn_gelu_bias``), but flipping to them is a LATER single-variable
-A/B — this pass keeps the descale + separate-epilogue form so the AMD
-numbers are directly comparable to the RTX-validated production path.
+``fp8_nn_gelu_bias``), and the biased forwards (vit / deepstack /
+vl_self_attn) now carry a FUSED-EPILOGUE tier behind the keyword-only
+``fused_epilogue`` switch (default False — the decomposed form stays the
+directly-RTX-comparable baseline). Fused form per biased GEMM site:
+
+    quantize_fp8_static_fp16(x, x_fp8, act_scale_devptr)          # unchanged
+    gemm.fp8_nn_bias(x_fp8, w_fp8, out, bias, M, N, K, alpha)     # bias in epilogue
+    gemm.fp8_nn_gelu_bias(...)                                    # bias+GELU sites
+
+with HOST ``alpha = act_scale * w_scale`` (python float) supplied through
+the ``alphas`` dict (key names parallel to ``scales_dev``; required when
+``fused_epilogue=True``). Numerics: the fused epilogue adds the bias on
+the FP32 accumulator BEFORE the fp16 round, whereas the decomposed form
+adds it AFTER rounding — slightly different, judged by the E2E gate, not
+bit-parity. The llm stage is biasless (Qwen3) and keeps descale GEMMs.
 
 Attention stays FP16 (the descale GEMM emits FP16 Q/K/V) and delegates
 to :class:`flash_rt.amd.hardware.cdna4.attn_backend_groot_n17.Cdna4GrootN17AttnBackend`.
@@ -73,7 +85,9 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
                         scales_dev, *, attn, stream: int = 0,
                         layers_subset=None,
                         deepstack_taps=(5, 11, 17),
-                        deepstack_capture=None) -> None:
+                        deepstack_capture=None,
+                        fused_epilogue: bool = False,
+                        alphas=None) -> None:
     """24-layer Qwen3-VL ViT, FP8 GEMMs via decomposed descale.
 
     Per layer (in-place residual on ``h``): LayerNorm → quantize → 3 split FP8
@@ -90,7 +104,22 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
                  (weight-scale dev ptrs); cos, sin (fp16 dev S×HD)
     scales_dev:  act_qkv, act_o, act_fc1, act_fc2 (lists of fp32 dev ptrs)
     dims:        S, D, NH, HD, ff_inner, Sper_view
+
+    fused_epilogue: replace every descale-GEMM + add_bias (+gelu) pair with
+        a single hipBLASLt fused-epilogue GEMM — ``fp8_nn_bias`` for the
+        Q/K/V/o/fc2 sites, ``fp8_nn_gelu_bias`` for fc1. Same buffers, no
+        extra scratch; the quantize front-end is unchanged. NUMERICS: the
+        epilogue adds bias on the FP32 accumulator BEFORE the fp16 round
+        (decomposed adds it after) — judged by the E2E gate, not bit-parity.
+    alphas: required iff ``fused_epilogue`` — per-site per-layer HOST float
+        lists, keys parallel to ``scales_dev``: act_qkv (one alpha for
+        q/k/v — shared fused-qkv weight scale), act_o, act_fc1, act_fc2;
+        each alpha = act_scale × w_scale.
     """
+    if fused_epilogue and alphas is None:
+        raise ValueError(
+            "qwen3vl_vit_forward: fused_epilogue=True requires host `alphas` "
+            "(act_qkv/act_o/act_fc1/act_fc2 per-layer float lists)")
     S  = int(dims["S"])
     D  = int(dims["D"])
     NH = int(dims["NH"])
@@ -122,17 +151,27 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
             h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
             xn_ptr, S, D, 1e-6, int(stream))
 
-        # ── Quantize xn once for Q/K/V; 3 split FP8 descale GEMMs + bias ──
+        # ── Quantize xn once for Q/K/V; 3 split FP8 GEMMs + bias ──
         fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
-                              S, D, D, a_qkv, int(weights["q_ws"][li]), int(stream))
-        fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), S, D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
-                              S, D, D, a_qkv, int(weights["k_ws"][li]), int(stream))
-        fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), S, D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
-                              S, D, D, a_qkv, int(weights["v_ws"][li]), int(stream))
-        fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), S, D, int(stream))
+        if fused_epilogue:
+            # FUSED: bias in the hipBLASLt epilogue, host alpha = act·w scale.
+            al_qkv = float(alphas["act_qkv"][li])
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
+                             int(weights["q_b"][li]), S, D, D, al_qkv, int(stream))
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
+                             int(weights["k_b"][li]), S, D, D, al_qkv, int(stream))
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
+                             int(weights["v_b"][li]), S, D, D, al_qkv, int(stream))
+        else:
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
+                                  S, D, D, a_qkv, int(weights["q_ws"][li]), int(stream))
+            fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), S, D, int(stream))
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
+                                  S, D, D, a_qkv, int(weights["k_ws"][li]), int(stream))
+            fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), S, D, int(stream))
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
+                                  S, D, D, a_qkv, int(weights["v_ws"][li]), int(stream))
+            fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), S, D, int(stream))
 
         # ── Split-half RoPE on Q and K ──
         fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
@@ -143,9 +182,15 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
 
         # ── O projection (FP8) ──
         fvk.quantize_fp8_static_fp16(O_ptr, xn_fp8_ptr, a_o, S * D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
-                              S, D, D, a_o, int(weights["o_ws"][li]), int(stream))
-        fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), S, D, int(stream))
+        if fused_epilogue:
+            # FUSED: o-proj bias in epilogue.
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
+                             int(weights["o_b"][li]), S, D, D,
+                             float(alphas["act_o"][li]), int(stream))
+        else:
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
+                                  S, D, D, a_o, int(weights["o_ws"][li]), int(stream))
+            fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), S, D, int(stream))
         fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
 
         # ── Pre-FF LayerNorm ──
@@ -155,14 +200,26 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
 
         # ── FF: D → FF (GELU) → D ──
         fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, S * D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
-                              S, FF, D, a_fc1, int(weights["fc1_ws"][li]), int(stream))
-        fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), S, FF, int(stream))
-        fvk.gelu_inplace_fp16(fc1_out_ptr, S * FF, int(stream))
-        fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, S * FF, int(stream))
-        gemm.fp8_descale_fp16(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
-                              S, D, FF, a_fc2, int(weights["fc2_ws"][li]), int(stream))
-        fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), S, D, int(stream))
+        if fused_epilogue:
+            # FUSED: fc1 bias+GELU in epilogue; fc2 bias in epilogue.
+            gemm.fp8_nn_gelu_bias(xn_fp8_ptr, int(weights["fc1_w"][li]),
+                                  fc1_out_ptr, int(weights["fc1_b"][li]),
+                                  S, FF, D, float(alphas["act_fc1"][li]),
+                                  int(stream))
+            fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2,
+                                         S * FF, int(stream))
+            gemm.fp8_nn_bias(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
+                             int(weights["fc2_b"][li]), S, D, FF,
+                             float(alphas["act_fc2"][li]), int(stream))
+        else:
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
+                                  S, FF, D, a_fc1, int(weights["fc1_ws"][li]), int(stream))
+            fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), S, FF, int(stream))
+            fvk.gelu_inplace_fp16(fc1_out_ptr, S * FF, int(stream))
+            fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, S * FF, int(stream))
+            gemm.fp8_descale_fp16(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
+                                  S, D, FF, a_fc2, int(weights["fc2_ws"][li]), int(stream))
+            fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), S, D, int(stream))
         fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
 
         # ── DeepStack tap callback ──
@@ -176,7 +233,9 @@ def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
 
 
 def deepstack_merge_forward(gemm, fvk, bufs, weights, dims,
-                            scales_dev, *, attn=None, stream: int = 0) -> None:
+                            scales_dev, *, attn=None, stream: int = 0,
+                            fused_epilogue: bool = False,
+                            alphas=None) -> None:
     """3 DeepStack mergers (taps ViT [5, 11, 17]) → 3 features for LLM [0,1,2].
 
     Per merger j: LayerNorm(4096) → quantize → FP8 fc1 (+bias, +GELU tanh) →
@@ -186,7 +245,18 @@ def deepstack_merge_forward(gemm, fvk, bufs, weights, dims,
     weights:    norm_w/b[j]; fc1/fc2_w[j] (fp8) + fc1/fc2_b[j]; fc1/fc2_ws[j]
     scales_dev: act_fc1[j], act_fc2[j]
     dims:       Nin, Din, Nout, Dmid, Dout
+
+    fused_epilogue: fold bias(+GELU) into the hipBLASLt epilogue —
+        ``fp8_nn_gelu_bias`` for fc1, ``fp8_nn_bias`` for fc2. Same buffers.
+        NUMERICS: bias is added on the FP32 accumulator BEFORE the fp16
+        round (decomposed adds it after) — judged by the E2E gate.
+    alphas: required iff ``fused_epilogue`` — HOST float lists keyed
+        act_fc1 / act_fc2 (per merger; alpha = act_scale × w_scale).
     """
+    if fused_epilogue and alphas is None:
+        raise ValueError(
+            "deepstack_merge_forward: fused_epilogue=True requires host "
+            "`alphas` (act_fc1/act_fc2 per-merger float lists)")
     Nout = int(dims["Nout"])
     Dmid = int(dims["Dmid"])
     Dout = int(dims["Dout"])
@@ -206,15 +276,26 @@ def deepstack_merge_forward(gemm, fvk, bufs, weights, dims,
             ln_out, Nout, Dmid, 1e-6, int(stream))
 
         fvk.quantize_fp8_static_fp16(ln_out, fp8_scratch, a_fc1, Nout * Dmid, int(stream))
-        gemm.fp8_descale_fp16(fp8_scratch, int(weights["fc1_w"][j]), fc1_out,
-                              Nout, Dmid, Dmid, a_fc1, int(weights["fc1_ws"][j]), int(stream))
-        fvk.add_bias_fp16(fc1_out, int(weights["fc1_b"][j]), Nout, Dmid, int(stream))
-        fvk.gelu_inplace_fp16(fc1_out, Nout * Dmid, int(stream))
+        if fused_epilogue:
+            # FUSED: fc1 bias+GELU in epilogue; fc2 bias in epilogue.
+            gemm.fp8_nn_gelu_bias(fp8_scratch, int(weights["fc1_w"][j]), fc1_out,
+                                  int(weights["fc1_b"][j]), Nout, Dmid, Dmid,
+                                  float(alphas["act_fc1"][j]), int(stream))
+            fvk.quantize_fp8_static_fp16(fc1_out, fp8_scratch, a_fc2,
+                                         Nout * Dmid, int(stream))
+            gemm.fp8_nn_bias(fp8_scratch, int(weights["fc2_w"][j]), out_ptr,
+                             int(weights["fc2_b"][j]), Nout, Dout, Dmid,
+                             float(alphas["act_fc2"][j]), int(stream))
+        else:
+            gemm.fp8_descale_fp16(fp8_scratch, int(weights["fc1_w"][j]), fc1_out,
+                                  Nout, Dmid, Dmid, a_fc1, int(weights["fc1_ws"][j]), int(stream))
+            fvk.add_bias_fp16(fc1_out, int(weights["fc1_b"][j]), Nout, Dmid, int(stream))
+            fvk.gelu_inplace_fp16(fc1_out, Nout * Dmid, int(stream))
 
-        fvk.quantize_fp8_static_fp16(fc1_out, fp8_scratch, a_fc2, Nout * Dmid, int(stream))
-        gemm.fp8_descale_fp16(fp8_scratch, int(weights["fc2_w"][j]), out_ptr,
-                              Nout, Dout, Dmid, a_fc2, int(weights["fc2_ws"][j]), int(stream))
-        fvk.add_bias_fp16(out_ptr, int(weights["fc2_b"][j]), Nout, Dout, int(stream))
+            fvk.quantize_fp8_static_fp16(fc1_out, fp8_scratch, a_fc2, Nout * Dmid, int(stream))
+            gemm.fp8_descale_fp16(fp8_scratch, int(weights["fc2_w"][j]), out_ptr,
+                                  Nout, Dout, Dmid, a_fc2, int(weights["fc2_ws"][j]), int(stream))
+            fvk.add_bias_fp16(out_ptr, int(weights["fc2_b"][j]), Nout, Dout, int(stream))
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -351,7 +432,9 @@ def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
 
 def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
                          scales_dev, *, attn, stream: int = 0,
-                         layers_subset=None) -> None:
+                         layers_subset=None,
+                         fused_epilogue: bool = False,
+                         alphas=None) -> None:
     """4-layer SelfAttentionTransformer, FP8 GEMMs via decomposed descale.
 
     Per layer: LayerNorm → quantize → FP8 Q/K/V (+bias, separate weight scales)
@@ -366,7 +449,22 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
                 q/k/v/o_ws, fc1/fc2_ws (weight-scale dev ptrs)
     scales_dev: act_qkv, act_o, act_fc1, act_fc2
     dims:       T, D, NH, HD, ff_inner
+
+    fused_epilogue: fold bias(+GELU for fc1) into the hipBLASLt epilogue —
+        ``fp8_nn_bias`` for Q/K/V/o/fc2, ``fp8_nn_gelu_bias`` for fc1. Same
+        buffers, no extra scratch. NUMERICS: bias added on the FP32
+        accumulator BEFORE the fp16 round (decomposed adds it after) —
+        judged by the E2E gate, not bit-parity.
+    alphas: required iff ``fused_epilogue`` — HOST floats, keys parallel to
+        ``scales_dev``: act_qkv is a per-layer list of ``(a_q, a_k, a_v)``
+        3-tuples (Q/K/V have SEPARATE weight scales here, so one shared
+        float cannot cover them); act_o / act_fc1 / act_fc2 are per-layer
+        float lists. Each alpha = act_scale × w_scale.
     """
+    if fused_epilogue and alphas is None:
+        raise ValueError(
+            "vl_self_attn_forward: fused_epilogue=True requires host `alphas` "
+            "(act_qkv 3-tuples + act_o/act_fc1/act_fc2 per-layer float lists)")
     T  = int(dims["T"])
     D  = int(dims["D"])
     FF = int(dims["ff_inner"])
@@ -394,25 +492,44 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
             xn_ptr, T, D, 1e-5, int(stream))
         fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, T * D, int(stream))
 
-        # ── Q / K / V FP8 descale GEMMs + bias (separate weight scales) ──
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
-                              T, D, D, a_qkv, int(weights["q_ws"][li]), int(stream))
-        fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), T, D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
-                              T, D, D, a_qkv, int(weights["k_ws"][li]), int(stream))
-        fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), T, D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
-                              T, D, D, a_qkv, int(weights["v_ws"][li]), int(stream))
-        fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), T, D, int(stream))
+        # ── Q / K / V FP8 GEMMs + bias (separate weight scales) ──
+        if fused_epilogue:
+            # FUSED: per-projection alphas (separate weight scales).
+            al_q, al_k, al_v = alphas["act_qkv"][li]
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
+                             int(weights["q_b"][li]), T, D, D,
+                             float(al_q), int(stream))
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
+                             int(weights["k_b"][li]), T, D, D,
+                             float(al_k), int(stream))
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
+                             int(weights["v_b"][li]), T, D, D,
+                             float(al_v), int(stream))
+        else:
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
+                                  T, D, D, a_qkv, int(weights["q_ws"][li]), int(stream))
+            fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), T, D, int(stream))
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
+                                  T, D, D, a_qkv, int(weights["k_ws"][li]), int(stream))
+            fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), T, D, int(stream))
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
+                                  T, D, D, a_qkv, int(weights["v_ws"][li]), int(stream))
+            fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), T, D, int(stream))
 
         # ── MHA ──
         attn.run("vl_self_attn", li, q_seq=T, kv_seq=T, stream=int(stream))
 
         # ── O projection (FP8) ──
         fvk.quantize_fp8_static_fp16(O_ptr, xn_fp8_ptr, a_o, T * D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
-                              T, D, D, a_o, int(weights["o_ws"][li]), int(stream))
-        fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), T, D, int(stream))
+        if fused_epilogue:
+            # FUSED: o-proj bias in epilogue (vlsa).
+            gemm.fp8_nn_bias(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
+                             int(weights["o_b"][li]), T, D, D,
+                             float(alphas["act_o"][li]), int(stream))
+        else:
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
+                                  T, D, D, a_o, int(weights["o_ws"][li]), int(stream))
+            fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), T, D, int(stream))
         fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
 
         # ── Pre-FF LayerNorm + FF (GELU) ──
@@ -420,12 +537,336 @@ def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
             h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
             xn_ptr, T, D, 1e-5, int(stream))
         fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, T * D, int(stream))
-        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
-                              T, FF, D, a_fc1, int(weights["fc1_ws"][li]), int(stream))
-        fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), T, FF, int(stream))
-        fvk.gelu_inplace_fp16(fc1_out_ptr, T * FF, int(stream))
-        fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, T * FF, int(stream))
-        gemm.fp8_descale_fp16(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
-                              T, D, FF, a_fc2, int(weights["fc2_ws"][li]), int(stream))
-        fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), T, D, int(stream))
+        if fused_epilogue:
+            # FUSED: fc1 bias+GELU in epilogue; fc2 bias in epilogue.
+            gemm.fp8_nn_gelu_bias(xn_fp8_ptr, int(weights["fc1_w"][li]),
+                                  fc1_out_ptr, int(weights["fc1_b"][li]),
+                                  T, FF, D, float(alphas["act_fc1"][li]),
+                                  int(stream))
+            fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2,
+                                         T * FF, int(stream))
+            gemm.fp8_nn_bias(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
+                             int(weights["fc2_b"][li]), T, D, FF,
+                             float(alphas["act_fc2"][li]), int(stream))
+        else:
+            gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
+                                  T, FF, D, a_fc1, int(weights["fc1_ws"][li]), int(stream))
+            fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), T, FF, int(stream))
+            fvk.gelu_inplace_fp16(fc1_out_ptr, T * FF, int(stream))
+            fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, T * FF, int(stream))
+            gemm.fp8_descale_fp16(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
+                                  T, D, FF, a_fc2, int(weights["fc2_ws"][li]), int(stream))
+            fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), T, D, int(stream))
         fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# DiT (bf16) — AMD FUSED-EPILOGUE variant of pipeline_thor.dit_forward
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def dit_forward(gemm, fvk, bufs, weights, dims,
+                *, attn, stream: int = 0, layers_subset=None,
+                fvk_fp4=None) -> None:
+    """AMD copy of :func:`flash_rt.models.groot_n17.pipeline_thor.dit_forward`
+    with the bf16 GEMM+bias pairs fused into hipBLASLt epilogues.
+
+    Same signature, same buffers, same order. The ONLY change: every
+    ``gemm.bf16_nn`` followed by ``fvk.add_bias_bf16`` on the SAME output
+    becomes one ``gemm.bf16_nn_bias`` (and ``bf16_nn_bias_gelu`` where the
+    pair is followed by ``gelu_inplace`` on that output) — 6 sites per
+    bf16 layer: Q, K, V (self), O, FFN up (+GELU), FFN down. Each is
+    marked ``# AMD FUSED``. NUMERICS: the epilogue adds bias on the FP32
+    accumulator BEFORE the bf16 round (the decomposed pair adds it after)
+    — judged by the E2E gate, not bit-parity. The FP8/FP4 branches are
+    kept byte-identical for fidelity (dead on AMD: ``_DIT_USE_FP8=False``
+    and no fp4 weights are supplied). See the pipeline_thor docstring for
+    the full per-layer contract.
+    """
+    Sa = int(dims["Sa"])
+    D = int(dims["D"])
+    FF = int(dims["FF"])
+    Skv_text = int(dims.get("Skv_text", 0))
+    Skv_image = int(dims.get("Skv_image", 0))
+
+    h_ptr      = int(bufs["h"])
+    xn_ptr     = int(bufs["xn"])
+    o_out_ptr  = int(bufs["o_proj_out"])
+    ff_out_ptr = int(bufs["ff_proj_out"])
+
+    layer_iter = range(32) if layers_subset is None else list(layers_subset)
+
+    # NVFP4 fast path: every DiT GEMM (fused QKV / cross-Q / O / FFN up /
+    # FFN down) runs as a block-scaled NVFP4 GEMM with a fused bf16 bias
+    # epilogue. At M=Sa=41 the DiT is weight-bandwidth-bound, so halving
+    # the weight bytes is the dominant win; the fused epilogues (bias,
+    # bias+residual, bias+GELU+fp4out) and the fused norm->fp4 front-ends
+    # additionally remove most of the per-layer elementwise launches.
+    use_fp4 = fvk_fp4 is not None and "ff_proj_w_fp4" in weights
+
+    def _ck(rc, what, li):
+        if rc != 0:
+            raise RuntimeError(
+                f"N1.7 DiT FP4 {what} layer {li} failed rc={rc}")
+
+    for li in layer_iter:
+        is_self = (li % 2 == 1)
+        # Backend's ``dit_self`` and ``dit_cross`` sites are indexed
+        # cross-only / self-only (16 entries each, NOT the full 0..31
+        # layer index). Map here.
+        j_attn = (li - 1) // 2 if is_self else li // 2
+
+        if use_fp4:
+            xn_fp4, xn_sfa = int(bufs["xn_fp4"]), int(bufs["xn_sfa"])
+            slots = attn.get_slot_ptrs("dit_self" if is_self else "dit_cross",
+                                       j_attn)
+            Q_ptr, K_ptr, V_ptr, O_ptr = (slots["Q"], slots["K"], slots["V"],
+                                          slots["O"])
+            # AdaLN-modulated norm1 -> fp4 + SFA (one fused kernel).
+            rc = fvk_fp4.ada_layer_norm_fp4_sfa_bf16(
+                h_ptr, int(weights["scale_msa"][li]),
+                int(weights["shift_msa"][li]),
+                xn_fp4, xn_sfa, Sa, D, 1e-5, int(stream))
+            _ck(rc, "adaln", li)
+            if is_self:
+                j = (li - 1) // 2
+                rc = fvk_fp4.cutlass_fp4_gemm_bias_bf16(
+                    xn_fp4, xn_sfa,
+                    int(weights["qkv_w_fp4"][j]), int(weights["qkv_sfb"][j]),
+                    int(weights["qkv_b_fp4"][j]), int(bufs["qkv_buf"]),
+                    Sa, 3 * D, D, int(stream))
+                _ck(rc, "qkv", li)
+                if not bufs.get("qkv_strided"):
+                    # The self-attn slots normally alias the fused QKV
+                    # output (token stride 3D); split into packed per-slot
+                    # buffers only when they do not.
+                    fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+                    fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+                    fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+                attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa,
+                         stream=int(stream))
+            else:
+                rc = fvk_fp4.cutlass_fp4_gemm_bias_bf16(
+                    xn_fp4, xn_sfa,
+                    int(weights["q_w_fp4"][j_attn]),
+                    int(weights["q_sfb"][j_attn]),
+                    int(weights["q_b"][li]), Q_ptr,
+                    Sa, D, D, int(stream))
+                _ck(rc, "q", li)
+                target_text = (li % 4 == 0)
+                kv_seq = Skv_text if target_text else Skv_image
+                attn.run("dit_cross", j_attn, q_seq=Sa, kv_seq=kv_seq,
+                         stream=int(stream))
+            # O projection: quantize the attention output, then fused
+            # bias + residual straight into h.
+            rc = fvk_fp4.quantize_fp4_dynamic_sfa_bf16_vec(
+                O_ptr, int(bufs["octx_fp4"]), int(bufs["octx_sfa"]),
+                Sa, D, False, int(stream))
+            _ck(rc, "o-quant", li)
+            rc = fvk_fp4.cutlass_fp4_gemm_bias_res_bf16(
+                int(bufs["octx_fp4"]), int(bufs["octx_sfa"]),
+                int(weights["o_w_fp4"][li]), int(weights["o_sfb"][li]),
+                int(weights["o_b"][li]), h_ptr, h_ptr,
+                Sa, D, D, int(stream))
+            _ck(rc, "o", li)
+            # FFN: LN -> fp4, up GEMM with fused bias+GELU+fp4out, down
+            # GEMM with fused bias+residual into h.
+            rc = fvk_fp4.layer_norm_no_affine_fp4_sfa_bf16(
+                h_ptr, xn_fp4, xn_sfa, Sa, D, 1e-5, int(stream))
+            _ck(rc, "ffn-ln", li)
+            rc = fvk_fp4.cutlass_fp4_gemm_bias_gelu_fp4out_bf16(
+                xn_fp4, xn_sfa,
+                int(weights["ff_proj_w_fp4"][li]),
+                int(weights["ff_proj_sfb"][li]),
+                int(weights["ff_proj_b"][li]),
+                int(bufs["hid_fp4"]), int(bufs["hid_sfa"]),
+                Sa, FF, D, int(stream))
+            _ck(rc, "ffn-up", li)
+            rc = fvk_fp4.cutlass_fp4_gemm_bias_res_bf16(
+                int(bufs["hid_fp4"]), int(bufs["hid_sfa"]),
+                int(weights["ff_down_w_fp4"][li]),
+                int(weights["ff_down_sfb"][li]),
+                int(weights["ff_down_b"][li]), h_ptr, h_ptr,
+                Sa, D, FF, int(stream))
+            _ck(rc, "ffn-down", li)
+            continue
+
+        # ── AdaLN modulated norm1 ─────────────────────────────────────
+        # For self-attn FP8 QKV, fuse the AdaLN and the FP8 quantize into one
+        # kernel — the AdaLN output feeds only the QKV projection, so it can
+        # be emitted directly as fp8 (one kernel instead of AdaLN + quantize).
+        # Cross-attn and the bf16 fallback keep the bf16 AdaLN.
+        is_self_fp8_sm120 = is_self and "qkv_w_fp8_nt" in weights
+        is_self_fp8 = is_self and ("qkv_w_fp8" in weights or is_self_fp8_sm120)
+        j_self = (li - 1) // 2
+        if is_self_fp8:
+            fvk.ada_layer_norm_fp8(
+                h_ptr, int(weights["scale_msa"][li]), int(weights["shift_msa"][li]),
+                int(bufs["qkv_xn_fp8"]), int(weights["act_qkv_scale"][j_self]),
+                Sa, D, 1e-5, int(stream),
+            )
+        else:
+            fvk.ada_layer_norm_bf16(
+                h_ptr,
+                int(weights["scale_msa"][li]), int(weights["shift_msa"][li]),
+                xn_ptr, Sa, D, 1e-5, int(stream),
+            )
+
+        # ── attention projections ─────────────────────────────────────
+        if is_self:
+            slots = attn.get_slot_ptrs("dit_self", j_attn)
+        else:
+            slots = attn.get_slot_ptrs("dit_cross", j_attn)
+        Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
+
+        # AMD delta vs pipeline_thor: hipBLASLt on gfx950 supports the bias
+        # (and bias+GELU) epilogue at M=Sa=41 — parity-validated GemmRunner
+        # entry points — so the bf16_nn + add_bias_bf16 pairs below run as
+        # single fused-epilogue GEMMs (the cuBLASLt M-alignment limitation
+        # that forced the decomposed form on Thor does not apply here).
+        if is_self_fp8_sm120:
+            gemm.fp8_nt_dev(
+                int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8_nt"][j_self]),
+                int(bufs["qkv_buf"]), Sa, 3 * D, D,
+                int(weights["act_qkv_scale"][j_self]),
+                int(weights["qkv_weight_scale"][j_self]), int(stream))
+            fvk.add_bias_bf16(
+                int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
+                Sa, 3 * D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+            attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
+        elif is_self_fp8:
+            # Fused FP8 QKV (self-attn): q/k/v share the post-AdaLN input,
+            # so one [D, 3D] GEMM (compute-bound, unlike 3 launch-bound D→D
+            # GEMMs) + a strided split into the Q/K/V slots. Cross-attn keeps
+            # a single Q GEMM (K/V come from the backbone-projected cross-KV).
+            qkv_fp8_layout = str(weights.get("qkv_fp8_layout", "kn"))
+            if qkv_fp8_layout == "nk":
+                gemm.fp8_nt_dev(
+                    int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8"][j_self]),
+                    int(bufs["qkv_buf"]), Sa, 3 * D, D,
+                    int(weights["act_qkv_scale"][j_self]),
+                    int(weights["w_qkv_scale"][j_self]), int(stream))
+            else:
+                gemm.fp8_nn_dev(
+                    int(bufs["qkv_xn_fp8"]), int(weights["qkv_w_fp8"][j_self]),
+                    int(bufs["qkv_buf"]), Sa, 3 * D, D,
+                    int(weights["act_qkv_scale"][j_self]),
+                    int(weights["w_qkv_scale"][j_self]), int(stream))
+            fvk.add_bias_bf16(
+                int(bufs["qkv_buf"]), int(weights["qkv_b"][j_self]),
+                Sa, 3 * D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), Q_ptr, Sa, D, 3 * D, 0, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), K_ptr, Sa, D, 3 * D, D, int(stream))
+            fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
+            attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
+        else:
+            # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (Q).
+            gemm.bf16_nn_bias(xn_ptr, int(weights["q_w"][li]),
+                              Q_ptr, int(weights["q_b"][li]),
+                              Sa, D, D, int(stream))
+            if is_self:
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (K).
+                gemm.bf16_nn_bias(xn_ptr, int(weights["k_w"][li]),
+                                  K_ptr, int(weights["k_b"][li]),
+                                  Sa, D, D, int(stream))
+                # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (V).
+                gemm.bf16_nn_bias(xn_ptr, int(weights["v_w"][li]),
+                                  V_ptr, int(weights["v_b"][li]),
+                                  Sa, D, D, int(stream))
+                attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
+            else:
+                target_text = (li % 4 == 0)
+                kv_seq = Skv_text if target_text else Skv_image
+                attn.run("dit_cross", j_attn, q_seq=Sa, kv_seq=kv_seq,
+                         stream=int(stream))
+
+        # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (O proj).
+        gemm.bf16_nn_bias(O_ptr, int(weights["o_w"][li]),
+                          o_out_ptr, int(weights["o_b"][li]),
+                          Sa, D, D, int(stream))
+        fvk.residual_add(h_ptr, o_out_ptr, Sa * D, int(stream))
+
+        # ── Pre-FF LayerNorm (no affine — DiT default) ───────────────
+        fvk.layer_norm_no_affine_bf16(
+            h_ptr, xn_ptr, Sa, D, 1e-5, int(stream),
+        )
+
+        # ── FFN: GELU(tanh-approx) ────────────────────────────────────
+        # The FFN GEMMs are the compute-bound part of the (M=41) DiT, so an
+        # FP8 path here is a real win (≈1.8× on the up-projection) and fuses
+        # the bias+GELU into the GEMM epilogue. Activated when calibrated FP8
+        # FFN weights/scales are supplied; otherwise the bf16 path runs. The
+        # attention GEMMs stay bf16 — at M=41 they are launch-bound, so FP8
+        # gives no speedup there.
+        if "ff_proj_w_fp8_sm120" in weights:
+            fvk.quantize_fp8_static(
+                xn_ptr, int(bufs["xn_fp8"]),
+                int(weights["act_fc1_scale"][li]), Sa * D, int(stream))
+            gemm.fp8_descale_fp16(
+                int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8_sm120"][li]),
+                int(bufs["ff_fp16"]), Sa, FF, D,
+                int(weights["act_fc1_scale"][li]),
+                int(weights["ff_proj_weight_scale"][li]), int(stream))
+            fvk.add_bias_fp16(
+                int(bufs["ff_fp16"]), int(weights["ff_proj_b"][li]),
+                Sa, FF, int(stream))
+            fvk.gelu_inplace_fp16(int(bufs["ff_fp16"]), Sa * FF, int(stream))
+            fvk.quantize_fp8_static_fp16(
+                int(bufs["ff_fp16"]), int(bufs["ff_fp8"]),
+                int(weights["act_fc2_scale"][li]), Sa * FF, int(stream))
+            gemm.fp8_nt_dev(
+                int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8_nt"][li]),
+                o_out_ptr, Sa, D, FF,
+                int(weights["act_fc2_scale"][li]),
+                int(weights["ff_down_weight_scale"][li]), int(stream))
+            fvk.add_bias_bf16(o_out_ptr, int(weights["ff_down_b"][li]),
+                              Sa, D, int(stream))
+        elif "ff_proj_w_fp8" in weights:
+            ff_fp8_layout = str(weights.get("ff_fp8_layout", "kn"))
+            fvk.quantize_fp8_static(
+                xn_ptr, int(bufs["xn_fp8"]),
+                int(weights["act_fc1_scale"][li]), Sa * D, int(stream))
+            if ff_fp8_layout == "nk":
+                gemm.fp8_nt_dev(
+                    int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8"][li]),
+                    ff_out_ptr, Sa, FF, D,
+                    int(weights["act_fc1_scale"][li]),
+                    int(weights["w_fc1_scale"][li]), int(stream))
+            else:
+                gemm.fp8_nn_dev(
+                    int(bufs["xn_fp8"]), int(weights["ff_proj_w_fp8"][li]),
+                    ff_out_ptr, Sa, FF, D,
+                    int(weights["act_fc1_scale"][li]),
+                    int(weights["w_fc1_scale"][li]), int(stream))
+            fvk.bias_gelu_quantize_fp8_static_bf16(
+                ff_out_ptr, int(weights["ff_proj_b"][li]),
+                int(bufs["ff_fp8"]), int(weights["act_fc2_scale"][li]),
+                Sa, FF, int(stream))
+            if ff_fp8_layout == "nk":
+                gemm.fp8_nt_dev(
+                    int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8"][li]),
+                    o_out_ptr, Sa, D, FF,
+                    int(weights["act_fc2_scale"][li]),
+                    int(weights["w_fc2_scale"][li]), int(stream))
+            else:
+                gemm.fp8_nn_dev(
+                    int(bufs["ff_fp8"]), int(weights["ff_down_w_fp8"][li]),
+                    o_out_ptr, Sa, D, FF,
+                    int(weights["act_fc2_scale"][li]),
+                    int(weights["w_fc2_scale"][li]), int(stream))
+            fvk.add_bias_bf16(o_out_ptr, int(weights["ff_down_b"][li]),
+                              Sa, D, int(stream))
+        else:
+            # AMD FUSED: bf16_nn + add_bias_bf16 + gelu_inplace →
+            # bf16_nn_bias_gelu (FFN up).
+            gemm.bf16_nn_bias_gelu(xn_ptr, int(weights["ff_proj_w"][li]),
+                                   ff_out_ptr, int(weights["ff_proj_b"][li]),
+                                   Sa, FF, D, int(stream))
+            # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (FFN down).
+            gemm.bf16_nn_bias(ff_out_ptr, int(weights["ff_down_w"][li]),
+                              o_out_ptr, int(weights["ff_down_b"][li]),
+                              Sa, D, FF, int(stream))
+        fvk.residual_add(h_ptr, o_out_ptr, Sa * D, int(stream))

--- a/flash_rt/amd/models/groot_n17/pipeline.py
+++ b/flash_rt/amd/models/groot_n17/pipeline.py
@@ -67,6 +67,8 @@ host↔device traffic; streams are raw ints).
 
 from __future__ import annotations
 
+import os
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Stage 4: VLLN — LayerNorm on backbone_features (no FP8; identical to RTX)
@@ -728,6 +730,40 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
 
     layer_iter = range(32) if layers_subset is None else list(layers_subset)
 
+    # ── Small-M MFMA packed-GEMM routing (measured list, the pi05
+    # FVK_AMD_DEC_GEMM precedent) ────────────────────────────────────
+    # The gfx950 packed bf16 kernel (csrc/amd/gemm/smallm_mfma_bf16.h)
+    # wins ONLY on the square (41, 1536, 1536) projection shape
+    # (standalone gate vs autotuned hipBLASLt: bias 1.41x, bias_res
+    # 1.12x); it LOSES on ff1 (41,6144,1536) and ff2 (41,1536,6144),
+    # which stay on hipBLASLt. Routed sites: Q (32 layers), K/V (16
+    # self layers), O (32 layers) — each only when the frontend supplied
+    # an MFMA-packed copy of that weight in weights["smallm_packed"].
+    # FVK_AMD_DIT_GEMM: "smallm" (default) enables the routing,
+    # "hipblaslt" keeps every site on the library path. Env read at
+    # graph-build time only — this function never runs post-capture.
+    smallm_packed = weights.get("smallm_packed") or {}
+    if os.environ.get("FVK_AMD_DIT_GEMM", "smallm").strip().lower() \
+            != "smallm":
+        smallm_packed = {}
+
+    def _dd_proj_bias(wkey: str, li: int, out_ptr: int, s: int) -> None:
+        """(Sa, D, D) bias-epilogue projection (Q/K/V, input xn).
+
+        Variant 3 = w4_split, hardcoded per the standalone gate: the
+        measured bias-epilogue winner at (41, 1536, 1536), 1.41x vs
+        autotuned hipBLASLt (auto's heuristic would not pick it here).
+        """
+        wp = smallm_packed.get(f"{wkey}_w_{li}")
+        if wp is not None:
+            fvk.smallm_mfma_bf16_nn_bias(
+                xn_ptr, int(wp), int(weights[f"{wkey}_b"][li]), out_ptr,
+                Sa, D, D, 3, s)
+        else:
+            gemm.bf16_nn_bias(xn_ptr, int(weights[f"{wkey}_w"][li]),
+                              out_ptr, int(weights[f"{wkey}_b"][li]),
+                              Sa, D, D, s)
+
     # NVFP4 fast path: every DiT GEMM (fused QKV / cross-Q / O / FFN up /
     # FFN down) runs as a block-scaled NVFP4 GEMM with a fused bf16 bias
     # epilogue. At M=Sa=41 the DiT is weight-bandwidth-bound, so halving
@@ -895,19 +931,15 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
             fvk.gpu_strided_copy_fp16(int(bufs["qkv_buf"]), V_ptr, Sa, D, 3 * D, 2 * D, int(stream))
             attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
         else:
-            # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (Q).
-            gemm.bf16_nn_bias(xn_ptr, int(weights["q_w"][li]),
-                              Q_ptr, int(weights["q_b"][li]),
-                              Sa, D, D, int(stream))
+            # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (Q);
+            # smallm-routed when a packed q_w copy exists (see
+            # _dd_proj_bias / FVK_AMD_DIT_GEMM above).
+            _dd_proj_bias("q", li, Q_ptr, int(stream))
             if is_self:
                 # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (K).
-                gemm.bf16_nn_bias(xn_ptr, int(weights["k_w"][li]),
-                                  K_ptr, int(weights["k_b"][li]),
-                                  Sa, D, D, int(stream))
+                _dd_proj_bias("k", li, K_ptr, int(stream))
                 # AMD FUSED: bf16_nn + add_bias_bf16 → bf16_nn_bias (V).
-                gemm.bf16_nn_bias(xn_ptr, int(weights["v_w"][li]),
-                                  V_ptr, int(weights["v_b"][li]),
-                                  Sa, D, D, int(stream))
+                _dd_proj_bias("v", li, V_ptr, int(stream))
                 attn.run("dit_self", j_attn, q_seq=Sa, kv_seq=Sa, stream=int(stream))
             else:
                 target_text = (li % 4 == 0)
@@ -922,9 +954,19 @@ def dit_forward(gemm, fvk, bufs, weights, dims,
         # NUMERICS: the residual is added BEFORE the single bf16 round
         # (decomposed rounds the GEMM output first) — same class as the
         # bias epilogues, judged by the E2E gate.
-        gemm.bf16_nn_bias_res(O_ptr, int(weights["o_w"][li]),
-                              h_ptr, int(weights["o_b"][li]),
-                              Sa, D, D, int(stream))
+        _o_wp = smallm_packed.get(f"o_w_{li}")
+        if _o_wp is not None:
+            # smallm-routed O proj (variant 4 = w8_split, hardcoded per
+            # the standalone gate: measured bias_res winner at
+            # (41, 1536, 1536), 1.12x vs autotuned hipBLASLt). Same
+            # D += acc + bias semantics as bf16_nn_bias_res (beta=1).
+            fvk.smallm_mfma_bf16_nn_bias_res(
+                O_ptr, int(_o_wp), int(weights["o_b"][li]), h_ptr,
+                Sa, D, D, 4, int(stream))
+        else:
+            gemm.bf16_nn_bias_res(O_ptr, int(weights["o_w"][li]),
+                                  h_ptr, int(weights["o_b"][li]),
+                                  Sa, D, D, int(stream))
 
         # ── Pre-FF LayerNorm (no affine — DiT default) ───────────────
         fvk.layer_norm_no_affine_bf16(

--- a/flash_rt/amd/models/groot_n17/pipeline.py
+++ b/flash_rt/amd/models/groot_n17/pipeline.py
@@ -1,0 +1,431 @@
+"""GR00T N1.7 FP8 backbone forward pipeline for AMD CDNA4 (MI350X, gfx950).
+
+Text mirror of ``flash_rt/models/groot_n17/pipeline_rtx_fp8.py`` — the
+validated SM120-safe FP8 decomposed form — retargeted at the AMD kernel
+surface (``flash_rt.amd.flash_rt_amd_kernels``). The decomposition is
+numerics-identical to the RTX production path:
+
+    quantize_fp8_static_fp16(x, x_fp8, act_scale_devptr)
+    gemm.fp8_descale_fp16(x_fp8, w_fp8, out, M, N, K,
+                          act_scale_devptr, w_scale_devptr)   # out = act·w·(A@B), fp16
+    fvk.add_bias_fp16(out, b)                                 # separate bias
+    fvk.gelu_inplace_fp16(out, ...)                           # separate activation
+
+hipBLASLt does support fused fp8 bias/gelu epilogues (``fp8_nn_bias`` /
+``fp8_nn_gelu_bias``), but flipping to them is a LATER single-variable
+A/B — this pass keeps the descale + separate-epilogue form so the AMD
+numbers are directly comparable to the RTX-validated production path.
+
+Attention stays FP16 (the descale GEMM emits FP16 Q/K/V) and delegates
+to :class:`flash_rt.amd.hardware.cdna4.attn_backend_groot_n17.Cdna4GrootN17AttnBackend`.
+
+Sanctioned delta vs the RTX source (the ONLY computation difference):
+
+  * llm GQA expand is SKIPPED. The AMD backend's llm K/V slots hold the
+    model's NATIVE 8 KV heads and aiter's ``mha_fwd`` performs GQA
+    internally, so the RTX ``gpu_repeat_interleave_heads`` K/V → 16-head
+    expand step is dropped and the Q/K/V GEMMs write straight into the
+    backend slots (Q 16 heads, K/V 8 heads).
+
+Both per-tensor scales are device fp32 scalar pointers:
+  * ``act_scale``  — from calibration (``flash_rt.models.groot_n17.calibration``
+    is pure torch / hardware-independent; the AMD frontend imports it
+    directly, along with ``mrope_table``).
+  * ``w_scale``    — the weight scale baked at load time, uploaded to a
+    device fp32 scalar by the frontend.
+
+Stages mirror ``pipeline_rtx_fp8.py``: ``qwen3vl_vit_forward`` →
+``deepstack_merge_forward`` → ``qwen3vl_llm_forward`` → ``vlln_forward`` →
+``vl_self_attn_forward``. Each forward is pointer-only (every device tensor
+is an int ``data_ptr`` supplied by the frontend; no allocation, no
+host↔device traffic; streams are raw ints).
+"""
+
+from __future__ import annotations
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 4: VLLN — LayerNorm on backbone_features (no FP8; identical to RTX)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def vlln_forward(gemm, fvk, bufs, weights, dims,
+                 scales_dev=None, *, attn=None, stream: int = 0) -> None:
+    """LayerNorm(2048, eps=1e-5) on backbone features ``(B, S, 2048)``.
+
+    Required:
+        bufs["x"], bufs["out"]      — fp16 (S × D)
+        weights["vlln_w"], ["vlln_b"]
+        dims["S"], dims["D"]
+    """
+    fvk.layer_norm_fp16(
+        int(bufs["x"]), int(weights["vlln_w"]), int(weights["vlln_b"]),
+        int(bufs["out"]), int(dims["S"]), int(dims["D"]), 1e-5, int(stream),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 1: Qwen3-VL ViT (24 layers)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def qwen3vl_vit_forward(gemm, fvk, bufs, weights, dims,
+                        scales_dev, *, attn, stream: int = 0,
+                        layers_subset=None,
+                        deepstack_taps=(5, 11, 17),
+                        deepstack_capture=None) -> None:
+    """24-layer Qwen3-VL ViT, FP8 GEMMs via decomposed descale.
+
+    Per layer (in-place residual on ``h``): LayerNorm → quantize → 3 split FP8
+    Q/K/V descale GEMMs (+bias) → split-half RoPE → multi-view FMHA → quantize
+    O → FP8 o-proj (+bias) → residual → LayerNorm → quantize → FP8 fc1 (+bias,
+    +GELU tanh) → quantize → FP8 fc2 (+bias) → residual.
+
+    Q/K/V share the fused-qkv weight scale (``q_ws == k_ws == v_ws``).
+
+    bufs:        h, xn (fp16 S×D); xn_fp8 (fp8 S×D); o_proj_out (fp16 S×D);
+                 fc1_out (fp16 S×FF); fc1_fp8 (fp8 S×FF)
+    weights:     norm1/2_w/b; q/k/v/o_w, q/k/v/o_b; fc1/fc2_w, fc1/fc2_b
+                 (fp8 weight ptrs + fp16 bias ptrs); q/k/v/o_ws, fc1/fc2_ws
+                 (weight-scale dev ptrs); cos, sin (fp16 dev S×HD)
+    scales_dev:  act_qkv, act_o, act_fc1, act_fc2 (lists of fp32 dev ptrs)
+    dims:        S, D, NH, HD, ff_inner, Sper_view
+    """
+    S  = int(dims["S"])
+    D  = int(dims["D"])
+    NH = int(dims["NH"])
+    HD = int(dims["HD"])
+    FF = int(dims["ff_inner"])
+
+    h_ptr       = int(bufs["h"])
+    xn_ptr      = int(bufs["xn"])
+    xn_fp8_ptr  = int(bufs["xn_fp8"])
+    o_proj_out  = int(bufs["o_proj_out"])
+    fc1_out_ptr = int(bufs["fc1_out"])
+    fc1_fp8_ptr = int(bufs["fc1_fp8"])
+    cos_ptr     = int(weights["cos"])
+    sin_ptr     = int(weights["sin"])
+
+    layer_iter = range(24) if layers_subset is None else list(layers_subset)
+    Sper = int(dims.get("Sper_view", S))
+
+    for li in layer_iter:
+        slots = attn.get_slot_ptrs("vit", li)
+        Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
+        a_qkv = int(scales_dev["act_qkv"][li])
+        a_o   = int(scales_dev["act_o"][li])
+        a_fc1 = int(scales_dev["act_fc1"][li])
+        a_fc2 = int(scales_dev["act_fc2"][li])
+
+        # ── Pre-attn LayerNorm ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+            xn_ptr, S, D, 1e-6, int(stream))
+
+        # ── Quantize xn once for Q/K/V; 3 split FP8 descale GEMMs + bias ──
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
+                              S, D, D, a_qkv, int(weights["q_ws"][li]), int(stream))
+        fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), S, D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
+                              S, D, D, a_qkv, int(weights["k_ws"][li]), int(stream))
+        fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), S, D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
+                              S, D, D, a_qkv, int(weights["v_ws"][li]), int(stream))
+        fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), S, D, int(stream))
+
+        # ── Split-half RoPE on Q and K ──
+        fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
+        fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NH, HD, int(stream))
+
+        # ── Multi-view batched FMHA ──
+        attn.run("vit", li, q_seq=Sper, kv_seq=Sper, stream=int(stream))
+
+        # ── O projection (FP8) ──
+        fvk.quantize_fp8_static_fp16(O_ptr, xn_fp8_ptr, a_o, S * D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
+                              S, D, D, a_o, int(weights["o_ws"][li]), int(stream))
+        fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), S, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
+
+        # ── Pre-FF LayerNorm ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm2_w"][li]), int(weights["norm2_b"][li]),
+            xn_ptr, S, D, 1e-6, int(stream))
+
+        # ── FF: D → FF (GELU) → D ──
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, S * D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
+                              S, FF, D, a_fc1, int(weights["fc1_ws"][li]), int(stream))
+        fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), S, FF, int(stream))
+        fvk.gelu_inplace_fp16(fc1_out_ptr, S * FF, int(stream))
+        fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, S * FF, int(stream))
+        gemm.fp8_descale_fp16(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
+                              S, D, FF, a_fc2, int(weights["fc2_ws"][li]), int(stream))
+        fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), S, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, S * D, int(stream))
+
+        # ── DeepStack tap callback ──
+        if deepstack_capture is not None and li in deepstack_taps:
+            deepstack_capture[deepstack_taps.index(li)](h_ptr)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 2: DeepStack mergers (3)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def deepstack_merge_forward(gemm, fvk, bufs, weights, dims,
+                            scales_dev, *, attn=None, stream: int = 0) -> None:
+    """3 DeepStack mergers (taps ViT [5, 11, 17]) → 3 features for LLM [0,1,2].
+
+    Per merger j: LayerNorm(4096) → quantize → FP8 fc1 (+bias, +GELU tanh) →
+    quantize → FP8 fc2 (+bias) → (Nout, 2048).
+
+    bufs:       in (list[3]), ln_out, fp8_scratch, fc1_out, out (list[3])
+    weights:    norm_w/b[j]; fc1/fc2_w[j] (fp8) + fc1/fc2_b[j]; fc1/fc2_ws[j]
+    scales_dev: act_fc1[j], act_fc2[j]
+    dims:       Nin, Din, Nout, Dmid, Dout
+    """
+    Nout = int(dims["Nout"])
+    Dmid = int(dims["Dmid"])
+    Dout = int(dims["Dout"])
+
+    ln_out      = int(bufs["ln_out"])
+    fp8_scratch = int(bufs["fp8_scratch"])
+    fc1_out     = int(bufs["fc1_out"])
+
+    for j in range(3):
+        in_ptr  = int(bufs["in"][j])
+        out_ptr = int(bufs["out"][j])
+        a_fc1 = int(scales_dev["act_fc1"][j])
+        a_fc2 = int(scales_dev["act_fc2"][j])
+
+        fvk.layer_norm_fp16(
+            in_ptr, int(weights["norm_w"][j]), int(weights["norm_b"][j]),
+            ln_out, Nout, Dmid, 1e-6, int(stream))
+
+        fvk.quantize_fp8_static_fp16(ln_out, fp8_scratch, a_fc1, Nout * Dmid, int(stream))
+        gemm.fp8_descale_fp16(fp8_scratch, int(weights["fc1_w"][j]), fc1_out,
+                              Nout, Dmid, Dmid, a_fc1, int(weights["fc1_ws"][j]), int(stream))
+        fvk.add_bias_fp16(fc1_out, int(weights["fc1_b"][j]), Nout, Dmid, int(stream))
+        fvk.gelu_inplace_fp16(fc1_out, Nout * Dmid, int(stream))
+
+        fvk.quantize_fp8_static_fp16(fc1_out, fp8_scratch, a_fc2, Nout * Dmid, int(stream))
+        gemm.fp8_descale_fp16(fp8_scratch, int(weights["fc2_w"][j]), out_ptr,
+                              Nout, Dout, Dmid, a_fc2, int(weights["fc2_ws"][j]), int(stream))
+        fvk.add_bias_fp16(out_ptr, int(weights["fc2_b"][j]), Nout, Dout, int(stream))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 3: Qwen3-VL truncated LLM (16 layers, causal, GQA)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def qwen3vl_llm_forward(gemm, fvk, bufs, weights, dims,
+                        scales_dev, *, attn, stream: int = 0,
+                        layers_subset=None) -> None:
+    """16 truncated Qwen3-VL LLM decoder layers, FP8 GEMMs via decomposed descale.
+
+    Per layer: RMSNorm → quantize → 3 split FP8 Q/K/V descale GEMMs (no bias) →
+    per-head q/k RMSNorm → M-RoPE → causal GQA MHA (aiter native — NO K/V head
+    expand, see below) → quantize O → FP8 o-proj → residual → RMSNorm →
+    quantize → FP8 gate/up → SiLU(gate)*up fused-to-FP8 → FP8 down → residual
+    → optional DeepStack inject.
+
+    Q/K/V share the fused-qkv weight scale.
+
+    AMD delta vs pipeline_rtx_fp8 (the ONLY sanctioned computation change):
+    the backend's llm K/V slots hold the NATIVE NHKV=8 heads and aiter's
+    ``mha_fwd`` handles GQA internally, so the Q/K/V descale GEMMs write
+    straight into the backend slots (``attn.get_slot_ptrs("llm", li)``) and
+    the RTX ``gpu_repeat_interleave_heads`` expand step is SKIPPED. The RTX
+    ``bufs`` keys Q/K/V/K_exp/V_exp are therefore NOT read here (the frontend
+    may omit them).
+
+    bufs:       h, xn (fp16 S×D); xn_fp8 (fp8 S×D); o_proj_out (fp16 S×D);
+                gate_out, up_out (fp16 S×FF); gu_fp8 (fp8 S×FF)
+    weights:    in_ln_w, post_ln_w, q_norm_w, k_norm_w; q/k/v/o_w, gate/up/down_w
+                (fp8); q/k/v/o_ws, gate/up/down_ws (weight-scale dev ptrs);
+                cos, sin; deepstack_inject (list[16], 0 = none)
+    scales_dev: act_qkv, act_o, act_gateup, act_down
+    dims:       S, D, NHQ, NHKV, HD, FF
+    """
+    S    = int(dims["S"])
+    D    = int(dims["D"])
+    NHQ  = int(dims["NHQ"])
+    NHKV = int(dims["NHKV"])
+    HD   = int(dims["HD"])
+    FF   = int(dims["FF"])
+
+    h_ptr      = int(bufs["h"])
+    xn_ptr     = int(bufs["xn"])
+    xn_fp8_ptr = int(bufs["xn_fp8"])
+    o_out_ptr  = int(bufs["o_proj_out"])
+    gate_ptr   = int(bufs["gate_out"])
+    up_ptr     = int(bufs["up_out"])
+    gu_fp8_ptr = int(bufs["gu_fp8"])
+    cos_ptr    = int(weights["cos"])
+    sin_ptr    = int(weights["sin"])
+
+    inject_ptrs = weights.get("deepstack_inject", [0] * 16)
+    layer_iter = range(16) if layers_subset is None else list(layers_subset)
+
+    for li in layer_iter:
+        slots = attn.get_slot_ptrs("llm", li)
+        # AMD: GEMM outputs land directly in the backend slots — Q holds
+        # NHQ=16 heads, K/V hold the native NHKV=8 heads (aiter GQA).
+        Q_ptr = int(slots["Q"])
+        K_ptr = int(slots["K"])
+        V_ptr = int(slots["V"])
+        O_ptr = int(slots["O"])
+        a_qkv = int(scales_dev["act_qkv"][li])
+        a_o   = int(scales_dev["act_o"][li])
+        a_gu  = int(scales_dev["act_gateup"][li])
+        a_dn  = int(scales_dev["act_down"][li])
+
+        # ── Pre-attn RMSNorm + quantize ──
+        fvk.rms_norm_fp16(h_ptr, int(weights["in_ln_w"][li]), xn_ptr,
+                          S, D, 1e-6, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, S * D, int(stream))
+
+        # ── 3 split FP8 descale GEMMs (no bias — Qwen3 QKV) ──
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
+                              S, NHQ * HD, D, a_qkv, int(weights["q_ws"][li]), int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
+                              S, NHKV * HD, D, a_qkv, int(weights["k_ws"][li]), int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
+                              S, NHKV * HD, D, a_qkv, int(weights["v_ws"][li]), int(stream))
+
+        # ── Per-head q_norm / k_norm (BEFORE M-RoPE) ──
+        fvk.rms_norm_fp16(Q_ptr, int(weights["q_norm_w"][li]), Q_ptr,
+                          S * NHQ, HD, 1e-6, int(stream))
+        fvk.rms_norm_fp16(K_ptr, int(weights["k_norm_w"][li]), K_ptr,
+                          S * NHKV, HD, 1e-6, int(stream))
+
+        # ── M-RoPE on Q and K ──
+        fvk.rope_rotate_half_fp16(Q_ptr, cos_ptr, sin_ptr, S, NHQ,  HD, int(stream))
+        fvk.rope_rotate_half_fp16(K_ptr, cos_ptr, sin_ptr, S, NHKV, HD, int(stream))
+
+        # ── (RTX had GQA expand K/V → NHQ heads here — SKIPPED on AMD:
+        #     aiter consumes the native 8 KV heads.) ──
+
+        # ── Causal MHA via attn backend ──
+        attn.run("llm", li, q_seq=S, kv_seq=S, stream=int(stream))
+
+        # ── O projection (FP8) ──
+        fvk.quantize_fp8_static_fp16(O_ptr, xn_fp8_ptr, a_o,
+                                     S * NHQ * HD, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_out_ptr,
+                              S, D, NHQ * HD, a_o, int(weights["o_ws"][li]), int(stream))
+        fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
+
+        # ── Pre-FFN RMSNorm + quantize ──
+        fvk.rms_norm_fp16(h_ptr, int(weights["post_ln_w"][li]), xn_ptr,
+                          S, D, 1e-6, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_gu, S * D, int(stream))
+
+        # ── gate / up FP8 GEMMs → fp16 ──
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["gate_w"][li]), gate_ptr,
+                              S, FF, D, a_gu, int(weights["gate_ws"][li]), int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["up_w"][li]), up_ptr,
+                              S, FF, D, a_gu, int(weights["up_ws"][li]), int(stream))
+
+        # ── SiLU(gate) * up → directly FP8 (fused) → down GEMM ──
+        fvk.silu_mul_split_fp8_fp16(gate_ptr, up_ptr, gu_fp8_ptr, S * FF,
+                                    a_dn, int(stream))
+        gemm.fp8_descale_fp16(gu_fp8_ptr, int(weights["down_w"][li]), o_out_ptr,
+                              S, D, FF, a_dn, int(weights["down_ws"][li]), int(stream))
+        fvk.residual_add_fp16(h_ptr, o_out_ptr, S * D, int(stream))
+
+        # ── DeepStack injection (HF: layers 0, 1, 2) ──
+        inject_ptr = int(inject_ptrs[li]) if li < len(inject_ptrs) else 0
+        if inject_ptr != 0:
+            fvk.residual_add_fp16(h_ptr, inject_ptr, S * D, int(stream))
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stage 5: VL self-attention (4 layers)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def vl_self_attn_forward(gemm, fvk, bufs, weights, dims,
+                         scales_dev, *, attn, stream: int = 0,
+                         layers_subset=None) -> None:
+    """4-layer SelfAttentionTransformer, FP8 GEMMs via decomposed descale.
+
+    Per layer: LayerNorm → quantize → FP8 Q/K/V (+bias, separate weight scales)
+    → MHA → quantize O → FP8 o-proj (+bias) → residual → LayerNorm → quantize →
+    FP8 fc1 (+bias, +GELU tanh) → quantize → FP8 fc2 (+bias) → residual.
+
+    Q/K/V each have their OWN weight scale (separate projections, not fused).
+
+    bufs:       h, xn (fp16 T×D); xn_fp8 (fp8 T×D); o_proj_out (fp16 T×D);
+                fc1_out (fp16 T×FF); fc1_fp8 (fp8 T×FF)
+    weights:    norm1/3_w/b; q/k/v/o_w, q/k/v/o_b; fc1/fc2_w, fc1/fc2_b (fp8);
+                q/k/v/o_ws, fc1/fc2_ws (weight-scale dev ptrs)
+    scales_dev: act_qkv, act_o, act_fc1, act_fc2
+    dims:       T, D, NH, HD, ff_inner
+    """
+    T  = int(dims["T"])
+    D  = int(dims["D"])
+    FF = int(dims["ff_inner"])
+
+    h_ptr       = int(bufs["h"])
+    xn_ptr      = int(bufs["xn"])
+    xn_fp8_ptr  = int(bufs["xn_fp8"])
+    o_proj_out  = int(bufs["o_proj_out"])
+    fc1_out_ptr = int(bufs["fc1_out"])
+    fc1_fp8_ptr = int(bufs["fc1_fp8"])
+
+    layer_iter = range(4) if layers_subset is None else list(layers_subset)
+
+    for li in layer_iter:
+        slots = attn.get_slot_ptrs("vl_self_attn", li)
+        Q_ptr, K_ptr, V_ptr, O_ptr = slots["Q"], slots["K"], slots["V"], slots["O"]
+        a_qkv = int(scales_dev["act_qkv"][li])
+        a_o   = int(scales_dev["act_o"][li])
+        a_fc1 = int(scales_dev["act_fc1"][li])
+        a_fc2 = int(scales_dev["act_fc2"][li])
+
+        # ── Pre-attn LayerNorm + quantize ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm1_w"][li]), int(weights["norm1_b"][li]),
+            xn_ptr, T, D, 1e-5, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_qkv, T * D, int(stream))
+
+        # ── Q / K / V FP8 descale GEMMs + bias (separate weight scales) ──
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["q_w"][li]), Q_ptr,
+                              T, D, D, a_qkv, int(weights["q_ws"][li]), int(stream))
+        fvk.add_bias_fp16(Q_ptr, int(weights["q_b"][li]), T, D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["k_w"][li]), K_ptr,
+                              T, D, D, a_qkv, int(weights["k_ws"][li]), int(stream))
+        fvk.add_bias_fp16(K_ptr, int(weights["k_b"][li]), T, D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["v_w"][li]), V_ptr,
+                              T, D, D, a_qkv, int(weights["v_ws"][li]), int(stream))
+        fvk.add_bias_fp16(V_ptr, int(weights["v_b"][li]), T, D, int(stream))
+
+        # ── MHA ──
+        attn.run("vl_self_attn", li, q_seq=T, kv_seq=T, stream=int(stream))
+
+        # ── O projection (FP8) ──
+        fvk.quantize_fp8_static_fp16(O_ptr, xn_fp8_ptr, a_o, T * D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["o_w"][li]), o_proj_out,
+                              T, D, D, a_o, int(weights["o_ws"][li]), int(stream))
+        fvk.add_bias_fp16(o_proj_out, int(weights["o_b"][li]), T, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))
+
+        # ── Pre-FF LayerNorm + FF (GELU) ──
+        fvk.layer_norm_fp16(
+            h_ptr, int(weights["norm3_w"][li]), int(weights["norm3_b"][li]),
+            xn_ptr, T, D, 1e-5, int(stream))
+        fvk.quantize_fp8_static_fp16(xn_ptr, xn_fp8_ptr, a_fc1, T * D, int(stream))
+        gemm.fp8_descale_fp16(xn_fp8_ptr, int(weights["fc1_w"][li]), fc1_out_ptr,
+                              T, FF, D, a_fc1, int(weights["fc1_ws"][li]), int(stream))
+        fvk.add_bias_fp16(fc1_out_ptr, int(weights["fc1_b"][li]), T, FF, int(stream))
+        fvk.gelu_inplace_fp16(fc1_out_ptr, T * FF, int(stream))
+        fvk.quantize_fp8_static_fp16(fc1_out_ptr, fc1_fp8_ptr, a_fc2, T * FF, int(stream))
+        gemm.fp8_descale_fp16(fc1_fp8_ptr, int(weights["fc2_w"][li]), o_proj_out,
+                              T, D, FF, a_fc2, int(weights["fc2_ws"][li]), int(stream))
+        fvk.add_bias_fp16(o_proj_out, int(weights["fc2_b"][li]), T, D, int(stream))
+        fvk.residual_add_fp16(h_ptr, o_proj_out, T * D, int(stream))

--- a/flash_rt/api.py
+++ b/flash_rt/api.py
@@ -731,12 +731,14 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
             ("groot_n17", "torch", "thor"),
             ("groot_n17", "torch", "rtx_sm120"),
             ("groot_n17", "torch", "rtx_sm89"),
+            ("groot_n17", "torch", "amd_cdna4"),
         }:
             raise ValueError(
                 "use_fp16=True is currently experimental and only supports "
                 "('pi05', 'torch', 'thor'/'rtx_sm120'/'rtx_sm89'), "
                 "('groot', 'torch', 'thor'/'rtx_sm120'), and "
-                "('groot_n17', 'torch', 'thor'/'rtx_sm120'/'rtx_sm89')")
+                "('groot_n17', 'torch', "
+                "'thor'/'rtx_sm120'/'rtx_sm89'/'amd_cdna4')")
 
     # FA4 is an attention-backend choice, not part of the NVFP4 tier: both
     # the FP8 Pi0.5 Thor frontend and its NVFP4 subclass accept use_fa4, and
@@ -781,6 +783,19 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 GrootN17TorchFrontendRtxFP8,
             )
             pipe_cls = GrootN17TorchFrontendRtxFP8
+
+    # GROOT N1.7 on AMD CDNA4 defaults to the FP8-backbone frontend
+    # (bf16 DiT), mirroring the RTX FP8 production tier; _PIPELINE_MAP
+    # already resolves amd_cdna4 to GrootN17TorchFrontendAmd. There is
+    # no BF16-only fallback, and the full-FP16 reference is not yet
+    # ported (use_fp16=True raises NotImplementedError below).
+    if config == "groot_n17" and framework == "torch" \
+            and arch == "amd_cdna4" and not use_fp16 and not use_fp8:
+        raise ValueError(
+            "GROOT N1.7 on AMD CDNA4 defaults to FP8; there is no "
+            "separate BF16-only fallback. The non-quantized full-FP16 "
+            "reference (use_fp16=True, use_fp8=False) is not yet ported "
+            "to CDNA4.")
 
     # GROOT N1.7 on Thor (SM110) runs the FP8 backbone (+ bf16 DiT) by
     # default. There is no BF16-only fallback; the non-quantized reference is
@@ -835,6 +850,11 @@ def load_model(checkpoint, framework="torch", num_views=2, autotune=3,
                 )
                 pipe_cls = GrootTorchFrontendRtxFP16
             else:  # config == "groot_n17"
+                if arch == "amd_cdna4":
+                    raise NotImplementedError(
+                        "the GROOT N1.7 full-FP16 reference is not yet "
+                        "ported to AMD CDNA4; use the default FP8 tier "
+                        "(use_fp8=True, use_fp16=False)")
                 if arch == "rtx_sm89":
                     from flash_rt.frontends.torch.groot_n17_rtx_sm89_fp16 import (
                         GrootN17TorchFrontendRtxSm89FP16,

--- a/flash_rt/hardware/__init__.py
+++ b/flash_rt/hardware/__init__.py
@@ -136,6 +136,9 @@ _PIPELINE_MAP: dict[tuple[str, str, str], tuple[str, str]] = {
     ("groot_n17", "torch", "rtx_sm89"):
         ("flash_rt.frontends.torch.groot_n17_rtx_sm89",
          "GrootN17TorchFrontendRtxSm89"),
+    ("groot_n17", "torch", "amd_cdna4"):
+        ("flash_rt.amd.frontends.torch.groot_n17",
+         "GrootN17TorchFrontendAmd"),
 
     # ── Motus (Wan2.2 + Qwen-VL + action/understanding experts) ──
     # RTX 5090 path only for now. Motus uses a bundle-based E2E contract

--- a/tests/test_amd_extension.py
+++ b/tests/test_amd_extension.py
@@ -137,10 +137,15 @@ _REQUIRED_CLASSES = ["FvkContext", "GemmRunner"]
 
 # GemmRunner methods the pi05 pipeline dispatches on by name.
 _REQUIRED_GEMM_METHODS = [
-    "bf16_run", "bf16_nn", "bf16_nn_bias", "bf16_nn_bias_gelu",
+    "bf16_run", "bf16_nn", "bf16_nn_res", "bf16_nn_bias",
+    "bf16_nn_bias_gelu", "bf16_nn_bias_res",
     "fp8_nn_dev", "fp8_nt_dev", "mxfp4_nt_dev",
+    # GROOT N1.7 surface: FP16 GEMM + FP8 epilogue variants
+    "fp16_nn", "fp8_nn_bias", "fp8_nn_gelu_bias", "fp8_descale_fp16",
+    "enable_lazy_autotune",
     "autotune_bf16_nn", "autotune_fp8_nn_dev", "autotune_fp8_nt_dev",
-    "autotune_mxfp4_nt_dev",
+    "autotune_mxfp4_nt_dev", "autotune_fp16_nn",
+    "autotune_fp8_descale_fp16",
 ]
 
 

--- a/tests/test_amd_groot_model.py
+++ b/tests/test_amd_groot_model.py
@@ -343,6 +343,19 @@ def test_actions_match_reference_when_provided(amd_env, frontend, aux):
     if not ref_path:
         pytest.skip("no reference fixture: export FLASH_RT_GROOT_N17_AMD_REF "
                     "to a torch.load-able fixture with inputs/actions")
+    # denormalize_action builds the HF processor, whose tokenizer metadata
+    # lookup transformers 4.57.x performs even in offline mode. The library
+    # deliberately refuses to patch huggingface_hub for that (it is shared
+    # process state); an offline caller injects a processor instead, which
+    # is what this harness does when the lookup is blocked.
+    try:
+        frontend._hf_processor()
+    except RuntimeError as exc:
+        if "HF_HUB_OFFLINE" not in str(exc):
+            raise
+        pytest.skip("processor load needs a Hub metadata lookup that this "
+                    "environment blocks; build one in setup code and call "
+                    "set_hf_processor() to run this gate offline")
     if not os.path.isfile(ref_path):
         pytest.skip("FLASH_RT_GROOT_N17_AMD_REF does not point at a file")
     if "initial_noise" not in aux:

--- a/tests/test_amd_groot_model.py
+++ b/tests/test_amd_groot_model.py
@@ -1,0 +1,372 @@
+"""GROOT N1.7 on AMD CDNA4 — checkpoint-gated E2E gates for the frontend.
+
+The full path on an MI350X: :class:`GrootN17TorchFrontendAmd` →
+``set_prompt`` (FP8 kernel backbone: ViT → DeepStack → truncated LLM → VL
+self-attn, plus the baked FP8 alphas) → ``infer`` (bf16 DiT action head
+replayed from a captured graph). Gates:
+
+  * the frontend constructs and reports the AMD class (not a silently
+    substituted RTX/Thor base);
+  * ``set_prompt`` really ran the FP8 backbone — backbone features of the
+    documented shape/dtype AND baked per-layer FP8 alphas for every stage
+    (features alone would also appear if a bf16 shadow path had run);
+  * ``infer`` returns finite normalized actions of shape
+    ``(1, action_horizon, 132)``, neither dead nor exploded;
+  * two infers with the SAME pinned ``initial_noise`` are BIT-identical —
+    the flow integration is deterministic given (backbone, state, noise),
+    so any wobble is a replay-determinism or buffer-reuse bug, never
+    acceptable "GPU noise";
+  * a different pinned noise changes the output (proves the noise input is
+    actually consumed and the equality gate above is not vacuous);
+  * optionally, denormalized actions match a reference fixture to
+    cosine >= 0.999.
+
+Inputs come from environment variables ONLY — nothing is hardcoded:
+
+    FLASH_RT_GROOT_N17_AMD_CKPT   (or bare GROOT_N17_AMD_CKPT)
+        GROOT N1.7 checkpoint directory (must contain statistics.json).
+    FLASH_RT_GROOT_N17_AMD_AUX    (or bare GROOT_N17_AMD_AUX)
+        torch.load-able bundle of HF-derived setup tensors that
+        ``set_prompt`` consumes (input_ids / visual_pos_masks /
+        position_ids / rope_cos / rope_sin / llm_input_embeds /
+        pixel_features / grid_thw). The prompt lives in this bundle's
+        embeddings; the prompt STRING below is cosmetic.
+    FLASH_RT_GROOT_N17_AMD_REF    (or bare GROOT_N17_AMD_REF)   [optional]
+        torch.load-able reference fixture with ``inputs["state"]``
+        (per-modality) and ``actions`` (per-modality). Absent → the one
+        cosine test skips; everything else still runs. Requires the aux
+        bundle to also carry ``initial_noise`` (the fixture's captured
+        noise), otherwise that test skips too.
+    FLASH_RT_GROOT_N17_AMD_EMBODIMENT                            [optional]
+        Embodiment tag; defaults to the relative-EEF DROID tag the AMD
+        line validates against.
+
+Skip conditions: ROCm torch + visible device + built extension + resolved
+checkpoint + resolved aux; each missing piece skips with its own reason.
+Every heavyweight import lives inside a fixture, so NVIDIA/no-ROCm CI
+collects this module cleanly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import numpy as np
+import pytest
+
+
+_PROMPT = "Put the blue block in the green bowl"
+_ACTION_HORIZON = 40
+_ACTION_DIM = 132
+_DEFAULT_EMBODIMENT = "oxe_droid_relative_eef_relative_joint"
+_REF_MODALITIES = ("eef_9d", "gripper_position", "joint_position")
+
+
+def _env(*names: str):
+    """First non-empty value among the FLASH_RT_-namespaced and bare names.
+
+    Mirrors the two-level lookup the rest of the AMD suite uses: the
+    namespaced form is documented, the bare form is accepted so existing
+    invocations keep working.
+    """
+    for name in names:
+        value = os.environ.get(f"FLASH_RT_{name}") or os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def amd_env():
+    """ROCm torch + device + extension + frontend, or skip with the reason."""
+    try:
+        importlib.import_module("flash_rt.amd.flash_rt_amd_kernels")
+    except ImportError as exc:
+        pytest.skip(f"flash_rt_amd_kernels not importable: {exc}")
+    try:
+        # Pulls in the Thor base and its third-party helpers (declared
+        # under an optional extra); skip rather than error on a lean env.
+        importlib.import_module("flash_rt.amd.frontends.torch.groot_n17")
+    except ImportError as exc:
+        pytest.skip(f"AMD GROOT N1.7 frontend not importable: {exc}")
+    torch = pytest.importorskip("torch")
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("torch is not a ROCm build")
+    if not torch.cuda.is_available():
+        pytest.skip("no ROCm device visible to torch")
+    return torch
+
+
+@pytest.fixture(scope="module")
+def ckpt(amd_env):
+    path = _env("GROOT_N17_AMD_CKPT")
+    if not path:
+        pytest.skip("no GROOT N1.7 checkpoint: export "
+                    "FLASH_RT_GROOT_N17_AMD_CKPT to a checkpoint directory")
+    if not os.path.isdir(path):
+        pytest.skip("FLASH_RT_GROOT_N17_AMD_CKPT is not a directory")
+    if not os.path.isfile(os.path.join(path, "statistics.json")):
+        pytest.skip("checkpoint dir lacks statistics.json — point "
+                    "FLASH_RT_GROOT_N17_AMD_CKPT at a GROOT N1.7 checkpoint")
+    return path
+
+
+@pytest.fixture(scope="module")
+def aux(amd_env):
+    """The HF-derived setup bundle ``set_prompt`` consumes."""
+    torch = amd_env
+    path = _env("GROOT_N17_AMD_AUX")
+    if not path:
+        pytest.skip("no aux bundle: export FLASH_RT_GROOT_N17_AMD_AUX to a "
+                    "torch.load-able set_prompt input bundle")
+    if not os.path.isfile(path):
+        pytest.skip("FLASH_RT_GROOT_N17_AMD_AUX does not point at a file")
+    bundle = torch.load(path, weights_only=False, map_location="cpu")
+    missing = [k for k in ("llm_input_embeds", "pixel_features", "grid_thw",
+                           "rope_cos", "rope_sin", "visual_pos_masks")
+               if k not in bundle]
+    if missing:
+        pytest.skip(f"aux bundle lacks required keys: {missing}")
+    return bundle
+
+
+@pytest.fixture(scope="module")
+def frontend(amd_env, ckpt, aux):
+    """One constructed + prompted frontend for the whole module.
+
+    ``set_prompt`` may only be called once per instance (the base refuses a
+    second call), and it is the expensive step — calibration shadow, FP8
+    alpha bake, cache write — so it is module-scoped by design.
+    """
+    from flash_rt.amd.frontends.torch.groot_n17 import GrootN17TorchFrontendAmd
+
+    embodiment = (_env("GROOT_N17_AMD_EMBODIMENT") or _DEFAULT_EMBODIMENT)
+    fe = GrootN17TorchFrontendAmd(
+        ckpt, num_views=2, embodiment_tag=embodiment)
+    fe.set_prompt(aux=aux, prompt=_PROMPT)
+    return fe
+
+
+@pytest.fixture(scope="module")
+def synthetic_state(frontend):
+    """An in-distribution state built from the checkpoint's own statistics.
+
+    Using the per-modality q01/q99 midpoint keeps the basic gates
+    independent of the optional reference fixture while staying inside the
+    normalizer's calibrated range (zeros would be out-of-range for some
+    modalities and would make "finite output" a weaker claim).
+    """
+    stats = frontend._read_statistics()["state"]
+    state_dict = {}
+    for mod_key, mod_stats in stats.items():
+        q01 = np.asarray(mod_stats["q01"], dtype=np.float32)
+        q99 = np.asarray(mod_stats["q99"], dtype=np.float32)
+        mid = (0.5 * (q01 + q99)).reshape(1, 1, -1)
+        state_dict[f"state.{mod_key}"] = mid
+    return state_dict
+
+
+@pytest.fixture(scope="module")
+def state_normed(frontend, synthetic_state):
+    return frontend.normalize_state(synthetic_state)
+
+
+def _noise(torch, seed: int):
+    """Deterministic (1, horizon, 132) initial noise, CPU-seeded.
+
+    Generated on CPU with an explicit generator so the same bytes are
+    produced on any device/driver — the bit-identity gate must compare two
+    runs of the model, not two draws of a device RNG.
+    """
+    gen = torch.Generator().manual_seed(seed)
+    return torch.randn(1, _ACTION_HORIZON, _ACTION_DIM, generator=gen,
+                       dtype=torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# Construction + set_prompt (FP8 kernel backbone)
+# ---------------------------------------------------------------------------
+
+
+def test_frontend_is_the_amd_class(frontend):
+    """The AMD frontend must be what was constructed — a silent fallback to
+    the Thor/RTX base would still run, on the wrong kernels."""
+    assert type(frontend).__name__ == "GrootN17TorchFrontendAmd"
+    assert type(frontend).__module__ == "flash_rt.amd.frontends.torch.groot_n17"
+    # The AMD production tier is FP8 backbone + bf16 DiT.
+    assert frontend._DIT_USE_FP8 is False
+
+
+def test_frontend_bound_the_amd_kernel_module(frontend):
+    """The base resolves ``_fvk``/``_gemm`` lazily and would otherwise fall
+    back to the CUDA extension; the AMD subclass must have seeded both with
+    the ROCm module before any base method ran."""
+    assert frontend._fvk.__name__.endswith("flash_rt_amd_kernels")
+    assert frontend._gemm is not None
+    assert frontend._mlp_gemm is not None
+
+
+def test_set_prompt_produced_backbone_features(frontend, aux):
+    """``set_prompt`` must leave fp16 backbone features of the documented
+    ``(1, S, 2048)`` shape, with S taken from the aux bundle — a shape or
+    dtype drift here silently mis-feeds every DiT cross-attention block."""
+    torch = pytest.importorskip("torch")
+    feats = frontend._backbone_features
+    seq = int(aux["llm_input_embeds"].shape[1])
+    assert frontend.Se == seq
+    assert tuple(feats.shape) == (1, seq, 2048)
+    assert feats.dtype is torch.float16
+    assert torch.isfinite(feats).all().item(), "non-finite backbone features"
+    assert feats.abs().max().item() > 0, "backbone features are all zero"
+
+
+def test_set_prompt_baked_fp8_alphas_for_every_stage(frontend):
+    """THE witness that the FP8 kernel backbone ran, not a bf16 shadow: the
+    per-layer act-scale device tensors and host alphas for all four stages
+    (ViT 24L, DeepStack 3 mergers, LLM 16L, VL self-attn) are baked. Finite
+    positive alphas are required — a zero or NaN alpha would scale a whole
+    layer's GEMM output to garbage without raising."""
+    per_stage = {
+        "_vit_alpha_q": 24, "_vit_alpha_o": 24,
+        "_vit_alpha_fc1": 24, "_vit_alpha_fc2": 24,
+        "_dsm_alpha_fc1": 3, "_dsm_alpha_fc2": 3,
+        "_vlsa_alpha_q": 4, "_vlsa_alpha_k": 4, "_vlsa_alpha_v": 4,
+        "_vlsa_alpha_o": 4, "_vlsa_alpha_fc1": 4, "_vlsa_alpha_fc2": 4,
+    }
+    for attr, count in per_stage.items():
+        alphas = getattr(frontend, attr, None)
+        assert alphas is not None, f"{attr} not baked by set_prompt"
+        assert len(alphas) == count, f"{attr} has {len(alphas)} != {count}"
+        for i, a in enumerate(alphas):
+            a = float(a)
+            assert np.isfinite(a) and a > 0.0, f"{attr}[{i}] = {a}"
+    # Device-side act scales for the LLM stage (one per layer, per GEMM).
+    assert len(frontend._llm_act_qkv_dev) == 16
+    assert len(frontend._llm_act_o_dev) == 16
+    assert len(frontend._llm_act_gateup_dev) == 16
+    assert len(frontend._llm_act_down_dev) == 16
+
+
+# ---------------------------------------------------------------------------
+# infer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def first_actions(amd_env, frontend, state_normed):
+    """First infer — also the call that captures the DiT graph chain."""
+    torch = amd_env
+    out = frontend.infer(state_normed, initial_noise=_noise(torch, 0))
+    return out.detach().float().cpu().clone()
+
+
+def test_infer_shape_and_finite(first_actions):
+    """The normalized action contract is (1, action_horizon, 132)."""
+    assert tuple(first_actions.shape) == (1, _ACTION_HORIZON, _ACTION_DIM)
+    arr = first_actions.numpy()
+    assert np.isfinite(arr).all(), "non-finite actions from the FP8 pipeline"
+    # Normalized actions are O(1): an all-zero output means a dead buffer,
+    # an exploded one means a broken scale — neither is a plausible policy.
+    assert np.abs(arr).max() > 1e-6
+    assert np.abs(arr).max() < 1e3
+
+
+def test_dit_graph_was_captured(frontend):
+    """The latency story on this backend is graph replay, not eager torch;
+    the first infer must have left a captured DiT graph chain behind."""
+    assert getattr(frontend, "_k_dit_graph", None) is not None, (
+        "first infer did not capture the kernelized DiT graph")
+
+
+def test_pinned_noise_is_bit_identical(amd_env, frontend, state_normed):
+    """Same pinned initial_noise twice → identical bytes.
+
+    The captured graph replays a fixed kernel sequence over persistent
+    buffers; with backbone, state and noise all pinned there is no
+    legitimate source of variation. This is an equality gate — a mismatch
+    is a determinism bug (uninitialized scratch, buffer aliasing, atomic
+    reduction), not "GPU noise". Both results are cloned off the returned
+    tensor first so the comparison can never degenerate into comparing a
+    persistent buffer with itself.
+    """
+    torch = amd_env
+    a1 = frontend.infer(state_normed,
+                        initial_noise=_noise(torch, 0)).detach().float().cpu().clone()
+    a2 = frontend.infer(state_normed,
+                        initial_noise=_noise(torch, 0)).detach().float().cpu().clone()
+    assert a1.data_ptr() != a2.data_ptr(), "results alias; gate is vacuous"
+    d1, d2 = a1.numpy(), a2.numpy()
+    assert np.array_equal(d1, d2), (
+        f"same pinned noise, different actions (max diff "
+        f"{np.abs(d1 - d2).max():.3e}) — graph replay is not deterministic")
+
+
+def test_different_noise_changes_the_actions(amd_env, frontend, state_normed,
+                                             first_actions):
+    """Guards the equality gate above from being vacuous: if the noise
+    input were dropped on the floor (never copied into the graph's action
+    buffer), every infer would match and the bit-identity test would pass
+    for the wrong reason."""
+    torch = amd_env
+    other = frontend.infer(
+        state_normed,
+        initial_noise=_noise(torch, 12345)).detach().float().cpu().clone()
+    assert not np.array_equal(other.numpy(), first_actions.numpy()), (
+        "a different initial_noise produced identical actions — the noise "
+        "input is not reaching the diffusion chain")
+
+
+# ---------------------------------------------------------------------------
+# Optional numeric reference gate
+# ---------------------------------------------------------------------------
+
+
+def test_actions_match_reference_when_provided(amd_env, frontend, aux):
+    """Cosine >= 0.999 on denormalized per-modality actions against a
+    reference fixture, driven by the fixture's own state and the aux
+    bundle's captured initial_noise. 0.999 is this backend's E2E
+    FP8-vs-reference acceptance bar; below it, quantization cannot be the
+    explanation and a real regression is in the graph.
+
+    Runs the full production output path (infer → denormalize_action with
+    the state_dict, which the relative-EEF embodiments require), so it also
+    covers the denormalization the shape/finite gates above skip.
+    """
+    torch = amd_env
+    ref_path = _env("GROOT_N17_AMD_REF")
+    if not ref_path:
+        pytest.skip("no reference fixture: export FLASH_RT_GROOT_N17_AMD_REF "
+                    "to a torch.load-able fixture with inputs/actions")
+    if not os.path.isfile(ref_path):
+        pytest.skip("FLASH_RT_GROOT_N17_AMD_REF does not point at a file")
+    if "initial_noise" not in aux:
+        pytest.skip("aux bundle carries no initial_noise; the reference "
+                    "comparison needs the fixture's captured noise")
+
+    fixture = torch.load(ref_path, weights_only=False, map_location="cpu")
+    if "actions" not in fixture or "inputs" not in fixture:
+        pytest.skip("reference fixture lacks 'inputs'/'actions'")
+    modalities = [k for k in _REF_MODALITIES if k in fixture["actions"]]
+    if not modalities:
+        pytest.skip(f"reference fixture has none of {_REF_MODALITIES}")
+
+    state_dict = {f"state.{k}": v
+                  for k, v in fixture["inputs"]["state"].items()}
+    normed = frontend.normalize_state(state_dict)
+    out = frontend.infer(normed, initial_noise=aux["initial_noise"])
+    assert torch.isfinite(out).all().item(), "infer produced NaN/Inf"
+
+    denorm = frontend.denormalize_action(out, state_dict=state_dict)
+    pred = torch.cat([torch.as_tensor(denorm[k]).flatten().double()
+                      for k in modalities])
+    ref = torch.cat([torch.as_tensor(fixture["actions"][k]).flatten().double()
+                     for k in modalities])
+    assert pred.shape == ref.shape, "denormalized actions shape mismatch"
+    cos = float(pred @ ref / (pred.norm() * ref.norm() + 1e-30))
+    assert cos >= 0.999, f"actions cos vs reference = {cos:.6f} < 0.999"

--- a/tests/test_amd_groot_routing.py
+++ b/tests/test_amd_groot_routing.py
@@ -1,0 +1,345 @@
+"""GROOT N1.7 on AMD CDNA4 — dispatch-table, load_model gates, attn backend.
+
+What this file protects:
+
+  * the ``("groot_n17", "torch", "amd_cdna4")`` registration in
+    ``flash_rt.hardware._PIPELINE_MAP`` — resolution is lazy, so a module
+    or class rename breaks only at runtime on an MI350X unless the exact
+    strings are pinned here;
+  * the ``load_model`` precision arms for this triple, as they are ACTUALLY
+    implemented in ``flash_rt/api.py`` (each assertion below was read out of
+    the source, not assumed):
+      - a bare ``use_fp8=False`` is refused rather than silently ignored —
+        there is no BF16-only GROOT N1.7 tier on CDNA4;
+      - ``use_fp16=True`` with the default ``use_fp8=True`` is refused by the
+        generic "fp16 requires fp8=False" guard, which fires FIRST;
+      - ``use_fp16=True, use_fp8=False`` reaches the CDNA4 arm and raises
+        ``NotImplementedError`` — the full-FP16 reference is not ported;
+  * :class:`~flash_rt.amd.hardware.cdna4.attn_backend_groot_n17.Cdna4GrootN17AttnBackend`
+    as the single backend serving all five documented sites, and its
+    argument validation — an unknown site or an out-of-range layer index
+    must raise instead of silently returning another site's slot pointer
+    (the pipeline writes Q/K/V through those raw pointers, so a wrong slot
+    is a silent-wrong-answer bug, not a crash).
+
+Environment matrix:
+  - No GPU / NVIDIA CI: the map test and every attention-backend test run
+    (the backend is constructed on CPU, see ``cpu_attn`` below); the
+    load_model arms skip, because the ``arch == "amd_cdna4"`` extension gate
+    in flash_rt/api.py raises ImportError before any of them is reached.
+  - MI350X with the extension built: everything runs.
+No checkpoint is needed anywhere in this file — every load_model call is
+aimed at an error that fires before checkpoint loading.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+_AMD_FRONTEND_MODULE = "flash_rt.amd.frontends.torch.groot_n17"
+_AMD_FRONTEND_CLASS = "GrootN17TorchFrontendAmd"
+
+# Deliberately nonexistent: every load_model assertion below must fire
+# before the checkpoint is opened, so this path must never be read.
+_BOGUS_CKPT = "/nonexistent/flashrt-amd-groot-test-ckpt"
+
+
+def _amd_ext_importable() -> bool:
+    """True iff the compiled AMD module is importable in this env."""
+    try:
+        import flash_rt.amd.flash_rt_amd_kernels  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _amd_groot_frontend_importable() -> bool:
+    """True iff the AMD GROOT N1.7 frontend module imports here.
+
+    Resolution of ("groot_n17","torch","amd_cdna4") imports the frontend,
+    which pulls in the Thor base and its third-party helpers (transformers
+    et al., declared under an optional extra rather than the base install).
+    Tests that must run *past* resolution gate on this so a lean
+    environment skips instead of erroring.
+    """
+    try:
+        import importlib
+        importlib.import_module(_AMD_FRONTEND_MODULE)
+        return True
+    except ImportError:
+        return False
+
+
+_EXT_SKIP = pytest.mark.skipif(
+    not _amd_ext_importable(),
+    reason="flash_rt_amd_kernels not built (the amd_cdna4 extension gate in "
+           "flash_rt/api.py raises ImportError before this check is reached)")
+_FRONTEND_SKIP = pytest.mark.skipif(
+    not _amd_groot_frontend_importable(),
+    reason="AMD GROOT N1.7 frontend not importable here (optional deps "
+           "missing); this assertion lives past resolve_pipeline_class")
+
+
+# ---------------------------------------------------------------------------
+# _PIPELINE_MAP registration
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_map_has_amd_groot_n17_entry():
+    """The AMD GROOT N1.7 dispatch entry must stay registered verbatim.
+
+    load_model resolves lazily through this dict; a drifted tuple (module
+    rename, class rename) breaks resolution only at runtime on an AMD box,
+    so the exact strings are pinned.
+    """
+    from flash_rt.hardware import _PIPELINE_MAP
+
+    key = ("groot_n17", "torch", "amd_cdna4")
+    assert key in _PIPELINE_MAP, "AMD GROOT N1.7 dispatch entry disappeared"
+    assert _PIPELINE_MAP[key] == (_AMD_FRONTEND_MODULE, _AMD_FRONTEND_CLASS)
+
+
+@_FRONTEND_SKIP
+def test_resolver_returns_the_amd_frontend_class():
+    """Resolution must hand back the real class object, not just a tuple —
+    this is what catches a renamed/removed class that the map still names."""
+    from flash_rt.hardware import resolve_pipeline_class
+
+    cls = resolve_pipeline_class("groot_n17", "torch", "amd_cdna4")
+    assert cls.__name__ == _AMD_FRONTEND_CLASS
+    assert cls.__module__ == _AMD_FRONTEND_MODULE
+
+
+def test_resolver_rejects_unported_groot_n17_combos():
+    """Only torch/amd_cdna4 is registered for GROOT N1.7 on AMD. A JAX
+    request, or an unknown arch string, must fail at resolution rather than
+    import half a backend."""
+    from flash_rt.hardware import resolve_pipeline_class
+
+    for config, framework, arch in [
+            ("groot_n17", "jax", "amd_cdna4"),
+            ("groot_n17", "torch", "amd_cdna3"),
+            ("groot_n17", "torch", "not_a_real_arch")]:
+        with pytest.raises(RuntimeError, match="no pipeline"):
+            resolve_pipeline_class(config, framework, arch)
+
+
+# ---------------------------------------------------------------------------
+# load_model precision arms (verified against flash_rt/api.py, not assumed)
+# ---------------------------------------------------------------------------
+
+
+@_EXT_SKIP
+@_FRONTEND_SKIP
+def test_bare_use_fp8_false_is_refused_on_amd():
+    """Verified behavior (flash_rt/api.py, groot_n17 + amd_cdna4 arm): a
+    bare ``use_fp8=False`` raises ValueError — the CDNA4 tier is FP8
+    backbone + bf16 DiT with no BF16-only fallback, so silently serving FP8
+    for a caller who asked for BF16 would be a correctness lie about which
+    numerics ran. The message must name the FP8 default and point at the
+    full-FP16 reference form."""
+    import flash_rt
+
+    with pytest.raises(ValueError) as caught:
+        flash_rt.load_model(_BOGUS_CKPT, framework="torch",
+                            config="groot_n17", hardware="amd_cdna4",
+                            use_fp8=False)
+    msg = str(caught.value)
+    assert "defaults to FP8" in msg
+    assert "use_fp16=True" in msg
+
+
+@_EXT_SKIP
+def test_use_fp16_without_clearing_fp8_is_refused():
+    """``use_fp8`` defaults to True, so a caller passing only
+    ``use_fp16=True`` is asking for two tiers at once. Verified: the
+    generic guard in flash_rt/api.py fires FIRST (before any arch-specific
+    GROOT arm), so this is the error a user actually sees."""
+    import flash_rt
+
+    with pytest.raises(ValueError, match="use_fp16=True requires "
+                                         "use_fp8=False"):
+        flash_rt.load_model(_BOGUS_CKPT, framework="torch",
+                            config="groot_n17", hardware="amd_cdna4",
+                            use_fp16=True)
+
+
+@_EXT_SKIP
+@_FRONTEND_SKIP
+def test_use_fp16_reference_is_not_implemented_on_amd():
+    """Verified behavior: ``use_fp16=True, use_fp8=False`` passes the
+    generic guard and the fp16 allow-set (the amd_cdna4 triple IS listed
+    there), then reaches the CDNA4 branch of the fp16 routing block and
+    raises NotImplementedError — the full-FP16 GROOT N1.7 reference is not
+    ported to CDNA4. NotImplementedError (not ValueError) is the contract:
+    the combination is legal, just unbuilt."""
+    import flash_rt
+
+    with pytest.raises(NotImplementedError, match="not yet.*ported"):
+        flash_rt.load_model(_BOGUS_CKPT, framework="torch",
+                            config="groot_n17", hardware="amd_cdna4",
+                            use_fp16=True, use_fp8=False)
+
+
+# ---------------------------------------------------------------------------
+# Cdna4GrootN17AttnBackend — sites and argument validation
+# ---------------------------------------------------------------------------
+#
+# The backend allocates its Q/K/V/O slots in __init__ (verified by reading
+# attn_backend_groot_n17.py: every slot is a torch.empty on ``device``), but
+# ``device`` is a constructor argument and the aiter import is deferred
+# behind FVK_AMD_ATTN. Constructing on "cpu" with FVK_AMD_ATTN=sdpa
+# therefore exercises the whole slot/validation surface with no GPU and no
+# aiter — which is exactly the part these tests are about. Dispatch itself
+# (``_attn``) is GPU/aiter territory and is covered by the model E2E suite.
+
+_SA = 41                # 1 state token + 40 action tokens
+_DIT_KV = 32
+_NUM_CROSS_BLOCKS = 16  # DiT cross-attention blocks
+_NUM_SELF_BLOCKS = 16   # DiT self-attention blocks (hardcoded in the backend)
+
+
+@pytest.fixture
+def cpu_attn(monkeypatch):
+    """A CPU-resident backend with tiny sequence lengths.
+
+    ``FVK_AMD_ATTN=sdpa`` keeps ``_resolve_mha_fwd`` (and therefore the
+    aiter dependency) out of construction; the slot geometry, the site
+    table and every range check are hardware-independent.
+    """
+    torch = pytest.importorskip("torch")
+    monkeypatch.setenv("FVK_AMD_ATTN", "sdpa")
+    from flash_rt.amd.hardware.cdna4.attn_backend_groot_n17 import (
+        Cdna4GrootN17AttnBackend,
+    )
+    return Cdna4GrootN17AttnBackend(
+        num_vit_views=2, vit_seq=8, llm_seq=16, vl_self_attn_seq=16,
+        sa=_SA, dit_kv_seq=_DIT_KV,
+        num_dit_cross_blocks=_NUM_CROSS_BLOCKS, device="cpu",
+        backbone_dtype=torch.float16, dit_dtype=torch.bfloat16)
+
+
+def test_backend_declares_the_five_documented_sites(cpu_attn):
+    """One backend serves the whole model on AMD. The pipeline addresses
+    slots by these exact strings, so the tuple is the interface."""
+    assert cpu_attn.sites() == (
+        "vit", "llm", "vl_self_attn", "dit_self", "dit_cross")
+
+
+def test_every_site_exposes_qkvo_slot_pointers(cpu_attn):
+    """``get_slot_ptrs`` is the pipeline's only handle on the slots; each
+    site must yield all four non-null pointers."""
+    for site in cpu_attn.sites():
+        ptrs = cpu_attn.get_slot_ptrs(site, 0)
+        assert set(ptrs) == {"Q", "K", "V", "O"}, site
+        assert all(isinstance(p, int) and p != 0 for p in ptrs.values()), site
+
+
+def test_dit_cross_blocks_have_distinct_kv_slots(cpu_attn):
+    """Cross K/V are per-block (computed once per prompt, read by every
+    denoise step). If two blocks aliased, later blocks would attend over
+    the wrong keys — a silent numeric bug, so distinctness is pinned."""
+    kv = [(cpu_attn.get_slot_ptrs("dit_cross", i)["K"],
+           cpu_attn.get_slot_ptrs("dit_cross", i)["V"])
+          for i in range(_NUM_CROSS_BLOCKS)]
+    assert len(set(kv)) == _NUM_CROSS_BLOCKS, "dit_cross K/V slots alias"
+    # Q and O are shared across blocks by design (one query set per step).
+    qo = {cpu_attn.get_slot_ptrs("dit_cross", i)["Q"]
+          for i in range(_NUM_CROSS_BLOCKS)}
+    assert len(qo) == 1
+
+
+def test_llm_kv_slots_keep_the_native_gqa_head_count(cpu_attn):
+    """AMD delta vs the RTX backend: aiter consumes GQA natively, so the
+    llm K/V slots hold 8 KV heads, not 16 expanded ones, and the AMD
+    forward must skip the head-repeat step. A silent re-widening here would
+    double llm K/V traffic and desync the pipeline's pointer arithmetic."""
+    assert cpu_attn.llm_Q.shape[1] == 16
+    assert cpu_attn.llm_K.shape[1] == 8
+    assert cpu_attn.llm_V.shape[1] == 8
+    assert cpu_attn.llm_O.shape[1] == 16
+
+
+@pytest.mark.parametrize("site", ["nope", "dit", "", "VIT"])
+def test_unknown_site_is_rejected(cpu_attn, site):
+    """An unknown site must raise, never fall through to another site's
+    pointers — the pipeline writes raw Q/K/V through whatever comes back."""
+    with pytest.raises(KeyError, match="unknown site"):
+        cpu_attn.get_slot_ptrs(site, 0)
+    with pytest.raises(KeyError, match="unknown site"):
+        cpu_attn.run(site, 0, 4)
+
+
+@pytest.mark.parametrize("site,num_blocks", [
+    ("dit_self", _NUM_SELF_BLOCKS),
+    ("dit_cross", _NUM_CROSS_BLOCKS),
+])
+@pytest.mark.parametrize("delta", [0, 1, 7])
+def test_layer_index_out_of_range_is_rejected(cpu_attn, site, num_blocks,
+                                              delta):
+    """Layer indexing into the per-block slot lists must be bounds-checked
+    on both ends. Python's negative indexing makes -1 a particularly nasty
+    silent alias (it would return the LAST block's K/V), hence it is tested
+    explicitly rather than trusting the list."""
+    with pytest.raises(IndexError, match="out of range"):
+        cpu_attn.get_slot_ptrs(site, num_blocks + delta)
+    with pytest.raises(IndexError, match="out of range"):
+        cpu_attn.get_slot_ptrs(site, -1 - delta)
+
+
+def test_run_rejects_out_of_range_sequence_lengths(cpu_attn):
+    """Slots are fixed-capacity; a q_seq/kv_seq past the allocation would
+    read or write out of bounds. Verified: the backend raises ValueError
+    before any dispatch, so these run on CPU without touching aiter."""
+    with pytest.raises(ValueError, match="out of range"):
+        cpu_attn.run("dit_self", 0, _SA + 1)
+    with pytest.raises(ValueError, match="out of range"):
+        cpu_attn.run("dit_self", 0, 0)
+    with pytest.raises(ValueError, match="out of range"):
+        cpu_attn.run("dit_cross", 0, _SA, kv_seq=_DIT_KV + 1)
+    with pytest.raises(ValueError, match="out of range"):
+        cpu_attn.run("llm", 0, 17)
+
+
+def test_run_rejects_asymmetric_self_attention(cpu_attn):
+    """The llm / dit_self sites are self-attention over one slot set; a
+    kv_seq differing from q_seq means the caller believes it is running
+    cross-attention and would silently read a truncated key set."""
+    with pytest.raises(ValueError, match="kv_seq must equal q_seq"):
+        cpu_attn.run("llm", 0, 8, kv_seq=4)
+    with pytest.raises(ValueError, match="kv_seq must equal q_seq"):
+        cpu_attn.run("dit_self", 0, 8, kv_seq=4)
+
+
+def test_vit_requires_the_per_view_sequence_length(cpu_attn):
+    """ViT attention is batched per view: the slot is (views * per_view)
+    rows and ``run`` reshapes on that split, so only the per-view length is
+    a legal q_seq. Passing the full multi-view length must raise, not
+    silently attend across view boundaries."""
+    per_view = 8 // 2
+    with pytest.raises(ValueError, match="per-view"):
+        cpu_attn.run("vit", 0, 8)
+    with pytest.raises(ValueError, match="per-view"):
+        cpu_attn.run("vit", 0, per_view, kv_seq=8)
+
+
+@pytest.mark.parametrize("kwargs,match", [
+    (dict(vit_seq=9), "not divisible"),          # views must tile the slot
+    (dict(sa=0), "must be positive"),
+    (dict(dit_kv_seq=0), "must be positive"),
+])
+def test_construction_rejects_inconsistent_geometry(monkeypatch, kwargs,
+                                                    match):
+    """Geometry errors must surface at construction, not as a wrong-shaped
+    view thousands of kernel launches later."""
+    pytest.importorskip("torch")
+    monkeypatch.setenv("FVK_AMD_ATTN", "sdpa")
+    from flash_rt.amd.hardware.cdna4.attn_backend_groot_n17 import (
+        Cdna4GrootN17AttnBackend,
+    )
+    base = dict(num_vit_views=2, vit_seq=8, llm_seq=16, vl_self_attn_seq=16,
+                sa=_SA, dit_kv_seq=_DIT_KV, device="cpu")
+    base.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        Cdna4GrootN17AttnBackend(**base)

--- a/tests/test_amd_kernel_parity.py
+++ b/tests/test_amd_kernel_parity.py
@@ -14,11 +14,38 @@ ramps would hide calibration- and rounding-path bugs):
     qkv_split_rope            — interleaved-pair rotation + V passthrough
     quantize_fp8_static       — BYTE-exact vs torch float8_e4m3fn with the
                                 SAME scale (never compared to raw fp32)
-    GemmRunner bf16_nn        — hipBLASLt BF16 layout convention
-    GemmRunner fp8_nn/nt_dev  — FP8 layouts + device-scale semantics
     attention_decoder_gqa     — split-KV flash decoder vs exact softmax
                                 reference, exact and seqused (fixed-shape
                                 graph) modes
+
+plus the COMPLETE GemmRunner / FvkContext surface bound by
+csrc/amd/gemm/bindings_gemm.inc — every layout convention, every
+epilogue, both scale-passing conventions, and every autotune entry:
+
+    FvkContext                — live hipBLASLt handle
+    bf16_run                  — NT layout (B stored (N,K))
+    bf16_nn                   — NN layout (B stored (K,N))
+    bf16_nn_res               — beta=1 accumulate into a seeded D
+    bf16_nn_bias              — BIAS epilogue, broadcast over N
+    bf16_nn_bias_gelu         — BIAS + tanh-approx GELU epilogue
+    bf16_nn_bias_res          — BIAS epilogue combined with beta=1
+    fp8_nn_dev / fp8_nt_dev   — FP8 layouts + DEVICE-scale semantics
+    fp16_nn                   — FP16 in/out NN GEMM
+    fp8_nn_bias               — HOST alpha + BIAS -> FP16
+    fp8_nn_gelu_bias          — HOST alpha + BIAS + GELU -> FP16
+    fp8_descale_fp16          — DEVICE descale pointers -> FP16
+    mxfp4_nt_dev              — OCP MX FP4 (E2M1 + per-1x32 UE8M0) NT
+    enable_lazy_autotune      — first-call timed selection
+    autotune_bf16_nn / _fp16_nn / _fp8_nn_dev / _fp8_nt_dev /
+    autotune_fp8_descale_fp16 / autotune_mxfp4_nt_dev
+                              — tuned algorithm must not change semantics
+
+The two other kernel families this branch adds — the packed-weight
+``smallm_mfma_bf16_*`` GEMM (csrc/amd/gemm/bindings_smallm_bf16.inc) and
+the 29-entry FP16/BF16/AdaLN backbone port
+(csrc/amd/kernels/bindings_fp16_port.inc) — are gated in the sibling
+module ``tests/test_amd_kernel_parity_groot.py``, which keeps this file
+to the pi05 kernel surface plus the hipBLASLt GEMM surface.
 
 Binding signatures were read from csrc/amd/bindings.cpp and
 csrc/amd/gemm/bindings_gemm.inc before writing any call here; every tensor
@@ -341,6 +368,709 @@ def test_gemm_fp8_nt_dev_matches_quantized_reference(env, gemm):
     ref = (A.float() @ Bt.float().t()) * (sa * sb)
     assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
     torch.testing.assert_close(D.float(), ref, atol=0.05, rtol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# GemmRunner — BF16 layouts and epilogues
+# ---------------------------------------------------------------------------
+
+# Extra gates, justified once:
+#  - COS_GEMM_FP4 0.9999: the MXFP4 path is compared against a reference
+#    that dequantizes the SAME E2M1/UE8M0 operands, so only the fp32
+#    accumulation order differs — the same bar as the other GEMMs. (A cos
+#    against the UNQUANTIZED matmul would measure MXFP4's quantization
+#    loss, ~0.99 on randn, and would pass with a broken block-scale path.)
+#  - COS_DECORRELATED 0.99: the "must NOT match the wrong interpretation"
+#    discriminators. Two independent random matmuls of the same shape have
+#    cos ~0 with overwhelming probability; 0.99 is a wide safety margin
+#    that still fails instantly on a genuine layout/epilogue regression.
+COS_GEMM_FP4 = 0.9999
+COS_DECORRELATED = 0.99
+
+E4M3_MAX = 448.0
+
+
+def _quant_fp8(torch, x):
+    """Per-tensor symmetric e4m3 quantize, the way production calibration
+    does it: scale = amax/448. Returns (fp8 tensor, fp32 scale scalar)."""
+    amax = x.float().abs().max().clamp(min=1e-8)
+    scale = (amax / E4M3_MAX).float()
+    q = (x.float() / scale).clamp(-E4M3_MAX, E4M3_MAX).to(torch.float8_e4m3fn)
+    return q, scale
+
+
+def test_fvk_context_creates_a_live_hipblaslt_handle(env):
+    """FvkContext wraps a hipblasLtHandle_t that raw-ABI call sites take by
+    address. A failed hipblasLtCreate would leave it null, and every
+    downstream GEMM would fault far from the cause — so the constructed
+    handle is asserted non-null here, on device, at import time of the
+    suite rather than mid-capture."""
+    torch, ext = env
+    ctx = ext.FvkContext()
+    assert isinstance(ctx.handle_ptr, int)
+    assert ctx.handle_ptr != 0, "hipblasLtCreate returned a null handle"
+
+
+def test_gemm_bf16_run_is_the_nt_layout(env, gemm):
+    """bf16_run is the NT path: D = A(M,K) @ B(N,K)^T, B stored row-major
+    as (N,K). N == K here on purpose, so the NN reading of the same bytes
+    is equally well-formed — the gate then discriminates between the two
+    conventions instead of relying on one of them being a shape error."""
+    torch, _ = env
+    M, N, K = 64, 256, 256
+    torch.manual_seed(30)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    Bt = (0.3 * torch.randn(N, K, device="cuda")).to(torch.bfloat16)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    gemm.bf16_run(A.data_ptr(), Bt.data_ptr(), D.data_ptr(), M, N, K,
+                  _stream(torch))
+    torch.cuda.synchronize()
+
+    ref_nt = A.float() @ Bt.float().t()
+    ref_nn = A.float() @ Bt.float()
+    assert _cos(D.float().cpu(), ref_nt.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref_nt, atol=0.5, rtol=0.05)
+    assert _cos(D.float().cpu(), ref_nn.cpu()) < COS_DECORRELATED, (
+        "bf16_run produced the NN result — the NT transpose was dropped")
+
+
+def test_gemm_bf16_nn_res_accumulates_into_the_destination(env, gemm):
+    """bf16_nn_res is beta=1: D += A @ B, with the residual landing on the
+    FP32 accumulator before the single bf16 round (that fused rounding is
+    the reason the entry exists instead of a separate residual_add).
+
+    Gated against a PRE-SEEDED D so the accumulate is actually exercised,
+    and additionally required not to match plain A@B — a beta=0 regression
+    would otherwise pass any gate that compared against a zeroed D.
+    """
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(31)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    # Seed magnitude ~ the matmul's own, so a dropped accumulate is a large
+    # relative error rather than a rounding-scale one.
+    seed = (2.5 * torch.randn(M, N, device="cuda")).to(torch.bfloat16)
+    D = seed.clone()
+
+    gemm.bf16_nn_res(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                     _stream(torch))
+    torch.cuda.synchronize()
+
+    prod = A.float() @ B.float()
+    ref = seed.float() + prod
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref, atol=0.5, rtol=0.05)
+    assert _cos(D.float().cpu(), prod.cpu()) < COS_DECORRELATED, (
+        "bf16_nn_res overwrote D (beta=0) instead of accumulating")
+
+
+def test_gemm_bf16_nn_bias_broadcasts_over_columns(env, gemm):
+    """BIAS epilogue: D = A@B + bias(N), one bias element per OUTPUT COLUMN
+    broadcast down the rows. A row-broadcast (length-M) mix-up is the
+    classic epilogue bug; the elementwise reference pins the direction."""
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(32)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    bias = (1.0 * torch.randn(N, device="cuda")).to(torch.bfloat16)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    gemm.bf16_nn_bias(A.data_ptr(), B.data_ptr(), D.data_ptr(),
+                      bias.data_ptr(), M, N, K, _stream(torch))
+    torch.cuda.synchronize()
+
+    prod = A.float() @ B.float()
+    ref = prod + bias.float()
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref, atol=0.5, rtol=0.05)
+    # Column-wise bias means every row shifts by the SAME vector; the
+    # residual after subtracting the matmul must be that vector, repeated.
+    delta = D.float() - prod
+    torch.testing.assert_close(delta, bias.float().expand(M, N).contiguous(),
+                               atol=0.5, rtol=0.05)
+
+
+def test_gemm_bf16_nn_bias_gelu_is_tanh_approx(env, gemm):
+    """BIAS + GELU epilogue: D = GELU(A@B + bias), tanh approximation (the
+    hipBLASLt GELU_BIAS semantics, matching activation.hip and the CUDA
+    class). The reference pins ``approximate="tanh"``; the extra gate
+    requires the output to differ from the un-activated bias form so a
+    dropped epilogue cannot pass."""
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(33)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    bias = (0.5 * torch.randn(N, device="cuda")).to(torch.bfloat16)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    gemm.bf16_nn_bias_gelu(A.data_ptr(), B.data_ptr(), D.data_ptr(),
+                           bias.data_ptr(), M, N, K, _stream(torch))
+    torch.cuda.synchronize()
+
+    pre = A.float() @ B.float() + bias.float()
+    ref = torch.nn.functional.gelu(pre, approximate="tanh")
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref, atol=0.5, rtol=0.05)
+    assert _cos(D.float().cpu(), pre.cpu()) < 0.999, "GELU was not applied"
+
+
+def test_gemm_bf16_nn_bias_res_adds_bias_and_accumulates(env, gemm):
+    """BIAS epilogue combined with beta=1: D += A@B + bias, both landing on
+    the FP32 accumulator before one bf16 round.
+
+    Two independent regressions are possible here and both get their own
+    discriminator: dropping the residual (would match A@B + bias) and
+    dropping the bias (would match D + A@B). The destination is pre-seeded
+    so the accumulate is genuinely exercised.
+    """
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(34)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    bias = (2.5 * torch.randn(N, device="cuda")).to(torch.bfloat16)
+    seed = (2.5 * torch.randn(M, N, device="cuda")).to(torch.bfloat16)
+    D = seed.clone()
+
+    gemm.bf16_nn_bias_res(A.data_ptr(), B.data_ptr(), D.data_ptr(),
+                          bias.data_ptr(), M, N, K, _stream(torch))
+    torch.cuda.synchronize()
+
+    prod = A.float() @ B.float()
+    ref = seed.float() + prod + bias.float()
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref, atol=0.5, rtol=0.05)
+    assert _cos(D.float().cpu(), (prod + bias.float()).cpu()) < COS_DECORRELATED, (
+        "bf16_nn_bias_res dropped the residual (beta=0)")
+    assert _cos(D.float().cpu(), (seed.float() + prod).cpu()) < COS_DECORRELATED, (
+        "bf16_nn_bias_res dropped the bias epilogue")
+
+
+# ---------------------------------------------------------------------------
+# GemmRunner — GROOT N1.7 FP16 / FP8-epilogue surface
+# ---------------------------------------------------------------------------
+
+# Real GROOT N1.7 GEMM shapes; the FP16/FP8-epilogue entries are dispatched
+# on exactly these (M,N,K) in production, and hipBLASLt picks a different
+# algorithm per shape — so parity is gated per shape, not on one token
+# shape. (label, M, N, K)
+GROOT_GEMM_SHAPES = [
+    ("vit_qkv", 1024, 3072, 1024),
+    ("vit_ff1", 1024, 4096, 1024),
+    ("vit_ff2", 1024, 1024, 4096),
+    ("vit_out", 1024, 2048, 1024),
+    ("llm_qkvproj", 968, 4096, 2048),
+    ("llm_ff", 968, 6144, 2048),
+    ("vlsa_proj", 968, 2048, 2048),
+    ("dit_ff1", 41, 6144, 1536),
+    ("dit_ff2", 41, 1536, 6144),
+    ("dit_qkv", 41, 1536, 1536),
+]
+
+_GROOT_IDS = [s[0] for s in GROOT_GEMM_SHAPES]
+
+# FP16 output tolerance: one fp16 ULP at the reference's ~0.8 magnitude is
+# ~5e-4; 2e-2 absolute / 5e-2 relative is the same loose layout tripwire
+# the bf16 entries use on top of the cos gate, not the real gate.
+ATOL_FP16_GEMM = 2e-2
+RTOL_FP16_GEMM = 5e-2
+
+
+def _groot_operands(torch, M, N, K, seed):
+    """Real-distribution operands at GROOT magnitudes: 0.5-sigma
+    activations, 0.02-sigma weights, 0.1-sigma bias. Random uniform or
+    constant fills would keep every value in one exponent bucket and hide
+    FP8 scale-path bugs."""
+    torch.manual_seed(seed)
+    A = (0.5 * torch.randn(M, K, device="cuda")).half()
+    B = (0.02 * torch.randn(K, N, device="cuda")).half()
+    bias = (0.1 * torch.randn(N, device="cuda")).half()
+    return A, B, bias
+
+
+@pytest.mark.parametrize("label,M,N,K", GROOT_GEMM_SHAPES, ids=_GROOT_IDS)
+def test_gemm_fp16_nn_matches_torch(env, gemm, label, M, N, K):
+    """fp16_nn contract: D_fp16(M,N) = A_fp16(M,K) @ B_fp16(K,N), all
+    row-major, no transpose, FP16 in AND out (the entry exists because the
+    ViT/LLM backbone runs fp16, not bf16 — a bf16 store would halve the
+    mantissa, which the tight cos gate catches)."""
+    torch, _ = env
+    A, B, _bias = _groot_operands(torch, M, N, K, seed=40 + M + N + K)
+    D = torch.empty(M, N, dtype=torch.half, device="cuda")
+
+    gemm.fp16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                 _stream(torch))
+    torch.cuda.synchronize()
+
+    assert D.dtype is torch.half
+    ref = (A.float() @ B.float()).half()
+    assert _cos(D.float().cpu(), ref.float().cpu()) > COS_GEMM, label
+    torch.testing.assert_close(D.float(), ref.float(),
+                               atol=ATOL_FP16_GEMM, rtol=RTOL_FP16_GEMM)
+
+
+@pytest.mark.parametrize("label,M,N,K", GROOT_GEMM_SHAPES, ids=_GROOT_IDS)
+def test_gemm_fp8_nn_bias_applies_host_alpha_then_bias(env, gemm, label,
+                                                       M, N, K):
+    """fp8_nn_bias: D_fp16 = alpha * (A_fp8 @ B_fp8) + bias_fp16, with
+    alpha a HOST float (not a device pointer — that is fp8_descale_fp16's
+    convention, and mixing the two up is the failure this pair of gates
+    separates).
+
+    The reference multiplies the SAME fp8-decoded operands, never the
+    pre-quantization fp16 originals: comparing against those would measure
+    e4m3's quantization error instead of the GEMM. The bias is added AFTER
+    alpha scaling — the ordering matters and is pinned by the reference.
+    """
+    torch, _ = env
+    A, B, bias = _groot_operands(torch, M, N, K, seed=50 + M + N + K)
+    A8, sa = _quant_fp8(torch, A)
+    B8, sb = _quant_fp8(torch, B)
+    alpha = float(sa * sb)
+    D = torch.empty(M, N, dtype=torch.half, device="cuda")
+
+    gemm.fp8_nn_bias(A8.data_ptr(), B8.data_ptr(), D.data_ptr(),
+                     bias.data_ptr(), M, N, K, alpha, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert D.dtype is torch.half
+    prod = A8.float() @ B8.float()
+    ref = (alpha * prod + bias.float()).half()
+    assert _cos(D.float().cpu(), ref.float().cpu()) > COS_GEMM, label
+    torch.testing.assert_close(D.float(), ref.float(),
+                               atol=ATOL_FP16_GEMM, rtol=RTOL_FP16_GEMM)
+    # The bias must actually land. A cosine cannot say so here — alpha*prod
+    # alone is 0.95-0.99 correlated with the reference on these shapes —
+    # so the discriminator is elementwise: the un-biased form must fall
+    # OUTSIDE the same tolerance the parity check just passed inside.
+    assert not torch.allclose(D.float(), (alpha * prod).float(),
+                              atol=ATOL_FP16_GEMM, rtol=RTOL_FP16_GEMM), (
+        "fp8_nn_bias did not apply the bias epilogue")
+
+
+@pytest.mark.parametrize("label,M,N,K", GROOT_GEMM_SHAPES, ids=_GROOT_IDS)
+def test_gemm_fp8_nn_gelu_bias_is_tanh_approx(env, gemm, label, M, N, K):
+    """fp8_nn_gelu_bias: D_fp16 = GELU(alpha * A_fp8 @ B_fp8 + bias).
+    The GELU is the tanh approximation (hipBLASLt GELU_BIAS); erf-GELU or
+    a missing activation both fail against this reference, and the extra
+    discriminator pins that the activation ran at all."""
+    torch, _ = env
+    A, B, bias = _groot_operands(torch, M, N, K, seed=60 + M + N + K)
+    A8, sa = _quant_fp8(torch, A)
+    B8, sb = _quant_fp8(torch, B)
+    alpha = float(sa * sb)
+    D = torch.empty(M, N, dtype=torch.half, device="cuda")
+
+    gemm.fp8_nn_gelu_bias(A8.data_ptr(), B8.data_ptr(), D.data_ptr(),
+                          bias.data_ptr(), M, N, K, alpha, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert D.dtype is torch.half
+    pre = alpha * (A8.float() @ B8.float()) + bias.float()
+    ref = torch.nn.functional.gelu(pre, approximate="tanh").half()
+    assert _cos(D.float().cpu(), ref.float().cpu()) > COS_GEMM, label
+    torch.testing.assert_close(D.float(), ref.float(),
+                               atol=ATOL_FP16_GEMM, rtol=RTOL_FP16_GEMM)
+    assert _cos(D.float().cpu(), pre.half().float().cpu()) < 0.999, (
+        "GELU epilogue was not applied")
+
+
+@pytest.mark.parametrize("label,M,N,K", GROOT_GEMM_SHAPES, ids=_GROOT_IDS)
+def test_gemm_fp8_descale_fp16_matches_quantized_reference(env, gemm, label,
+                                                           M, N, K):
+    """fp8_descale_fp16: D_fp16 = s_a * s_b * (A_fp8 @ B_fp8) with the
+    descales read from DEVICE float pointers (A/B_SCALE_POINTER semantics)
+    — same scale contract as fp8_nn_dev, only the output dtype differs.
+    Reference over the same fp8-decoded operands."""
+    torch, _ = env
+    A, B, _bias = _groot_operands(torch, M, N, K, seed=70 + M + N + K)
+    A8, sa = _quant_fp8(torch, A)
+    B8, sb = _quant_fp8(torch, B)
+    dsa = sa.reshape(1).contiguous().cuda()
+    dsb = sb.reshape(1).contiguous().cuda()
+    D = torch.empty(M, N, dtype=torch.half, device="cuda")
+
+    gemm.fp8_descale_fp16(A8.data_ptr(), B8.data_ptr(), D.data_ptr(),
+                          M, N, K, dsa.data_ptr(), dsb.data_ptr(),
+                          _stream(torch))
+    torch.cuda.synchronize()
+
+    assert D.dtype is torch.half
+    ref = (float(sa) * float(sb) * (A8.float() @ B8.float())).half()
+    assert _cos(D.float().cpu(), ref.float().cpu()) > COS_GEMM, label
+    torch.testing.assert_close(D.float(), ref.float(),
+                               atol=ATOL_FP16_GEMM, rtol=RTOL_FP16_GEMM)
+
+
+def test_gemm_fp8_descale_fp16_reads_the_scales_at_launch(env, gemm):
+    """The descales must be READ FROM THE DEVICE POINTER when the kernel
+    runs, not captured into the cached descriptor at first use.
+
+    This is the property HIP-Graph replay depends on: a captured graph
+    replays the same pointers, and the pipeline updates the calibrated
+    scale IN PLACE between replays. The gate mutates the scale tensor in
+    place (never rebinding the pointer) and requires the output to track
+    it — a descriptor that baked in the first value would return the old
+    result and pass every static parity test above.
+    """
+    torch, _ = env
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(80)
+    A8 = (0.3 * torch.randn(M, K, device="cuda")).to(torch.float8_e4m3fn)
+    B8 = (0.3 * torch.randn(K, N, device="cuda")).to(torch.float8_e4m3fn)
+    # Magnitudes chosen so both arms stay well inside fp16 normal range.
+    dsa = torch.tensor([0.1], dtype=torch.float32, device="cuda")
+    dsb = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+    D1 = torch.empty(M, N, dtype=torch.half, device="cuda")
+    D2 = torch.empty(M, N, dtype=torch.half, device="cuda")
+
+    gemm.fp8_descale_fp16(A8.data_ptr(), B8.data_ptr(), D1.data_ptr(),
+                          M, N, K, dsa.data_ptr(), dsb.data_ptr(),
+                          _stream(torch))
+    torch.cuda.synchronize()
+
+    dsa.fill_(0.2)                      # in place: same device pointer
+    gemm.fp8_descale_fp16(A8.data_ptr(), B8.data_ptr(), D2.data_ptr(),
+                          M, N, K, dsa.data_ptr(), dsb.data_ptr(),
+                          _stream(torch))
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(D2.float(), 2.0 * D1.float(),
+                               atol=1e-3, rtol=1e-2)
+    assert not torch.allclose(D2.float(), D1.float(), atol=1e-4), (
+        "output did not change when the device scale did — the descale is "
+        "baked into the descriptor instead of read at launch")
+
+
+# ---------------------------------------------------------------------------
+# GemmRunner — MXFP4 (OCP MX: E2M1 elements + per-1x32-block UE8M0 scales)
+# ---------------------------------------------------------------------------
+#
+# Host-side pack reference, matching what mxfp4_nt_dev consumes directly
+# (csrc/amd/gemm/hipblaslt_runner.h):
+#     packed : uint8 (rows, K/2)   element 2i low nibble, 2i+1 high nibble
+#     scales : uint8 (rows, K/32)  UE8M0, value = 2^(byte - 127)
+# Scale rule is the OCP MX v1.0 one: E = floor(log2(amax)) - emax(E2M1),
+# emax(E2M1) = 2, computed exactly via frexp (no log2 rounding hazard).
+
+_E2M1_CODES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+_E2M1_MIDPOINTS = (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+_E2M1_MAX = 6.0
+_E2M1_EMAX = 2
+_MX_BLOCK = 32
+_UE8M0_BIAS = 127
+
+
+def _mxfp4_quantize(torch, x):
+    """(rows, K) -> (packed uint8 (rows, K/2), scales uint8 (rows, K/32))."""
+    rows, K = x.shape
+    assert K % _MX_BLOCK == 0
+    xf = x.reshape(rows, K // _MX_BLOCK, _MX_BLOCK).float()
+    amax = xf.abs().amax(dim=-1)
+    _, e = torch.frexp(amax)                  # amax = m * 2^e, m in [0.5, 1)
+    E = e.to(torch.int32) - 1 - _E2M1_EMAX
+    E = torch.where(amax == 0, torch.zeros_like(E), E)
+    E = E.clamp(-_UE8M0_BIAS, _UE8M0_BIAS)
+    scales_u8 = (E + _UE8M0_BIAS).to(torch.uint8)
+    scale = torch.ldexp(torch.ones_like(E, dtype=torch.float32), E)
+
+    q = xf / scale.unsqueeze(-1)
+    aq = q.abs().clamp(max=_E2M1_MAX)         # spec-sanctioned saturation
+    mids = torch.tensor(_E2M1_MIDPOINTS, device=x.device, dtype=torch.float32)
+    idx = torch.bucketize(aq, mids, right=True)
+    tie = (idx > 0) & (aq == mids[(idx - 1).clamp(min=0)])
+    idx = torch.where(tie & (idx % 2 == 1), idx - 1, idx)   # ties-to-even
+    sign = torch.signbit(q).to(torch.uint8)
+    nib = (idx.to(torch.uint8) | (sign << 3)).reshape(rows, K)
+    packed = nib[:, 0::2] | (nib[:, 1::2] << 4)
+    return packed.contiguous(), scales_u8.contiguous()
+
+
+def _mxfp4_dequantize(torch, packed, scales):
+    """Exact inverse of _mxfp4_quantize -> float32 (rows, K)."""
+    rows, half_k = packed.shape
+    K = half_k * 2
+    nib = torch.empty(rows, K, dtype=torch.uint8, device=packed.device)
+    nib[:, 0::2] = packed & 0x0F
+    nib[:, 1::2] = packed >> 4
+    codes = torch.tensor(_E2M1_CODES, device=packed.device,
+                         dtype=torch.float32)
+    mag = codes[(nib & 0x7).long()]
+    val = torch.where((nib & 0x8) != 0, -mag, mag)
+    E = scales.to(torch.int32) - _UE8M0_BIAS
+    scale = torch.ldexp(torch.ones_like(E, dtype=torch.float32), E)
+    val = val.reshape(rows, K // _MX_BLOCK, _MX_BLOCK) * scale.unsqueeze(-1)
+    return val.reshape(rows, K)
+
+
+def test_mxfp4_pack_reference_is_self_consistent(env):
+    """The MXFP4 GEMM gate below is only as good as this host packer, so it
+    is validated first, without touching the GPU kernel: the packed nibble
+    stream must round-trip, dequantize(quantize(x)) must be an idempotent
+    fixed point (proving the RNE-with-ties-to-even codebook search has no
+    off-by-one), and the UE8M0 NaN byte 255 must never be emitted."""
+    torch, _ = env
+    torch.manual_seed(90)
+    for rows, K in ((4, 64), (41, 1536), (64, 1024)):
+        x = torch.randn(rows, K, device="cuda", dtype=torch.bfloat16)
+        x[::max(rows // 4, 1)] *= 20.0        # force distinct block scales
+        packed, scales = _mxfp4_quantize(torch, x)
+        assert packed.shape == (rows, K // 2)
+        assert scales.shape == (rows, K // _MX_BLOCK)
+        assert not bool((scales == 255).any()), "emitted the e8m0 NaN byte"
+        assert scales.unique().numel() > 1, "all blocks got the same scale"
+        dq = _mxfp4_dequantize(torch, packed, scales)
+        p2, s2 = _mxfp4_quantize(torch, dq)
+        assert torch.equal(packed, p2) and torch.equal(scales, s2), (
+            "MXFP4 quantize/dequantize is not idempotent")
+
+
+@pytest.mark.parametrize("M,N,K", [(64, 512, 1024), (41, 1536, 1536)])
+def test_gemm_mxfp4_nt_dev_matches_dequantized_reference(env, gemm, M, N, K):
+    """mxfp4_nt_dev: D_bf16 = A_fp4(M,K) @ B_fp4(N,K)^T with per-1x32-block
+    UE8M0 scales installed via A/B_SCALE_MODE = VEC32_UE8M0.
+
+    The reference matmuls the DEQUANTIZED operands — the exact values the
+    hardware sees — so this gates the GEMM and the block-scale plumbing,
+    not MXFP4's quantization loss. (cos against the unquantized fp32
+    matmul sits around 0.99 on randn data: a gate at that level would pass
+    even with the block scales wired wrong.) B is (N,K): the NT layout is
+    part of the contract and a swapped layout decorrelates.
+    """
+    torch, _ = env
+    torch.manual_seed(91)
+    A = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    Bt = (0.5 * torch.randn(N, K, device="cuda")).to(torch.bfloat16)
+    A_p, A_s = _mxfp4_quantize(torch, A)
+    B_p, B_s = _mxfp4_quantize(torch, Bt)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    try:
+        gemm.mxfp4_nt_dev(A_p.data_ptr(), A_s.data_ptr(),
+                          B_p.data_ptr(), B_s.data_ptr(), D.data_ptr(),
+                          M, N, K, _stream(torch))
+        torch.cuda.synchronize()
+    except RuntimeError as exc:
+        # hipBLASLt without MXFP4 a4w4 support answers "no algorithm found";
+        # that is an environment capability, not a kernel regression.
+        if "no algorithm" not in str(exc):
+            raise
+        pytest.skip(f"hipBLASLt has no MXFP4 algorithm here: {exc}")
+
+    ref = (_mxfp4_dequantize(torch, A_p, A_s)
+           @ _mxfp4_dequantize(torch, B_p, B_s).t())
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM_FP4
+    assert bool(torch.isfinite(D.float()).all())
+
+
+# ---------------------------------------------------------------------------
+# GemmRunner — autotune entry points
+# ---------------------------------------------------------------------------
+#
+# Autotuning selects a different hipBLASLt algorithm (different split-K,
+# tile, and epilogue fusion) and caches it for the shape. That MUST NOT
+# change what the entry computes — a tuned pick that reorders K into a
+# different split-K count is fine, one that silently changes layout or
+# drops an epilogue is not. Each gate therefore tunes on a FRESH runner
+# (so it cannot inherit or poison the module-scoped runner's cache) and
+# then re-checks parity through the normal inference entry.
+
+
+def _fresh_runner(ext):
+    return ext.GemmRunner()
+
+
+def test_autotune_bf16_nn_preserves_semantics(env):
+    """autotune_bf16_nn times num_algos candidates and caches the winner
+    for (BF16_NN, M, N, K). The tuned pick must still compute A @ B in the
+    NN layout — a candidate with a different split-K count is fine, one
+    that changes the layout or the accumulate type is not."""
+    torch, ext = env
+    runner = _fresh_runner(ext)
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(100)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    runner.autotune_bf16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(),
+                            M, N, K, 4)
+    torch.cuda.synchronize()
+    runner.bf16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                   _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = A.float() @ B.float()
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+
+
+def test_autotune_fp16_nn_preserves_semantics(env):
+    """autotune_fp16_nn on a real GROOT DiT shape: the tuned FP16 algorithm
+    must keep both the NN layout and the FP16 output dtype (a candidate
+    that promoted the store to bf16 would halve the mantissa and slip past
+    any gate that only looked at magnitudes)."""
+    torch, ext = env
+    runner = _fresh_runner(ext)
+    M, N, K = 41, 1536, 1536
+    A, B, _bias = _groot_operands(torch, M, N, K, seed=101)
+    D = torch.empty(M, N, dtype=torch.half, device="cuda")
+
+    runner.autotune_fp16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(),
+                            M, N, K, 4)
+    torch.cuda.synchronize()
+    runner.fp16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                   _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = (A.float() @ B.float()).half()
+    assert _cos(D.float().cpu(), ref.float().cpu()) > COS_GEMM
+
+
+def test_autotune_fp8_nn_dev_preserves_semantics(env):
+    """autotune_fp8_nn_dev tunes with the DEVICE scale pointers in place;
+    the cached algorithm must still apply scale_a * scale_b to the FP32
+    accumulator afterwards, so the gate re-checks the scaled reference
+    through the normal inference entry."""
+    torch, ext = env
+    runner = _fresh_runner(ext)
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(102)
+    A8 = (0.3 * torch.randn(M, K, device="cuda")).to(torch.float8_e4m3fn)
+    B8 = (0.3 * torch.randn(K, N, device="cuda")).to(torch.float8_e4m3fn)
+    dsa = torch.tensor([0.01], dtype=torch.float32, device="cuda")
+    dsb = torch.tensor([0.02], dtype=torch.float32, device="cuda")
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    runner.autotune_fp8_nn_dev(A8.data_ptr(), B8.data_ptr(), D.data_ptr(),
+                               M, N, K, dsa.data_ptr(), dsb.data_ptr(), 4)
+    torch.cuda.synchronize()
+    runner.fp8_nn_dev(A8.data_ptr(), B8.data_ptr(), D.data_ptr(), M, N, K,
+                      dsa.data_ptr(), dsb.data_ptr(), _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = (A8.float() @ B8.float()) * (dsa * dsb)
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+
+
+def test_autotune_fp8_nt_dev_preserves_semantics(env):
+    """autotune_fp8_nt_dev, same contract as the NN tune plus the NT
+    transpose: B stays (N,K) row-major and the tuned pick must keep
+    D = A @ B^T. This is the production pi05 FP8 layout, so a tuned
+    candidate that silently transposed would corrupt every decoder GEMM."""
+    torch, ext = env
+    runner = _fresh_runner(ext)
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(103)
+    A8 = (0.3 * torch.randn(M, K, device="cuda")).to(torch.float8_e4m3fn)
+    Bt8 = (0.3 * torch.randn(N, K, device="cuda")).to(torch.float8_e4m3fn)
+    dsa = torch.tensor([0.01], dtype=torch.float32, device="cuda")
+    dsb = torch.tensor([0.02], dtype=torch.float32, device="cuda")
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    runner.autotune_fp8_nt_dev(A8.data_ptr(), Bt8.data_ptr(), D.data_ptr(),
+                               M, N, K, dsa.data_ptr(), dsb.data_ptr(), 4)
+    torch.cuda.synchronize()
+    runner.fp8_nt_dev(A8.data_ptr(), Bt8.data_ptr(), D.data_ptr(), M, N, K,
+                      dsa.data_ptr(), dsb.data_ptr(), _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = (A8.float() @ Bt8.float().t()) * (dsa * dsb)
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+
+
+def test_autotune_fp8_descale_fp16_preserves_semantics(env):
+    """autotune_fp8_descale_fp16 on the widest GROOT DiT shape (K=6144,
+    where split-K candidates differ most): the tuned algorithm must keep
+    both the device-descale semantics and the FP16 output."""
+    torch, ext = env
+    runner = _fresh_runner(ext)
+    M, N, K = 41, 1536, 6144
+    A, B, _bias = _groot_operands(torch, M, N, K, seed=104)
+    A8, sa = _quant_fp8(torch, A)
+    B8, sb = _quant_fp8(torch, B)
+    dsa = sa.reshape(1).contiguous().cuda()
+    dsb = sb.reshape(1).contiguous().cuda()
+    D = torch.empty(M, N, dtype=torch.half, device="cuda")
+
+    runner.autotune_fp8_descale_fp16(A8.data_ptr(), B8.data_ptr(),
+                                     D.data_ptr(), M, N, K,
+                                     dsa.data_ptr(), dsb.data_ptr(), 4)
+    torch.cuda.synchronize()
+    runner.fp8_descale_fp16(A8.data_ptr(), B8.data_ptr(), D.data_ptr(),
+                            M, N, K, dsa.data_ptr(), dsb.data_ptr(),
+                            _stream(torch))
+    torch.cuda.synchronize()
+
+    ref = (float(sa) * float(sb) * (A8.float() @ B8.float())).half()
+    assert _cos(D.float().cpu(), ref.float().cpu()) > COS_GEMM
+
+
+def test_autotune_mxfp4_nt_dev_preserves_semantics(env):
+    """autotune_mxfp4_nt_dev: the tuned MXFP4 algorithm must keep the
+    per-1x32-block UE8M0 scale plumbing wired to the right operand. Skips
+    when hipBLASLt exposes no MXFP4 algorithm at all (an environment
+    capability, not a kernel regression)."""
+    torch, ext = env
+    runner = _fresh_runner(ext)
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(105)
+    A = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    Bt = (0.5 * torch.randn(N, K, device="cuda")).to(torch.bfloat16)
+    A_p, A_s = _mxfp4_quantize(torch, A)
+    B_p, B_s = _mxfp4_quantize(torch, Bt)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    try:
+        runner.autotune_mxfp4_nt_dev(A_p.data_ptr(), A_s.data_ptr(),
+                                     B_p.data_ptr(), B_s.data_ptr(),
+                                     D.data_ptr(), M, N, K, 4)
+        torch.cuda.synchronize()
+        runner.mxfp4_nt_dev(A_p.data_ptr(), A_s.data_ptr(),
+                            B_p.data_ptr(), B_s.data_ptr(), D.data_ptr(),
+                            M, N, K, _stream(torch))
+        torch.cuda.synchronize()
+    except RuntimeError as exc:
+        if "no algorithm" not in str(exc):
+            raise
+        pytest.skip(f"hipBLASLt has no MXFP4 algorithm here: {exc}")
+
+    ref = (_mxfp4_dequantize(torch, A_p, A_s)
+           @ _mxfp4_dequantize(torch, B_p, B_s).t())
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM_FP4
+
+
+def test_enable_lazy_autotune_preserves_semantics(env):
+    """enable_lazy_autotune arms a timed selection on the FIRST call of
+    each (type, M, N, K). The header warns that the timed loop re-runs the
+    op with the caller's real pointers, so a lazily tuned FIRST call must
+    not be trusted for numerics — but every call after it must be exact.
+    That is the contract the pipeline relies on (warm every shape eagerly,
+    then capture), so the gate checks the SECOND call, on a fresh runner
+    so the module-scoped one keeps its default configuration."""
+    torch, ext = env
+    runner = _fresh_runner(ext)
+    runner.enable_lazy_autotune(4)
+    M, N, K = 64, 512, 1024
+    torch.manual_seed(106)
+    A = (0.3 * torch.randn(M, K, device="cuda")).to(torch.bfloat16)
+    B = (0.3 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    D = torch.empty(M, N, dtype=torch.bfloat16, device="cuda")
+
+    runner.bf16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                   _stream(torch))          # warmup: triggers the timed pick
+    torch.cuda.synchronize()
+    D.zero_()
+    runner.bf16_nn(A.data_ptr(), B.data_ptr(), D.data_ptr(), M, N, K,
+                   _stream(torch))          # the gated call
+    torch.cuda.synchronize()
+
+    ref = A.float() @ B.float()
+    assert _cos(D.float().cpu(), ref.cpu()) > COS_GEMM
+    torch.testing.assert_close(D.float(), ref, atol=0.5, rtol=0.05)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_amd_kernel_parity_groot.py
+++ b/tests/test_amd_kernel_parity_groot.py
@@ -1,0 +1,1326 @@
+"""AMD GROOT N1.7 kernel port — per-kernel numerical parity gates.
+
+Companion to ``tests/test_amd_kernel_parity.py`` (which owns the pi05
+kernel surface and the whole ``GemmRunner`` / hipBLASLt GEMM surface).
+This module owns the two families the GROOT N1.7 branch adds on top:
+
+    csrc/amd/gemm/bindings_smallm_bf16.inc   4 entry points
+        the hand-written packed-weight MFMA small-M BF16 GEMM
+        (smallm_mfma_bf16_nn_bias / _bias_gelu / _bias_res) and its
+        variant enumerator.
+
+    csrc/amd/kernels/bindings_fp16_port.inc  29 entry points
+        the FP16/BF16 backbone port: elementwise, activation, casts,
+        layout ops, norms, RoPE, the fused norm->FP8 pair, the seven
+        ``*_vec`` fast paths and the AdaLN (LayerNorm-style) family.
+
+Every bound name in those two files gets at least one gate here; the
+inventory is asserted mechanically by ``test_entry_point_inventory``
+so a name added to the .inc without a gate fails this file.
+
+What the gates protect (why they are not loose cosines):
+
+  * FP8 outputs are compared BYTE-for-byte against a torch
+    ``float8_e4m3fn`` cast of the same fp32 reference through the SAME
+    device scale, replicating the kernel's exact arithmetic (multiply by
+    the fp32 reciprocal of the scale, clamp to +-448, RNE convert).
+    Comparing an FP8 output against an unquantized fp32 reference would
+    measure the e4m3 format (cos ~0.9996 on randn) instead of the
+    kernel, so it would pass with a broken scale path.
+  * Residual / accumulate variants run against a PRE-SEEDED destination
+    and additionally assert the result is NOT the non-accumulated form,
+    so a dropped ``+=`` cannot pass.
+  * GELU references pin the tanh approximation (``approximate="tanh"``),
+    the hipBLASLt GELU_BIAS / activation.hip semantics; erf-GELU would
+    sail through a loose cosine on symmetric data.
+  * Pure-copy / cast / layout kernels are gated BITWISE, not by
+    tolerance — they have no arithmetic to round.
+  * The packed GEMM is fed through the documented torch view/permute
+    one-liner from ``csrc/amd/gemm/smallm_mfma_bf16.h``, and a companion
+    gate feeds the SAME weight unpacked and requires the answer to be
+    wrong — proving the pack layout is load-bearing rather than
+    incidental.
+  * The ``*_vec`` entries return ``int``: 0 when their alignment /
+    divisibility preconditions hold, -1 when they do not. Both branches
+    are gated, and the reject branch also asserts the destination was
+    left untouched (a silent partial write is the dangerous failure).
+
+Numeric thresholds, justified once (see the ``_TOL`` block below).
+
+Binding signatures were read from ``csrc/amd/kernels/bindings_fp16_port.inc``
+and ``csrc/amd/gemm/bindings_smallm_bf16.inc`` before writing any call
+here; every tensor is bound to a named variable before ``.data_ptr()``
+(an inline temporary would be GC'd before the launch reads it).
+
+Skip conditions: ROCm torch + a visible device + the built extension.
+Every AMD-tree import happens inside a fixture, so this module collects
+cleanly on a CUDA-only box and every test skips with a reason.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ext():
+    """The compiled AMD module, or a skip with the reason.
+
+    Importing does not need a GPU, so the inventory test can run on any
+    box that has the .so built.
+    """
+    try:
+        return importlib.import_module("flash_rt.amd.flash_rt_amd_kernels")
+    except ImportError as exc:  # pragma: no cover - build/env dependent
+        pytest.skip(f"flash_rt_amd_kernels not importable: {exc}")
+
+
+@pytest.fixture(scope="module")
+def env(ext):
+    """(torch, extension) on a ROCm box with a visible device."""
+    torch = pytest.importorskip("torch")
+    if not getattr(torch.version, "hip", None):
+        pytest.skip("torch is not a ROCm build")
+    if not torch.cuda.is_available():
+        pytest.skip("no ROCm device visible to torch")
+    return torch, ext
+
+
+def _stream(torch) -> int:
+    """Launch on torch's current stream so torch-side tensor prep and the
+    raw-pointer launches are ordered without extra events."""
+    return torch.cuda.current_stream().cuda_stream
+
+
+def _cos(torch, a, b) -> float:
+    af = a.detach().double().reshape(-1)
+    bf = b.detach().double().reshape(-1)
+    denom = af.norm() * bf.norm()
+    if float(denom) == 0.0:
+        return 1.0 if float((af - bf).abs().max()) == 0.0 else 0.0
+    return float((af @ bf) / denom)
+
+
+# ---------------------------------------------------------------------------
+# Numeric gates, justified once
+# ---------------------------------------------------------------------------
+#
+#  COS_TIGHT 0.9999  — kernel and reference share the same fp32 math and
+#      differ only in reduction order plus the final dtype round; a real
+#      semantic bug (wrong weight fold, wrong activation, shifted row)
+#      lands orders of magnitude below this.
+#  ATOL_FP16 1e-3    — one fp16 ULP at unit scale is 2^-11 ~ 4.9e-4;
+#      1e-3 covers two chained roundings and still fails on O(1) errors.
+#  ATOL_FP16_ACT 2e-3 — activations (GELU/SiLU/RoPE) evaluate a
+#      transcendental on device vs torch; allow one extra ULP of spread.
+#  ATOL_FP16_NORM 5e-3 — norms carry a block reduction over 2048 terms
+#      whose wave64 order differs from torch's; the spread is a few fp16
+#      ULPs of the normalized value.
+#  ATOL_BF16 2e-2    — one bf16 ULP at unit scale is 2^-8 ~ 3.9e-3.
+#  FP8_MISMATCH_RNE 1e-3 — for FP8 kernels whose pre-quantization value
+#      comes out of a device transcendental (expf / tanhf), a last-ULP
+#      fp32 difference can flip an RNE tie and change one byte. 0.1% of
+#      elements is far above the observed rate and far below anything a
+#      scale-path bug produces (those miss on ~100% of bytes).
+#  FP8_MISMATCH_REDUCE 5e-3 — same idea for the norm-fused FP8 kernels,
+#      which additionally differ in block-reduction order.
+#  Pure elementwise FP8 (multiply-clamp-convert, no reduction, no
+#      transcendental) is gated at ZERO mismatched bytes.
+COS_TIGHT = 0.9999
+COS_FP8_DEQ = 0.99999
+ATOL_FP16 = 1e-3
+ATOL_FP16_ACT = 2e-3
+ATOL_FP16_NORM = 5e-3
+ATOL_BF16 = 2e-2
+FP8_MISMATCH_RNE = 1e-3
+FP8_MISMATCH_REDUCE = 5e-3
+
+E4M3_MAX = 448.0
+
+
+# ---------------------------------------------------------------------------
+# FP8 helpers
+# ---------------------------------------------------------------------------
+
+
+def _static_scale(torch, ref_f32):
+    """Per-tensor symmetric static scale (device fp32 scalar), computed the
+    way production calibration does: amax / 448."""
+    amax = ref_f32.detach().float().abs().max().clamp(min=1e-8)
+    return (amax / E4M3_MAX).float().reshape(1).contiguous()
+
+
+def _fp8_ref_bytes(torch, ref_f32, scale):
+    """torch float8_e4m3fn cast of ``ref_f32`` through the SAME device
+    scale, replicating the kernel arithmetic exactly: the kernels compute
+    ``inv = 1.0f / (*d_scale)`` once and then ``value * inv``, clamp to
+    +-448 and RNE-convert. ``torch.reciprocal`` is the same fp32 op."""
+    inv = torch.reciprocal(scale)
+    q = (ref_f32.float() * inv).clamp(-E4M3_MAX, E4M3_MAX)
+    return q.to(torch.float8_e4m3fn).view(torch.uint8)
+
+
+def _assert_fp8(torch, name, out_u8, ref_f32, scale, max_mismatch):
+    """Byte gate + a dequantized-magnitude cross-check.
+
+    The byte comparison is the contract (the encoding must match torch's
+    e4m3 with the same scale). The dequantized cosine is a second, coarser
+    net: it catches wholesale corruption (wrong row stride, wrong operand)
+    that a permissive mismatch budget might otherwise absorb.
+    """
+    ref_u8 = _fp8_ref_bytes(torch, ref_f32, scale).reshape(out_u8.shape)
+    mismatch = float((out_u8 != ref_u8).float().mean())
+    assert mismatch <= max_mismatch, (
+        f"{name}: {mismatch:.5f} of FP8 bytes differ from torch e4m3 with "
+        f"the same scale (budget {max_mismatch}) — encoding or scale-path "
+        "drift silently poisons every downstream FP8 GEMM")
+    got = out_u8.view(torch.float8_e4m3fn).float()
+    ref = ref_u8.view(torch.float8_e4m3fn).float()
+    assert _cos(torch, got, ref) > COS_FP8_DEQ, f"{name}: dequantized cos"
+
+
+def _gelu_tanh(torch, x_f32):
+    return torch.nn.functional.gelu(x_f32, approximate="tanh")
+
+
+# ---------------------------------------------------------------------------
+# Entry-point inventory
+# ---------------------------------------------------------------------------
+
+# csrc/amd/kernels/bindings_fp16_port.inc — every m.def in the file.
+FP16_PORT_ENTRY_POINTS = [
+    # elementwise / activation
+    "add_bias_fp16", "gelu_inplace_fp16", "silu_inplace_fp16",
+    "relu_inplace_bf16", "mul_fp16", "residual_add_fp16",
+    "gpu_fill_neginf_fp16", "gpu_strided_copy_fp16",
+    "gpu_repeat_interleave_heads", "cast_fp16_to_bf16", "cast_bf16_to_fp16",
+    "concat2_bf16",
+    # quantize / FP8 fusion
+    "quantize_fp8_static_fp16", "silu_mul_split_fp8_fp16",
+    # norm / RoPE / norm->FP8
+    "layer_norm_fp16", "rope_rotate_half_fp16", "rms_norm_fp8_fp16",
+    "residual_add_rms_norm_fp8_fp16",
+    # vectorized fast paths (int status returns)
+    "rms_norm_fp16_vec", "layer_norm_fp16_vec",
+    "layer_norm_fp8_static_fp16_vec", "rope_rotate_half_fp16_vec",
+    "quantize_fp8_static_fp16_vec", "residual_add_fp16_vec",
+    "gpu_repeat_interleave_heads_vec",
+    # AdaLN family
+    "layer_norm_no_affine_bf16", "ada_layer_norm_bf16", "ada_layer_norm_fp8",
+    "bias_gelu_quantize_fp8_static_bf16",
+]
+
+# csrc/amd/gemm/bindings_smallm_bf16.inc — every m.def in the file.
+SMALLM_BF16_ENTRY_POINTS = [
+    "smallm_mfma_bf16_nn_bias",
+    "smallm_mfma_bf16_nn_bias_gelu",
+    "smallm_mfma_bf16_nn_bias_res",
+    "smallm_mfma_bf16_variants",
+]
+
+
+def test_entry_point_inventory(ext):
+    """Every name bound by the two .inc files this module gates must exist
+    on the compiled module.
+
+    This is the fail-fast half of the contract: the numerical tests below
+    only fire on a ROCm box, but a name dropped from (or renamed in) the
+    bindings must fail anywhere the .so imports. It is also the tripwire
+    that keeps this file honest — a NEW m.def added to either .inc without
+    a gate here has to be added to these lists in the same commit.
+    """
+    expected = FP16_PORT_ENTRY_POINTS + SMALLM_BF16_ENTRY_POINTS
+    missing = [n for n in expected if not hasattr(ext, n)]
+    assert not missing, (
+        "flash_rt_amd_kernels is missing bound entry points from "
+        "bindings_fp16_port.inc / bindings_smallm_bf16.inc "
+        f"(bindings drift or partial build): {missing}")
+    not_callable = [n for n in expected if not callable(getattr(ext, n))]
+    assert not not_callable, f"bound but not callable: {not_callable}"
+
+
+# ---------------------------------------------------------------------------
+# FP16 elementwise / activation
+# ---------------------------------------------------------------------------
+
+
+def test_add_bias_fp16_broadcasts_along_the_row(env):
+    """``x[i] += b[i % D]`` in place: the bias is a length-D vector
+    broadcast over rows. A transposed broadcast (per-row instead of
+    per-column) is the classic bug here, so the reference uses a bias whose
+    every element differs and the gate is elementwise, not aggregate."""
+    torch, ext = env
+    S, D = 64, 2048
+    torch.manual_seed(0)
+    x = torch.randn(S, D, device="cuda").half()
+    b = (0.1 * torch.randn(D, device="cuda")).half()
+    ref = (x.float() + b.float()).half()
+
+    ext.add_bias_fp16(x.data_ptr(), b.data_ptr(), S, D, _stream(torch))
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(x.float(), ref.float(),
+                               atol=ATOL_FP16, rtol=0.0)
+
+
+def test_gelu_inplace_fp16_is_tanh_approx(env):
+    """Must be the tanh approximation, not erf-GELU and not SiLU. The
+    tolerance is tight enough that SiLU (which differs by ~0.02 near
+    x = -1) fails, and the explicit not-relu / not-identity checks pin the
+    shape of the activation independently of the reference."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(1)
+    x = torch.randn(n, device="cuda").half()
+    x0 = x.clone()
+    ref = _gelu_tanh(torch, x.float()).half()
+
+    ext.gelu_inplace_fp16(x.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert _cos(torch, x, ref) > COS_TIGHT
+    torch.testing.assert_close(x.float(), ref.float(),
+                               atol=ATOL_FP16_ACT, rtol=0.0)
+    neg = x0.float() < -1.0
+    assert float(x.float()[neg].min()) < -1e-3, (
+        "GELU must pass a small negative through; ReLU would clamp to 0")
+    assert not torch.allclose(x.float(), x0.float(), atol=1e-2), "identity"
+
+
+def test_silu_inplace_fp16_matches_torch(env):
+    """SiLU x*sigmoid(x), in place. Same not-GELU discriminator in reverse:
+    the tolerance is ~1/10th of the peak GELU-vs-SiLU gap."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(2)
+    x = torch.randn(n, device="cuda").half()
+    ref = torch.nn.functional.silu(x.float()).half()
+
+    ext.silu_inplace_fp16(x.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert _cos(torch, x, ref) > COS_TIGHT
+    torch.testing.assert_close(x.float(), ref.float(),
+                               atol=ATOL_FP16_ACT, rtol=0.0)
+
+
+def test_relu_inplace_bf16_is_bit_exact(env):
+    """ReLU is a select, not arithmetic: max(x, 0) on bf16 rounds nothing,
+    so the gate is bitwise equality. Anything else means the kernel is
+    doing math it should not (e.g. computing in fp32 and re-rounding)."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(3)
+    x = torch.randn(n, device="cuda").bfloat16()
+    ref = torch.nn.functional.relu(x.float()).bfloat16()
+
+    ext.relu_inplace_bf16(x.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.equal(x.view(torch.uint16), ref.view(torch.uint16)), (
+        "relu_inplace_bf16 is not bit-exact vs max(x, 0)")
+
+
+def test_mul_fp16_covers_the_scalar_tail(env):
+    """Elementwise a*b into a separate output. n is deliberately NOT a
+    multiple of 8 so the packed vector body AND the scalar tail both run —
+    a tail bug leaves the last few elements stale, which an n%8==0 test
+    would never see."""
+    torch, ext = env
+    n = 64 * 2048 + 5
+    torch.manual_seed(4)
+    a = torch.randn(n, device="cuda").half()
+    b = torch.randn(n, device="cuda").half()
+    out = torch.full((n,), float("nan"), device="cuda", dtype=torch.half)
+    ref = (a.float() * b.float()).half()
+
+    ext.mul_fp16(a.data_ptr(), b.data_ptr(), out.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(out.float()).all(), "tail elements left unwritten"
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_FP16, rtol=0.0)
+
+
+def test_residual_add_fp16_accumulates_in_place(env):
+    """``residual += x``, in place on the residual buffer. Gated against a
+    pre-seeded destination and additionally required NOT to equal x — a
+    kernel that overwrote instead of accumulating would pass a
+    cos-vs-anything gate on correlated data."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(5)
+    residual = torch.randn(n, device="cuda").half()
+    seed = residual.clone()
+    x = torch.randn(n, device="cuda").half()
+    ref = (seed.float() + x.float()).half()
+
+    ext.residual_add_fp16(residual.data_ptr(), x.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(residual.float(), ref.float(),
+                               atol=ATOL_FP16, rtol=0.0)
+    assert not torch.allclose(residual.float(), x.float(), atol=1e-2), (
+        "residual_add overwrote the destination instead of accumulating")
+
+
+def test_gpu_fill_neginf_fp16_saturates_to_minus_inf(env):
+    """The kernel writes ``__float2half(-1e30f)``, which saturates to fp16
+    -inf. Attention masks depend on that saturation (a finite -65504 would
+    still leak probability mass after a large positive score), so the gate
+    asserts -inf exactly, on every element."""
+    torch, ext = env
+    n = 64 * 2048
+    dst = torch.zeros(n, device="cuda", dtype=torch.half)
+
+    ext.gpu_fill_neginf_fp16(dst.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert bool(torch.isinf(dst).all()) and bool((dst < 0).all()), (
+        "gpu_fill_neginf_fp16 must saturate to fp16 -inf on every element")
+
+
+def test_gpu_strided_copy_fp16_is_bit_exact_slice(env):
+    """``dst[r, :] = src[r, off : off + dst_cols]`` — a pure copy out of a
+    wider row stride (the fused-QKV column slice). Bitwise gate: a copy
+    that rounds is a copy that is doing something wrong. The offset and
+    stride are deliberately unequal to dst_cols so a stride/offset swap
+    cannot alias into a passing result."""
+    torch, ext = env
+    rows, dst_cols, src_stride, off = 64, 512, 1536, 512
+    torch.manual_seed(6)
+    src = torch.randn(rows, src_stride, device="cuda").half()
+    dst = torch.full((rows, dst_cols), float("nan"),
+                     device="cuda", dtype=torch.half)
+    ref = src[:, off:off + dst_cols].contiguous()
+
+    ext.gpu_strided_copy_fp16(src.data_ptr(), dst.data_ptr(),
+                              rows, dst_cols, src_stride, off, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.equal(dst.view(torch.uint16), ref.view(torch.uint16))
+
+
+def test_gpu_repeat_interleave_heads_is_bit_exact(env):
+    """GQA head expansion: each of NH_src heads is repeated ``repeat``
+    times CONSECUTIVELY (repeat_interleave), not tiled (repeat). The two
+    differ only in ordering, so the gate is bitwise against
+    ``torch.repeat_interleave`` and a tile would fail loudly."""
+    torch, ext = env
+    S, NH_src, HD, repeat = 32, 8, 128, 2
+    torch.manual_seed(7)
+    src = torch.randn(S, NH_src, HD, device="cuda").half()
+    dst = torch.full((S, NH_src * repeat, HD), float("nan"),
+                     device="cuda", dtype=torch.half)
+    ref = torch.repeat_interleave(src, repeat, dim=1)
+
+    ext.gpu_repeat_interleave_heads(src.data_ptr(), dst.data_ptr(),
+                                    S, NH_src, HD, repeat, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.equal(dst.view(torch.uint16), ref.contiguous().view(torch.uint16))
+
+
+def test_cast_fp16_to_bf16_is_bit_exact(env):
+    """fp16 -> bf16 is a narrowing round; the gate is bitwise against
+    torch's own round so a truncating cast (drop the low mantissa bits
+    instead of RNE) fails on ~half the elements."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(8)
+    src = torch.randn(n, device="cuda").half()
+    out = torch.empty(n, device="cuda", dtype=torch.bfloat16)
+    ref = src.float().bfloat16()
+
+    ext.cast_fp16_to_bf16(src.data_ptr(), out.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.equal(out.view(torch.uint16), ref.view(torch.uint16))
+
+
+def test_cast_bf16_to_fp16_is_bit_exact(env):
+    """bf16 -> fp16 is exact for every finite bf16 in fp16 range (bf16 has
+    fewer mantissa bits), so the gate is bitwise."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(9)
+    src = torch.randn(n, device="cuda").bfloat16()
+    out = torch.empty(n, device="cuda", dtype=torch.half)
+    ref = src.float().half()
+
+    ext.cast_bf16_to_fp16(src.data_ptr(), out.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.equal(out.view(torch.uint16), ref.view(torch.uint16))
+
+
+def test_concat2_bf16_is_bit_exact(env):
+    """Row-wise concat of two (rows, cols_*) bf16 blocks. cols_a != cols_b
+    so a swapped-width bug cannot produce the right total layout; bitwise
+    gate because concat is a copy."""
+    torch, ext = env
+    rows, cols_a, cols_b = 64, 1536, 512
+    torch.manual_seed(10)
+    a = torch.randn(rows, cols_a, device="cuda").bfloat16()
+    b = torch.randn(rows, cols_b, device="cuda").bfloat16()
+    out = torch.empty(rows, cols_a + cols_b, device="cuda",
+                      dtype=torch.bfloat16)
+    ref = torch.cat([a, b], dim=1)
+
+    ext.concat2_bf16(a.data_ptr(), b.data_ptr(), out.data_ptr(),
+                     rows, cols_a, cols_b, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert torch.equal(out.view(torch.uint16), ref.contiguous().view(torch.uint16))
+
+
+# ---------------------------------------------------------------------------
+# FP16 quantize / FP8 fusion
+# ---------------------------------------------------------------------------
+
+
+def test_quantize_fp8_static_fp16_is_byte_exact(env):
+    """Pure multiply-by-reciprocal, clamp, RNE-convert — no reduction and
+    no transcendental, so the kernel's arithmetic is exactly reproducible
+    in torch and the budget is ZERO mismatched bytes."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(11)
+    x = (2.0 * torch.randn(n, device="cuda")).half()
+    scale = _static_scale(torch, x.float()).cuda()
+    out = torch.empty(n, device="cuda", dtype=torch.uint8)
+
+    ext.quantize_fp8_static_fp16(x.data_ptr(), out.data_ptr(),
+                                 scale.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    _assert_fp8(torch, "quantize_fp8_static_fp16", out, x.float(), scale,
+                max_mismatch=0.0)
+
+
+def test_quantize_fp8_static_fp16_vec_matches_the_scalar_path(env):
+    """The vectorized entry must be a pure speed variant: same bytes as the
+    scalar kernel on the same input, not merely 'close'. Gated bitwise
+    against the scalar path AND against the torch reference, plus rc == 0
+    for a geometry that satisfies n%16 and 16-byte alignment."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(11)
+    x = (2.0 * torch.randn(n, device="cuda")).half()
+    scale = _static_scale(torch, x.float()).cuda()
+    out_scalar = torch.empty(n, device="cuda", dtype=torch.uint8)
+    out_vec = torch.empty(n, device="cuda", dtype=torch.uint8)
+
+    ext.quantize_fp8_static_fp16(x.data_ptr(), out_scalar.data_ptr(),
+                                 scale.data_ptr(), n, _stream(torch))
+    rc = ext.quantize_fp8_static_fp16_vec(x.data_ptr(), out_vec.data_ptr(),
+                                          scale.data_ptr(), n, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert rc == 0, f"vec path rejected an aligned n={n} (rc={rc})"
+    assert torch.equal(out_vec, out_scalar), (
+        "quantize_fp8_static_fp16_vec differs from the scalar path")
+    _assert_fp8(torch, "quantize_fp8_static_fp16_vec", out_vec, x.float(),
+                scale, max_mismatch=0.0)
+
+
+def test_silu_mul_split_fp8_fp16_fuses_silu_mul_and_quantize(env):
+    """``out_fp8 = quant(silu(gate) * up)``. The reference uses the
+    kernel's own SiLU form ``g / (1 + exp(-g))`` (not torch's
+    ``g * sigmoid(g)``) so the only remaining difference is one ULP of
+    ``expf``; the byte budget is sized for that RNE-tie flip. The
+    discriminator gates check the multiply is really by ``up`` and the
+    activation is really on ``gate``, which a cos-only gate would blur."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(12)
+    gate = torch.randn(n, device="cuda").half()
+    up = torch.randn(n, device="cuda").half()
+    g = gate.float()
+    ref_f32 = (g / (1.0 + torch.exp(-g))) * up.float()
+    scale = _static_scale(torch, ref_f32).cuda()
+    out = torch.empty(n, device="cuda", dtype=torch.uint8)
+
+    ext.silu_mul_split_fp8_fp16(gate.data_ptr(), up.data_ptr(),
+                                out.data_ptr(), n, scale.data_ptr(),
+                                _stream(torch))
+    torch.cuda.synchronize()
+
+    _assert_fp8(torch, "silu_mul_split_fp8_fp16", out, ref_f32, scale,
+                max_mismatch=FP8_MISMATCH_RNE)
+    got = out.view(torch.float8_e4m3fn).float() * scale
+    # Operand-order discriminators: silu(up)*gate and gate*up (no
+    # activation) are both plausible mis-wirings and both decorrelate.
+    swapped = (up.float() / (1.0 + torch.exp(-up.float()))) * g
+    assert _cos(torch, got, swapped) < 0.99, "gate/up operands swapped"
+    assert _cos(torch, got, g * up.float()) < 0.99, "SiLU not applied"
+
+
+# ---------------------------------------------------------------------------
+# FP16 norm / RoPE / fused norm -> FP8
+# ---------------------------------------------------------------------------
+
+
+def test_layer_norm_fp16_matches_torch(env):
+    """LayerNorm with plain affine ``w`` and ``b`` (NOT the Gemma ``1+w``
+    fold — that fold happens at weight-conversion time, so a kernel
+    secretly applying 1+w would double it). Weights are drawn around 1.0
+    and bias around 0 so a dropped bias or a dropped weight both move the
+    output well outside the tolerance."""
+    torch, ext = env
+    S, D, eps = 64, 2048, 1e-6
+    torch.manual_seed(13)
+    x = torch.randn(S, D, device="cuda").half()
+    w = (1.0 + 0.1 * torch.randn(D, device="cuda")).half()
+    b = (0.1 * torch.randn(D, device="cuda")).half()
+    out = torch.empty(S, D, device="cuda", dtype=torch.half)
+    ref = torch.nn.functional.layer_norm(
+        x.float(), (D,), w.float(), b.float(), eps).half()
+
+    ext.layer_norm_fp16(x.data_ptr(), w.data_ptr(), b.data_ptr(),
+                        out.data_ptr(), S, D, eps, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert _cos(torch, out, ref) > COS_TIGHT
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_FP16_NORM, rtol=0.0)
+
+
+def test_layer_norm_fp16_vec_matches_the_scalar_path(env):
+    """Same math as the scalar entry; gated against the same torch
+    reference AND required to return 0 on a dim%8==0, 16-byte-aligned
+    geometry (the documented precondition)."""
+    torch, ext = env
+    S, D, eps = 64, 2048, 1e-6
+    torch.manual_seed(13)
+    x = torch.randn(S, D, device="cuda").half()
+    w = (1.0 + 0.1 * torch.randn(D, device="cuda")).half()
+    b = (0.1 * torch.randn(D, device="cuda")).half()
+    out = torch.empty(S, D, device="cuda", dtype=torch.half)
+    ref = torch.nn.functional.layer_norm(
+        x.float(), (D,), w.float(), b.float(), eps).half()
+
+    rc = ext.layer_norm_fp16_vec(x.data_ptr(), w.data_ptr(), b.data_ptr(),
+                                 out.data_ptr(), S, D, eps, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert rc == 0, f"vec path rejected an aligned dim={D} (rc={rc})"
+    assert _cos(torch, out, ref) > COS_TIGHT
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_FP16_NORM, rtol=0.0)
+
+
+def test_rms_norm_fp16_vec_uses_plain_weight_semantics(env):
+    """RMSNorm with plain ``w`` multiplication and mean-of-squares (not
+    sum-of-squares, not variance-about-the-mean). The reference spells the
+    math out rather than calling a torch module so all three choices are
+    pinned; rc == 0 checks the vector precondition contract."""
+    torch, ext = env
+    S, D, eps = 64, 2048, 1e-6
+    torch.manual_seed(14)
+    x = torch.randn(S, D, device="cuda").half()
+    w = (1.0 + 0.1 * torch.randn(D, device="cuda")).half()
+    out = torch.empty(S, D, device="cuda", dtype=torch.half)
+    xf = x.float()
+    ref = (xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps)
+           * w.float()).half()
+
+    rc = ext.rms_norm_fp16_vec(x.data_ptr(), w.data_ptr(), out.data_ptr(),
+                               S, D, eps, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert rc == 0, f"vec path rejected an aligned dim={D} (rc={rc})"
+    assert _cos(torch, out, ref) > COS_TIGHT
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_FP16_NORM, rtol=0.0)
+
+
+def _rope_tables(torch, S, HD):
+    """Rotate-half tables: (S, HD) with cos/sin duplicated across the two
+    halves, the layout ``rope_rotate_half_fp16`` indexes."""
+    half = HD // 2
+    pos = torch.arange(S, device="cuda").float()
+    inv = 1.0 / (10000.0 ** (torch.arange(half, device="cuda").float() / half))
+    ang = pos[:, None] * inv[None, :]
+    cos_t = torch.cat([ang.cos(), ang.cos()], dim=1).half()
+    sin_t = torch.cat([ang.sin(), ang.sin()], dim=1).half()
+    return cos_t, sin_t
+
+
+def _rope_ref(torch, x, cos_t, sin_t, S, NH, HD):
+    """ROTATE-HALF reference: pair element i with i + HD/2. (The pi05
+    kernel `qkv_split_rope` uses the INTERLEAVED convention instead — the
+    two are different kernels and each is gated against its own
+    convention, which is the point of spelling this out.)"""
+    half = HD // 2
+    xv = x.float().view(S, NH, HD)
+    lo, hi = xv[..., :half], xv[..., half:]
+    c = cos_t.float()[:, None, :half]
+    s = sin_t.float()[:, None, :half]
+    return torch.cat([lo * c - hi * s, hi * c + lo * s], dim=-1) \
+        .view(S, NH * HD).half()
+
+
+def test_rope_rotate_half_fp16_uses_the_half_split_convention(env):
+    """In-place rotate-half RoPE over (S, NH*HD). The gate additionally
+    requires the output to DISAGREE with the interleaved-pair convention,
+    because both conventions preserve norms and would pass a magnitude
+    check."""
+    torch, ext = env
+    S, NH, HD = 32, 16, 128
+    torch.manual_seed(15)
+    x = torch.randn(S, NH * HD, device="cuda").half()
+    x0 = x.clone()
+    cos_t, sin_t = _rope_tables(torch, S, HD)
+    ref = _rope_ref(torch, x0, cos_t, sin_t, S, NH, HD)
+
+    ext.rope_rotate_half_fp16(x.data_ptr(), cos_t.data_ptr(),
+                              sin_t.data_ptr(), S, NH, HD, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert _cos(torch, x, ref) > COS_TIGHT
+    torch.testing.assert_close(x.float(), ref.float(),
+                               atol=ATOL_FP16_ACT, rtol=0.0)
+    assert _cos(torch, x, x0) < 0.999, "RoPE did not rotate anything"
+
+
+def test_rope_rotate_half_fp16_vec_matches_the_scalar_path(env):
+    """Vector fast path, same convention, plus the rc == 0 precondition
+    contract for (HD/2) % 8 == 0 and 16-byte-aligned tables."""
+    torch, ext = env
+    S, NH, HD = 32, 16, 128
+    torch.manual_seed(15)
+    x = torch.randn(S, NH * HD, device="cuda").half()
+    x0 = x.clone()
+    cos_t, sin_t = _rope_tables(torch, S, HD)
+    ref = _rope_ref(torch, x0, cos_t, sin_t, S, NH, HD)
+
+    rc = ext.rope_rotate_half_fp16_vec(x.data_ptr(), cos_t.data_ptr(),
+                                       sin_t.data_ptr(), S, NH, HD,
+                                       _stream(torch))
+    torch.cuda.synchronize()
+
+    assert rc == 0, f"vec path rejected HD={HD} (rc={rc})"
+    assert _cos(torch, x, ref) > COS_TIGHT
+    torch.testing.assert_close(x.float(), ref.float(),
+                               atol=ATOL_FP16_ACT, rtol=0.0)
+
+
+def test_rms_norm_fp8_fp16_fuses_norm_and_quantize(env):
+    """RMSNorm straight to FP8 with a device scale. The reference is the
+    fp32 norm result put through torch e4m3 with the SAME scale, so this
+    gates the fused path's encoding, not e4m3's error. Budget covers the
+    wave64 reduction-order difference only."""
+    torch, ext = env
+    S, D, eps = 64, 2048, 1e-6
+    torch.manual_seed(16)
+    x = torch.randn(S, D, device="cuda").half()
+    w = (1.0 + 0.1 * torch.randn(D, device="cuda")).half()
+    xf = x.float()
+    ref_f32 = (xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps)
+               * w.float())
+    scale = _static_scale(torch, ref_f32).cuda()
+    out = torch.empty(S, D, device="cuda", dtype=torch.uint8)
+
+    ext.rms_norm_fp8_fp16(x.data_ptr(), w.data_ptr(), out.data_ptr(),
+                          S, D, eps, scale.data_ptr(), _stream(torch))
+    torch.cuda.synchronize()
+
+    _assert_fp8(torch, "rms_norm_fp8_fp16", out, ref_f32, scale,
+                max_mismatch=FP8_MISMATCH_REDUCE)
+
+
+def test_residual_add_rms_norm_fp8_fp16_updates_residual_and_quantizes(env):
+    """Three-in-one: ``residual += x`` in place, RMSNorm the sum, emit FP8.
+
+    Two separate contracts are gated:
+      1. the residual buffer really is updated in place (checked against a
+         pre-seeded copy, and required NOT to equal the seed);
+      2. the FP8 output matches the kernel's exact intermediate — which is
+         NOT ``rmsnorm(round_fp16(r + x))``: the kernel accumulates the
+         sum-of-squares from the UNROUNDED fp32 sums but normalizes the
+         value it read back from the fp16 residual it just stored
+         (csrc/amd/kernels/norm_fp16.hip). The reference reproduces that
+         asymmetry deliberately; using the naive form would need a much
+         looser budget and would stop catching real drift.
+    """
+    torch, ext = env
+    S, D, eps = 64, 2048, 1e-6
+    torch.manual_seed(17)
+    residual = torch.randn(S, D, device="cuda").half()
+    seed = residual.clone()
+    x = torch.randn(S, D, device="cuda").half()
+    w = (1.0 + 0.1 * torch.randn(D, device="cuda")).half()
+
+    unrounded = seed.float() + x.float()
+    residual_ref = unrounded.half()
+    rms = torch.rsqrt(unrounded.pow(2).mean(-1, keepdim=True) + eps)
+    ref_f32 = residual_ref.float() * rms * w.float()
+    scale = _static_scale(torch, ref_f32).cuda()
+    out = torch.empty(S, D, device="cuda", dtype=torch.uint8)
+
+    ext.residual_add_rms_norm_fp8_fp16(
+        residual.data_ptr(), x.data_ptr(), w.data_ptr(), out.data_ptr(),
+        S, D, eps, scale.data_ptr(), _stream(torch))
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(residual.float(), residual_ref.float(),
+                               atol=ATOL_FP16, rtol=0.0)
+    assert not torch.allclose(residual.float(), seed.float(), atol=1e-2), (
+        "residual buffer was not updated in place")
+    _assert_fp8(torch, "residual_add_rms_norm_fp8_fp16", out, ref_f32, scale,
+                max_mismatch=FP8_MISMATCH_REDUCE)
+
+
+def test_layer_norm_fp8_static_fp16_vec_rounds_through_fp16(env):
+    """LayerNorm -> FP8 in one launch. The kernel rounds the normalized
+    value through fp16 before the e4m3 convert (it is the fused form of
+    ``layer_norm_fp16`` followed by ``quantize_fp8_static_fp16``), so the
+    reference rounds through fp16 too — otherwise the byte comparison
+    would drift on the elements where the two roundings disagree."""
+    torch, ext = env
+    S, D, eps = 64, 2048, 1e-6
+    torch.manual_seed(18)
+    x = torch.randn(S, D, device="cuda").half()
+    w = (1.0 + 0.1 * torch.randn(D, device="cuda")).half()
+    b = (0.1 * torch.randn(D, device="cuda")).half()
+    ref_f32 = torch.nn.functional.layer_norm(
+        x.float(), (D,), w.float(), b.float(), eps).half().float()
+    scale = _static_scale(torch, ref_f32).cuda()
+    out = torch.empty(S, D, device="cuda", dtype=torch.uint8)
+
+    rc = ext.layer_norm_fp8_static_fp16_vec(
+        x.data_ptr(), w.data_ptr(), b.data_ptr(), out.data_ptr(),
+        scale.data_ptr(), S, D, eps, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert rc == 0, f"vec path rejected an aligned dim={D} (rc={rc})"
+    _assert_fp8(torch, "layer_norm_fp8_static_fp16_vec", out, ref_f32, scale,
+                max_mismatch=FP8_MISMATCH_REDUCE)
+
+
+def test_residual_add_fp16_vec_matches_the_scalar_path(env):
+    """Vector residual accumulate: same pre-seeded-destination contract as
+    the scalar entry, plus rc == 0 on an n%8==0, 16-byte-aligned buffer."""
+    torch, ext = env
+    n = 64 * 2048
+    torch.manual_seed(19)
+    residual = torch.randn(n, device="cuda").half()
+    seed = residual.clone()
+    x = torch.randn(n, device="cuda").half()
+    ref = (seed.float() + x.float()).half()
+
+    rc = ext.residual_add_fp16_vec(residual.data_ptr(), x.data_ptr(), n,
+                                   _stream(torch))
+    torch.cuda.synchronize()
+
+    assert rc == 0, f"vec path rejected an aligned n={n} (rc={rc})"
+    torch.testing.assert_close(residual.float(), ref.float(),
+                               atol=ATOL_FP16, rtol=0.0)
+    assert not torch.allclose(residual.float(), x.float(), atol=1e-2), (
+        "residual_add_fp16_vec overwrote instead of accumulating")
+
+
+def test_gpu_repeat_interleave_heads_vec_matches_the_scalar_path(env):
+    """Vector GQA head expansion: bitwise identical to the scalar entry's
+    reference, plus rc == 0 on an HD%8==0, 16-byte-aligned geometry."""
+    torch, ext = env
+    S, NH_src, HD, repeat = 32, 8, 128, 2
+    torch.manual_seed(20)
+    src = torch.randn(S, NH_src, HD, device="cuda").half()
+    dst = torch.full((S, NH_src * repeat, HD), float("nan"),
+                     device="cuda", dtype=torch.half)
+    ref = torch.repeat_interleave(src, repeat, dim=1).contiguous()
+
+    rc = ext.gpu_repeat_interleave_heads_vec(src.data_ptr(), dst.data_ptr(),
+                                             S, NH_src, HD, repeat,
+                                             _stream(torch))
+    torch.cuda.synchronize()
+
+    assert rc == 0, f"vec path rejected HD={HD} (rc={rc})"
+    assert torch.equal(dst.view(torch.uint16), ref.view(torch.uint16))
+
+
+# ---------------------------------------------------------------------------
+# *_vec precondition contract
+# ---------------------------------------------------------------------------
+
+
+def test_vec_entries_reject_unsupported_geometry(env):
+    """Every ``*_vec`` entry returns -1 (not 0, not a crash) when its
+    divisibility / alignment precondition fails, and MUST NOT touch the
+    destination when it does.
+
+    This is the half of the contract the callers depend on: the pipeline
+    calls the vector entry, checks the status, and falls back to the
+    scalar kernel on -1. A vec entry that returned 0 while writing a
+    partial result — or that wrote a partial result before returning -1 —
+    would corrupt silently, because the fallback would then run on top of
+    half-written data. Preconditions are read from
+    csrc/amd/kernels/{norm_fp16,elementwise_fp16}.hip:
+    dim%8 / n%8 / n%16 / (HD/2)%8 / HD%8.
+    """
+    torch, ext = env
+    dev = "cuda"
+    torch.manual_seed(21)
+
+    # dim % 8 != 0 for the three norm entries (dim stays even so the
+    # non-vector packed path would still be legal — the rejection has to
+    # come from the vector precondition, not from a shape being absurd).
+    rows, bad_dim, eps = 4, 12, 1e-6
+    x = torch.randn(rows, bad_dim, device=dev).half()
+    w = (1.0 + 0.1 * torch.randn(bad_dim, device=dev)).half()
+    b = (0.1 * torch.randn(bad_dim, device=dev)).half()
+    scale = torch.tensor([0.01], dtype=torch.float32, device=dev)
+
+    out_f16 = torch.full((rows, bad_dim), float("nan"),
+                         device=dev, dtype=torch.half)
+    out_u8 = torch.full((rows, bad_dim), 0xAB, device=dev, dtype=torch.uint8)
+
+    rc = ext.rms_norm_fp16_vec(x.data_ptr(), w.data_ptr(), out_f16.data_ptr(),
+                               rows, bad_dim, eps, _stream(torch))
+    assert rc == -1, f"rms_norm_fp16_vec accepted dim={bad_dim} (rc={rc})"
+
+    rc = ext.layer_norm_fp16_vec(x.data_ptr(), w.data_ptr(), b.data_ptr(),
+                                 out_f16.data_ptr(), rows, bad_dim, eps,
+                                 _stream(torch))
+    assert rc == -1, f"layer_norm_fp16_vec accepted dim={bad_dim} (rc={rc})"
+
+    rc = ext.layer_norm_fp8_static_fp16_vec(
+        x.data_ptr(), w.data_ptr(), b.data_ptr(), out_u8.data_ptr(),
+        scale.data_ptr(), rows, bad_dim, eps, _stream(torch))
+    assert rc == -1, (
+        f"layer_norm_fp8_static_fp16_vec accepted dim={bad_dim} (rc={rc})")
+
+    # (HD/2) % 8 != 0
+    S, NH, bad_hd = 4, 2, 20
+    xr = torch.randn(S, NH * bad_hd, device=dev).half()
+    xr0 = xr.clone()
+    cos_t, sin_t = _rope_tables(torch, S, bad_hd)
+    rc = ext.rope_rotate_half_fp16_vec(xr.data_ptr(), cos_t.data_ptr(),
+                                       sin_t.data_ptr(), S, NH, bad_hd,
+                                       _stream(torch))
+    assert rc == -1, f"rope_rotate_half_fp16_vec accepted HD={bad_hd} (rc={rc})"
+
+    # n % 16 != 0 (quantize) and n % 8 != 0 (residual add)
+    bad_n_q, bad_n_r = 24, 12
+    xq = torch.randn(bad_n_q, device=dev).half()
+    oq = torch.full((bad_n_q,), 0xAB, device=dev, dtype=torch.uint8)
+    rc = ext.quantize_fp8_static_fp16_vec(xq.data_ptr(), oq.data_ptr(),
+                                          scale.data_ptr(), bad_n_q,
+                                          _stream(torch))
+    assert rc == -1, (
+        f"quantize_fp8_static_fp16_vec accepted n={bad_n_q} (rc={rc})")
+
+    res = torch.randn(bad_n_r, device=dev).half()
+    res0 = res.clone()
+    xr2 = torch.randn(bad_n_r, device=dev).half()
+    rc = ext.residual_add_fp16_vec(res.data_ptr(), xr2.data_ptr(), bad_n_r,
+                                   _stream(torch))
+    assert rc == -1, f"residual_add_fp16_vec accepted n={bad_n_r} (rc={rc})"
+
+    # HD % 8 != 0
+    bad_hd_r = 12
+    src = torch.randn(S, NH, bad_hd_r, device=dev).half()
+    dst = torch.full((S, NH * 2, bad_hd_r), float("nan"),
+                     device=dev, dtype=torch.half)
+    rc = ext.gpu_repeat_interleave_heads_vec(src.data_ptr(), dst.data_ptr(),
+                                             S, NH, bad_hd_r, 2,
+                                             _stream(torch))
+    assert rc == -1, (
+        f"gpu_repeat_interleave_heads_vec accepted HD={bad_hd_r} (rc={rc})")
+
+    torch.cuda.synchronize()
+
+    # Destinations untouched by every rejected call.
+    assert bool(torch.isnan(out_f16).all()), "rejected norm vec wrote output"
+    assert bool((out_u8 == 0xAB).all()), "rejected fp8 norm vec wrote output"
+    assert bool((oq == 0xAB).all()), "rejected quantize vec wrote output"
+    assert torch.equal(xr.view(torch.uint16), xr0.view(torch.uint16)), (
+        "rejected rope vec mutated its in-place buffer")
+    assert torch.equal(res.view(torch.uint16), res0.view(torch.uint16)), (
+        "rejected residual vec mutated its in-place buffer")
+    assert bool(torch.isnan(dst).all()), "rejected repeat vec wrote output"
+
+
+# ---------------------------------------------------------------------------
+# AdaLN family (LayerNorm math, BF16 + FP8 out)
+# ---------------------------------------------------------------------------
+
+# The AdaLN family defaults to eps 1e-5 (bf16 entries) and 1e-6
+# (ada_layer_norm_fp8); the tests pass eps explicitly so a changed default
+# shows up as a parity failure here rather than as DiT drift.
+_ADALN_EPS_BF16 = 1e-5
+_ADALN_EPS_FP8 = 1e-6
+
+
+def test_layer_norm_no_affine_bf16_has_no_weight(env):
+    """LayerNorm with NO affine at all: mean/variance normalize only. The
+    reference passes weight=None/bias=None explicitly, so a kernel that
+    quietly folded in a unit weight-and-bias would still pass, but one
+    that read a weight pointer it should not have would not."""
+    torch, ext = env
+    S, D = 64, 2048
+    torch.manual_seed(22)
+    x = torch.randn(S, D, device="cuda").bfloat16()
+    out = torch.empty(S, D, device="cuda", dtype=torch.bfloat16)
+    ref = torch.nn.functional.layer_norm(
+        x.float(), (D,), None, None, _ADALN_EPS_BF16).bfloat16()
+
+    ext.layer_norm_no_affine_bf16(x.data_ptr(), out.data_ptr(), S, D,
+                                  _ADALN_EPS_BF16, _stream(torch))
+    torch.cuda.synchronize()
+
+    assert _cos(torch, out, ref) > COS_TIGHT
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_BF16, rtol=0.0)
+
+
+def test_ada_layer_norm_bf16_applies_one_plus_scale(env):
+    """AdaLN modulation is ``LN(x) * (1 + scale) + shift`` — the ``1 +``
+    is the whole point (scale is a delta produced by the DiT conditioning
+    MLP and is near zero at init). The gate additionally requires the
+    output to DISAGREE with the ``LN(x) * scale + shift`` form, which is
+    the exact bug the ``1 +`` exists to prevent and which a cosine against
+    correlated data would not separate."""
+    torch, ext = env
+    S, D = 64, 2048
+    torch.manual_seed(23)
+    x = torch.randn(S, D, device="cuda").bfloat16()
+    scale = (0.2 * torch.randn(D, device="cuda")).bfloat16()
+    shift = (0.2 * torch.randn(D, device="cuda")).bfloat16()
+    out = torch.empty(S, D, device="cuda", dtype=torch.bfloat16)
+    ln = torch.nn.functional.layer_norm(x.float(), (D,), None, None,
+                                        _ADALN_EPS_BF16)
+    ref = (ln * (1.0 + scale.float()) + shift.float()).bfloat16()
+
+    ext.ada_layer_norm_bf16(x.data_ptr(), scale.data_ptr(), shift.data_ptr(),
+                            out.data_ptr(), S, D, _ADALN_EPS_BF16,
+                            _stream(torch))
+    torch.cuda.synchronize()
+
+    assert _cos(torch, out, ref) > COS_TIGHT
+    torch.testing.assert_close(out.float(), ref.float(),
+                               atol=ATOL_BF16, rtol=0.0)
+    no_one = (ln * scale.float() + shift.float())
+    assert _cos(torch, out.float(), no_one) < 0.99, (
+        "ada_layer_norm_bf16 dropped the '1 +' in (1 + scale)")
+
+
+def test_ada_layer_norm_fp8_rounds_through_bf16_before_quantizing(env):
+    """AdaLN straight to FP8 (reviewer-named entry point).
+
+    Contract from csrc/amd/kernels/adaln_layer_norm.hip: the modulated
+    value is rounded through bf16 IN REGISTERS before the e4m3 convert,
+    which is what makes this single launch bit-equivalent to the two-launch
+    ``ada_layer_norm_bf16`` -> ``quantize_fp8_static`` chain it replaces.
+    The reference therefore rounds through bf16 too, and the comparison is
+    byte-level against torch e4m3 with the SAME device scale — an
+    unquantized fp32 reference here would pass with the bf16 round-through
+    silently missing, which is precisely the regression that would break
+    equivalence with the two-launch form.
+    """
+    torch, ext = env
+    S, D = 64, 2048
+    torch.manual_seed(24)
+    x = torch.randn(S, D, device="cuda").bfloat16()
+    scale = (0.2 * torch.randn(D, device="cuda")).bfloat16()
+    shift = (0.2 * torch.randn(D, device="cuda")).bfloat16()
+    ln = torch.nn.functional.layer_norm(x.float(), (D,), None, None,
+                                        _ADALN_EPS_FP8)
+    modulated = ln * (1.0 + scale.float()) + shift.float()
+    ref_f32 = modulated.bfloat16().float()          # the bf16 round-through
+    act_scale = _static_scale(torch, ref_f32).cuda()
+    out = torch.empty(S, D, device="cuda", dtype=torch.uint8)
+
+    ext.ada_layer_norm_fp8(x.data_ptr(), scale.data_ptr(), shift.data_ptr(),
+                           out.data_ptr(), act_scale.data_ptr(), S, D,
+                           _ADALN_EPS_FP8, _stream(torch))
+    torch.cuda.synchronize()
+
+    _assert_fp8(torch, "ada_layer_norm_fp8", out, ref_f32, act_scale,
+                max_mismatch=FP8_MISMATCH_REDUCE)
+
+
+def test_ada_layer_norm_fp8_equals_the_two_launch_chain(env):
+    """The reason ada_layer_norm_fp8 exists: it must produce the same FP8
+    bytes as ``ada_layer_norm_bf16`` followed by ``quantize_fp8_static_fp16``
+    would, on the same input and scale. Gated against the FUSED kernel's
+    own two-launch equivalent (bf16 AdaLN, then the bf16 result quantized
+    by torch with the same scale) rather than against a fresh fp32
+    computation, so it isolates the fusion from the norm math already
+    gated above."""
+    torch, ext = env
+    S, D = 64, 2048
+    torch.manual_seed(25)
+    x = torch.randn(S, D, device="cuda").bfloat16()
+    scale = (0.2 * torch.randn(D, device="cuda")).bfloat16()
+    shift = (0.2 * torch.randn(D, device="cuda")).bfloat16()
+
+    two_launch = torch.empty(S, D, device="cuda", dtype=torch.bfloat16)
+    ext.ada_layer_norm_bf16(x.data_ptr(), scale.data_ptr(), shift.data_ptr(),
+                            two_launch.data_ptr(), S, D, _ADALN_EPS_FP8,
+                            _stream(torch))
+    torch.cuda.synchronize()
+
+    act_scale = _static_scale(torch, two_launch.float()).cuda()
+    fused = torch.empty(S, D, device="cuda", dtype=torch.uint8)
+    ext.ada_layer_norm_fp8(x.data_ptr(), scale.data_ptr(), shift.data_ptr(),
+                           fused.data_ptr(), act_scale.data_ptr(), S, D,
+                           _ADALN_EPS_FP8, _stream(torch))
+    torch.cuda.synchronize()
+
+    _assert_fp8(torch, "ada_layer_norm_fp8 vs two-launch chain", fused,
+                two_launch.float(), act_scale,
+                max_mismatch=FP8_MISMATCH_REDUCE)
+
+
+def test_bias_gelu_quantize_fp8_static_bf16_with_bias(env):
+    """``out_fp8 = quant(gelu_tanh(in + bias))``, bias broadcast over rows.
+    The GELU reference pins the tanh approximation (the kernel implements
+    0.5x(1+tanh(0.7978845608(x + 0.044715 x^3))) verbatim); the byte budget
+    covers one ULP of device ``tanhf``."""
+    torch, ext = env
+    S, D = 64, 2048
+    torch.manual_seed(26)
+    x = torch.randn(S, D, device="cuda").bfloat16()
+    bias = (0.1 * torch.randn(D, device="cuda")).bfloat16()
+    ref_f32 = _gelu_tanh(torch, x.float() + bias.float())
+    act_scale = _static_scale(torch, ref_f32).cuda()
+    out = torch.empty(S, D, device="cuda", dtype=torch.uint8)
+
+    ext.bias_gelu_quantize_fp8_static_bf16(
+        x.data_ptr(), bias.data_ptr(), out.data_ptr(), act_scale.data_ptr(),
+        S, D, _stream(torch))
+    torch.cuda.synchronize()
+
+    _assert_fp8(torch, "bias_gelu_quantize_fp8_static_bf16", out, ref_f32,
+                act_scale, max_mismatch=FP8_MISMATCH_RNE)
+    # The bias must actually land. A dequantized cosine cannot say so
+    # (gelu(x+b) and gelu(x) are ~0.995 correlated at this bias scale), so
+    # the discriminator is at the byte level: dropping the bias moves a
+    # large majority of the FP8 codes, hundreds of times the RNE budget.
+    no_bias_u8 = _fp8_ref_bytes(torch, _gelu_tanh(torch, x.float()),
+                                act_scale).reshape(out.shape)
+    changed = float((out != no_bias_u8).float().mean())
+    assert changed > 0.1, (
+        f"only {changed:.4f} of FP8 bytes differ from the un-biased GELU — "
+        "the bias was not applied")
+
+
+def test_bias_gelu_quantize_fp8_static_bf16_accepts_null_bias(env):
+    """The binding forwards a 0 bias pointer as ``nullptr`` (the C++ kernel
+    branches on it). That null path is a distinct code path in the kernel
+    and is what the no-bias production sites use, so it gets its own gate:
+    the result must be the un-biased GELU, not a read of address 0 and not
+    the biased form."""
+    torch, ext = env
+    S, D = 64, 2048
+    torch.manual_seed(26)
+    x = torch.randn(S, D, device="cuda").bfloat16()
+    ref_f32 = _gelu_tanh(torch, x.float())
+    act_scale = _static_scale(torch, ref_f32).cuda()
+    out = torch.empty(S, D, device="cuda", dtype=torch.uint8)
+
+    ext.bias_gelu_quantize_fp8_static_bf16(
+        x.data_ptr(), 0, out.data_ptr(), act_scale.data_ptr(),
+        S, D, _stream(torch))
+    torch.cuda.synchronize()
+
+    _assert_fp8(torch, "bias_gelu_quantize_fp8_static_bf16 (null bias)", out,
+                ref_f32, act_scale, max_mismatch=FP8_MISMATCH_RNE)
+
+
+# ---------------------------------------------------------------------------
+# smallm_mfma_bf16 — packed-weight small-M BF16 GEMM
+# ---------------------------------------------------------------------------
+
+# Real GROOT N1.7 DiT projection shapes at M=41 (csrc/amd/gemm/
+# smallm_mfma_bf16.h): q/k/v/o, ffn up, ffn down.
+SMALLM_BF16_SHAPES = [
+    ("dit_qkvo", 41, 1536, 1536),
+    ("dit_ff1", 41, 6144, 1536),
+    ("dit_ff2", 41, 1536, 6144),
+]
+
+SMALLM_BF16_EPILOGUES = ("bias", "bias_gelu", "bias_res")
+
+_SMALLM_BF16_FN = {
+    "bias": "smallm_mfma_bf16_nn_bias",
+    "bias_gelu": "smallm_mfma_bf16_nn_bias_gelu",
+    "bias_res": "smallm_mfma_bf16_nn_bias_res",
+}
+
+# cos gate for the packed GEMM: fp32 MFMA accumulation vs a torch fp32
+# matmul over the SAME bf16 operands — only the K-reduction order and the
+# final bf16 store differ, so 0.9999 is the same bar the hipBLASLt GEMM
+# entries are held to in tests/test_amd_kernel_parity.py.
+COS_SMALLM = 0.9999
+
+
+def _pack_bf16_weight(torch, W):
+    """The documented pack one-liner from csrc/amd/gemm/smallm_mfma_bf16.h.
+
+    W is the (K, N) row-major bf16 weight; the kernel consumes a linear
+    stream of 16-byte chunks in per-lane order, chunk index inside each
+    16-column n-tile being ``step*64 + lane`` with
+    ``lane = (k_group << 4) | n_lane``:
+
+        Wp = W.view(K//32, 4, 8, N//16, 16).permute(3, 0, 1, 4, 2)
+
+    Exercising the pack through this exact expression is the point: the
+    header documents it as the supported way to produce Wp, so if the
+    kernel's layout ever changes without the header, this test fails.
+    """
+    K, N = W.shape
+    return W.view(K // 32, 4, 8, N // 16, 16) \
+            .permute(3, 0, 1, 4, 2).contiguous()
+
+
+def _smallm_bf16_case(torch, M, N, K, seed):
+    """Real-distribution operands: unit-normal activations with heavy
+    post-residual rows, 0.02-sigma weights, 0.1-sigma bias. Constant or
+    ramp inputs would hide an accumulator or fragment-mapping bug."""
+    torch.manual_seed(seed)
+    A = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    A[::max(M // 4, 1)] *= 8.0
+    W = (0.02 * torch.randn(K, N, device="cuda")).to(torch.bfloat16)
+    bias = (0.1 * torch.randn(N, device="cuda")).to(torch.bfloat16)
+    return A, W, _pack_bf16_weight(torch, W), bias
+
+
+def _valid_variants(ext, K):
+    """Variant ids whose wave depth divides this K into a supported number
+    of MFMA steps (header: K/(32*waves) must be in {6, 12, 24, 48})."""
+    names = list(ext.smallm_mfma_bf16_variants())
+    ok = []
+    for vid, name in enumerate(names):
+        if name == "auto":
+            ok.append((vid, name))
+            continue
+        waves = 4 if name.startswith("w4") else 8
+        if K % (32 * waves) == 0 and K // (32 * waves) in (6, 12, 24, 48):
+            ok.append((vid, name))
+    return ok
+
+
+def test_smallm_mfma_bf16_variants_enumerator(env):
+    """The variant enumerator is pure host introspection and is what the
+    parity/bench harnesses iterate; it must answer with at least the
+    documented ``auto`` entry plus the w4/w8 x fused/split forms, and the
+    ids must be contiguous from 0 (the binding passes the index straight
+    through as the ``variant`` argument)."""
+    torch, ext = env
+    names = list(ext.smallm_mfma_bf16_variants())
+    assert len(names) >= 5, f"expected auto + 4 launch forms, got {names}"
+    assert names[0] == "auto", f"variant 0 must be the auto heuristic: {names}"
+    assert all(isinstance(n, str) and n for n in names)
+    assert len(set(names)) == len(names), f"duplicate variant names: {names}"
+
+
+@pytest.mark.parametrize("label,M,N,K", SMALLM_BF16_SHAPES,
+                         ids=[s[0] for s in SMALLM_BF16_SHAPES])
+@pytest.mark.parametrize("epilogue", SMALLM_BF16_EPILOGUES)
+def test_smallm_mfma_bf16_epilogue_parity(env, label, M, N, K, epilogue):
+    """Every epilogue x every valid launch variant x every production
+    shape, against a torch fp32 matmul over the SAME bf16 operands.
+
+    Semantics gated per epilogue (csrc/amd/gemm/smallm_mfma_bf16.h):
+      bias      : D = bf16(A@W + bias)             — bias broadcast over N
+      bias_gelu : D = bf16(gelu_tanh(A@W + bias))  — tanh approx, and the
+                  result is required to differ from the plain-bias form so
+                  a dropped activation cannot pass
+      bias_res  : D = bf16(float(D) + A@W + bias)  — ACCUMULATE into a
+                  pre-seeded destination, and the result is required to
+                  differ from the non-accumulated form so a beta=0
+                  regression cannot pass
+
+    Running every variant matters because they are different kernels
+    (fused vs split m-tile placement, 4 vs 8 waves): a fragment-mapping or
+    LDS-reduction bug can be present in one and absent in the others.
+    """
+    torch, ext = env
+    A, W, Wp, bias = _smallm_bf16_case(torch, M, N, K, seed=M * 7919 + N + K)
+    base = A.float() @ W.float() + bias.float()
+    if epilogue == "bias_gelu":
+        expected_no_res = _gelu_tanh(torch, base)
+    else:
+        expected_no_res = base
+
+    torch.manual_seed(1234)
+    seed_buf = torch.randn(M, N, device="cuda", dtype=torch.bfloat16)
+    fn = getattr(ext, _SMALLM_BF16_FN[epilogue])
+
+    variants = _valid_variants(ext, K)
+    assert variants, f"no valid launch variant for K={K}"
+    for vid, vname in variants:
+        D = torch.full((M, N), float("nan"), device="cuda",
+                       dtype=torch.bfloat16)
+        if epilogue == "bias_res":
+            D.copy_(seed_buf)
+            ref = seed_buf.float() + expected_no_res
+        else:
+            ref = expected_no_res
+
+        fn(A.data_ptr(), Wp.data_ptr(), bias.data_ptr(), D.data_ptr(),
+           M, N, K, vid, _stream(torch))
+        torch.cuda.synchronize()
+
+        assert bool(torch.isfinite(D.float()).all()), (
+            f"{label}/{epilogue}/{vname}: non-finite output (unwritten tile)")
+        c = _cos(torch, D, ref)
+        assert c > COS_SMALLM, (
+            f"{label}/{epilogue}/{vname} M={M} N={N} K={K}: cos={c:.7f}")
+
+        if epilogue == "bias_res":
+            assert _cos(torch, D.float(), expected_no_res) < 0.999, (
+                f"{vname}: bias_res overwrote D instead of accumulating")
+        if epilogue == "bias_gelu":
+            assert _cos(torch, D.float(), base) < 0.999, (
+                f"{vname}: bias_gelu did not apply the activation")
+
+
+def test_smallm_mfma_bf16_requires_the_documented_pack_layout(env):
+    """Feeding the SAME weight bytes UNPACKED must give the wrong answer.
+
+    The packed layout is the kernel's whole contract with the caller (a
+    (K,N) row-major weight is reinterpreted as a per-lane consumption-order
+    stream of 16-byte chunks). An unpacked weight has identical size and
+    alignment, so the kernel runs happily and returns garbage — which is
+    exactly why a parity test that only ever feeds the packed form cannot
+    tell whether the pack one-liner in the header is still correct. This
+    gate pins that the permutation is load-bearing: if the kernel ever
+    started accepting the plain layout, the header's documented one-liner
+    (and every caller following it) would be silently wrong.
+    """
+    torch, ext = env
+    M, N, K = 41, 1536, 1536
+    A, W, Wp, bias = _smallm_bf16_case(torch, M, N, K, seed=999)
+    ref = A.float() @ W.float() + bias.float()
+
+    D_packed = torch.full((M, N), float("nan"), device="cuda",
+                          dtype=torch.bfloat16)
+    ext.smallm_mfma_bf16_nn_bias(A.data_ptr(), Wp.data_ptr(), bias.data_ptr(),
+                                 D_packed.data_ptr(), M, N, K, 0,
+                                 _stream(torch))
+    torch.cuda.synchronize()
+    assert _cos(torch, D_packed, ref) > COS_SMALLM, "packed control arm"
+
+    W_plain = W.contiguous()
+    assert W_plain.numel() == Wp.numel(), "unpacked arm must read the same bytes"
+    D_plain = torch.full((M, N), float("nan"), device="cuda",
+                         dtype=torch.bfloat16)
+    ext.smallm_mfma_bf16_nn_bias(A.data_ptr(), W_plain.data_ptr(),
+                                 bias.data_ptr(), D_plain.data_ptr(),
+                                 M, N, K, 0, _stream(torch))
+    torch.cuda.synchronize()
+    assert _cos(torch, D_plain, ref) < 0.99, (
+        "the unpacked weight produced a correct result — the documented "
+        "pack one-liner is no longer the layout the kernel consumes")

--- a/tests/test_amd_no_global_patching.py
+++ b/tests/test_amd_no_global_patching.py
@@ -1,0 +1,104 @@
+"""The AMD frontends must not mutate third-party module state.
+
+An earlier revision worked around a transformers offline-mode bug by
+replacing ``huggingface_hub.model_info`` — first permanently at import,
+then temporarily around one call. Both are wrong for a library: the
+substitution is visible to every other thread in the process, and a
+save/restore pair is not safe under concurrency (two interleaved scopes
+can leave a wrapper installed for good).
+
+These gates pin the current contract: importing or constructing the AMD
+frontends leaves third-party callables untouched, and the offline case
+is handled by reporting it with an injection point instead.
+"""
+import importlib
+
+import pytest
+
+# Third-party callables an earlier revision replaced, plus the ones most
+# likely to be reached for by a future workaround.
+_WATCHED = [
+    ("huggingface_hub", "model_info"),
+    ("huggingface_hub", "snapshot_download"),
+]
+
+_AMD_FRONTENDS = [
+    "flash_rt.amd.frontends.torch.pi05",
+    "flash_rt.amd.frontends.torch.groot_n17",
+]
+
+
+def _snapshot():
+    """Identity of each watched callable, skipping absent modules."""
+    seen = {}
+    for mod_name, attr in _WATCHED:
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        fn = getattr(mod, attr, None)
+        if fn is not None:
+            seen[(mod_name, attr)] = fn
+    return seen
+
+
+@pytest.mark.parametrize("frontend", _AMD_FRONTENDS)
+def test_importing_a_frontend_leaves_third_party_callables_alone(frontend):
+    """Importing a frontend must not swap out third-party functions."""
+    before = _snapshot()
+    if not before:
+        pytest.skip("huggingface_hub is not installed here")
+    try:
+        importlib.import_module(frontend)
+    except ImportError as exc:
+        pytest.skip(f"{frontend} not importable here: {exc}")
+    after = _snapshot()
+    for key, original in before.items():
+        assert after.get(key) is original, (
+            f"importing {frontend} replaced {key[0]}.{key[1]}")
+
+
+@pytest.mark.parametrize("frontend", _AMD_FRONTENDS)
+def test_frontend_source_does_not_assign_to_third_party_globals(frontend):
+    """Guard the pattern itself, not just its effect at import time.
+
+    A workaround installed inside a function would pass the import test
+    above while still mutating shared state when it runs, so the source
+    must not assign to the watched attributes at all.
+    """
+    try:
+        module = importlib.import_module(frontend)
+    except ImportError as exc:
+        pytest.skip(f"{frontend} not importable here: {exc}")
+    source = open(module.__file__, encoding="utf-8").read()
+    for mod_name, attr in _WATCHED:
+        for alias in (mod_name, mod_name.split(".")[-1], "hh"):
+            assert f"{alias}.{attr} =" not in source, (
+                f"{frontend} assigns to {alias}.{attr}; a library must not "
+                f"replace third-party callables, even temporarily")
+
+
+def test_groot_frontend_exposes_a_processor_injection_point():
+    """The supported alternative to patching must stay available.
+
+    Offline callers build the processor themselves and inject it, which
+    is why the frontend does not need to touch huggingface_hub.
+    """
+    try:
+        mod = importlib.import_module(
+            "flash_rt.amd.frontends.torch.groot_n17")
+    except ImportError as exc:
+        pytest.skip(f"GROOT AMD frontend not importable here: {exc}")
+    cls = mod.GrootN17TorchFrontendAmd
+    assert hasattr(cls, "set_hf_processor")
+
+    class _Stub:
+        pass
+
+    stub = _Stub()
+    # Bypass __init__ (it needs a device and a checkpoint): the setter and
+    # the cache lookup are what this gate covers.
+    obj = cls.__new__(cls)
+    cls.set_hf_processor(obj, stub)
+    assert cls._hf_processor(obj) is stub, (
+        "an injected processor must be used without attempting a load")


### PR DESCRIPTION
Stacked on #189 (the AMD CDNA4 backend). Review that one first — this branch contains its commits.

## Summary

Adds GROOT N1.7 to the AMD MI350X (gfx950 / CDNA4) backend: an FP8 kernel backbone with an unquantized bf16 DiT action head. Same contracts as the rest of the backend — bare-kernel hot path, raw-pointer ABI, capture-then-replay, real-data calibration.

Precision scope, stated precisely: the Thor and RTX FP8 frontends inherit `_DIT_USE_FP8 = True` and additionally quantize the DiT FFN and fused self-attention QKV. This backend sets `_DIT_USE_FP8 = False`, so its DiT is fully bf16 — a **less** quantized tier than its CUDA counterparts. Porting that DiT calibration path to CDNA4 is open work and remains available headroom rather than something this PR ships.

## Performance

GROOT N1.7 (3.1 B), 2 camera views, 4-step flow matching, action horizon 40. Median **full-frame** latency — a fresh observation through the backbone graph plus the action chain, i.e. what a serving loop pays per frame:

| Configuration | Latency | vs eager |
|---|---|---|
| PyTorch eager (official policy) | 67.9 ms | 1.00× |
| torch.compile (max-autotune) | 77.9 ms | 0.87× |
| **FlashRT AMD, FP8 backbone + bf16 DiT** | **16.0 ms** | **4.24×** |

`torch.compile` is slower than eager for this model on this stack, so the judged baseline is eager. The frame splits into roughly 7 ms of backbone replay and 9 ms of action chain; deployments that reuse backbone features across frames pay only the latter.

Accuracy: combined denormalized-action cosine 0.9995 against the reference with the initial noise pinned (the 1-D gripper channel is near-constant over a trajectory, so its cosine is not a useful gate and is reported separately).

How it got there, each step an A/B with one variable changed in one process and an accuracy gate:

| Step | Full-frame median |
|---|---|
| First working port | 21.2 ms |
| Timed hipBLASLt algorithm selection | 20.6 ms |
| Fused GEMM epilogues (backbone + DiT) | 18.4 ms |
| Fused frontend closure epilogues | 18.2 ms |
| Fused norm→quantize chains, residual-accumulate GEMMs | 17.5 ms |
| Packed-weight MFMA GEMMs on the DiT projections | 16.0 ms |

## What is new here

- `flash_rt/amd/models/groot_n17/pipeline.py` — the five backbone forwards plus an AMD-local `dit_forward`. The decomposed form mirrors the RTX FP8 path exactly; the fused tier uses hipBLASLt epilogues that the CUDA SM120 path cannot (fused FP8 bias and bias+GELU), so this backend starts from a more fused shape than its CUDA twin.
- `flash_rt/amd/frontends/torch/groot_n17.py` — subclasses the existing GROOT frontend and its FP8 backbone mixin, overriding eight hooks (kernel-module seeding, the backbone stage driver, the attention backend, cross-KV setup and refresh, DiT graph capture, and the processor load). `torch.cuda.CUDAGraph` is HIP-backed, so the base class's graph machinery is reused unchanged.
- `flash_rt/amd/hardware/cdna4/attn_backend_groot_n17.py` — one backend for all five attention sites. aiter beat torch SDPA at every measured GROOT geometry (1.19×–1.83×), including head_dim 48 and the GQA causal site; `FVK_AMD_ATTN=sdpa` remains the fallback. The LLM K/V slots keep the model's native 8 KV heads because aiter does GQA internally.
- `csrc/amd/gemm/` — FP16 GEMM and FP8 bias/GELU/descale epilogue entry points (signature-identical to the CUDA class), lazy timed algorithm selection, and a bf16 packed-weight small-M MFMA family.
- `csrc/amd/kernels/` — the FP16 elementwise / norm / rope / quantize families and LayerNorm-style AdaLN kernels the model needs.

## Kernel routing policy

The hand-written MFMA GEMM is routed only where it measured faster than the autotuned library: the DiT projections at M=41 (1.41× on the bias epilogue, 951 GB/s versus 673 GB/s effective weight bandwidth). The FFN shapes measured slower and deliberately stay on hipBLASLt. `FVK_AMD_DIT_GEMM=hipblaslt` disables the routing; `FVK_AMD_FUSED_EPILOGUE=0` selects the decomposed form. Both are read at setup only.

## Validation

Every entry point this branch adds to `csrc/amd` is gated numerically. The three binding fragments contribute 54 entry points (21 in the hipBLASLt runner, 4 in the packed-weight MFMA family, 29 in the fp16/bf16/fp8-fusion/AdaLN kernels) and all 54 now have tests:

- `tests/test_amd_kernel_parity.py` — extended to the full `GemmRunner` surface (`fp16_nn`, `fp8_nn_bias`, `fp8_nn_gelu_bias`, `fp8_descale_fp16`, `bf16_nn_res`, `bf16_nn_bias`, `bf16_nn_bias_gelu`, `bf16_nn_bias_res`, `bf16_run`, `mxfp4_nt_dev`, and the autotune entry points).
- `tests/test_amd_kernel_parity_groot.py` — the packed-weight `smallm_mfma_bf16_*` family and the 29 hand-written kernels, including `ada_layer_norm_fp8`, `silu_mul_split_fp8_fp16`, `layer_norm_fp8_static_fp16_vec` and the `*_vec` status contracts.
- `tests/test_amd_groot_routing.py` — pipeline-map entry, `load_model` precision-tier contracts, attention-backend site and layer-index validation. Runs without a GPU.
- `tests/test_amd_groot_model.py` — end-to-end: `set_prompt` through the FP8 kernel backbone (asserted via the baked per-stage scales, so a silent fallback fails the test), finite actions of the expected shape, bit-identical results under a pinned initial noise, and a cosine gate against a reference fixture when provided.

The gates assert semantics rather than a loose cosine: FP8 outputs are byte-compared against a `torch.float8_e4m3fn` cast through the same device scale, replicating the kernel's reciprocal-multiply (zero permitted byte differences on the pure multiply-clamp-convert paths); residual-accumulate variants run against a pre-seeded destination and must not match the non-accumulated form; bias and GELU variants are pinned to the tanh approximation with a discriminator that fails if the term is dropped; and the packed-weight GEMM is additionally fed the same weights unpacked, which must produce a wrong answer, proving the permutation is load-bearing.

### Running the tests

On a gfx950 machine with ROCm 7.x and a ROCm PyTorch build:

```bash
# 1. build the extension (rejects a non-gfx950 target)
bash scripts/amd/build_amd.sh gfx950

# 2. hardware-independent gates — also runnable on a CUDA-only box,
#    where every ROCm-dependent case skips with a stated reason
python -m pytest tests/test_amd_routing.py tests/test_amd_arch_gate.py \
                 tests/test_amd_groot_routing.py -v

# 3. per-kernel parity for every entry point (needs the built .so
#    and a ROCm device)
python -m pytest tests/test_amd_kernel_parity.py \
                 tests/test_amd_kernel_parity_groot.py -v

# 4. extension inventory and HIP graph capture/replay
python -m pytest tests/test_amd_extension.py tests/test_amd_hip_graph.py -v

# 5. model-level gates (checkpoints and fixtures via environment)
export FLASH_RT_GROOT_N17_AMD_CKPT=<groot_n17_checkpoint_dir>
export FLASH_RT_GROOT_N17_AMD_AUX=<processor_aux_bundle.pt>
export FLASH_RT_GROOT_N17_AMD_REF=<reference_fixture.pt>        # optional
export FLASH_RT_PI05_AMD_CKPT=<pi05_checkpoint_dir>             # for the pi05 gates
python -m pytest tests/test_amd_pi05_model.py \
                 tests/test_amd_groot_model.py -v
```

Results on an MI350X: step 3 gives **111 passed, 1 skipped** (the skip is `mxfp4_nt_dev`, which hipBLASLt reports no algorithm for at that shape — a library capability gap, not a kernel regression), and steps 2, 4 and 5 together give **90 passed, 2 skipped**. Total **201 passed, 3 skipped, 0 failed**. On a CUDA-only machine the whole suite collects cleanly and every hardware-dependent case skips with a stated reason.

Attention runs on aiter when importable and falls back to torch SDPA otherwise; the numbers above are with aiter available.

## Docs

`docs/deployment_amd_groot_n17.md` (model guide: performance, precision tier, attention, fusion and routing knobs, tests, reproduction) linked from `docs/deployment_amd.md`, which is the model-independent AMD guide.

