### PR TITLE
catalog: LTX-2.5 host bindings (DiT and video pipeline)

### DIFF
--- a/docs/ltx25_usage.md
+++ b/docs/ltx25_usage.md
@@ -121,3 +121,133 @@ Measured on 5090 at 1536×1024×121f (median, video self-attention site,
 S=24576): SDPA-cudnn 42.4ms, sage2 17.4ms, sage3 13.0ms. End-to-end stage-2
 denoise per step: 5.11s (SDPA) → 3.84s (sage2), with output quality equivalent
 under matched-input single-forward cosine and frame inspection.
+
+## The same model through the structures layer
+
+The runtime above drives the official pipeline. The transformer is also
+reachable as an ordinary Diffusers host, where the structures layer attaches
+to it without a model-specific path:
+
+```python
+from flash_rt import structures
+
+plan = structures.attach(model, forward, scheme="nvfp4_balance")
+print(plan.report())          # bound seams, gate results, ledger
+plan.detach()                 # restores the host exactly
+```
+
+`attach` discovers the seams, calibrates on one real forward, gates accuracy
+and latency per family, and keeps the host path wherever a gate declines.
+Nothing here is LTX-specific: the attention seam is recognised by the
+processor contract (separate query/key rotary boundaries, per-head gating),
+not by a model or class name.
+
+`scheme=` selects the precision profile, and two are relevant here:
+
+| scheme | what it quantizes |
+|---|---|
+| `"nvfp4_balance"` | the projection GEMMs (W4A4); attention keeps the family's precision-first order |
+| `"nvfp4_balance_sage"` | the same, and allows the quantized attention forms to be weighed first |
+
+The split is deliberate. A quantized attention form trades a bounded error
+for speed, so it is a precision decision like any other and arrives through
+the profile a deployment selected — never through a device check or a host
+binding. Naming a form does not force it: the family still qualifies the
+shape, speed-gates the result, and falls through to the published order when
+the installed package does not serve the site.
+
+To tune one seam without registering a profile, name the forms directly:
+
+```python
+plan = structures.attach(model, forward, scheme="nvfp4_balance",
+                         attention_forms=("sage2",))
+```
+
+Either way the answer comes back measured. `plan.report()` prints each
+family's accuracy band and the paired latency it was judged on, and the
+attachment can be reverted exactly, so the way to decide between these is to
+run both and read the two reports rather than to take this table's word for
+it on a different card.
+
+### End to end
+
+What a request costs, wall clock, same prompt and seed, distilled
+single-pass recipe. The baseline is the unmodified host: a 44GB bf16
+checkpoint that does not fit on a 32GB part, so it runs with weight
+offloading, which is what a user of this model on this class of card
+actually starts from.
+
+| Request | Host (offload) | `"nvfp4_balance"` | `"nvfp4_balance_sage"` |
+|---|---|---|---|
+| 768×512×49f | 99.8 s | 6.0 s (16.6×), peak 29.9 GB | **5.7 s (17.5×)**, peak 26.8 GB |
+| 1536×1024×121f | 181.6 s | **87.9 s (2.07×)**, peak 28.0 GB | does not fit, see below |
+
+Medians of three warm runs, eager. Frames are inspection-equivalent to the
+host's own output.
+
+The full-size row is the honest one to read closely. Attaching all 48 blocks
+succeeds and each block's gate measures 1.48×, but the assembled pipeline
+sits close to the limit of a 32GB part: 23.9 GB resident before the request
+begins, 28.0 GB at peak, and video-VAE tiling is needed for decode to have
+room at all. Three things account for the distance between 2.07× here and
+what the same hardware reaches with a hand-assembled configuration:
+
+- this measurement is eager, with no compilation of the block stack;
+- the quantized attention profile does not fit at this size yet — the
+  per-shape staging pool costs about 3 GB on top, which the assembly step
+  runs out of;
+- the audio feed-forward stays at host precision throughout, 3.0 GB across
+  the model, because its 126-row calls sit outside the fused chain's
+  128-row alignment and the seam declines them rather than produce an
+  unwritten output.
+
+### Where the time goes, one transformer block
+
+The table below is a diagnostic, not the result: it says which family earned
+which part of the request time above. Real checkpoint weights, real captured
+deployment inputs, paired alternating timing inside the gate.
+
+| Site shape | `scheme=` | Block latency | Attention family | Peak memory |
+|---|---|---|---|---|
+| S=24576 (1536×1024×121f) | host, unattached | 134.3 ms | — | 12.2 GB |
+| | `"nvfp4_balance"` | 117.1 ms (1.15×) | BF16 form bound, declined at 1.006× | 8.2 GB |
+| | `"nvfp4_balance_sage"` | **89.8 ms (1.49×)** | activated, 1.259× | at the 32GB ceiling |
+| S=2688 (768×512×49f) | host, unattached | 10.2 ms | — | 2.3 GB |
+| | `"nvfp4_balance"` | 8.2 ms (1.25×) | declined | 1.7 GB |
+| | `"nvfp4_balance_sage"` | 8.0 ms (1.28×) | activated, 1.022× | 4.7 GB |
+
+Matched-forward cosine against the host's own output is 0.99999 in every row,
+and `detach` restores it bit-exactly (max-abs 0.0). Three things in that table
+are easy to misread, so they are worth stating:
+
+- **A block ratio is not a kernel ratio.** The same attention that measures
+  2.34× on its own (45.9 → 19.6 ms at S=24576) shows up as 1.259× for the
+  attention unit, because the unit is judged against the whole block. The
+  27 ms it saves is the same 27 ms in both numbers.
+- **The projections-only profile leaves the BF16 attention form bound and
+  declined.** That form measures 46.1 ms against the host's 45.9 ms here, so
+  the gate is right to keep the host path; nothing about the quantized forms
+  is being judged in that row.
+- **Peak memory moves in both directions.** Quantizing the projections takes
+  it from 12.2 to 8.2 GB. Preferring quantized attention gives some back,
+  because each attention site owns its staging and quantization workspace:
+  four sites at S=24576 reach the ceiling of a 32GB part. Pooling those
+  workspaces is the open item before that profile is usable at full size.
+
+### How the whole-model figures were produced
+
+Blocks are attached one at a time, because a 44GB bf16 checkpoint is not
+resident on a 32GB part: each block is materialized alone, attached on its
+own real inputs, and its host weights released before the next. The
+feed-forward seams are bound explicitly rather than by discovery, because
+`vision_ffn` does not claim this host's shape — its projections carry no
+bias and its norm sits outside the seam, both of which the structure's
+boundary requires. Whether to widen that boundary is a catalog decision.
+
+### Kernel availability is the package's own statement
+
+The forms read their envelope from the installed artifact. The sage3 package
+publishes head_dim 128 only in its CUDA 13 builds; on a CUDA 12.8 host it
+advertises head_dim 64, so a 128-wide site is refused there and the ladder
+falls through — visible on the refusal trail rather than as a silent
+slowdown. Nothing in this repository keeps a second table of that.

--- a/flash_rt/catalog/bindings/ltx25_dit.yaml
+++ b/flash_rt/catalog/bindings/ltx25_dit.yaml
@@ -1,0 +1,27 @@
+binding: ltx25_dit
+structure: vision_ffn
+dims: {D: 4096, F: 16384, layers: 48}
+variant: {activation: gelu}    # host applies the tanh approximation
+boundary_dtype: bf16
+
+m_profile:
+  denoise_stage1: {m_class: large, phase: denoise}   # M = video tokens, first distilled phase
+  denoise_stage2: {m_class: large, phase: denoise}   # M = 4x tokens after latent upsample
+
+weights_map:
+  diffusers:
+    layout: out_in
+    w_fc1: "transformer_blocks.{i}.ff.net.0.proj.weight"
+    b_fc1: {const: zeros}    # ff_bias=false on this host family
+    w_fc2: "transformer_blocks.{i}.ff.net.2.weight"
+    b_fc2: {const: zeros}
+    w_norm: {const: ones}    # norm2 is non-affine; scale/shift come from the
+    b_norm: {const: zeros}   # per-token adaptive tables, outside this seam
+
+quantized_layers: "0-41"     # the checkpoint's own quantization whitelist:
+                             # the last six blocks stay at host precision
+
+hosts:
+  diffusers:
+    module_path: "transformer_blocks.{i}.ff"
+    versions: ">=0.40"

--- a/flash_rt/catalog/bindings/ltx25_video_pipeline.yaml
+++ b/flash_rt/catalog/bindings/ltx25_video_pipeline.yaml
@@ -1,0 +1,155 @@
+binding: ltx25_video_pipeline
+structure: video_generation_pipeline
+
+# Joint audio+video DiT host. The distilled checkpoint's official recipe is
+# a single pass per step: every guidance/modality scale is 1.0, so no
+# classifier-free or modality-isolation passes exist on the hot path. A
+# binding that re-enables them changes the program being measured, not a
+# knob on the same program.
+recipe:
+  guidance_scale: 1.0
+  audio_guidance_scale: 1.0
+  modality_scale: 1.0
+  audio_modality_scale: 1.0
+  phases:
+    - {name: stage1, steps: 8}
+    - {name: stage2, steps: 3, after: latent_upsample}
+
+# Sites the checkpoint family itself quantizes; a scheme refuses to adopt
+# outside this list unless explicitly overridden. The last six transformer
+# blocks, every adaptive-norm single, the modality connectors, and the
+# patchify/proj_out boundary stay at host precision.
+quantization:
+  adopt_blocks: "0-41"
+  adopt_modules:
+    - "attn1"
+    - "attn2"
+    - "audio_attn1"
+    - "audio_attn2"
+    - "audio_to_video_attn"
+    - "video_to_audio_attn"
+    - "ff"
+    - "audio_ff"
+  adopt_leaves:
+    attention: ["to_q", "to_k", "to_v", "to_out.0"]
+    feed_forward: ["net.0.proj", "net.2"]
+
+stages:
+  condition_encode:
+    seam: "text encoder and per-modality connectors"
+    capture: eager_or_offloaded
+    residency: staged    # encoder weights leave the device before denoise
+  latent_prepare:
+    seam: "video/audio latent initialization from the request seed"
+    capture: eager
+  denoise:
+    seam: "joint transformer forward under the ancestral solver loop"
+    loop_steps: "@recipe.phases"
+    capture: host_dependent
+  decode:
+    seam: "video VAE decode and audio vocoder"
+    capture: eager
+    tiling_budget: resident_aware    # decode tiling must be sized against
+                                     # memory the resident transformer holds
+
+coverage:
+  contract: complete_hot_path
+  hot_path:
+    - prompt_encode
+    - modality_connectors
+    - latent_initialization
+    - denoise_control
+    - adaptive_norm_tables
+    - per_head_gating
+    - qk_norm_rope
+    - video_self_attention
+    - video_cross_attention
+    - audio_attention
+    - cross_modal_attention
+    - video_ffn
+    - audio_ffn
+    - attention_projections
+    - latent_upsample
+    - scheduler_update
+    - vae_decode
+  segments:
+    - name: prompt_encode
+      stage: condition_encode
+      classification: host_stage
+      seam: "text encoder forward"
+    - name: modality_connectors
+      stage: condition_encode
+      classification: host_stage
+      seam: "per-modality connector projections over encoder output"
+    - name: latent_initialization
+      stage: latent_prepare
+      classification: state_region
+      seam: "seeded video/audio latents and their patchified views"
+    - name: denoise_control
+      stage: denoise
+      classification: control
+      seam: "two-phase ancestral Euler schedule, single pass per step"
+    - name: adaptive_norm_tables
+      stage: denoise
+      classification: host_stage
+      seam: "per-token scale/shift/gate table lookups around every block"
+    - name: per_head_gating
+      stage: denoise
+      classification: host_stage
+      seam: "sigmoid per-head gate on attention outputs"
+    - name: qk_norm_rope
+      stage: denoise
+      classification: host_stage
+      seam: "per-head Q/K RMSNorm and rotary application"
+    - name: video_self_attention
+      stage: denoise
+      classification: structure
+      seam: "video branch attn1, dense unmasked, head_dim 128"
+      structures: [attention_core]
+    - name: video_cross_attention
+      stage: denoise
+      classification: structure
+      seam: "video branch attn2 over connector tokens, head_dim 128"
+      structures: [attention_core]
+    - name: audio_attention
+      stage: denoise
+      classification: host_stage
+      seam: "audio branch attention, head_dim 64 — outside the measured
+             net-win band of the claimed attention forms"
+    - name: cross_modal_attention
+      stage: denoise
+      classification: host_stage
+      seam: "audio-to-video and video-to-audio attention"
+    - name: video_ffn
+      stage: denoise
+      classification: structure
+      seam: "video branch feed-forward, tanh-GELU"
+      structures: [vision_ffn]
+    - name: audio_ffn
+      stage: denoise
+      classification: host_stage
+      seam: "audio branch feed-forward — small-M band measured net-negative
+             for the W4A4 form, retained on the host"
+    - name: attention_projections
+      stage: denoise
+      classification: structure
+      seam: "Q/K/V/O and feed-forward projections on the checkpoint's own
+             quantization whitelist"
+      structures: [linear_proj]
+    - name: latent_upsample
+      stage: denoise
+      classification: host_stage
+      seam: "latent upsampler between the two distilled phases"
+    - name: scheduler_update
+      stage: denoise
+      classification: state_region
+      seam: "ancestral solver latent update"
+    - name: vae_decode
+      stage: decode
+      classification: host_stage
+      seam: "tiled video VAE decode and audio vocoder"
+
+hosts:
+  diffusers:
+    module_path: "diffusers.LTX2VideoTransformer3DModel"
+    versions: ">=0.40"


### PR DESCRIPTION
The FlashRT half of #174 after the structures split: the two LTX-2.5 bindings land in `flash_rt/catalog/bindings`, and `docs/ltx25_usage.md` gains the structures-layer section. The executable forms, adapters and doors from #174 continue in FlashRT-Structures (flashrt-project/FlashRT-Structures, PR `pr/ltx25`), which reads these bindings through the flash-rt distribution.

Verified: `flash_rt.catalog` loads 29 bindings including `ltx25_dit` and `ltx25_video_pipeline`; `tests/test_catalog_*.py` 60 passed.