### PR TITLE
Fix scalar timestep construction during PI0.5 graph capture

### DIFF
--- a/docs/pi05_scalar_capture.md
+++ b/docs/pi05_scalar_capture.md
@@ -1,0 +1,40 @@
+# Scalar timestep capture compatibility
+
+Target: LeRobot PI0.5 `sample_actions`, FP32 scalar timestep to fixed-step
+denoising, batch 1, action horizon 10, padded action width 32, three RGB views.
+The boundary is host graph lowering, not a new structure or kernel. The
+consumer remains the original host method; Nexus only receives its later export.
+
+## Coverage and ownership
+
+The existing `bindings/pi05_tick.yaml` supplies the complete hot-path map.
+Native symbols below refer to `flash_rt/models/pi05/pipeline_rtx.py`.
+This fix qualifies only scalar construction, not the other regions' performance.
+
+| Native region / symbol | Existing owner | Classification for this change |
+|---|---|---|
+| `input_images_buf`, `set_language_embeds` | host input processing | intentionally_retained |
+| `vision_encoder`, `_vision_layer` | vision FFN, QKV, attention, normalization | configured, unchanged |
+| vision projector in `vision_encoder` | linear projection | configured, unchanged |
+| `transformer_encoder`, `_encoder_layer` | prefix FFN, QKV, attention, normalization | configured, unchanged |
+| encoder K/V buffers | prefix state | host_stage_or_state, unchanged |
+| `transformer_decoder` fixed-step loop | host schedule lowering | host_stage_or_state, scalar construction under test |
+| decoder time/style tables | adaptive-normalization producer | configured, unchanged |
+| decoder action input projection | linear projection | configured, unchanged |
+| `_decoder_layer` | denoise transformer structures | configured, unchanged |
+| final adaptive norm and action projection | normalization and projection | configured, unchanged |
+| `input_noise_buf` | action/noise window | host_stage_or_state, unchanged |
+
+LeRobot constructs `torch.tensor(time, dtype=float32, device=device)` each
+step. OpenPI's PyTorch `sample_actions` also constructs scalar `dt` and initial
+`time`; the broader fixed-loop normalization remains a separate concern.
+The list-shaped schedule already has a resident-cache path. A scalar must
+instead be constructed device-natively: caching a mutable scalar could retain
+the previous call's updates. No unrelated-model catalog generalization is made.
+
+No Hub API is missing at this boundary: PyTorch's `full` supplies the scalar
+construction. Existing Hub kernels, calibration, precision and routing are
+unchanged. CPU contracts cover scalar shape/dtype/value, list preservation,
+recognition and restoration. GPU gates cover eager and compiled capture plus
+repeated changing inputs. Full-model parity and task acceptance are separate
+gates; passing the scalar contract alone does not certify the deployment.

--- a/flash_rt/structures/impls/graph_lowering/pi052_denoise.py
+++ b/flash_rt/structures/impls/graph_lowering/pi052_denoise.py
@@ -16,6 +16,8 @@ device resolves to a cached resident tensor — same values, same
 device, same dtype, allocated once outside capture. Everything else
 passes straight through, the schedule stays value-identical by
 construction, and the undo restores the host method bit-for-bit.
+Scalar constructors use device-native fills instead of a CPU staging copy;
+unlike list schedules, mutable scalars are not cached between calls.
 """
 
 from __future__ import annotations
@@ -60,6 +62,9 @@ class Pi05DenoiseGraphLoweringAdapter:
 
         def caching_tensor(data, *args, **kwargs):
             device = kwargs.get("device")
+            if (device is not None and not args
+                    and isinstance(data, (float, int, bool))):
+                return torch.full((), data, **kwargs)
             if (device is not None and isinstance(data, (list, tuple))
                     and data
                     and all(isinstance(x, (float, int, bool))

--- a/tests/test_pi05_scalar_capture.py
+++ b/tests/test_pi05_scalar_capture.py
@@ -1,0 +1,92 @@
+"""Host-constructor contracts, not model calibration or quality fixtures."""
+
+import pytest
+import torch
+
+from flash_rt.structures.impls.graph_lowering.pi052_denoise import (
+    Pi05DenoiseGraphLoweringAdapter,
+)
+
+
+class FlowHost(torch.nn.Module):
+    paligemma_with_expert = None
+
+    def embed_suffix(self):
+        pass
+
+    def denoise_step(self):
+        pass
+
+    def sample_actions(self, data, **kwargs):
+        return torch.tensor(data, **kwargs)
+
+
+@pytest.mark.parametrize("data", [0.3, 2, True, [0.3, 0.2]])
+@pytest.mark.parametrize("dtype", [None, torch.float32, torch.float64])
+def test_constructor_value_shape_dtype_and_restore(data, dtype):
+    host = FlowHost()
+    original = torch.tensor
+    expected = host.sample_actions(data, device="cpu", dtype=dtype)
+    lowering = Pi05DenoiseGraphLoweringAdapter().lower(host, lambda: None)
+    try:
+        actual = host.sample_actions(data, device="cpu", dtype=dtype)
+        assert torch.equal(actual, expected)
+        assert actual.shape == expected.shape and actual.dtype == expected.dtype
+        assert torch.tensor is original
+    finally:
+        lowering.undo()
+    assert "sample_actions" not in host.__dict__
+    assert torch.equal(host.sample_actions(data, device="cpu", dtype=dtype), expected)
+
+
+def test_scalar_is_fresh_and_unrecognized_host_is_unchanged():
+    original = torch.tensor
+    adapter = Pi05DenoiseGraphLoweringAdapter()
+    assert adapter.lower(torch.nn.Identity(), lambda: None) is None
+    host = FlowHost()
+    lowering = adapter.lower(host, lambda: None)
+    try:
+        host.sample_actions(0.5, device="cpu").add_(1)
+        assert host.sample_actions(0.5, device="cpu").item() == 0.5
+        with pytest.raises(RuntimeError, match="Could not infer dtype"):
+            host.sample_actions(object(), device="cpu")
+        assert torch.tensor is original
+    finally:
+        lowering.undo()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA capture gate")
+@pytest.mark.parametrize("compiled", [False, True])
+def test_scalar_and_list_capture_repeated_inputs(compiled):
+    host = FlowHost()
+    lowering = Pi05DenoiseGraphLoweringAdapter().lower(host, lambda: None)
+    inputs = torch.ones(3, device="cuda")
+
+    def hot():
+        scalar = host.sample_actions(0.25, device=inputs.device, dtype=inputs.dtype)
+        schedule = host.sample_actions([0.5, 0.25], device=inputs.device,
+                                       dtype=inputs.dtype)
+        return inputs * scalar + schedule.sum()
+
+    expected = hot()
+    run = torch.compile(hot) if compiled else hot
+    try:
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                run()
+        stream.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            output = run()
+        for value in (1, 3, 1):
+            with torch.cuda.stream(stream):
+                inputs.fill_(value)
+                graph.replay()
+            stream.synchronize()
+            torch.testing.assert_close(output, expected + (value - 1) * 0.25,
+                                       atol=0, rtol=0)
+    finally:
+        lowering.undo()
+        torch._dynamo.reset()


### PR DESCRIPTION
## Scope

Fix scalar timestep construction in the existing PI0.5 host graph lowering.
LeRobot's current `sample_actions` constructs a scalar tensor per denoise step;
after a graph break that becomes an uncapturable CPU-to-CUDA staging copy.
The existing lowering handled list schedules only.

Use `torch.full((), value, ...)` for explicit-device Python scalars. Scalars
remain fresh so in-place timestep updates cannot contaminate a later call.
List schedules keep their existing cache. No model forward, calibration,
kernel, package metadata, architecture routing, exec or runtime ABI changes.

This is a host-stage compatibility fix, not a new catalog structure or a
performance claim. The native coverage/ownership map is in
`docs/pi05_scalar_capture.md`. OpenPI's scalar timestep form is source evidence;
its full tensor-controlled loop is not newly qualified by this PR.

## Validation

- RTX 5090 / SM120, PyTorch 2.11.0+cu128, Transformers 5.5.4,
  LeRobot revision `c31f1b0f`.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. python -m pytest -q tests/test_pi05_scalar_capture.py tests/test_graph_lowering_registry.py`:
  18 passed, including eager and compiled CUDA capture, repeated input 1/3/1,
  scalar value/shape/dtype, list regression, negative recognition and restore.
- PI0.5 LIBERO, three views, batch 1, chunk 10, padded action width 32:
  the formerly failing full capture completed with 317 swaps and cosine
  0.999603 against the same-input stock reference. This is a calibration-frame
  residual, not held-out accuracy or a speedup claim.
- Full deployment export through Nexus executed successfully. Two recorded
  observations (the calibration frame and one held-out frame), same seed per
  observation, stock versus optimized robot-space actions: minimum cosine
  0.9998608, maximum absolute error 0.0268385. This is a smoke, not a benchmark.
- LeRobot + Structures + Nexus completed LIBERO task 0 / init 0, seed 7:
  85 steps, 15 chunks, zero fallback/late/held actions after correcting the
  consumer's control clock. This single-episode smoke does not certify a full
  model benchmark. No other hardware is claimed qualified.

## Structures self-review

- [x] Owning layer and affected host-stage contract identified; no kernel work.
- [x] Existing structural recognition preserved and negative case tested.
- [x] No catalog bytes, calibration API, precision scheme or hardware table changed.
- [x] Focused tests cover values, mutable-scalar freshness, restore, compile/capture.
- [x] No local paths, credentials, checkpoints, generated binaries or logs in diff.
- [x] Optional imports and public signatures unchanged.
- [x] Held-out action smoke and one task episode recorded; no performance or full-benchmark certification claimed.
