### PR TITLE
feat(pi05): add no-CUDA-Graph mode for kernel profiling on Orin-64G

### DIFF
--- a/docs/deployment_orin.md
+++ b/docs/deployment_orin.md
@@ -65,6 +65,7 @@ pipe = Pi05TorchFrontendRtx(
     vision_pool_factor=1,  # 1=no pool, 2=2×2, 4=4×4
     vision_num_layers=27,  # SigLIP layers (1-27)
     cache_frames=1,        # 1=bit-equal lossless, 2=K/V reuse (cos 0.991)
+    use_cuda_graph=True,   # False=normal kernel dispatch for inspecting kernels with nsys
 )
 pipe.set_prompt("pick up the black envelope on the table")
 pipe.calibrate_with_real_data([obs])  # once at startup, ~2 s
@@ -155,6 +156,26 @@ python examples/orin/bench_pi05.py \
 `bench_pi05.py` reports p50 / p95 / min latency and computed Hz. The cosine
 numbers above were measured separately against the BF16 reference path on the
 same fixed-seed sequence.
+
+### Inspect individual kernels with Nsight Systems
+
+The benchmark uses CUDA Graph capture/replay by default. To make individual
+kernel launches visible in an Nsight Systems timeline, add `--no-cuda-graph`:
+
+```bash
+nsys profile --trace=cuda,nvtx,osrt -o pi05_no_graph \
+  python examples/orin/bench_pi05.py \
+  --checkpoint /path/to/pi05_droid_pytorch \
+  --preset lossless \
+  --warmup 3 --reps 10 \
+  --no-int8 --no-cuda-graph
+```
+
+`--no-cuda-graph` disables only CUDA Graph capture/replay; calibration and
+kernel autotuning still run. It supports both `cache_frames=1` and
+`cache_frames=2`. This mode is intended for kernel inspection and debugging,
+not for measuring production latency. The benchmark prints
+`cuda_graph=False` when the option is active.
 
 ## Known limitations on SM87
 

--- a/examples/orin/bench_pi05.py
+++ b/examples/orin/bench_pi05.py
@@ -63,6 +63,9 @@ def parse_args():
                    help="Enable INT8 fast path (sets FVK_PI05_RTX_FORCE_INT8=1, default ON)")
     p.add_argument("--no-int8", dest="int8", action="store_false",
                    help="Run BF16 reference path instead of INT8 fast path")
+    p.add_argument("--no-cuda-graph", dest="use_cuda_graph",
+                   action="store_false", default=True,
+                   help="Disable CUDA Graph capture/replay for kernel profiling")
     return p.parse_args()
 
 
@@ -101,6 +104,7 @@ def main():
         vision_pool_factor=args.pool,
         vision_num_layers=args.layers,
         cache_frames=args.cache_frames,
+        use_cuda_graph=args.use_cuda_graph,
     )
 
     pipe.set_prompt(args.prompt)
@@ -130,7 +134,8 @@ def main():
     print("=" * 55)
     print(f"  Config : num_views={args.num_views}  pool={args.pool}"
           f"  layers={args.layers}  steps={args.steps}"
-          f"  cache_frames={args.cache_frames}")
+          f"  cache_frames={args.cache_frames}"
+          f"  cuda_graph={args.use_cuda_graph}")
     print(f"  Actions: {out['actions'].shape}")
     print(f"  p50    : {p50:.1f} ms   → {1000/p50:.2f} Hz")
     print(f"  p95    : {p95:.1f} ms")

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -1384,17 +1384,16 @@ class Pi05TorchFrontendRtx:
                     "(~0.96 vs dynamic 0.991 on test sequence). Set "
                     "FVK_PI05_RTX_INT8_ENCODER_STATIC=0 to disable.")
             self.pipeline.autotune_gemms()
-            if self.use_cuda_graph:
-                from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
-                apply_frontend_capture_hooks(self)
-                self.pipeline.record_infer_graph(external_stream_int=stream_int)
+            self._record_infer_graph_if_enabled(stream_int)
 
         self.calibrated = True
         self.graph_recorded = self.use_cuda_graph
         self._precision_spec = self._snapshot_precision_spec(
             method="single_frame", n=1, percentile=None)
         self._warn_if_scale_ceiling_exceeded()
-        logger.info("Calibration + graph capture complete")
+        logger.info(
+            "Calibration%s complete",
+            " + graph capture" if self.use_cuda_graph else "")
 
     def _calibrate_multi_frame(
         self, obs_list, *, percentile: float, verbose: bool,
@@ -1452,10 +1451,7 @@ class Pi05TorchFrontendRtx:
 
             self.pipeline.fp8_calibrated = True
             self.pipeline.autotune_gemms()
-            if self.use_cuda_graph:
-                from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
-                apply_frontend_capture_hooks(self)
-                self.pipeline.record_infer_graph(external_stream_int=stream_int)
+            self._record_infer_graph_if_enabled(stream_int)
 
         self.calibrated = True
         self.graph_recorded = self.use_cuda_graph
@@ -1463,14 +1459,24 @@ class Pi05TorchFrontendRtx:
             method="percentile", n=n, percentile=percentile)
         self._warn_if_scale_ceiling_exceeded(label=f"pi05_rtx_N{n}")
         logger.info(
-            "Pi0.5 multi-frame calibration + graph capture complete "
-            "(N=%d, percentile=%.2f)", n, percentile)
+            "Pi0.5 multi-frame calibration%s complete "
+            "(N=%d, percentile=%.2f)",
+            " + graph capture" if self.use_cuda_graph else "",
+            n, percentile)
 
     def _zero_pipeline_scales(self) -> None:
         for buf in self.pipeline.fp8_act_scales.values():
             buf.zero_()
         for buf in getattr(self.pipeline, "int8_act_scales", {}).values():
             buf.zero_()
+
+    def _record_infer_graph_if_enabled(self, stream_int: int) -> None:
+        """Apply capture hooks and record graphs when graph mode is enabled."""
+        if not self.use_cuda_graph:
+            return
+        from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
+        apply_frontend_capture_hooks(self)
+        self.pipeline.record_infer_graph(external_stream_int=stream_int)
 
     def _warn_if_scale_ceiling_exceeded(self, label: str = "pi05_rtx") -> None:
         """Diagnostic warning if any FP8 scale exceeds the sanity ceiling."""
@@ -1575,9 +1581,7 @@ class Pi05TorchFrontendRtx:
         # pipeline (vision + encoder + decoder); intermediate frames skip
         # vision and encoder and replay only the decoder with fresh noise,
         # reusing the encoder K/V cache from the last full forward.
-        self._frame_count += 1
-        use_full = (self._cache_frames <= 1 or
-                    self._frame_count % self._cache_frames == 1)
+        use_full = self._use_full_pipeline_for_next_frame()
 
         with torch.cuda.stream(self._graph_torch_stream):
             stream_int = self._graph_torch_stream.cuda_stream
@@ -1616,6 +1620,12 @@ class Pi05TorchFrontendRtx:
             logger.info("Latency: %.1f ms", latency_ms)
 
         return {"actions": robot_actions}
+
+    def _use_full_pipeline_for_next_frame(self) -> bool:
+        """Advance the frame counter and select full vs decode-only work."""
+        self._frame_count += 1
+        return (self._cache_frames <= 1 or
+                self._frame_count % self._cache_frames == 1)
 
     def _infer_cfg_batched(self, observation: dict,
                            debug: bool = False) -> dict:
@@ -1821,10 +1831,7 @@ class Pi05TorchFrontendRtx:
                 noise, self.pipeline.input_noise_buf, stream_int)
             self.pipeline.calibrate_fp8()
             self.pipeline.autotune_gemms()
-            if self.use_cuda_graph:
-                from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
-                apply_frontend_capture_hooks(self)
-                self.pipeline.record_infer_graph(external_stream_int=stream_int)
+            self._record_infer_graph_if_enabled(stream_int)
         self.calibrated = True
         self.graph_recorded = self.use_cuda_graph
 

--- a/flash_rt/frontends/torch/pi05_rtx.py
+++ b/flash_rt/frontends/torch/pi05_rtx.py
@@ -473,7 +473,8 @@ class Pi05TorchFrontendRtx:
                  use_fp8: bool = True,
                  hardware: Optional[str] = None,
                  fp8_layout: Optional[str] = None,
-                 state_prompt_mode: str = "exact"):
+                 state_prompt_mode: str = "exact",
+                 use_cuda_graph: bool = True):
         checkpoint_dir = pathlib.Path(checkpoint_dir)
         # State-in-prompt graph strategy (Pi0.5 renders robot state into the
         # prompt, so its token length drifts with the state values):
@@ -517,6 +518,7 @@ class Pi05TorchFrontendRtx:
                 f"got {self._vision_num_layers}")
         # _use_int8_vision_static is set after _force_int8_decoder below
         self.use_fp8 = bool(use_fp8)
+        self.use_cuda_graph = bool(use_cuda_graph)
         self.hardware = _resolve_effective_hardware(hardware)
         self.fp8_layout = select_fp8_layout(hardware, fp8_layout)
 
@@ -1382,12 +1384,13 @@ class Pi05TorchFrontendRtx:
                     "(~0.96 vs dynamic 0.991 on test sequence). Set "
                     "FVK_PI05_RTX_INT8_ENCODER_STATIC=0 to disable.")
             self.pipeline.autotune_gemms()
-            from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
-            apply_frontend_capture_hooks(self)
-            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+            if self.use_cuda_graph:
+                from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
+                apply_frontend_capture_hooks(self)
+                self.pipeline.record_infer_graph(external_stream_int=stream_int)
 
         self.calibrated = True
-        self.graph_recorded = True
+        self.graph_recorded = self.use_cuda_graph
         self._precision_spec = self._snapshot_precision_spec(
             method="single_frame", n=1, percentile=None)
         self._warn_if_scale_ceiling_exceeded()
@@ -1449,12 +1452,13 @@ class Pi05TorchFrontendRtx:
 
             self.pipeline.fp8_calibrated = True
             self.pipeline.autotune_gemms()
-            from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
-            apply_frontend_capture_hooks(self)
-            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+            if self.use_cuda_graph:
+                from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
+                apply_frontend_capture_hooks(self)
+                self.pipeline.record_infer_graph(external_stream_int=stream_int)
 
         self.calibrated = True
-        self.graph_recorded = True
+        self.graph_recorded = self.use_cuda_graph
         self._precision_spec = self._snapshot_precision_spec(
             method="percentile", n=n, percentile=percentile)
         self._warn_if_scale_ceiling_exceeded(label=f"pi05_rtx_N{n}")
@@ -1586,10 +1590,10 @@ class Pi05TorchFrontendRtx:
                 self._fill_img_buf(observation)
                 self._copy_tensor_to_pipeline_buf_stream(
                     self._img_buf, self.pipeline.input_images_buf, stream_int)
-                out_ptr = self.pipeline.forward()
+                out_ptr = self.pipeline.forward(stream=stream_int)
             else:
                 # Decode-only: skip vision+encoder, reuse cached K/V
-                out_ptr = self.pipeline.forward_decode_only()
+                out_ptr = self.pipeline.forward_decode_only(stream=stream_int)
 
             # D2D download → staging torch tensor
             self._cudart.cudaMemcpyAsync(
@@ -1640,7 +1644,7 @@ class Pi05TorchFrontendRtx:
                 self._noise_buf_b2, self.pipeline.input_noise_buf_b2, stream_int)
 
             # Graph replay returns the cond slot's noise pointer.
-            out_ptr = self.pipeline.forward()
+            out_ptr = self.pipeline.forward(stream=stream_int)
 
             # D2D download of just the cond slot (chunk * ACTION_DIM bf16)
             self._cudart.cudaMemcpyAsync(
@@ -1817,11 +1821,12 @@ class Pi05TorchFrontendRtx:
                 noise, self.pipeline.input_noise_buf, stream_int)
             self.pipeline.calibrate_fp8()
             self.pipeline.autotune_gemms()
-            from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
-            apply_frontend_capture_hooks(self)
-            self.pipeline.record_infer_graph(external_stream_int=stream_int)
+            if self.use_cuda_graph:
+                from flash_rt.subgraphs.capture import apply_frontend_capture_hooks
+                apply_frontend_capture_hooks(self)
+                self.pipeline.record_infer_graph(external_stream_int=stream_int)
         self.calibrated = True
-        self.graph_recorded = True
+        self.graph_recorded = self.use_cuda_graph
 
     def infer_batch(self, observations: list) -> list:
         """Run B=2 inference on two independent observations.
@@ -1854,7 +1859,7 @@ class Pi05TorchFrontendRtx:
             self._copy_tensor_to_pipeline_buf_stream(
                 self._noise_buf_b2, self.pipeline.input_noise_buf_b2, stream_int)
 
-            out_ptr = self.pipeline.forward()
+            out_ptr = self.pipeline.forward(stream=stream_int)
 
             self._cudart.cudaMemcpyAsync(
                 ctypes.c_void_p(self._noise_out_b2.data_ptr()),

--- a/flash_rt/models/pi05/pipeline_rtx.py
+++ b/flash_rt/models/pi05/pipeline_rtx.py
@@ -2148,17 +2148,8 @@ class Pi05Pipeline:
             self._lang_embeds_buf.ptr,
             self._lang_embeds_buf.nbytes, 3, stream)  # D2D
 
-    def forward(self) -> int:
-        """Replay the captured graph (or fall back to ``run_pipeline``).
-
-        The frontend must have already written the inputs:
-            - ``input_images_buf``       (observation images)
-            - ``input_noise_buf``        (initial diffusion noise)
-            - language embeds via :meth:`set_language_embeds` (once per prompt)
-
-        After this returns, ``input_noise_buf`` contains the final actions.
-        Returns the device pointer of that buffer for the frontend to read.
-        """
+    def forward(self, stream: int | None = None) -> int:
+        """Replay the captured graph, or run the pipeline without a graph."""
         if self._graph is not None:
             if getattr(self, "_use_exec", False):
                 rc = self._exec_full.replay(0, self._exec_gs_id)
@@ -2168,20 +2159,13 @@ class Pi05Pipeline:
                 self._graph.replay(self._graph_stream)
             self._cudart.cudaStreamSynchronize(self._graph_stream)
         else:
-            self.run_pipeline(stream=0)
-            self._cudart.cudaDeviceSynchronize()
+            run_stream = 0 if stream is None else int(stream)
+            self.run_pipeline(stream=run_stream)
+            self._cudart.cudaStreamSynchronize(ctypes.c_void_p(run_stream))
         return self.bufs["diffusion_noise"].ptr.value
 
-    def forward_decode_only(self) -> int:
-        """Replay the decoder-only graph for temporal K/V caching.
-
-        Skips vision_encoder + transformer_encoder and runs only
-        transformer_decoder, reusing the encoder K/V cache from the last
-        full :meth:`forward` call. The frontend must write fresh noise into
-        ``input_noise_buf`` before calling this.
-
-        Returns the device pointer of ``diffusion_noise`` (final actions).
-        """
+    def forward_decode_only(self, stream: int | None = None) -> int:
+        """Replay the decoder-only graph, or run the decoder without a graph."""
         if hasattr(self, "_decoder_only_graph") and self._decoder_only_graph is not None:
             if getattr(self, "_use_exec", False):
                 rc = self._exec_dec.replay(0, self._exec_gs_id)
@@ -2191,8 +2175,9 @@ class Pi05Pipeline:
                 self._decoder_only_graph.replay(self._graph_stream)
             self._cudart.cudaStreamSynchronize(self._graph_stream)
         else:
-            self.transformer_decoder(stream=0)
-            self._cudart.cudaDeviceSynchronize()
+            run_stream = 0 if stream is None else int(stream)
+            self.transformer_decoder(stream=run_stream)
+            self._cudart.cudaStreamSynchronize(ctypes.c_void_p(run_stream))
         return self.bufs["diffusion_noise"].ptr.value
 
     def export_runtime(self, identity=None, extra_regions=None):

--- a/flash_rt/models/pi05/pipeline_rtx_batched.py
+++ b/flash_rt/models/pi05/pipeline_rtx_batched.py
@@ -1160,7 +1160,7 @@ class Pi05BatchedPipeline(Pi05Pipeline):
     #   Public API: input/output buffer handles for the batched path
     # ══════════════════════════════════════════════════════════════════
 
-    def forward(self) -> int:
+    def forward(self, stream: int | None = None) -> int:
         """Replay the captured B=2 graph and return the batched-noise ptr.
 
         Override of :meth:`Pi05Pipeline.forward` so the returned pointer
@@ -1172,8 +1172,9 @@ class Pi05BatchedPipeline(Pi05Pipeline):
             self._graph.replay(self._graph_stream)
             self._cudart.cudaStreamSynchronize(self._graph_stream)
         else:
-            self.run_pipeline(stream=0)
-            self._cudart.cudaDeviceSynchronize()
+            run_stream = 0 if stream is None else int(stream)
+            self.run_pipeline(stream=run_stream)
+            self._cudart.cudaStreamSynchronize(ctypes.c_void_p(run_stream))
         return self.bufs["diffusion_noise_b2"].ptr.value
 
     @property

--- a/flash_rt/models/pi05/pipeline_rtx_cfg_batched.py
+++ b/flash_rt/models/pi05/pipeline_rtx_cfg_batched.py
@@ -416,7 +416,7 @@ class Pi05CFGBatchedPipeline(Pi05BatchedPipeline):
     #   Output routing: action readback comes from the cond slot
     # ══════════════════════════════════════════════════════════════════
 
-    def forward(self) -> int:
+    def forward(self, stream: int | None = None) -> int:
         """Replay the captured B=2 CFG graph; return the cond slot pointer.
 
         The batched pipeline runs both slots' decoder per step, but the
@@ -427,8 +427,9 @@ class Pi05CFGBatchedPipeline(Pi05BatchedPipeline):
             self._graph.replay(self._graph_stream)
             self._cudart.cudaStreamSynchronize(self._graph_stream)
         else:
-            self.run_pipeline(stream=0)
-            self._cudart.cudaDeviceSynchronize()
+            run_stream = 0 if stream is None else int(stream)
+            self.run_pipeline(stream=run_stream)
+            self._cudart.cudaStreamSynchronize(ctypes.c_void_p(run_stream))
         per_slot_bytes = self.chunk_size * ACTION_DIM * 2
         return (self.bufs["diffusion_noise_b2"].ptr.value
                 + self.COND_SLOT * per_slot_bytes)

--- a/tests/test_pi05_cuda_graph_modes.py
+++ b/tests/test_pi05_cuda_graph_modes.py
@@ -1,0 +1,152 @@
+"""CPU-only contract tests for Pi0.5 CUDA-graph and stream routing."""
+
+import ctypes
+from types import SimpleNamespace
+
+import pytest
+
+from flash_rt.frontends.torch.pi05_rtx import Pi05TorchFrontendRtx
+from flash_rt.models.pi05.pipeline_rtx import Pi05Pipeline
+from flash_rt.models.pi05.pipeline_rtx_batched import Pi05BatchedPipeline
+from flash_rt.models.pi05.pipeline_rtx_cfg_batched import Pi05CFGBatchedPipeline
+
+
+class _CudaRuntimeSpy:
+    def __init__(self):
+        self.synchronized = []
+
+    def cudaStreamSynchronize(self, stream):
+        self.synchronized.append(
+            stream.value if isinstance(stream, ctypes.c_void_p) else stream)
+
+
+class _GraphSpy:
+    def __init__(self):
+        self.replayed = []
+
+    def replay(self, stream):
+        self.replayed.append(stream)
+
+
+def _pipeline(pipeline_cls, output_name):
+    pipeline = pipeline_cls.__new__(pipeline_cls)
+    pipeline._graph = None
+    pipeline._cudart = _CudaRuntimeSpy()
+    pipeline.bufs = {output_name: SimpleNamespace(ptr=SimpleNamespace(value=1234))}
+    pipeline.run_streams = []
+    pipeline.run_pipeline = lambda *, stream: pipeline.run_streams.append(stream)
+    if isinstance(pipeline, Pi05CFGBatchedPipeline):
+        pipeline.COND_SLOT = 0
+        pipeline.chunk_size = 50
+    return pipeline
+
+
+@pytest.mark.parametrize(
+    ("pipeline_cls", "output_name", "expected_ptr"),
+    [
+        (Pi05Pipeline, "diffusion_noise", 1234),
+        (Pi05BatchedPipeline, "diffusion_noise_b2", 1234),
+        (Pi05CFGBatchedPipeline, "diffusion_noise_b2", 1234),
+    ],
+)
+def test_no_graph_full_forward_uses_requested_stream(
+    pipeline_cls, output_name, expected_ptr,
+):
+    pipeline = _pipeline(pipeline_cls, output_name)
+
+    result = pipeline.forward(stream=73)
+
+    assert pipeline.run_streams == [73]
+    assert pipeline._cudart.synchronized == [73]
+    assert result == expected_ptr
+
+
+def test_cfg_batched_no_graph_returns_conditioned_slot():
+    pipeline = _pipeline(Pi05CFGBatchedPipeline, "diffusion_noise_b2")
+    pipeline.COND_SLOT = 1
+    pipeline.chunk_size = 50
+
+    result = pipeline.forward(stream=91)
+
+    assert result == 1234 + 50 * 32 * 2
+
+
+@pytest.mark.parametrize(
+    ("pipeline_cls", "output_name"),
+    [
+        (Pi05Pipeline, "diffusion_noise"),
+        (Pi05BatchedPipeline, "diffusion_noise_b2"),
+        (Pi05CFGBatchedPipeline, "diffusion_noise_b2"),
+    ],
+)
+def test_graph_forward_still_replays_captured_stream(pipeline_cls, output_name):
+    pipeline = _pipeline(pipeline_cls, output_name)
+    pipeline._graph = _GraphSpy()
+    pipeline._graph_stream = 17
+
+    pipeline.forward(stream=73)
+
+    assert pipeline._graph.replayed == [17]
+    assert pipeline.run_streams == []
+    assert pipeline._cudart.synchronized == [17]
+
+
+def test_no_graph_decode_only_uses_requested_stream():
+    pipeline = _pipeline(Pi05Pipeline, "diffusion_noise")
+    pipeline.transformer_streams = []
+    pipeline.transformer_decoder = (
+        lambda *, stream: pipeline.transformer_streams.append(stream))
+
+    result = pipeline.forward_decode_only(stream=29)
+
+    assert pipeline.transformer_streams == [29]
+    assert pipeline._cudart.synchronized == [29]
+    assert result == 1234
+
+
+def test_disabled_graph_mode_does_not_record(monkeypatch):
+    frontend = Pi05TorchFrontendRtx.__new__(Pi05TorchFrontendRtx)
+    frontend.use_cuda_graph = False
+    frontend.pipeline = SimpleNamespace(record_infer_graph=lambda **_: pytest.fail(
+        "record_infer_graph must not run when CUDA graphs are disabled"))
+    monkeypatch.setattr(
+        "flash_rt.subgraphs.capture.apply_frontend_capture_hooks",
+        lambda _: pytest.fail("capture hooks must not run"))
+
+    frontend._record_infer_graph_if_enabled(41)
+
+
+def test_default_graph_mode_records_on_requested_stream(monkeypatch):
+    frontend = Pi05TorchFrontendRtx.__new__(Pi05TorchFrontendRtx)
+    frontend.use_cuda_graph = True
+    recorded = []
+    frontend.pipeline = SimpleNamespace(
+        record_infer_graph=lambda **kwargs: recorded.append(kwargs))
+    hooked = []
+    monkeypatch.setattr(
+        "flash_rt.subgraphs.capture.apply_frontend_capture_hooks",
+        lambda value: hooked.append(value))
+
+    frontend._record_infer_graph_if_enabled(41)
+
+    assert hooked == [frontend]
+    assert recorded == [{"external_stream_int": 41}]
+
+
+@pytest.mark.parametrize(
+    ("cache_frames", "expected"),
+    [
+        (1, [True, True, True, True]),
+        (2, [True, False, True, False]),
+    ],
+)
+def test_cache_frame_schedule_alternates_full_and_decode_only(
+    cache_frames, expected,
+):
+    frontend = Pi05TorchFrontendRtx.__new__(Pi05TorchFrontendRtx)
+    frontend._cache_frames = cache_frames
+    frontend._frame_count = 0
+
+    actual = [frontend._use_full_pipeline_for_next_frame() for _ in expected]
+
+    assert actual == expected


### PR DESCRIPTION
# Background

The Pi0.5 benchmark uses CUDA Graph capture/replay by default. For kernel-level profiling, `--no-cuda-graph` skips capture/replay while preserving calibration, GEMM autotuning, and normal kernel dispatch.

This switch lives in the shared RTX frontend and is available on supported RTX-family backends, including Orin SM87. The PR's profiling example and validation target Orin 64GB.

# Changes

- Add `use_cuda_graph=True` to `Pi05TorchFrontendRtx`.
- Add benchmark flag `--no-cuda-graph`.
- Preserve the default CUDA Graph capture/replay behavior.
- Run full, decoder-only, batched, and CFG-batched no-graph fallbacks on the caller's CUDA stream.
- Support `cache_frames=1` and `cache_frames=2` routing.
- Report whether CUDA Graph is enabled in benchmark output.
- Make calibration completion logs accurate in both modes.
- Document Python and Nsight Systems usage in `docs/deployment_orin.md`.

# Validation

Hardware available for this revision:

- GPU: NVIDIA Thor (SM110), not the target Orin SM87
- Driver: 580.00
- Container: NVIDIA PyTorch 25.12
- PyTorch: 2.10.0a0+b4e4ee8
- CUDA runtime: 13.1 (driver exposes CUDA 13.0 compatibility)
- Build: existing `bagel-test:latest` test image; no kernel/CMake/binding changes in this PR

Commands and results:

```bash
docker run --rm --runtime=nvidia \
  -v "$PWD:/workspace" -w /workspace bagel-test:latest \
  python -m pytest \
    tests/test_pi05_cuda_graph_modes.py \
    tests/test_pi05_batched_inference.py \
    tests/test_pi05_cfg_batched_inference.py -q
# 12 passed, 12 skipped

git diff --check
# passed

python -m compileall -q \
  flash_rt/frontends/torch/pi05_rtx.py \
  flash_rt/models/pi05/pipeline_rtx_batched.py \
  flash_rt/models/pi05/pipeline_rtx_cfg_batched.py \
  tests/test_pi05_cuda_graph_modes.py
# passed
```

The CPU-only contract tests cover:

- graph mode still replays the captured stream;
- no-graph full and decoder-only paths use and synchronize the requested stream;
- batched and CFG-batched `forward(stream=...)` contracts;
- graph-disabled calibration does not install hooks or call `record_infer_graph()`;
- graph-enabled calibration records on the requested stream;
- `cache_frames=1` selects full execution every frame;
- `cache_frames=2` alternates full and decoder-only execution.

The 12 skipped tests require `PI05_LIBERO_PYTORCH_CHECKPOINT`, which is not present in this environment. Consequently, graph/no-graph fixed-noise output comparison, batched/CFG checkpoint E2E, and real Orin `cache_frames=1/2` runs remain unverified here and should be run on the target system before merge.

# Usage

```bash
nsys profile \
  --trace=cuda,nvtx,osrt \
  -o pi05_no_graph \
  python examples/orin/bench_pi05.py \
  --checkpoint "$HOME/.cache/openpi/openpi-assets/checkpoints/pi05_libero_pytorch" \
  --preset lossless \
  --warmup 3 \
  --reps 10 \
  --no-int8 \
  --no-cuda-graph
```

Without `--no-cuda-graph`, CUDA Graph remains enabled by default.
